### PR TITLE
Add missing toolchains plugin in react-native-gradle-plugin

### DIFF
--- a/packages/react-native-gradle-plugin/settings.gradle.kts
+++ b/packages/react-native-gradle-plugin/settings.gradle.kts
@@ -13,4 +13,8 @@ pluginManagement {
   }
 }
 
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention").version("0.5.0")
+}
+
 rootProject.name = "react-native-gradle-plugin"


### PR DESCRIPTION
## Summary:

I was getting the following error when trying to run RN Tester on Android.

```
A problem occurred configuring project ':packages:react-native:ReactAndroid'.
> Could not determine the dependencies of task ':react-native-gradle-plugin:compileKotlin'.
   > No matching toolchains found for requested specification: {languageVersion=17, vendor=any, implementation=vendor-specific} for MAC_OS on aarch64.
      > No locally installed toolchains match and toolchain download repositories have not been configured.
```

This is fixed by adding the `org.gradle.toolchains.foojay-resolver-convention` plugin in settings.gradle, this was done already for the root one, but not in the one in `react-native-gradle-plugin`.

## Changelog:

[INTERNAL] [FIXED] - Add missing toolchains plugin in react-native-gradle-plugin

## Test Plan:

Build RN Tester on android
