### PR TITLE
Compile hermes-engine with -DHERMES_ENABLE_DEBUGGER=False on Release

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -191,6 +191,8 @@ android {
             externalNativeBuild {
                 cmake {
                     arguments "-DCMAKE_BUILD_TYPE=MinSizeRel"
+                    // For release builds, we don't want to enable the Hermes Debugger.
+                    arguments "-DHERMES_ENABLE_DEBUGGER=False"
                 }
             }
         }


### PR DESCRIPTION
Summary:
This mirrors the same logic that the Hermes team has on facebook/hermes.
Practically, we want to pass the CMake config flag `HERMES_ENABLE_DEBUGGER=False` only for Release
so that their CMake build is configured correctly.

Their build always enables the Debugger and allows us to selectively turn it off only for release
builds.

More context: https://github.com/facebook/hermes/commit/eabf5fcd25

Changelog:
[Internal] [Changed] - Compile hermes-engine with -DHERMES_ENABLE_DEBUGGER=False on Release

Reviewed By: cipolleschi

Differential Revision: D47252735

