### PR TITLE
fix: return the correct default trait collection

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -36,6 +36,18 @@ NSString *RCTCurrentOverrideAppearancePreference()
   return sColorSchemeOverride;
 }
 
+UITraitCollection* getKeyWindowTraitCollection() {
+  if ([NSThread isMainThread]) {
+    return [UIApplication sharedApplication].delegate.window.traitCollection;
+  } else {
+    __block UITraitCollection* traitCollection = nil;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      traitCollection = [UIApplication sharedApplication].delegate.window.traitCollection;
+    });
+    return traitCollection;
+  }
+}
+
 NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
 {
   static NSDictionary *appearances;
@@ -57,7 +69,7 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
     return RCTAppearanceColorSchemeLight;
   }
 
-  traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
+  traitCollection = traitCollection ?: getKeyWindowTraitCollection();
   return appearances[@(traitCollection.userInterfaceStyle)] ?: RCTAppearanceColorSchemeLight;
 
   // Default to light on older OS version - same behavior as Android.

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -37,15 +37,11 @@ NSString *RCTCurrentOverrideAppearancePreference()
 }
 
 UITraitCollection* getKeyWindowTraitCollection() {
-  if ([NSThread isMainThread]) {
-    return [UIApplication sharedApplication].delegate.window.traitCollection;
-  } else {
-    __block UITraitCollection* traitCollection = nil;
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      traitCollection = [UIApplication sharedApplication].delegate.window.traitCollection;
-    });
-    return traitCollection;
-  }
+  __block UITraitCollection* traitCollection = nil;
+  RCTExecuteOnMainQueue(^{
+    traitCollection = RCTSharedApplication().delegate.window.traitCollection;
+  });
+  return traitCollection;
 }
 
 NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)


### PR DESCRIPTION
## Summary:
Currently, when the `_currentColorScheme` is nil the default comes from `[UITraitCollection currentTraitCollection]` which provides the trait collection of the context it was called in. Generally, this will work but in some cases the context can be different and this will return the wrong value also if the `Appearance` property is set in the plist, then initially that value is returned, regardless of if you have overridden it.  Seen as the `userInterfaceStyle` of the window is overridden when the value is changed, then the default should be whatever the current style of the window is and not dependent on the calling context.

<table>
    <tr><th>Before</th><th>After</th></tr>
    <tr>
    <td>
        <video src="https://github.com/facebook/react-native/assets/30924086/3bd2d217-00f2-41d5-9229-05c31da2ecf5"/>
   </td>
   <td>
       <video src="https://github.com/facebook/react-native/assets/30924086/6ed67e4c-dd01-40ff-84fd-0d7ffdf6534c"   />  
    </td>
</tr> 
</table> 

## Changelog:

[IOS] [FIXED] - Fix the default trait collection to always return the value of the window

## Test Plan:

Tested on rn-tester and verified the current behaviour is unaffected and also in our own repo to make sure it addresses the problem. Video provided above
