### PR TITLE
Make PointerEvent a subclass of EventPayload

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.cpp
@@ -9,6 +9,41 @@
 
 namespace facebook::react {
 
+jsi::Value PointerEvent::asJSIValue(jsi::Runtime &runtime) const {
+  auto object = jsi::Object(runtime);
+  object.setProperty(runtime, "pointerId", this->pointerId);
+  object.setProperty(runtime, "pressure", this->pressure);
+  object.setProperty(runtime, "pointerType", this->pointerType);
+  object.setProperty(runtime, "clientX", this->clientPoint.x);
+  object.setProperty(runtime, "clientY", this->clientPoint.y);
+  // x/y are an alias to clientX/Y
+  object.setProperty(runtime, "x", this->clientPoint.x);
+  object.setProperty(runtime, "y", this->clientPoint.y);
+  // since RN doesn't have a scrollable root, pageX/Y will always equal
+  // clientX/Y
+  object.setProperty(runtime, "pageX", this->clientPoint.x);
+  object.setProperty(runtime, "pageY", this->clientPoint.y);
+  object.setProperty(runtime, "screenX", this->screenPoint.x);
+  object.setProperty(runtime, "screenY", this->screenPoint.y);
+  object.setProperty(runtime, "offsetX", this->offsetPoint.x);
+  object.setProperty(runtime, "offsetY", this->offsetPoint.y);
+  object.setProperty(runtime, "width", this->width);
+  object.setProperty(runtime, "height", this->height);
+  object.setProperty(runtime, "tiltX", this->tiltX);
+  object.setProperty(runtime, "tiltY", this->tiltY);
+  object.setProperty(runtime, "detail", this->detail);
+  object.setProperty(runtime, "buttons", this->buttons);
+  object.setProperty(runtime, "tangentialPressure", this->tangentialPressure);
+  object.setProperty(runtime, "twist", this->twist);
+  object.setProperty(runtime, "ctrlKey", this->ctrlKey);
+  object.setProperty(runtime, "shiftKey", this->shiftKey);
+  object.setProperty(runtime, "altKey", this->altKey);
+  object.setProperty(runtime, "metaKey", this->metaKey);
+  object.setProperty(runtime, "isPrimary", this->isPrimary);
+  object.setProperty(runtime, "button", this->button);
+  return object;
+}
+
 #if RN_DEBUG_STRING_CONVERTIBLE
 
 std::string getDebugName(PointerEvent const & /*pointerEvent*/) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
@@ -7,13 +7,14 @@
 
 #pragma once
 
+#include <react/renderer/core/EventPayload.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Point.h>
 
 namespace facebook::react {
 
-struct PointerEvent {
+struct PointerEvent : public EventPayload {
   /*
    * A unique identifier for the pointer causing the event.
    */
@@ -109,6 +110,11 @@ struct PointerEvent {
    * was fired.
    */
   int button;
+
+  /*
+   * EventPayload implementations
+   */
+  jsi::Value asJSIValue(jsi::Runtime &runtime) const override;
 };
 
 #if RN_DEBUG_STRING_CONVERTIBLE

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -58,43 +58,6 @@ static jsi::Value touchEventPayload(
   return object;
 }
 
-static jsi::Value pointerEventPayload(
-    jsi::Runtime &runtime,
-    PointerEvent const &event) {
-  auto object = jsi::Object(runtime);
-  object.setProperty(runtime, "pointerId", event.pointerId);
-  object.setProperty(runtime, "pressure", event.pressure);
-  object.setProperty(runtime, "pointerType", event.pointerType);
-  object.setProperty(runtime, "clientX", event.clientPoint.x);
-  object.setProperty(runtime, "clientY", event.clientPoint.y);
-  // x/y are an alias to clientX/Y
-  object.setProperty(runtime, "x", event.clientPoint.x);
-  object.setProperty(runtime, "y", event.clientPoint.y);
-  // since RN doesn't have a scrollable root, pageX/Y will always equal
-  // clientX/Y
-  object.setProperty(runtime, "pageX", event.clientPoint.x);
-  object.setProperty(runtime, "pageY", event.clientPoint.y);
-  object.setProperty(runtime, "screenX", event.screenPoint.x);
-  object.setProperty(runtime, "screenY", event.screenPoint.y);
-  object.setProperty(runtime, "offsetX", event.offsetPoint.x);
-  object.setProperty(runtime, "offsetY", event.offsetPoint.y);
-  object.setProperty(runtime, "width", event.width);
-  object.setProperty(runtime, "height", event.height);
-  object.setProperty(runtime, "tiltX", event.tiltX);
-  object.setProperty(runtime, "tiltY", event.tiltY);
-  object.setProperty(runtime, "detail", event.detail);
-  object.setProperty(runtime, "buttons", event.buttons);
-  object.setProperty(runtime, "tangentialPressure", event.tangentialPressure);
-  object.setProperty(runtime, "twist", event.twist);
-  object.setProperty(runtime, "ctrlKey", event.ctrlKey);
-  object.setProperty(runtime, "shiftKey", event.shiftKey);
-  object.setProperty(runtime, "altKey", event.altKey);
-  object.setProperty(runtime, "metaKey", event.metaKey);
-  object.setProperty(runtime, "isPrimary", event.isPrimary);
-  object.setProperty(runtime, "button", event.button);
-  return object;
-}
-
 void TouchEventEmitter::dispatchTouchEvent(
     std::string type,
     TouchEvent const &event,
@@ -116,9 +79,7 @@ void TouchEventEmitter::dispatchPointerEvent(
     RawEvent::Category category) const {
   dispatchEvent(
       std::move(type),
-      [event](jsi::Runtime &runtime) {
-        return pointerEventPayload(runtime, event);
-      },
+      [event](jsi::Runtime &runtime) { return event.asJSIValue(runtime); },
       priority,
       category);
 }
@@ -179,7 +140,7 @@ void TouchEventEmitter::onPointerDown(const PointerEvent &event) const {
 
 void TouchEventEmitter::onPointerMove(const PointerEvent &event) const {
   dispatchUniqueEvent("pointerMove", [event](jsi::Runtime &runtime) {
-    return pointerEventPayload(runtime, event);
+    return event.asJSIValue(runtime);
   });
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(react_render_core
         folly_runtime
         glog
         jsi
+        logger
         react_config
         react_debug
         react_render_debug

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -84,7 +84,7 @@ void EventEmitter::dispatchEvent(
   eventDispatcher->dispatchEvent(
       RawEvent(
           normalizeEventType(std::move(type)),
-          payloadFactory,
+          std::make_shared<ValueFactoryEventPayload>(payloadFactory),
           eventTarget_,
           category),
       priority);
@@ -102,7 +102,7 @@ void EventEmitter::dispatchUniqueEvent(
 
   eventDispatcher->dispatchUniqueEvent(RawEvent(
       normalizeEventType(std::move(type)),
-      payloadFactory,
+      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
       eventTarget_,
       RawEvent::Category::Continuous));
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -12,9 +12,11 @@
 
 #include <folly/dynamic.h>
 #include <react/renderer/core/EventDispatcher.h>
+#include <react/renderer/core/EventPayload.h>
 #include <react/renderer/core/EventPriority.h>
 #include <react/renderer/core/EventTarget.h>
 #include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/core/ValueFactoryEventPayload.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPayload.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPayload.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace facebook::react {
+
+/**
+ * Abstract base class for all event payload types.
+ */
+struct EventPayload {
+  virtual ~EventPayload() = default;
+
+  EventPayload() = default;
+  EventPayload(const EventPayload &) = default;
+  EventPayload &operator=(const EventPayload &) = default;
+  EventPayload(EventPayload &&) = default;
+  EventPayload &operator=(EventPayload &&) = default;
+
+  virtual jsi::Value asJSIValue(jsi::Runtime &runtime) const = 0;
+};
+
+using SharedEventPayload = std::shared_ptr<const EventPayload>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cxxreact/JSExecutor.h>
+#include <logger/react_native_log.h>
 #include "EventEmitter.h"
 #include "EventLogger.h"
 #include "EventQueue.h"
@@ -53,12 +54,18 @@ void EventQueueProcessor::flushEvents(
       eventLogger->onEventDispatch(event.loggingTag);
     }
 
+    if (event.eventPayload == nullptr) {
+      react_native_log_error(
+          "EventQueueProcessor: Unexpected null event payload");
+      continue;
+    }
+
     eventPipe_(
         runtime,
         event.eventTarget.get(),
         event.type,
         reactPriority,
-        event.payloadFactory);
+        *event.eventPayload);
 
     if (eventLogger != nullptr) {
       eventLogger->onEventEnd(event.loggingTag);

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
@@ -11,11 +11,11 @@ namespace facebook::react {
 
 RawEvent::RawEvent(
     std::string type,
-    ValueFactory payloadFactory,
+    SharedEventPayload eventPayload,
     SharedEventTarget eventTarget,
     Category category)
     : type(std::move(type)),
-      payloadFactory(std::move(payloadFactory)),
+      eventPayload(std::move(eventPayload)),
       eventTarget(std::move(eventTarget)),
       category(category) {}
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
@@ -11,8 +11,8 @@
 #include <string>
 
 #include <react/renderer/core/EventLogger.h>
+#include <react/renderer/core/EventPayload.h>
 #include <react/renderer/core/EventTarget.h>
-#include <react/renderer/core/ValueFactory.h>
 
 namespace facebook::react {
 
@@ -60,12 +60,12 @@ struct RawEvent {
 
   RawEvent(
       std::string type,
-      ValueFactory payloadFactory,
+      SharedEventPayload eventPayload,
       SharedEventTarget eventTarget,
       Category category = Category::Unspecified);
 
   std::string type;
-  ValueFactory payloadFactory;
+  SharedEventPayload eventPayload;
   SharedEventTarget eventTarget;
   Category category;
   EventTag loggingTag{0};

--- a/packages/react-native/ReactCommon/react/renderer/core/ValueFactoryEventPayload.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ValueFactoryEventPayload.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ValueFactoryEventPayload.h"
+
+namespace facebook::react {
+
+ValueFactoryEventPayload::ValueFactoryEventPayload(ValueFactory factory)
+    : valueFactory_(std::move(factory)) {}
+
+jsi::Value ValueFactoryEventPayload::asJSIValue(jsi::Runtime &runtime) const {
+  return valueFactory_(runtime);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ValueFactoryEventPayload.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ValueFactoryEventPayload.h
@@ -7,22 +7,18 @@
 
 #pragma once
 
-#include <functional>
-#include <string>
-
-#include <jsi/jsi.h>
 #include <react/renderer/core/EventPayload.h>
-#include <react/renderer/core/EventTarget.h>
-#include <react/renderer/core/ReactEventPriority.h>
 #include <react/renderer/core/ValueFactory.h>
 
 namespace facebook::react {
 
-using EventPipe = std::function<void(
-    jsi::Runtime &runtime,
-    const EventTarget *eventTarget,
-    const std::string &type,
-    ReactEventPriority priority,
-    const EventPayload &payload)>;
+class ValueFactoryEventPayload : public EventPayload {
+ public:
+  explicit ValueFactoryEventPayload(ValueFactory factory);
+  jsi::Value asJSIValue(jsi::Runtime &runtime) const override;
+
+ private:
+  ValueFactory valueFactory_;
+};
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
@@ -11,6 +11,7 @@
 #include <react/renderer/core/EventPipe.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/StatePipe.h>
+#include <react/renderer/core/ValueFactoryEventPayload.h>
 
 #include <memory>
 
@@ -26,7 +27,7 @@ class EventQueueProcessorTest : public testing::Test {
                          const EventTarget * /*eventTarget*/,
                          const std::string &type,
                          ReactEventPriority priority,
-                         const ValueFactory & /*payloadFactory*/) {
+                         const EventPayload & /*payload*/) {
       eventTypes_.push_back(type);
       eventPriorities_.push_back(priority);
     };
@@ -49,7 +50,7 @@ TEST_F(EventQueueProcessorTest, singleUnspecifiedEvent) {
       *runtime_,
       {RawEvent(
           "my type",
-          dummyValueFactory_,
+          std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
           nullptr,
           RawEvent::Category::Unspecified)});
 
@@ -63,22 +64,22 @@ TEST_F(EventQueueProcessorTest, continuousEvent) {
       *runtime_,
       {RawEvent(
            "touchStart",
-           dummyValueFactory_,
+           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
            RawEvent::Category::ContinuousStart),
        RawEvent(
            "touchMove",
-           dummyValueFactory_,
+           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
            RawEvent::Category::Unspecified),
        RawEvent(
            "touchEnd",
-           dummyValueFactory_,
+           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
            RawEvent::Category::ContinuousEnd),
        RawEvent(
            "custom event",
-           dummyValueFactory_,
+           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
            RawEvent::Category::Unspecified)});
 
@@ -103,7 +104,7 @@ TEST_F(EventQueueProcessorTest, alwaysContinuousEvent) {
       {
           RawEvent(
               "onScroll",
-              dummyValueFactory_,
+              std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
               nullptr,
               RawEvent::Category::Continuous),
       });
@@ -120,7 +121,7 @@ TEST_F(EventQueueProcessorTest, alwaysDiscreteEvent) {
       {
           RawEvent(
               "onChange",
-              dummyValueFactory_,
+              std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
               nullptr,
               RawEvent::Category::Discrete),
       });

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -60,11 +60,11 @@ Scheduler::Scheduler(
                        const EventTarget *eventTarget,
                        const std::string &type,
                        ReactEventPriority priority,
-                       const ValueFactory &payloadFactory) {
+                       const EventPayload &payload) {
     uiManager->visitBinding(
         [&](UIManagerBinding const &uiManagerBinding) {
           uiManagerBinding.dispatchEvent(
-              runtime, eventTarget, type, priority, payloadFactory);
+              runtime, eventTarget, type, priority, payload);
         },
         runtime);
     if (runtimeScheduler != nullptr) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -93,10 +93,10 @@ void UIManagerBinding::dispatchEvent(
     EventTarget const *eventTarget,
     std::string const &type,
     ReactEventPriority priority,
-    ValueFactory const &payloadFactory) const {
+    const EventPayload &eventPayload) const {
   SystraceSection s("UIManagerBinding::dispatchEvent", "type", type);
 
-  auto payload = payloadFactory(runtime);
+  auto payload = eventPayload.asJSIValue(runtime);
 
   // If a payload is null, the factory has decided to cancel the event
   if (payload.isNull()) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -52,7 +52,7 @@ class UIManagerBinding : public jsi::HostObject {
       EventTarget const *eventTarget,
       std::string const &type,
       ReactEventPriority priority,
-      ValueFactory const &payloadFactory) const;
+      const EventPayload &payload) const;
 
   /*
    * Invalidates the binding and underlying UIManager.


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Make PointerEvent a subclass of EventPayload

This is another refactor diff in preparation of intercepting events in UIManagerBinding to accomplish the Pointer Capture APIs (and more) by making the PointerEvent struct implement EventPayload. Now that this struct will be passed to the event pipeline itself we'll be able to determine in UIManagerBinding that the event is a PointerEvent by dynamic casting and access the event's properties without converting to/from JSI values.

Differential Revision: D47300801

