### PR TITLE
Enable debugging in debug build

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector/CMakeLists.txt
@@ -20,6 +20,14 @@ target_compile_options(
         -fexceptions
 )
 
+if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+        target_compile_options(
+                hermes_inspector
+                PRIVATE
+                -DHERMES_ENABLE_DEBUGGER=1
+        )
+endif()
+
 target_include_directories(hermes_inspector PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(hermes_inspector
         jsinspector


### PR DESCRIPTION
Summary:
Enable the preprocessor flag to allow debugging when in a debug build. This flag influences the Hermes headers included in the inspector, and causes them to include the debugging functionality.

Changelog:
    [General][Fixed] - Re-enabled debugging for debug builds

Differential Revision: D47243235

