### PR TITLE
Add @react-native/babel-plugin-codegen to @react-native/babel-preset

### DIFF
--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/babel-preset",
-  "version": "0.73.15",
+  "version": "0.73.16",
   "description": "Babel preset for React Native applications",
   "main": "src/index.js",
   "repository": {
@@ -51,6 +51,7 @@
     "@babel/plugin-transform-typescript": "^7.5.0",
     "@babel/plugin-transform-unicode-regex": "^7.0.0",
     "@babel/template": "^7.0.0",
+    "@react-native/babel-plugin-codegen": "*",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "react-refresh": "^0.4.0"
   },

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -54,6 +54,13 @@ const getPreset = (src, options) => {
     ]);
   }
 
+  if (
+    !options.disableStaticViewConfigsCodegen &&
+    /\bcodegenNativeComponent</.test(src)
+  ) {
+    extraPlugins.push([require('@react-native/babel-plugin-codegen')]);
+  }
+
   if (!options || !options.disableImportExportTransform) {
     extraPlugins.push(
       [require('@babel/plugin-proposal-export-default-from')],

--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -17,7 +17,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@react-native/babel-preset": "^0.73.15",
+    "@react-native/babel-preset": "^0.73.16",
     "@react-native/eslint-config": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",
     "@react-native/typescript-config": "^0.73.0",


### PR DESCRIPTION
Summary:
This diff enables react-native/babel-plugin-codegen to react-native/babel-preset. This will enable static view configs generation for properly schematized native components.

Changelog: [General][Changed] - react-native/babel-plugin-codegen to react-native/babel-preset

Differential Revision: D46688516

