### PR TITLE
Add Babel Flow lib defs to React Native repo

### DIFF
--- a/flow-typed/npm/babel-traverse_v7.x.x.js
+++ b/flow-typed/npm/babel-traverse_v7.x.x.js
@@ -1,0 +1,1891 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+// The sections between BEGIN GENERATED and END GENERATED are generated
+// by the updateBabelTraverseTypes.js script. You can update the sections with
+// node ./xplat/js/tools/metro/scripts/updateBabelTraverseTypes.js path/to/this/file
+
+'use strict';
+
+declare module '@babel/traverse' {
+  declare export type TraverseOptions<TState> = {
+    ...Visitor<TState>,
+    scope?: Scope,
+    noScope?: boolean,
+  };
+
+  declare export interface HubInterface {
+    getCode(): ?string;
+    getScope(): ?Scope;
+    addHelper(name: string): {};
+    buildError<TError: Error>(
+      node: BabelNode,
+      msg: string,
+      Error: Class<TError>,
+    ): TError;
+  }
+
+  declare export class Hub implements HubInterface {
+    constructor(): Hub;
+    getCode(): ?string;
+    getScope(): ?Scope;
+    addHelper(name: string): {};
+    buildError<TError: Error>(
+      node: BabelNode,
+      msg: string,
+      Error: Class<TError>,
+    ): TError;
+  }
+
+  declare export interface TraversalContext {
+    parentPath: NodePath<>;
+    scope: Scope;
+    state: any;
+    opts: any;
+    queue: ?Array<NodePath<>>;
+
+    constructor(
+      scope: Scope,
+      opts: TraverseOptions<mixed>,
+      state: any,
+      parentPath: NodePath<>,
+    ): TraversalContext;
+
+    shouldVisit(node: BabelNode): boolean;
+    create(
+      node: BabelNode,
+      obj: Array<BabelNode>,
+      key: string,
+      listKey: string,
+    ): NodePath<>;
+    maybeQueue(path: NodePath<>, notPriority?: boolean): void;
+    visitMultiple(
+      container: Array<BabelNode>,
+      parent: BabelNode,
+      listKey: string,
+    ): boolean;
+    visitSingle(node: BabelNode, key: string): boolean;
+    visitQueue(queue: Array<NodePath<>>): boolean;
+    visit(node: BabelNode, key: string): boolean;
+  }
+
+  declare export class Scope {
+    static globals: Array<string>;
+    static conextVariables: Array<string>;
+
+    constructor(path: NodePath<>): Scope;
+    path: NodePath<>;
+    block: BabelNode;
+    +labels: Map<string, NodePath<>>;
+    +parentBlock: BabelNode;
+    +parent: Scope;
+    +hub: HubInterface;
+    bindings?: {[name: string]: Binding};
+    references?: {[name: string]: boolean};
+    globals?: {[name: string]: BabelNode};
+    uids?: {[name: string]: boolean};
+    data?: {[key: string]: any};
+    inited: boolean;
+
+    /** Traverse node with current scope and path. */
+    traverse<S>(
+      node: BabelNode | Array<BabelNode>,
+      opts: $ReadOnly<TraverseOptions<S>>,
+      state: S,
+    ): void;
+
+    /** Generate a unique identifier and add it to the current scope. */
+    generateDeclaredUidIdentifier(name?: string): BabelNodeIdentifier;
+
+    /** Generate a unique identifier. */
+    generateUidIdentifier(name?: string): BabelNodeIdentifier;
+
+    /** Generate a unique `_id1` binding. */
+    generateUid(name?: string): string;
+
+    generateUidBasedOnNode(node: BabelNode, defaultName?: string): string;
+
+    /** Generate a unique identifier based on a node. */
+    generateUidIdentifierBasedOnNode(
+      parent: BabelNode,
+      defaultName?: string,
+    ): BabelNodeIdentifier;
+
+    /**
+     * Determine whether evaluating the specific input `node` is a consequenceless reference. ie.
+     * evaluating it wont result in potentially arbitrary code from being ran. The following are
+     * whitelisted and determined not to cause side effects:
+     *
+     *  - `this` expressions
+     *  - `super` expressions
+     *  - Bound identifiers
+     */
+    isStatic(node: BabelNode): boolean;
+
+    /** Possibly generate a memoised identifier if it is not static and has consequences. */
+    maybeGenerateMemoised(
+      node: BabelNode,
+      dontPush?: boolean,
+    ): BabelNodeIdentifier;
+
+    checkBlockScopedCollisions(
+      local: BabelNode,
+      kind: string,
+      name: string,
+      id: {},
+    ): void;
+
+    rename(oldName: string, newName?: string, block?: BabelNode): void;
+
+    dump(): void;
+
+    toArray(
+      node: BabelNode,
+      i?: number | boolean,
+      allowArrayLike?: boolean,
+    ): BabelNode;
+
+    hasLabel(name: string): boolean;
+
+    getLabel(name: string): NodePath<>;
+
+    registerLabel(path: NodePath<>): void;
+
+    registerDeclaration(path: NodePath<>): void;
+
+    buildUndefinedNode(): BabelNode;
+
+    registerConstantViolation(path: NodePath<>): void;
+
+    registerBinding(
+      kind: BindingKind,
+      path: NodePath<>,
+      bindingPath?: NodePath<>,
+    ): void;
+
+    addGlobal(node: BabelNode): void;
+
+    hasUid(name: string): boolean;
+
+    hasGlobal(name: string): boolean;
+
+    hasReference(name: string): boolean;
+
+    isPure(node: BabelNode, constantsOnly?: boolean): boolean;
+
+    /**
+     * Set some arbitrary data on the current scope.
+     */
+    setData(key: string, val: any): any;
+
+    /**
+     * Recursively walk up scope tree looking for the data `key`.
+     */
+    getData(key: string): any;
+
+    /**
+     * Recursively walk up scope tree looking for the data `key` and if it exists,
+     * remove it.
+     */
+    removeData(key: string): void;
+
+    init(): void;
+
+    crawl(): void;
+
+    push(opts: {
+      id: BabelNodeLVal,
+      init?: BabelNodeExpression,
+      unique?: boolean,
+      _blockHoist?: ?number,
+      kind?: 'var' | 'let',
+    }): void;
+
+    getProgramParent(): Scope;
+
+    getFunctionParent(): Scope | null;
+
+    getBlockParent(): Scope;
+
+    /** Walks the scope tree and gathers **all** bindings. */
+    getAllBindings(): {[name: string]: Binding};
+
+    getAllBindingsOfKind(...kind: Array<BindingKind>): {
+      [name: string]: Binding,
+    };
+
+    bindingIdentifierEquals(name: string, node: BabelNode): boolean;
+
+    getBinding(name: string): Binding | void;
+
+    getOwnBinding(name: string): Binding | void;
+
+    getBindingIdentifier(name: string): BabelNodeIdentifier | void;
+
+    getOwnBindingIdentifier(name: string): BabelNodeIdentifier | void;
+
+    hasOwnBinding(name: string): boolean;
+
+    hasBinding(name: string, noGlobals?: boolean): boolean;
+
+    parentHasBinding(name: string, noGlobals?: boolean): boolean;
+
+    /** Move a binding of `name` to another `scope`. */
+    moveBindingTo(name: string, scope: Scope): void;
+
+    removeOwnBinding(name: string): void;
+
+    removeBinding(name: string): void;
+  }
+
+  declare export type BindingKind =
+    | 'var'
+    | 'let'
+    | 'const'
+    | 'module'
+    | 'hoisted'
+    | 'unknown';
+
+  declare export class Binding {
+    constructor(opts: {
+      identifier: BabelNodeIdentifier,
+      scope: Scope,
+      path: NodePath<>,
+      kind: BindingKind,
+    }): Binding;
+    identifier: BabelNodeIdentifier;
+    scope: Scope;
+    path: NodePath<>;
+    kind: BindingKind;
+    referenced: boolean;
+    references: number;
+    referencePaths: Array<NodePath<>>;
+    constant: boolean;
+    constantViolations: Array<NodePath<>>;
+    hasDeoptedValue: boolean;
+    hasValue: boolean;
+    value: any;
+
+    deoptValue(): void;
+
+    setValue(value: any): void;
+
+    clearValue(): void;
+
+    /**
+     * Register a constant violation with the provided `path`.
+     */
+    reassign(path: NodePath<>): void;
+
+    /**
+     * Increment the amount of references to this binding.
+     */
+    reference(path: NodePath<>): void;
+
+    dereference(): void;
+  }
+
+  declare function getNodePathType(node: BabelNode): NodePath<>;
+  declare function getNodePathType(nodes: Array<BabelNode>): Array<NodePath<>>;
+
+  declare type Opts = {...};
+
+  declare export class NodePath<+TNode: BabelNode = BabelNode> {
+    parent: BabelNode;
+    hub: HubInterface;
+    contexts: Array<TraversalContext>;
+    data: {[key: string]: mixed} | null;
+    shouldSkip: boolean;
+    shouldStop: boolean;
+    removed: boolean;
+    state: mixed;
+    +opts: $ReadOnly<TraverseOptions<mixed>> | null;
+    skipKeys: null | {[key: string]: boolean};
+    parentPath: ?NodePath<>;
+    context: TraversalContext;
+    container: null | {...} | Array<{...}>;
+    listKey: null | string;
+    key: null | string;
+
+    /* Declaring node as readonly isn't entirely correct since the node can be
+     * changed by e.g. calling replaceWith. However, this is needed to reasonably
+     * work with `NodePath`, e.g. that passing `NodePath<CallExpression>` to a
+     * `NodePath<Node> works.
+     */
+    +node: TNode;
+
+    parentKey: string;
+    scope: Scope;
+    type: null | $PropertyType<BabelNode, 'type'>;
+    inList: boolean;
+    typeAnnotation?: BabelNodeTypeAnnotation;
+
+    constructor(hub: HubInterface, parent: BabelNode): NodePath<TNode>;
+
+    static get({
+      hub: HubInterface,
+      parentPath: ?NodePath<>,
+      parent: BabelNode,
+      container: null | {...} | Array<{...}>,
+      listKey: null | string,
+      key: null | string,
+    }): NodePath<>;
+
+    getScope(scope: Scope): Scope;
+
+    setData<TVal>(key: string, val: TVal): TVal;
+    getData<TVal = mixed>(key: string, def?: TVal): TVal;
+
+    buildCodeFrameError<TError: Error>(
+      msg: string,
+      Error?: Class<TError>,
+    ): TError;
+
+    traverse<TState>(
+      visitor: $ReadOnly<TraverseOptions<TState>>,
+      state: TState,
+    ): void;
+
+    set(key: string, node: BabelNode): void;
+    getPathLocation(): string;
+
+    debug(message: string): void;
+
+    toString(): string;
+
+    // _ancestry
+    /**
+     * Starting at the parent path of the current `NodePath` and going up the
+     * tree, return the first `NodePath` that causes the provided `callback`
+     * to return a truthy value, or `null` if the `callback` never returns a
+     * truthy value.
+     */
+    findParent(callback: (path: NodePath<>) => boolean): NodePath<> | null;
+
+    /**
+     * Starting at current `NodePath` and going up the tree, return the first
+     * `NodePath` that causes the provided `callback` to return a truthy value,
+     * or `null` if the `callback` never returns a truthy value.
+     */
+    find(callback: (path: NodePath<>) => boolean): NodePath<> | null;
+
+    /**
+     * Get the parent function of the current path.
+     */
+    getFunctionParent(): NodePath<BabelNodeFunction> | null;
+
+    /**
+     * Walk up the tree until we hit a parent node path in a list.
+     */
+    getStatementParent(): NodePath<BabelNodeStatement>;
+
+    /**
+     * Get the deepest common ancestor and then from it, get the earliest relationship path
+     * to that ancestor.
+     *
+     * Earliest is defined as being "before" all the other nodes in terms of list container
+     * position and visiting key.
+     */
+    getEarliestCommonAncestorFrom(
+      paths: $ReadOnlyArray<NodePath<>>,
+    ): NodePath<>;
+
+    /**
+     * Get the earliest path in the tree where the provided `paths` intersect.
+     *
+     * TODO: Possible optimisation target.
+     */
+    getDeepestCommonAncestorFrom(
+      paths: $ReadOnlyArray<NodePath<>>,
+      filter?: (
+        lastCommon: BabelNode,
+        lastCommonIndex: number,
+        ancestries: Array<NodePath<>>,
+      ) => NodePath<>,
+    ): NodePath<>;
+
+    /**
+     * Build an array of node paths containing the entire ancestry of the current node path.
+     *
+     * NOTE: The current node path is included in this.
+     */
+    getAncestry(): Array<NodePath<>>;
+
+    /**
+     * A helper to find if `this` path is an ancestor of @param maybeDescendant
+     */
+    isAncestor(maybeDescendant: NodePath<>): boolean;
+
+    /**
+     * A helper to find if `this` path is a descendant of @param maybeAncestor
+     */
+    isDescendant(maybeAncestor: NodePath<>): boolean;
+
+    inType(...candidateTypes: Array<$PropertyType<BabelNode, 'type'>>): boolean;
+
+    // _inference
+
+    /**
+     * Infer the type of the current `NodePath`.
+     */
+    getTypeAnnotation(): BabelNodeTypeAnnotation;
+
+    isBaseType(baseName: string, soft?: boolean): boolean;
+    couldBeBaseType(
+      name:
+        | 'string'
+        | 'number'
+        | 'boolean'
+        | 'any'
+        | 'mixed'
+        | 'empty'
+        | 'void',
+    ): boolean;
+    baseTypeStrictlyMatches(right: NodePath<>): ?boolean;
+    isGenericType(genericName: string): boolean;
+
+    // _replacement
+
+    /**
+     * Replace a node with an array of multiple. This method performs the following steps:
+     *
+     *  - Inherit the comments of first provided node with that of the current node.
+     *  - Insert the provided nodes after the current node.
+     *  - Remove the current node.
+     */
+    replaceWithMultiple(node: Array<BabelNode>): Array<NodePath<>>;
+
+    /**
+     * Parse a string as an expression and replace the current node with the result.
+     *
+     * NOTE: This is typically not a good idea to use. Building source strings when
+     * transforming ASTs is an antipattern and SHOULD NOT be encouraged. Even if it's
+     * easier to use, your transforms will be extremely brittle.
+     */
+    replaceWithSourceString(replacement: string): Array<NodePath<>>;
+
+    /**
+     * Replace the current node with another.
+     */
+    replaceWith(replacement: BabelNode | NodePath<>): Array<NodePath<>>;
+
+    /**
+     * This method takes an array of statements nodes and then explodes it
+     * into expressions. This method retains completion records which is
+     * extremely important to retain original semantics.
+     */
+    replaceExpressionWithStatement(
+      nodes: Array<BabelNodeStatement>,
+    ): Array<NodePath<>>;
+
+    replaceInline(nodes: BabelNode | Array<BabelNode>): Array<NodePath<>>;
+
+    // _evaluation
+
+    /**
+     * Walk the input `node` and statically evaluate if it's truthy.
+     *
+     * Returning `true` when we're sure that the expression will evaluate to a
+     * truthy value, `false` if we're sure that it will evaluate to a falsy
+     * value and `undefined` if we aren't sure. Because of this please do not
+     * rely on coercion when using this method and check with === if it's false.
+     *
+     * For example do:
+     *
+     *   if (t.evaluateTruthy(node) === false) falsyLogic();
+     *
+     * **AND NOT**
+     *
+     *   if (!t.evaluateTruthy(node)) falsyLogic();
+     *
+     */
+    evaluateTruthy(): boolean | void;
+
+    /**
+     * Walk the input `node` and statically evaluate it.
+     *
+     * Returns an object in the form `{ confident, value }`. `confident` indicates
+     * whether or not we had to drop out of evaluating the expression because of
+     * hitting an unknown node that we couldn't confidently find the value of.
+     *
+     * Example:
+     *
+     *   t.evaluate(parse("5 + 5")) // { confident: true, value: 10 }
+     *   t.evaluate(parse("!true")) // { confident: true, value: false }
+     *   t.evaluate(parse("foo + foo")) // { confident: false, value: undefined }
+     *
+     */
+    evaluate():
+      | {confident: true, value: any, deopt: null}
+      | {confident: false, value: void, deopt: NodePath<>};
+
+    // conversion
+    toComputedKey(): BabelNode;
+
+    ensureBlock(): BabelNode;
+
+    /**
+     * Given an arbitrary function, process its content as if it were an arrow function, moving references
+     * to "this", "arguments", "super", and such into the function's parent scope. This method is useful if
+     * you have wrapped some set of items in an IIFE or other function, but want "this", "arguments", and super"
+     * to continue behaving as expected.
+     */
+    unwrapFunctionEnvironment(): void;
+
+    /**
+     * Convert a given arrow function into a normal ES5 function expression.
+     */
+    arrowFunctionToExpression(options?: {
+      allowInsertArrow?: boolean,
+      specCompliant?: boolean,
+    }): void;
+
+    // introspection
+
+    /**
+     * Match the current node if it matches the provided `pattern`.
+     *
+     * For example, given the match `React.createClass` it would match the
+     * parsed nodes of `React.createClass` and `React["createClass"]`.
+     */
+    matchesPattern(pattern: string, allowPartial?: boolean): boolean;
+
+    /**
+     * Check whether we have the input `key`. If the `key` references an array then we check
+     * if the array has any items, otherwise we just check if it's falsy.
+     */
+    has(key: $Keys<TNode>): boolean;
+
+    isStatic(): boolean;
+
+    /**
+     * Alias of `has`.
+     */
+    is(key: $Keys<TNode>): boolean;
+
+    /**
+     * Opposite of `has`.
+     */
+    isnt(key: $Keys<TNode>): boolean;
+
+    /**
+     * Check whether the path node `key` strict equals `value`.
+     */
+    equals(key: $Keys<TNode>, value: any): boolean;
+
+    /**
+     * Check the type against our stored internal type of the node. This is handy when a node has
+     * been removed yet we still internally know the type and need it to calculate node replacement.
+     */
+    isNodeType(type: $PropertyType<BabelNode, 'type'>): boolean;
+
+    /**
+     * This checks whether or not we're in one of the following positions:
+     *
+     *   for (KEY in right);
+     *   for (KEY;;);
+     *
+     * This is because these spots allow VariableDeclarations AND normal expressions so we need
+     * to tell the path replacement that it's ok to replace this with an expression.
+     */
+    canHaveVariableDeclarationOrExpression(): boolean;
+
+    /**
+     * This checks whether we are swapping an arrow function's body between an
+     * expression and a block statement (or vice versa).
+     *
+     * This is because arrow functions may implicitly return an expression, which
+     * is the same as containing a block statement.
+     */
+    canSwapBetweenExpressionAndStatement(replacement: BabelNode): boolean;
+
+    /**
+     * Check whether the current path references a completion record
+     */
+    isCompletionRecord(allowInsideFunction?: boolean): boolean;
+
+    /**
+     * Check whether or not the current `key` allows either a single statement or block statement
+     * so we can explode it if necessary.
+     */
+    isStatementOrBlock(): boolean;
+
+    /**
+     * Check if the currently assigned path references the `importName` of `moduleSource`.
+     */
+    referencesImport(moduleSource: string, importName?: string): boolean;
+
+    /**
+     * Get the source code associated with this node.
+     */
+    getSource(): string;
+
+    willIMaybeExecuteBefore(target: NodePath<>): boolean;
+
+    /**
+     * Resolve a "pointer" `NodePath` to it's absolute path.
+     */
+    resolve(dangerous?: boolean, resolved?: Array<NodePath<>>): NodePath<>;
+
+    isConstantExpression(): boolean;
+
+    isInStrictMode(): boolean;
+
+    // context
+    call(key: string): boolean;
+
+    isBlacklisted(): boolean;
+
+    visit(): boolean;
+
+    skip(): boolean;
+
+    skipKey(key: string): boolean;
+
+    stop(): void;
+
+    setScope(): void;
+
+    setContext(context: TraversalContext): NodePath<TNode>;
+
+    /**
+     * Here we resync the node paths `key` and `container`. If they've changed according
+     * to what we have stored internally then we attempt to resync by crawling and looking
+     * for the new values.
+     */
+    resync(): void;
+
+    popContext(): void;
+
+    pushContext(context: TraversalContext): void;
+
+    setup(
+      parentPath: NodePath<>,
+      container: ?{...} | ?Array<{...}>,
+      listKey: string,
+      key: string,
+    ): void;
+
+    setKey(key: string): void;
+
+    requeue(pathToQueue?: NodePath<>): void;
+
+    // removal
+    remove(): void;
+
+    // modification
+
+    /**
+     * Insert the provided nodes before the current one.
+     */
+    insertBefore(nodes: BabelNode | Array<BabelNode>): Array<NodePath<>>;
+
+    /**
+     * Insert the provided nodes after the current one. When inserting nodes after an
+     * expression, ensure that the completion record is correct by pushing the current node.
+     */
+    insertAfter(nodes: BabelNode | Array<BabelNode>): Array<NodePath<>>;
+
+    /**
+     * Update all sibling node paths after `fromIndex` by `incrementBy`.
+     */
+    updateSiblingKeys(fromIndex: number, incrementBy: number): void;
+
+    unshiftContainer(
+      listKey: string,
+      nodes: BabelNode | Array<BabelNode>,
+    ): Array<NodePath<>>;
+
+    pushContainer(
+      listKey: string,
+      nodes: BabelNode | Array<BabelNode>,
+    ): Array<NodePath<>>;
+
+    /**
+     * Hoist the current node to the highest scope possible and return a UID
+     * referencing it.
+     */
+    hoist(scope?: Scope): ?NodePath<>;
+
+    // family
+    getOpposite(): ?NodePath<>;
+
+    getCompletionRecords(): Array<NodePath<>>;
+
+    getSibling(key: string): NodePath<>;
+
+    getPrevSibling(): NodePath<>;
+
+    getNextSibling(): NodePath<>;
+
+    getAllNextSiblings(): Array<NodePath<>>;
+
+    getAllPrevSiblings(): Array<NodePath<>>;
+
+    get<TKey: $Keys<TNode>>(
+      key: TKey,
+      context?: boolean | TraversalContext,
+    ): $Call<typeof getNodePathType, TNode[TKey]>;
+
+    get(
+      key: string,
+      context?: boolean | TraversalContext,
+    ): NodePath<> | Array<NodePath<>>;
+
+    getBindingIdentifiers(duplicates?: void | false): {
+      [key: string]: BabelNodeIdentifier,
+    };
+
+    getBindingIdentifiers(duplicates: true): {
+      [key: string]: Array<BabelNodeIdentifier>,
+    };
+
+    getOuterBindingIdentifiers(duplicates: true): {
+      [key: string]: Array<BabelNodeIdentifier>,
+    };
+    getOuterBindingIdentifiers(duplicates?: false): {
+      [key: string]: BabelNodeIdentifier,
+    };
+    getOuterBindingIdentifiers(duplicates: boolean): {
+      [key: string]: BabelNodeIdentifier | Array<BabelNodeIdentifier>,
+    };
+
+    getBindingIdentifierPaths(
+      duplicates?: void | false,
+      outerOnly?: boolean,
+    ): {[key: string]: NodePath<BabelNodeIdentifier>};
+
+    getBindingIdentifierPaths(
+      duplicates: true,
+      outerOnly?: boolean,
+    ): {[key: string]: Array<NodePath<BabelNodeIdentifier>>};
+
+    getOuterBindingIdentifierPaths(duplicates?: void | false): {
+      [key: string]: NodePath<BabelNodeIdentifier>,
+    };
+
+    getOuterBindingIdentifierPaths(duplicates: true): {
+      [key: string]: Array<NodePath<BabelNodeIdentifier>>,
+    };
+
+    // comments
+    shareCommentsWithSiblings(): void;
+
+    addComment(
+      type: 'leading' | 'inner' | 'trailing',
+      content: string,
+      line?: boolean,
+    ): void;
+
+    addComments(
+      type: 'leading' | 'inner' | 'trailing',
+      comments: Array<BabelNodeComment>,
+    ): void;
+
+    // This section is automatically generated. Don't edit by hand.
+    // See the comment at the top of the file on how to update the definitions.
+    // BEGIN GENERATED NODE PATH METHODS
+    isAnyTypeAnnotation(opts?: Opts): boolean;
+    isArgumentPlaceholder(opts?: Opts): boolean;
+    isArrayExpression(opts?: Opts): boolean;
+    isArrayPattern(opts?: Opts): boolean;
+    isArrayTypeAnnotation(opts?: Opts): boolean;
+    isArrowFunctionExpression(opts?: Opts): boolean;
+    isAssignmentExpression(opts?: Opts): boolean;
+    isAssignmentPattern(opts?: Opts): boolean;
+    isAwaitExpression(opts?: Opts): boolean;
+    isBigIntLiteral(opts?: Opts): boolean;
+    isBinary(opts?: Opts): boolean;
+    isBinaryExpression(opts?: Opts): boolean;
+    isBindExpression(opts?: Opts): boolean;
+    isBindingIdentifier(opts?: Opts): boolean;
+    isBlock(opts?: Opts): boolean;
+    isBlockParent(opts?: Opts): boolean;
+    isBlockScoped(opts?: Opts): boolean;
+    isBlockStatement(opts?: Opts): boolean;
+    isBooleanLiteral(opts?: Opts): boolean;
+    isBooleanLiteralTypeAnnotation(opts?: Opts): boolean;
+    isBooleanTypeAnnotation(opts?: Opts): boolean;
+    isBreakStatement(opts?: Opts): boolean;
+    isCallExpression(opts?: Opts): boolean;
+    isCatchClause(opts?: Opts): boolean;
+    isClass(opts?: Opts): boolean;
+    isClassBody(opts?: Opts): boolean;
+    isClassDeclaration(opts?: Opts): boolean;
+    isClassExpression(opts?: Opts): boolean;
+    isClassImplements(opts?: Opts): boolean;
+    isClassMethod(opts?: Opts): boolean;
+    isClassPrivateMethod(opts?: Opts): boolean;
+    isClassPrivateProperty(opts?: Opts): boolean;
+    isClassProperty(opts?: Opts): boolean;
+    isCompletionStatement(opts?: Opts): boolean;
+    isConditional(opts?: Opts): boolean;
+    isConditionalExpression(opts?: Opts): boolean;
+    isContinueStatement(opts?: Opts): boolean;
+    isDebuggerStatement(opts?: Opts): boolean;
+    isDecimalLiteral(opts?: Opts): boolean;
+    isDeclaration(opts?: Opts): boolean;
+    isDeclareClass(opts?: Opts): boolean;
+    isDeclareExportAllDeclaration(opts?: Opts): boolean;
+    isDeclareExportDeclaration(opts?: Opts): boolean;
+    isDeclareFunction(opts?: Opts): boolean;
+    isDeclareInterface(opts?: Opts): boolean;
+    isDeclareModule(opts?: Opts): boolean;
+    isDeclareModuleExports(opts?: Opts): boolean;
+    isDeclareOpaqueType(opts?: Opts): boolean;
+    isDeclareTypeAlias(opts?: Opts): boolean;
+    isDeclareVariable(opts?: Opts): boolean;
+    isDeclaredPredicate(opts?: Opts): boolean;
+    isDecorator(opts?: Opts): boolean;
+    isDirective(opts?: Opts): boolean;
+    isDirectiveLiteral(opts?: Opts): boolean;
+    isDoExpression(opts?: Opts): boolean;
+    isDoWhileStatement(opts?: Opts): boolean;
+    isEmptyStatement(opts?: Opts): boolean;
+    isEmptyTypeAnnotation(opts?: Opts): boolean;
+    isEnumBody(opts?: Opts): boolean;
+    isEnumBooleanBody(opts?: Opts): boolean;
+    isEnumBooleanMember(opts?: Opts): boolean;
+    isEnumDeclaration(opts?: Opts): boolean;
+    isEnumDefaultedMember(opts?: Opts): boolean;
+    isEnumMember(opts?: Opts): boolean;
+    isEnumNumberBody(opts?: Opts): boolean;
+    isEnumNumberMember(opts?: Opts): boolean;
+    isEnumStringBody(opts?: Opts): boolean;
+    isEnumStringMember(opts?: Opts): boolean;
+    isEnumSymbolBody(opts?: Opts): boolean;
+    isExistentialTypeParam(opts?: Opts): boolean;
+    isExistsTypeAnnotation(opts?: Opts): boolean;
+    isExportAllDeclaration(opts?: Opts): boolean;
+    isExportDeclaration(opts?: Opts): boolean;
+    isExportDefaultDeclaration(opts?: Opts): boolean;
+    isExportDefaultSpecifier(opts?: Opts): boolean;
+    isExportNamedDeclaration(opts?: Opts): boolean;
+    isExportNamespaceSpecifier(opts?: Opts): boolean;
+    isExportSpecifier(opts?: Opts): boolean;
+    isExpression(opts?: Opts): boolean;
+    isExpressionStatement(opts?: Opts): boolean;
+    isExpressionWrapper(opts?: Opts): boolean;
+    isFile(opts?: Opts): boolean;
+    isFlow(opts?: Opts): boolean;
+    isFlowBaseAnnotation(opts?: Opts): boolean;
+    isFlowDeclaration(opts?: Opts): boolean;
+    isFlowPredicate(opts?: Opts): boolean;
+    isFlowType(opts?: Opts): boolean;
+    isFor(opts?: Opts): boolean;
+    isForAwaitStatement(opts?: Opts): boolean;
+    isForInStatement(opts?: Opts): boolean;
+    isForOfStatement(opts?: Opts): boolean;
+    isForStatement(opts?: Opts): boolean;
+    isForXStatement(opts?: Opts): boolean;
+    isFunction(opts?: Opts): boolean;
+    isFunctionDeclaration(opts?: Opts): boolean;
+    isFunctionExpression(opts?: Opts): boolean;
+    isFunctionParent(opts?: Opts): boolean;
+    isFunctionTypeAnnotation(opts?: Opts): boolean;
+    isFunctionTypeParam(opts?: Opts): boolean;
+    isGenerated(opts?: Opts): boolean;
+    isGenericTypeAnnotation(opts?: Opts): boolean;
+    isIdentifier(opts?: Opts): boolean;
+    isIfStatement(opts?: Opts): boolean;
+    isImmutable(opts?: Opts): boolean;
+    isImport(opts?: Opts): boolean;
+    isImportAttribute(opts?: Opts): boolean;
+    isImportDeclaration(opts?: Opts): boolean;
+    isImportDefaultSpecifier(opts?: Opts): boolean;
+    isImportNamespaceSpecifier(opts?: Opts): boolean;
+    isImportSpecifier(opts?: Opts): boolean;
+    isIndexedAccessType(opts?: Opts): boolean;
+    isInferredPredicate(opts?: Opts): boolean;
+    isInterfaceDeclaration(opts?: Opts): boolean;
+    isInterfaceExtends(opts?: Opts): boolean;
+    isInterfaceTypeAnnotation(opts?: Opts): boolean;
+    isInterpreterDirective(opts?: Opts): boolean;
+    isIntersectionTypeAnnotation(opts?: Opts): boolean;
+    isJSX(opts?: Opts): boolean;
+    isJSXAttribute(opts?: Opts): boolean;
+    isJSXClosingElement(opts?: Opts): boolean;
+    isJSXClosingFragment(opts?: Opts): boolean;
+    isJSXElement(opts?: Opts): boolean;
+    isJSXEmptyExpression(opts?: Opts): boolean;
+    isJSXExpressionContainer(opts?: Opts): boolean;
+    isJSXFragment(opts?: Opts): boolean;
+    isJSXIdentifier(opts?: Opts): boolean;
+    isJSXMemberExpression(opts?: Opts): boolean;
+    isJSXNamespacedName(opts?: Opts): boolean;
+    isJSXOpeningElement(opts?: Opts): boolean;
+    isJSXOpeningFragment(opts?: Opts): boolean;
+    isJSXSpreadAttribute(opts?: Opts): boolean;
+    isJSXSpreadChild(opts?: Opts): boolean;
+    isJSXText(opts?: Opts): boolean;
+    isLVal(opts?: Opts): boolean;
+    isLabeledStatement(opts?: Opts): boolean;
+    isLiteral(opts?: Opts): boolean;
+    isLogicalExpression(opts?: Opts): boolean;
+    isLoop(opts?: Opts): boolean;
+    isMemberExpression(opts?: Opts): boolean;
+    isMetaProperty(opts?: Opts): boolean;
+    isMethod(opts?: Opts): boolean;
+    isMixedTypeAnnotation(opts?: Opts): boolean;
+    isModuleDeclaration(opts?: Opts): boolean;
+    isModuleExpression(opts?: Opts): boolean;
+    isModuleSpecifier(opts?: Opts): boolean;
+    isNewExpression(opts?: Opts): boolean;
+    isNoop(opts?: Opts): boolean;
+    isNullLiteral(opts?: Opts): boolean;
+    isNullLiteralTypeAnnotation(opts?: Opts): boolean;
+    isNullableTypeAnnotation(opts?: Opts): boolean;
+    isNumberLiteral(opts?: Opts): boolean;
+    isNumberLiteralTypeAnnotation(opts?: Opts): boolean;
+    isNumberTypeAnnotation(opts?: Opts): boolean;
+    isNumericLiteral(opts?: Opts): boolean;
+    isNumericLiteralTypeAnnotation(opts?: Opts): boolean;
+    isObjectExpression(opts?: Opts): boolean;
+    isObjectMember(opts?: Opts): boolean;
+    isObjectMethod(opts?: Opts): boolean;
+    isObjectPattern(opts?: Opts): boolean;
+    isObjectProperty(opts?: Opts): boolean;
+    isObjectTypeAnnotation(opts?: Opts): boolean;
+    isObjectTypeCallProperty(opts?: Opts): boolean;
+    isObjectTypeIndexer(opts?: Opts): boolean;
+    isObjectTypeInternalSlot(opts?: Opts): boolean;
+    isObjectTypeProperty(opts?: Opts): boolean;
+    isObjectTypeSpreadProperty(opts?: Opts): boolean;
+    isOpaqueType(opts?: Opts): boolean;
+    isOptionalCallExpression(opts?: Opts): boolean;
+    isOptionalIndexedAccessType(opts?: Opts): boolean;
+    isOptionalMemberExpression(opts?: Opts): boolean;
+    isParenthesizedExpression(opts?: Opts): boolean;
+    isPattern(opts?: Opts): boolean;
+    isPatternLike(opts?: Opts): boolean;
+    isPipelineBareFunction(opts?: Opts): boolean;
+    isPipelinePrimaryTopicReference(opts?: Opts): boolean;
+    isPipelineTopicExpression(opts?: Opts): boolean;
+    isPlaceholder(opts?: Opts): boolean;
+    isPrivate(opts?: Opts): boolean;
+    isPrivateName(opts?: Opts): boolean;
+    isProgram(opts?: Opts): boolean;
+    isProperty(opts?: Opts): boolean;
+    isPure(opts?: Opts): boolean;
+    isPureish(opts?: Opts): boolean;
+    isQualifiedTypeIdentifier(opts?: Opts): boolean;
+    isRecordExpression(opts?: Opts): boolean;
+    isReferenced(opts?: Opts): boolean;
+    isReferencedIdentifier(opts?: Opts): boolean;
+    isReferencedMemberExpression(opts?: Opts): boolean;
+    isRegExpLiteral(opts?: Opts): boolean;
+    isRegexLiteral(opts?: Opts): boolean;
+    isRestElement(opts?: Opts): boolean;
+    isRestProperty(opts?: Opts): boolean;
+    isReturnStatement(opts?: Opts): boolean;
+    isScopable(opts?: Opts): boolean;
+    isScope(opts?: Opts): boolean;
+    isSequenceExpression(opts?: Opts): boolean;
+    isSpreadElement(opts?: Opts): boolean;
+    isSpreadProperty(opts?: Opts): boolean;
+    isStatement(opts?: Opts): boolean;
+    isStaticBlock(opts?: Opts): boolean;
+    isStringLiteral(opts?: Opts): boolean;
+    isStringLiteralTypeAnnotation(opts?: Opts): boolean;
+    isStringTypeAnnotation(opts?: Opts): boolean;
+    isSuper(opts?: Opts): boolean;
+    isSwitchCase(opts?: Opts): boolean;
+    isSwitchStatement(opts?: Opts): boolean;
+    isSymbolTypeAnnotation(opts?: Opts): boolean;
+    isTSAnyKeyword(opts?: Opts): boolean;
+    isTSArrayType(opts?: Opts): boolean;
+    isTSAsExpression(opts?: Opts): boolean;
+    isTSBaseType(opts?: Opts): boolean;
+    isTSBigIntKeyword(opts?: Opts): boolean;
+    isTSBooleanKeyword(opts?: Opts): boolean;
+    isTSCallSignatureDeclaration(opts?: Opts): boolean;
+    isTSConditionalType(opts?: Opts): boolean;
+    isTSConstructSignatureDeclaration(opts?: Opts): boolean;
+    isTSConstructorType(opts?: Opts): boolean;
+    isTSDeclareFunction(opts?: Opts): boolean;
+    isTSDeclareMethod(opts?: Opts): boolean;
+    isTSEntityName(opts?: Opts): boolean;
+    isTSEnumDeclaration(opts?: Opts): boolean;
+    isTSEnumMember(opts?: Opts): boolean;
+    isTSExportAssignment(opts?: Opts): boolean;
+    isTSExpressionWithTypeArguments(opts?: Opts): boolean;
+    isTSExternalModuleReference(opts?: Opts): boolean;
+    isTSFunctionType(opts?: Opts): boolean;
+    isTSImportEqualsDeclaration(opts?: Opts): boolean;
+    isTSImportType(opts?: Opts): boolean;
+    isTSIndexSignature(opts?: Opts): boolean;
+    isTSIndexedAccessType(opts?: Opts): boolean;
+    isTSInferType(opts?: Opts): boolean;
+    isTSInterfaceBody(opts?: Opts): boolean;
+    isTSInterfaceDeclaration(opts?: Opts): boolean;
+    isTSIntersectionType(opts?: Opts): boolean;
+    isTSIntrinsicKeyword(opts?: Opts): boolean;
+    isTSLiteralType(opts?: Opts): boolean;
+    isTSMappedType(opts?: Opts): boolean;
+    isTSMethodSignature(opts?: Opts): boolean;
+    isTSModuleBlock(opts?: Opts): boolean;
+    isTSModuleDeclaration(opts?: Opts): boolean;
+    isTSNamedTupleMember(opts?: Opts): boolean;
+    isTSNamespaceExportDeclaration(opts?: Opts): boolean;
+    isTSNeverKeyword(opts?: Opts): boolean;
+    isTSNonNullExpression(opts?: Opts): boolean;
+    isTSNullKeyword(opts?: Opts): boolean;
+    isTSNumberKeyword(opts?: Opts): boolean;
+    isTSObjectKeyword(opts?: Opts): boolean;
+    isTSOptionalType(opts?: Opts): boolean;
+    isTSParameterProperty(opts?: Opts): boolean;
+    isTSParenthesizedType(opts?: Opts): boolean;
+    isTSPropertySignature(opts?: Opts): boolean;
+    isTSQualifiedName(opts?: Opts): boolean;
+    isTSRestType(opts?: Opts): boolean;
+    isTSStringKeyword(opts?: Opts): boolean;
+    isTSSymbolKeyword(opts?: Opts): boolean;
+    isTSThisType(opts?: Opts): boolean;
+    isTSTupleType(opts?: Opts): boolean;
+    isTSType(opts?: Opts): boolean;
+    isTSTypeAliasDeclaration(opts?: Opts): boolean;
+    isTSTypeAnnotation(opts?: Opts): boolean;
+    isTSTypeAssertion(opts?: Opts): boolean;
+    isTSTypeElement(opts?: Opts): boolean;
+    isTSTypeLiteral(opts?: Opts): boolean;
+    isTSTypeOperator(opts?: Opts): boolean;
+    isTSTypeParameter(opts?: Opts): boolean;
+    isTSTypeParameterDeclaration(opts?: Opts): boolean;
+    isTSTypeParameterInstantiation(opts?: Opts): boolean;
+    isTSTypePredicate(opts?: Opts): boolean;
+    isTSTypeQuery(opts?: Opts): boolean;
+    isTSTypeReference(opts?: Opts): boolean;
+    isTSUndefinedKeyword(opts?: Opts): boolean;
+    isTSUnionType(opts?: Opts): boolean;
+    isTSUnknownKeyword(opts?: Opts): boolean;
+    isTSVoidKeyword(opts?: Opts): boolean;
+    isTaggedTemplateExpression(opts?: Opts): boolean;
+    isTemplateElement(opts?: Opts): boolean;
+    isTemplateLiteral(opts?: Opts): boolean;
+    isTerminatorless(opts?: Opts): boolean;
+    isThisExpression(opts?: Opts): boolean;
+    isThisTypeAnnotation(opts?: Opts): boolean;
+    isThrowStatement(opts?: Opts): boolean;
+    isTryStatement(opts?: Opts): boolean;
+    isTupleExpression(opts?: Opts): boolean;
+    isTupleTypeAnnotation(opts?: Opts): boolean;
+    isTypeAlias(opts?: Opts): boolean;
+    isTypeAnnotation(opts?: Opts): boolean;
+    isTypeCastExpression(opts?: Opts): boolean;
+    isTypeParameter(opts?: Opts): boolean;
+    isTypeParameterDeclaration(opts?: Opts): boolean;
+    isTypeParameterInstantiation(opts?: Opts): boolean;
+    isTypeofTypeAnnotation(opts?: Opts): boolean;
+    isUnaryExpression(opts?: Opts): boolean;
+    isUnaryLike(opts?: Opts): boolean;
+    isUnionTypeAnnotation(opts?: Opts): boolean;
+    isUpdateExpression(opts?: Opts): boolean;
+    isUser(opts?: Opts): boolean;
+    isUserWhitespacable(opts?: Opts): boolean;
+    isV8IntrinsicIdentifier(opts?: Opts): boolean;
+    isVar(opts?: Opts): boolean;
+    isVariableDeclaration(opts?: Opts): boolean;
+    isVariableDeclarator(opts?: Opts): boolean;
+    isVariance(opts?: Opts): boolean;
+    isVoidTypeAnnotation(opts?: Opts): boolean;
+    isWhile(opts?: Opts): boolean;
+    isWhileStatement(opts?: Opts): boolean;
+    isWithStatement(opts?: Opts): boolean;
+    isYieldExpression(opts?: Opts): boolean;
+    assertAnyTypeAnnotation(opts?: Opts): void;
+    assertArgumentPlaceholder(opts?: Opts): void;
+    assertArrayExpression(opts?: Opts): void;
+    assertArrayPattern(opts?: Opts): void;
+    assertArrayTypeAnnotation(opts?: Opts): void;
+    assertArrowFunctionExpression(opts?: Opts): void;
+    assertAssignmentExpression(opts?: Opts): void;
+    assertAssignmentPattern(opts?: Opts): void;
+    assertAwaitExpression(opts?: Opts): void;
+    assertBigIntLiteral(opts?: Opts): void;
+    assertBinary(opts?: Opts): void;
+    assertBinaryExpression(opts?: Opts): void;
+    assertBindExpression(opts?: Opts): void;
+    assertBindingIdentifier(opts?: Opts): void;
+    assertBlock(opts?: Opts): void;
+    assertBlockParent(opts?: Opts): void;
+    assertBlockScoped(opts?: Opts): void;
+    assertBlockStatement(opts?: Opts): void;
+    assertBooleanLiteral(opts?: Opts): void;
+    assertBooleanLiteralTypeAnnotation(opts?: Opts): void;
+    assertBooleanTypeAnnotation(opts?: Opts): void;
+    assertBreakStatement(opts?: Opts): void;
+    assertCallExpression(opts?: Opts): void;
+    assertCatchClause(opts?: Opts): void;
+    assertClass(opts?: Opts): void;
+    assertClassBody(opts?: Opts): void;
+    assertClassDeclaration(opts?: Opts): void;
+    assertClassExpression(opts?: Opts): void;
+    assertClassImplements(opts?: Opts): void;
+    assertClassMethod(opts?: Opts): void;
+    assertClassPrivateMethod(opts?: Opts): void;
+    assertClassPrivateProperty(opts?: Opts): void;
+    assertClassProperty(opts?: Opts): void;
+    assertCompletionStatement(opts?: Opts): void;
+    assertConditional(opts?: Opts): void;
+    assertConditionalExpression(opts?: Opts): void;
+    assertContinueStatement(opts?: Opts): void;
+    assertDebuggerStatement(opts?: Opts): void;
+    assertDecimalLiteral(opts?: Opts): void;
+    assertDeclaration(opts?: Opts): void;
+    assertDeclareClass(opts?: Opts): void;
+    assertDeclareExportAllDeclaration(opts?: Opts): void;
+    assertDeclareExportDeclaration(opts?: Opts): void;
+    assertDeclareFunction(opts?: Opts): void;
+    assertDeclareInterface(opts?: Opts): void;
+    assertDeclareModule(opts?: Opts): void;
+    assertDeclareModuleExports(opts?: Opts): void;
+    assertDeclareOpaqueType(opts?: Opts): void;
+    assertDeclareTypeAlias(opts?: Opts): void;
+    assertDeclareVariable(opts?: Opts): void;
+    assertDeclaredPredicate(opts?: Opts): void;
+    assertDecorator(opts?: Opts): void;
+    assertDirective(opts?: Opts): void;
+    assertDirectiveLiteral(opts?: Opts): void;
+    assertDoExpression(opts?: Opts): void;
+    assertDoWhileStatement(opts?: Opts): void;
+    assertEmptyStatement(opts?: Opts): void;
+    assertEmptyTypeAnnotation(opts?: Opts): void;
+    assertEnumBody(opts?: Opts): void;
+    assertEnumBooleanBody(opts?: Opts): void;
+    assertEnumBooleanMember(opts?: Opts): void;
+    assertEnumDeclaration(opts?: Opts): void;
+    assertEnumDefaultedMember(opts?: Opts): void;
+    assertEnumMember(opts?: Opts): void;
+    assertEnumNumberBody(opts?: Opts): void;
+    assertEnumNumberMember(opts?: Opts): void;
+    assertEnumStringBody(opts?: Opts): void;
+    assertEnumStringMember(opts?: Opts): void;
+    assertEnumSymbolBody(opts?: Opts): void;
+    assertExistentialTypeParam(opts?: Opts): void;
+    assertExistsTypeAnnotation(opts?: Opts): void;
+    assertExportAllDeclaration(opts?: Opts): void;
+    assertExportDeclaration(opts?: Opts): void;
+    assertExportDefaultDeclaration(opts?: Opts): void;
+    assertExportDefaultSpecifier(opts?: Opts): void;
+    assertExportNamedDeclaration(opts?: Opts): void;
+    assertExportNamespaceSpecifier(opts?: Opts): void;
+    assertExportSpecifier(opts?: Opts): void;
+    assertExpression(opts?: Opts): void;
+    assertExpressionStatement(opts?: Opts): void;
+    assertExpressionWrapper(opts?: Opts): void;
+    assertFile(opts?: Opts): void;
+    assertFlow(opts?: Opts): void;
+    assertFlowBaseAnnotation(opts?: Opts): void;
+    assertFlowDeclaration(opts?: Opts): void;
+    assertFlowPredicate(opts?: Opts): void;
+    assertFlowType(opts?: Opts): void;
+    assertFor(opts?: Opts): void;
+    assertForAwaitStatement(opts?: Opts): void;
+    assertForInStatement(opts?: Opts): void;
+    assertForOfStatement(opts?: Opts): void;
+    assertForStatement(opts?: Opts): void;
+    assertForXStatement(opts?: Opts): void;
+    assertFunction(opts?: Opts): void;
+    assertFunctionDeclaration(opts?: Opts): void;
+    assertFunctionExpression(opts?: Opts): void;
+    assertFunctionParent(opts?: Opts): void;
+    assertFunctionTypeAnnotation(opts?: Opts): void;
+    assertFunctionTypeParam(opts?: Opts): void;
+    assertGenerated(opts?: Opts): void;
+    assertGenericTypeAnnotation(opts?: Opts): void;
+    assertIdentifier(opts?: Opts): void;
+    assertIfStatement(opts?: Opts): void;
+    assertImmutable(opts?: Opts): void;
+    assertImport(opts?: Opts): void;
+    assertImportAttribute(opts?: Opts): void;
+    assertImportDeclaration(opts?: Opts): void;
+    assertImportDefaultSpecifier(opts?: Opts): void;
+    assertImportNamespaceSpecifier(opts?: Opts): void;
+    assertImportSpecifier(opts?: Opts): void;
+    assertIndexedAccessType(opts?: Opts): void;
+    assertInferredPredicate(opts?: Opts): void;
+    assertInterfaceDeclaration(opts?: Opts): void;
+    assertInterfaceExtends(opts?: Opts): void;
+    assertInterfaceTypeAnnotation(opts?: Opts): void;
+    assertInterpreterDirective(opts?: Opts): void;
+    assertIntersectionTypeAnnotation(opts?: Opts): void;
+    assertJSX(opts?: Opts): void;
+    assertJSXAttribute(opts?: Opts): void;
+    assertJSXClosingElement(opts?: Opts): void;
+    assertJSXClosingFragment(opts?: Opts): void;
+    assertJSXElement(opts?: Opts): void;
+    assertJSXEmptyExpression(opts?: Opts): void;
+    assertJSXExpressionContainer(opts?: Opts): void;
+    assertJSXFragment(opts?: Opts): void;
+    assertJSXIdentifier(opts?: Opts): void;
+    assertJSXMemberExpression(opts?: Opts): void;
+    assertJSXNamespacedName(opts?: Opts): void;
+    assertJSXOpeningElement(opts?: Opts): void;
+    assertJSXOpeningFragment(opts?: Opts): void;
+    assertJSXSpreadAttribute(opts?: Opts): void;
+    assertJSXSpreadChild(opts?: Opts): void;
+    assertJSXText(opts?: Opts): void;
+    assertLVal(opts?: Opts): void;
+    assertLabeledStatement(opts?: Opts): void;
+    assertLiteral(opts?: Opts): void;
+    assertLogicalExpression(opts?: Opts): void;
+    assertLoop(opts?: Opts): void;
+    assertMemberExpression(opts?: Opts): void;
+    assertMetaProperty(opts?: Opts): void;
+    assertMethod(opts?: Opts): void;
+    assertMixedTypeAnnotation(opts?: Opts): void;
+    assertModuleDeclaration(opts?: Opts): void;
+    assertModuleExpression(opts?: Opts): void;
+    assertModuleSpecifier(opts?: Opts): void;
+    assertNewExpression(opts?: Opts): void;
+    assertNoop(opts?: Opts): void;
+    assertNullLiteral(opts?: Opts): void;
+    assertNullLiteralTypeAnnotation(opts?: Opts): void;
+    assertNullableTypeAnnotation(opts?: Opts): void;
+    assertNumberLiteral(opts?: Opts): void;
+    assertNumberLiteralTypeAnnotation(opts?: Opts): void;
+    assertNumberTypeAnnotation(opts?: Opts): void;
+    assertNumericLiteral(opts?: Opts): void;
+    assertNumericLiteralTypeAnnotation(opts?: Opts): void;
+    assertObjectExpression(opts?: Opts): void;
+    assertObjectMember(opts?: Opts): void;
+    assertObjectMethod(opts?: Opts): void;
+    assertObjectPattern(opts?: Opts): void;
+    assertObjectProperty(opts?: Opts): void;
+    assertObjectTypeAnnotation(opts?: Opts): void;
+    assertObjectTypeCallProperty(opts?: Opts): void;
+    assertObjectTypeIndexer(opts?: Opts): void;
+    assertObjectTypeInternalSlot(opts?: Opts): void;
+    assertObjectTypeProperty(opts?: Opts): void;
+    assertObjectTypeSpreadProperty(opts?: Opts): void;
+    assertOpaqueType(opts?: Opts): void;
+    assertOptionalCallExpression(opts?: Opts): void;
+    assertOptionalIndexedAccessType(opts?: Opts): void;
+    assertOptionalMemberExpression(opts?: Opts): void;
+    assertParenthesizedExpression(opts?: Opts): void;
+    assertPattern(opts?: Opts): void;
+    assertPatternLike(opts?: Opts): void;
+    assertPipelineBareFunction(opts?: Opts): void;
+    assertPipelinePrimaryTopicReference(opts?: Opts): void;
+    assertPipelineTopicExpression(opts?: Opts): void;
+    assertPlaceholder(opts?: Opts): void;
+    assertPrivate(opts?: Opts): void;
+    assertPrivateName(opts?: Opts): void;
+    assertProgram(opts?: Opts): void;
+    assertProperty(opts?: Opts): void;
+    assertPure(opts?: Opts): void;
+    assertPureish(opts?: Opts): void;
+    assertQualifiedTypeIdentifier(opts?: Opts): void;
+    assertRecordExpression(opts?: Opts): void;
+    assertReferenced(opts?: Opts): void;
+    assertReferencedIdentifier(opts?: Opts): void;
+    assertReferencedMemberExpression(opts?: Opts): void;
+    assertRegExpLiteral(opts?: Opts): void;
+    assertRegexLiteral(opts?: Opts): void;
+    assertRestElement(opts?: Opts): void;
+    assertRestProperty(opts?: Opts): void;
+    assertReturnStatement(opts?: Opts): void;
+    assertScopable(opts?: Opts): void;
+    assertScope(opts?: Opts): void;
+    assertSequenceExpression(opts?: Opts): void;
+    assertSpreadElement(opts?: Opts): void;
+    assertSpreadProperty(opts?: Opts): void;
+    assertStatement(opts?: Opts): void;
+    assertStaticBlock(opts?: Opts): void;
+    assertStringLiteral(opts?: Opts): void;
+    assertStringLiteralTypeAnnotation(opts?: Opts): void;
+    assertStringTypeAnnotation(opts?: Opts): void;
+    assertSuper(opts?: Opts): void;
+    assertSwitchCase(opts?: Opts): void;
+    assertSwitchStatement(opts?: Opts): void;
+    assertSymbolTypeAnnotation(opts?: Opts): void;
+    assertTSAnyKeyword(opts?: Opts): void;
+    assertTSArrayType(opts?: Opts): void;
+    assertTSAsExpression(opts?: Opts): void;
+    assertTSBaseType(opts?: Opts): void;
+    assertTSBigIntKeyword(opts?: Opts): void;
+    assertTSBooleanKeyword(opts?: Opts): void;
+    assertTSCallSignatureDeclaration(opts?: Opts): void;
+    assertTSConditionalType(opts?: Opts): void;
+    assertTSConstructSignatureDeclaration(opts?: Opts): void;
+    assertTSConstructorType(opts?: Opts): void;
+    assertTSDeclareFunction(opts?: Opts): void;
+    assertTSDeclareMethod(opts?: Opts): void;
+    assertTSEntityName(opts?: Opts): void;
+    assertTSEnumDeclaration(opts?: Opts): void;
+    assertTSEnumMember(opts?: Opts): void;
+    assertTSExportAssignment(opts?: Opts): void;
+    assertTSExpressionWithTypeArguments(opts?: Opts): void;
+    assertTSExternalModuleReference(opts?: Opts): void;
+    assertTSFunctionType(opts?: Opts): void;
+    assertTSImportEqualsDeclaration(opts?: Opts): void;
+    assertTSImportType(opts?: Opts): void;
+    assertTSIndexSignature(opts?: Opts): void;
+    assertTSIndexedAccessType(opts?: Opts): void;
+    assertTSInferType(opts?: Opts): void;
+    assertTSInterfaceBody(opts?: Opts): void;
+    assertTSInterfaceDeclaration(opts?: Opts): void;
+    assertTSIntersectionType(opts?: Opts): void;
+    assertTSIntrinsicKeyword(opts?: Opts): void;
+    assertTSLiteralType(opts?: Opts): void;
+    assertTSMappedType(opts?: Opts): void;
+    assertTSMethodSignature(opts?: Opts): void;
+    assertTSModuleBlock(opts?: Opts): void;
+    assertTSModuleDeclaration(opts?: Opts): void;
+    assertTSNamedTupleMember(opts?: Opts): void;
+    assertTSNamespaceExportDeclaration(opts?: Opts): void;
+    assertTSNeverKeyword(opts?: Opts): void;
+    assertTSNonNullExpression(opts?: Opts): void;
+    assertTSNullKeyword(opts?: Opts): void;
+    assertTSNumberKeyword(opts?: Opts): void;
+    assertTSObjectKeyword(opts?: Opts): void;
+    assertTSOptionalType(opts?: Opts): void;
+    assertTSParameterProperty(opts?: Opts): void;
+    assertTSParenthesizedType(opts?: Opts): void;
+    assertTSPropertySignature(opts?: Opts): void;
+    assertTSQualifiedName(opts?: Opts): void;
+    assertTSRestType(opts?: Opts): void;
+    assertTSStringKeyword(opts?: Opts): void;
+    assertTSSymbolKeyword(opts?: Opts): void;
+    assertTSThisType(opts?: Opts): void;
+    assertTSTupleType(opts?: Opts): void;
+    assertTSType(opts?: Opts): void;
+    assertTSTypeAliasDeclaration(opts?: Opts): void;
+    assertTSTypeAnnotation(opts?: Opts): void;
+    assertTSTypeAssertion(opts?: Opts): void;
+    assertTSTypeElement(opts?: Opts): void;
+    assertTSTypeLiteral(opts?: Opts): void;
+    assertTSTypeOperator(opts?: Opts): void;
+    assertTSTypeParameter(opts?: Opts): void;
+    assertTSTypeParameterDeclaration(opts?: Opts): void;
+    assertTSTypeParameterInstantiation(opts?: Opts): void;
+    assertTSTypePredicate(opts?: Opts): void;
+    assertTSTypeQuery(opts?: Opts): void;
+    assertTSTypeReference(opts?: Opts): void;
+    assertTSUndefinedKeyword(opts?: Opts): void;
+    assertTSUnionType(opts?: Opts): void;
+    assertTSUnknownKeyword(opts?: Opts): void;
+    assertTSVoidKeyword(opts?: Opts): void;
+    assertTaggedTemplateExpression(opts?: Opts): void;
+    assertTemplateElement(opts?: Opts): void;
+    assertTemplateLiteral(opts?: Opts): void;
+    assertTerminatorless(opts?: Opts): void;
+    assertThisExpression(opts?: Opts): void;
+    assertThisTypeAnnotation(opts?: Opts): void;
+    assertThrowStatement(opts?: Opts): void;
+    assertTryStatement(opts?: Opts): void;
+    assertTupleExpression(opts?: Opts): void;
+    assertTupleTypeAnnotation(opts?: Opts): void;
+    assertTypeAlias(opts?: Opts): void;
+    assertTypeAnnotation(opts?: Opts): void;
+    assertTypeCastExpression(opts?: Opts): void;
+    assertTypeParameter(opts?: Opts): void;
+    assertTypeParameterDeclaration(opts?: Opts): void;
+    assertTypeParameterInstantiation(opts?: Opts): void;
+    assertTypeofTypeAnnotation(opts?: Opts): void;
+    assertUnaryExpression(opts?: Opts): void;
+    assertUnaryLike(opts?: Opts): void;
+    assertUnionTypeAnnotation(opts?: Opts): void;
+    assertUpdateExpression(opts?: Opts): void;
+    assertUser(opts?: Opts): void;
+    assertUserWhitespacable(opts?: Opts): void;
+    assertV8IntrinsicIdentifier(opts?: Opts): void;
+    assertVar(opts?: Opts): void;
+    assertVariableDeclaration(opts?: Opts): void;
+    assertVariableDeclarator(opts?: Opts): void;
+    assertVariance(opts?: Opts): void;
+    assertVoidTypeAnnotation(opts?: Opts): void;
+    assertWhile(opts?: Opts): void;
+    assertWhileStatement(opts?: Opts): void;
+    assertWithStatement(opts?: Opts): void;
+    assertYieldExpression(opts?: Opts): void;
+    // END GENERATED NODE PATH METHODS
+  }
+
+  declare export type VisitNodeFunction<-TNode: BabelNode, TState> = (
+    path: NodePath<TNode>,
+    state: TState,
+  ) => void;
+
+  declare export type VisitNodeObject<-TNode: BabelNode, TState> = Partial<{
+    enter(path: NodePath<TNode>, state: TState): void,
+    exit(path: NodePath<TNode>, state: TState): void,
+  }>;
+
+  declare export type VisitNode<-TNode: BabelNode, TState> =
+    | VisitNodeFunction<TNode, TState>
+    | VisitNodeObject<TNode, TState>;
+
+  declare export type Visitor<TState = void> = $ReadOnly<{
+    enter?: VisitNodeFunction<BabelNode, TState>,
+    exit?: VisitNodeFunction<BabelNode, TState>,
+
+    // This section is automatically generated. Don't edit by hand.
+    // See the comment at the top of the file on how to update the definitions.
+    // BEGIN GENERATED VISITOR METHODS
+    AnyTypeAnnotation?: VisitNode<BabelNodeAnyTypeAnnotation, TState>,
+    ArgumentPlaceholder?: VisitNode<BabelNodeArgumentPlaceholder, TState>,
+    ArrayExpression?: VisitNode<BabelNodeArrayExpression, TState>,
+    ArrayPattern?: VisitNode<BabelNodeArrayPattern, TState>,
+    ArrayTypeAnnotation?: VisitNode<BabelNodeArrayTypeAnnotation, TState>,
+    ArrowFunctionExpression?: VisitNode<
+      BabelNodeArrowFunctionExpression,
+      TState,
+    >,
+    AssignmentExpression?: VisitNode<BabelNodeAssignmentExpression, TState>,
+    AssignmentPattern?: VisitNode<BabelNodeAssignmentPattern, TState>,
+    AwaitExpression?: VisitNode<BabelNodeAwaitExpression, TState>,
+    BigIntLiteral?: VisitNode<BabelNodeBigIntLiteral, TState>,
+    Binary?: VisitNode<BabelNodeBinary, TState>,
+    BinaryExpression?: VisitNode<BabelNodeBinaryExpression, TState>,
+    BindExpression?: VisitNode<BabelNodeBindExpression, TState>,
+    BindingIdentifier?: VisitNode<BabelNode, TState>,
+    Block?: VisitNode<BabelNodeBlock, TState>,
+    BlockParent?: VisitNode<BabelNodeBlockParent, TState>,
+    BlockScoped?: VisitNode<BabelNode, TState>,
+    BlockStatement?: VisitNode<BabelNodeBlockStatement, TState>,
+    BooleanLiteral?: VisitNode<BabelNodeBooleanLiteral, TState>,
+    BooleanLiteralTypeAnnotation?: VisitNode<
+      BabelNodeBooleanLiteralTypeAnnotation,
+      TState,
+    >,
+    BooleanTypeAnnotation?: VisitNode<BabelNodeBooleanTypeAnnotation, TState>,
+    BreakStatement?: VisitNode<BabelNodeBreakStatement, TState>,
+    CallExpression?: VisitNode<BabelNodeCallExpression, TState>,
+    CatchClause?: VisitNode<BabelNodeCatchClause, TState>,
+    Class?: VisitNode<BabelNodeClass, TState>,
+    ClassBody?: VisitNode<BabelNodeClassBody, TState>,
+    ClassDeclaration?: VisitNode<BabelNodeClassDeclaration, TState>,
+    ClassExpression?: VisitNode<BabelNodeClassExpression, TState>,
+    ClassImplements?: VisitNode<BabelNodeClassImplements, TState>,
+    ClassMethod?: VisitNode<BabelNodeClassMethod, TState>,
+    ClassPrivateMethod?: VisitNode<BabelNodeClassPrivateMethod, TState>,
+    ClassPrivateProperty?: VisitNode<BabelNodeClassPrivateProperty, TState>,
+    ClassProperty?: VisitNode<BabelNodeClassProperty, TState>,
+    CompletionStatement?: VisitNode<BabelNodeCompletionStatement, TState>,
+    Conditional?: VisitNode<BabelNodeConditional, TState>,
+    ConditionalExpression?: VisitNode<BabelNodeConditionalExpression, TState>,
+    ContinueStatement?: VisitNode<BabelNodeContinueStatement, TState>,
+    DebuggerStatement?: VisitNode<BabelNodeDebuggerStatement, TState>,
+    DecimalLiteral?: VisitNode<BabelNodeDecimalLiteral, TState>,
+    Declaration?: VisitNode<BabelNodeDeclaration, TState>,
+    DeclareClass?: VisitNode<BabelNodeDeclareClass, TState>,
+    DeclareExportAllDeclaration?: VisitNode<
+      BabelNodeDeclareExportAllDeclaration,
+      TState,
+    >,
+    DeclareExportDeclaration?: VisitNode<
+      BabelNodeDeclareExportDeclaration,
+      TState,
+    >,
+    DeclareFunction?: VisitNode<BabelNodeDeclareFunction, TState>,
+    DeclareInterface?: VisitNode<BabelNodeDeclareInterface, TState>,
+    DeclareModule?: VisitNode<BabelNodeDeclareModule, TState>,
+    DeclareModuleExports?: VisitNode<BabelNodeDeclareModuleExports, TState>,
+    DeclareOpaqueType?: VisitNode<BabelNodeDeclareOpaqueType, TState>,
+    DeclareTypeAlias?: VisitNode<BabelNodeDeclareTypeAlias, TState>,
+    DeclareVariable?: VisitNode<BabelNodeDeclareVariable, TState>,
+    DeclaredPredicate?: VisitNode<BabelNodeDeclaredPredicate, TState>,
+    Decorator?: VisitNode<BabelNodeDecorator, TState>,
+    Directive?: VisitNode<BabelNodeDirective, TState>,
+    DirectiveLiteral?: VisitNode<BabelNodeDirectiveLiteral, TState>,
+    DoExpression?: VisitNode<BabelNodeDoExpression, TState>,
+    DoWhileStatement?: VisitNode<BabelNodeDoWhileStatement, TState>,
+    EmptyStatement?: VisitNode<BabelNodeEmptyStatement, TState>,
+    EmptyTypeAnnotation?: VisitNode<BabelNodeEmptyTypeAnnotation, TState>,
+    EnumBody?: VisitNode<BabelNodeEnumBody, TState>,
+    EnumBooleanBody?: VisitNode<BabelNodeEnumBooleanBody, TState>,
+    EnumBooleanMember?: VisitNode<BabelNodeEnumBooleanMember, TState>,
+    EnumDeclaration?: VisitNode<BabelNodeEnumDeclaration, TState>,
+    EnumDefaultedMember?: VisitNode<BabelNodeEnumDefaultedMember, TState>,
+    EnumMember?: VisitNode<BabelNodeEnumMember, TState>,
+    EnumNumberBody?: VisitNode<BabelNodeEnumNumberBody, TState>,
+    EnumNumberMember?: VisitNode<BabelNodeEnumNumberMember, TState>,
+    EnumStringBody?: VisitNode<BabelNodeEnumStringBody, TState>,
+    EnumStringMember?: VisitNode<BabelNodeEnumStringMember, TState>,
+    EnumSymbolBody?: VisitNode<BabelNodeEnumSymbolBody, TState>,
+    ExistentialTypeParam?: VisitNode<BabelNode, TState>,
+    ExistsTypeAnnotation?: VisitNode<BabelNodeExistsTypeAnnotation, TState>,
+    ExportAllDeclaration?: VisitNode<BabelNodeExportAllDeclaration, TState>,
+    ExportDeclaration?: VisitNode<BabelNodeExportDeclaration, TState>,
+    ExportDefaultDeclaration?: VisitNode<
+      BabelNodeExportDefaultDeclaration,
+      TState,
+    >,
+    ExportDefaultSpecifier?: VisitNode<BabelNodeExportDefaultSpecifier, TState>,
+    ExportNamedDeclaration?: VisitNode<BabelNodeExportNamedDeclaration, TState>,
+    ExportNamespaceSpecifier?: VisitNode<
+      BabelNodeExportNamespaceSpecifier,
+      TState,
+    >,
+    ExportSpecifier?: VisitNode<BabelNodeExportSpecifier, TState>,
+    Expression?: VisitNode<BabelNodeExpression, TState>,
+    ExpressionStatement?: VisitNode<BabelNodeExpressionStatement, TState>,
+    ExpressionWrapper?: VisitNode<BabelNodeExpressionWrapper, TState>,
+    Flow?: VisitNode<BabelNodeFlow, TState>,
+    FlowBaseAnnotation?: VisitNode<BabelNodeFlowBaseAnnotation, TState>,
+    FlowDeclaration?: VisitNode<BabelNodeFlowDeclaration, TState>,
+    FlowPredicate?: VisitNode<BabelNodeFlowPredicate, TState>,
+    FlowType?: VisitNode<BabelNodeFlowType, TState>,
+    For?: VisitNode<BabelNodeFor, TState>,
+    ForAwaitStatement?: VisitNode<BabelNode, TState>,
+    ForInStatement?: VisitNode<BabelNodeForInStatement, TState>,
+    ForOfStatement?: VisitNode<BabelNodeForOfStatement, TState>,
+    ForStatement?: VisitNode<BabelNodeForStatement, TState>,
+    ForXStatement?: VisitNode<BabelNodeForXStatement, TState>,
+    Function?: VisitNode<BabelNodeFunction, TState>,
+    FunctionDeclaration?: VisitNode<BabelNodeFunctionDeclaration, TState>,
+    FunctionExpression?: VisitNode<BabelNodeFunctionExpression, TState>,
+    FunctionParent?: VisitNode<BabelNodeFunctionParent, TState>,
+    FunctionTypeAnnotation?: VisitNode<BabelNodeFunctionTypeAnnotation, TState>,
+    FunctionTypeParam?: VisitNode<BabelNodeFunctionTypeParam, TState>,
+    Generated?: VisitNode<BabelNode, TState>,
+    GenericTypeAnnotation?: VisitNode<BabelNodeGenericTypeAnnotation, TState>,
+    Identifier?: VisitNode<BabelNodeIdentifier, TState>,
+    IfStatement?: VisitNode<BabelNodeIfStatement, TState>,
+    Immutable?: VisitNode<BabelNodeImmutable, TState>,
+    Import?: VisitNode<BabelNodeImport, TState>,
+    ImportAttribute?: VisitNode<BabelNodeImportAttribute, TState>,
+    ImportDeclaration?: VisitNode<BabelNodeImportDeclaration, TState>,
+    ImportDefaultSpecifier?: VisitNode<BabelNodeImportDefaultSpecifier, TState>,
+    ImportNamespaceSpecifier?: VisitNode<
+      BabelNodeImportNamespaceSpecifier,
+      TState,
+    >,
+    ImportSpecifier?: VisitNode<BabelNodeImportSpecifier, TState>,
+    IndexedAccessType?: VisitNode<BabelNodeIndexedAccessType, TState>,
+    InferredPredicate?: VisitNode<BabelNodeInferredPredicate, TState>,
+    InterfaceDeclaration?: VisitNode<BabelNodeInterfaceDeclaration, TState>,
+    InterfaceExtends?: VisitNode<BabelNodeInterfaceExtends, TState>,
+    InterfaceTypeAnnotation?: VisitNode<
+      BabelNodeInterfaceTypeAnnotation,
+      TState,
+    >,
+    InterpreterDirective?: VisitNode<BabelNodeInterpreterDirective, TState>,
+    IntersectionTypeAnnotation?: VisitNode<
+      BabelNodeIntersectionTypeAnnotation,
+      TState,
+    >,
+    JSX?: VisitNode<BabelNodeJSX, TState>,
+    JSXAttribute?: VisitNode<BabelNodeJSXAttribute, TState>,
+    JSXClosingElement?: VisitNode<BabelNodeJSXClosingElement, TState>,
+    JSXClosingFragment?: VisitNode<BabelNodeJSXClosingFragment, TState>,
+    JSXElement?: VisitNode<BabelNodeJSXElement, TState>,
+    JSXEmptyExpression?: VisitNode<BabelNodeJSXEmptyExpression, TState>,
+    JSXExpressionContainer?: VisitNode<BabelNodeJSXExpressionContainer, TState>,
+    JSXFragment?: VisitNode<BabelNodeJSXFragment, TState>,
+    JSXIdentifier?: VisitNode<BabelNodeJSXIdentifier, TState>,
+    JSXMemberExpression?: VisitNode<BabelNodeJSXMemberExpression, TState>,
+    JSXNamespacedName?: VisitNode<BabelNodeJSXNamespacedName, TState>,
+    JSXOpeningElement?: VisitNode<BabelNodeJSXOpeningElement, TState>,
+    JSXOpeningFragment?: VisitNode<BabelNodeJSXOpeningFragment, TState>,
+    JSXSpreadAttribute?: VisitNode<BabelNodeJSXSpreadAttribute, TState>,
+    JSXSpreadChild?: VisitNode<BabelNodeJSXSpreadChild, TState>,
+    JSXText?: VisitNode<BabelNodeJSXText, TState>,
+    LVal?: VisitNode<BabelNodeLVal, TState>,
+    LabeledStatement?: VisitNode<BabelNodeLabeledStatement, TState>,
+    Literal?: VisitNode<BabelNodeLiteral, TState>,
+    LogicalExpression?: VisitNode<BabelNodeLogicalExpression, TState>,
+    Loop?: VisitNode<BabelNodeLoop, TState>,
+    MemberExpression?: VisitNode<BabelNodeMemberExpression, TState>,
+    MetaProperty?: VisitNode<BabelNodeMetaProperty, TState>,
+    Method?: VisitNode<BabelNodeMethod, TState>,
+    MixedTypeAnnotation?: VisitNode<BabelNodeMixedTypeAnnotation, TState>,
+    ModuleDeclaration?: VisitNode<BabelNodeModuleDeclaration, TState>,
+    ModuleExpression?: VisitNode<BabelNodeModuleExpression, TState>,
+    ModuleSpecifier?: VisitNode<BabelNodeModuleSpecifier, TState>,
+    NewExpression?: VisitNode<BabelNodeNewExpression, TState>,
+    Noop?: VisitNode<BabelNodeNoop, TState>,
+    NullLiteral?: VisitNode<BabelNodeNullLiteral, TState>,
+    NullLiteralTypeAnnotation?: VisitNode<
+      BabelNodeNullLiteralTypeAnnotation,
+      TState,
+    >,
+    NullableTypeAnnotation?: VisitNode<BabelNodeNullableTypeAnnotation, TState>,
+    NumberLiteral?: VisitNode<BabelNode, TState>,
+    NumberLiteralTypeAnnotation?: VisitNode<
+      BabelNodeNumberLiteralTypeAnnotation,
+      TState,
+    >,
+    NumberTypeAnnotation?: VisitNode<BabelNodeNumberTypeAnnotation, TState>,
+    NumericLiteral?: VisitNode<BabelNodeNumericLiteral, TState>,
+    NumericLiteralTypeAnnotation?: VisitNode<BabelNode, TState>,
+    ObjectExpression?: VisitNode<BabelNodeObjectExpression, TState>,
+    ObjectMember?: VisitNode<BabelNodeObjectMember, TState>,
+    ObjectMethod?: VisitNode<BabelNodeObjectMethod, TState>,
+    ObjectPattern?: VisitNode<BabelNodeObjectPattern, TState>,
+    ObjectProperty?: VisitNode<BabelNodeObjectProperty, TState>,
+    ObjectTypeAnnotation?: VisitNode<BabelNodeObjectTypeAnnotation, TState>,
+    ObjectTypeCallProperty?: VisitNode<BabelNodeObjectTypeCallProperty, TState>,
+    ObjectTypeIndexer?: VisitNode<BabelNodeObjectTypeIndexer, TState>,
+    ObjectTypeInternalSlot?: VisitNode<BabelNodeObjectTypeInternalSlot, TState>,
+    ObjectTypeProperty?: VisitNode<BabelNodeObjectTypeProperty, TState>,
+    ObjectTypeSpreadProperty?: VisitNode<
+      BabelNodeObjectTypeSpreadProperty,
+      TState,
+    >,
+    OpaqueType?: VisitNode<BabelNodeOpaqueType, TState>,
+    OptionalCallExpression?: VisitNode<BabelNodeOptionalCallExpression, TState>,
+    OptionalIndexedAccessType?: VisitNode<
+      BabelNodeOptionalIndexedAccessType,
+      TState,
+    >,
+    OptionalMemberExpression?: VisitNode<
+      BabelNodeOptionalMemberExpression,
+      TState,
+    >,
+    ParenthesizedExpression?: VisitNode<
+      BabelNodeParenthesizedExpression,
+      TState,
+    >,
+    Pattern?: VisitNode<BabelNodePattern, TState>,
+    PatternLike?: VisitNode<BabelNodePatternLike, TState>,
+    PipelineBareFunction?: VisitNode<BabelNodePipelineBareFunction, TState>,
+    PipelinePrimaryTopicReference?: VisitNode<
+      BabelNodePipelinePrimaryTopicReference,
+      TState,
+    >,
+    PipelineTopicExpression?: VisitNode<
+      BabelNodePipelineTopicExpression,
+      TState,
+    >,
+    Placeholder?: VisitNode<BabelNodePlaceholder, TState>,
+    Private?: VisitNode<BabelNodePrivate, TState>,
+    PrivateName?: VisitNode<BabelNodePrivateName, TState>,
+    Program?: VisitNode<BabelNodeProgram, TState>,
+    Property?: VisitNode<BabelNodeProperty, TState>,
+    Pure?: VisitNode<BabelNode, TState>,
+    Pureish?: VisitNode<BabelNodePureish, TState>,
+    QualifiedTypeIdentifier?: VisitNode<
+      BabelNodeQualifiedTypeIdentifier,
+      TState,
+    >,
+    RecordExpression?: VisitNode<BabelNodeRecordExpression, TState>,
+    Referenced?: VisitNode<BabelNode, TState>,
+    ReferencedIdentifier?: VisitNode<BabelNode, TState>,
+    ReferencedMemberExpression?: VisitNode<BabelNode, TState>,
+    RegExpLiteral?: VisitNode<BabelNodeRegExpLiteral, TState>,
+    RegexLiteral?: VisitNode<BabelNode, TState>,
+    RestElement?: VisitNode<BabelNodeRestElement, TState>,
+    RestProperty?: VisitNode<BabelNode, TState>,
+    ReturnStatement?: VisitNode<BabelNodeReturnStatement, TState>,
+    Scopable?: VisitNode<BabelNodeScopable, TState>,
+    Scope?: VisitNode<BabelNode, TState>,
+    SequenceExpression?: VisitNode<BabelNodeSequenceExpression, TState>,
+    SpreadElement?: VisitNode<BabelNodeSpreadElement, TState>,
+    SpreadProperty?: VisitNode<BabelNode, TState>,
+    Statement?: VisitNode<BabelNodeStatement, TState>,
+    StaticBlock?: VisitNode<BabelNodeStaticBlock, TState>,
+    StringLiteral?: VisitNode<BabelNodeStringLiteral, TState>,
+    StringLiteralTypeAnnotation?: VisitNode<
+      BabelNodeStringLiteralTypeAnnotation,
+      TState,
+    >,
+    StringTypeAnnotation?: VisitNode<BabelNodeStringTypeAnnotation, TState>,
+    Super?: VisitNode<BabelNodeSuper, TState>,
+    SwitchCase?: VisitNode<BabelNodeSwitchCase, TState>,
+    SwitchStatement?: VisitNode<BabelNodeSwitchStatement, TState>,
+    SymbolTypeAnnotation?: VisitNode<BabelNodeSymbolTypeAnnotation, TState>,
+    TSAnyKeyword?: VisitNode<BabelNodeTSAnyKeyword, TState>,
+    TSArrayType?: VisitNode<BabelNodeTSArrayType, TState>,
+    TSAsExpression?: VisitNode<BabelNodeTSAsExpression, TState>,
+    TSBaseType?: VisitNode<BabelNodeTSBaseType, TState>,
+    TSBigIntKeyword?: VisitNode<BabelNodeTSBigIntKeyword, TState>,
+    TSBooleanKeyword?: VisitNode<BabelNodeTSBooleanKeyword, TState>,
+    TSCallSignatureDeclaration?: VisitNode<
+      BabelNodeTSCallSignatureDeclaration,
+      TState,
+    >,
+    TSConditionalType?: VisitNode<BabelNodeTSConditionalType, TState>,
+    TSConstructSignatureDeclaration?: VisitNode<
+      BabelNodeTSConstructSignatureDeclaration,
+      TState,
+    >,
+    TSConstructorType?: VisitNode<BabelNodeTSConstructorType, TState>,
+    TSDeclareFunction?: VisitNode<BabelNodeTSDeclareFunction, TState>,
+    TSDeclareMethod?: VisitNode<BabelNodeTSDeclareMethod, TState>,
+    TSEntityName?: VisitNode<BabelNodeTSEntityName, TState>,
+    TSEnumDeclaration?: VisitNode<BabelNodeTSEnumDeclaration, TState>,
+    TSEnumMember?: VisitNode<BabelNodeTSEnumMember, TState>,
+    TSExportAssignment?: VisitNode<BabelNodeTSExportAssignment, TState>,
+    TSExpressionWithTypeArguments?: VisitNode<
+      BabelNodeTSExpressionWithTypeArguments,
+      TState,
+    >,
+    TSExternalModuleReference?: VisitNode<
+      BabelNodeTSExternalModuleReference,
+      TState,
+    >,
+    TSFunctionType?: VisitNode<BabelNodeTSFunctionType, TState>,
+    TSImportEqualsDeclaration?: VisitNode<
+      BabelNodeTSImportEqualsDeclaration,
+      TState,
+    >,
+    TSImportType?: VisitNode<BabelNodeTSImportType, TState>,
+    TSIndexSignature?: VisitNode<BabelNodeTSIndexSignature, TState>,
+    TSIndexedAccessType?: VisitNode<BabelNodeTSIndexedAccessType, TState>,
+    TSInferType?: VisitNode<BabelNodeTSInferType, TState>,
+    TSInterfaceBody?: VisitNode<BabelNodeTSInterfaceBody, TState>,
+    TSInterfaceDeclaration?: VisitNode<BabelNodeTSInterfaceDeclaration, TState>,
+    TSIntersectionType?: VisitNode<BabelNodeTSIntersectionType, TState>,
+    TSIntrinsicKeyword?: VisitNode<BabelNodeTSIntrinsicKeyword, TState>,
+    TSLiteralType?: VisitNode<BabelNodeTSLiteralType, TState>,
+    TSMappedType?: VisitNode<BabelNodeTSMappedType, TState>,
+    TSMethodSignature?: VisitNode<BabelNodeTSMethodSignature, TState>,
+    TSModuleBlock?: VisitNode<BabelNodeTSModuleBlock, TState>,
+    TSModuleDeclaration?: VisitNode<BabelNodeTSModuleDeclaration, TState>,
+    TSNamedTupleMember?: VisitNode<BabelNodeTSNamedTupleMember, TState>,
+    TSNamespaceExportDeclaration?: VisitNode<
+      BabelNodeTSNamespaceExportDeclaration,
+      TState,
+    >,
+    TSNeverKeyword?: VisitNode<BabelNodeTSNeverKeyword, TState>,
+    TSNonNullExpression?: VisitNode<BabelNodeTSNonNullExpression, TState>,
+    TSNullKeyword?: VisitNode<BabelNodeTSNullKeyword, TState>,
+    TSNumberKeyword?: VisitNode<BabelNodeTSNumberKeyword, TState>,
+    TSObjectKeyword?: VisitNode<BabelNodeTSObjectKeyword, TState>,
+    TSOptionalType?: VisitNode<BabelNodeTSOptionalType, TState>,
+    TSParameterProperty?: VisitNode<BabelNodeTSParameterProperty, TState>,
+    TSParenthesizedType?: VisitNode<BabelNodeTSParenthesizedType, TState>,
+    TSPropertySignature?: VisitNode<BabelNodeTSPropertySignature, TState>,
+    TSQualifiedName?: VisitNode<BabelNodeTSQualifiedName, TState>,
+    TSRestType?: VisitNode<BabelNodeTSRestType, TState>,
+    TSStringKeyword?: VisitNode<BabelNodeTSStringKeyword, TState>,
+    TSSymbolKeyword?: VisitNode<BabelNodeTSSymbolKeyword, TState>,
+    TSThisType?: VisitNode<BabelNodeTSThisType, TState>,
+    TSTupleType?: VisitNode<BabelNodeTSTupleType, TState>,
+    TSType?: VisitNode<BabelNodeTSType, TState>,
+    TSTypeAliasDeclaration?: VisitNode<BabelNodeTSTypeAliasDeclaration, TState>,
+    TSTypeAnnotation?: VisitNode<BabelNodeTSTypeAnnotation, TState>,
+    TSTypeAssertion?: VisitNode<BabelNodeTSTypeAssertion, TState>,
+    TSTypeElement?: VisitNode<BabelNodeTSTypeElement, TState>,
+    TSTypeLiteral?: VisitNode<BabelNodeTSTypeLiteral, TState>,
+    TSTypeOperator?: VisitNode<BabelNodeTSTypeOperator, TState>,
+    TSTypeParameter?: VisitNode<BabelNodeTSTypeParameter, TState>,
+    TSTypeParameterDeclaration?: VisitNode<
+      BabelNodeTSTypeParameterDeclaration,
+      TState,
+    >,
+    TSTypeParameterInstantiation?: VisitNode<
+      BabelNodeTSTypeParameterInstantiation,
+      TState,
+    >,
+    TSTypePredicate?: VisitNode<BabelNodeTSTypePredicate, TState>,
+    TSTypeQuery?: VisitNode<BabelNodeTSTypeQuery, TState>,
+    TSTypeReference?: VisitNode<BabelNodeTSTypeReference, TState>,
+    TSUndefinedKeyword?: VisitNode<BabelNodeTSUndefinedKeyword, TState>,
+    TSUnionType?: VisitNode<BabelNodeTSUnionType, TState>,
+    TSUnknownKeyword?: VisitNode<BabelNodeTSUnknownKeyword, TState>,
+    TSVoidKeyword?: VisitNode<BabelNodeTSVoidKeyword, TState>,
+    TaggedTemplateExpression?: VisitNode<
+      BabelNodeTaggedTemplateExpression,
+      TState,
+    >,
+    TemplateElement?: VisitNode<BabelNodeTemplateElement, TState>,
+    TemplateLiteral?: VisitNode<BabelNodeTemplateLiteral, TState>,
+    Terminatorless?: VisitNode<BabelNodeTerminatorless, TState>,
+    ThisExpression?: VisitNode<BabelNodeThisExpression, TState>,
+    ThisTypeAnnotation?: VisitNode<BabelNodeThisTypeAnnotation, TState>,
+    ThrowStatement?: VisitNode<BabelNodeThrowStatement, TState>,
+    TryStatement?: VisitNode<BabelNodeTryStatement, TState>,
+    TupleExpression?: VisitNode<BabelNodeTupleExpression, TState>,
+    TupleTypeAnnotation?: VisitNode<BabelNodeTupleTypeAnnotation, TState>,
+    TypeAlias?: VisitNode<BabelNodeTypeAlias, TState>,
+    TypeAnnotation?: VisitNode<BabelNodeTypeAnnotation, TState>,
+    TypeCastExpression?: VisitNode<BabelNodeTypeCastExpression, TState>,
+    TypeParameter?: VisitNode<BabelNodeTypeParameter, TState>,
+    TypeParameterDeclaration?: VisitNode<
+      BabelNodeTypeParameterDeclaration,
+      TState,
+    >,
+    TypeParameterInstantiation?: VisitNode<
+      BabelNodeTypeParameterInstantiation,
+      TState,
+    >,
+    TypeofTypeAnnotation?: VisitNode<BabelNodeTypeofTypeAnnotation, TState>,
+    UnaryExpression?: VisitNode<BabelNodeUnaryExpression, TState>,
+    UnaryLike?: VisitNode<BabelNodeUnaryLike, TState>,
+    UnionTypeAnnotation?: VisitNode<BabelNodeUnionTypeAnnotation, TState>,
+    UpdateExpression?: VisitNode<BabelNodeUpdateExpression, TState>,
+    User?: VisitNode<BabelNode, TState>,
+    UserWhitespacable?: VisitNode<BabelNodeUserWhitespacable, TState>,
+    V8IntrinsicIdentifier?: VisitNode<BabelNodeV8IntrinsicIdentifier, TState>,
+    Var?: VisitNode<BabelNode, TState>,
+    VariableDeclaration?: VisitNode<BabelNodeVariableDeclaration, TState>,
+    VariableDeclarator?: VisitNode<BabelNodeVariableDeclarator, TState>,
+    Variance?: VisitNode<BabelNodeVariance, TState>,
+    VoidTypeAnnotation?: VisitNode<BabelNodeVoidTypeAnnotation, TState>,
+    While?: VisitNode<BabelNodeWhile, TState>,
+    WhileStatement?: VisitNode<BabelNodeWhileStatement, TState>,
+    WithStatement?: VisitNode<BabelNodeWithStatement, TState>,
+    YieldExpression?: VisitNode<BabelNodeYieldExpression, TState>,
+    // END GENERATED VISITOR METHODS
+  }>;
+
+  declare type Visitors = {
+    explode<TState>(visitor: Visitor<TState>): Visitor<TState>,
+    verify<TState>(visitor: Visitor<TState>): void,
+    merge(
+      visitors: Array<$ReadOnly<Visitor<any>>>,
+      states: Array<any>,
+      wrapper?: ?Function,
+    ): Array<Visitor<any>>,
+  };
+
+  declare export var visitors: Visitors;
+
+  declare export type Cache = {
+    path: $ReadOnlyWeakMap<BabelNode, mixed>,
+    scope: $ReadOnlyWeakMap<BabelNode, mixed>,
+    clear(): void,
+    clearPath(): void,
+    clearScope(): void,
+  };
+
+  declare export type Traverse = {
+    <TState>(
+      parent?: BabelNode | Array<BabelNode>,
+      opts?: $ReadOnly<TraverseOptions<TState>>,
+      scope?: ?Scope,
+      state: TState,
+      parentPath?: ?NodePath<BabelNode>,
+    ): void,
+
+    +cache: Cache,
+    +visitors: Visitors,
+    +verify: Visitors['verify'],
+    +explode: Visitors['explode'],
+
+    cheap<TOptions>(
+      node: BabelNode,
+      enter: (node: BabelNode, opts: TOptions) => void,
+    ): void,
+
+    node<TState>(
+      node: BabelNode,
+      opts: $ReadOnly<TraverseOptions<TState>>,
+      scope: Scope,
+      state: TState,
+      parentPath: NodePath<>,
+      skipKeys?: {[key: string]: boolean},
+    ): void,
+
+    clearNode(node: BabelNode, opts?: {...}): void,
+    removeProperties(tree: BabelNode, opts?: {...}): BabelNode,
+    hasType(
+      tree: BabelNode,
+      type: BabelNode['type'],
+      blacklistTypes: Array<BabelNode['type']>,
+    ): boolean,
+  };
+
+  declare export default Traverse;
+}

--- a/flow-typed/npm/babel-types_v7.x.x.js
+++ b/flow-typed/npm/babel-types_v7.x.x.js
@@ -1,0 +1,4014 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @generated
+ * See xplat/js/tools/metro/scripts/updateBabelTypesFlowTypes.js.
+ * @flow strict
+ */
+
+declare type BabelNodeBaseComment = {
+  value: string;
+  start: number;
+  end: number;
+  loc: BabelNodeSourceLocation;
+};
+
+declare type BabelNodeCommentBlock = {
+  ...BabelNodeBaseComment;
+  type: "CommentBlock";
+};
+
+declare type BabelNodeCommentLine ={
+  ...BabelNodeBaseComment,
+  type: "CommentLine";
+};
+
+declare type BabelNodeComment = BabelNodeCommentBlock | BabelNodeCommentLine;
+
+declare type BabelNodeSourceLocation = {
+  start: {
+    line: number;
+    column: number;
+  };
+
+  end: {
+    line: number;
+    column: number;
+  };
+};
+
+
+declare type BabelNodeArrayExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ArrayExpression";
+  elements?: Array<null | BabelNodeExpression | BabelNodeSpreadElement>;
+};
+
+declare type BabelNodeAssignmentExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "AssignmentExpression";
+  operator: string;
+  left: BabelNodeLVal;
+  right: BabelNodeExpression;
+};
+
+declare type BabelNodeBinaryExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "BinaryExpression";
+  operator: "+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<=";
+  left: BabelNodeExpression | BabelNodePrivateName;
+  right: BabelNodeExpression;
+};
+
+declare type BabelNodeInterpreterDirective = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "InterpreterDirective";
+  value: string;
+};
+
+declare type BabelNodeDirective = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Directive";
+  value: BabelNodeDirectiveLiteral;
+};
+
+declare type BabelNodeDirectiveLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DirectiveLiteral";
+  value: string;
+};
+
+declare type BabelNodeBlockStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "BlockStatement";
+  body: Array<BabelNodeStatement>;
+  directives?: Array<BabelNodeDirective>;
+};
+
+declare type BabelNodeBreakStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "BreakStatement";
+  label?: BabelNodeIdentifier;
+};
+
+declare type BabelNodeCallExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "CallExpression";
+  callee: BabelNodeExpression | BabelNodeV8IntrinsicIdentifier;
+  arguments: Array<BabelNodeExpression | BabelNodeSpreadElement | BabelNodeJSXNamespacedName | BabelNodeArgumentPlaceholder>;
+  optional?: true | false;
+  typeArguments?: BabelNodeTypeParameterInstantiation;
+  typeParameters?: BabelNodeTSTypeParameterInstantiation;
+};
+
+declare type BabelNodeCatchClause = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "CatchClause";
+  param?: BabelNodeIdentifier | BabelNodeArrayPattern | BabelNodeObjectPattern;
+  body: BabelNodeBlockStatement;
+};
+
+declare type BabelNodeConditionalExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ConditionalExpression";
+  test: BabelNodeExpression;
+  consequent: BabelNodeExpression;
+  alternate: BabelNodeExpression;
+};
+
+declare type BabelNodeContinueStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ContinueStatement";
+  label?: BabelNodeIdentifier;
+};
+
+declare type BabelNodeDebuggerStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DebuggerStatement";
+};
+
+declare type BabelNodeDoWhileStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DoWhileStatement";
+  test: BabelNodeExpression;
+  body: BabelNodeStatement;
+};
+
+declare type BabelNodeEmptyStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EmptyStatement";
+};
+
+declare type BabelNodeExpressionStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ExpressionStatement";
+  expression: BabelNodeExpression;
+};
+
+declare type BabelNodeFile = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "File";
+  program: BabelNodeProgram;
+  comments?: Array<BabelNodeCommentBlock | BabelNodeCommentLine>;
+  tokens?: Array<any>;
+};
+
+declare type BabelNodeForInStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ForInStatement";
+  left: BabelNodeVariableDeclaration | BabelNodeLVal;
+  right: BabelNodeExpression;
+  body: BabelNodeStatement;
+};
+
+declare type BabelNodeForStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ForStatement";
+  init?: BabelNodeVariableDeclaration | BabelNodeExpression;
+  test?: BabelNodeExpression;
+  update?: BabelNodeExpression;
+  body: BabelNodeStatement;
+};
+
+declare type BabelNodeFunctionDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "FunctionDeclaration";
+  id?: BabelNodeIdentifier;
+  params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>;
+  body: BabelNodeBlockStatement;
+  generator?: boolean;
+  async?: boolean;
+  declare?: boolean;
+  returnType?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  typeParameters?: BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+};
+
+declare type BabelNodeFunctionExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "FunctionExpression";
+  id?: BabelNodeIdentifier;
+  params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>;
+  body: BabelNodeBlockStatement;
+  generator?: boolean;
+  async?: boolean;
+  returnType?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  typeParameters?: BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+};
+
+declare type BabelNodeIdentifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Identifier";
+  name: string;
+  decorators?: Array<BabelNodeDecorator>;
+  optional?: boolean;
+  typeAnnotation?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+};
+
+declare type BabelNodeIfStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "IfStatement";
+  test: BabelNodeExpression;
+  consequent: BabelNodeStatement;
+  alternate?: BabelNodeStatement;
+};
+
+declare type BabelNodeLabeledStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "LabeledStatement";
+  label: BabelNodeIdentifier;
+  body: BabelNodeStatement;
+};
+
+declare type BabelNodeStringLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "StringLiteral";
+  value: string;
+};
+
+declare type BabelNodeNumericLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "NumericLiteral";
+  value: number;
+};
+
+declare type BabelNodeNullLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "NullLiteral";
+};
+
+declare type BabelNodeBooleanLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "BooleanLiteral";
+  value: boolean;
+};
+
+declare type BabelNodeRegExpLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "RegExpLiteral";
+  pattern: string;
+  flags?: string;
+};
+
+declare type BabelNodeLogicalExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "LogicalExpression";
+  operator: "||" | "&&" | "??";
+  left: BabelNodeExpression;
+  right: BabelNodeExpression;
+};
+
+declare type BabelNodeMemberExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "MemberExpression";
+  object: BabelNodeExpression;
+  property: BabelNodeExpression | BabelNodeIdentifier | BabelNodePrivateName;
+  computed?: boolean;
+  optional?: true | false;
+};
+
+declare type BabelNodeNewExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "NewExpression";
+  callee: BabelNodeExpression | BabelNodeV8IntrinsicIdentifier;
+  arguments: Array<BabelNodeExpression | BabelNodeSpreadElement | BabelNodeJSXNamespacedName | BabelNodeArgumentPlaceholder>;
+  optional?: true | false;
+  typeArguments?: BabelNodeTypeParameterInstantiation;
+  typeParameters?: BabelNodeTSTypeParameterInstantiation;
+};
+
+declare type BabelNodeProgram = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Program";
+  body: Array<BabelNodeStatement>;
+  directives?: Array<BabelNodeDirective>;
+  sourceType?: "script" | "module";
+  interpreter?: BabelNodeInterpreterDirective;
+  sourceFile: string;
+};
+
+declare type BabelNodeObjectExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectExpression";
+  properties: Array<BabelNodeObjectMethod | BabelNodeObjectProperty | BabelNodeSpreadElement>;
+};
+
+declare type BabelNodeObjectMethod = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectMethod";
+  kind?: "method" | "get" | "set";
+  key: BabelNodeExpression | BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral;
+  params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>;
+  body: BabelNodeBlockStatement;
+  computed?: boolean;
+  generator?: boolean;
+  async?: boolean;
+  decorators?: Array<BabelNodeDecorator>;
+  returnType?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  typeParameters?: BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+};
+
+declare type BabelNodeObjectProperty = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectProperty";
+  key: BabelNodeExpression | BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral;
+  value: BabelNodeExpression | BabelNodePatternLike;
+  computed?: boolean;
+  shorthand?: boolean;
+  decorators?: Array<BabelNodeDecorator>;
+};
+
+declare type BabelNodeRestElement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "RestElement";
+  argument: BabelNodeLVal;
+  decorators?: Array<BabelNodeDecorator>;
+  typeAnnotation?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+};
+
+declare type BabelNodeReturnStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ReturnStatement";
+  argument?: BabelNodeExpression;
+};
+
+declare type BabelNodeSequenceExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "SequenceExpression";
+  expressions: Array<BabelNodeExpression>;
+};
+
+declare type BabelNodeParenthesizedExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ParenthesizedExpression";
+  expression: BabelNodeExpression;
+};
+
+declare type BabelNodeSwitchCase = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "SwitchCase";
+  test?: BabelNodeExpression;
+  consequent: Array<BabelNodeStatement>;
+};
+
+declare type BabelNodeSwitchStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "SwitchStatement";
+  discriminant: BabelNodeExpression;
+  cases: Array<BabelNodeSwitchCase>;
+};
+
+declare type BabelNodeThisExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ThisExpression";
+};
+
+declare type BabelNodeThrowStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ThrowStatement";
+  argument: BabelNodeExpression;
+};
+
+declare type BabelNodeTryStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TryStatement";
+  block: BabelNodeBlockStatement;
+  handler?: BabelNodeCatchClause;
+  finalizer?: BabelNodeBlockStatement;
+};
+
+declare type BabelNodeUnaryExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "UnaryExpression";
+  operator: "void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof";
+  argument: BabelNodeExpression;
+  prefix?: boolean;
+};
+
+declare type BabelNodeUpdateExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "UpdateExpression";
+  operator: "++" | "--";
+  argument: BabelNodeExpression;
+  prefix?: boolean;
+};
+
+declare type BabelNodeVariableDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "VariableDeclaration";
+  kind: "var" | "let" | "const";
+  declarations: Array<BabelNodeVariableDeclarator>;
+  declare?: boolean;
+};
+
+declare type BabelNodeVariableDeclarator = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "VariableDeclarator";
+  id: BabelNodeLVal;
+  init?: BabelNodeExpression;
+  definite?: boolean;
+};
+
+declare type BabelNodeWhileStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "WhileStatement";
+  test: BabelNodeExpression;
+  body: BabelNodeStatement;
+};
+
+declare type BabelNodeWithStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "WithStatement";
+  object: BabelNodeExpression;
+  body: BabelNodeStatement;
+};
+
+declare type BabelNodeAssignmentPattern = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "AssignmentPattern";
+  left: BabelNodeIdentifier | BabelNodeObjectPattern | BabelNodeArrayPattern | BabelNodeMemberExpression;
+  right: BabelNodeExpression;
+  decorators?: Array<BabelNodeDecorator>;
+  typeAnnotation?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+};
+
+declare type BabelNodeArrayPattern = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ArrayPattern";
+  elements: Array<null | BabelNodePatternLike>;
+  decorators?: Array<BabelNodeDecorator>;
+  typeAnnotation?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+};
+
+declare type BabelNodeArrowFunctionExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ArrowFunctionExpression";
+  params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>;
+  body: BabelNodeBlockStatement | BabelNodeExpression;
+  async?: boolean;
+  expression: boolean;
+  generator?: boolean;
+  returnType?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  typeParameters?: BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+};
+
+declare type BabelNodeClassBody = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ClassBody";
+  body: Array<BabelNodeClassMethod | BabelNodeClassPrivateMethod | BabelNodeClassProperty | BabelNodeClassPrivateProperty | BabelNodeTSDeclareMethod | BabelNodeTSIndexSignature>;
+};
+
+declare type BabelNodeClassExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ClassExpression";
+  id?: BabelNodeIdentifier;
+  superClass?: BabelNodeExpression;
+  body: BabelNodeClassBody;
+  decorators?: Array<BabelNodeDecorator>;
+  implements?: Array<BabelNodeTSExpressionWithTypeArguments | BabelNodeClassImplements>;
+  mixins?: BabelNodeInterfaceExtends;
+  superTypeParameters?: BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation;
+  typeParameters?: BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+};
+
+declare type BabelNodeClassDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ClassDeclaration";
+  id: BabelNodeIdentifier;
+  superClass?: BabelNodeExpression;
+  body: BabelNodeClassBody;
+  decorators?: Array<BabelNodeDecorator>;
+  abstract?: boolean;
+  declare?: boolean;
+  implements?: Array<BabelNodeTSExpressionWithTypeArguments | BabelNodeClassImplements>;
+  mixins?: BabelNodeInterfaceExtends;
+  superTypeParameters?: BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation;
+  typeParameters?: BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+};
+
+declare type BabelNodeExportAllDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ExportAllDeclaration";
+  source: BabelNodeStringLiteral;
+  assertions?: Array<BabelNodeImportAttribute>;
+  exportKind?: "type" | "value";
+};
+
+declare type BabelNodeExportDefaultDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ExportDefaultDeclaration";
+  declaration: BabelNodeFunctionDeclaration | BabelNodeTSDeclareFunction | BabelNodeClassDeclaration | BabelNodeExpression;
+};
+
+declare type BabelNodeExportNamedDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ExportNamedDeclaration";
+  declaration?: BabelNodeDeclaration;
+  specifiers?: Array<BabelNodeExportSpecifier | BabelNodeExportDefaultSpecifier | BabelNodeExportNamespaceSpecifier>;
+  source?: BabelNodeStringLiteral;
+  assertions?: Array<BabelNodeImportAttribute>;
+  exportKind?: "type" | "value";
+};
+
+declare type BabelNodeExportSpecifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ExportSpecifier";
+  local: BabelNodeIdentifier;
+  exported: BabelNodeIdentifier | BabelNodeStringLiteral;
+};
+
+declare type BabelNodeForOfStatement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ForOfStatement";
+  left: BabelNodeVariableDeclaration | BabelNodeLVal;
+  right: BabelNodeExpression;
+  body: BabelNodeStatement;
+  await?: boolean;
+};
+
+declare type BabelNodeImportDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ImportDeclaration";
+  specifiers: Array<BabelNodeImportSpecifier | BabelNodeImportDefaultSpecifier | BabelNodeImportNamespaceSpecifier>;
+  source: BabelNodeStringLiteral;
+  assertions?: Array<BabelNodeImportAttribute>;
+  importKind?: "type" | "typeof" | "value";
+};
+
+declare type BabelNodeImportDefaultSpecifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ImportDefaultSpecifier";
+  local: BabelNodeIdentifier;
+};
+
+declare type BabelNodeImportNamespaceSpecifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ImportNamespaceSpecifier";
+  local: BabelNodeIdentifier;
+};
+
+declare type BabelNodeImportSpecifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ImportSpecifier";
+  local: BabelNodeIdentifier;
+  imported: BabelNodeIdentifier | BabelNodeStringLiteral;
+  importKind?: "type" | "typeof";
+};
+
+declare type BabelNodeMetaProperty = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "MetaProperty";
+  meta: BabelNodeIdentifier;
+  property: BabelNodeIdentifier;
+};
+
+declare type BabelNodeClassMethod = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ClassMethod";
+  kind?: "get" | "set" | "method" | "constructor";
+  key: BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeExpression;
+  params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>;
+  body: BabelNodeBlockStatement;
+  computed?: boolean;
+  static?: boolean;
+  generator?: boolean;
+  async?: boolean;
+  abstract?: boolean;
+  access?: "public" | "private" | "protected";
+  accessibility?: "public" | "private" | "protected";
+  decorators?: Array<BabelNodeDecorator>;
+  optional?: boolean;
+  override?: boolean;
+  returnType?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  typeParameters?: BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+};
+
+declare type BabelNodeObjectPattern = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectPattern";
+  properties: Array<BabelNodeRestElement | BabelNodeObjectProperty>;
+  decorators?: Array<BabelNodeDecorator>;
+  typeAnnotation?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+};
+
+declare type BabelNodeSpreadElement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "SpreadElement";
+  argument: BabelNodeExpression;
+};
+
+declare type BabelNodeSuper = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Super";
+};
+
+declare type BabelNodeTaggedTemplateExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TaggedTemplateExpression";
+  tag: BabelNodeExpression;
+  quasi: BabelNodeTemplateLiteral;
+  typeParameters?: BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation;
+};
+
+declare type BabelNodeTemplateElement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TemplateElement";
+  value: { raw: string, cooked?: string };
+  tail?: boolean;
+};
+
+declare type BabelNodeTemplateLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TemplateLiteral";
+  quasis: Array<BabelNodeTemplateElement>;
+  expressions: Array<BabelNodeExpression | BabelNodeTSType>;
+};
+
+declare type BabelNodeYieldExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "YieldExpression";
+  argument?: BabelNodeExpression;
+  delegate?: boolean;
+};
+
+declare type BabelNodeAwaitExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "AwaitExpression";
+  argument: BabelNodeExpression;
+};
+
+declare type BabelNodeImport = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Import";
+};
+
+declare type BabelNodeBigIntLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "BigIntLiteral";
+  value: string;
+};
+
+declare type BabelNodeExportNamespaceSpecifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ExportNamespaceSpecifier";
+  exported: BabelNodeIdentifier;
+};
+
+declare type BabelNodeOptionalMemberExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "OptionalMemberExpression";
+  object: BabelNodeExpression;
+  property: BabelNodeExpression | BabelNodeIdentifier;
+  computed?: boolean;
+  optional: boolean;
+};
+
+declare type BabelNodeOptionalCallExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "OptionalCallExpression";
+  callee: BabelNodeExpression;
+  arguments: Array<BabelNodeExpression | BabelNodeSpreadElement | BabelNodeJSXNamespacedName | BabelNodeArgumentPlaceholder>;
+  optional: boolean;
+  typeArguments?: BabelNodeTypeParameterInstantiation;
+  typeParameters?: BabelNodeTSTypeParameterInstantiation;
+};
+
+declare type BabelNodeAnyTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "AnyTypeAnnotation";
+};
+
+declare type BabelNodeArrayTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ArrayTypeAnnotation";
+  elementType: BabelNodeFlowType;
+};
+
+declare type BabelNodeBooleanTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "BooleanTypeAnnotation";
+};
+
+declare type BabelNodeBooleanLiteralTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "BooleanLiteralTypeAnnotation";
+  value: boolean;
+};
+
+declare type BabelNodeNullLiteralTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "NullLiteralTypeAnnotation";
+};
+
+declare type BabelNodeClassImplements = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ClassImplements";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTypeParameterInstantiation;
+};
+
+declare type BabelNodeDeclareClass = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareClass";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTypeParameterDeclaration;
+  extends?: Array<BabelNodeInterfaceExtends>;
+  body: BabelNodeObjectTypeAnnotation;
+  implements?: Array<BabelNodeClassImplements>;
+  mixins?: Array<BabelNodeInterfaceExtends>;
+};
+
+declare type BabelNodeDeclareFunction = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareFunction";
+  id: BabelNodeIdentifier;
+  predicate?: BabelNodeDeclaredPredicate;
+};
+
+declare type BabelNodeDeclareInterface = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareInterface";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTypeParameterDeclaration;
+  extends?: Array<BabelNodeInterfaceExtends>;
+  body: BabelNodeObjectTypeAnnotation;
+  implements?: Array<BabelNodeClassImplements>;
+  mixins?: Array<BabelNodeInterfaceExtends>;
+};
+
+declare type BabelNodeDeclareModule = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareModule";
+  id: BabelNodeIdentifier | BabelNodeStringLiteral;
+  body: BabelNodeBlockStatement;
+  kind?: "CommonJS" | "ES";
+};
+
+declare type BabelNodeDeclareModuleExports = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareModuleExports";
+  typeAnnotation: BabelNodeTypeAnnotation;
+};
+
+declare type BabelNodeDeclareTypeAlias = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareTypeAlias";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTypeParameterDeclaration;
+  right: BabelNodeFlowType;
+};
+
+declare type BabelNodeDeclareOpaqueType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareOpaqueType";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTypeParameterDeclaration;
+  supertype?: BabelNodeFlowType;
+};
+
+declare type BabelNodeDeclareVariable = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareVariable";
+  id: BabelNodeIdentifier;
+};
+
+declare type BabelNodeDeclareExportDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareExportDeclaration";
+  declaration?: BabelNodeFlow;
+  specifiers?: Array<BabelNodeExportSpecifier | BabelNodeExportNamespaceSpecifier>;
+  source?: BabelNodeStringLiteral;
+  default?: boolean;
+};
+
+declare type BabelNodeDeclareExportAllDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclareExportAllDeclaration";
+  source: BabelNodeStringLiteral;
+  exportKind?: "type" | "value";
+};
+
+declare type BabelNodeDeclaredPredicate = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DeclaredPredicate";
+  value: BabelNodeFlow;
+};
+
+declare type BabelNodeExistsTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ExistsTypeAnnotation";
+};
+
+declare type BabelNodeFunctionTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "FunctionTypeAnnotation";
+  typeParameters?: BabelNodeTypeParameterDeclaration;
+  params: Array<BabelNodeFunctionTypeParam>;
+  rest?: BabelNodeFunctionTypeParam;
+  returnType: BabelNodeFlowType;
+  this?: BabelNodeFunctionTypeParam;
+};
+
+declare type BabelNodeFunctionTypeParam = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "FunctionTypeParam";
+  name?: BabelNodeIdentifier;
+  typeAnnotation: BabelNodeFlowType;
+  optional?: boolean;
+};
+
+declare type BabelNodeGenericTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "GenericTypeAnnotation";
+  id: BabelNodeIdentifier | BabelNodeQualifiedTypeIdentifier;
+  typeParameters?: BabelNodeTypeParameterInstantiation;
+};
+
+declare type BabelNodeInferredPredicate = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "InferredPredicate";
+};
+
+declare type BabelNodeInterfaceExtends = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "InterfaceExtends";
+  id: BabelNodeIdentifier | BabelNodeQualifiedTypeIdentifier;
+  typeParameters?: BabelNodeTypeParameterInstantiation;
+};
+
+declare type BabelNodeInterfaceDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "InterfaceDeclaration";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTypeParameterDeclaration;
+  extends?: Array<BabelNodeInterfaceExtends>;
+  body: BabelNodeObjectTypeAnnotation;
+  implements?: Array<BabelNodeClassImplements>;
+  mixins?: Array<BabelNodeInterfaceExtends>;
+};
+
+declare type BabelNodeInterfaceTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "InterfaceTypeAnnotation";
+  extends?: Array<BabelNodeInterfaceExtends>;
+  body: BabelNodeObjectTypeAnnotation;
+};
+
+declare type BabelNodeIntersectionTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "IntersectionTypeAnnotation";
+  types: Array<BabelNodeFlowType>;
+};
+
+declare type BabelNodeMixedTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "MixedTypeAnnotation";
+};
+
+declare type BabelNodeEmptyTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EmptyTypeAnnotation";
+};
+
+declare type BabelNodeNullableTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "NullableTypeAnnotation";
+  typeAnnotation: BabelNodeFlowType;
+};
+
+declare type BabelNodeNumberLiteralTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "NumberLiteralTypeAnnotation";
+  value: number;
+};
+
+declare type BabelNodeNumberTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "NumberTypeAnnotation";
+};
+
+declare type BabelNodeObjectTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectTypeAnnotation";
+  properties: Array<BabelNodeObjectTypeProperty | BabelNodeObjectTypeSpreadProperty>;
+  indexers?: Array<BabelNodeObjectTypeIndexer>;
+  callProperties?: Array<BabelNodeObjectTypeCallProperty>;
+  internalSlots?: Array<BabelNodeObjectTypeInternalSlot>;
+  exact?: boolean;
+  inexact?: boolean;
+};
+
+declare type BabelNodeObjectTypeInternalSlot = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectTypeInternalSlot";
+  id: BabelNodeIdentifier;
+  value: BabelNodeFlowType;
+  optional: boolean;
+  static: boolean;
+  method: boolean;
+};
+
+declare type BabelNodeObjectTypeCallProperty = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectTypeCallProperty";
+  value: BabelNodeFlowType;
+  static: boolean;
+};
+
+declare type BabelNodeObjectTypeIndexer = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectTypeIndexer";
+  id?: BabelNodeIdentifier;
+  key: BabelNodeFlowType;
+  value: BabelNodeFlowType;
+  variance?: BabelNodeVariance;
+  static: boolean;
+};
+
+declare type BabelNodeObjectTypeProperty = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectTypeProperty";
+  key: BabelNodeIdentifier | BabelNodeStringLiteral;
+  value: BabelNodeFlowType;
+  variance?: BabelNodeVariance;
+  kind: "init" | "get" | "set";
+  method: boolean;
+  optional: boolean;
+  proto: boolean;
+  static: boolean;
+};
+
+declare type BabelNodeObjectTypeSpreadProperty = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ObjectTypeSpreadProperty";
+  argument: BabelNodeFlowType;
+};
+
+declare type BabelNodeOpaqueType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "OpaqueType";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTypeParameterDeclaration;
+  supertype?: BabelNodeFlowType;
+  impltype: BabelNodeFlowType;
+};
+
+declare type BabelNodeQualifiedTypeIdentifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "QualifiedTypeIdentifier";
+  id: BabelNodeIdentifier;
+  qualification: BabelNodeIdentifier | BabelNodeQualifiedTypeIdentifier;
+};
+
+declare type BabelNodeStringLiteralTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "StringLiteralTypeAnnotation";
+  value: string;
+};
+
+declare type BabelNodeStringTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "StringTypeAnnotation";
+};
+
+declare type BabelNodeSymbolTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "SymbolTypeAnnotation";
+};
+
+declare type BabelNodeThisTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ThisTypeAnnotation";
+};
+
+declare type BabelNodeTupleTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TupleTypeAnnotation";
+  types: Array<BabelNodeFlowType>;
+};
+
+declare type BabelNodeTypeofTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TypeofTypeAnnotation";
+  argument: BabelNodeFlowType;
+};
+
+declare type BabelNodeTypeAlias = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TypeAlias";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTypeParameterDeclaration;
+  right: BabelNodeFlowType;
+};
+
+declare type BabelNodeTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TypeAnnotation";
+  typeAnnotation: BabelNodeFlowType;
+};
+
+declare type BabelNodeTypeCastExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TypeCastExpression";
+  expression: BabelNodeExpression;
+  typeAnnotation: BabelNodeTypeAnnotation;
+};
+
+declare type BabelNodeTypeParameter = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TypeParameter";
+  bound?: BabelNodeTypeAnnotation;
+  default?: BabelNodeFlowType;
+  variance?: BabelNodeVariance;
+  name: string;
+};
+
+declare type BabelNodeTypeParameterDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TypeParameterDeclaration";
+  params: Array<BabelNodeTypeParameter>;
+};
+
+declare type BabelNodeTypeParameterInstantiation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TypeParameterInstantiation";
+  params: Array<BabelNodeFlowType>;
+};
+
+declare type BabelNodeUnionTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "UnionTypeAnnotation";
+  types: Array<BabelNodeFlowType>;
+};
+
+declare type BabelNodeVariance = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Variance";
+  kind: "minus" | "plus";
+};
+
+declare type BabelNodeVoidTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "VoidTypeAnnotation";
+};
+
+declare type BabelNodeEnumDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumDeclaration";
+  id: BabelNodeIdentifier;
+  body: BabelNodeEnumBooleanBody | BabelNodeEnumNumberBody | BabelNodeEnumStringBody | BabelNodeEnumSymbolBody;
+};
+
+declare type BabelNodeEnumBooleanBody = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumBooleanBody";
+  members: Array<BabelNodeEnumBooleanMember>;
+  explicitType: boolean;
+  hasUnknownMembers: boolean;
+};
+
+declare type BabelNodeEnumNumberBody = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumNumberBody";
+  members: Array<BabelNodeEnumNumberMember>;
+  explicitType: boolean;
+  hasUnknownMembers: boolean;
+};
+
+declare type BabelNodeEnumStringBody = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumStringBody";
+  members: Array<BabelNodeEnumStringMember | BabelNodeEnumDefaultedMember>;
+  explicitType: boolean;
+  hasUnknownMembers: boolean;
+};
+
+declare type BabelNodeEnumSymbolBody = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumSymbolBody";
+  members: Array<BabelNodeEnumDefaultedMember>;
+  hasUnknownMembers: boolean;
+};
+
+declare type BabelNodeEnumBooleanMember = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumBooleanMember";
+  id: BabelNodeIdentifier;
+  init: BabelNodeBooleanLiteral;
+};
+
+declare type BabelNodeEnumNumberMember = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumNumberMember";
+  id: BabelNodeIdentifier;
+  init: BabelNodeNumericLiteral;
+};
+
+declare type BabelNodeEnumStringMember = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumStringMember";
+  id: BabelNodeIdentifier;
+  init: BabelNodeStringLiteral;
+};
+
+declare type BabelNodeEnumDefaultedMember = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "EnumDefaultedMember";
+  id: BabelNodeIdentifier;
+};
+
+declare type BabelNodeIndexedAccessType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "IndexedAccessType";
+  objectType: BabelNodeFlowType;
+  indexType: BabelNodeFlowType;
+};
+
+declare type BabelNodeOptionalIndexedAccessType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "OptionalIndexedAccessType";
+  objectType: BabelNodeFlowType;
+  indexType: BabelNodeFlowType;
+  optional: boolean;
+};
+
+declare type BabelNodeJSXAttribute = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXAttribute";
+  name: BabelNodeJSXIdentifier | BabelNodeJSXNamespacedName;
+  value?: BabelNodeJSXElement | BabelNodeJSXFragment | BabelNodeStringLiteral | BabelNodeJSXExpressionContainer;
+};
+
+declare type BabelNodeJSXClosingElement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXClosingElement";
+  name: BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName;
+};
+
+declare type BabelNodeJSXElement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXElement";
+  openingElement: BabelNodeJSXOpeningElement;
+  closingElement?: BabelNodeJSXClosingElement;
+  children: Array<BabelNodeJSXText | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXElement | BabelNodeJSXFragment>;
+  selfClosing?: boolean;
+};
+
+declare type BabelNodeJSXEmptyExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXEmptyExpression";
+};
+
+declare type BabelNodeJSXExpressionContainer = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXExpressionContainer";
+  expression: BabelNodeExpression | BabelNodeJSXEmptyExpression;
+};
+
+declare type BabelNodeJSXSpreadChild = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXSpreadChild";
+  expression: BabelNodeExpression;
+};
+
+declare type BabelNodeJSXIdentifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXIdentifier";
+  name: string;
+};
+
+declare type BabelNodeJSXMemberExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXMemberExpression";
+  object: BabelNodeJSXMemberExpression | BabelNodeJSXIdentifier;
+  property: BabelNodeJSXIdentifier;
+};
+
+declare type BabelNodeJSXNamespacedName = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXNamespacedName";
+  namespace: BabelNodeJSXIdentifier;
+  name: BabelNodeJSXIdentifier;
+};
+
+declare type BabelNodeJSXOpeningElement = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXOpeningElement";
+  name: BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName;
+  attributes: Array<BabelNodeJSXAttribute | BabelNodeJSXSpreadAttribute>;
+  selfClosing?: boolean;
+  typeParameters?: BabelNodeTypeParameterInstantiation | BabelNodeTSTypeParameterInstantiation;
+};
+
+declare type BabelNodeJSXSpreadAttribute = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXSpreadAttribute";
+  argument: BabelNodeExpression;
+};
+
+declare type BabelNodeJSXText = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXText";
+  value: string;
+};
+
+declare type BabelNodeJSXFragment = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXFragment";
+  openingFragment: BabelNodeJSXOpeningFragment;
+  closingFragment: BabelNodeJSXClosingFragment;
+  children: Array<BabelNodeJSXText | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXElement | BabelNodeJSXFragment>;
+};
+
+declare type BabelNodeJSXOpeningFragment = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXOpeningFragment";
+};
+
+declare type BabelNodeJSXClosingFragment = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "JSXClosingFragment";
+};
+
+declare type BabelNodeNoop = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Noop";
+};
+
+declare type BabelNodePlaceholder = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Placeholder";
+  expectedNode: "Identifier" | "StringLiteral" | "Expression" | "Statement" | "Declaration" | "BlockStatement" | "ClassBody" | "Pattern";
+  name: BabelNodeIdentifier;
+};
+
+declare type BabelNodeV8IntrinsicIdentifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "V8IntrinsicIdentifier";
+  name: string;
+};
+
+declare type BabelNodeArgumentPlaceholder = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ArgumentPlaceholder";
+};
+
+declare type BabelNodeBindExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "BindExpression";
+  object: BabelNodeExpression;
+  callee: BabelNodeExpression;
+};
+
+declare type BabelNodeClassProperty = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ClassProperty";
+  key: BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeExpression;
+  value?: BabelNodeExpression;
+  typeAnnotation?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  decorators?: Array<BabelNodeDecorator>;
+  computed?: boolean;
+  static?: boolean;
+  abstract?: boolean;
+  accessibility?: "public" | "private" | "protected";
+  declare?: boolean;
+  definite?: boolean;
+  optional?: boolean;
+  override?: boolean;
+  readonly?: boolean;
+};
+
+declare type BabelNodePipelineTopicExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "PipelineTopicExpression";
+  expression: BabelNodeExpression;
+};
+
+declare type BabelNodePipelineBareFunction = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "PipelineBareFunction";
+  callee: BabelNodeExpression;
+};
+
+declare type BabelNodePipelinePrimaryTopicReference = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "PipelinePrimaryTopicReference";
+};
+
+declare type BabelNodeClassPrivateProperty = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ClassPrivateProperty";
+  key: BabelNodePrivateName;
+  value?: BabelNodeExpression;
+  decorators?: Array<BabelNodeDecorator>;
+  static: any;
+  typeAnnotation?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+};
+
+declare type BabelNodeClassPrivateMethod = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ClassPrivateMethod";
+  kind?: "get" | "set" | "method" | "constructor";
+  key: BabelNodePrivateName;
+  params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>;
+  body: BabelNodeBlockStatement;
+  static?: boolean;
+  abstract?: boolean;
+  access?: "public" | "private" | "protected";
+  accessibility?: "public" | "private" | "protected";
+  async?: boolean;
+  computed?: boolean;
+  decorators?: Array<BabelNodeDecorator>;
+  generator?: boolean;
+  optional?: boolean;
+  override?: boolean;
+  returnType?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  typeParameters?: BabelNodeTypeParameterDeclaration | BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+};
+
+declare type BabelNodeImportAttribute = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ImportAttribute";
+  key: BabelNodeIdentifier | BabelNodeStringLiteral;
+  value: BabelNodeStringLiteral;
+};
+
+declare type BabelNodeDecorator = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "Decorator";
+  expression: BabelNodeExpression;
+};
+
+declare type BabelNodeDoExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DoExpression";
+  body: BabelNodeBlockStatement;
+  async?: boolean;
+};
+
+declare type BabelNodeExportDefaultSpecifier = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ExportDefaultSpecifier";
+  exported: BabelNodeIdentifier;
+};
+
+declare type BabelNodePrivateName = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "PrivateName";
+  id: BabelNodeIdentifier;
+};
+
+declare type BabelNodeRecordExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "RecordExpression";
+  properties: Array<BabelNodeObjectProperty | BabelNodeSpreadElement>;
+};
+
+declare type BabelNodeTupleExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TupleExpression";
+  elements?: Array<BabelNodeExpression | BabelNodeSpreadElement>;
+};
+
+declare type BabelNodeDecimalLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "DecimalLiteral";
+  value: string;
+};
+
+declare type BabelNodeStaticBlock = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "StaticBlock";
+  body: Array<BabelNodeStatement>;
+};
+
+declare type BabelNodeModuleExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "ModuleExpression";
+  body: BabelNodeProgram;
+};
+
+declare type BabelNodeTSParameterProperty = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSParameterProperty";
+  parameter: BabelNodeIdentifier | BabelNodeAssignmentPattern;
+  accessibility?: "public" | "private" | "protected";
+  readonly?: boolean;
+};
+
+declare type BabelNodeTSDeclareFunction = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSDeclareFunction";
+  id?: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+  params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>;
+  returnType?: BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  async?: boolean;
+  declare?: boolean;
+  generator?: boolean;
+};
+
+declare type BabelNodeTSDeclareMethod = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSDeclareMethod";
+  decorators?: Array<BabelNodeDecorator>;
+  key: BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeExpression;
+  typeParameters?: BabelNodeTSTypeParameterDeclaration | BabelNodeNoop;
+  params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>;
+  returnType?: BabelNodeTSTypeAnnotation | BabelNodeNoop;
+  abstract?: boolean;
+  access?: "public" | "private" | "protected";
+  accessibility?: "public" | "private" | "protected";
+  async?: boolean;
+  computed?: boolean;
+  generator?: boolean;
+  kind?: "get" | "set" | "method" | "constructor";
+  optional?: boolean;
+  override?: boolean;
+  static?: boolean;
+};
+
+declare type BabelNodeTSQualifiedName = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSQualifiedName";
+  left: BabelNodeTSEntityName;
+  right: BabelNodeIdentifier;
+};
+
+declare type BabelNodeTSCallSignatureDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSCallSignatureDeclaration";
+  typeParameters?: BabelNodeTSTypeParameterDeclaration;
+  parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>;
+  typeAnnotation?: BabelNodeTSTypeAnnotation;
+};
+
+declare type BabelNodeTSConstructSignatureDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSConstructSignatureDeclaration";
+  typeParameters?: BabelNodeTSTypeParameterDeclaration;
+  parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>;
+  typeAnnotation?: BabelNodeTSTypeAnnotation;
+};
+
+declare type BabelNodeTSPropertySignature = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSPropertySignature";
+  key: BabelNodeExpression;
+  typeAnnotation?: BabelNodeTSTypeAnnotation;
+  initializer?: BabelNodeExpression;
+  computed?: boolean;
+  optional?: boolean;
+  readonly?: boolean;
+};
+
+declare type BabelNodeTSMethodSignature = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSMethodSignature";
+  key: BabelNodeExpression;
+  typeParameters?: BabelNodeTSTypeParameterDeclaration;
+  parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>;
+  typeAnnotation?: BabelNodeTSTypeAnnotation;
+  computed?: boolean;
+  kind: "method" | "get" | "set";
+  optional?: boolean;
+};
+
+declare type BabelNodeTSIndexSignature = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSIndexSignature";
+  parameters: Array<BabelNodeIdentifier>;
+  typeAnnotation?: BabelNodeTSTypeAnnotation;
+  readonly?: boolean;
+  static?: boolean;
+};
+
+declare type BabelNodeTSAnyKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSAnyKeyword";
+};
+
+declare type BabelNodeTSBooleanKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSBooleanKeyword";
+};
+
+declare type BabelNodeTSBigIntKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSBigIntKeyword";
+};
+
+declare type BabelNodeTSIntrinsicKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSIntrinsicKeyword";
+};
+
+declare type BabelNodeTSNeverKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSNeverKeyword";
+};
+
+declare type BabelNodeTSNullKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSNullKeyword";
+};
+
+declare type BabelNodeTSNumberKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSNumberKeyword";
+};
+
+declare type BabelNodeTSObjectKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSObjectKeyword";
+};
+
+declare type BabelNodeTSStringKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSStringKeyword";
+};
+
+declare type BabelNodeTSSymbolKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSSymbolKeyword";
+};
+
+declare type BabelNodeTSUndefinedKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSUndefinedKeyword";
+};
+
+declare type BabelNodeTSUnknownKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSUnknownKeyword";
+};
+
+declare type BabelNodeTSVoidKeyword = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSVoidKeyword";
+};
+
+declare type BabelNodeTSThisType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSThisType";
+};
+
+declare type BabelNodeTSFunctionType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSFunctionType";
+  typeParameters?: BabelNodeTSTypeParameterDeclaration;
+  parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>;
+  typeAnnotation?: BabelNodeTSTypeAnnotation;
+};
+
+declare type BabelNodeTSConstructorType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSConstructorType";
+  typeParameters?: BabelNodeTSTypeParameterDeclaration;
+  parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>;
+  typeAnnotation?: BabelNodeTSTypeAnnotation;
+  abstract?: boolean;
+};
+
+declare type BabelNodeTSTypeReference = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeReference";
+  typeName: BabelNodeTSEntityName;
+  typeParameters?: BabelNodeTSTypeParameterInstantiation;
+};
+
+declare type BabelNodeTSTypePredicate = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypePredicate";
+  parameterName: BabelNodeIdentifier | BabelNodeTSThisType;
+  typeAnnotation?: BabelNodeTSTypeAnnotation;
+  asserts?: boolean;
+};
+
+declare type BabelNodeTSTypeQuery = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeQuery";
+  exprName: BabelNodeTSEntityName | BabelNodeTSImportType;
+};
+
+declare type BabelNodeTSTypeLiteral = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeLiteral";
+  members: Array<BabelNodeTSTypeElement>;
+};
+
+declare type BabelNodeTSArrayType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSArrayType";
+  elementType: BabelNodeTSType;
+};
+
+declare type BabelNodeTSTupleType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTupleType";
+  elementTypes: Array<BabelNodeTSType | BabelNodeTSNamedTupleMember>;
+};
+
+declare type BabelNodeTSOptionalType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSOptionalType";
+  typeAnnotation: BabelNodeTSType;
+};
+
+declare type BabelNodeTSRestType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSRestType";
+  typeAnnotation: BabelNodeTSType;
+};
+
+declare type BabelNodeTSNamedTupleMember = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSNamedTupleMember";
+  label: BabelNodeIdentifier;
+  elementType: BabelNodeTSType;
+  optional?: boolean;
+};
+
+declare type BabelNodeTSUnionType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSUnionType";
+  types: Array<BabelNodeTSType>;
+};
+
+declare type BabelNodeTSIntersectionType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSIntersectionType";
+  types: Array<BabelNodeTSType>;
+};
+
+declare type BabelNodeTSConditionalType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSConditionalType";
+  checkType: BabelNodeTSType;
+  extendsType: BabelNodeTSType;
+  trueType: BabelNodeTSType;
+  falseType: BabelNodeTSType;
+};
+
+declare type BabelNodeTSInferType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSInferType";
+  typeParameter: BabelNodeTSTypeParameter;
+};
+
+declare type BabelNodeTSParenthesizedType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSParenthesizedType";
+  typeAnnotation: BabelNodeTSType;
+};
+
+declare type BabelNodeTSTypeOperator = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeOperator";
+  typeAnnotation: BabelNodeTSType;
+  operator: string;
+};
+
+declare type BabelNodeTSIndexedAccessType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSIndexedAccessType";
+  objectType: BabelNodeTSType;
+  indexType: BabelNodeTSType;
+};
+
+declare type BabelNodeTSMappedType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSMappedType";
+  typeParameter: BabelNodeTSTypeParameter;
+  typeAnnotation?: BabelNodeTSType;
+  nameType?: BabelNodeTSType;
+  optional?: boolean;
+  readonly?: boolean;
+};
+
+declare type BabelNodeTSLiteralType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSLiteralType";
+  literal: BabelNodeNumericLiteral | BabelNodeStringLiteral | BabelNodeBooleanLiteral | BabelNodeBigIntLiteral;
+};
+
+declare type BabelNodeTSExpressionWithTypeArguments = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSExpressionWithTypeArguments";
+  expression: BabelNodeTSEntityName;
+  typeParameters?: BabelNodeTSTypeParameterInstantiation;
+};
+
+declare type BabelNodeTSInterfaceDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSInterfaceDeclaration";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTSTypeParameterDeclaration;
+  extends?: Array<BabelNodeTSExpressionWithTypeArguments>;
+  body: BabelNodeTSInterfaceBody;
+  declare?: boolean;
+};
+
+declare type BabelNodeTSInterfaceBody = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSInterfaceBody";
+  body: Array<BabelNodeTSTypeElement>;
+};
+
+declare type BabelNodeTSTypeAliasDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeAliasDeclaration";
+  id: BabelNodeIdentifier;
+  typeParameters?: BabelNodeTSTypeParameterDeclaration;
+  typeAnnotation: BabelNodeTSType;
+  declare?: boolean;
+};
+
+declare type BabelNodeTSAsExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSAsExpression";
+  expression: BabelNodeExpression;
+  typeAnnotation: BabelNodeTSType;
+};
+
+declare type BabelNodeTSTypeAssertion = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeAssertion";
+  typeAnnotation: BabelNodeTSType;
+  expression: BabelNodeExpression;
+};
+
+declare type BabelNodeTSEnumDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSEnumDeclaration";
+  id: BabelNodeIdentifier;
+  members: Array<BabelNodeTSEnumMember>;
+  const?: boolean;
+  declare?: boolean;
+  initializer?: BabelNodeExpression;
+};
+
+declare type BabelNodeTSEnumMember = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSEnumMember";
+  id: BabelNodeIdentifier | BabelNodeStringLiteral;
+  initializer?: BabelNodeExpression;
+};
+
+declare type BabelNodeTSModuleDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSModuleDeclaration";
+  id: BabelNodeIdentifier | BabelNodeStringLiteral;
+  body: BabelNodeTSModuleBlock | BabelNodeTSModuleDeclaration;
+  declare?: boolean;
+  global?: boolean;
+};
+
+declare type BabelNodeTSModuleBlock = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSModuleBlock";
+  body: Array<BabelNodeStatement>;
+};
+
+declare type BabelNodeTSImportType = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSImportType";
+  argument: BabelNodeStringLiteral;
+  qualifier?: BabelNodeTSEntityName;
+  typeParameters?: BabelNodeTSTypeParameterInstantiation;
+};
+
+declare type BabelNodeTSImportEqualsDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSImportEqualsDeclaration";
+  id: BabelNodeIdentifier;
+  moduleReference: BabelNodeTSEntityName | BabelNodeTSExternalModuleReference;
+  isExport: boolean;
+};
+
+declare type BabelNodeTSExternalModuleReference = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSExternalModuleReference";
+  expression: BabelNodeStringLiteral;
+};
+
+declare type BabelNodeTSNonNullExpression = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSNonNullExpression";
+  expression: BabelNodeExpression;
+};
+
+declare type BabelNodeTSExportAssignment = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSExportAssignment";
+  expression: BabelNodeExpression;
+};
+
+declare type BabelNodeTSNamespaceExportDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSNamespaceExportDeclaration";
+  id: BabelNodeIdentifier;
+};
+
+declare type BabelNodeTSTypeAnnotation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeAnnotation";
+  typeAnnotation: BabelNodeTSType;
+};
+
+declare type BabelNodeTSTypeParameterInstantiation = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeParameterInstantiation";
+  params: Array<BabelNodeTSType>;
+};
+
+declare type BabelNodeTSTypeParameterDeclaration = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeParameterDeclaration";
+  params: Array<BabelNodeTSTypeParameter>;
+};
+
+declare type BabelNodeTSTypeParameter = {
+  leadingComments?: Array<BabelNodeComment>;
+  innerComments?: Array<BabelNodeComment>;
+  trailingComments?: Array<BabelNodeComment>;
+  start: ?number;
+  end: ?number;
+  loc: ?BabelNodeSourceLocation,
+  type: "TSTypeParameter";
+  constraint?: BabelNodeTSType;
+  default?: BabelNodeTSType;
+  name: string;
+};
+
+declare type BabelNode = BabelNodeArrayExpression | BabelNodeAssignmentExpression | BabelNodeBinaryExpression | BabelNodeInterpreterDirective | BabelNodeDirective | BabelNodeDirectiveLiteral | BabelNodeBlockStatement | BabelNodeBreakStatement | BabelNodeCallExpression | BabelNodeCatchClause | BabelNodeConditionalExpression | BabelNodeContinueStatement | BabelNodeDebuggerStatement | BabelNodeDoWhileStatement | BabelNodeEmptyStatement | BabelNodeExpressionStatement | BabelNodeFile | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeIdentifier | BabelNodeIfStatement | BabelNodeLabeledStatement | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeRegExpLiteral | BabelNodeLogicalExpression | BabelNodeMemberExpression | BabelNodeNewExpression | BabelNodeProgram | BabelNodeObjectExpression | BabelNodeObjectMethod | BabelNodeObjectProperty | BabelNodeRestElement | BabelNodeReturnStatement | BabelNodeSequenceExpression | BabelNodeParenthesizedExpression | BabelNodeSwitchCase | BabelNodeSwitchStatement | BabelNodeThisExpression | BabelNodeThrowStatement | BabelNodeTryStatement | BabelNodeUnaryExpression | BabelNodeUpdateExpression | BabelNodeVariableDeclaration | BabelNodeVariableDeclarator | BabelNodeWhileStatement | BabelNodeWithStatement | BabelNodeAssignmentPattern | BabelNodeArrayPattern | BabelNodeArrowFunctionExpression | BabelNodeClassBody | BabelNodeClassExpression | BabelNodeClassDeclaration | BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeExportSpecifier | BabelNodeForOfStatement | BabelNodeImportDeclaration | BabelNodeImportDefaultSpecifier | BabelNodeImportNamespaceSpecifier | BabelNodeImportSpecifier | BabelNodeMetaProperty | BabelNodeClassMethod | BabelNodeObjectPattern | BabelNodeSpreadElement | BabelNodeSuper | BabelNodeTaggedTemplateExpression | BabelNodeTemplateElement | BabelNodeTemplateLiteral | BabelNodeYieldExpression | BabelNodeAwaitExpression | BabelNodeImport | BabelNodeBigIntLiteral | BabelNodeExportNamespaceSpecifier | BabelNodeOptionalMemberExpression | BabelNodeOptionalCallExpression | BabelNodeAnyTypeAnnotation | BabelNodeArrayTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeBooleanLiteralTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeClassImplements | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareOpaqueType | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeDeclaredPredicate | BabelNodeExistsTypeAnnotation | BabelNodeFunctionTypeAnnotation | BabelNodeFunctionTypeParam | BabelNodeGenericTypeAnnotation | BabelNodeInferredPredicate | BabelNodeInterfaceExtends | BabelNodeInterfaceDeclaration | BabelNodeInterfaceTypeAnnotation | BabelNodeIntersectionTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeEmptyTypeAnnotation | BabelNodeNullableTypeAnnotation | BabelNodeNumberLiteralTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeObjectTypeAnnotation | BabelNodeObjectTypeInternalSlot | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty | BabelNodeObjectTypeSpreadProperty | BabelNodeOpaqueType | BabelNodeQualifiedTypeIdentifier | BabelNodeStringLiteralTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeSymbolTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeTupleTypeAnnotation | BabelNodeTypeofTypeAnnotation | BabelNodeTypeAlias | BabelNodeTypeAnnotation | BabelNodeTypeCastExpression | BabelNodeTypeParameter | BabelNodeTypeParameterDeclaration | BabelNodeTypeParameterInstantiation | BabelNodeUnionTypeAnnotation | BabelNodeVariance | BabelNodeVoidTypeAnnotation | BabelNodeEnumDeclaration | BabelNodeEnumBooleanBody | BabelNodeEnumNumberBody | BabelNodeEnumStringBody | BabelNodeEnumSymbolBody | BabelNodeEnumBooleanMember | BabelNodeEnumNumberMember | BabelNodeEnumStringMember | BabelNodeEnumDefaultedMember | BabelNodeIndexedAccessType | BabelNodeOptionalIndexedAccessType | BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXEmptyExpression | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName | BabelNodeJSXOpeningElement | BabelNodeJSXSpreadAttribute | BabelNodeJSXText | BabelNodeJSXFragment | BabelNodeJSXOpeningFragment | BabelNodeJSXClosingFragment | BabelNodeNoop | BabelNodePlaceholder | BabelNodeV8IntrinsicIdentifier | BabelNodeArgumentPlaceholder | BabelNodeBindExpression | BabelNodeClassProperty | BabelNodePipelineTopicExpression | BabelNodePipelineBareFunction | BabelNodePipelinePrimaryTopicReference | BabelNodeClassPrivateProperty | BabelNodeClassPrivateMethod | BabelNodeImportAttribute | BabelNodeDecorator | BabelNodeDoExpression | BabelNodeExportDefaultSpecifier | BabelNodePrivateName | BabelNodeRecordExpression | BabelNodeTupleExpression | BabelNodeDecimalLiteral | BabelNodeStaticBlock | BabelNodeModuleExpression | BabelNodeTSParameterProperty | BabelNodeTSDeclareFunction | BabelNodeTSDeclareMethod | BabelNodeTSQualifiedName | BabelNodeTSCallSignatureDeclaration | BabelNodeTSConstructSignatureDeclaration | BabelNodeTSPropertySignature | BabelNodeTSMethodSignature | BabelNodeTSIndexSignature | BabelNodeTSAnyKeyword | BabelNodeTSBooleanKeyword | BabelNodeTSBigIntKeyword | BabelNodeTSIntrinsicKeyword | BabelNodeTSNeverKeyword | BabelNodeTSNullKeyword | BabelNodeTSNumberKeyword | BabelNodeTSObjectKeyword | BabelNodeTSStringKeyword | BabelNodeTSSymbolKeyword | BabelNodeTSUndefinedKeyword | BabelNodeTSUnknownKeyword | BabelNodeTSVoidKeyword | BabelNodeTSThisType | BabelNodeTSFunctionType | BabelNodeTSConstructorType | BabelNodeTSTypeReference | BabelNodeTSTypePredicate | BabelNodeTSTypeQuery | BabelNodeTSTypeLiteral | BabelNodeTSArrayType | BabelNodeTSTupleType | BabelNodeTSOptionalType | BabelNodeTSRestType | BabelNodeTSNamedTupleMember | BabelNodeTSUnionType | BabelNodeTSIntersectionType | BabelNodeTSConditionalType | BabelNodeTSInferType | BabelNodeTSParenthesizedType | BabelNodeTSTypeOperator | BabelNodeTSIndexedAccessType | BabelNodeTSMappedType | BabelNodeTSLiteralType | BabelNodeTSExpressionWithTypeArguments | BabelNodeTSInterfaceDeclaration | BabelNodeTSInterfaceBody | BabelNodeTSTypeAliasDeclaration | BabelNodeTSAsExpression | BabelNodeTSTypeAssertion | BabelNodeTSEnumDeclaration | BabelNodeTSEnumMember | BabelNodeTSModuleDeclaration | BabelNodeTSModuleBlock | BabelNodeTSImportType | BabelNodeTSImportEqualsDeclaration | BabelNodeTSExternalModuleReference | BabelNodeTSNonNullExpression | BabelNodeTSExportAssignment | BabelNodeTSNamespaceExportDeclaration | BabelNodeTSTypeAnnotation | BabelNodeTSTypeParameterInstantiation | BabelNodeTSTypeParameterDeclaration | BabelNodeTSTypeParameter;
+declare type BabelNodeExpression = BabelNodeArrayExpression | BabelNodeAssignmentExpression | BabelNodeBinaryExpression | BabelNodeCallExpression | BabelNodeConditionalExpression | BabelNodeFunctionExpression | BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeRegExpLiteral | BabelNodeLogicalExpression | BabelNodeMemberExpression | BabelNodeNewExpression | BabelNodeObjectExpression | BabelNodeSequenceExpression | BabelNodeParenthesizedExpression | BabelNodeThisExpression | BabelNodeUnaryExpression | BabelNodeUpdateExpression | BabelNodeArrowFunctionExpression | BabelNodeClassExpression | BabelNodeMetaProperty | BabelNodeSuper | BabelNodeTaggedTemplateExpression | BabelNodeTemplateLiteral | BabelNodeYieldExpression | BabelNodeAwaitExpression | BabelNodeImport | BabelNodeBigIntLiteral | BabelNodeOptionalMemberExpression | BabelNodeOptionalCallExpression | BabelNodeTypeCastExpression | BabelNodeJSXElement | BabelNodeJSXFragment | BabelNodeBindExpression | BabelNodePipelinePrimaryTopicReference | BabelNodeDoExpression | BabelNodeRecordExpression | BabelNodeTupleExpression | BabelNodeDecimalLiteral | BabelNodeModuleExpression | BabelNodeTSAsExpression | BabelNodeTSTypeAssertion | BabelNodeTSNonNullExpression;
+declare type BabelNodeBinary = BabelNodeBinaryExpression | BabelNodeLogicalExpression;
+declare type BabelNodeScopable = BabelNodeBlockStatement | BabelNodeCatchClause | BabelNodeDoWhileStatement | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeProgram | BabelNodeObjectMethod | BabelNodeSwitchStatement | BabelNodeWhileStatement | BabelNodeArrowFunctionExpression | BabelNodeClassExpression | BabelNodeClassDeclaration | BabelNodeForOfStatement | BabelNodeClassMethod | BabelNodeClassPrivateMethod | BabelNodeStaticBlock | BabelNodeTSModuleBlock;
+declare type BabelNodeBlockParent = BabelNodeBlockStatement | BabelNodeCatchClause | BabelNodeDoWhileStatement | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeProgram | BabelNodeObjectMethod | BabelNodeSwitchStatement | BabelNodeWhileStatement | BabelNodeArrowFunctionExpression | BabelNodeForOfStatement | BabelNodeClassMethod | BabelNodeClassPrivateMethod | BabelNodeStaticBlock | BabelNodeTSModuleBlock;
+declare type BabelNodeBlock = BabelNodeBlockStatement | BabelNodeProgram | BabelNodeTSModuleBlock;
+declare type BabelNodeStatement = BabelNodeBlockStatement | BabelNodeBreakStatement | BabelNodeContinueStatement | BabelNodeDebuggerStatement | BabelNodeDoWhileStatement | BabelNodeEmptyStatement | BabelNodeExpressionStatement | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeFunctionDeclaration | BabelNodeIfStatement | BabelNodeLabeledStatement | BabelNodeReturnStatement | BabelNodeSwitchStatement | BabelNodeThrowStatement | BabelNodeTryStatement | BabelNodeVariableDeclaration | BabelNodeWhileStatement | BabelNodeWithStatement | BabelNodeClassDeclaration | BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeForOfStatement | BabelNodeImportDeclaration | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareOpaqueType | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeInterfaceDeclaration | BabelNodeOpaqueType | BabelNodeTypeAlias | BabelNodeEnumDeclaration | BabelNodeTSDeclareFunction | BabelNodeTSInterfaceDeclaration | BabelNodeTSTypeAliasDeclaration | BabelNodeTSEnumDeclaration | BabelNodeTSModuleDeclaration | BabelNodeTSImportEqualsDeclaration | BabelNodeTSExportAssignment | BabelNodeTSNamespaceExportDeclaration;
+declare type BabelNodeTerminatorless = BabelNodeBreakStatement | BabelNodeContinueStatement | BabelNodeReturnStatement | BabelNodeThrowStatement | BabelNodeYieldExpression | BabelNodeAwaitExpression;
+declare type BabelNodeCompletionStatement = BabelNodeBreakStatement | BabelNodeContinueStatement | BabelNodeReturnStatement | BabelNodeThrowStatement;
+declare type BabelNodeConditional = BabelNodeConditionalExpression | BabelNodeIfStatement;
+declare type BabelNodeLoop = BabelNodeDoWhileStatement | BabelNodeForInStatement | BabelNodeForStatement | BabelNodeWhileStatement | BabelNodeForOfStatement;
+declare type BabelNodeWhile = BabelNodeDoWhileStatement | BabelNodeWhileStatement;
+declare type BabelNodeExpressionWrapper = BabelNodeExpressionStatement | BabelNodeParenthesizedExpression | BabelNodeTypeCastExpression;
+declare type BabelNodeFor = BabelNodeForInStatement | BabelNodeForStatement | BabelNodeForOfStatement;
+declare type BabelNodeForXStatement = BabelNodeForInStatement | BabelNodeForOfStatement;
+declare type BabelNodeFunction = BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeObjectMethod | BabelNodeArrowFunctionExpression | BabelNodeClassMethod | BabelNodeClassPrivateMethod;
+declare type BabelNodeFunctionParent = BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeObjectMethod | BabelNodeArrowFunctionExpression | BabelNodeClassMethod | BabelNodeClassPrivateMethod;
+declare type BabelNodePureish = BabelNodeFunctionDeclaration | BabelNodeFunctionExpression | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeRegExpLiteral | BabelNodeArrowFunctionExpression | BabelNodeBigIntLiteral | BabelNodeDecimalLiteral;
+declare type BabelNodeDeclaration = BabelNodeFunctionDeclaration | BabelNodeVariableDeclaration | BabelNodeClassDeclaration | BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeImportDeclaration | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareOpaqueType | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeInterfaceDeclaration | BabelNodeOpaqueType | BabelNodeTypeAlias | BabelNodeEnumDeclaration | BabelNodeTSDeclareFunction | BabelNodeTSInterfaceDeclaration | BabelNodeTSTypeAliasDeclaration | BabelNodeTSEnumDeclaration | BabelNodeTSModuleDeclaration;
+declare type BabelNodePatternLike = BabelNodeIdentifier | BabelNodeRestElement | BabelNodeAssignmentPattern | BabelNodeArrayPattern | BabelNodeObjectPattern;
+declare type BabelNodeLVal = BabelNodeIdentifier | BabelNodeMemberExpression | BabelNodeRestElement | BabelNodeAssignmentPattern | BabelNodeArrayPattern | BabelNodeObjectPattern | BabelNodeTSParameterProperty;
+declare type BabelNodeTSEntityName = BabelNodeIdentifier | BabelNodeTSQualifiedName;
+declare type BabelNodeLiteral = BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeRegExpLiteral | BabelNodeTemplateLiteral | BabelNodeBigIntLiteral | BabelNodeDecimalLiteral;
+declare type BabelNodeImmutable = BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeNullLiteral | BabelNodeBooleanLiteral | BabelNodeBigIntLiteral | BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXOpeningElement | BabelNodeJSXText | BabelNodeJSXFragment | BabelNodeJSXOpeningFragment | BabelNodeJSXClosingFragment | BabelNodeDecimalLiteral;
+declare type BabelNodeUserWhitespacable = BabelNodeObjectMethod | BabelNodeObjectProperty | BabelNodeObjectTypeInternalSlot | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty | BabelNodeObjectTypeSpreadProperty;
+declare type BabelNodeMethod = BabelNodeObjectMethod | BabelNodeClassMethod | BabelNodeClassPrivateMethod;
+declare type BabelNodeObjectMember = BabelNodeObjectMethod | BabelNodeObjectProperty;
+declare type BabelNodeProperty = BabelNodeObjectProperty | BabelNodeClassProperty | BabelNodeClassPrivateProperty;
+declare type BabelNodeUnaryLike = BabelNodeUnaryExpression | BabelNodeSpreadElement;
+declare type BabelNodePattern = BabelNodeAssignmentPattern | BabelNodeArrayPattern | BabelNodeObjectPattern;
+declare type BabelNodeClass = BabelNodeClassExpression | BabelNodeClassDeclaration;
+declare type BabelNodeModuleDeclaration = BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration | BabelNodeImportDeclaration;
+declare type BabelNodeExportDeclaration = BabelNodeExportAllDeclaration | BabelNodeExportDefaultDeclaration | BabelNodeExportNamedDeclaration;
+declare type BabelNodeModuleSpecifier = BabelNodeExportSpecifier | BabelNodeImportDefaultSpecifier | BabelNodeImportNamespaceSpecifier | BabelNodeImportSpecifier | BabelNodeExportNamespaceSpecifier | BabelNodeExportDefaultSpecifier;
+declare type BabelNodeFlow = BabelNodeAnyTypeAnnotation | BabelNodeArrayTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeBooleanLiteralTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeClassImplements | BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareOpaqueType | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeDeclaredPredicate | BabelNodeExistsTypeAnnotation | BabelNodeFunctionTypeAnnotation | BabelNodeFunctionTypeParam | BabelNodeGenericTypeAnnotation | BabelNodeInferredPredicate | BabelNodeInterfaceExtends | BabelNodeInterfaceDeclaration | BabelNodeInterfaceTypeAnnotation | BabelNodeIntersectionTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeEmptyTypeAnnotation | BabelNodeNullableTypeAnnotation | BabelNodeNumberLiteralTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeObjectTypeAnnotation | BabelNodeObjectTypeInternalSlot | BabelNodeObjectTypeCallProperty | BabelNodeObjectTypeIndexer | BabelNodeObjectTypeProperty | BabelNodeObjectTypeSpreadProperty | BabelNodeOpaqueType | BabelNodeQualifiedTypeIdentifier | BabelNodeStringLiteralTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeSymbolTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeTupleTypeAnnotation | BabelNodeTypeofTypeAnnotation | BabelNodeTypeAlias | BabelNodeTypeAnnotation | BabelNodeTypeCastExpression | BabelNodeTypeParameter | BabelNodeTypeParameterDeclaration | BabelNodeTypeParameterInstantiation | BabelNodeUnionTypeAnnotation | BabelNodeVariance | BabelNodeVoidTypeAnnotation | BabelNodeIndexedAccessType | BabelNodeOptionalIndexedAccessType;
+declare type BabelNodeFlowType = BabelNodeAnyTypeAnnotation | BabelNodeArrayTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeBooleanLiteralTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeExistsTypeAnnotation | BabelNodeFunctionTypeAnnotation | BabelNodeGenericTypeAnnotation | BabelNodeInterfaceTypeAnnotation | BabelNodeIntersectionTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeEmptyTypeAnnotation | BabelNodeNullableTypeAnnotation | BabelNodeNumberLiteralTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeObjectTypeAnnotation | BabelNodeStringLiteralTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeSymbolTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeTupleTypeAnnotation | BabelNodeTypeofTypeAnnotation | BabelNodeUnionTypeAnnotation | BabelNodeVoidTypeAnnotation | BabelNodeIndexedAccessType | BabelNodeOptionalIndexedAccessType;
+declare type BabelNodeFlowBaseAnnotation = BabelNodeAnyTypeAnnotation | BabelNodeBooleanTypeAnnotation | BabelNodeNullLiteralTypeAnnotation | BabelNodeMixedTypeAnnotation | BabelNodeEmptyTypeAnnotation | BabelNodeNumberTypeAnnotation | BabelNodeStringTypeAnnotation | BabelNodeSymbolTypeAnnotation | BabelNodeThisTypeAnnotation | BabelNodeVoidTypeAnnotation;
+declare type BabelNodeFlowDeclaration = BabelNodeDeclareClass | BabelNodeDeclareFunction | BabelNodeDeclareInterface | BabelNodeDeclareModule | BabelNodeDeclareModuleExports | BabelNodeDeclareTypeAlias | BabelNodeDeclareOpaqueType | BabelNodeDeclareVariable | BabelNodeDeclareExportDeclaration | BabelNodeDeclareExportAllDeclaration | BabelNodeInterfaceDeclaration | BabelNodeOpaqueType | BabelNodeTypeAlias;
+declare type BabelNodeFlowPredicate = BabelNodeDeclaredPredicate | BabelNodeInferredPredicate;
+declare type BabelNodeEnumBody = BabelNodeEnumBooleanBody | BabelNodeEnumNumberBody | BabelNodeEnumStringBody | BabelNodeEnumSymbolBody;
+declare type BabelNodeEnumMember = BabelNodeEnumBooleanMember | BabelNodeEnumNumberMember | BabelNodeEnumStringMember | BabelNodeEnumDefaultedMember;
+declare type BabelNodeJSX = BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXEmptyExpression | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName | BabelNodeJSXOpeningElement | BabelNodeJSXSpreadAttribute | BabelNodeJSXText | BabelNodeJSXFragment | BabelNodeJSXOpeningFragment | BabelNodeJSXClosingFragment;
+declare type BabelNodePrivate = BabelNodeClassPrivateProperty | BabelNodeClassPrivateMethod | BabelNodePrivateName;
+declare type BabelNodeTSTypeElement = BabelNodeTSCallSignatureDeclaration | BabelNodeTSConstructSignatureDeclaration | BabelNodeTSPropertySignature | BabelNodeTSMethodSignature | BabelNodeTSIndexSignature;
+declare type BabelNodeTSType = BabelNodeTSAnyKeyword | BabelNodeTSBooleanKeyword | BabelNodeTSBigIntKeyword | BabelNodeTSIntrinsicKeyword | BabelNodeTSNeverKeyword | BabelNodeTSNullKeyword | BabelNodeTSNumberKeyword | BabelNodeTSObjectKeyword | BabelNodeTSStringKeyword | BabelNodeTSSymbolKeyword | BabelNodeTSUndefinedKeyword | BabelNodeTSUnknownKeyword | BabelNodeTSVoidKeyword | BabelNodeTSThisType | BabelNodeTSFunctionType | BabelNodeTSConstructorType | BabelNodeTSTypeReference | BabelNodeTSTypePredicate | BabelNodeTSTypeQuery | BabelNodeTSTypeLiteral | BabelNodeTSArrayType | BabelNodeTSTupleType | BabelNodeTSOptionalType | BabelNodeTSRestType | BabelNodeTSUnionType | BabelNodeTSIntersectionType | BabelNodeTSConditionalType | BabelNodeTSInferType | BabelNodeTSParenthesizedType | BabelNodeTSTypeOperator | BabelNodeTSIndexedAccessType | BabelNodeTSMappedType | BabelNodeTSLiteralType | BabelNodeTSExpressionWithTypeArguments | BabelNodeTSImportType;
+declare type BabelNodeTSBaseType = BabelNodeTSAnyKeyword | BabelNodeTSBooleanKeyword | BabelNodeTSBigIntKeyword | BabelNodeTSIntrinsicKeyword | BabelNodeTSNeverKeyword | BabelNodeTSNullKeyword | BabelNodeTSNumberKeyword | BabelNodeTSObjectKeyword | BabelNodeTSStringKeyword | BabelNodeTSSymbolKeyword | BabelNodeTSUndefinedKeyword | BabelNodeTSUnknownKeyword | BabelNodeTSVoidKeyword | BabelNodeTSThisType | BabelNodeTSLiteralType;
+
+declare module "@babel/types" {
+  declare export function arrayExpression(elements?: Array<null | BabelNodeExpression | BabelNodeSpreadElement>): BabelNodeArrayExpression;
+  declare export function assignmentExpression(operator: string, left: BabelNodeLVal, right: BabelNodeExpression): BabelNodeAssignmentExpression;
+  declare export function binaryExpression(operator: "+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<=", left: BabelNodeExpression | BabelNodePrivateName, right: BabelNodeExpression): BabelNodeBinaryExpression;
+  declare export function interpreterDirective(value: string): BabelNodeInterpreterDirective;
+  declare export function directive(value: BabelNodeDirectiveLiteral): BabelNodeDirective;
+  declare export function directiveLiteral(value: string): BabelNodeDirectiveLiteral;
+  declare export function blockStatement(body: Array<BabelNodeStatement>, directives?: Array<BabelNodeDirective>): BabelNodeBlockStatement;
+  declare export function breakStatement(label?: BabelNodeIdentifier): BabelNodeBreakStatement;
+  declare export function callExpression(callee: BabelNodeExpression | BabelNodeV8IntrinsicIdentifier, _arguments: Array<BabelNodeExpression | BabelNodeSpreadElement | BabelNodeJSXNamespacedName | BabelNodeArgumentPlaceholder>): BabelNodeCallExpression;
+  declare export function catchClause(param?: BabelNodeIdentifier | BabelNodeArrayPattern | BabelNodeObjectPattern, body: BabelNodeBlockStatement): BabelNodeCatchClause;
+  declare export function conditionalExpression(test: BabelNodeExpression, consequent: BabelNodeExpression, alternate: BabelNodeExpression): BabelNodeConditionalExpression;
+  declare export function continueStatement(label?: BabelNodeIdentifier): BabelNodeContinueStatement;
+  declare export function debuggerStatement(): BabelNodeDebuggerStatement;
+  declare export function doWhileStatement(test: BabelNodeExpression, body: BabelNodeStatement): BabelNodeDoWhileStatement;
+  declare export function emptyStatement(): BabelNodeEmptyStatement;
+  declare export function expressionStatement(expression: BabelNodeExpression): BabelNodeExpressionStatement;
+  declare export function file(program: BabelNodeProgram, comments?: Array<BabelNodeCommentBlock | BabelNodeCommentLine>, tokens?: Array<any>): BabelNodeFile;
+  declare export function forInStatement(left: BabelNodeVariableDeclaration | BabelNodeLVal, right: BabelNodeExpression, body: BabelNodeStatement): BabelNodeForInStatement;
+  declare export function forStatement(init?: BabelNodeVariableDeclaration | BabelNodeExpression, test?: BabelNodeExpression, update?: BabelNodeExpression, body: BabelNodeStatement): BabelNodeForStatement;
+  declare export function functionDeclaration(id?: BabelNodeIdentifier, params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean): BabelNodeFunctionDeclaration;
+  declare export function functionExpression(id?: BabelNodeIdentifier, params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>, body: BabelNodeBlockStatement, generator?: boolean, async?: boolean): BabelNodeFunctionExpression;
+  declare export function identifier(name: string): BabelNodeIdentifier;
+  declare export function ifStatement(test: BabelNodeExpression, consequent: BabelNodeStatement, alternate?: BabelNodeStatement): BabelNodeIfStatement;
+  declare export function labeledStatement(label: BabelNodeIdentifier, body: BabelNodeStatement): BabelNodeLabeledStatement;
+  declare export function stringLiteral(value: string): BabelNodeStringLiteral;
+  declare export function numericLiteral(value: number): BabelNodeNumericLiteral;
+  declare export function nullLiteral(): BabelNodeNullLiteral;
+  declare export function booleanLiteral(value: boolean): BabelNodeBooleanLiteral;
+  declare export function regExpLiteral(pattern: string, flags?: string): BabelNodeRegExpLiteral;
+  declare export function logicalExpression(operator: "||" | "&&" | "??", left: BabelNodeExpression, right: BabelNodeExpression): BabelNodeLogicalExpression;
+  declare export function memberExpression(object: BabelNodeExpression, property: BabelNodeExpression | BabelNodeIdentifier | BabelNodePrivateName, computed?: boolean, optional?: true | false): BabelNodeMemberExpression;
+  declare export function newExpression(callee: BabelNodeExpression | BabelNodeV8IntrinsicIdentifier, _arguments: Array<BabelNodeExpression | BabelNodeSpreadElement | BabelNodeJSXNamespacedName | BabelNodeArgumentPlaceholder>): BabelNodeNewExpression;
+  declare export function program(body: Array<BabelNodeStatement>, directives?: Array<BabelNodeDirective>, sourceType?: "script" | "module", interpreter?: BabelNodeInterpreterDirective): BabelNodeProgram;
+  declare export function objectExpression(properties: Array<BabelNodeObjectMethod | BabelNodeObjectProperty | BabelNodeSpreadElement>): BabelNodeObjectExpression;
+  declare export function objectMethod(kind?: "method" | "get" | "set", key: BabelNodeExpression | BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral, params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>, body: BabelNodeBlockStatement, computed?: boolean, generator?: boolean, async?: boolean): BabelNodeObjectMethod;
+  declare export function objectProperty(key: BabelNodeExpression | BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral, value: BabelNodeExpression | BabelNodePatternLike, computed?: boolean, shorthand?: boolean, decorators?: Array<BabelNodeDecorator>): BabelNodeObjectProperty;
+  declare export function restElement(argument: BabelNodeLVal): BabelNodeRestElement;
+  declare export function returnStatement(argument?: BabelNodeExpression): BabelNodeReturnStatement;
+  declare export function sequenceExpression(expressions: Array<BabelNodeExpression>): BabelNodeSequenceExpression;
+  declare export function parenthesizedExpression(expression: BabelNodeExpression): BabelNodeParenthesizedExpression;
+  declare export function switchCase(test?: BabelNodeExpression, consequent: Array<BabelNodeStatement>): BabelNodeSwitchCase;
+  declare export function switchStatement(discriminant: BabelNodeExpression, cases: Array<BabelNodeSwitchCase>): BabelNodeSwitchStatement;
+  declare export function thisExpression(): BabelNodeThisExpression;
+  declare export function throwStatement(argument: BabelNodeExpression): BabelNodeThrowStatement;
+  declare export function tryStatement(block: BabelNodeBlockStatement, handler?: BabelNodeCatchClause, finalizer?: BabelNodeBlockStatement): BabelNodeTryStatement;
+  declare export function unaryExpression(operator: "void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof", argument: BabelNodeExpression, prefix?: boolean): BabelNodeUnaryExpression;
+  declare export function updateExpression(operator: "++" | "--", argument: BabelNodeExpression, prefix?: boolean): BabelNodeUpdateExpression;
+  declare export function variableDeclaration(kind: "var" | "let" | "const", declarations: Array<BabelNodeVariableDeclarator>): BabelNodeVariableDeclaration;
+  declare export function variableDeclarator(id: BabelNodeLVal, init?: BabelNodeExpression): BabelNodeVariableDeclarator;
+  declare export function whileStatement(test: BabelNodeExpression, body: BabelNodeStatement): BabelNodeWhileStatement;
+  declare export function withStatement(object: BabelNodeExpression, body: BabelNodeStatement): BabelNodeWithStatement;
+  declare export function assignmentPattern(left: BabelNodeIdentifier | BabelNodeObjectPattern | BabelNodeArrayPattern | BabelNodeMemberExpression, right: BabelNodeExpression): BabelNodeAssignmentPattern;
+  declare export function arrayPattern(elements: Array<null | BabelNodePatternLike>): BabelNodeArrayPattern;
+  declare export function arrowFunctionExpression(params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>, body: BabelNodeBlockStatement | BabelNodeExpression, async?: boolean): BabelNodeArrowFunctionExpression;
+  declare export function classBody(body: Array<BabelNodeClassMethod | BabelNodeClassPrivateMethod | BabelNodeClassProperty | BabelNodeClassPrivateProperty | BabelNodeTSDeclareMethod | BabelNodeTSIndexSignature>): BabelNodeClassBody;
+  declare export function classExpression(id?: BabelNodeIdentifier, superClass?: BabelNodeExpression, body: BabelNodeClassBody, decorators?: Array<BabelNodeDecorator>): BabelNodeClassExpression;
+  declare export function classDeclaration(id: BabelNodeIdentifier, superClass?: BabelNodeExpression, body: BabelNodeClassBody, decorators?: Array<BabelNodeDecorator>): BabelNodeClassDeclaration;
+  declare export function exportAllDeclaration(source: BabelNodeStringLiteral): BabelNodeExportAllDeclaration;
+  declare export function exportDefaultDeclaration(declaration: BabelNodeFunctionDeclaration | BabelNodeTSDeclareFunction | BabelNodeClassDeclaration | BabelNodeExpression): BabelNodeExportDefaultDeclaration;
+  declare export function exportNamedDeclaration(declaration?: BabelNodeDeclaration, specifiers?: Array<BabelNodeExportSpecifier | BabelNodeExportDefaultSpecifier | BabelNodeExportNamespaceSpecifier>, source?: BabelNodeStringLiteral): BabelNodeExportNamedDeclaration;
+  declare export function exportSpecifier(local: BabelNodeIdentifier, exported: BabelNodeIdentifier | BabelNodeStringLiteral): BabelNodeExportSpecifier;
+  declare export function forOfStatement(left: BabelNodeVariableDeclaration | BabelNodeLVal, right: BabelNodeExpression, body: BabelNodeStatement, _await?: boolean): BabelNodeForOfStatement;
+  declare export function importDeclaration(specifiers: Array<BabelNodeImportSpecifier | BabelNodeImportDefaultSpecifier | BabelNodeImportNamespaceSpecifier>, source: BabelNodeStringLiteral): BabelNodeImportDeclaration;
+  declare export function importDefaultSpecifier(local: BabelNodeIdentifier): BabelNodeImportDefaultSpecifier;
+  declare export function importNamespaceSpecifier(local: BabelNodeIdentifier): BabelNodeImportNamespaceSpecifier;
+  declare export function importSpecifier(local: BabelNodeIdentifier, imported: BabelNodeIdentifier | BabelNodeStringLiteral): BabelNodeImportSpecifier;
+  declare export function metaProperty(meta: BabelNodeIdentifier, property: BabelNodeIdentifier): BabelNodeMetaProperty;
+  declare export function classMethod(kind?: "get" | "set" | "method" | "constructor", key: BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeExpression, params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>, body: BabelNodeBlockStatement, computed?: boolean, _static?: boolean, generator?: boolean, async?: boolean): BabelNodeClassMethod;
+  declare export function objectPattern(properties: Array<BabelNodeRestElement | BabelNodeObjectProperty>): BabelNodeObjectPattern;
+  declare export function spreadElement(argument: BabelNodeExpression): BabelNodeSpreadElement;
+  declare var _super: () => BabelNodeSuper;
+  declare export { _super as super }
+  declare export function taggedTemplateExpression(tag: BabelNodeExpression, quasi: BabelNodeTemplateLiteral): BabelNodeTaggedTemplateExpression;
+  declare export function templateElement(value: { raw: string, cooked?: string }, tail?: boolean): BabelNodeTemplateElement;
+  declare export function templateLiteral(quasis: Array<BabelNodeTemplateElement>, expressions: Array<BabelNodeExpression | BabelNodeTSType>): BabelNodeTemplateLiteral;
+  declare export function yieldExpression(argument?: BabelNodeExpression, delegate?: boolean): BabelNodeYieldExpression;
+  declare export function awaitExpression(argument: BabelNodeExpression): BabelNodeAwaitExpression;
+  declare var _import: () => BabelNodeImport;
+  declare export { _import as import }
+  declare export function bigIntLiteral(value: string): BabelNodeBigIntLiteral;
+  declare export function exportNamespaceSpecifier(exported: BabelNodeIdentifier): BabelNodeExportNamespaceSpecifier;
+  declare export function optionalMemberExpression(object: BabelNodeExpression, property: BabelNodeExpression | BabelNodeIdentifier, computed?: boolean, optional: boolean): BabelNodeOptionalMemberExpression;
+  declare export function optionalCallExpression(callee: BabelNodeExpression, _arguments: Array<BabelNodeExpression | BabelNodeSpreadElement | BabelNodeJSXNamespacedName | BabelNodeArgumentPlaceholder>, optional: boolean): BabelNodeOptionalCallExpression;
+  declare export function anyTypeAnnotation(): BabelNodeAnyTypeAnnotation;
+  declare export function arrayTypeAnnotation(elementType: BabelNodeFlowType): BabelNodeArrayTypeAnnotation;
+  declare export function booleanTypeAnnotation(): BabelNodeBooleanTypeAnnotation;
+  declare export function booleanLiteralTypeAnnotation(value: boolean): BabelNodeBooleanLiteralTypeAnnotation;
+  declare export function nullLiteralTypeAnnotation(): BabelNodeNullLiteralTypeAnnotation;
+  declare export function classImplements(id: BabelNodeIdentifier, typeParameters?: BabelNodeTypeParameterInstantiation): BabelNodeClassImplements;
+  declare export function declareClass(id: BabelNodeIdentifier, typeParameters?: BabelNodeTypeParameterDeclaration, _extends?: Array<BabelNodeInterfaceExtends>, body: BabelNodeObjectTypeAnnotation): BabelNodeDeclareClass;
+  declare export function declareFunction(id: BabelNodeIdentifier): BabelNodeDeclareFunction;
+  declare export function declareInterface(id: BabelNodeIdentifier, typeParameters?: BabelNodeTypeParameterDeclaration, _extends?: Array<BabelNodeInterfaceExtends>, body: BabelNodeObjectTypeAnnotation): BabelNodeDeclareInterface;
+  declare export function declareModule(id: BabelNodeIdentifier | BabelNodeStringLiteral, body: BabelNodeBlockStatement, kind?: "CommonJS" | "ES"): BabelNodeDeclareModule;
+  declare export function declareModuleExports(typeAnnotation: BabelNodeTypeAnnotation): BabelNodeDeclareModuleExports;
+  declare export function declareTypeAlias(id: BabelNodeIdentifier, typeParameters?: BabelNodeTypeParameterDeclaration, right: BabelNodeFlowType): BabelNodeDeclareTypeAlias;
+  declare export function declareOpaqueType(id: BabelNodeIdentifier, typeParameters?: BabelNodeTypeParameterDeclaration, supertype?: BabelNodeFlowType): BabelNodeDeclareOpaqueType;
+  declare export function declareVariable(id: BabelNodeIdentifier): BabelNodeDeclareVariable;
+  declare export function declareExportDeclaration(declaration?: BabelNodeFlow, specifiers?: Array<BabelNodeExportSpecifier | BabelNodeExportNamespaceSpecifier>, source?: BabelNodeStringLiteral): BabelNodeDeclareExportDeclaration;
+  declare export function declareExportAllDeclaration(source: BabelNodeStringLiteral): BabelNodeDeclareExportAllDeclaration;
+  declare export function declaredPredicate(value: BabelNodeFlow): BabelNodeDeclaredPredicate;
+  declare export function existsTypeAnnotation(): BabelNodeExistsTypeAnnotation;
+  declare export function functionTypeAnnotation(typeParameters?: BabelNodeTypeParameterDeclaration, params: Array<BabelNodeFunctionTypeParam>, rest?: BabelNodeFunctionTypeParam, returnType: BabelNodeFlowType): BabelNodeFunctionTypeAnnotation;
+  declare export function functionTypeParam(name?: BabelNodeIdentifier, typeAnnotation: BabelNodeFlowType): BabelNodeFunctionTypeParam;
+  declare export function genericTypeAnnotation(id: BabelNodeIdentifier | BabelNodeQualifiedTypeIdentifier, typeParameters?: BabelNodeTypeParameterInstantiation): BabelNodeGenericTypeAnnotation;
+  declare export function inferredPredicate(): BabelNodeInferredPredicate;
+  declare export function interfaceExtends(id: BabelNodeIdentifier | BabelNodeQualifiedTypeIdentifier, typeParameters?: BabelNodeTypeParameterInstantiation): BabelNodeInterfaceExtends;
+  declare export function interfaceDeclaration(id: BabelNodeIdentifier, typeParameters?: BabelNodeTypeParameterDeclaration, _extends?: Array<BabelNodeInterfaceExtends>, body: BabelNodeObjectTypeAnnotation): BabelNodeInterfaceDeclaration;
+  declare export function interfaceTypeAnnotation(_extends?: Array<BabelNodeInterfaceExtends>, body: BabelNodeObjectTypeAnnotation): BabelNodeInterfaceTypeAnnotation;
+  declare export function intersectionTypeAnnotation(types: Array<BabelNodeFlowType>): BabelNodeIntersectionTypeAnnotation;
+  declare export function mixedTypeAnnotation(): BabelNodeMixedTypeAnnotation;
+  declare export function emptyTypeAnnotation(): BabelNodeEmptyTypeAnnotation;
+  declare export function nullableTypeAnnotation(typeAnnotation: BabelNodeFlowType): BabelNodeNullableTypeAnnotation;
+  declare export function numberLiteralTypeAnnotation(value: number): BabelNodeNumberLiteralTypeAnnotation;
+  declare export function numberTypeAnnotation(): BabelNodeNumberTypeAnnotation;
+  declare export function objectTypeAnnotation(properties: Array<BabelNodeObjectTypeProperty | BabelNodeObjectTypeSpreadProperty>, indexers?: Array<BabelNodeObjectTypeIndexer>, callProperties?: Array<BabelNodeObjectTypeCallProperty>, internalSlots?: Array<BabelNodeObjectTypeInternalSlot>, exact?: boolean): BabelNodeObjectTypeAnnotation;
+  declare export function objectTypeInternalSlot(id: BabelNodeIdentifier, value: BabelNodeFlowType, optional: boolean, _static: boolean, method: boolean): BabelNodeObjectTypeInternalSlot;
+  declare export function objectTypeCallProperty(value: BabelNodeFlowType): BabelNodeObjectTypeCallProperty;
+  declare export function objectTypeIndexer(id?: BabelNodeIdentifier, key: BabelNodeFlowType, value: BabelNodeFlowType, variance?: BabelNodeVariance): BabelNodeObjectTypeIndexer;
+  declare export function objectTypeProperty(key: BabelNodeIdentifier | BabelNodeStringLiteral, value: BabelNodeFlowType, variance?: BabelNodeVariance): BabelNodeObjectTypeProperty;
+  declare export function objectTypeSpreadProperty(argument: BabelNodeFlowType): BabelNodeObjectTypeSpreadProperty;
+  declare export function opaqueType(id: BabelNodeIdentifier, typeParameters?: BabelNodeTypeParameterDeclaration, supertype?: BabelNodeFlowType, impltype: BabelNodeFlowType): BabelNodeOpaqueType;
+  declare export function qualifiedTypeIdentifier(id: BabelNodeIdentifier, qualification: BabelNodeIdentifier | BabelNodeQualifiedTypeIdentifier): BabelNodeQualifiedTypeIdentifier;
+  declare export function stringLiteralTypeAnnotation(value: string): BabelNodeStringLiteralTypeAnnotation;
+  declare export function stringTypeAnnotation(): BabelNodeStringTypeAnnotation;
+  declare export function symbolTypeAnnotation(): BabelNodeSymbolTypeAnnotation;
+  declare export function thisTypeAnnotation(): BabelNodeThisTypeAnnotation;
+  declare export function tupleTypeAnnotation(types: Array<BabelNodeFlowType>): BabelNodeTupleTypeAnnotation;
+  declare export function typeofTypeAnnotation(argument: BabelNodeFlowType): BabelNodeTypeofTypeAnnotation;
+  declare export function typeAlias(id: BabelNodeIdentifier, typeParameters?: BabelNodeTypeParameterDeclaration, right: BabelNodeFlowType): BabelNodeTypeAlias;
+  declare export function typeAnnotation(typeAnnotation: BabelNodeFlowType): BabelNodeTypeAnnotation;
+  declare export function typeCastExpression(expression: BabelNodeExpression, typeAnnotation: BabelNodeTypeAnnotation): BabelNodeTypeCastExpression;
+  declare export function typeParameter(bound?: BabelNodeTypeAnnotation, _default?: BabelNodeFlowType, variance?: BabelNodeVariance): BabelNodeTypeParameter;
+  declare export function typeParameterDeclaration(params: Array<BabelNodeTypeParameter>): BabelNodeTypeParameterDeclaration;
+  declare export function typeParameterInstantiation(params: Array<BabelNodeFlowType>): BabelNodeTypeParameterInstantiation;
+  declare export function unionTypeAnnotation(types: Array<BabelNodeFlowType>): BabelNodeUnionTypeAnnotation;
+  declare export function variance(kind: "minus" | "plus"): BabelNodeVariance;
+  declare export function voidTypeAnnotation(): BabelNodeVoidTypeAnnotation;
+  declare export function enumDeclaration(id: BabelNodeIdentifier, body: BabelNodeEnumBooleanBody | BabelNodeEnumNumberBody | BabelNodeEnumStringBody | BabelNodeEnumSymbolBody): BabelNodeEnumDeclaration;
+  declare export function enumBooleanBody(members: Array<BabelNodeEnumBooleanMember>): BabelNodeEnumBooleanBody;
+  declare export function enumNumberBody(members: Array<BabelNodeEnumNumberMember>): BabelNodeEnumNumberBody;
+  declare export function enumStringBody(members: Array<BabelNodeEnumStringMember | BabelNodeEnumDefaultedMember>): BabelNodeEnumStringBody;
+  declare export function enumSymbolBody(members: Array<BabelNodeEnumDefaultedMember>): BabelNodeEnumSymbolBody;
+  declare export function enumBooleanMember(id: BabelNodeIdentifier): BabelNodeEnumBooleanMember;
+  declare export function enumNumberMember(id: BabelNodeIdentifier, init: BabelNodeNumericLiteral): BabelNodeEnumNumberMember;
+  declare export function enumStringMember(id: BabelNodeIdentifier, init: BabelNodeStringLiteral): BabelNodeEnumStringMember;
+  declare export function enumDefaultedMember(id: BabelNodeIdentifier): BabelNodeEnumDefaultedMember;
+  declare export function indexedAccessType(objectType: BabelNodeFlowType, indexType: BabelNodeFlowType): BabelNodeIndexedAccessType;
+  declare export function optionalIndexedAccessType(objectType: BabelNodeFlowType, indexType: BabelNodeFlowType): BabelNodeOptionalIndexedAccessType;
+  declare export function jsxAttribute(name: BabelNodeJSXIdentifier | BabelNodeJSXNamespacedName, value?: BabelNodeJSXElement | BabelNodeJSXFragment | BabelNodeStringLiteral | BabelNodeJSXExpressionContainer): BabelNodeJSXAttribute;
+  declare export function jsxClosingElement(name: BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName): BabelNodeJSXClosingElement;
+  declare export function jsxElement(openingElement: BabelNodeJSXOpeningElement, closingElement?: BabelNodeJSXClosingElement, children: Array<BabelNodeJSXText | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXElement | BabelNodeJSXFragment>, selfClosing?: boolean): BabelNodeJSXElement;
+  declare export function jsxEmptyExpression(): BabelNodeJSXEmptyExpression;
+  declare export function jsxExpressionContainer(expression: BabelNodeExpression | BabelNodeJSXEmptyExpression): BabelNodeJSXExpressionContainer;
+  declare export function jsxSpreadChild(expression: BabelNodeExpression): BabelNodeJSXSpreadChild;
+  declare export function jsxIdentifier(name: string): BabelNodeJSXIdentifier;
+  declare export function jsxMemberExpression(object: BabelNodeJSXMemberExpression | BabelNodeJSXIdentifier, property: BabelNodeJSXIdentifier): BabelNodeJSXMemberExpression;
+  declare export function jsxNamespacedName(namespace: BabelNodeJSXIdentifier, name: BabelNodeJSXIdentifier): BabelNodeJSXNamespacedName;
+  declare export function jsxOpeningElement(name: BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName, attributes: Array<BabelNodeJSXAttribute | BabelNodeJSXSpreadAttribute>, selfClosing?: boolean): BabelNodeJSXOpeningElement;
+  declare export function jsxSpreadAttribute(argument: BabelNodeExpression): BabelNodeJSXSpreadAttribute;
+  declare export function jsxText(value: string): BabelNodeJSXText;
+  declare export function jsxFragment(openingFragment: BabelNodeJSXOpeningFragment, closingFragment: BabelNodeJSXClosingFragment, children: Array<BabelNodeJSXText | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXElement | BabelNodeJSXFragment>): BabelNodeJSXFragment;
+  declare export function jsxOpeningFragment(): BabelNodeJSXOpeningFragment;
+  declare export function jsxClosingFragment(): BabelNodeJSXClosingFragment;
+  declare export function noop(): BabelNodeNoop;
+  declare export function placeholder(expectedNode: "Identifier" | "StringLiteral" | "Expression" | "Statement" | "Declaration" | "BlockStatement" | "ClassBody" | "Pattern", name: BabelNodeIdentifier): BabelNodePlaceholder;
+  declare export function v8IntrinsicIdentifier(name: string): BabelNodeV8IntrinsicIdentifier;
+  declare export function argumentPlaceholder(): BabelNodeArgumentPlaceholder;
+  declare export function bindExpression(object: BabelNodeExpression, callee: BabelNodeExpression): BabelNodeBindExpression;
+  declare export function classProperty(key: BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeExpression, value?: BabelNodeExpression, typeAnnotation?: BabelNodeTypeAnnotation | BabelNodeTSTypeAnnotation | BabelNodeNoop, decorators?: Array<BabelNodeDecorator>, computed?: boolean, _static?: boolean): BabelNodeClassProperty;
+  declare export function pipelineTopicExpression(expression: BabelNodeExpression): BabelNodePipelineTopicExpression;
+  declare export function pipelineBareFunction(callee: BabelNodeExpression): BabelNodePipelineBareFunction;
+  declare export function pipelinePrimaryTopicReference(): BabelNodePipelinePrimaryTopicReference;
+  declare export function classPrivateProperty(key: BabelNodePrivateName, value?: BabelNodeExpression, decorators?: Array<BabelNodeDecorator>, _static: any): BabelNodeClassPrivateProperty;
+  declare export function classPrivateMethod(kind?: "get" | "set" | "method" | "constructor", key: BabelNodePrivateName, params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>, body: BabelNodeBlockStatement, _static?: boolean): BabelNodeClassPrivateMethod;
+  declare export function importAttribute(key: BabelNodeIdentifier | BabelNodeStringLiteral, value: BabelNodeStringLiteral): BabelNodeImportAttribute;
+  declare export function decorator(expression: BabelNodeExpression): BabelNodeDecorator;
+  declare export function doExpression(body: BabelNodeBlockStatement, async?: boolean): BabelNodeDoExpression;
+  declare export function exportDefaultSpecifier(exported: BabelNodeIdentifier): BabelNodeExportDefaultSpecifier;
+  declare export function privateName(id: BabelNodeIdentifier): BabelNodePrivateName;
+  declare export function recordExpression(properties: Array<BabelNodeObjectProperty | BabelNodeSpreadElement>): BabelNodeRecordExpression;
+  declare export function tupleExpression(elements?: Array<BabelNodeExpression | BabelNodeSpreadElement>): BabelNodeTupleExpression;
+  declare export function decimalLiteral(value: string): BabelNodeDecimalLiteral;
+  declare export function staticBlock(body: Array<BabelNodeStatement>): BabelNodeStaticBlock;
+  declare export function moduleExpression(body: BabelNodeProgram): BabelNodeModuleExpression;
+  declare export function tsParameterProperty(parameter: BabelNodeIdentifier | BabelNodeAssignmentPattern): BabelNodeTSParameterProperty;
+  declare export function tsDeclareFunction(id?: BabelNodeIdentifier, typeParameters?: BabelNodeTSTypeParameterDeclaration | BabelNodeNoop, params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>, returnType?: BabelNodeTSTypeAnnotation | BabelNodeNoop): BabelNodeTSDeclareFunction;
+  declare export function tsDeclareMethod(decorators?: Array<BabelNodeDecorator>, key: BabelNodeIdentifier | BabelNodeStringLiteral | BabelNodeNumericLiteral | BabelNodeExpression, typeParameters?: BabelNodeTSTypeParameterDeclaration | BabelNodeNoop, params: Array<BabelNodeIdentifier | BabelNodePattern | BabelNodeRestElement | BabelNodeTSParameterProperty>, returnType?: BabelNodeTSTypeAnnotation | BabelNodeNoop): BabelNodeTSDeclareMethod;
+  declare export function tsQualifiedName(left: BabelNodeTSEntityName, right: BabelNodeIdentifier): BabelNodeTSQualifiedName;
+  declare export function tsCallSignatureDeclaration(typeParameters?: BabelNodeTSTypeParameterDeclaration, parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>, typeAnnotation?: BabelNodeTSTypeAnnotation): BabelNodeTSCallSignatureDeclaration;
+  declare export function tsConstructSignatureDeclaration(typeParameters?: BabelNodeTSTypeParameterDeclaration, parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>, typeAnnotation?: BabelNodeTSTypeAnnotation): BabelNodeTSConstructSignatureDeclaration;
+  declare export function tsPropertySignature(key: BabelNodeExpression, typeAnnotation?: BabelNodeTSTypeAnnotation, initializer?: BabelNodeExpression): BabelNodeTSPropertySignature;
+  declare export function tsMethodSignature(key: BabelNodeExpression, typeParameters?: BabelNodeTSTypeParameterDeclaration, parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>, typeAnnotation?: BabelNodeTSTypeAnnotation): BabelNodeTSMethodSignature;
+  declare export function tsIndexSignature(parameters: Array<BabelNodeIdentifier>, typeAnnotation?: BabelNodeTSTypeAnnotation): BabelNodeTSIndexSignature;
+  declare export function tsAnyKeyword(): BabelNodeTSAnyKeyword;
+  declare export function tsBooleanKeyword(): BabelNodeTSBooleanKeyword;
+  declare export function tsBigIntKeyword(): BabelNodeTSBigIntKeyword;
+  declare export function tsIntrinsicKeyword(): BabelNodeTSIntrinsicKeyword;
+  declare export function tsNeverKeyword(): BabelNodeTSNeverKeyword;
+  declare export function tsNullKeyword(): BabelNodeTSNullKeyword;
+  declare export function tsNumberKeyword(): BabelNodeTSNumberKeyword;
+  declare export function tsObjectKeyword(): BabelNodeTSObjectKeyword;
+  declare export function tsStringKeyword(): BabelNodeTSStringKeyword;
+  declare export function tsSymbolKeyword(): BabelNodeTSSymbolKeyword;
+  declare export function tsUndefinedKeyword(): BabelNodeTSUndefinedKeyword;
+  declare export function tsUnknownKeyword(): BabelNodeTSUnknownKeyword;
+  declare export function tsVoidKeyword(): BabelNodeTSVoidKeyword;
+  declare export function tsThisType(): BabelNodeTSThisType;
+  declare export function tsFunctionType(typeParameters?: BabelNodeTSTypeParameterDeclaration, parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>, typeAnnotation?: BabelNodeTSTypeAnnotation): BabelNodeTSFunctionType;
+  declare export function tsConstructorType(typeParameters?: BabelNodeTSTypeParameterDeclaration, parameters: Array<BabelNodeIdentifier | BabelNodeRestElement>, typeAnnotation?: BabelNodeTSTypeAnnotation): BabelNodeTSConstructorType;
+  declare export function tsTypeReference(typeName: BabelNodeTSEntityName, typeParameters?: BabelNodeTSTypeParameterInstantiation): BabelNodeTSTypeReference;
+  declare export function tsTypePredicate(parameterName: BabelNodeIdentifier | BabelNodeTSThisType, typeAnnotation?: BabelNodeTSTypeAnnotation, asserts?: boolean): BabelNodeTSTypePredicate;
+  declare export function tsTypeQuery(exprName: BabelNodeTSEntityName | BabelNodeTSImportType): BabelNodeTSTypeQuery;
+  declare export function tsTypeLiteral(members: Array<BabelNodeTSTypeElement>): BabelNodeTSTypeLiteral;
+  declare export function tsArrayType(elementType: BabelNodeTSType): BabelNodeTSArrayType;
+  declare export function tsTupleType(elementTypes: Array<BabelNodeTSType | BabelNodeTSNamedTupleMember>): BabelNodeTSTupleType;
+  declare export function tsOptionalType(typeAnnotation: BabelNodeTSType): BabelNodeTSOptionalType;
+  declare export function tsRestType(typeAnnotation: BabelNodeTSType): BabelNodeTSRestType;
+  declare export function tsNamedTupleMember(label: BabelNodeIdentifier, elementType: BabelNodeTSType, optional?: boolean): BabelNodeTSNamedTupleMember;
+  declare export function tsUnionType(types: Array<BabelNodeTSType>): BabelNodeTSUnionType;
+  declare export function tsIntersectionType(types: Array<BabelNodeTSType>): BabelNodeTSIntersectionType;
+  declare export function tsConditionalType(checkType: BabelNodeTSType, extendsType: BabelNodeTSType, trueType: BabelNodeTSType, falseType: BabelNodeTSType): BabelNodeTSConditionalType;
+  declare export function tsInferType(typeParameter: BabelNodeTSTypeParameter): BabelNodeTSInferType;
+  declare export function tsParenthesizedType(typeAnnotation: BabelNodeTSType): BabelNodeTSParenthesizedType;
+  declare export function tsTypeOperator(typeAnnotation: BabelNodeTSType): BabelNodeTSTypeOperator;
+  declare export function tsIndexedAccessType(objectType: BabelNodeTSType, indexType: BabelNodeTSType): BabelNodeTSIndexedAccessType;
+  declare export function tsMappedType(typeParameter: BabelNodeTSTypeParameter, typeAnnotation?: BabelNodeTSType, nameType?: BabelNodeTSType): BabelNodeTSMappedType;
+  declare export function tsLiteralType(literal: BabelNodeNumericLiteral | BabelNodeStringLiteral | BabelNodeBooleanLiteral | BabelNodeBigIntLiteral): BabelNodeTSLiteralType;
+  declare export function tsExpressionWithTypeArguments(expression: BabelNodeTSEntityName, typeParameters?: BabelNodeTSTypeParameterInstantiation): BabelNodeTSExpressionWithTypeArguments;
+  declare export function tsInterfaceDeclaration(id: BabelNodeIdentifier, typeParameters?: BabelNodeTSTypeParameterDeclaration, _extends?: Array<BabelNodeTSExpressionWithTypeArguments>, body: BabelNodeTSInterfaceBody): BabelNodeTSInterfaceDeclaration;
+  declare export function tsInterfaceBody(body: Array<BabelNodeTSTypeElement>): BabelNodeTSInterfaceBody;
+  declare export function tsTypeAliasDeclaration(id: BabelNodeIdentifier, typeParameters?: BabelNodeTSTypeParameterDeclaration, typeAnnotation: BabelNodeTSType): BabelNodeTSTypeAliasDeclaration;
+  declare export function tsAsExpression(expression: BabelNodeExpression, typeAnnotation: BabelNodeTSType): BabelNodeTSAsExpression;
+  declare export function tsTypeAssertion(typeAnnotation: BabelNodeTSType, expression: BabelNodeExpression): BabelNodeTSTypeAssertion;
+  declare export function tsEnumDeclaration(id: BabelNodeIdentifier, members: Array<BabelNodeTSEnumMember>): BabelNodeTSEnumDeclaration;
+  declare export function tsEnumMember(id: BabelNodeIdentifier | BabelNodeStringLiteral, initializer?: BabelNodeExpression): BabelNodeTSEnumMember;
+  declare export function tsModuleDeclaration(id: BabelNodeIdentifier | BabelNodeStringLiteral, body: BabelNodeTSModuleBlock | BabelNodeTSModuleDeclaration): BabelNodeTSModuleDeclaration;
+  declare export function tsModuleBlock(body: Array<BabelNodeStatement>): BabelNodeTSModuleBlock;
+  declare export function tsImportType(argument: BabelNodeStringLiteral, qualifier?: BabelNodeTSEntityName, typeParameters?: BabelNodeTSTypeParameterInstantiation): BabelNodeTSImportType;
+  declare export function tsImportEqualsDeclaration(id: BabelNodeIdentifier, moduleReference: BabelNodeTSEntityName | BabelNodeTSExternalModuleReference): BabelNodeTSImportEqualsDeclaration;
+  declare export function tsExternalModuleReference(expression: BabelNodeStringLiteral): BabelNodeTSExternalModuleReference;
+  declare export function tsNonNullExpression(expression: BabelNodeExpression): BabelNodeTSNonNullExpression;
+  declare export function tsExportAssignment(expression: BabelNodeExpression): BabelNodeTSExportAssignment;
+  declare export function tsNamespaceExportDeclaration(id: BabelNodeIdentifier): BabelNodeTSNamespaceExportDeclaration;
+  declare export function tsTypeAnnotation(typeAnnotation: BabelNodeTSType): BabelNodeTSTypeAnnotation;
+  declare export function tsTypeParameterInstantiation(params: Array<BabelNodeTSType>): BabelNodeTSTypeParameterInstantiation;
+  declare export function tsTypeParameterDeclaration(params: Array<BabelNodeTSTypeParameter>): BabelNodeTSTypeParameterDeclaration;
+  declare export function tsTypeParameter(constraint?: BabelNodeTSType, _default?: BabelNodeTSType, name: string): BabelNodeTSTypeParameter;
+  declare export function isArrayExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ArrayExpression');
+  declare export function isAssignmentExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'AssignmentExpression');
+  declare export function isBinaryExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'BinaryExpression');
+  declare export function isInterpreterDirective(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'InterpreterDirective');
+  declare export function isDirective(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Directive');
+  declare export function isDirectiveLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DirectiveLiteral');
+  declare export function isBlockStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'BlockStatement');
+  declare export function isBreakStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'BreakStatement');
+  declare export function isCallExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'CallExpression');
+  declare export function isCatchClause(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'CatchClause');
+  declare export function isConditionalExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ConditionalExpression');
+  declare export function isContinueStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ContinueStatement');
+  declare export function isDebuggerStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DebuggerStatement');
+  declare export function isDoWhileStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DoWhileStatement');
+  declare export function isEmptyStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EmptyStatement');
+  declare export function isExpressionStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ExpressionStatement');
+  declare export function isFile(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'File');
+  declare export function isForInStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ForInStatement');
+  declare export function isForStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ForStatement');
+  declare export function isFunctionDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'FunctionDeclaration');
+  declare export function isFunctionExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'FunctionExpression');
+  declare export function isIdentifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Identifier');
+  declare export function isIfStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'IfStatement');
+  declare export function isLabeledStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'LabeledStatement');
+  declare export function isStringLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'StringLiteral');
+  declare export function isNumericLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'NumericLiteral');
+  declare export function isNullLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'NullLiteral');
+  declare export function isBooleanLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'BooleanLiteral');
+  declare export function isRegExpLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'RegExpLiteral');
+  declare export function isLogicalExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'LogicalExpression');
+  declare export function isMemberExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'MemberExpression');
+  declare export function isNewExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'NewExpression');
+  declare export function isProgram(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Program');
+  declare export function isObjectExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectExpression');
+  declare export function isObjectMethod(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectMethod');
+  declare export function isObjectProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectProperty');
+  declare export function isRestElement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'RestElement');
+  declare export function isReturnStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ReturnStatement');
+  declare export function isSequenceExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'SequenceExpression');
+  declare export function isParenthesizedExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ParenthesizedExpression');
+  declare export function isSwitchCase(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'SwitchCase');
+  declare export function isSwitchStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'SwitchStatement');
+  declare export function isThisExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ThisExpression');
+  declare export function isThrowStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ThrowStatement');
+  declare export function isTryStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TryStatement');
+  declare export function isUnaryExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'UnaryExpression');
+  declare export function isUpdateExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'UpdateExpression');
+  declare export function isVariableDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'VariableDeclaration');
+  declare export function isVariableDeclarator(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'VariableDeclarator');
+  declare export function isWhileStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'WhileStatement');
+  declare export function isWithStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'WithStatement');
+  declare export function isAssignmentPattern(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'AssignmentPattern');
+  declare export function isArrayPattern(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ArrayPattern');
+  declare export function isArrowFunctionExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ArrowFunctionExpression');
+  declare export function isClassBody(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ClassBody');
+  declare export function isClassExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ClassExpression');
+  declare export function isClassDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ClassDeclaration');
+  declare export function isExportAllDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ExportAllDeclaration');
+  declare export function isExportDefaultDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ExportDefaultDeclaration');
+  declare export function isExportNamedDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ExportNamedDeclaration');
+  declare export function isExportSpecifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ExportSpecifier');
+  declare export function isForOfStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ForOfStatement');
+  declare export function isImportDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ImportDeclaration');
+  declare export function isImportDefaultSpecifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ImportDefaultSpecifier');
+  declare export function isImportNamespaceSpecifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ImportNamespaceSpecifier');
+  declare export function isImportSpecifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ImportSpecifier');
+  declare export function isMetaProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'MetaProperty');
+  declare export function isClassMethod(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ClassMethod');
+  declare export function isObjectPattern(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectPattern');
+  declare export function isSpreadElement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'SpreadElement');
+  declare export function isSuper(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Super');
+  declare export function isTaggedTemplateExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TaggedTemplateExpression');
+  declare export function isTemplateElement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TemplateElement');
+  declare export function isTemplateLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TemplateLiteral');
+  declare export function isYieldExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'YieldExpression');
+  declare export function isAwaitExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'AwaitExpression');
+  declare export function isImport(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Import');
+  declare export function isBigIntLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'BigIntLiteral');
+  declare export function isExportNamespaceSpecifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ExportNamespaceSpecifier');
+  declare export function isOptionalMemberExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'OptionalMemberExpression');
+  declare export function isOptionalCallExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'OptionalCallExpression');
+  declare export function isAnyTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'AnyTypeAnnotation');
+  declare export function isArrayTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ArrayTypeAnnotation');
+  declare export function isBooleanTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'BooleanTypeAnnotation');
+  declare export function isBooleanLiteralTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'BooleanLiteralTypeAnnotation');
+  declare export function isNullLiteralTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'NullLiteralTypeAnnotation');
+  declare export function isClassImplements(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ClassImplements');
+  declare export function isDeclareClass(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareClass');
+  declare export function isDeclareFunction(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareFunction');
+  declare export function isDeclareInterface(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareInterface');
+  declare export function isDeclareModule(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareModule');
+  declare export function isDeclareModuleExports(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareModuleExports');
+  declare export function isDeclareTypeAlias(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareTypeAlias');
+  declare export function isDeclareOpaqueType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareOpaqueType');
+  declare export function isDeclareVariable(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareVariable');
+  declare export function isDeclareExportDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareExportDeclaration');
+  declare export function isDeclareExportAllDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclareExportAllDeclaration');
+  declare export function isDeclaredPredicate(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DeclaredPredicate');
+  declare export function isExistsTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ExistsTypeAnnotation');
+  declare export function isFunctionTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'FunctionTypeAnnotation');
+  declare export function isFunctionTypeParam(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'FunctionTypeParam');
+  declare export function isGenericTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'GenericTypeAnnotation');
+  declare export function isInferredPredicate(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'InferredPredicate');
+  declare export function isInterfaceExtends(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'InterfaceExtends');
+  declare export function isInterfaceDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'InterfaceDeclaration');
+  declare export function isInterfaceTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'InterfaceTypeAnnotation');
+  declare export function isIntersectionTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'IntersectionTypeAnnotation');
+  declare export function isMixedTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'MixedTypeAnnotation');
+  declare export function isEmptyTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EmptyTypeAnnotation');
+  declare export function isNullableTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'NullableTypeAnnotation');
+  declare export function isNumberLiteralTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'NumberLiteralTypeAnnotation');
+  declare export function isNumberTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'NumberTypeAnnotation');
+  declare export function isObjectTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectTypeAnnotation');
+  declare export function isObjectTypeInternalSlot(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectTypeInternalSlot');
+  declare export function isObjectTypeCallProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectTypeCallProperty');
+  declare export function isObjectTypeIndexer(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectTypeIndexer');
+  declare export function isObjectTypeProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectTypeProperty');
+  declare export function isObjectTypeSpreadProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ObjectTypeSpreadProperty');
+  declare export function isOpaqueType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'OpaqueType');
+  declare export function isQualifiedTypeIdentifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'QualifiedTypeIdentifier');
+  declare export function isStringLiteralTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'StringLiteralTypeAnnotation');
+  declare export function isStringTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'StringTypeAnnotation');
+  declare export function isSymbolTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'SymbolTypeAnnotation');
+  declare export function isThisTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ThisTypeAnnotation');
+  declare export function isTupleTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TupleTypeAnnotation');
+  declare export function isTypeofTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TypeofTypeAnnotation');
+  declare export function isTypeAlias(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TypeAlias');
+  declare export function isTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TypeAnnotation');
+  declare export function isTypeCastExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TypeCastExpression');
+  declare export function isTypeParameter(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TypeParameter');
+  declare export function isTypeParameterDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TypeParameterDeclaration');
+  declare export function isTypeParameterInstantiation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TypeParameterInstantiation');
+  declare export function isUnionTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'UnionTypeAnnotation');
+  declare export function isVariance(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Variance');
+  declare export function isVoidTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'VoidTypeAnnotation');
+  declare export function isEnumDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumDeclaration');
+  declare export function isEnumBooleanBody(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumBooleanBody');
+  declare export function isEnumNumberBody(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumNumberBody');
+  declare export function isEnumStringBody(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumStringBody');
+  declare export function isEnumSymbolBody(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumSymbolBody');
+  declare export function isEnumBooleanMember(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumBooleanMember');
+  declare export function isEnumNumberMember(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumNumberMember');
+  declare export function isEnumStringMember(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumStringMember');
+  declare export function isEnumDefaultedMember(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'EnumDefaultedMember');
+  declare export function isIndexedAccessType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'IndexedAccessType');
+  declare export function isOptionalIndexedAccessType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'OptionalIndexedAccessType');
+  declare export function isJSXAttribute(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXAttribute');
+  declare export function isJSXClosingElement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXClosingElement');
+  declare export function isJSXElement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXElement');
+  declare export function isJSXEmptyExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXEmptyExpression');
+  declare export function isJSXExpressionContainer(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXExpressionContainer');
+  declare export function isJSXSpreadChild(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXSpreadChild');
+  declare export function isJSXIdentifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXIdentifier');
+  declare export function isJSXMemberExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXMemberExpression');
+  declare export function isJSXNamespacedName(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXNamespacedName');
+  declare export function isJSXOpeningElement(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXOpeningElement');
+  declare export function isJSXSpreadAttribute(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXSpreadAttribute');
+  declare export function isJSXText(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXText');
+  declare export function isJSXFragment(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXFragment');
+  declare export function isJSXOpeningFragment(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXOpeningFragment');
+  declare export function isJSXClosingFragment(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'JSXClosingFragment');
+  declare export function isNoop(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Noop');
+  declare export function isPlaceholder(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Placeholder');
+  declare export function isV8IntrinsicIdentifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'V8IntrinsicIdentifier');
+  declare export function isArgumentPlaceholder(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ArgumentPlaceholder');
+  declare export function isBindExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'BindExpression');
+  declare export function isClassProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ClassProperty');
+  declare export function isPipelineTopicExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'PipelineTopicExpression');
+  declare export function isPipelineBareFunction(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'PipelineBareFunction');
+  declare export function isPipelinePrimaryTopicReference(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'PipelinePrimaryTopicReference');
+  declare export function isClassPrivateProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ClassPrivateProperty');
+  declare export function isClassPrivateMethod(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ClassPrivateMethod');
+  declare export function isImportAttribute(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ImportAttribute');
+  declare export function isDecorator(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'Decorator');
+  declare export function isDoExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DoExpression');
+  declare export function isExportDefaultSpecifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ExportDefaultSpecifier');
+  declare export function isPrivateName(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'PrivateName');
+  declare export function isRecordExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'RecordExpression');
+  declare export function isTupleExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TupleExpression');
+  declare export function isDecimalLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'DecimalLiteral');
+  declare export function isStaticBlock(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'StaticBlock');
+  declare export function isModuleExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'ModuleExpression');
+  declare export function isTSParameterProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSParameterProperty');
+  declare export function isTSDeclareFunction(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSDeclareFunction');
+  declare export function isTSDeclareMethod(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSDeclareMethod');
+  declare export function isTSQualifiedName(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSQualifiedName');
+  declare export function isTSCallSignatureDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSCallSignatureDeclaration');
+  declare export function isTSConstructSignatureDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSConstructSignatureDeclaration');
+  declare export function isTSPropertySignature(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSPropertySignature');
+  declare export function isTSMethodSignature(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSMethodSignature');
+  declare export function isTSIndexSignature(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSIndexSignature');
+  declare export function isTSAnyKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSAnyKeyword');
+  declare export function isTSBooleanKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSBooleanKeyword');
+  declare export function isTSBigIntKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSBigIntKeyword');
+  declare export function isTSIntrinsicKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSIntrinsicKeyword');
+  declare export function isTSNeverKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSNeverKeyword');
+  declare export function isTSNullKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSNullKeyword');
+  declare export function isTSNumberKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSNumberKeyword');
+  declare export function isTSObjectKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSObjectKeyword');
+  declare export function isTSStringKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSStringKeyword');
+  declare export function isTSSymbolKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSSymbolKeyword');
+  declare export function isTSUndefinedKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSUndefinedKeyword');
+  declare export function isTSUnknownKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSUnknownKeyword');
+  declare export function isTSVoidKeyword(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSVoidKeyword');
+  declare export function isTSThisType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSThisType');
+  declare export function isTSFunctionType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSFunctionType');
+  declare export function isTSConstructorType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSConstructorType');
+  declare export function isTSTypeReference(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeReference');
+  declare export function isTSTypePredicate(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypePredicate');
+  declare export function isTSTypeQuery(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeQuery');
+  declare export function isTSTypeLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeLiteral');
+  declare export function isTSArrayType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSArrayType');
+  declare export function isTSTupleType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTupleType');
+  declare export function isTSOptionalType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSOptionalType');
+  declare export function isTSRestType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSRestType');
+  declare export function isTSNamedTupleMember(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSNamedTupleMember');
+  declare export function isTSUnionType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSUnionType');
+  declare export function isTSIntersectionType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSIntersectionType');
+  declare export function isTSConditionalType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSConditionalType');
+  declare export function isTSInferType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSInferType');
+  declare export function isTSParenthesizedType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSParenthesizedType');
+  declare export function isTSTypeOperator(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeOperator');
+  declare export function isTSIndexedAccessType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSIndexedAccessType');
+  declare export function isTSMappedType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSMappedType');
+  declare export function isTSLiteralType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSLiteralType');
+  declare export function isTSExpressionWithTypeArguments(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSExpressionWithTypeArguments');
+  declare export function isTSInterfaceDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSInterfaceDeclaration');
+  declare export function isTSInterfaceBody(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSInterfaceBody');
+  declare export function isTSTypeAliasDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeAliasDeclaration');
+  declare export function isTSAsExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSAsExpression');
+  declare export function isTSTypeAssertion(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeAssertion');
+  declare export function isTSEnumDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSEnumDeclaration');
+  declare export function isTSEnumMember(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSEnumMember');
+  declare export function isTSModuleDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSModuleDeclaration');
+  declare export function isTSModuleBlock(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSModuleBlock');
+  declare export function isTSImportType(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSImportType');
+  declare export function isTSImportEqualsDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSImportEqualsDeclaration');
+  declare export function isTSExternalModuleReference(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSExternalModuleReference');
+  declare export function isTSNonNullExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSNonNullExpression');
+  declare export function isTSExportAssignment(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSExportAssignment');
+  declare export function isTSNamespaceExportDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSNamespaceExportDeclaration');
+  declare export function isTSTypeAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeAnnotation');
+  declare export function isTSTypeParameterInstantiation(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeParameterInstantiation');
+  declare export function isTSTypeParameterDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeParameterDeclaration');
+  declare export function isTSTypeParameter(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'TSTypeParameter');
+  declare export function isExpression(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ArrayExpression' || node.type === 'AssignmentExpression' || node.type === 'BinaryExpression' || node.type === 'CallExpression' || node.type === 'ConditionalExpression' || node.type === 'FunctionExpression' || node.type === 'Identifier' || node.type === 'StringLiteral' || node.type === 'NumericLiteral' || node.type === 'NullLiteral' || node.type === 'BooleanLiteral' || node.type === 'RegExpLiteral' || node.type === 'LogicalExpression' || node.type === 'MemberExpression' || node.type === 'NewExpression' || node.type === 'ObjectExpression' || node.type === 'SequenceExpression' || node.type === 'ParenthesizedExpression' || node.type === 'ThisExpression' || node.type === 'UnaryExpression' || node.type === 'UpdateExpression' || node.type === 'ArrowFunctionExpression' || node.type === 'ClassExpression' || node.type === 'MetaProperty' || node.type === 'Super' || node.type === 'TaggedTemplateExpression' || node.type === 'TemplateLiteral' || node.type === 'YieldExpression' || node.type === 'AwaitExpression' || node.type === 'Import' || node.type === 'BigIntLiteral' || node.type === 'OptionalMemberExpression' || node.type === 'OptionalCallExpression' || node.type === 'TypeCastExpression' || node.type === 'JSXElement' || node.type === 'JSXFragment' || node.type === 'BindExpression' || node.type === 'PipelinePrimaryTopicReference' || node.type === 'DoExpression' || node.type === 'RecordExpression' || node.type === 'TupleExpression' || node.type === 'DecimalLiteral' || node.type === 'ModuleExpression' || node.type === 'TSAsExpression' || node.type === 'TSTypeAssertion' || node.type === 'TSNonNullExpression'));
+  declare export function isBinary(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'BinaryExpression' || node.type === 'LogicalExpression'));
+  declare export function isScopable(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'BlockStatement' || node.type === 'CatchClause' || node.type === 'DoWhileStatement' || node.type === 'ForInStatement' || node.type === 'ForStatement' || node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'Program' || node.type === 'ObjectMethod' || node.type === 'SwitchStatement' || node.type === 'WhileStatement' || node.type === 'ArrowFunctionExpression' || node.type === 'ClassExpression' || node.type === 'ClassDeclaration' || node.type === 'ForOfStatement' || node.type === 'ClassMethod' || node.type === 'ClassPrivateMethod' || node.type === 'StaticBlock' || node.type === 'TSModuleBlock'));
+  declare export function isBlockParent(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'BlockStatement' || node.type === 'CatchClause' || node.type === 'DoWhileStatement' || node.type === 'ForInStatement' || node.type === 'ForStatement' || node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'Program' || node.type === 'ObjectMethod' || node.type === 'SwitchStatement' || node.type === 'WhileStatement' || node.type === 'ArrowFunctionExpression' || node.type === 'ForOfStatement' || node.type === 'ClassMethod' || node.type === 'ClassPrivateMethod' || node.type === 'StaticBlock' || node.type === 'TSModuleBlock'));
+  declare export function isBlock(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'BlockStatement' || node.type === 'Program' || node.type === 'TSModuleBlock'));
+  declare export function isStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'BlockStatement' || node.type === 'BreakStatement' || node.type === 'ContinueStatement' || node.type === 'DebuggerStatement' || node.type === 'DoWhileStatement' || node.type === 'EmptyStatement' || node.type === 'ExpressionStatement' || node.type === 'ForInStatement' || node.type === 'ForStatement' || node.type === 'FunctionDeclaration' || node.type === 'IfStatement' || node.type === 'LabeledStatement' || node.type === 'ReturnStatement' || node.type === 'SwitchStatement' || node.type === 'ThrowStatement' || node.type === 'TryStatement' || node.type === 'VariableDeclaration' || node.type === 'WhileStatement' || node.type === 'WithStatement' || node.type === 'ClassDeclaration' || node.type === 'ExportAllDeclaration' || node.type === 'ExportDefaultDeclaration' || node.type === 'ExportNamedDeclaration' || node.type === 'ForOfStatement' || node.type === 'ImportDeclaration' || node.type === 'DeclareClass' || node.type === 'DeclareFunction' || node.type === 'DeclareInterface' || node.type === 'DeclareModule' || node.type === 'DeclareModuleExports' || node.type === 'DeclareTypeAlias' || node.type === 'DeclareOpaqueType' || node.type === 'DeclareVariable' || node.type === 'DeclareExportDeclaration' || node.type === 'DeclareExportAllDeclaration' || node.type === 'InterfaceDeclaration' || node.type === 'OpaqueType' || node.type === 'TypeAlias' || node.type === 'EnumDeclaration' || node.type === 'TSDeclareFunction' || node.type === 'TSInterfaceDeclaration' || node.type === 'TSTypeAliasDeclaration' || node.type === 'TSEnumDeclaration' || node.type === 'TSModuleDeclaration' || node.type === 'TSImportEqualsDeclaration' || node.type === 'TSExportAssignment' || node.type === 'TSNamespaceExportDeclaration'));
+  declare export function isTerminatorless(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'BreakStatement' || node.type === 'ContinueStatement' || node.type === 'ReturnStatement' || node.type === 'ThrowStatement' || node.type === 'YieldExpression' || node.type === 'AwaitExpression'));
+  declare export function isCompletionStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'BreakStatement' || node.type === 'ContinueStatement' || node.type === 'ReturnStatement' || node.type === 'ThrowStatement'));
+  declare export function isConditional(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ConditionalExpression' || node.type === 'IfStatement'));
+  declare export function isLoop(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'DoWhileStatement' || node.type === 'ForInStatement' || node.type === 'ForStatement' || node.type === 'WhileStatement' || node.type === 'ForOfStatement'));
+  declare export function isWhile(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'DoWhileStatement' || node.type === 'WhileStatement'));
+  declare export function isExpressionWrapper(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ExpressionStatement' || node.type === 'ParenthesizedExpression' || node.type === 'TypeCastExpression'));
+  declare export function isFor(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ForInStatement' || node.type === 'ForStatement' || node.type === 'ForOfStatement'));
+  declare export function isForXStatement(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ForInStatement' || node.type === 'ForOfStatement'));
+  declare export function isFunction(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ObjectMethod' || node.type === 'ArrowFunctionExpression' || node.type === 'ClassMethod' || node.type === 'ClassPrivateMethod'));
+  declare export function isFunctionParent(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ObjectMethod' || node.type === 'ArrowFunctionExpression' || node.type === 'ClassMethod' || node.type === 'ClassPrivateMethod'));
+  declare export function isPureish(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'StringLiteral' || node.type === 'NumericLiteral' || node.type === 'NullLiteral' || node.type === 'BooleanLiteral' || node.type === 'RegExpLiteral' || node.type === 'ArrowFunctionExpression' || node.type === 'BigIntLiteral' || node.type === 'DecimalLiteral'));
+  declare export function isDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'FunctionDeclaration' || node.type === 'VariableDeclaration' || node.type === 'ClassDeclaration' || node.type === 'ExportAllDeclaration' || node.type === 'ExportDefaultDeclaration' || node.type === 'ExportNamedDeclaration' || node.type === 'ImportDeclaration' || node.type === 'DeclareClass' || node.type === 'DeclareFunction' || node.type === 'DeclareInterface' || node.type === 'DeclareModule' || node.type === 'DeclareModuleExports' || node.type === 'DeclareTypeAlias' || node.type === 'DeclareOpaqueType' || node.type === 'DeclareVariable' || node.type === 'DeclareExportDeclaration' || node.type === 'DeclareExportAllDeclaration' || node.type === 'InterfaceDeclaration' || node.type === 'OpaqueType' || node.type === 'TypeAlias' || node.type === 'EnumDeclaration' || node.type === 'TSDeclareFunction' || node.type === 'TSInterfaceDeclaration' || node.type === 'TSTypeAliasDeclaration' || node.type === 'TSEnumDeclaration' || node.type === 'TSModuleDeclaration'));
+  declare export function isPatternLike(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'Identifier' || node.type === 'RestElement' || node.type === 'AssignmentPattern' || node.type === 'ArrayPattern' || node.type === 'ObjectPattern'));
+  declare export function isLVal(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'Identifier' || node.type === 'MemberExpression' || node.type === 'RestElement' || node.type === 'AssignmentPattern' || node.type === 'ArrayPattern' || node.type === 'ObjectPattern' || node.type === 'TSParameterProperty'));
+  declare export function isTSEntityName(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'Identifier' || node.type === 'TSQualifiedName'));
+  declare export function isLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'StringLiteral' || node.type === 'NumericLiteral' || node.type === 'NullLiteral' || node.type === 'BooleanLiteral' || node.type === 'RegExpLiteral' || node.type === 'TemplateLiteral' || node.type === 'BigIntLiteral' || node.type === 'DecimalLiteral'));
+  declare export function isImmutable(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'StringLiteral' || node.type === 'NumericLiteral' || node.type === 'NullLiteral' || node.type === 'BooleanLiteral' || node.type === 'BigIntLiteral' || node.type === 'JSXAttribute' || node.type === 'JSXClosingElement' || node.type === 'JSXElement' || node.type === 'JSXExpressionContainer' || node.type === 'JSXSpreadChild' || node.type === 'JSXOpeningElement' || node.type === 'JSXText' || node.type === 'JSXFragment' || node.type === 'JSXOpeningFragment' || node.type === 'JSXClosingFragment' || node.type === 'DecimalLiteral'));
+  declare export function isUserWhitespacable(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ObjectMethod' || node.type === 'ObjectProperty' || node.type === 'ObjectTypeInternalSlot' || node.type === 'ObjectTypeCallProperty' || node.type === 'ObjectTypeIndexer' || node.type === 'ObjectTypeProperty' || node.type === 'ObjectTypeSpreadProperty'));
+  declare export function isMethod(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ObjectMethod' || node.type === 'ClassMethod' || node.type === 'ClassPrivateMethod'));
+  declare export function isObjectMember(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ObjectMethod' || node.type === 'ObjectProperty'));
+  declare export function isProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ObjectProperty' || node.type === 'ClassProperty' || node.type === 'ClassPrivateProperty'));
+  declare export function isUnaryLike(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'UnaryExpression' || node.type === 'SpreadElement'));
+  declare export function isPattern(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'AssignmentPattern' || node.type === 'ArrayPattern' || node.type === 'ObjectPattern'));
+  declare export function isClass(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ClassExpression' || node.type === 'ClassDeclaration'));
+  declare export function isModuleDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ExportAllDeclaration' || node.type === 'ExportDefaultDeclaration' || node.type === 'ExportNamedDeclaration' || node.type === 'ImportDeclaration'));
+  declare export function isExportDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ExportAllDeclaration' || node.type === 'ExportDefaultDeclaration' || node.type === 'ExportNamedDeclaration'));
+  declare export function isModuleSpecifier(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ExportSpecifier' || node.type === 'ImportDefaultSpecifier' || node.type === 'ImportNamespaceSpecifier' || node.type === 'ImportSpecifier' || node.type === 'ExportNamespaceSpecifier' || node.type === 'ExportDefaultSpecifier'));
+  declare export function isFlow(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'AnyTypeAnnotation' || node.type === 'ArrayTypeAnnotation' || node.type === 'BooleanTypeAnnotation' || node.type === 'BooleanLiteralTypeAnnotation' || node.type === 'NullLiteralTypeAnnotation' || node.type === 'ClassImplements' || node.type === 'DeclareClass' || node.type === 'DeclareFunction' || node.type === 'DeclareInterface' || node.type === 'DeclareModule' || node.type === 'DeclareModuleExports' || node.type === 'DeclareTypeAlias' || node.type === 'DeclareOpaqueType' || node.type === 'DeclareVariable' || node.type === 'DeclareExportDeclaration' || node.type === 'DeclareExportAllDeclaration' || node.type === 'DeclaredPredicate' || node.type === 'ExistsTypeAnnotation' || node.type === 'FunctionTypeAnnotation' || node.type === 'FunctionTypeParam' || node.type === 'GenericTypeAnnotation' || node.type === 'InferredPredicate' || node.type === 'InterfaceExtends' || node.type === 'InterfaceDeclaration' || node.type === 'InterfaceTypeAnnotation' || node.type === 'IntersectionTypeAnnotation' || node.type === 'MixedTypeAnnotation' || node.type === 'EmptyTypeAnnotation' || node.type === 'NullableTypeAnnotation' || node.type === 'NumberLiteralTypeAnnotation' || node.type === 'NumberTypeAnnotation' || node.type === 'ObjectTypeAnnotation' || node.type === 'ObjectTypeInternalSlot' || node.type === 'ObjectTypeCallProperty' || node.type === 'ObjectTypeIndexer' || node.type === 'ObjectTypeProperty' || node.type === 'ObjectTypeSpreadProperty' || node.type === 'OpaqueType' || node.type === 'QualifiedTypeIdentifier' || node.type === 'StringLiteralTypeAnnotation' || node.type === 'StringTypeAnnotation' || node.type === 'SymbolTypeAnnotation' || node.type === 'ThisTypeAnnotation' || node.type === 'TupleTypeAnnotation' || node.type === 'TypeofTypeAnnotation' || node.type === 'TypeAlias' || node.type === 'TypeAnnotation' || node.type === 'TypeCastExpression' || node.type === 'TypeParameter' || node.type === 'TypeParameterDeclaration' || node.type === 'TypeParameterInstantiation' || node.type === 'UnionTypeAnnotation' || node.type === 'Variance' || node.type === 'VoidTypeAnnotation' || node.type === 'IndexedAccessType' || node.type === 'OptionalIndexedAccessType'));
+  declare export function isFlowType(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'AnyTypeAnnotation' || node.type === 'ArrayTypeAnnotation' || node.type === 'BooleanTypeAnnotation' || node.type === 'BooleanLiteralTypeAnnotation' || node.type === 'NullLiteralTypeAnnotation' || node.type === 'ExistsTypeAnnotation' || node.type === 'FunctionTypeAnnotation' || node.type === 'GenericTypeAnnotation' || node.type === 'InterfaceTypeAnnotation' || node.type === 'IntersectionTypeAnnotation' || node.type === 'MixedTypeAnnotation' || node.type === 'EmptyTypeAnnotation' || node.type === 'NullableTypeAnnotation' || node.type === 'NumberLiteralTypeAnnotation' || node.type === 'NumberTypeAnnotation' || node.type === 'ObjectTypeAnnotation' || node.type === 'StringLiteralTypeAnnotation' || node.type === 'StringTypeAnnotation' || node.type === 'SymbolTypeAnnotation' || node.type === 'ThisTypeAnnotation' || node.type === 'TupleTypeAnnotation' || node.type === 'TypeofTypeAnnotation' || node.type === 'UnionTypeAnnotation' || node.type === 'VoidTypeAnnotation' || node.type === 'IndexedAccessType' || node.type === 'OptionalIndexedAccessType'));
+  declare export function isFlowBaseAnnotation(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'AnyTypeAnnotation' || node.type === 'BooleanTypeAnnotation' || node.type === 'NullLiteralTypeAnnotation' || node.type === 'MixedTypeAnnotation' || node.type === 'EmptyTypeAnnotation' || node.type === 'NumberTypeAnnotation' || node.type === 'StringTypeAnnotation' || node.type === 'SymbolTypeAnnotation' || node.type === 'ThisTypeAnnotation' || node.type === 'VoidTypeAnnotation'));
+  declare export function isFlowDeclaration(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'DeclareClass' || node.type === 'DeclareFunction' || node.type === 'DeclareInterface' || node.type === 'DeclareModule' || node.type === 'DeclareModuleExports' || node.type === 'DeclareTypeAlias' || node.type === 'DeclareOpaqueType' || node.type === 'DeclareVariable' || node.type === 'DeclareExportDeclaration' || node.type === 'DeclareExportAllDeclaration' || node.type === 'InterfaceDeclaration' || node.type === 'OpaqueType' || node.type === 'TypeAlias'));
+  declare export function isFlowPredicate(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'DeclaredPredicate' || node.type === 'InferredPredicate'));
+  declare export function isEnumBody(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'EnumBooleanBody' || node.type === 'EnumNumberBody' || node.type === 'EnumStringBody' || node.type === 'EnumSymbolBody'));
+  declare export function isEnumMember(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'EnumBooleanMember' || node.type === 'EnumNumberMember' || node.type === 'EnumStringMember' || node.type === 'EnumDefaultedMember'));
+  declare export function isJSX(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'JSXAttribute' || node.type === 'JSXClosingElement' || node.type === 'JSXElement' || node.type === 'JSXEmptyExpression' || node.type === 'JSXExpressionContainer' || node.type === 'JSXSpreadChild' || node.type === 'JSXIdentifier' || node.type === 'JSXMemberExpression' || node.type === 'JSXNamespacedName' || node.type === 'JSXOpeningElement' || node.type === 'JSXSpreadAttribute' || node.type === 'JSXText' || node.type === 'JSXFragment' || node.type === 'JSXOpeningFragment' || node.type === 'JSXClosingFragment'));
+  declare export function isPrivate(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'ClassPrivateProperty' || node.type === 'ClassPrivateMethod' || node.type === 'PrivateName'));
+  declare export function isTSTypeElement(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'TSCallSignatureDeclaration' || node.type === 'TSConstructSignatureDeclaration' || node.type === 'TSPropertySignature' || node.type === 'TSMethodSignature' || node.type === 'TSIndexSignature'));
+  declare export function isTSType(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'TSAnyKeyword' || node.type === 'TSBooleanKeyword' || node.type === 'TSBigIntKeyword' || node.type === 'TSIntrinsicKeyword' || node.type === 'TSNeverKeyword' || node.type === 'TSNullKeyword' || node.type === 'TSNumberKeyword' || node.type === 'TSObjectKeyword' || node.type === 'TSStringKeyword' || node.type === 'TSSymbolKeyword' || node.type === 'TSUndefinedKeyword' || node.type === 'TSUnknownKeyword' || node.type === 'TSVoidKeyword' || node.type === 'TSThisType' || node.type === 'TSFunctionType' || node.type === 'TSConstructorType' || node.type === 'TSTypeReference' || node.type === 'TSTypePredicate' || node.type === 'TSTypeQuery' || node.type === 'TSTypeLiteral' || node.type === 'TSArrayType' || node.type === 'TSTupleType' || node.type === 'TSOptionalType' || node.type === 'TSRestType' || node.type === 'TSUnionType' || node.type === 'TSIntersectionType' || node.type === 'TSConditionalType' || node.type === 'TSInferType' || node.type === 'TSParenthesizedType' || node.type === 'TSTypeOperator' || node.type === 'TSIndexedAccessType' || node.type === 'TSMappedType' || node.type === 'TSLiteralType' || node.type === 'TSExpressionWithTypeArguments' || node.type === 'TSImportType'));
+  declare export function isTSBaseType(node: ?Object, opts?: ?Object): boolean %checks (node != null && (node.type === 'TSAnyKeyword' || node.type === 'TSBooleanKeyword' || node.type === 'TSBigIntKeyword' || node.type === 'TSIntrinsicKeyword' || node.type === 'TSNeverKeyword' || node.type === 'TSNullKeyword' || node.type === 'TSNumberKeyword' || node.type === 'TSObjectKeyword' || node.type === 'TSStringKeyword' || node.type === 'TSSymbolKeyword' || node.type === 'TSUndefinedKeyword' || node.type === 'TSUnknownKeyword' || node.type === 'TSVoidKeyword' || node.type === 'TSThisType' || node.type === 'TSLiteralType'));
+  declare export function isNumberLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'NumericLiteral');
+  declare export function isRegexLiteral(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'RegExpLiteral');
+  declare export function isRestProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'RestElement');
+  declare export function isSpreadProperty(node: ?Object, opts?: ?Object): boolean %checks (node != null && node.type === 'SpreadElement');
+  declare export function createTypeAnnotationBasedOnTypeof(type: 'string' | 'number' | 'undefined' | 'boolean' | 'function' | 'object' | 'symbol'): BabelNodeTypeAnnotation
+  declare export function createUnionTypeAnnotation(types: Array<BabelNodeFlowType>): BabelNodeUnionTypeAnnotation
+  declare export function createFlowUnionType(types: Array<BabelNodeFlowType>): BabelNodeUnionTypeAnnotation
+  declare export function buildChildren(node: { children: Array<BabelNodeJSXText | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXElement | BabelNodeJSXFragment | BabelNodeJSXEmptyExpression> }): Array<BabelNodeJSXText | BabelNodeJSXExpressionContainer | BabelNodeJSXSpreadChild | BabelNodeJSXElement | BabelNodeJSXFragment>
+  declare export function clone<T>(n: T): T;
+  declare export function cloneDeep<T>(n: T): T;
+  declare export function cloneDeepWithoutLoc<T>(n: T): T;
+  declare export function cloneNode<T>(n: T, deep?: boolean, withoutLoc?: boolean): T;
+  declare export function cloneWithoutLoc<T>(n: T): T;
+  declare type CommentTypeShorthand = 'leading' | 'inner' | 'trailing'
+  declare export function addComment<T: Node>(node: T, type: CommentTypeShorthand, content: string, line?: boolean): T
+  declare export function addComments<T: Node>(node: T, type: CommentTypeShorthand, comments: Array<Comment>): T
+  declare export function inheritInnerComments(node: Node, parent: Node): void
+  declare export function inheritLeadingComments(node: Node, parent: Node): void
+  declare export function inheritsComments<T: Node>(node: T, parent: Node): void
+  declare export function inheritTrailingComments(node: Node, parent: Node): void
+  declare export function removeComments<T: Node>(node: T): T
+  declare export function ensureBlock(node: BabelNode, key: string): BabelNodeBlockStatement
+  declare export function toBindingIdentifierName(name?: ?string): string
+  declare export function toBlock(node: BabelNodeStatement | BabelNodeExpression, parent?: BabelNodeFunction | null): BabelNodeBlockStatement
+  declare export function toComputedKey(node: BabelNodeMethod | BabelNodeProperty, key?: BabelNodeExpression | BabelNodeIdentifier): BabelNodeExpression
+  declare export function toExpression(node: BabelNodeExpressionStatement | BabelNodeExpression | BabelNodeClass | BabelNodeFunction): BabelNodeExpression
+  declare export function toIdentifier(name?: ?string): string
+  declare export function toKeyAlias(node: BabelNodeMethod | BabelNodeProperty, key?: BabelNode): string
+  declare export function toStatement(node: BabelNodeStatement | BabelNodeClass | BabelNodeFunction | BabelNodeAssignmentExpression, ignore?: boolean): BabelNodeStatement | void
+  declare export function valueToNode(value: any): BabelNodeExpression
+  declare export function removeTypeDuplicates(types: Array<BabelNodeFlowType>): Array<BabelNodeFlowType>
+  declare export function appendToMemberExpression(member: BabelNodeMemberExpression, append: BabelNode, computed?: boolean): BabelNodeMemberExpression
+  declare export function inherits<T: Node>(child: T, parent: BabelNode | null | void): T
+  declare export function prependToMemberExpression(member: BabelNodeMemberExpression, prepend: BabelNodeExpression): BabelNodeMemberExpression
+  declare export function removeProperties<T>(n: T, opts: ?{}): void;
+  declare export function removePropertiesDeep<T>(n: T, opts: ?{}): T;
+  declare export function getBindingIdentifiers(node: BabelNode, duplicates: boolean, outerOnly?: boolean): { [key: string]: BabelNodeIdentifier | Array<BabelNodeIdentifier> }
+  declare export function getOuterBindingIdentifiers(node: Node, duplicates: boolean): { [key: string]: BabelNodeIdentifier | Array<BabelNodeIdentifier> }
+  declare export type TraversalAncestors = Array<{
+    node: BabelNode,
+    key: string,
+    index?: number,
+  }>;
+  declare export type TraversalHandler<T> = (BabelNode, TraversalAncestors, T) => void;
+  declare export type TraversalHandlers<T> = {
+    enter?: TraversalHandler<T>,
+    exit?: TraversalHandler<T>,
+  };
+  declare export function traverse<T>(n: BabelNode, TraversalHandler<T> | TraversalHandlers<T>, state?: T): void;
+  declare export function traverseFast<T>(n: Node, h: TraversalHandler<T>, state?: T): void;
+  declare export function shallowEqual(actual: Object, expected: Object): boolean
+  declare export function buildMatchMemberExpression(match: string, allowPartial?: boolean): (?BabelNode) => boolean
+  declare export function is(type: string, n: BabelNode, opts: Object): boolean;
+  declare export function isBinding(node: BabelNode, parent: BabelNode, grandparent?: BabelNode): boolean
+  declare export function isBlockScoped(node: BabelNode): boolean
+  declare export function isLet(node: BabelNode): boolean %checks (node.type === 'VariableDeclaration')
+  declare export function isNode(node: ?Object): boolean
+  declare export function isNodesEquivalent(a: any, b: any): boolean
+  declare export function isPlaceholderType(placeholderType: string, targetType: string): boolean
+  declare export function isReferenced(node: BabelNode, parent: BabelNode, grandparent?: BabelNode): boolean
+  declare export function isScope(node: BabelNode, parent: BabelNode): boolean %checks (node.type === 'BlockStatement' ||  node.type === 'CatchClause' || node.type === 'DoWhileStatement' || node.type === 'ForInStatement' || node.type === 'ForStatement' || node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'Program' || node.type === 'ObjectMethod' || node.type === 'SwitchStatement' || node.type === 'WhileStatement' || node.type === 'ArrowFunctionExpression' || node.type === 'ClassExpression' || node.type === 'ClassDeclaration' || node.type === 'ForOfStatement' || node.type === 'ClassMethod' || node.type === 'ClassPrivateMethod' || node.type === 'TSModuleBlock')
+  declare export function isSpecifierDefault(specifier: BabelNodeModuleSpecifier): boolean
+  declare export function isType(nodetype: ?string, targetType: string): boolean
+  declare export function isValidES3Identifier(name: string): boolean
+  declare export function isValidES3Identifier(name: string): boolean
+  declare export function isValidIdentifier(name: string): boolean
+  declare export function isVar(node: BabelNode): boolean %checks (node.type === 'VariableDeclaration')
+  declare export function matchesPattern(node: ?BabelNode, match: string | Array<string>, allowPartial?: boolean): boolean
+  declare export function validate(n: BabelNode, key: string, value: mixed): void;
+  declare export type Node = BabelNode;
+  declare export type CommentBlock = BabelNodeCommentBlock;
+  declare export type CommentLine = BabelNodeCommentLine;
+  declare export type Comment = BabelNodeComment;
+  declare export type SourceLocation = BabelNodeSourceLocation;
+  declare export type ArrayExpression = BabelNodeArrayExpression;
+  declare export type AssignmentExpression = BabelNodeAssignmentExpression;
+  declare export type BinaryExpression = BabelNodeBinaryExpression;
+  declare export type InterpreterDirective = BabelNodeInterpreterDirective;
+  declare export type Directive = BabelNodeDirective;
+  declare export type DirectiveLiteral = BabelNodeDirectiveLiteral;
+  declare export type BlockStatement = BabelNodeBlockStatement;
+  declare export type BreakStatement = BabelNodeBreakStatement;
+  declare export type CallExpression = BabelNodeCallExpression;
+  declare export type CatchClause = BabelNodeCatchClause;
+  declare export type ConditionalExpression = BabelNodeConditionalExpression;
+  declare export type ContinueStatement = BabelNodeContinueStatement;
+  declare export type DebuggerStatement = BabelNodeDebuggerStatement;
+  declare export type DoWhileStatement = BabelNodeDoWhileStatement;
+  declare export type EmptyStatement = BabelNodeEmptyStatement;
+  declare export type ExpressionStatement = BabelNodeExpressionStatement;
+  declare export type File = BabelNodeFile;
+  declare export type ForInStatement = BabelNodeForInStatement;
+  declare export type ForStatement = BabelNodeForStatement;
+  declare export type FunctionDeclaration = BabelNodeFunctionDeclaration;
+  declare export type FunctionExpression = BabelNodeFunctionExpression;
+  declare export type Identifier = BabelNodeIdentifier;
+  declare export type IfStatement = BabelNodeIfStatement;
+  declare export type LabeledStatement = BabelNodeLabeledStatement;
+  declare export type StringLiteral = BabelNodeStringLiteral;
+  declare export type NumericLiteral = BabelNodeNumericLiteral;
+  declare export type NullLiteral = BabelNodeNullLiteral;
+  declare export type BooleanLiteral = BabelNodeBooleanLiteral;
+  declare export type RegExpLiteral = BabelNodeRegExpLiteral;
+  declare export type LogicalExpression = BabelNodeLogicalExpression;
+  declare export type MemberExpression = BabelNodeMemberExpression;
+  declare export type NewExpression = BabelNodeNewExpression;
+  declare export type Program = BabelNodeProgram;
+  declare export type ObjectExpression = BabelNodeObjectExpression;
+  declare export type ObjectMethod = BabelNodeObjectMethod;
+  declare export type ObjectProperty = BabelNodeObjectProperty;
+  declare export type RestElement = BabelNodeRestElement;
+  declare export type ReturnStatement = BabelNodeReturnStatement;
+  declare export type SequenceExpression = BabelNodeSequenceExpression;
+  declare export type ParenthesizedExpression = BabelNodeParenthesizedExpression;
+  declare export type SwitchCase = BabelNodeSwitchCase;
+  declare export type SwitchStatement = BabelNodeSwitchStatement;
+  declare export type ThisExpression = BabelNodeThisExpression;
+  declare export type ThrowStatement = BabelNodeThrowStatement;
+  declare export type TryStatement = BabelNodeTryStatement;
+  declare export type UnaryExpression = BabelNodeUnaryExpression;
+  declare export type UpdateExpression = BabelNodeUpdateExpression;
+  declare export type VariableDeclaration = BabelNodeVariableDeclaration;
+  declare export type VariableDeclarator = BabelNodeVariableDeclarator;
+  declare export type WhileStatement = BabelNodeWhileStatement;
+  declare export type WithStatement = BabelNodeWithStatement;
+  declare export type AssignmentPattern = BabelNodeAssignmentPattern;
+  declare export type ArrayPattern = BabelNodeArrayPattern;
+  declare export type ArrowFunctionExpression = BabelNodeArrowFunctionExpression;
+  declare export type ClassBody = BabelNodeClassBody;
+  declare export type ClassExpression = BabelNodeClassExpression;
+  declare export type ClassDeclaration = BabelNodeClassDeclaration;
+  declare export type ExportAllDeclaration = BabelNodeExportAllDeclaration;
+  declare export type ExportDefaultDeclaration = BabelNodeExportDefaultDeclaration;
+  declare export type ExportNamedDeclaration = BabelNodeExportNamedDeclaration;
+  declare export type ExportSpecifier = BabelNodeExportSpecifier;
+  declare export type ForOfStatement = BabelNodeForOfStatement;
+  declare export type ImportDeclaration = BabelNodeImportDeclaration;
+  declare export type ImportDefaultSpecifier = BabelNodeImportDefaultSpecifier;
+  declare export type ImportNamespaceSpecifier = BabelNodeImportNamespaceSpecifier;
+  declare export type ImportSpecifier = BabelNodeImportSpecifier;
+  declare export type MetaProperty = BabelNodeMetaProperty;
+  declare export type ClassMethod = BabelNodeClassMethod;
+  declare export type ObjectPattern = BabelNodeObjectPattern;
+  declare export type SpreadElement = BabelNodeSpreadElement;
+  declare export type Super = BabelNodeSuper;
+  declare export type TaggedTemplateExpression = BabelNodeTaggedTemplateExpression;
+  declare export type TemplateElement = BabelNodeTemplateElement;
+  declare export type TemplateLiteral = BabelNodeTemplateLiteral;
+  declare export type YieldExpression = BabelNodeYieldExpression;
+  declare export type AwaitExpression = BabelNodeAwaitExpression;
+  declare export type Import = BabelNodeImport;
+  declare export type BigIntLiteral = BabelNodeBigIntLiteral;
+  declare export type ExportNamespaceSpecifier = BabelNodeExportNamespaceSpecifier;
+  declare export type OptionalMemberExpression = BabelNodeOptionalMemberExpression;
+  declare export type OptionalCallExpression = BabelNodeOptionalCallExpression;
+  declare export type AnyTypeAnnotation = BabelNodeAnyTypeAnnotation;
+  declare export type ArrayTypeAnnotation = BabelNodeArrayTypeAnnotation;
+  declare export type BooleanTypeAnnotation = BabelNodeBooleanTypeAnnotation;
+  declare export type BooleanLiteralTypeAnnotation = BabelNodeBooleanLiteralTypeAnnotation;
+  declare export type NullLiteralTypeAnnotation = BabelNodeNullLiteralTypeAnnotation;
+  declare export type ClassImplements = BabelNodeClassImplements;
+  declare export type DeclareClass = BabelNodeDeclareClass;
+  declare export type DeclareFunction = BabelNodeDeclareFunction;
+  declare export type DeclareInterface = BabelNodeDeclareInterface;
+  declare export type DeclareModule = BabelNodeDeclareModule;
+  declare export type DeclareModuleExports = BabelNodeDeclareModuleExports;
+  declare export type DeclareTypeAlias = BabelNodeDeclareTypeAlias;
+  declare export type DeclareOpaqueType = BabelNodeDeclareOpaqueType;
+  declare export type DeclareVariable = BabelNodeDeclareVariable;
+  declare export type DeclareExportDeclaration = BabelNodeDeclareExportDeclaration;
+  declare export type DeclareExportAllDeclaration = BabelNodeDeclareExportAllDeclaration;
+  declare export type DeclaredPredicate = BabelNodeDeclaredPredicate;
+  declare export type ExistsTypeAnnotation = BabelNodeExistsTypeAnnotation;
+  declare export type FunctionTypeAnnotation = BabelNodeFunctionTypeAnnotation;
+  declare export type FunctionTypeParam = BabelNodeFunctionTypeParam;
+  declare export type GenericTypeAnnotation = BabelNodeGenericTypeAnnotation;
+  declare export type InferredPredicate = BabelNodeInferredPredicate;
+  declare export type InterfaceExtends = BabelNodeInterfaceExtends;
+  declare export type InterfaceDeclaration = BabelNodeInterfaceDeclaration;
+  declare export type InterfaceTypeAnnotation = BabelNodeInterfaceTypeAnnotation;
+  declare export type IntersectionTypeAnnotation = BabelNodeIntersectionTypeAnnotation;
+  declare export type MixedTypeAnnotation = BabelNodeMixedTypeAnnotation;
+  declare export type EmptyTypeAnnotation = BabelNodeEmptyTypeAnnotation;
+  declare export type NullableTypeAnnotation = BabelNodeNullableTypeAnnotation;
+  declare export type NumberLiteralTypeAnnotation = BabelNodeNumberLiteralTypeAnnotation;
+  declare export type NumberTypeAnnotation = BabelNodeNumberTypeAnnotation;
+  declare export type ObjectTypeAnnotation = BabelNodeObjectTypeAnnotation;
+  declare export type ObjectTypeInternalSlot = BabelNodeObjectTypeInternalSlot;
+  declare export type ObjectTypeCallProperty = BabelNodeObjectTypeCallProperty;
+  declare export type ObjectTypeIndexer = BabelNodeObjectTypeIndexer;
+  declare export type ObjectTypeProperty = BabelNodeObjectTypeProperty;
+  declare export type ObjectTypeSpreadProperty = BabelNodeObjectTypeSpreadProperty;
+  declare export type OpaqueType = BabelNodeOpaqueType;
+  declare export type QualifiedTypeIdentifier = BabelNodeQualifiedTypeIdentifier;
+  declare export type StringLiteralTypeAnnotation = BabelNodeStringLiteralTypeAnnotation;
+  declare export type StringTypeAnnotation = BabelNodeStringTypeAnnotation;
+  declare export type SymbolTypeAnnotation = BabelNodeSymbolTypeAnnotation;
+  declare export type ThisTypeAnnotation = BabelNodeThisTypeAnnotation;
+  declare export type TupleTypeAnnotation = BabelNodeTupleTypeAnnotation;
+  declare export type TypeofTypeAnnotation = BabelNodeTypeofTypeAnnotation;
+  declare export type TypeAlias = BabelNodeTypeAlias;
+  declare export type TypeAnnotation = BabelNodeTypeAnnotation;
+  declare export type TypeCastExpression = BabelNodeTypeCastExpression;
+  declare export type TypeParameter = BabelNodeTypeParameter;
+  declare export type TypeParameterDeclaration = BabelNodeTypeParameterDeclaration;
+  declare export type TypeParameterInstantiation = BabelNodeTypeParameterInstantiation;
+  declare export type UnionTypeAnnotation = BabelNodeUnionTypeAnnotation;
+  declare export type Variance = BabelNodeVariance;
+  declare export type VoidTypeAnnotation = BabelNodeVoidTypeAnnotation;
+  declare export type EnumDeclaration = BabelNodeEnumDeclaration;
+  declare export type EnumBooleanBody = BabelNodeEnumBooleanBody;
+  declare export type EnumNumberBody = BabelNodeEnumNumberBody;
+  declare export type EnumStringBody = BabelNodeEnumStringBody;
+  declare export type EnumSymbolBody = BabelNodeEnumSymbolBody;
+  declare export type EnumBooleanMember = BabelNodeEnumBooleanMember;
+  declare export type EnumNumberMember = BabelNodeEnumNumberMember;
+  declare export type EnumStringMember = BabelNodeEnumStringMember;
+  declare export type EnumDefaultedMember = BabelNodeEnumDefaultedMember;
+  declare export type IndexedAccessType = BabelNodeIndexedAccessType;
+  declare export type OptionalIndexedAccessType = BabelNodeOptionalIndexedAccessType;
+  declare export type JSXAttribute = BabelNodeJSXAttribute;
+  declare export type JSXClosingElement = BabelNodeJSXClosingElement;
+  declare export type JSXElement = BabelNodeJSXElement;
+  declare export type JSXEmptyExpression = BabelNodeJSXEmptyExpression;
+  declare export type JSXExpressionContainer = BabelNodeJSXExpressionContainer;
+  declare export type JSXSpreadChild = BabelNodeJSXSpreadChild;
+  declare export type JSXIdentifier = BabelNodeJSXIdentifier;
+  declare export type JSXMemberExpression = BabelNodeJSXMemberExpression;
+  declare export type JSXNamespacedName = BabelNodeJSXNamespacedName;
+  declare export type JSXOpeningElement = BabelNodeJSXOpeningElement;
+  declare export type JSXSpreadAttribute = BabelNodeJSXSpreadAttribute;
+  declare export type JSXText = BabelNodeJSXText;
+  declare export type JSXFragment = BabelNodeJSXFragment;
+  declare export type JSXOpeningFragment = BabelNodeJSXOpeningFragment;
+  declare export type JSXClosingFragment = BabelNodeJSXClosingFragment;
+  declare export type Noop = BabelNodeNoop;
+  declare export type Placeholder = BabelNodePlaceholder;
+  declare export type V8IntrinsicIdentifier = BabelNodeV8IntrinsicIdentifier;
+  declare export type ArgumentPlaceholder = BabelNodeArgumentPlaceholder;
+  declare export type BindExpression = BabelNodeBindExpression;
+  declare export type ClassProperty = BabelNodeClassProperty;
+  declare export type PipelineTopicExpression = BabelNodePipelineTopicExpression;
+  declare export type PipelineBareFunction = BabelNodePipelineBareFunction;
+  declare export type PipelinePrimaryTopicReference = BabelNodePipelinePrimaryTopicReference;
+  declare export type ClassPrivateProperty = BabelNodeClassPrivateProperty;
+  declare export type ClassPrivateMethod = BabelNodeClassPrivateMethod;
+  declare export type ImportAttribute = BabelNodeImportAttribute;
+  declare export type Decorator = BabelNodeDecorator;
+  declare export type DoExpression = BabelNodeDoExpression;
+  declare export type ExportDefaultSpecifier = BabelNodeExportDefaultSpecifier;
+  declare export type PrivateName = BabelNodePrivateName;
+  declare export type RecordExpression = BabelNodeRecordExpression;
+  declare export type TupleExpression = BabelNodeTupleExpression;
+  declare export type DecimalLiteral = BabelNodeDecimalLiteral;
+  declare export type StaticBlock = BabelNodeStaticBlock;
+  declare export type ModuleExpression = BabelNodeModuleExpression;
+  declare export type TSParameterProperty = BabelNodeTSParameterProperty;
+  declare export type TSDeclareFunction = BabelNodeTSDeclareFunction;
+  declare export type TSDeclareMethod = BabelNodeTSDeclareMethod;
+  declare export type TSQualifiedName = BabelNodeTSQualifiedName;
+  declare export type TSCallSignatureDeclaration = BabelNodeTSCallSignatureDeclaration;
+  declare export type TSConstructSignatureDeclaration = BabelNodeTSConstructSignatureDeclaration;
+  declare export type TSPropertySignature = BabelNodeTSPropertySignature;
+  declare export type TSMethodSignature = BabelNodeTSMethodSignature;
+  declare export type TSIndexSignature = BabelNodeTSIndexSignature;
+  declare export type TSAnyKeyword = BabelNodeTSAnyKeyword;
+  declare export type TSBooleanKeyword = BabelNodeTSBooleanKeyword;
+  declare export type TSBigIntKeyword = BabelNodeTSBigIntKeyword;
+  declare export type TSIntrinsicKeyword = BabelNodeTSIntrinsicKeyword;
+  declare export type TSNeverKeyword = BabelNodeTSNeverKeyword;
+  declare export type TSNullKeyword = BabelNodeTSNullKeyword;
+  declare export type TSNumberKeyword = BabelNodeTSNumberKeyword;
+  declare export type TSObjectKeyword = BabelNodeTSObjectKeyword;
+  declare export type TSStringKeyword = BabelNodeTSStringKeyword;
+  declare export type TSSymbolKeyword = BabelNodeTSSymbolKeyword;
+  declare export type TSUndefinedKeyword = BabelNodeTSUndefinedKeyword;
+  declare export type TSUnknownKeyword = BabelNodeTSUnknownKeyword;
+  declare export type TSVoidKeyword = BabelNodeTSVoidKeyword;
+  declare export type TSThisType = BabelNodeTSThisType;
+  declare export type TSFunctionType = BabelNodeTSFunctionType;
+  declare export type TSConstructorType = BabelNodeTSConstructorType;
+  declare export type TSTypeReference = BabelNodeTSTypeReference;
+  declare export type TSTypePredicate = BabelNodeTSTypePredicate;
+  declare export type TSTypeQuery = BabelNodeTSTypeQuery;
+  declare export type TSTypeLiteral = BabelNodeTSTypeLiteral;
+  declare export type TSArrayType = BabelNodeTSArrayType;
+  declare export type TSTupleType = BabelNodeTSTupleType;
+  declare export type TSOptionalType = BabelNodeTSOptionalType;
+  declare export type TSRestType = BabelNodeTSRestType;
+  declare export type TSNamedTupleMember = BabelNodeTSNamedTupleMember;
+  declare export type TSUnionType = BabelNodeTSUnionType;
+  declare export type TSIntersectionType = BabelNodeTSIntersectionType;
+  declare export type TSConditionalType = BabelNodeTSConditionalType;
+  declare export type TSInferType = BabelNodeTSInferType;
+  declare export type TSParenthesizedType = BabelNodeTSParenthesizedType;
+  declare export type TSTypeOperator = BabelNodeTSTypeOperator;
+  declare export type TSIndexedAccessType = BabelNodeTSIndexedAccessType;
+  declare export type TSMappedType = BabelNodeTSMappedType;
+  declare export type TSLiteralType = BabelNodeTSLiteralType;
+  declare export type TSExpressionWithTypeArguments = BabelNodeTSExpressionWithTypeArguments;
+  declare export type TSInterfaceDeclaration = BabelNodeTSInterfaceDeclaration;
+  declare export type TSInterfaceBody = BabelNodeTSInterfaceBody;
+  declare export type TSTypeAliasDeclaration = BabelNodeTSTypeAliasDeclaration;
+  declare export type TSAsExpression = BabelNodeTSAsExpression;
+  declare export type TSTypeAssertion = BabelNodeTSTypeAssertion;
+  declare export type TSEnumDeclaration = BabelNodeTSEnumDeclaration;
+  declare export type TSEnumMember = BabelNodeTSEnumMember;
+  declare export type TSModuleDeclaration = BabelNodeTSModuleDeclaration;
+  declare export type TSModuleBlock = BabelNodeTSModuleBlock;
+  declare export type TSImportType = BabelNodeTSImportType;
+  declare export type TSImportEqualsDeclaration = BabelNodeTSImportEqualsDeclaration;
+  declare export type TSExternalModuleReference = BabelNodeTSExternalModuleReference;
+  declare export type TSNonNullExpression = BabelNodeTSNonNullExpression;
+  declare export type TSExportAssignment = BabelNodeTSExportAssignment;
+  declare export type TSNamespaceExportDeclaration = BabelNodeTSNamespaceExportDeclaration;
+  declare export type TSTypeAnnotation = BabelNodeTSTypeAnnotation;
+  declare export type TSTypeParameterInstantiation = BabelNodeTSTypeParameterInstantiation;
+  declare export type TSTypeParameterDeclaration = BabelNodeTSTypeParameterDeclaration;
+  declare export type TSTypeParameter = BabelNodeTSTypeParameter;
+  declare export type Expression = BabelNodeExpression;
+  declare export type Binary = BabelNodeBinary;
+  declare export type Scopable = BabelNodeScopable;
+  declare export type BlockParent = BabelNodeBlockParent;
+  declare export type Block = BabelNodeBlock;
+  declare export type Statement = BabelNodeStatement;
+  declare export type Terminatorless = BabelNodeTerminatorless;
+  declare export type CompletionStatement = BabelNodeCompletionStatement;
+  declare export type Conditional = BabelNodeConditional;
+  declare export type Loop = BabelNodeLoop;
+  declare export type While = BabelNodeWhile;
+  declare export type ExpressionWrapper = BabelNodeExpressionWrapper;
+  declare export type For = BabelNodeFor;
+  declare export type ForXStatement = BabelNodeForXStatement;
+  declare export type Function = BabelNodeFunction;
+  declare export type FunctionParent = BabelNodeFunctionParent;
+  declare export type Pureish = BabelNodePureish;
+  declare export type Declaration = BabelNodeDeclaration;
+  declare export type PatternLike = BabelNodePatternLike;
+  declare export type LVal = BabelNodeLVal;
+  declare export type TSEntityName = BabelNodeTSEntityName;
+  declare export type Literal = BabelNodeLiteral;
+  declare export type Immutable = BabelNodeImmutable;
+  declare export type UserWhitespacable = BabelNodeUserWhitespacable;
+  declare export type Method = BabelNodeMethod;
+  declare export type ObjectMember = BabelNodeObjectMember;
+  declare export type Property = BabelNodeProperty;
+  declare export type UnaryLike = BabelNodeUnaryLike;
+  declare export type Pattern = BabelNodePattern;
+  declare export type Class = BabelNodeClass;
+  declare export type ModuleDeclaration = BabelNodeModuleDeclaration;
+  declare export type ExportDeclaration = BabelNodeExportDeclaration;
+  declare export type ModuleSpecifier = BabelNodeModuleSpecifier;
+  declare export type Flow = BabelNodeFlow;
+  declare export type FlowType = BabelNodeFlowType;
+  declare export type FlowBaseAnnotation = BabelNodeFlowBaseAnnotation;
+  declare export type FlowDeclaration = BabelNodeFlowDeclaration;
+  declare export type FlowPredicate = BabelNodeFlowPredicate;
+  declare export type EnumBody = BabelNodeEnumBody;
+  declare export type EnumMember = BabelNodeEnumMember;
+  declare export type JSX = BabelNodeJSX;
+  declare export type Private = BabelNodePrivate;
+  declare export type TSTypeElement = BabelNodeTSTypeElement;
+  declare export type TSType = BabelNodeTSType;
+  declare export type TSBaseType = BabelNodeTSBaseType;
+}

--- a/flow-typed/npm/babel_v7.x.x.js
+++ b/flow-typed/npm/babel_v7.x.x.js
@@ -1,0 +1,1330 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+declare type BabelNode_DEPRECATED = any;
+
+type _BabelSourceMap = $ReadOnly<{
+  file?: string,
+  mappings: string,
+  names: Array<string>,
+  sourceRoot?: string,
+  sources: Array<string>,
+  sourcesContent?: Array<?string>,
+  version: number,
+}>;
+
+type _BabelSourceMapSegment = {
+  generated: {column: number, line: number, ...},
+  name?: ?string,
+  original?: {column: number, line: number, ...},
+  source?: ?string,
+  ...
+};
+
+export type BabelSourceLocation = $ReadOnly<{
+  start: $ReadOnly<{line: number, column: number}>,
+  end: $ReadOnly<{line: number, column: number}>,
+}>;
+
+declare module '@babel/parser' {
+  // See https://github.com/babel/babel/blob/master/packages/babel-parser/typings/babel-parser.d.ts
+  declare export type ParserPlugin =
+    | 'asyncGenerators'
+    | 'bigInt'
+    | 'classPrivateMethods'
+    | 'classPrivateProperties'
+    | 'classProperties'
+    | 'decorators'
+    | 'decorators-legacy'
+    | 'doExpressions'
+    | 'dynamicImport'
+    | 'estree'
+    | 'exportDefaultFrom'
+    | 'exportNamespaceFrom' // deprecated
+    | 'flow'
+    | 'flowComments'
+    | 'functionBind'
+    | 'functionSent'
+    | 'importMeta'
+    | 'jsx'
+    | 'logicalAssignment'
+    | 'moduleAttributes'
+    | 'nullishCoalescingOperator'
+    | 'numericSeparator'
+    | 'objectRestSpread'
+    | 'optionalCatchBinding'
+    | 'optionalChaining'
+    | 'partialApplication'
+    | 'pipelineOperator'
+    | 'placeholders'
+    | 'privateIn'
+    | 'throwExpressions'
+    | 'topLevelAwait'
+    | 'typescript'
+    | 'v8intrinsic'
+    | ParserPluginWithOptions;
+
+  declare export type ParserPluginWithOptions =
+    | ['decorators', DecoratorsPluginOptions]
+    | ['pipelineOperator', PipelineOperatorPluginOptions]
+    | ['flow', FlowPluginOptions];
+
+  declare type DecoratorsPluginOptions = {
+    decoratorsBeforeExport?: boolean,
+  };
+
+  declare type PipelineOperatorPluginOptions = {
+    proposal: 'minimal' | 'smart',
+  };
+
+  declare type FlowPluginOptions = {
+    all?: boolean,
+    enums?: boolean,
+  };
+
+  declare export type ParserOptions = {
+    /**
+     * By default, import and export declarations can only appear at a program's top level.
+     * Setting this option to true allows them anywhere where a statement is allowed.
+     * @default false
+     */
+    allowImportExportEverywhere?: boolean,
+
+    /**
+     * By default, await use is only allowed inside of an async function or, when the topLevelAwait plugin is enabled, in the top-level scope of modules.
+     * Set this to true to also accept it in the top-level scope of scripts.
+     * @default false
+     */
+    allowAwaitOutsideFunction?: boolean,
+
+    /**
+     * By default, a return statement at the top level raises an error. Set this to true to accept such code.
+     * @default false
+     */
+    allowReturnOutsideFunction?: boolean,
+
+    /**
+     * By default, super use is not allowed outside of class and object methods. Set this to true to accept such code.
+     * @default false
+     */
+    allowSuperOutsideMethod?: boolean,
+
+    /**
+     * By default, exporting an identifier that was not declared in the current module scope will raise an error.
+     * While this behavior is required by the ECMAScript modules specification,
+     * Babel's parser cannot anticipate transforms later in the plugin pipeline that might insert the appropriate declarations,
+     * so it is sometimes important to set this option to true to prevent the parser from prematurely complaining about undeclared exports that will be added later.
+     * @default false
+     */
+    allowUndeclaredExports?: boolean,
+
+    /**
+     * By default, the parser sets extra.parenthesized on the expression nodes.
+     * When this option is set to true, ParenthesizedExpression AST nodes are created instead.
+     * @default false
+     */
+    createParenthesizedExpressions?: boolean,
+
+    /**
+     * By default, Babel always throws an error when it finds some invalid code.
+     * When this option is set to true, it will store the parsing error and try to continue parsing the invalid input file.
+     * The resulting AST will have an errors property representing an array of all the parsing errors.
+     * Note that even when this option is enabled, @babel/parser could throw for unrecoverable errors.
+     * @default false
+     */
+    errorRecovery?: boolean,
+
+    /**
+     * Array containing the plugins that you want to enable.
+     */
+    plugins?: Array<ParserPlugin>,
+
+    /**
+     * Indicate the mode the code should be parsed in. Can be one of "script", "module", or "unambiguous".
+     * Defaults to "script". "unambiguous" will make @babel/parser attempt to guess, based on the presence of ES6 import or export statements.
+     * Files with ES6 imports and exports are considered "module" and are otherwise "script".
+     * @default 'script'
+     */
+    sourceType?: 'script' | 'module' | 'unambiguous',
+
+    /**
+     * Correlate output AST nodes with their source filename.
+     * Useful when generating code and source maps from the ASTs of multiple input files.
+     */
+    sourceFilename?: string,
+
+    /**
+     * By default, the first line of code parsed is treated as line 1.
+     * You can provide a line number to alternatively start with. Useful for integration with other source tools.
+     * @default 1
+     */
+    startLine?: number,
+
+    /**
+     * By default, ECMAScript code is parsed as strict only if a "use strict"; directive is present or if the parsed file is an ECMAScript module.
+     * Set this option to true to always parse files in strict mode.
+     * @default false
+     */
+    strictMode?: boolean,
+
+    /**
+     * Adds a range property to each node: [node.start, node.end]
+     * @default false
+     */
+    ranges?: boolean,
+
+    /**
+     * Adds all parsed tokens to a tokens property on the File node
+     * default false
+     */
+    tokens?: boolean,
+  };
+
+  /**
+   * Parse the provided code as an entire ECMAScript program.
+   */
+  declare export function parse(
+    input: string,
+    options?: ParserOptions,
+  ): BabelNodeFile;
+
+  /**
+   * Parse the provided code as a single expression.
+   */
+  declare export function parseExpression(
+    input: string,
+    options?: ParserOptions,
+  ): BabelNodeExpression;
+
+  declare type TokenOptions = {
+    keyword?: string,
+    beforeExpr?: boolean,
+    startsExpr?: boolean,
+    rightAssociative?: boolean,
+    isLoop?: boolean,
+    isAssign?: boolean,
+    prefix?: boolean,
+    postfix?: boolean,
+    binop?: ?number,
+  };
+
+  declare class TokenType {
+    label: string;
+    keyword: ?string;
+    beforeExpr: boolean;
+    startsExpr: boolean;
+    rightAssociative: boolean;
+    isLoop: boolean;
+    isAssign: boolean;
+    prefix: boolean;
+    postfix: boolean;
+    binop: ?number;
+    updateContext: ?(prevType: TokenType) => void;
+
+    constructor(label: string, conf?: TokenOptions): TokenType;
+  }
+
+  declare export var tokTypes: {[name: string]: TokenType};
+}
+
+declare module '@babel/core' {
+  import type {Visitor, Scope, Hub, NodePath} from '@babel/traverse';
+  import type {ParserOptions} from '@babel/parser';
+  import typeof {tokTypes as TokTypes} from '@babel/parser';
+  import type {Options as GeneratorOptions} from '@babel/generator';
+  import typeof Template from '@babel/template';
+  import typeof Traverse from '@babel/traverse';
+  import typeof * as Types from '@babel/types';
+
+  declare export var version: string;
+  declare export var tokTypes: TokTypes;
+
+  declare type ImportSpecifier =
+    | {
+        kind: 'named',
+        imported: string,
+        local: string,
+      }
+    | {
+        kind: 'namespace',
+        local: string,
+      };
+
+  declare type ExportSpecifier =
+    | {
+        kind: 'local',
+        name: string,
+        exported: string,
+      }
+    | {
+        kind: 'external',
+        local: string,
+        exported: string,
+        source: string | null,
+      }
+    | {
+        kind: 'external-namespace',
+        exported: string,
+        source: string | null,
+      }
+    | {
+        kind: 'external-all',
+        source: string | null,
+      };
+
+  declare export type BabelFileModulesMetadata = {
+    imports: Array<{
+      source: string,
+      imported: Array<string>,
+      specifiers: Array<ImportSpecifier>,
+    }>,
+    exports: {
+      exported: Array<BabelNode>,
+      specifiers: Array<ExportSpecifier>,
+    },
+  };
+
+  declare export type BabelFileMetadata = {
+    usedHelpers?: Array<string>,
+    marked?: Array<{
+      type: string,
+      message: string,
+      loc: BabelNodeSourceLocation,
+    }>,
+    modules?: BabelFileModulesMetadata,
+    ...
+  };
+
+  declare class Store {
+    constructor(): Store;
+    setDynamic(key: string, fn: () => mixed): void;
+    set(key: string, val: mixed): void;
+    get(key: string): mixed;
+  }
+
+  declare export class File extends Store {
+    static helpers: Array<string>;
+
+    opts: BabelCoreOptions;
+    pluginPasses: Array<Array<{...}>>;
+    parserOpts: ParserOptions;
+    dynamicImportTypes: {...};
+    dynamicImportIds: {...};
+    dynamicImports: Array<{...}>;
+    declarations: {...};
+    usedHelpers: {...};
+    code: string;
+    shebang: string;
+    ast: BabelNode | {};
+    scope: Scope;
+    hub: Hub;
+    path: NodePath<> | null;
+    metadata: BabelFileMetadata;
+
+    constructor(
+      options: BabelCoreOptions,
+      input: $ReadOnly<{ast: BabelNode, code: string, inputMap: any}>,
+    ): File;
+
+    getMetadata(): void;
+
+    getModuleName(): ?string;
+
+    resolveModuleSource(source: string): string;
+
+    addImport(
+      source: string,
+      imported: string,
+      name?: string,
+    ): BabelNodeIdentifier;
+
+    addHelper(name: string): BabelNodeIdentifier;
+
+    addTemplateObject(
+      helperName: string,
+      strings: Array<{...}>,
+      raw: BabelNodeArrayExpression,
+    ): BabelNodeIdentifier;
+
+    buildCodeFrameError<TError: Error>(
+      node: BabelNode,
+      msg: string,
+      Class<TError>,
+    ): TError;
+
+    mergeSourceMap(map: _BabelSourceMap): _BabelSourceMap;
+
+    parse(code: string): BabelNode;
+
+    addAst(ast: BabelNode): void;
+
+    transform(): TransformResult<>;
+
+    wrap(code: string, callback: () => mixed): TransformResult<>;
+
+    addCode(code: string): void;
+
+    parseCode(): void;
+
+    parseInputSourceMap(code: string): string;
+
+    parseShebang(): void;
+
+    makeResult<T>(TransformResult<T>): TransformResult<T>;
+
+    generate(): TransformResult<>;
+  }
+
+  declare export type MatchPattern =
+    | string
+    | RegExp
+    | ((
+        filename: string | void,
+        context: {caller: {name: string} | void},
+        envName: string,
+        dirname: string,
+      ) => boolean);
+
+  declare export type PluginObj<TVisitorState = void> = {
+    name?: string,
+    inherits?: mixed,
+    maniuplateOptions?: (
+      opts: BabelCoreOptions,
+      parserOpts: ParserOptions,
+    ) => void,
+    // this is a PluginPass
+    pre?: (file: File) => void,
+    visitor: Visitor<TVisitorState>,
+    // this is a PluginPass
+    post?: (file: File) => void,
+  };
+
+  // Represents a plugin or presets at a given location in a config object.
+  // At this point these have been resolved to a specific object or function,
+  // but have not yet been executed to call functions with options.
+  declare export type UnloadedDescriptor = {
+    name: string | void,
+    value: PluginObj<mixed> | (() => PluginObj<mixed>),
+    options: EntryOptions,
+    dirname: string,
+    alias: string,
+    ownPass?: boolean,
+    file?: {
+      request: string,
+      resolved: string,
+    } | void,
+  };
+
+  declare export class ConfigItem {
+    +value: PluginObj<mixed> | (() => PluginObj<mixed>);
+    +options: EntryOptions;
+    +dirname: string;
+    +name: string | void;
+    +file: {
+      +request: string,
+      +resolved: string,
+    } | void;
+
+    constructor(descriptor: UnloadedDescriptor): ConfigItem;
+  }
+
+  declare export type EntryTarget = string | {...} | Function;
+  declare export type EntryOptions = {...} | false | void;
+  declare export type PluginEntry =
+    | EntryTarget
+    | ConfigItem
+    | [EntryTarget]
+    | [EntryTarget, EntryOptions]
+    | [EntryTarget, EntryOptions, string | void];
+
+  declare export type Plugins = Array<PluginEntry>;
+  declare export type PresetEntry = PluginEntry;
+  declare export type Presets = Array<PresetEntry>;
+
+  // See https://babeljs.io/docs/en/next/options#code-generator-options
+  declare export type BabelCoreOptions = {|
+    // Primary options
+
+    /**
+     * The working directory that all paths in the programmatic options will be resolved relative to.
+     * default process.cwd()
+     */
+    cwd?: string,
+
+    caller?: {
+      name: string,
+      supportsStaticESM?: boolean,
+      supportsDynamicImport?: boolean,
+      supportsTopLevelAwait?: boolean,
+      supportsExportNamespaceFrom?: boolean,
+      ...
+    },
+
+    /**
+     * The filename associated with the code currently being compiled, if there is one.
+     * The filename is optional, but not all of Babel's functionality is available when the filename is unknown, because a subset of options rely on the filename for their functionality.
+     *
+     * The three primary cases users could run into are:
+     * - The filename is exposed to plugins. Some plugins may require the presence of the filename.
+     * - Options like "test", "exclude", and "ignore" require the filename for string/RegExp matching.
+     * - .babelrc.json files are loaded relative to the file being compiled. If this option is omitted, Babel will behave as if babelrc: false has been set.
+     */
+    filename?: string,
+
+    /**
+     * Used as the default value for Babel's sourceFileName option, and used as part of generation of filenames for the AMD / UMD / SystemJS module transforms.
+     * @default path.relative(opts.cwd, opts.filename) (if opts.filename was passed)
+     */
+    filenameRelative?: string,
+
+    /**
+     * Babel's default return value includes code and map properties with the resulting generated code.
+     * In some contexts where multiple calls to Babel are being made,
+     * it can be helpful to disable code generation and instead use ast: true to get the AST directly in order to avoid doing unnecessary work.
+     * @default true
+     */
+    code?: boolean,
+
+    /**
+     * Babel's default is to generate a string and a sourcemap, but in some contexts it can be useful to get the AST itself.
+     * The primary use case for this would be a chain of multiple transform passes.
+     * @default false
+     */
+    ast?: boolean,
+
+    /**
+     * By default babel.transformFromAst will clone the input AST to avoid mutations.
+     * Specifying cloneInputAst: false can improve parsing performance if the input AST is not used elsewhere.
+     */
+    cloneInputAst?: boolean,
+
+    // Config Loading options
+
+    /**
+     * The initial path that will be processed based on the "rootMode" to determine the conceptual root folder for the current Babel project.
+     * This is used in two primary cases:
+     *
+     * - The base directory when checking for the default "configFile" value
+     * - The default value for "babelrcRoots".
+     * @default opts.cwd
+     */
+    root?: string,
+
+    /**
+     * This option, combined with the "root" value, defines how Babel chooses its project root.
+     * The different modes define different ways that Babel can process the "root" value to get the final project root.
+     * - "root" - Passes the "root" value through as unchanged.
+     * - "upward" - Walks upward from the "root" directory, looking for a directory containing a babel.config.json file,
+     *              and throws an error if a babel.config.json is not found.
+     * - "upward-optional" - Walk upward from the "root" directory, looking for a directory containing a babel.config.json file,
+     *            and falls back to "root" if a babel.config.json is not found.
+     *
+     * "root" is the default mode because it avoids the risk that Babel will accidentally load a babel.config.json
+     * that is entirely outside of the current project folder. If you use "upward-optional",
+     * be aware that it will walk up the directory structure all the way to the filesystem root,
+     * and it is always possible that someone will have a forgotten babel.config.json in their home directory,
+     * which could cause unexpected errors in your builds.
+     *
+     * Users with monorepo project structures that run builds/tests on a per-package basis may well want to use "upward"
+     * since monorepos often have a babel.config.json in the project root.
+     * Running Babel in a monorepo subdirectory without "upward",
+     * will cause Babel to skip loading any babel.config.json files in the project root,
+     * which can lead to unexpected errors and compilation failure.
+     * @default "root"
+     */
+    rootMode?: 'root' | 'upward' | 'upward-optional',
+
+    /**
+     * The current active environment used during configuration loading.
+     * This value is used as the key when resolving "env" configs, and is also available inside configuration functions,
+     * plugins, and presets, via the api.env() function.
+     * @default process.env.BABEL_ENV || process.env.NODE_ENV || "development"
+     */
+    envName?: string,
+
+    /**
+     * Defaults to searching for a default babel.config.json file, but can be passed the path of any JS or JSON5 config file.
+     *
+     * NOTE: This option does not affect loading of .babelrc.json files, so while it may be tempting to do configFile: "./foo/.babelrc.json",
+     * it is not recommended. If the given .babelrc.json is loaded via the standard file-relative logic,
+     * you'll end up loading the same config file twice, merging it with itself.
+     * If you are linking a specific config file, it is recommended to stick with a naming scheme that is independent of the "babelrc" name.
+     *
+     * @default path.resolve(opts.root, "babel.config.json"), if exists, false otherwise
+     */
+    configFile?: string | boolean,
+
+    /**
+     * true will enable searching for configuration files relative to the "filename" provided to Babel.
+     * A babelrc value passed in the programmatic options will override one set within a configuration file.
+     *
+     * Note: .babelrc.json files are only loaded if the current "filename" is inside of a package that matches one of the "babelrcRoots" packages.
+     *
+     * @default true as long as the filename option has been specified
+     */
+    babelrc?: boolean,
+
+    /**
+     * By default, Babel will only search for .babelrc.json files within the "root" package
+     * because otherwise Babel cannot know if a given .babelrc.json is meant to be loaded,
+     * or if it's "plugins" and "presets" have even been installed, since the file being compiled could be inside node_modules,
+     * or have been symlinked into the project.
+     *
+     * This option allows users to provide a list of other packages that should be considered "root" packages
+     * when considering whether to load .babelrc.json files.
+     *
+     * @default opts.root
+     */
+    babelrcRoots?: boolean | MatchPattern | Array<MatchPattern>,
+
+    // Plugin and Preset options
+
+    /**
+     * An array of plugins to activate when processing this file.
+     * For more information on how individual entries interact, especially when used across multiple nested "env" and "overrides" configs,
+     * see merging.
+     *
+     * Note: The option also allows Plugin instances from Babel itself, but using these directly is not recommended.
+     * If you need to create a persistent representation of a plugin or preset, you should use babel.createConfigItem().
+     *
+     * @default []
+     */
+    plugins?: Plugins,
+
+    /**
+     * An array of presets to activate when processing this file.
+     * For more information on how individual entries interact,
+     * especially when used across multiple nested "env" and "overrides" configs, see merging.
+     *
+     * Note: The format of presets is identical to plugins,
+     * except for the fact that name normalization expects "preset-" instead of "plugin-", and presets cannot be instances of Plugin.
+     *
+     * @default []
+     */
+    presets?: Presets,
+
+    /**
+     * Instructs Babel to run each of the presets in the presets array as an independent pass.
+     * This option tends to introduce a lot of confusion around the exact ordering of plugins,
+     * but can be useful if you absolutely need to run a set of operations as independent compilation passes.
+     *
+     * Note: This option may be removed in future Babel versions as we add better support for defining ordering between plugins.
+     *
+     * @default false
+     * @deprecated
+     */
+    passPerPreset?: boolean,
+
+    // Output targets
+
+    /**
+     * Describes the environments you support/target for your project.
+     * When no targets are specified: Babel will assume you are targeting the oldest browsers possible. For example, @babel/preset-env will transform all ES2015-ES2020 code to be ES5 compatible.
+     */
+    targets?:
+      | string
+      | Array<string>
+      | {[env: string]: string}
+      | {
+          esmodules?: boolean,
+          node?: string | 'current' | true,
+          safari?: string | 'tp',
+          browsers?: string | Array<string>,
+        },
+
+    /**
+     * Toggles whether or not browserslist config sources are used,
+     * which includes searching for any browserslist files or referencing the browserslist key inside package.json.
+     * This is useful for projects that use a browserslist config for files that won't be compiled with Babel.
+     *
+     * If a string is specified, it must represent the path of a browserslist configuration file.
+     * Relative paths are resolved relative to the configuration file which specifies this option,
+     * or to cwd when it's passed as part of the programmatic options.
+     */
+    browserslistConfigFile?: boolean | string,
+
+    /**
+     * The Browserslist environment to use.
+     *
+     * @see https://github.com/browserslist/browserslist#configuring-for-different-environments
+     */
+    browserslistEnv?: string | void,
+
+    // Config Merging options
+
+    /**
+     * Configs may "extend" other configuration files.
+     * Config fields in the current config will be merged on top of the extended file's configuration.
+     */
+    extends?: string,
+
+    /**
+     * Placement: May not be nested inside of another env block.
+     *
+     * Allows for entire nested configuration options that will only be enabled if the envKey matches the envName option.
+     *
+     * Note: env[envKey] options will be merged on top of the options specified in the root object.
+     */
+    env?: {[envKey: string]: BabelCoreOptions},
+
+    /**
+     * Placement: May not be nested inside of another overrides object, or within an env block.
+     *
+     * Allows users to provide an array of options that will be merged into the current configuration one at a time.
+     * This feature is best used alongside the "test"/"include"/"exclude" options to provide conditions for which an override should apply.
+     * For example:
+     *
+     * ```
+     * overrides: [{
+     *  test: "./vendor/large.min.js",
+     *  compact: true,
+     * }],
+     * ```
+     *
+     * could be used to enable the compact option for one specific file that is known to be large and minified,
+     * and tell Babel not to bother trying to print the file nicely.
+     */
+    overrides?: Array<BabelCoreOptions>,
+
+    /**
+     * If all patterns fail to match, the current configuration object is considered inactive and is ignored during config processing.
+     * This option is most useful when used within an overrides option object, but it's allowed anywhere.
+     *
+     * Note: These toggles do not affect the programmatic and config-loading options in earlier sections,
+     * since they are taken into account long before the configuration that is prepared for merging.
+     */
+    test?: MatchPattern | Array<MatchPattern>,
+
+    /**
+     * This option is a synonym for "test".
+     */
+    include?: MatchPattern | Array<MatchPattern>,
+
+    /**
+     * If any of patterns match, the current configuration object is considered inactive and is ignored during config processing.
+     * This option is most useful when used within an overrides option object, but it's allowed anywhere.
+     *
+     * Note: These toggles do not affect the programmatic and config-loading options in earlier sections,
+     * since they are taken into account long before the configuration that is prepared for merging.
+     */
+    exclude?: MatchPattern | Array<MatchPattern>,
+
+    /**
+     * If any of the patterns match, Babel will immediately stop all processing of the current build.
+     * For example, a user may want to do something like: `ignore: ['./lib']` to explicitly disable Babel compilation of files inside the lib directory.
+     *
+     * Note: This option disables all Babel processing of a file. While that has its uses,
+     * it is also worth considering the "exclude" option as a less aggressive alternative.
+     */
+    ignore?: MatchPattern | Array<MatchPattern>,
+
+    /**
+     * If all of the patterns fail to match, Babel will immediately stop all processing of the current build.
+     * For example, a user may want to do something like `only: ['./src']` to explicitly enable Babel compilation of files inside the src directory while disabling everything else.
+     *
+     * Note: This option disables all Babel processing of a file. While that has its uses,
+     * it is also worth considering the "test"/"include" options as a less aggressive alternative.
+     */
+    only?: MatchPattern | Array<MatchPattern>,
+
+    // Source Map options
+
+    /**
+     * true will attempt to load an input sourcemap from the file itself, if it contains a //# sourceMappingURL=... comment.
+     * If no map is found, or the map fails to load and parse, it will be silently discarded.
+     *
+     * If an object is provided, it will be treated as the source map object itself.
+     *
+     * @default true
+     */
+    inputSourceMap?: boolean | _BabelSourceMap,
+
+    /**
+     * - true to generate a sourcemap for the code and include it in the result object.
+     * - "inline" to generate a sourcemap and append it as a data URL to the end of the code, but not include it in the result object.
+     * - "both" is the same as inline, but will include the map in the result object.
+     *
+     * @babel/cli overloads some of these to also affect how maps are written to disk:
+     * - true will write the map to a .map file on disk
+     * - "inline" will write the file directly, so it will have a data: containing the map
+     * - "both" will write the file with a data: URL and also a .map.
+     *
+     * Note: These options are bit weird, so it may make the most sense to just use true and handle the rest in your own code, depending on your use case.
+     *
+     * @default true
+     */
+    sourceMaps?: boolean | 'inline' | 'both',
+
+    /**
+     * This is an synonym for sourceMaps. Using sourceMaps is recommended.
+     */
+    sourceMap?: boolean,
+
+    /**
+     * The name to use for the file inside the source map object.
+     * @default path.basename(opts.filenameRelative) when available, or "unknown"
+     */
+    sourceFileName?: string,
+
+    /**
+     * The sourceRoot fields to set in the generated source map, if one is desired.
+     */
+    sourceRoot?: string,
+
+    // Misc options
+
+    /**
+     * - "script" - Parse the file using the ECMAScript Script grammar. No import/export statements allowed, and files are not in strict mode.
+     * - "module" - Parse the file using the ECMAScript Module grammar. Files are automatically strict, and import/export statements are allowed.
+     * - "unambiguous" - Consider the file a "module" if import/export statements are present, or else consider it a "script".
+     *
+     * unambiguous can be quite useful in contexts where the type is unknown,
+     * but it can lead to false matches because it's perfectly valid to have a module file that does not use import/export statements.
+     *
+     * This option is important because the type of the current file affects both parsing of input files,
+     * and certain transforms that may wish to add import/require usage to the current file.
+     *
+     * For instance, @babel/plugin-transform-runtime relies on the type of the current document to decide whether to insert an import declaration,
+     * or a require() call. @babel/preset-env also does the same for its "useBuiltIns" option.
+     * Since Babel defaults to treating files are ES modules, generally these plugins/presets will insert import statements.
+     * Setting the correct sourceType can be important because having the wrong type
+     * can lead to cases where Babel would insert import statements into files that are meant to be CommonJS files.
+     * This can be particularly important in projects where compilation of node_modules dependencies is being performed,
+     * because inserting an import statements can cause Webpack and other tooling to see a file as an ES module,
+     * breaking what would otherwise be a functional CommonJS file.
+     *
+     * Note: This option will not affect parsing of .mjs files, as they are currently hard-coded to always parse as "module" files.
+     *
+     * @default 'module'
+     */
+    sourceType?: 'script' | 'module' | 'unambiguous',
+
+    /**
+     * Highlight tokens in code snippets in Babel's error messages to make them easier to read.
+     *
+     * @default true
+     */
+    highlightCode?: boolean,
+
+    /**
+     * Set assumptions that Babel can make in order to produce smaller output
+     * @see https://babel.dev/assumptions
+     */
+    assumptions?: {[assumption: string]: boolean},
+
+    /**
+     * Allows users to add a wrapper on each visitor in order to inspect the visitor process as Babel executes the plugins.
+     *
+     * - key is a simple opaque string that represents the plugin being executed.
+     * - nodeType is the type of AST node currently being visited.
+     * - fn is the visitor function itself.
+     *
+     * Users can return a replacement function that should call the original function after performing whatever logging
+     * and analysis they wish to do.
+     */
+    wrapPluginVisitorMethod?: (
+      key: string,
+      nodeType: $PropertyType<BabelNode, 'type'>,
+      fn: Function,
+    ) => Function,
+
+    /**
+     * An opaque object containing options to pass through to the parser being used.
+     */
+    parserOpts?: ParserOptions,
+
+    /**
+     * An opaque object containing options to pass through to the code generator being used.
+     */
+    generatorOpts?: GeneratorOptions,
+
+    // Code Generator options
+
+    /**
+     * Optional string to add as a block comment at the start of the output file
+     */
+    auxiliaryCommentBefore?: string,
+
+    /**
+     * Optional string to add as a block comment at the end of the output file
+     */
+    auxiliaryCommentAfter?: string,
+
+    /**
+     * Function that takes a comment (as a string) and returns true if the comment should be included in the output.
+     * By default, comments are included if opts.comments is true or if opts.minified is false and the comment contains @preserve or @license
+     */
+    shouldPrintComment?: (comment: string) => boolean,
+
+    /**
+     * Attempt to use the same line numbers in the output code as in the source code (helps preserve stack traces)
+     * @default false
+     */
+    retainLines?: boolean,
+
+    /**
+     * Should comments be included in output
+     * @default true
+     */
+    comments?: boolean,
+
+    /**
+     * Set to true to avoid adding whitespace for formatting
+     * @default opts.minified
+     */
+    compact?: boolean | 'auto',
+
+    /**
+     * Should the output be minified
+     * @default false
+     */
+    minified?: boolean,
+
+    // AMD / UMD / SystemJS module options
+
+    /**
+     * Enables module ID generation.
+     *
+     * @default !!opts.moduleId
+     */
+    moduleIds?: boolean,
+
+    /**
+     * A hard-coded ID to use for the module. Cannot be used alongside getModuleId.
+     */
+    moduleId?: string,
+
+    /**
+     * Given the babel-generated module name, return the name to use. Returning a falsy value will use the original name.
+     */
+    getModuleId?: (name: string) => string,
+
+    /**
+     * A root path to include on generated module names.
+     */
+    moduleRoot?: string,
+  |};
+
+  declare export type TransformResult<T = BabelFileMetadata> = {|
+    metadata: T,
+    options: BabelCoreOptions,
+    code: string,
+    map: _BabelSourceMap | null,
+    ast: BabelNodeFile | null,
+    ignored?: boolean,
+  |};
+
+  declare type TransformCallback<TMetadata> =
+    | ((Error, null) => mixed)
+    | ((null, TransformResult<TMetadata> | null) => mixed);
+
+  /**
+   * Transforms the passed in code. Calling a callback with an object with the generated code, source map, and AST.
+   */
+  declare export function transform<TMetadata = BabelFileMetadata>(
+    code: string,
+    options: ?BabelCoreOptions,
+    callback: TransformCallback<TMetadata>,
+  ): void;
+
+  /***
+   * Transforms the passed in code. Returning an object with the generated code, source map, and AST.
+   */
+  declare export function transformSync<TMetadata = BabelFileMetadata>(
+    code: string,
+    options?: BabelCoreOptions,
+  ): TransformResult<TMetadata>;
+
+  /**
+   * Transforms the passed in code. Returning an promise for an object with the generated code, source map, and AST.
+   */
+  declare export function transformAsync<TMetadata = BabelFileMetadata>(
+    code: string,
+    options?: BabelCoreOptions,
+  ): Promise<TransformResult<TMetadata>>;
+
+  /**
+   * Asynchronously transforms the entire contents of a file.
+   */
+  declare export function transformFile<TMetadata = BabelFileMetadata>(
+    filename: string,
+    options?: BabelCoreOptions,
+    callback: TransformCallback<TMetadata>,
+  ): void;
+
+  /**
+   * Synchronous version of babel.transformFile. Returns the transformed contents of the filename.
+   */
+  declare export function transformFileSync<TMetadata = BabelFileMetadata>(
+    filename: string,
+    options?: BabelCoreOptions,
+  ): TransformResult<TMetadata>;
+
+  /**
+   * Promise version of babel.transformFile. Returns a promise for the transformed contents of the filename.
+   */
+  declare export function transformFileAsync<TMetadata = BabelFileMetadata>(
+    filename: string,
+    options?: BabelCoreOptions,
+  ): Promise<TransformResult<TMetadata>>;
+
+  /**
+   * Given an AST, transform it.
+   */
+  declare export function transformFromAst<TMetadata = BabelFileMetadata>(
+    ast: BabelNodeFile | BabelNodeProgram,
+    code?: string,
+    options?: BabelCoreOptions,
+    callback: TransformCallback<TMetadata>,
+  ): void;
+
+  /**
+   * Given an AST, transform it.
+   */
+  declare export function transformFromAstSync<TMetadata = BabelFileMetadata>(
+    ast: BabelNodeFile | BabelNodeProgram,
+    code?: string,
+    options?: BabelCoreOptions,
+  ): TransformResult<TMetadata>;
+
+  /**
+   * Given an AST, transform it.
+   */
+  declare export function transformFromAstAsync<TMetadata = BabelFileMetadata>(
+    ast: BabelNodeFile | BabelNodeProgram,
+    code?: string,
+    options?: BabelCoreOptions,
+  ): Promise<TransformResult<TMetadata>>;
+
+  /**
+   * Given some code, parse it using Babel's standard behavior. Referenced presets and plugins will be loaded such that optional syntax plugins are automatically enabled.
+   */
+  declare export function parse(
+    code: string,
+    options?: BabelCoreOptions,
+    callback: ((error: Error) => void) | ((void, BabelNodeFile) => void),
+  ): void;
+
+  declare export function parseSync(
+    code: string,
+    options?: BabelCoreOptions,
+  ): BabelNodeFile;
+
+  declare export function parseAsync(
+    code: string,
+    options?: BabelCoreOptions,
+  ): Promise<BabelNodeFile>;
+
+  declare export var template: Template;
+  declare export var traverse: Traverse;
+  declare export var types: Types;
+  declare export var DEFAULT_EXTENSIONS: $ReadOnlyArray<string>;
+
+  declare export function buildExternalHelpers(
+    whitelist?: Array<string>,
+    outputType?: 'global' | 'module' | 'umd' | 'var',
+  ): string;
+
+  declare export function getEnv(defaultValue?: string): string;
+
+  declare export function resolvePlugin(
+    name: string,
+    dirname: string,
+  ): string | null;
+
+  declare export function resolvePreset(
+    name: string,
+    dirname: string,
+  ): string | null;
+
+  declare export function createConfigItem(
+    value:
+      | EntryTarget
+      | [EntryTarget, EntryOptions]
+      | [EntryTarget, EntryOptions, string | void],
+    options: ?{
+      dirname?: string,
+      type?: 'preset' | 'plugin',
+    },
+  ): ConfigItem;
+
+  declare export type ResolvedConfig = {
+    options: BabelCoreOptions,
+    passes: Array<Array<PluginObj<mixed> | (() => PluginObj<mixed>)>>,
+  };
+
+  declare export function loadOptions(
+    options?: mixed,
+    callback:
+      | ((error: Error, null) => mixed)
+      | ((null, config: ResolvedConfig | null) => mixed),
+  ): void;
+  declare export function loadOptionsSync(
+    options?: mixed,
+  ): ResolvedConfig | null;
+  declare export function loadOptionsAsync(
+    options?: mixed,
+  ): Promise<ResolvedConfig | null>;
+
+  // For now
+  declare type ValidatedOptions = BabelCoreOptions;
+
+  declare class PartialConfig {
+    +options: $ReadOnly<ValidatedOptions>;
+    +babelrc: string | void;
+    +babelignore: string | void;
+    +config: string | void;
+
+    constructor(options: ValidatedOptions): PartialConfig;
+
+    hasFilesystemConfig(): boolean;
+  }
+
+  declare export function loadPartialConfig(
+    options?: mixed,
+    callback:
+      | ((error: Error, null) => mixed)
+      | ((null, config: PartialConfig | null) => mixed),
+  ): void;
+  declare export function loadPartialConfigSync(
+    options?: mixed,
+  ): PartialConfig | null;
+  declare export function loadPartialConfigAsync(
+    options?: mixed,
+  ): Promise<PartialConfig | null>;
+}
+
+declare module '@babel/generator' {
+  declare export type BabelSourceMapSegment = _BabelSourceMapSegment;
+
+  declare export type GeneratorResult = {
+    code: string,
+    map: ?_BabelSourceMap,
+    rawMappings: ?Array<BabelSourceMapSegment>,
+  };
+
+  declare export class CodeGenerator {
+    constructor(ast: BabelNode, opts: {...}, code: string): CodeGenerator;
+
+    generate(): GeneratorResult;
+  }
+
+  declare export type Options = {
+    /**
+     * Optional string to add as a block comment at the start of the output file
+     */
+    auxiliaryCommentBefore?: string,
+
+    /**
+     * Optional string to add as a block comment at the end of the output file
+     */
+    auxiliaryCommentAfter?: string,
+
+    /**
+     * Function that takes a comment (as a string) and returns true if the comment should be included in the output.
+     * By default, comments are included if opts.comments is true or if opts.minified is false and the comment contains @preserve or @license
+     */
+    shouldPrintComment?: (comment: string) => boolean,
+
+    /**
+     * Attempt to use the same line numbers in the output code as in the source code (helps preserve stack traces)
+     * @default false
+     */
+    retainLines?: boolean,
+
+    /**
+     * Retain parens around function expressions (could be used to change engine parsing behavior)
+     * @default false
+     */
+    retainFunctionParens?: boolean,
+
+    /**
+     * Should comments be included in output
+     * @default true
+     */
+    comments?: boolean,
+
+    /**
+     * Set to true to avoid adding whitespace for formatting
+     * @default opts.minified
+     */
+    compact?: boolean | 'auto',
+
+    /**
+     * Should the output be minified
+     * @default false
+     */
+    minified?: boolean,
+
+    /**
+     * Set to true to reduce whitespace (but not as much as opts.compact)
+     * @default false
+     */
+    concise?: boolean,
+
+    /**
+     * Used in warning messages
+     */
+    filename?: string,
+
+    /**
+     * Set to true to run jsesc with "json": true to print "\u00A9" vs. "©";
+     * @default false
+     */
+    jsonCompatibleStrings?: boolean,
+
+    /**
+     * Use jsesc to process literals. jsesc is applied to numbers only if jsescOption.numbers is present.
+     * You can customize jsesc by passing options to it.
+     */
+    jsecsOption?: {...},
+
+    decoratorsBeforeExport?: boolean,
+    recordAndTupleSyntaxType?: mixed,
+
+    /**
+     * Enable generating source maps
+     * @default false
+     */
+    sourceMaps?: boolean,
+
+    /**
+     * A root for all relative URLs in the source map
+     */
+    sourceRoot?: string,
+
+    /**
+     * The filename for the source code (i.e. the code in the code argument). This will only be used if code is a string.
+     */
+    sourceFileName?: string,
+    /**
+     * The filename of the generated code that the source map will be associated with
+     */
+    sourceMapTarget?: string,
+  };
+
+  declare export default (
+    ast: BabelNode,
+    options?: Options,
+    code?: string | {[string]: string, ...},
+  ) => GeneratorResult;
+
+  declare export default (
+    ast: BabelNode,
+    options?: Options,
+    code?: string | {|[filename: string]: string|},
+  ) => GeneratorResult;
+}
+
+declare module '@babel/template' {
+  import type {Node, Statement, Expression, Program} from '@babel/types';
+
+  declare export type PublicOpts = {
+    /**
+     * A set of placeholder names to automatically accept, ignoring the given
+     * pattern entirely.
+     *
+     * This option can be used when using %%foo%% style placeholders.
+     */
+    placeholderWhitelist?: ?Set<string>,
+
+    /**
+     * A pattern to search for when looking for Identifier and StringLiteral
+     * nodes that can be replaced.
+     *
+     * 'false' will disable placeholder searching entirely, leaving only the
+     * 'placeholderWhitelist' value to find replacements.
+     *
+     * Defaults to /^[_$A-Z0-9]+$/.
+     *
+     * This option can be used when using %%foo%% style placeholders.
+     */
+    placeholderPattern?: ?(RegExp | false),
+
+    /**
+     * 'true' to pass through comments from the template into the resulting AST,
+     * or 'false' to automatically discard comments. Defaults to 'false'.
+     */
+    preserveComments?: ?boolean,
+
+    /**
+     * 'true' to use %%foo%% style placeholders, 'false' to use legacy placeholders
+     * described by placeholderPattern or placeholderWhitelist.
+     * When it is not set, it behaves as 'true' if there are syntactic placeholders,
+     * otherwise as 'false'.
+     */
+    syntacticPlaceholders?: ?boolean,
+  };
+
+  declare export type PublicReplacements =
+    | {[string]: ?BabelNode}
+    | Array<?BabelNode>;
+
+  declare export type TemplateBuilder<T> = {
+    // Build a new builder, merging the given options with the previous ones.
+    (opts: PublicOpts): TemplateBuilder<T>,
+
+    // Building from a string produces an AST builder function by default.
+    (tpl: string, opts: ?PublicOpts): (?PublicReplacements) => T,
+
+    // Building from a template literal produces an AST builder function by default.
+    (tpl: Array<string>, ...args: Array<mixed>): (?PublicReplacements) => T,
+
+    // Allow users to explicitly create templates that produce ASTs, skipping
+    // the need for an intermediate function.
+    ast: {
+      (tpl: string, opts: ?PublicOpts): T,
+      (tpl: Array<string>, ...args: Array<mixed>): T,
+    },
+  };
+
+  declare export type smart = TemplateBuilder<Statement | Array<Statement>>;
+  declare export type expression = TemplateBuilder<Expression>;
+  declare export type statement = TemplateBuilder<Statement>;
+  declare export type statements = TemplateBuilder<Array<Statement>>;
+  declare export type program = TemplateBuilder<Program>;
+
+  declare export type DefaultTemplateBuilder = {
+    smart: smart,
+    statement: statement,
+    statements: statements,
+    expression: expression,
+    program: program,
+
+    // The call signatures are missing if I spread the `TemplateBuilder` type for whatever reason
+    // Copy paste the definition in here solves the problem.
+
+    // Build a new builder, merging the given options with the previous ones.
+    (opts: PublicOpts): TemplateBuilder<Statement | Array<Statement>>,
+
+    // Building from a string produces an AST builder function by default.
+    (
+      tpl: string,
+      opts: ?PublicOpts,
+    ): (?PublicReplacements) => Statement | Array<Statement>,
+
+    // Building from a template literal produces an AST builder function by default.
+    (
+      tpl: Array<string>,
+      ...args: Array<mixed>
+    ): (?PublicReplacements) => Statement | Array<Statement>,
+
+    // Allow users to explicitly create templates that produce ASTs, skipping
+    // the need for an intermediate function.
+    ast: {
+      (tpl: string, opts: ?PublicOpts): Statement | Array<Statement>,
+      (tpl: Array<string>, ...args: Array<mixed>): Statement | Array<Statement>,
+    },
+  };
+
+  declare export default DefaultTemplateBuilder;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,6 +5312,11 @@ hermes-estree@0.12.0:
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.12.0.tgz#8a289f9aee854854422345e6995a48613bac2ca8"
   integrity sha512-+e8xR6SCen0wyAKrMT3UD0ZCCLymKhRgjEB5sS28rKiFir/fXgLoeRilRUssFCILmGHb+OvHDUlhxs0+IEyvQw==
 
+hermes-estree@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.12.0.tgz#8a289f9aee854854422345e6995a48613bac2ca8"
+  integrity sha512-+e8xR6SCen0wyAKrMT3UD0ZCCLymKhRgjEB5sS28rKiFir/fXgLoeRilRUssFCILmGHb+OvHDUlhxs0+IEyvQw==
+
 hermes-estree@0.12.1:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.12.1.tgz#74901ee351387fecbf3c683c90b1fa7d22f1c6f0"


### PR DESCRIPTION
Summary:
Add Babel type definitions ahead of moving `metro-react-native-babel-transformer` under `react-natve`.

These are mostly duplicated from https://github.com/facebook/metro, adapted for RN's naming conventions and lint rules.

Changelog:
[Internal]

Differential Revision: D47154206

