### PR TITLE
Make react-native-gradle-plugin Java 8 compatible

### DIFF
--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -56,17 +56,17 @@ dependencies {
 
 java {
   // We intentionally don't build for Java 17 as users will see a cryptic bytecode version
-  // error first. Instead we produce a Java 11-compatible Gradle Plugin, so that AGP can print their
+  // error first. Instead we produce a Java 8-compatible Gradle Plugin, so that AGP can print their
   // nice message showing that JDK 11 (or 17) is required first
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 kotlin { jvmToolchain(17) }
 
 tasks.withType<KotlinCompile> {
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    jvmTarget = JavaVersion.VERSION_1_8.majorVersion
     apiVersion = "1.5"
     languageVersion = "1.5"
   }

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -66,7 +66,7 @@ kotlin { jvmToolchain(17) }
 
 tasks.withType<KotlinCompile> {
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_1_8.majorVersion
+    jvmTarget = "1.8"
     apiVersion = "1.5"
     languageVersion = "1.5"
   }


### PR DESCRIPTION
## Summary:

This will make the error of JDK 8 users more graceful rather then letting the build fail at dependency resolution time.

## Changelog:

[INTERNAL] - Make react-native-gradle-plugin Java 8 compatible

## Test Plan:

CI