### PR TITLE
Re-alings soloader version to 0.10.5

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -225,7 +225,7 @@ android {
 
     dependencies {
         implementation("com.facebook.fbjni:fbjni:0.4.0")
-        implementation("com.facebook.soloader:soloader:0.10.4")
+        implementation("com.facebook.soloader:soloader:0.10.5")
         implementation("com.facebook.yoga:proguard-annotations:1.19.0")
         implementation("androidx.annotation:annotation:1.3.0")
     }


### PR DESCRIPTION
Summary:
I'm just making sure all the dependencies use the same version fo SoLoader that React Native is using: 0.10.5
See https://github.com/facebook/react-native/blob/50f620a1ad8e925a46d2aa8e6439d5ce6f4f2ce4/packages/react-native/ReactAndroid/gradle.properties#L22

Changelog:
[Internal] [Changed] - Re-alings soloader version to 0.10.5

Reviewed By: javache

Differential Revision: D47331908

