### PR TITLE
W3CPointerEvents: include screen coordinates in pointer events

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -674,16 +674,14 @@ public class JSPointerDispatcher {
     Map<Integer, float[]> newOffsets = new HashMap<>(original.getOffsetByPointerId());
     Map<Integer, float[]> newEventCoords = new HashMap<>(original.getEventCoordinatesByPointerId());
 
+    float[] rootOffset = {rootX, rootY};
     for (Map.Entry<Integer, float[]> offsetEntry : newOffsets.entrySet()) {
-      float[] offsetValue = offsetEntry.getValue();
-      offsetValue[0] = rootX;
-      offsetValue[1] = rootY;
+      offsetEntry.setValue(rootOffset);
     }
 
+    float[] zeroOffset = {0, 0};
     for (Map.Entry<Integer, float[]> eventCoordsEntry : newEventCoords.entrySet()) {
-      float[] eventCoordsValue = eventCoordsEntry.getValue();
-      eventCoordsValue[0] = 0;
-      eventCoordsValue[1] = 0;
+      eventCoordsEntry.setValue(zeroOffset);
     }
 
     return new PointerEventState(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
@@ -215,6 +215,12 @@ public class PointerEvent extends Event<PointerEvent> {
     pointerEvent.putDouble("clientX", clientX);
     pointerEvent.putDouble("clientY", clientY);
 
+    float[] screenCoords = mEventState.getScreenCoordinatesByPointerId().get(pointerId);
+    double screenX = PixelUtil.toDIPFromPixel(screenCoords[0]);
+    double screenY = PixelUtil.toDIPFromPixel(screenCoords[1]);
+    pointerEvent.putDouble("screenX", screenX);
+    pointerEvent.putDouble("screenY", screenY);
+
     // x,y values are aliases of clientX, clientY
     pointerEvent.putDouble("x", clientX);
     pointerEvent.putDouble("y", clientY);
@@ -338,6 +344,7 @@ public class PointerEvent extends Event<PointerEvent> {
     private Map<Integer, float[]> mOffsetByPointerId;
     private Map<Integer, List<TouchTargetHelper.ViewTarget>> mHitPathByPointerId;
     private Map<Integer, float[]> mEventCoordinatesByPointerId;
+    private Map<Integer, float[]> mScreenCoordinatesByPointerId;
     private Set<Integer> mHoveringPointerIds;
 
     public PointerEventState(
@@ -348,6 +355,7 @@ public class PointerEvent extends Event<PointerEvent> {
         Map<Integer, float[]> offsetByPointerId,
         Map<Integer, List<TouchTargetHelper.ViewTarget>> hitPathByPointerId,
         Map<Integer, float[]> eventCoordinatesByPointerId,
+        Map<Integer, float[]> screenCoordinatesByPointerId,
         Set<Integer> hoveringPointerIds) {
       mPrimaryPointerId = primaryPointerId;
       mActivePointerId = activePointerId;
@@ -356,6 +364,7 @@ public class PointerEvent extends Event<PointerEvent> {
       mOffsetByPointerId = offsetByPointerId;
       mHitPathByPointerId = hitPathByPointerId;
       mEventCoordinatesByPointerId = eventCoordinatesByPointerId;
+      mScreenCoordinatesByPointerId = screenCoordinatesByPointerId;
       mHoveringPointerIds = new HashSet<>(hoveringPointerIds);
     }
 
@@ -393,6 +402,10 @@ public class PointerEvent extends Event<PointerEvent> {
 
     public final Map<Integer, float[]> getEventCoordinatesByPointerId() {
       return mEventCoordinatesByPointerId;
+    }
+
+    public final Map<Integer, float[]> getScreenCoordinatesByPointerId() {
+      return mScreenCoordinatesByPointerId;
     }
 
     public final List<TouchTargetHelper.ViewTarget> getHitPathForActivePointer() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.uimanager.events;
 
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import androidx.annotation.Nullable;
 import androidx.core.util.Pools;
@@ -183,6 +184,13 @@ public class PointerEvent extends Event<PointerEvent> {
     return w3cPointerEvents;
   }
 
+  private void addModifierKeyData(WritableMap pointerEvent, int modifierKeyMask) {
+    pointerEvent.putBoolean("ctrlKey", (modifierKeyMask & KeyEvent.META_CTRL_ON) != 0);
+    pointerEvent.putBoolean("shiftKey", (modifierKeyMask & KeyEvent.META_SHIFT_ON) != 0);
+    pointerEvent.putBoolean("altKey", (modifierKeyMask & KeyEvent.META_ALT_ON) != 0);
+    pointerEvent.putBoolean("metaKey", (modifierKeyMask & KeyEvent.META_META_ON) != 0);
+  }
+
   private WritableMap createW3CPointerEvent(int index) {
     WritableMap pointerEvent = Arguments.createMap();
     int pointerId = mMotionEvent.getPointerId(index);
@@ -253,6 +261,8 @@ public class PointerEvent extends Event<PointerEvent> {
 
     pointerEvent.putDouble("pressure", pressure);
     pointerEvent.putDouble("tangentialPressure", 0.0);
+
+    addModifierKeyData(pointerEvent, mMotionEvent.getMetaState());
 
     return pointerEvent;
   }


### PR DESCRIPTION
Summary:
Changelog: [Android] [Fixed] - W3CPointerEvents: include screen coordinates in pointer events

The [spec](https://www.w3.org/TR/uievents/#idl-mouseevent) says there should be properties on mouse events (and hence pointer events) indicating the screen coordinates of the event (i.e. coords relative to screen of the device).

This change adds those properties.

Reviewed By: javache

Differential Revision: D47162962

