### PR TITLE
Fix multiple warnings post Kotlin migration

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -15,7 +15,6 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Callback;
@@ -58,7 +57,7 @@ public class ReactActivityDelegate {
     return null;
   }
 
-  protected @NonNull Bundle composeLaunchOptions() {
+  protected @Nullable Bundle composeLaunchOptions() {
     Bundle composedLaunchOptions = getLaunchOptions();
     if (isFabricEnabled()) {
       if (composedLaunchOptions == null) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react
 
-import android.app.Activity
 import android.os.Bundle
 import org.junit.Assert.*
 import org.junit.Test
@@ -17,7 +16,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ReactActivityDelegateTest {
 
-  val nullDelegate: Activity? = null
+  val nullDelegate: ReactActivity? = null
 
   @Test
   fun delegateWithFabricEnabled_populatesInitialPropsCorrectly() {
@@ -25,7 +24,7 @@ class ReactActivityDelegateTest {
         object : ReactActivityDelegate(nullDelegate, "test-delegate") {
           override fun isFabricEnabled() = true
 
-          public val inspectLaunchOptions: Bundle?
+          val inspectLaunchOptions: Bundle?
             get() = composeLaunchOptions()
         }
 
@@ -40,7 +39,7 @@ class ReactActivityDelegateTest {
         object : ReactActivityDelegate(nullDelegate, "test-delegate") {
           override fun isFabricEnabled() = false
 
-          public val inspectLaunchOptions: Bundle?
+          val inspectLaunchOptions: Bundle?
             get() = composeLaunchOptions()
         }
 
@@ -56,7 +55,7 @@ class ReactActivityDelegateTest {
           override fun getLaunchOptions(): Bundle =
               Bundle().apply { putString("test-property", "test-value") }
 
-          public val inspectLaunchOptions: Bundle?
+          val inspectLaunchOptions: Bundle?
             get() = composeLaunchOptions()
         }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION") // Suppressing as we want to test RCTEventEmitter here
 package com.facebook.react
 
 import android.app.Activity

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION") // Suppressing as we want to test RCTEventEmitter here
 package com.facebook.react.animated
 
 import android.annotation.SuppressLint
@@ -872,6 +873,7 @@ class NativeAnimatedNodeTraversalTest {
       }
 
       @Override
+      @Deprecated("Deprecated in Java")
       override fun dispatch(rctEventEmitter: RCTEventEmitter) {
         rctEventEmitter.receiveEvent(
             tag, "topScroll", JavaOnlyMap.of("contentOffset", JavaOnlyMap.of("y", value)))
@@ -881,7 +883,7 @@ class NativeAnimatedNodeTraversalTest {
 
   @Test
   fun testNativeAnimatedEventDoUpdate() {
-    val viewTag: Int = 1000
+    val viewTag = 1000
 
     createSimpleAnimatedViewWithOpacity(viewTag)
 
@@ -903,7 +905,7 @@ class NativeAnimatedNodeTraversalTest {
 
   @Test
   fun testNativeAnimatedEventDoNotUpdate() {
-    val viewTag: Int = 1000
+    val viewTag = 1000
 
     createSimpleAnimatedViewWithOpacity()
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.kt
@@ -77,6 +77,7 @@ class BaseJavaModuleTest {
     generatedModuleWrapper.invoke(methodId, arguments)
   }
 
+  @Suppress("UNUSED_PARAMETER")
   private class MethodsModule : BaseJavaModule() {
     override fun getName(): String = "Methods"
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/FallbackJSBundleLoaderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/FallbackJSBundleLoaderTest.kt
@@ -134,6 +134,7 @@ class FallbackJSBundleLoaderTest {
 
   private fun recoverableMsg(errMsg: String): String = FallbackJSBundleLoader.RECOVERABLE + errMsg
 
+  @Suppress("UNUSED_PARAMETER")
   private fun recoverableLoader(url: String, errMsg: String): JSBundleLoader {
     val loader = mock(JSBundleLoader::class.java)
     whenever(loader.loadScript(null))
@@ -144,6 +145,7 @@ class FallbackJSBundleLoaderTest {
 
   private fun fatalMsg(errMsg: String): String = UNRECOVERABLE + errMsg
 
+  @Suppress("UNUSED_PARAMETER")
   private fun fatalLoader(url: String, errMsg: String): JSBundleLoader {
     val loader = mock(JSBundleLoader::class.java)
     whenever(loader.loadScript(null)).thenThrow(RuntimeException(UNRECOVERABLE + errMsg))

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/FakeRCTEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/FakeRCTEventEmitter.kt
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION") // Suppressing as we want to fake a RCTEventEmitter here
 package com.facebook.react.bridge.interop
 
 import com.facebook.react.bridge.WritableArray

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress(
+    "DEPRECATION") // Suppressing as we want to test specifically with RCTEventEmitter here
 package com.facebook.react.bridge.interop
 
 import com.facebook.react.config.ReactFeatureFlags

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/interop/FakeEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/interop/FakeEventDispatcher.kt
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION") // Suppressing as RCTEventEmitter is part of the API
 package com.facebook.react.fabric.interop
 
 import com.facebook.react.uimanager.events.BatchEventDispatchedListener

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/share/ShareModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/share/ShareModuleTest.kt
@@ -58,13 +58,13 @@ class ShareModuleTest {
     val chooserIntent = shadowOf(RuntimeEnvironment.application).nextStartedActivity
     assertNotNull("Dialog was not displayed", chooserIntent)
     assertEquals(Intent.ACTION_CHOOSER, chooserIntent.action)
-    assertEquals(dialogTitle, chooserIntent.extras?.get(Intent.EXTRA_TITLE))
+    assertEquals(dialogTitle, chooserIntent.extras?.getString(Intent.EXTRA_TITLE))
 
-    val contentIntent = chooserIntent.extras?.get(Intent.EXTRA_INTENT) as Intent?
+    val contentIntent = chooserIntent.extras?.getParcelable(Intent.EXTRA_INTENT, Intent::class.java)
     assertNotNull("Intent was not built correctly", contentIntent)
     assertEquals(Intent.ACTION_SEND, contentIntent?.action)
-    assertEquals(title, contentIntent?.extras?.get(Intent.EXTRA_SUBJECT))
-    assertEquals(message, contentIntent?.extras?.get(Intent.EXTRA_TEXT))
+    assertEquals(title, contentIntent?.extras?.getString(Intent.EXTRA_SUBJECT))
+    assertEquals(message, contentIntent?.extras?.getString(Intent.EXTRA_TEXT))
 
     assertEquals(1, promise.resolved)
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowSoLoader.kt
@@ -13,6 +13,7 @@ import kotlin.jvm.JvmStatic
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
 
+@Suppress("UNUSED_PARAMETER")
 @Implements(SoLoader::class)
 class ShadowSoLoader {
   companion object {


### PR DESCRIPTION
Summary:
As we migrated several files from Java to Kotlin, our build log got really noisy with several compilation warnings.
That's happing as the Kotlin compiler is stricter than the Java one.

Here I've fixed most of them.

Changelog:
[Internal] [Changed] - Fix multiple warnings post Kotlin migration

Differential Revision: D47185820

