### PR TITLE
iOS: Add Commands and Constants properties to native view config

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -1485,6 +1485,13 @@ NSMutableDictionary<NSString *, id> *RCTModuleConstantsForDestructuredComponent(
   moduleConstants[@"baseModuleName"] = viewConfig[@"baseModuleName"];
   moduleConstants[@"bubblingEventTypes"] = bubblingEventTypes;
   moduleConstants[@"directEventTypes"] = directEventTypes;
+  // In the Old Architecture the "Commands" and "Constants" properties of view manager config are populated by
+  // lazifyViewManagerConfig function in JS. This fuction uses NativeModules global object that is not available in the
+  // New Architecture. To make native view configs work in the New Architecture we will populate these properties in
+  // native.
+  moduleConstants[@"Commands"] = viewConfig[@"Commands"];
+  // In the Old Architecture "Constants" are empty.
+  moduleConstants[@"Constants"] = [NSDictionary new];
 
   // Add direct events
   for (NSString *eventName in viewConfig[@"directEvents"]) {


### PR DESCRIPTION
Summary:
View configs are supposed to have `Commands` and `Constants`. See [ReactNativeTypes.js](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js#L68-L69).
Android sets them in native: see [UIManagerModuleConstantsHelper.java](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java#L172-L179).
ut iOS doesn't: see [RCTUIManager.m](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Modules/RCTUIManager.m#L1484-L1487)
Instead there is code for that in [PaperUIManager.js](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/ReactNative/PaperUIManager.js#L117-L160).
It accesses viewManagers like this: `const viewManager = NativeModules[viewConfig.Manager]`. But `NativeModules` object is not available in the bridgeless mode. So we fail to provide complete native view configs in the New Architecture.

This diff implements `Commands` and `Constants` in native in iOS.
This change should have no effect in the old architecture because these properties are overwritten by `lazifyViewManagerConfig`.

Changelog: [Internal] - Add Commands and Constants properties to native view config.

Differential Revision: D47096624

