### PR TITLE
Update globals.d.ts for File declaration in Typescript

### DIFF
--- a/packages/react-native/types/modules/globals.d.ts
+++ b/packages/react-native/types/modules/globals.d.ts
@@ -80,6 +80,20 @@ declare var Blob: {
   new (blobParts?: Array<Blob | string>, options?: BlobOptions): Blob;
 };
 
+interface File extends Blob {
+  name: string;
+  lastModified: number;
+}
+
+declare var File: {
+  prototype: File;
+  new (
+    fileParts?: Array<Blob | string>,
+    name?: string,
+    options?: BlobOptions,
+  ): File;
+};
+
 type FormDataValue =
   | string
   | {name?: string | undefined; type?: string | undefined; uri: string};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
In Webstorm or VSCode when using Typescript the declaration of the class "File" is missing. So both IDEs show "File" as error. With this change it fixes the issue https://github.com/facebook/react-native/issues/38061 .

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #38061

## Changelog:
[GENERAL] [FIXED] Fixed missing File declaration in Typescript global.d.ts
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
I ran 
`yarn run test-typescript`
with no error

After that i initialized a new react-native project and installed the react-native library with my local changes of global.d.ts. Webstorm and VSCode now find the declaration of "File" and don't show "File" as error and suggest the right parameters.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
