### PR TITLE
Migrate TurboModule system off RCTTurboModuleEnabled() flag

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -159,6 +159,16 @@ class LegacyModuleNativeMethodCallInvoker : public ModuleNativeMethodCallInvoker
     ModuleNativeMethodCallInvoker::invokeSync(methodName, std::move(work));
   }
 };
+
+bool isTurboModuleClass(Class cls)
+{
+  return [cls conformsToProtocol:@protocol(RCTTurboModule)];
+}
+
+bool isTurboModuleInstance(id module)
+{
+  return isTurboModuleClass([module class]);
+}
 }
 
 // Fallback lookup since RCT class prefix is sometimes stripped in the existing NativeModule system.
@@ -218,7 +228,7 @@ static Class getFallbackClassFromName(const char *name)
 
       if ([_delegate respondsToSelector:@selector(extraModulesForBridge:)]) {
         for (id<RCTBridgeModule> module in [_delegate extraModulesForBridge:nil]) {
-          if (!RCT_IS_TURBO_MODULE_INSTANCE(module)) {
+          if (!isTurboModuleInstance(module)) {
             [legacyInitializedModules setObject:module forKey:RCTBridgeModuleNameForClass([module class])];
           }
         }
@@ -227,7 +237,7 @@ static Class getFallbackClassFromName(const char *name)
 
       NSMutableDictionary<NSString *, Class> *legacyEagerlyRegisteredModuleClasses = [NSMutableDictionary new];
       for (Class moduleClass in RCTGetModuleClasses()) {
-        if (!RCT_IS_TURBO_MODULE_CLASS(moduleClass)) {
+        if (!isTurboModuleClass(moduleClass)) {
           [legacyEagerlyRegisteredModuleClasses setObject:moduleClass forKey:RCTBridgeModuleNameForClass(moduleClass)];
         }
       }
@@ -438,8 +448,7 @@ static Class getFallbackClassFromName(const char *name)
   }
 
   Class moduleClass = [self _getModuleClassFromName:moduleName];
-  return moduleClass != nil &&
-      (RCT_IS_TURBO_MODULE_CLASS(moduleClass) && ![moduleClass isSubclassOfClass:RCTCxxModule.class]);
+  return moduleClass != nil && (isTurboModuleClass(moduleClass) && ![moduleClass isSubclassOfClass:RCTCxxModule.class]);
 }
 
 - (BOOL)_isLegacyModule:(const char *)moduleName
@@ -458,8 +467,7 @@ static Class getFallbackClassFromName(const char *name)
     return YES;
   }
 
-  return moduleClass != nil &&
-      (!RCT_IS_TURBO_MODULE_CLASS(moduleClass) || [moduleClass isSubclassOfClass:RCTCxxModule.class]);
+  return moduleClass != nil && (!isTurboModuleClass(moduleClass) || [moduleClass isSubclassOfClass:RCTCxxModule.class]);
 }
 
 - (ModuleHolder *)_getOrCreateModuleHolder:(const char *)moduleName


### PR DESCRIPTION
Summary:
The TurboModule system should just assume that RCTTurboModuleEnabled() is true.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D47074303

