### PR TITLE
Rollout TurboModuleBinding::Prototype

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -105,17 +105,6 @@ public class ReactFeatureFlags {
   public static boolean enableFabricPendingEventQueue = false;
 
   /**
-   * Feature flag that controls how turbo modules are exposed to JS
-   *
-   * <ul>
-   *   <li>0 = as a HostObject
-   *   <li>1 = as a plain object, backed with a HostObject as prototype
-   *   <li>2 = as a plain object, with all methods eagerly configured
-   * </ul>
-   */
-  public static int turboModuleBindingMode = 0;
-
-  /**
    * Feature Flag to enable View Recycling. When enabled, individual ViewManagers must still opt-in.
    */
   public static boolean enableViewRecycling = false;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -91,17 +91,6 @@ class JMethodDescriptor : public jni::JavaClass<JMethodDescriptor> {
 };
 } // namespace
 
-constexpr static auto ReactFeatureFlagsJavaDescriptor =
-    "com/facebook/react/config/ReactFeatureFlags";
-
-static int getFeatureFlagValue(const char *name) {
-  static const auto reactFeatureFlagsJavaDescriptor =
-      jni::findClassStatic(ReactFeatureFlagsJavaDescriptor);
-  const auto field =
-      reactFeatureFlagsJavaDescriptor->getStaticField<jint>(name);
-  return reactFeatureFlagsJavaDescriptor->getStaticFieldValue(field);
-}
-
 TurboModuleManager::TurboModuleManager(
     jni::alias_ref<TurboModuleManager::javaobject> jThis,
     RuntimeExecutor runtimeExecutor,
@@ -319,20 +308,13 @@ void TurboModuleManager::installJSIBindings(bool shouldCreateLegacyModules) {
   bool isInteropLayerDisabled = !shouldCreateLegacyModules;
 
   runtimeExecutor_([this, isInteropLayerDisabled](jsi::Runtime &runtime) {
-    TurboModuleBindingMode bindingMode = static_cast<TurboModuleBindingMode>(
-        getFeatureFlagValue("turboModuleBindingMode"));
-
     if (isInteropLayerDisabled) {
-      TurboModuleBinding::install(
-          runtime, bindingMode, createTurboModuleProvider());
+      TurboModuleBinding::install(runtime, createTurboModuleProvider());
       return;
     }
 
     TurboModuleBinding::install(
-        runtime,
-        bindingMode,
-        createTurboModuleProvider(),
-        createLegacyModuleProvider());
+        runtime, createTurboModuleProvider(), createLegacyModuleProvider());
   });
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -14,12 +14,6 @@
 
 namespace facebook::react {
 
-enum class TurboModuleBindingMode : uint8_t {
-  HostObject = 0,
-  Prototype = 1,
-  Eager = 2,
-};
-
 class BridgelessNativeModuleProxy;
 
 /**
@@ -33,13 +27,10 @@ class TurboModuleBinding {
    */
   static void install(
       jsi::Runtime &runtime,
-      TurboModuleBindingMode bindingMode,
       TurboModuleProviderFunctionType &&moduleProvider,
       TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr);
 
-  TurboModuleBinding(
-      TurboModuleBindingMode bindingMode,
-      TurboModuleProviderFunctionType &&moduleProvider);
+  TurboModuleBinding(TurboModuleProviderFunctionType &&moduleProvider);
   virtual ~TurboModuleBinding();
 
  private:
@@ -52,7 +43,6 @@ class TurboModuleBinding {
   jsi::Value getModule(jsi::Runtime &runtime, const std::string &moduleName)
       const;
 
-  TurboModuleBindingMode bindingMode_;
   TurboModuleProviderFunctionType moduleProvider_;
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -17,8 +17,6 @@
 #import <ReactCommon/TurboModuleBinding.h>
 #import "RCTTurboModule.h"
 
-RCT_EXTERN void RCTTurboModuleSetBindingMode(facebook::react::TurboModuleBindingMode bindingMode);
-
 @protocol RCTTurboModuleManagerDelegate <NSObject>
 
 /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -33,12 +33,6 @@
 using namespace facebook;
 using namespace facebook::react;
 
-static TurboModuleBindingMode sTurboModuleBindingMode = TurboModuleBindingMode::HostObject;
-void RCTTurboModuleSetBindingMode(TurboModuleBindingMode bindingMode)
-{
-  sTurboModuleBindingMode = bindingMode;
-}
-
 /**
  * A global variable whose address we use to associate method queues to id<RCTBridgeModule> objects.
  */
@@ -962,10 +956,9 @@ static Class getFallbackClassFromName(const char *name)
       return turboModule;
     };
 
-    TurboModuleBinding::install(
-        runtime, sTurboModuleBindingMode, std::move(turboModuleProvider), std::move(legacyModuleProvider));
+    TurboModuleBinding::install(runtime, std::move(turboModuleProvider), std::move(legacyModuleProvider));
   } else {
-    TurboModuleBinding::install(runtime, sTurboModuleBindingMode, std::move(turboModuleProvider));
+    TurboModuleBinding::install(runtime, std::move(turboModuleProvider));
   }
 }
 


### PR DESCRIPTION
Summary:
We ran an experiment to test different implementations of TurboModules HostObjects, as the current one has various inefficiencies, such as re-creating HostFunctions on every property access. The strategy we found to be most efficient and flexible longer-term is to represent the TurboModule with a plain JavaScript object and use a HostObject as its prototype. Whenever a property is accessed through the prototype, we cache the property value on the plain object, so it can be efficiently resolved by the VM for future accesses.

Changelog: [General] TurboModules are now exposed to JS as the prototype of a plain JS object, so methods can be cached

Differential Revision: D47258286

