### PR TITLE
Fix autoscrollToTopThreshold on iOS old arch

### DIFF
--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -954,7 +954,7 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
             CGPointMake(self->_scrollView.contentOffset.x + deltaX, self->_scrollView.contentOffset.y);
         if (autoscrollThreshold != nil) {
           // If the offset WAS within the threshold of the start, animate to the start.
-          if (x - deltaX <= [autoscrollThreshold integerValue]) {
+          if (x <= [autoscrollThreshold integerValue]) {
             [self scrollToOffset:CGPointMake(-leftInset, self->_scrollView.contentOffset.y) animated:YES];
           }
         }
@@ -970,7 +970,7 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
             CGPointMake(self->_scrollView.contentOffset.x, self->_scrollView.contentOffset.y + deltaY);
         if (autoscrollThreshold != nil) {
           // If the offset WAS within the threshold of the start, animate to the start.
-          if (y - deltaY <= [autoscrollThreshold integerValue]) {
+          if (y <= [autoscrollThreshold integerValue]) {
             [self scrollToOffset:CGPointMake(self->_scrollView.contentOffset.x, -bottomInset) animated:YES];
           }
         }


### PR DESCRIPTION
## Summary:

Currently `autoscrollToTopThreshold` does not work correctly, it will scroll to top even when the scroll position is past the `autoscrollToTopThreshold` value.

The value of x/y is taken before we adjust the scroll position so we do not need to subtract the delta.

Note that this was already fixed when I ported this code to fabric, so this fix is only needed in the old arch code.

## Changelog:

[IOS] [FIXED] - Fix autoscrollToTopThreshold on iOS old arch

## Test Plan:

In RNTester example, threshold is set to 10, so it should not scroll to top if we are further than 10px from the top of the list.

Before:

https://github.com/facebook/react-native/assets/2677334/13723787-1bc4-4263-9bcb-91ddf7454de3

After:

https://github.com/facebook/react-native/assets/2677334/a8cfdaac-59fc-40de-970a-ff992366e25f
