### PR TITLE
Update Yargs flow lib def to allow .fail(false)

### DIFF
--- a/flow-typed/npm/yargs_v17.x.x.js
+++ b/flow-typed/npm/yargs_v17.x.x.js
@@ -191,7 +191,7 @@ declare module "yargs" {
 
     exitProcess(enable: boolean): this;
 
-    fail(fn: (failureMessage: string, err: Error, yargs: Yargs) => mixed): this;
+    fail(fn: false | (failureMessage: string, err: Error, yargs: Yargs) => mixed): this;
 
     getCompletion(
       args: Array<string>,


### PR DESCRIPTION
Summary:
Update Flow types to match for Yargs `.fail()` to match [Yargs docs](https://github.com/yargs/yargs/blob/v17.6.2/docs/api.md#failfn--boolean).

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D47337206

