### PR TITLE
Guard against stopped surface in FabricUIManager.getColor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -505,6 +505,11 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   public int getColor(int surfaceId, String[] resourcePaths) {
     ThemedReactContext context =
         mMountingManager.getSurfaceManagerEnforced(surfaceId, "getColor").getContext();
+    // Surface may have been stopped
+    if (context == null) {
+      return 0;
+    }
+
     for (String resourcePath : resourcePaths) {
       Integer color = ColorPropConverter.resolveResourcePath(context, resourcePath);
       if (color != null) {
@@ -598,16 +603,14 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
    * @return if theme data is available in the output parameters.
    */
   public boolean getThemeData(int surfaceId, float[] defaultTextInputPadding) {
-    SurfaceMountingManager surfaceMountingManager =
-        mMountingManager.getSurfaceManagerEnforced(surfaceId, "getThemeData");
-    ThemedReactContext themedReactContext = surfaceMountingManager.getContext();
-
-    if (themedReactContext == null) {
+    Context context =
+        mMountingManager.getSurfaceManagerEnforced(surfaceId, "getThemeData").getContext();
+    if (context == null) {
       FLog.w(TAG, "\"themedReactContext\" is null when call \"getThemeData\"");
       return false;
     }
-    float[] defaultTextInputPaddingForTheme =
-        UIManagerHelper.getDefaultTextInputPadding(themedReactContext);
+
+    float[] defaultTextInputPaddingForTheme = UIManagerHelper.getDefaultTextInputPadding(context);
     defaultTextInputPadding[0] = defaultTextInputPaddingForTheme[PADDING_START_INDEX];
     defaultTextInputPadding[1] = defaultTextInputPaddingForTheme[PADDING_END_INDEX];
     defaultTextInputPadding[2] = defaultTextInputPaddingForTheme[PADDING_TOP_INDEX];
@@ -869,12 +872,12 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       return;
     }
 
-    ThemedReactContext reactContext = surfaceMountingManager.getContext();
+    Context context = surfaceMountingManager.getContext();
     boolean isRTL = false;
     boolean doLeftAndRightSwapInRTL = false;
-    if (reactContext != null) {
-      isRTL = I18nUtil.getInstance().isRTL(reactContext);
-      doLeftAndRightSwapInRTL = I18nUtil.getInstance().doLeftAndRightSwapInRTL(reactContext);
+    if (context != null) {
+      isRTL = I18nUtil.getInstance().isRTL(context);
+      doLeftAndRightSwapInRTL = I18nUtil.getInstance().doLeftAndRightSwapInRTL(context);
     }
 
     mBinding.setConstraints(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
@@ -206,7 +206,7 @@ public class UIManagerHelper {
    * @return the default padding used by Android EditText's. This method returns the padding in an
    *     array to avoid extra classloading during hot-path of RN Android.
    */
-  public static float[] getDefaultTextInputPadding(ThemedReactContext context) {
+  public static float[] getDefaultTextInputPadding(Context context) {
     EditText editText = new EditText(context);
     float[] padding = new float[4];
     padding[PADDING_START_INDEX] = PixelUtil.toDIPFromPixel(ViewCompat.getPaddingStart(editText));


### PR DESCRIPTION
Summary:
In D46840717 I made SurfaceMountingManager reset its context on stop as the Context may be keeping various other objects alive and was causing memory leaks.

This does cause a race condition if JS is still rendering at this time, as it needs to access to context to support things like PlatformColor.

Changelog: [Android] Fix crash on teardown in new architecture

Differential Revision: D47290581

