### PR TITLE
rn-tester > Use code-generated Turbo Module name constants

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -71,7 +71,7 @@
     return std::make_shared<facebook::react::SampleTurboCxxModule>(jsInvoker);
   }
 #ifdef RCT_NEW_ARCH_ENABLED
-  if (name == std::string([@"NativeCxxModuleExampleCxx" UTF8String])) {
+  if (name == facebook::react::NativeCxxModuleExample::kModuleName) {
     return std::make_shared<facebook::react::NativeCxxModuleExample>(jsInvoker);
   }
 #endif

--- a/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
+++ b/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
@@ -33,7 +33,7 @@ void registerComponents(
 std::shared_ptr<TurboModule> cxxModuleProvider(
     const std::string &name,
     const std::shared_ptr<CallInvoker> &jsInvoker) {
-  if (name == "NativeCxxModuleExampleCxx") {
+  if (name == NativeCxxModuleExample::kModuleName) {
     return std::make_shared<NativeCxxModuleExample>(jsInvoker);
   }
   return nullptr;


### PR DESCRIPTION
Summary:
Continuation of https://github.com/facebook/react-native/pull/38295

Changelog:
[Internal] [Changed] - Use code-generated Turbo Module name constants

Differential Revision: D47376344

