### PR TITLE
Fix text drawing with border and background on iOS Fabric

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -587,6 +587,8 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
           borderMetrics.borderWidths.left == 0 ||
           colorComponentsFromColor(borderMetrics.borderColors.left).alpha == 0 || self.clipsToBounds);
 
+  layer.backgroundColor = _backgroundColor.CGColor;
+
   if (useCoreAnimationBorderRendering) {
     layer.mask = nil;
     if (_borderLayer) {
@@ -602,7 +604,6 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 
     layer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
 
-    layer.backgroundColor = _backgroundColor.CGColor;
   } else {
     if (!_borderLayer) {
       _borderLayer = [CALayer new];
@@ -612,7 +613,6 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
       [layer addSublayer:_borderLayer];
     }
 
-    layer.backgroundColor = nil;
     layer.borderWidth = 0;
     layer.borderColor = nil;
     layer.cornerRadius = 0;
@@ -625,7 +625,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
         RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
         RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths),
         borderColors,
-        _backgroundColor.CGColor,
+        UIColor.clearColor.CGColor,
         self.clipsToBounds);
 
     RCTReleaseRCTBorderColors(borderColors);
@@ -653,7 +653,8 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     // Stage 2.5. Custom Clipping Mask
     CAShapeLayer *maskLayer = nil;
     CGFloat cornerRadius = 0;
-    if (self.clipsToBounds) {
+    // When not using core animation border rendering we need to clip the background color.
+    if (self.clipsToBounds || (!useCoreAnimationBorderRendering && CGColorGetAlpha(_backgroundColor.CGColor) > 0)) {
       if (borderMetrics.borderRadii.isUniform()) {
         // In this case we can simply use `cornerRadius` exclusively.
         cornerRadius = borderMetrics.borderRadii.topLeft;

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -235,6 +235,32 @@ class TextExample extends React.Component<{...}> {
             This text is indented by 10px padding on all sides.
           </Text>
         </RNTesterBlock>
+        <RNTesterBlock title="Border">
+          <Text
+            style={{
+              borderRadius: 6,
+              borderColor: 'red',
+              borderWidth: 2,
+              borderStyle: 'solid',
+              backgroundColor: '#eee',
+              marginBottom: 8,
+              overflow: 'hidden',
+            }}>
+            Text can have simple borders.
+          </Text>
+          <Text
+            style={{
+              borderRadius: 6,
+              borderLeftColor: 'red',
+              borderRightColor: 'green',
+              borderTopColor: 'blue',
+              borderBottomColor: 'orange',
+              borderWidth: 2,
+              backgroundColor: '#eee',
+            }}>
+            And even complex ones.
+          </Text>
+        </RNTesterBlock>
         <RNTesterBlock title="Text metrics legend">
           <TextLegend />
         </RNTesterBlock>

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -611,6 +611,39 @@ exports.examples = [
     },
   },
   {
+    title: 'Border',
+    render: function (): React.Node {
+      return (
+        <View>
+          <Text
+            style={{
+              borderRadius: 6,
+              borderColor: 'red',
+              borderWidth: 2,
+              borderStyle: 'solid',
+              backgroundColor: '#eee',
+              marginBottom: 8,
+              overflow: 'hidden',
+            }}>
+            Text can have simple borders.
+          </Text>
+          <Text
+            style={{
+              borderRadius: 6,
+              borderLeftColor: 'red',
+              borderRightColor: 'green',
+              borderTopColor: 'blue',
+              borderBottomColor: 'orange',
+              borderWidth: 2,
+              backgroundColor: '#eee',
+            }}>
+            And even complex ones with the new renderer.
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
     title: 'Font Family',
     render: function (): React.Node {
       return (


### PR DESCRIPTION
## Summary:

Currently on iOS Fabric when a text has border + background the text will not appear. This is because the background is drawn over the text.

This happens only when we are using custom border drawing. In this case `RCTViewComponentView` adds a sublayer with the image for the background + border. The problem is that `RCTParagraphComponentView` draws on the root layer in `drawRect` which is then covered by drawing in the sublayer.

To fix this we can draw a transparent background and use the layer background property + our current clipping code.

## Changelog:

[IOS] [FIXED] - Fix text drawing with border and background on iOS Fabric

## Test Plan:

Added a repro of this issue in RN Tester Text example.

Before:

<img width="337" alt="image" src="https://github.com/facebook/react-native/assets/2677334/5095b461-21d5-4791-a412-0aecae9322fa">

After:

<img width="343" alt="image" src="https://github.com/facebook/react-native/assets/2677334/b8e8af3a-8c48-4711-ad1e-2ea768c6815c">
