### PR TITLE
W3CPointerEvents: fix unintentional shallow copy of coordinates

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -674,16 +674,14 @@ public class JSPointerDispatcher {
     Map<Integer, float[]> newOffsets = new HashMap<>(original.getOffsetByPointerId());
     Map<Integer, float[]> newEventCoords = new HashMap<>(original.getEventCoordinatesByPointerId());
 
+    float[] rootOffset = {rootX, rootY};
     for (Map.Entry<Integer, float[]> offsetEntry : newOffsets.entrySet()) {
-      float[] offsetValue = offsetEntry.getValue();
-      offsetValue[0] = rootX;
-      offsetValue[1] = rootY;
+      offsetEntry.setValue(rootOffset);
     }
 
+    float[] zeroOffset = {0, 0};
     for (Map.Entry<Integer, float[]> eventCoordsEntry : newEventCoords.entrySet()) {
-      float[] eventCoordsValue = eventCoordsEntry.getValue();
-      eventCoordsValue[0] = 0;
-      eventCoordsValue[1] = 0;
+      eventCoordsEntry.setValue(zeroOffset);
     }
 
     return new PointerEventState(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.uimanager.events;
 
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import androidx.annotation.Nullable;
 import androidx.core.util.Pools;
@@ -183,6 +184,13 @@ public class PointerEvent extends Event<PointerEvent> {
     return w3cPointerEvents;
   }
 
+  private void addModifierKeyData(WritableMap pointerEvent, int modifierKeyMask) {
+    pointerEvent.putBoolean("ctrlKey", (modifierKeyMask & KeyEvent.META_CTRL_ON) != 0);
+    pointerEvent.putBoolean("shiftKey", (modifierKeyMask & KeyEvent.META_SHIFT_ON) != 0);
+    pointerEvent.putBoolean("altKey", (modifierKeyMask & KeyEvent.META_ALT_ON) != 0);
+    pointerEvent.putBoolean("metaKey", (modifierKeyMask & KeyEvent.META_META_ON) != 0);
+  }
+
   private WritableMap createW3CPointerEvent(int index) {
     WritableMap pointerEvent = Arguments.createMap();
     int pointerId = mMotionEvent.getPointerId(index);
@@ -253,6 +261,8 @@ public class PointerEvent extends Event<PointerEvent> {
 
     pointerEvent.putDouble("pressure", pressure);
     pointerEvent.putDouble("tangentialPressure", 0.0);
+
+    addModifierKeyData(pointerEvent, mMotionEvent.getMetaState());
 
     return pointerEvent;
   }


### PR DESCRIPTION
Summary:
Changelog: [Android] [Internal] - W3CPointerEvents: fix unintentional shallow copy of coordinates

When normalizing pointer event state, we previously only made a shallow copy and thus unintentionally modified the coordinate values in the original event state. This change fixes the issue by creating new coordinate arrays for the normalized event state instead of reusing the existing ones.

Reviewed By: yungsters

Differential Revision: D47230953

