### PR TITLE
Remove duplicate changelog entry (#36442)

### DIFF
--- a/CHANGELOG-pre-070.md
+++ b/CHANGELOG-pre-070.md
@@ -61,14 +61,6 @@ This file contains all changelogs for releases in the 0.60-0.69 range. Please ch
 
 - Mitigation for Samsung TextInput Hangs ([be69c8b5a7](https://github.com/facebook/react-native/commit/be69c8b5a77ae60cced1b2af64e48b90d9955be5) by [@NickGerleman](https://github.com/NickGerleman))
 
-## v0.69.8
-
-### Fixed
-
-#### Android specific
-
-- Mitigation for Samsung TextInput Hangs ([be69c8b5a7](https://github.com/facebook/react-native/commit/be69c8b5a77ae60cced1b2af64e48b90d9955be5) by [@NickGerleman](https://github.com/NickGerleman))
-
 ## v0.69.7
 
 ### Fixed
@@ -384,14 +376,6 @@ This file contains all changelogs for releases in the 0.60-0.69 range. Please ch
 - Minimize Spans 3/N: ReactBackgroundColorSpan ([cc0ba57ea4](https://github.com/facebook/react-native/commit/cc0ba57ea42d876155b2fd7d9ee78604ff8aa57a) by [@NickGerleman](https://github.com/NickGerleman))
 - Minimize Spans 1/N: Fix precedence ([1743dd7ab4](https://github.com/facebook/react-native/commit/1743dd7ab40998c4d3491e3b2c56c531daf5dc47) by [@NickGerleman](https://github.com/NickGerleman))
 - Fix measurement of uncontrolled TextInput after edit ([8a0fe30591](https://github.com/facebook/react-native/commit/8a0fe30591e21b90a3481c1ef3eeadd4b592f3ed) by [@NickGerleman](https://github.com/NickGerleman))
-
-## v0.68.6
-
-### Fixed
-
-#### Android specific
-
-- Mitigation for Samsung TextInput Hangs ([be69c8b5a7](https://github.com/facebook/react-native/commit/be69c8b5a77ae60cced1b2af64e48b90d9955be5) by [@NickGerleman](https://github.com/NickGerleman))
 
 ## v0.68.6
 


### PR DESCRIPTION
Summary:
Closes #36442

Remove duplicated entries for versions 0.68.6 and 0.69.8 in CHANGELOG.md

Changelog:
[Internal] [Changed] - Remove duplicated entries for versions 0.68.6 and 0.69.8 in CHANGELOG.md

Differential Revision: D47208049

