### PR TITLE
fix(xcode): Pass `hermesc` $EXTRA_COMPILER_ARGS as individual arguments

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -176,7 +176,7 @@ else
   if [[ $EMIT_SOURCEMAP == true ]]; then
     EXTRA_COMPILER_ARGS="$EXTRA_COMPILER_ARGS -output-source-map"
   fi
-  "$HERMES_CLI_PATH" -emit-binary -max-diagnostic-width=80 "$EXTRA_COMPILER_ARGS" -out "$DEST/main.jsbundle" "$BUNDLE_FILE"
+  "$HERMES_CLI_PATH" -emit-binary -max-diagnostic-width=80 $EXTRA_COMPILER_ARGS -out "$DEST/main.jsbundle" "$BUNDLE_FILE"
   if [[ $EMIT_SOURCEMAP == true ]]; then
     HBC_SOURCEMAP_FILE="$DEST/main.jsbundle.map"
     "$NODE_BINARY" "$COMPOSE_SOURCEMAP_PATH" "$PACKAGER_SOURCEMAP_FILE" "$HBC_SOURCEMAP_FILE" -o "$SOURCEMAP_FILE"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

If "$EXTRA_COMPILER_ARGS" is wrapped by `"` it will be passed to `hermesc` binary as one argument which will cause `Unknown command line argument` error when using `$SOURCEMAP_FILE` to generate Hermes source maps.

```
+ EXTRA_COMPILER_ARGS='-O -output-source-map'
+ /ios/Pods/hermes-engine/destroot/bin/hermesc -emit-binary -max-diagnostic-width=80 '-O -output-source-map' -out /dtnzzmpchfyuyyajisnbghavfleb/Build/Products/Release-iphonesimulator/sampleNewArchitecture.app/main.jsbundle /dtnzzmpchfyuyyajisnbghavfleb/Build/Products/Release-iphonesimulator/main.jsbundle
hermesc: Unknown command line argument '-O -output-source-map'.  Try: '/ios/Pods/hermes-engine/destroot/bin/hermesc -help'
```

This error doesn't happen by default as the only argument in `$EXTRA_COMPILER_ARGS` is `-O` but if you add an extra argument or use `$SOURCEMAP_FILE` which results in multiple extra compiler args the error will happen.

Introduced in https://github.com/facebook/react-native/commit/a168f4bbcbd4f4c0a90b5dc2462ec360c372c75c
Affects 0.72.0 and 0.72.1

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Pass `hermesc` $EXTRA_COMPILER_ARGS as individual arguments

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run build with `$SOURCEMAP_FILE` or any other `$EXTRA_COMPILER_ARGS` which has more than one argument.