### PR TITLE
Remove package comment from JSCExecutor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.java
@@ -14,7 +14,7 @@ import com.facebook.react.bridge.ReadableNativeMap;
 import com.facebook.soloader.SoLoader;
 
 @DoNotStrip
-/* package */ public class JSCExecutor extends JavaScriptExecutor {
+public class JSCExecutor extends JavaScriptExecutor {
 
   static {
     loadLibrary();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RNLog.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RNLog.java
@@ -97,29 +97,15 @@ public class RNLog {
   private static String levelToString(int level) {
     switch (level) {
       case LOG:
-        {
-          return "log";
-        }
       case TRACE:
-        {
-          return "log";
-        }
+        return "log";
       case ADVICE:
-        {
-          return "warn";
-        }
       case WARN:
-        {
-          return "warn";
-        }
+        return "warn";
       case ERROR:
-        {
-          return "error";
-        }
+        return "error";
       default:
-        {
-          return "none";
-        }
+        return "none";
     }
   }
 }


### PR DESCRIPTION
Summary:
Remove package comment from JSCExecutor
This class was made public as part of D30346032, seems it's safe for it to be public

changelog: [internal] internal

Differential Revision: D47309285

