### PR TITLE
Do not directly access RuntimeEnvironment.application in tests

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -64,7 +64,7 @@ class RootViewTest {
     whenever(SystemClock.uptimeMillis()).thenAnswer { ts }
 
     catalystInstanceMock = ReactTestHelper.createMockCatalystInstance()
-    reactContext = spy(ReactApplicationContext(RuntimeEnvironment.application))
+    reactContext = spy(ReactApplicationContext(RuntimeEnvironment.getApplication()))
     reactContext.initializeWithInstance(catalystInstanceMock)
 
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(reactContext)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ReactTestHelper.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ReactTestHelper.kt
@@ -24,7 +24,7 @@ object ReactTestHelper {
    */
   @JvmStatic
   fun createCatalystContextForTest(): ReactApplicationContext =
-      ReactApplicationContext(RuntimeEnvironment.application).apply {
+      ReactApplicationContext(RuntimeEnvironment.getApplication()).apply {
         initializeWithInstance(createMockCatalystInstance())
       }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/interop/InteropEventEmitterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/interop/InteropEventEmitterTest.kt
@@ -25,7 +25,7 @@ class InteropEventEmitterTest {
 
   @Before
   fun setup() {
-    reactContext = ReactApplicationContext(RuntimeEnvironment.application)
+    reactContext = ReactApplicationContext(RuntimeEnvironment.getApplication())
     eventDispatcher = FakeEventDispatcher()
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/clipboard/ClipboardModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/clipboard/ClipboardModuleTest.kt
@@ -28,9 +28,9 @@ class ClipboardModuleTest {
 
   @Before
   fun setUp() {
-    clipboardModule = ClipboardModule(ReactApplicationContext(RuntimeEnvironment.application))
+    clipboardModule = ClipboardModule(ReactApplicationContext(RuntimeEnvironment.getApplication()))
     clipboardManager =
-        RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE)
+        RuntimeEnvironment.getApplication().getSystemService(Context.CLIPBOARD_SERVICE)
             as ClipboardManager
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.kt
@@ -47,7 +47,7 @@ class DeviceInfoModuleTest : TestCase() {
   public override fun setUp() {
     initTestData()
     PowerMockito.mockStatic(DisplayMetricsHolder::class.java)
-    reactContext = spy(ReactApplicationContext(RuntimeEnvironment.application))
+    reactContext = spy(ReactApplicationContext(RuntimeEnvironment.getApplication()))
     val catalystInstanceMock = ReactTestHelper.createMockCatalystInstance()
     reactContext.initializeWithInstance(catalystInstanceMock)
     deviceInfoModule = DeviceInfoModule(reactContext)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/share/ShareModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/share/ShareModuleTest.kt
@@ -55,7 +55,7 @@ class ShareModuleTest {
 
     shareModule.share(content, dialogTitle, promise)
 
-    val chooserIntent = shadowOf(RuntimeEnvironment.application).nextStartedActivity
+    val chooserIntent = shadowOf(RuntimeEnvironment.getApplication()).nextStartedActivity
     assertNotNull("Dialog was not displayed", chooserIntent)
     assertEquals(Intent.ACTION_CHOOSER, chooserIntent.action)
     assertEquals(dialogTitle, chooserIntent.extras?.getString(Intent.EXTRA_TITLE))

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.java
@@ -46,7 +46,7 @@ public class BaseViewManagerTest {
   @Before
   public void setUp() {
     mViewManager = new ReactViewManager();
-    mView = new ReactViewGroup(RuntimeEnvironment.application);
+    mView = new ReactViewGroup(RuntimeEnvironment.getApplication());
     PowerMockito.mockStatic(Arguments.class);
     PowerMockito.when(Arguments.createMap())
         .thenAnswer(

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.java
@@ -123,7 +123,7 @@ public class ReactPropConstantsTest {
   public void testNativePropsIncludeCorrectTypes() {
     List<ViewManager> viewManagers = Arrays.<ViewManager>asList(new ViewManagerUnderTest());
     ReactApplicationContext reactContext =
-        new ReactApplicationContext(RuntimeEnvironment.application);
+        new ReactApplicationContext(RuntimeEnvironment.getApplication());
     UIManagerModule uiManagerModule = new UIManagerModule(reactContext, viewManagers, 0);
     Map<String, String> constants =
         (Map) valueAtPath(uiManagerModule.getConstants(), "SomeView", "NativeProps");

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.java
@@ -66,7 +66,7 @@ public class SimpleViewPropertyTest {
 
   @Before
   public void setup() {
-    mContext = new ReactApplicationContext(RuntimeEnvironment.application);
+    mContext = new ReactApplicationContext(RuntimeEnvironment.getApplication());
     mCatalystInstanceMock = ReactTestHelper.createMockCatalystInstance();
     mContext.initializeWithInstance(mCatalystInstanceMock);
     mThemedContext = new ThemedReactContext(mContext, mContext);

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsTest.java
@@ -47,7 +47,7 @@ public class UIManagerModuleConstantsTest {
 
   @Before
   public void setUp() {
-    mReactContext = new ReactApplicationContext(RuntimeEnvironment.application);
+    mReactContext = new ReactApplicationContext(RuntimeEnvironment.getApplication());
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
@@ -100,7 +100,7 @@ public class UIManagerModuleTest {
             any(ChoreographerCompat.FrameCallback.class));
 
     mCatalystInstanceMock = ReactTestHelper.createMockCatalystInstance();
-    mReactContext = new ReactApplicationContext(RuntimeEnvironment.application);
+    mReactContext = new ReactApplicationContext(RuntimeEnvironment.getApplication());
     mReactContext.initializeWithInstance(mCatalystInstanceMock);
 
     UIManagerModule uiManagerModuleMock = mock(UIManagerModule.class);
@@ -145,7 +145,7 @@ public class UIManagerModuleTest {
     UIManagerModule uiManager = getUIManagerModule();
 
     ReactRootView rootView =
-        new ReactRootView(RuntimeEnvironment.application.getApplicationContext());
+        new ReactRootView(RuntimeEnvironment.getApplication().getApplicationContext());
     int rootTag = uiManager.addRootView(rootView);
     int viewTag = rootTag + 1;
     int subViewTag = viewTag + 1;
@@ -491,7 +491,7 @@ public class UIManagerModuleTest {
   public void testRemoveSubviewsFromContainerWithID() {
     UIManagerModule uiManager = getUIManagerModule();
     ReactRootView rootView =
-        new ReactRootView(RuntimeEnvironment.application.getApplicationContext());
+        new ReactRootView(RuntimeEnvironment.getApplication().getApplicationContext());
     int rootTag = uiManager.addRootView(rootView);
 
     final int containerTag = rootTag + 1;
@@ -541,7 +541,7 @@ public class UIManagerModuleTest {
    */
   private ViewGroup createSimpleTextHierarchy(UIManagerModule uiManager, String text) {
     ReactRootView rootView =
-        new ReactRootView(RuntimeEnvironment.application.getApplicationContext());
+        new ReactRootView(RuntimeEnvironment.getApplication().getApplicationContext());
     int rootTag = uiManager.addRootView(rootView);
     int textTag = rootTag + 1;
     int rawTextTag = textTag + 1;

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.java
@@ -85,7 +85,7 @@ public class ReactImagePropertyTest {
     RNLog.w(null, "");
 
     SoLoader.setInTestMode();
-    mContext = new ReactApplicationContext(RuntimeEnvironment.application);
+    mContext = new ReactApplicationContext(RuntimeEnvironment.getApplication());
     mCatalystInstanceMock = ReactTestHelper.createMockCatalystInstance();
     mContext.initializeWithInstance(mCatalystInstanceMock);
     mThemeContext = new ThemedReactContext(mContext, mContext);

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
@@ -476,7 +476,7 @@ public class ReactTextTest {
 
   private ReactRootView createText(
       UIManagerModule uiManager, JavaOnlyMap textProps, JavaOnlyMap rawTextProps) {
-    ReactRootView rootView = new ReactRootView(RuntimeEnvironment.application);
+    ReactRootView rootView = new ReactRootView(RuntimeEnvironment.getApplication());
     int rootTag = uiManager.addRootView(rootView);
     int textTag = rootTag + 1;
     int rawTextTag = textTag + 1;

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
@@ -52,7 +52,7 @@ public class ReactTextInputPropertyTest {
 
   @Before
   public void setup() {
-    mContext = new ReactApplicationContext(RuntimeEnvironment.application);
+    mContext = new ReactApplicationContext(RuntimeEnvironment.getApplication());
     mCatalystInstanceMock = ReactTestHelper.createMockCatalystInstance();
     mContext.initializeWithInstance(mCatalystInstanceMock);
     mThemedContext = new ThemedReactContext(mContext, mContext);

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
@@ -87,7 +87,7 @@ public class TextInputTest {
   public void testPropsApplied() {
     UIManagerModule uiManager = getUIManagerModule();
 
-    ReactRootView rootView = new ReactRootView(RuntimeEnvironment.application);
+    ReactRootView rootView = new ReactRootView(RuntimeEnvironment.getApplication());
     rootView.setLayoutParams(new ReactRootView.LayoutParams(100, 100));
     int rootTag = uiManager.addRootView(rootView);
     int textInputTag = rootTag + 1;
@@ -115,7 +115,7 @@ public class TextInputTest {
   public void testPropsUpdate() {
     UIManagerModule uiManager = getUIManagerModule();
 
-    ReactRootView rootView = new ReactRootView(RuntimeEnvironment.application);
+    ReactRootView rootView = new ReactRootView(RuntimeEnvironment.getApplication());
     rootView.setLayoutParams(new ReactRootView.LayoutParams(100, 100));
     int rootTag = uiManager.addRootView(rootView);
     int textInputTag = rootTag + 1;


### PR DESCRIPTION
Summary:
Accessing `RuntimeEnvironment.application` is deprecated and we should instead use `RuntimeEnvironment.getApplication()`

Changelog:
[Internal] [Changed] - Do not directly access RuntimeEnvironment.application in tests

Differential Revision: D47186902

