### PR TITLE
Fix: iOS <TextInput multiline/> onChangeText does not fire if only one character

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -268,7 +268,11 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 {
   if (_lastStringStateWasUpdatedWith && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
     [self textViewDidChange:_backedTextInputView];
-    _ignoreNextTextInputCall = YES;
+    // Since, textViewDidChange does not gets automatically called when attributedText is empty,
+    // we only need to set _ignoreNextTextInputCall if attributedText is no-empty
+    if(_backedTextInputView.attributedText.length != 0){
+      _ignoreNextTextInputCall = YES;
+    }
   }
   _lastStringStateWasUpdatedWith = _backedTextInputView.attributedText;
   [self textViewProbablyDidChangeSelection];


### PR DESCRIPTION
## Summary:

This change fixes #38105 

## Changelog:

Pick one each for the category and type tags:

[IOS] [FIXED] - Fix for #38105 


## Test Plan:


https://github.com/facebook/react-native/assets/13821669/4b90b9b7-22a9-41ad-b7c8-bdcb701f95de


