### PR TITLE
[metro-config] add InitializeCore in getModulesRunBeforeMainModule

### DIFF
--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -45,6 +45,7 @@ function getDefaultConfig(
       unstable_conditionNames: ['require', 'import', 'react-native'],
     },
     serializer: {
+      // Note: This option is overridden in cli-plugin-metro (getOverrideConfig)
       getModulesRunBeforeMainModule: () => [
         require.resolve('react-native/Libraries/Core/InitializeCore'),
       ],

--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -45,6 +45,9 @@ function getDefaultConfig(
       unstable_conditionNames: ['require', 'import', 'react-native'],
     },
     serializer: {
+      getModulesRunBeforeMainModule: () => [
+        require.resolve('react-native/Libraries/Core/InitializeCore'),
+      ],
       getPolyfills: () => require('@react-native/js-polyfills')(),
     },
     server: {


### PR DESCRIPTION
## Summary:

the `IntializeCore` is critical to react-native for setup polyfills. without this, we would have some erros like undefined `global.performance`. since the effort is now proposing `@react-native/metro-config` as universal metro-config, it is better to have the `IntializeCore` in it.

we ran into issues when using expo-cli in bare react-native projects. it happens when using [the default metro config](https://github.com/facebook/react-native/blob/5f84d7338f42fe9b1d5bf2a9b1c8321b59551f15/packages/react-native/template/metro.config.js) and starting metro server without the react-native-community-cli.

### Why the issue does not happen on `yarn react-native start`?

when using `yarn react-native start`, the react-native-community-cli will merge its internal metro-config with the `InitializeCore` ([#1](https://github.com/react-native-community/cli/blob/5d8a8478cd104adf4a4dd34c09c2e256325ae61d/packages/cli-plugin-metro/src/commands/start/runServer.ts#L56), [#2](https://github.com/react-native-community/cli/blob/e8e7402512da8c3fbbc58a195284ef0008c7491f/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts#L51-L61)). that's why the issue doesn't happen on react-native-community-cli.

## Changelog:

[GENERAL][FIXED] - `global.performance` in undefined when starting metro from Expo CLI

## Test Plan:

```sh
$ npx react-native init RN072 --version 0.72
$ cd RN072
$ yarn add expo
$ npx expo run:ios
# then it hits the exception because the global.performance is undefined.
```
