### PR TITLE
Refactor event pipeline to accept typed event payloads

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(react_render_core
         folly_runtime
         glog
         jsi
+        logger
         react_config
         react_debug
         react_render_debug

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -84,7 +84,7 @@ void EventEmitter::dispatchEvent(
   eventDispatcher->dispatchEvent(
       RawEvent(
           normalizeEventType(std::move(type)),
-          payloadFactory,
+          std::make_shared<ValueFactoryEventPayload>(payloadFactory),
           eventTarget_,
           category),
       priority);
@@ -102,7 +102,7 @@ void EventEmitter::dispatchUniqueEvent(
 
   eventDispatcher->dispatchUniqueEvent(RawEvent(
       normalizeEventType(std::move(type)),
-      payloadFactory,
+      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
       eventTarget_,
       RawEvent::Category::Continuous));
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -12,9 +12,11 @@
 
 #include <folly/dynamic.h>
 #include <react/renderer/core/EventDispatcher.h>
+#include <react/renderer/core/EventPayload.h>
 #include <react/renderer/core/EventPriority.h>
 #include <react/renderer/core/EventTarget.h>
 #include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/core/ValueFactoryEventPayload.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPayload.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPayload.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace facebook::react {
+
+/**
+ * Abstract base class for all event payload types.
+ */
+struct EventPayload {
+  virtual ~EventPayload() = default;
+
+  EventPayload() = default;
+  EventPayload(const EventPayload &) = default;
+  EventPayload &operator=(const EventPayload &) = default;
+  EventPayload(EventPayload &&) = default;
+  EventPayload &operator=(EventPayload &&) = default;
+
+  virtual jsi::Value asJSIValue(jsi::Runtime &runtime) const = 0;
+};
+
+using SharedEventPayload = std::shared_ptr<const EventPayload>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cxxreact/JSExecutor.h>
+#include <logger/react_native_log.h>
 #include "EventEmitter.h"
 #include "EventLogger.h"
 #include "EventQueue.h"
@@ -53,12 +54,18 @@ void EventQueueProcessor::flushEvents(
       eventLogger->onEventDispatch(event.loggingTag);
     }
 
+    if (event.eventPayload == nullptr) {
+      react_native_log_error(
+          "EventQueueProcessor: Unexpected null event payload");
+      continue;
+    }
+
     eventPipe_(
         runtime,
         event.eventTarget.get(),
         event.type,
         reactPriority,
-        event.payloadFactory);
+        *event.eventPayload);
 
     if (eventLogger != nullptr) {
       eventLogger->onEventEnd(event.loggingTag);

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
@@ -11,11 +11,11 @@ namespace facebook::react {
 
 RawEvent::RawEvent(
     std::string type,
-    ValueFactory payloadFactory,
+    SharedEventPayload eventPayload,
     SharedEventTarget eventTarget,
     Category category)
     : type(std::move(type)),
-      payloadFactory(std::move(payloadFactory)),
+      eventPayload(std::move(eventPayload)),
       eventTarget(std::move(eventTarget)),
       category(category) {}
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
@@ -11,8 +11,8 @@
 #include <string>
 
 #include <react/renderer/core/EventLogger.h>
+#include <react/renderer/core/EventPayload.h>
 #include <react/renderer/core/EventTarget.h>
-#include <react/renderer/core/ValueFactory.h>
 
 namespace facebook::react {
 
@@ -60,12 +60,12 @@ struct RawEvent {
 
   RawEvent(
       std::string type,
-      ValueFactory payloadFactory,
+      SharedEventPayload eventPayload,
       SharedEventTarget eventTarget,
       Category category = Category::Unspecified);
 
   std::string type;
-  ValueFactory payloadFactory;
+  SharedEventPayload eventPayload;
   SharedEventTarget eventTarget;
   Category category;
   EventTag loggingTag{0};

--- a/packages/react-native/ReactCommon/react/renderer/core/ValueFactoryEventPayload.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ValueFactoryEventPayload.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ValueFactoryEventPayload.h"
+
+namespace facebook::react {
+
+ValueFactoryEventPayload::ValueFactoryEventPayload(ValueFactory factory)
+    : valueFactory_(std::move(factory)) {}
+
+jsi::Value ValueFactoryEventPayload::asJSIValue(jsi::Runtime &runtime) const {
+  return valueFactory_(runtime);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ValueFactoryEventPayload.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ValueFactoryEventPayload.h
@@ -7,22 +7,18 @@
 
 #pragma once
 
-#include <functional>
-#include <string>
-
-#include <jsi/jsi.h>
 #include <react/renderer/core/EventPayload.h>
-#include <react/renderer/core/EventTarget.h>
-#include <react/renderer/core/ReactEventPriority.h>
 #include <react/renderer/core/ValueFactory.h>
 
 namespace facebook::react {
 
-using EventPipe = std::function<void(
-    jsi::Runtime &runtime,
-    const EventTarget *eventTarget,
-    const std::string &type,
-    ReactEventPriority priority,
-    const EventPayload &payload)>;
+class ValueFactoryEventPayload : public EventPayload {
+ public:
+  explicit ValueFactoryEventPayload(ValueFactory factory);
+  jsi::Value asJSIValue(jsi::Runtime &runtime) const override;
+
+ private:
+  ValueFactory valueFactory_;
+};
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
@@ -11,6 +11,7 @@
 #include <react/renderer/core/EventPipe.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/StatePipe.h>
+#include <react/renderer/core/ValueFactoryEventPayload.h>
 
 #include <memory>
 
@@ -26,7 +27,7 @@ class EventQueueProcessorTest : public testing::Test {
                          const EventTarget * /*eventTarget*/,
                          const std::string &type,
                          ReactEventPriority priority,
-                         const ValueFactory & /*payloadFactory*/) {
+                         const EventPayload & /*payload*/) {
       eventTypes_.push_back(type);
       eventPriorities_.push_back(priority);
     };
@@ -49,7 +50,7 @@ TEST_F(EventQueueProcessorTest, singleUnspecifiedEvent) {
       *runtime_,
       {RawEvent(
           "my type",
-          dummyValueFactory_,
+          std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
           nullptr,
           RawEvent::Category::Unspecified)});
 
@@ -63,22 +64,22 @@ TEST_F(EventQueueProcessorTest, continuousEvent) {
       *runtime_,
       {RawEvent(
            "touchStart",
-           dummyValueFactory_,
+           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
            RawEvent::Category::ContinuousStart),
        RawEvent(
            "touchMove",
-           dummyValueFactory_,
+           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
            RawEvent::Category::Unspecified),
        RawEvent(
            "touchEnd",
-           dummyValueFactory_,
+           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
            RawEvent::Category::ContinuousEnd),
        RawEvent(
            "custom event",
-           dummyValueFactory_,
+           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
            RawEvent::Category::Unspecified)});
 
@@ -103,7 +104,7 @@ TEST_F(EventQueueProcessorTest, alwaysContinuousEvent) {
       {
           RawEvent(
               "onScroll",
-              dummyValueFactory_,
+              std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
               nullptr,
               RawEvent::Category::Continuous),
       });
@@ -120,7 +121,7 @@ TEST_F(EventQueueProcessorTest, alwaysDiscreteEvent) {
       {
           RawEvent(
               "onChange",
-              dummyValueFactory_,
+              std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
               nullptr,
               RawEvent::Category::Discrete),
       });

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -60,11 +60,11 @@ Scheduler::Scheduler(
                        const EventTarget *eventTarget,
                        const std::string &type,
                        ReactEventPriority priority,
-                       const ValueFactory &payloadFactory) {
+                       const EventPayload &payload) {
     uiManager->visitBinding(
         [&](UIManagerBinding const &uiManagerBinding) {
           uiManagerBinding.dispatchEvent(
-              runtime, eventTarget, type, priority, payloadFactory);
+              runtime, eventTarget, type, priority, payload);
         },
         runtime);
     if (runtimeScheduler != nullptr) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -93,10 +93,10 @@ void UIManagerBinding::dispatchEvent(
     EventTarget const *eventTarget,
     std::string const &type,
     ReactEventPriority priority,
-    ValueFactory const &payloadFactory) const {
+    const EventPayload &eventPayload) const {
   SystraceSection s("UIManagerBinding::dispatchEvent", "type", type);
 
-  auto payload = payloadFactory(runtime);
+  auto payload = eventPayload.asJSIValue(runtime);
 
   // If a payload is null, the factory has decided to cancel the event
   if (payload.isNull()) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -52,7 +52,7 @@ class UIManagerBinding : public jsi::HostObject {
       EventTarget const *eventTarget,
       std::string const &type,
       ReactEventPriority priority,
-      ValueFactory const &payloadFactory) const;
+      const EventPayload &payload) const;
 
   /*
    * Invalidates the binding and underlying UIManager.


### PR DESCRIPTION
Summary:
Changelog: [Internal] Refactor Fabric event pipeline to accept typed event payloads

As a first step towards my project of managing the Pointer Capture API by intercepting events in UIManagerBinding I need infrastructure to be able to safely & efficently read the properties of the event payload which is what this diff lays the ground work of addressing.

Currently the events are passed from the EventEmitter all the way to UIManagerBinding with only a ValueFactory (std::function lambda) which is called to produce the jsi::Value. My diff introduces a new virtual base class, EventPayload, which provides the same functionality but in a member function, asJSIValue. To ease the transition to this new paradigm I also introduce the first concrete subclass of EventPayload: ValueFactoryEventPayload — which simply stores and calls a ValueFactory so that we can incrementally migrate to typed events (or frankly, continue to be used for events that we don't *need* to be typed, as the only real use-case in the beginning will be for Pointer Events).

This diff notably does not change any behavior and should behave the exact same way it did before — it is in later diffs where I will begin applying this to the pointer events.

Differential Revision: D47299631

