### PR TITLE
Introduce jest-e2e test for TurboModule Interop

### DIFF
--- a/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
@@ -129,7 +129,9 @@ class SampleLegacyModuleExample extends React.Component<{||}, State> {
     const result = this.state.testResults[name] || {};
     return (
       <View style={styles.result}>
-        <Text style={[styles.value]}>{JSON.stringify(result.value)}</Text>
+        <Text testID={name + '-result'} style={[styles.value]}>
+          {(JSON.stringify(result.value) || '').replaceAll('"', "'")}
+        </Text>
         <Text style={[styles.type]}>{result.type}</Text>
       </View>
     );
@@ -145,6 +147,7 @@ class SampleLegacyModuleExample extends React.Component<{||}, State> {
         <View style={styles.item}>
           <TouchableOpacity
             style={[styles.column, styles.button]}
+            testID="run-all-tests"
             onPress={() =>
               Object.keys(this._tests).forEach(item => {
                 try {


### PR DESCRIPTION
Summary:
This test will ensure that the TurboModule interop layer works in Catalyst.

It will navigate to the sample legacy module screen, and ensure that all methods work.

Steps:
1. Open up Catalyst
2. Navigate to the Legacy Native Module example
3. Click "Run all tests"
4. Validate that all tests match expectations.

Differential Revision: D46917689

