### PR TITLE
[iOS][ActivityIndicator] Remove deprecated uses of UIActivityIndicatorViewStyle

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
@@ -21,9 +21,9 @@ static UIActivityIndicatorViewStyle convertActivityIndicatorViewStyle(const Acti
 {
   switch (size) {
     case ActivityIndicatorViewSize::Small:
-      return UIActivityIndicatorViewStyleWhite;
+      return UIActivityIndicatorViewStyleMedium;
     case ActivityIndicatorViewSize::Large:
-      return UIActivityIndicatorViewStyleWhiteLarge;
+      return UIActivityIndicatorViewStyleLarge;
   }
 }
 

--- a/packages/react-native/React/Views/RCTActivityIndicatorViewManager.m
+++ b/packages/react-native/React/Views/RCTActivityIndicatorViewManager.m
@@ -18,10 +18,10 @@
 RCT_ENUM_CONVERTER(
     UIActivityIndicatorViewStyle,
     (@{
-      @"large" : @(UIActivityIndicatorViewStyleWhiteLarge),
-      @"small" : @(UIActivityIndicatorViewStyleWhite),
+      @"large" : @(UIActivityIndicatorViewStyleLarge),
+      @"small" : @(UIActivityIndicatorViewStyleMedium),
     }),
-    UIActivityIndicatorViewStyleWhiteLarge,
+    UIActivityIndicatorViewStyleLarge,
     integerValue)
 
 @end


### PR DESCRIPTION
## Summary:

Super simple change to replace some deprecated ENUM values with the correct one, now that we're on iOS 13.0+.

From `UIActivityIndicator.h`:
```
typedef NS_ENUM(NSInteger, UIActivityIndicatorViewStyle) {
    UIActivityIndicatorViewStyleMedium  API_AVAILABLE(ios(13.0), tvos(13.0)) = 100,
    UIActivityIndicatorViewStyleLarge   API_AVAILABLE(ios(13.0), tvos(13.0)) = 101,
    
    UIActivityIndicatorViewStyleWhiteLarge API_DEPRECATED_WITH_REPLACEMENT("UIActivityIndicatorViewStyleLarge", ios(2.0, 13.0), tvos(9.0, 13.0)) = 0,
    UIActivityIndicatorViewStyleWhite API_DEPRECATED_WITH_REPLACEMENT("UIActivityIndicatorViewStyleMedium", ios(2.0, 13.0), tvos(9.0, 13.0)) = 1,
    UIActivityIndicatorViewStyleGray API_DEPRECATED_WITH_REPLACEMENT("UIActivityIndicatorViewStyleMedium", ios(2.0, 13.0)) API_UNAVAILABLE(tvos) = 2,
};
```

## Changelog:

[IOS] [CHANGED] - Remove deprecated uses of UIActivityIndicatorViewStyle

## Test Plan:

CI should pass
