### PR TITLE
Android: Introduce RN$LegacyInterop_UIManager_getConstants

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -154,4 +154,7 @@ public class ReactFeatureFlags {
 
   /** Disable the background executor for layout in Fabric */
   public static boolean enableBackgroundExecutor = false;
+
+  /** Use native view configs in bridgeless mode. */
+  public static boolean useNativeViewConfigsInBridgelessMode = false;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIConstantsProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIConstantsProvider.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager;
+
+import com.facebook.proguard.annotations.DoNotStripAny;
+import com.facebook.react.bridge.NativeMap;
+
+@DoNotStripAny
+public interface UIConstantsProvider {
+
+  /* Returns UIManager's constants. */
+  NativeMap getConstants();
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIConstantsProviderManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIConstantsProviderManager.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager;
+
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.proguard.annotations.DoNotStripAny;
+import com.facebook.react.bridge.RuntimeExecutor;
+import com.facebook.soloader.SoLoader;
+
+@DoNotStripAny
+public class UIConstantsProviderManager {
+
+  static {
+    staticInit();
+  }
+
+  @DoNotStrip
+  @SuppressWarnings("unused")
+  private final HybridData mHybridData;
+
+  public UIConstantsProviderManager(
+      RuntimeExecutor runtimeExecutor, Object uiConstantsProviderManager) {
+    mHybridData = initHybrid(runtimeExecutor, uiConstantsProviderManager);
+    installJSIBindings();
+  }
+
+  private native HybridData initHybrid(
+      RuntimeExecutor runtimeExecutor, Object uiConstantsProviderManager);
+
+  private native void installJSIBindings();
+
+  private static void staticInit() {
+    SoLoader.loadLibrary("uimanagerjni");
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -229,7 +229,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
     }
   }
 
-  private static Map<String, Object> createConstants(
+  public static Map<String, Object> createConstants(
       List<ViewManager> viewManagers,
       @Nullable Map<String, Object> customBubblingEvents,
       @Nullable Map<String, Object> customDirectEvents) {

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -101,6 +101,7 @@ add_react_common_subdir(react/nativemodule/core)
 add_react_common_subdir(jserrorhandler)
 add_react_common_subdir(react/bridgeless)
 add_react_common_subdir(react/bridgeless/hermes)
+add_react_common_subdir(react/bridgeless/nativeviewconfig)
 
 # ReactAndroid JNI targets
 add_react_build_subdir(generated/source/codegen/jni)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(uimanagerjni
         folly_runtime
         glog
         glog_init
+        bridgelessnativeviewconfig
         rrc_native
         yoga
         callinvokerholder

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/OnLoad.cpp
@@ -8,9 +8,11 @@
 #include <fbjni/fbjni.h>
 
 #include "ComponentNameResolverManager.h"
+#include "UIConstantsProviderManager.h"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
   return facebook::jni::initialize(vm, [] {
     facebook::react::ComponentNameResolverManager::registerNatives();
+    facebook::react::UIConstantsProviderManager::registerNatives();
   });
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/UIConstantsProviderManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/UIConstantsProviderManager.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <string>
+
+#include <fbjni/fbjni.h>
+#include <jsi/JSIDynamic.h>
+#include <jsi/jsi.h>
+#include <react/jni/NativeMap.h>
+
+#include <react/bridgeless/nativeviewconfig/LegacyUIManagerConstantsProviderBinding.h>
+#include "UIConstantsProviderManager.h"
+
+namespace facebook::react {
+
+using namespace facebook::jni;
+
+UIConstantsProviderManager::UIConstantsProviderManager(
+    jni::alias_ref<UIConstantsProviderManager::javaobject> jThis,
+    RuntimeExecutor runtimeExecutor,
+    jni::alias_ref<jobject> uiConstantsProvider)
+    : javaPart_(jni::make_global(jThis)),
+      runtimeExecutor_(runtimeExecutor),
+      uiConstantsProvider_(jni::make_global(uiConstantsProvider)) {}
+
+jni::local_ref<UIConstantsProviderManager::jhybriddata>
+UIConstantsProviderManager::initHybrid(
+    jni::alias_ref<jhybridobject> jThis,
+    jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutor,
+    jni::alias_ref<jobject> uiConstantsProvider) {
+  return makeCxxInstance(
+      jThis, runtimeExecutor->cthis()->get(), uiConstantsProvider);
+}
+
+void UIConstantsProviderManager::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("initHybrid", UIConstantsProviderManager::initHybrid),
+      makeNativeMethod(
+          "installJSIBindings", UIConstantsProviderManager::installJSIBindings),
+  });
+}
+
+void UIConstantsProviderManager::installJSIBindings() {
+  runtimeExecutor_([thizz = this](jsi::Runtime &runtime) {
+    auto uiConstantsProvider = [thizz, &runtime]() -> jsi::Value {
+      static auto getConstants =
+          jni::findClassStatic(
+              UIConstantsProviderManager::UIConstantsProviderJavaDescriptor)
+              ->getMethod<jni::alias_ref<NativeMap::jhybridobject>()>(
+                  "getConstants");
+      auto constants = getConstants(thizz->uiConstantsProvider_.get());
+      return jsi::valueFromDynamic(runtime, constants->cthis()->consume());
+    };
+
+    LegacyUIManagerConstantsProviderBinding::install(
+        runtime, std::move(uiConstantsProvider));
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/UIConstantsProviderManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/UIConstantsProviderManager.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <fbjni/fbjni.h>
+#include <react/jni/JRuntimeExecutor.h>
+
+namespace facebook::react {
+
+class UIConstantsProviderManager
+    : public facebook::jni::HybridClass<UIConstantsProviderManager> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/uimanager/UIConstantsProviderManager;";
+
+  constexpr static auto UIConstantsProviderJavaDescriptor =
+      "com/facebook/react/uimanager/UIConstantsProvider";
+
+  static facebook::jni::local_ref<jhybriddata> initHybrid(
+      facebook::jni::alias_ref<jhybridobject> jThis,
+      facebook::jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutor,
+      facebook::jni::alias_ref<jobject> uiConstantsProviderManager);
+
+  static void registerNatives();
+
+ private:
+  friend HybridBase;
+  facebook::jni::global_ref<UIConstantsProviderManager::javaobject> javaPart_;
+  RuntimeExecutor runtimeExecutor_;
+
+  facebook::jni::global_ref<jobject> uiConstantsProvider_;
+
+  void installJSIBindings();
+
+  explicit UIConstantsProviderManager(
+      facebook::jni::alias_ref<UIConstantsProviderManager::jhybridobject> jThis,
+      RuntimeExecutor runtimeExecutor,
+      facebook::jni::alias_ref<jobject> uiConstantsProviderManager);
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/nativeviewconfig/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridgeless/nativeviewconfig/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+add_compile_options(-std=c++17)
+
+file(GLOB_RECURSE bridgeless_nativeviewconfig_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(
+        bridgelessnativeviewconfig
+        STATIC
+        ${bridgeless_nativeviewconfig_SRC}
+)
+target_include_directories(bridgelessnativeviewconfig PUBLIC .)
+
+target_link_libraries(bridgelessnativeviewconfig jsi)


### PR DESCRIPTION
Summary:
This diff adds Android specific implementation of `RN$LegacyInterop_UIManager_getConstants` and binds it to JS runtime. It is supposed to be used as a substitute to UIManager.getConstants in bridgeless mode.

Changelog:
[Internal] - Introduce RN$LegacyInterop_UIManager_getConstants in Android.

Reviewed By: RSNara

Differential Revision: D45773342

