### PR TITLE
Bridgeless mode: Attach bridge/bridgeless apis to interop modules

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -9,6 +9,7 @@
 
 #import <React/RCTBridgeDelegate.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTBridgeModuleDecorator.h>
 #import <React/RCTDefines.h>
 #import <React/RCTFrameUpdate.h>
 #import <React/RCTInvalidating.h>
@@ -149,7 +150,7 @@ RCT_EXTERN void RCTSetTurboModuleCleanupMode(RCTTurboModuleCleanupMode mode);
  * It allows the bridge to attach properties to ObjC modules that give those modules
  * access to Bridge APIs.
  */
-- (void)attachBridgeAPIsToObjCModule:(id<RCTBridgeModule>)module;
+- (RCTBridgeModuleDecorator *)bridgeModuleDecorator;
 
 /**
  * Convenience method for retrieving all modules conforming to a given protocol.

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -226,9 +226,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   [self.batchedBridge setRCTTurboModuleRegistry:turboModuleRegistry];
 }
 
-- (void)attachBridgeAPIsToObjCModule:(id<RCTBridgeModule>)module
+- (RCTBridgeModuleDecorator *)bridgeModuleDecorator
 {
-  [self.batchedBridge attachBridgeAPIsToObjCModule:module];
+  return [self.batchedBridge bridgeModuleDecorator];
 }
 
 - (void)didReceiveReloadCommand

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -245,14 +245,12 @@ struct RCTInstanceCallback : public InstanceCallback {
   [_objCModuleRegistry setTurboModuleRegistry:_turboModuleRegistry];
 }
 
-- (void)attachBridgeAPIsToObjCModule:(id<RCTBridgeModule>)module
+- (RCTBridgeModuleDecorator *)bridgeModuleDecorator
 {
-  RCTBridgeModuleDecorator *bridgeModuleDecorator =
-      [[RCTBridgeModuleDecorator alloc] initWithViewRegistry:_viewRegistry_DEPRECATED
-                                              moduleRegistry:_objCModuleRegistry
-                                               bundleManager:_bundleManager
-                                           callableJSModules:_callableJSModules];
-  [bridgeModuleDecorator attachInteropAPIsToModule:module];
+  return [[RCTBridgeModuleDecorator alloc] initWithViewRegistry:_viewRegistry_DEPRECATED
+                                                 moduleRegistry:_objCModuleRegistry
+                                                  bundleManager:_bundleManager
+                                              callableJSModules:_callableJSModules];
 }
 
 - (std::shared_ptr<MessageQueueThread>)jsMessageThread

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -9,6 +9,7 @@
 
 #import <memory>
 
+#import <React/RCTBridgeModuleDecorator.h>
 #import <React/RCTBridgeProxy.h>
 #import <React/RCTDefines.h>
 #import <React/RCTTurboModuleRegistry.h>
@@ -59,15 +60,17 @@ RCT_EXTERN void RCTTurboModuleSetBindingMode(facebook::react::TurboModuleBinding
                       delegate:(id<RCTTurboModuleManagerDelegate>)delegate
                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;
 
+- (instancetype)initWithBridgeProxy:(RCTBridgeProxy *)bridgeProxy
+              bridgeModuleDecorator:(RCTBridgeModuleDecorator *)bridgeModuleDecorator
+                           delegate:(id<RCTTurboModuleManagerDelegate>)delegate
+                          jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;
+
 - (void)installJSBindings:(facebook::jsi::Runtime &)runtime;
 
 /**
  * @deprecated: use installJSBindings instead
  */
 - (void)installJSBindingWithRuntimeExecutor:(facebook::react::RuntimeExecutor &)runtimeExecutor;
-
-// TODO: Should we move this into the initializer?
-- (void)setBridgeProxy:(RCTBridgeProxy *)bridgeProxy;
 
 - (void)invalidate;
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -159,6 +159,16 @@ class LegacyModuleNativeMethodCallInvoker : public ModuleNativeMethodCallInvoker
     ModuleNativeMethodCallInvoker::invokeSync(methodName, std::move(work));
   }
 };
+
+bool isTurboModuleClass(Class cls)
+{
+  return [cls conformsToProtocol:@protocol(RCTTurboModule)];
+}
+
+bool isTurboModuleInstance(id module)
+{
+  return isTurboModuleClass([module class]);
+}
 }
 
 // Fallback lookup since RCT class prefix is sometimes stripped in the existing NativeModule system.
@@ -218,7 +228,7 @@ static Class getFallbackClassFromName(const char *name)
 
       if ([_delegate respondsToSelector:@selector(extraModulesForBridge:)]) {
         for (id<RCTBridgeModule> module in [_delegate extraModulesForBridge:nil]) {
-          if (!RCT_IS_TURBO_MODULE_INSTANCE(module)) {
+          if (!isTurboModuleInstance(module)) {
             [legacyInitializedModules setObject:module forKey:RCTBridgeModuleNameForClass([module class])];
           }
         }
@@ -227,7 +237,7 @@ static Class getFallbackClassFromName(const char *name)
 
       NSMutableDictionary<NSString *, Class> *legacyEagerlyRegisteredModuleClasses = [NSMutableDictionary new];
       for (Class moduleClass in RCTGetModuleClasses()) {
-        if (!RCT_IS_TURBO_MODULE_CLASS(moduleClass)) {
+        if (!isTurboModuleClass(moduleClass)) {
           [legacyEagerlyRegisteredModuleClasses setObject:moduleClass forKey:RCTBridgeModuleNameForClass(moduleClass)];
         }
       }
@@ -438,8 +448,7 @@ static Class getFallbackClassFromName(const char *name)
   }
 
   Class moduleClass = [self _getModuleClassFromName:moduleName];
-  return moduleClass != nil &&
-      (RCT_IS_TURBO_MODULE_CLASS(moduleClass) && ![moduleClass isSubclassOfClass:RCTCxxModule.class]);
+  return moduleClass != nil && (isTurboModuleClass(moduleClass) && ![moduleClass isSubclassOfClass:RCTCxxModule.class]);
 }
 
 - (BOOL)_isLegacyModule:(const char *)moduleName
@@ -458,8 +467,7 @@ static Class getFallbackClassFromName(const char *name)
     return YES;
   }
 
-  return moduleClass != nil &&
-      (!RCT_IS_TURBO_MODULE_CLASS(moduleClass) || [moduleClass isSubclassOfClass:RCTCxxModule.class]);
+  return moduleClass != nil && (!isTurboModuleClass(moduleClass) || [moduleClass isSubclassOfClass:RCTCxxModule.class]);
 }
 
 - (ModuleHolder *)_getOrCreateModuleHolder:(const char *)moduleName


### PR DESCRIPTION
Summary:
## Context
Native modules can synthesize these bridge/bridgeless-agnostic abstractions:
- viewRegistry_DEPRECATED
- bundleManager
- callableJSModules
- moduleRegistry

## The Problem
The TurboModule interop layer wasn't attaching these abstractions to legacy modules.

## The Issue
In Bridgeless mode, the React instance attaches these abstractions to **all** modules, by implementing TurboModuleManagerDelegate.

But, the TurboModuleManager creates legacy modules without calling into the TurboModuleManagerDelegate. So, legacy modules never had these abstractions attached.

## The Fix
Move the attachment logic to within TurboModuleManager.

Changelog: [Internal]

Reviewed By: dmytrorykun

Differential Revision: D47074304

