### PR TITLE
[0.69] Use `Content-Location` header in bundle response as JS source URL (#37501)

### DIFF
--- a/React/Base/RCTJavaScriptLoader.mm
+++ b/React/Base/RCTJavaScriptLoader.mm
@@ -312,7 +312,17 @@ static void attemptAsynchronousLoadOfBundleAtURL(
           return;
         }
 
-        RCTSource *source = RCTSourceCreate(scriptURL, data, data.length);
+        // Prefer `Content-Location` as the canonical source URL, if given, or fall back to scriptURL.
+        NSURL *sourceURL = scriptURL;
+        NSString *contentLocationHeader = headers[@"Content-Location"];
+        if (contentLocationHeader) {
+          NSURL *contentLocationURL = [NSURL URLWithString:contentLocationHeader relativeToURL:scriptURL];
+          if (contentLocationURL) {
+            sourceURL = contentLocationURL;
+          }
+        }
+
+        RCTSource *source = RCTSourceCreate(sourceURL, data, data.length);
         parseHeaders(headers, source);
         onComplete(nil, source);
       }

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -473,6 +473,7 @@ struct RCTInstanceCallback : public InstanceCallback {
   // Load the source asynchronously, then store it for later execution.
   dispatch_group_enter(prepareBridge);
   __block NSData *sourceCode;
+  __block NSURL *sourceURL = self.bundleURL;
 
 #if (RCT_DEV | RCT_ENABLE_LOADING_VIEW) && __has_include(<React/RCTDevLoadingViewProtocol.h>)
   {
@@ -488,6 +489,9 @@ struct RCTInstanceCallback : public InstanceCallback {
         }
 
         sourceCode = source.data;
+        if (source.url) {
+          sourceURL = source.url;
+        }
         dispatch_group_leave(prepareBridge);
       }
       onProgress:^(RCTLoadingProgress *progressData) {
@@ -502,7 +506,7 @@ struct RCTInstanceCallback : public InstanceCallback {
   dispatch_group_notify(prepareBridge, dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
     RCTCxxBridge *strongSelf = weakSelf;
     if (sourceCode && strongSelf.loading) {
-      [strongSelf executeSourceCode:sourceCode sync:NO];
+      [strongSelf executeSourceCode:sourceCode withSourceURL:sourceURL sync:NO];
     }
   });
   RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
@@ -1048,7 +1052,7 @@ struct RCTInstanceCallback : public InstanceCallback {
   [_displayLink registerModuleForFrameUpdates:module withModuleData:moduleData];
 }
 
-- (void)executeSourceCode:(NSData *)sourceCode sync:(BOOL)sync
+- (void)executeSourceCode:(NSData *)sourceCode withSourceURL:(NSURL *)url sync:(BOOL)sync
 {
   // This will get called from whatever thread was actually executing JS.
   dispatch_block_t completion = ^{
@@ -1073,12 +1077,13 @@ struct RCTInstanceCallback : public InstanceCallback {
   };
 
   if (sync) {
-    [self executeApplicationScriptSync:sourceCode url:self.bundleURL];
+    [self executeApplicationScriptSync:sourceCode url:url];
     completion();
   } else {
-    [self enqueueApplicationScript:sourceCode url:self.bundleURL onComplete:completion];
+    [self enqueueApplicationScript:sourceCode url:url onComplete:completion];
   }
 
+  // Use the original request URL here - HMRClient uses this to derive the /hot URL and entry point.
   [self.devSettings setupHMRClientWithBundleURL:self.bundleURL];
 }
 


### PR DESCRIPTION
**This is a pick of https://github.com/facebook/react-native/pull/37501 into 0.69-stable**

Summary:
Pull Request resolved: https://github.com/facebook/react-native/pull/37501

This is the iOS side of the fix for https://github.com/facebook/react-native/issues/36794.

That issue aside for the moment, the high-level idea here is to conceptually separate the bundle *request URL*, which represents a request for the *latest* bundle, from the *source URL* passed to JS engines, which should represent the code actually being executed. In future, we'd like to use this to refer to a point-in-time snapshot of the bundle, so that stack traces more often refer to the code that was actually run, even if it's since been updated on disk (actually implementing this isn't planned at the moment, but it helps describe the distinction).

Short term, this separation gives us a way to address the issue with JSC on iOS 16.4 by allowing Metro to provide the client with a [JSC-safe URL](https://github.com/react-native-community/discussions-and-proposals/pull/646) to pass to the JS engine, even where the request URL isn't JSC-safe.

We'll deliver that URL to the client on HTTP bundle requests via the [`Content-Location`](https://www.rfc-editor.org/rfc/rfc9110#name-content-location) header, which is a published standard for communicating a location for the content provided in a successful response (typically used to provide a direct URL to an asset after content negotiation, but I think it fits here too).

For the long-term goal we should follow up with the same functionality on Android and out-of-tree platforms, but it's non-essential for anything other than iOS 16.4 at the moment.

For the issue fix to work end-to-end we'll also need to update Metro, but the two pieces are decoupled and non-breaking so it doesn't matter which lands first.

Changelog:
[iOS][Changed] Prefer `Content-Location` header in bundle response as JS source URL

Reviewed By: huntie

Differential Revision: D45950661

fbshipit-source-id: 170fcd63a098f81bdcba55ebde0cf3569dceb88d
