### PR TITLE
Fix hermes inspector broken on android

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(hermes_inspector
 target_compile_options(
         hermes_inspector
         PRIVATE
+        -DHERMES_ENABLE_DEBUGGER=1
         -DHERMES_INSPECTOR_FOLLY_KLUDGE=1
         -std=c++17
         -fexceptions


### PR DESCRIPTION
## Summary:

a regression from react-native 0.72.0 where the hermes inspector is not working on android

the root cause is that building the Inspector.cpp or some other files without the `HERMES_ENABLE_DEBUGGER` defined.

it was defined in [0.71](https://github.com/facebook/react-native/blob/49d16d5aefd703ff20ab5d05544d78d6ce446427/ReactCommon/hermes/inspector/CMakeLists.txt#L18C9-L18C35) but missing from 0.72 probably because of the monorepo changes.

## Changelog:

[ANDROID][FIXED] - Hermes Inspector is not working on Android

## Test Plan:

tested on rn-tester hermesDebug + flipper
