### PR TITLE
Sync RN-Metro Babel flow lib defs

### DIFF
--- a/flow-typed/npm/babel-traverse_v7.x.x.js
+++ b/flow-typed/npm/babel-traverse_v7.x.x.js
@@ -324,7 +324,7 @@ declare module '@babel/traverse' {
 
     parentKey: string;
     scope: Scope;
-    type: null | $PropertyType<BabelNode, 'type'>;
+    type: null | BabelNode['type'];
     inList: boolean;
     typeAnnotation?: BabelNodeTypeAnnotation;
 
@@ -429,7 +429,7 @@ declare module '@babel/traverse' {
      */
     isDescendant(maybeAncestor: NodePath<>): boolean;
 
-    inType(...candidateTypes: Array<$PropertyType<BabelNode, 'type'>>): boolean;
+    inType(...candidateTypes: Array<BabelNode['type']>): boolean;
 
     // _inference
 
@@ -585,7 +585,7 @@ declare module '@babel/traverse' {
      * Check the type against our stored internal type of the node. This is handy when a node has
      * been removed yet we still internally know the type and need it to calculate node replacement.
      */
-    isNodeType(type: $PropertyType<BabelNode, 'type'>): boolean;
+    isNodeType(type: BabelNode['type']): boolean;
 
     /**
      * This checks whether or not we're in one of the following positions:

--- a/flow-typed/npm/babel_v7.x.x.js
+++ b/flow-typed/npm/babel_v7.x.x.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-declare type BabelNode_DEPRECATED = any;
-
 type _BabelSourceMap = $ReadOnly<{
   file?: string,
   mappings: string,
@@ -833,7 +831,7 @@ declare module '@babel/core' {
      */
     wrapPluginVisitorMethod?: (
       key: string,
-      nodeType: $PropertyType<BabelNode, 'type'>,
+      nodeType: BabelNode['type'],
       fn: Function,
     ) => Function,
 


### PR DESCRIPTION
Summary:
Enable automatic (within Meta) sync checks between these duplicated definitions across the RN and Metro repositories, by using a common naming convention.

Changelog: [Internal]

Differential Revision: D47361815

