### PR TITLE
Update when view are added to the ViewRegistry

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
@@ -24,6 +24,7 @@
 
 - (void)dealloc
 {
+  [_coordinator removeViewFromRegistryWithTag:_tag];
   [_paperView removeFromSuperview];
   [_coordinator removeObserveForTag:_tag];
 }
@@ -39,6 +40,7 @@
                             weakSelf.eventInterceptor(eventName, event);
                           }
                         }];
+    [_coordinator addViewToRegistry:_paperView withTag:_tag];
   }
   return _paperView;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
@@ -38,6 +38,10 @@ typedef void (^InterceptorBlock)(std::string eventName, folly::dynamic event);
              reactTag:(NSInteger)tag
             paperView:(UIView *)paperView;
 
+- (void)removeViewFromRegistryWithTag:(NSInteger)tag;
+
+- (void)addViewToRegistry:(UIView *)view withTag:(NSInteger)tag;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
@@ -131,22 +131,19 @@ using namespace facebook::react;
   NSArray *newArgs = [@[ [NSNumber numberWithInteger:tag] ] arrayByAddingObjectsFromArray:args];
 
   if (_bridge) {
-    [self _addViewToRegistry:paperView withTag:tag];
     [_bridge.batchedBridge
         dispatchBlock:^{
           [method invokeWithBridge:self->_bridge module:self->_componentData.manager arguments:newArgs];
           [self->_bridge.uiManager setNeedsLayout];
         }
                 queue:RCTGetUIManagerQueue()];
-    [self _removeViewFromRegistryWithTag:tag];
   } else {
     // TODO T86826778 - Figure out which queue this should be dispatched to.
     [method invokeWithBridge:nil module:self->_componentData.manager arguments:newArgs];
   }
 }
 
-#pragma mark - Private
-- (void)_addViewToRegistry:(UIView *)view withTag:(NSInteger)tag
+- (void)addViewToRegistry:(UIView *)view withTag:(NSInteger)tag
 {
   [self _addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     if ([viewRegistry objectForKey:@(tag)] != NULL) {
@@ -158,7 +155,7 @@ using namespace facebook::react;
   }];
 }
 
-- (void)_removeViewFromRegistryWithTag:(NSInteger)tag
+- (void)removeViewFromRegistryWithTag:(NSInteger)tag
 {
   [self _addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     if ([viewRegistry objectForKey:@(tag)] == NULL) {
@@ -170,6 +167,8 @@ using namespace facebook::react;
     [mutableViewRegistry removeObjectForKey:@(tag)];
   }];
 }
+
+#pragma mark - Private
 
 - (void)_addUIBlock:(RCTViewManagerUIBlock)block
 {


### PR DESCRIPTION
Summary:
Before this change, the InteropLayer was adding the view to the registry right before invoking a command and right after the command was invoked. This model was too strict as some view commands may have async behaviors that make the lookup in the registry fail.

After this change, we are going to register the view when it's created and we are going to remove it when the view is deallocated.

## Changelog:
[iOS][Changed] - Update logic to add and remove views in the view registry for the interop layer.

Differential Revision: D47262664

