### PR TITLE
Interop: Implement RCTBridgeProxy registerSegmentWithId

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeProxy.h
+++ b/packages/react-native/React/Base/RCTBridgeProxy.h
@@ -19,7 +19,8 @@
                       moduleRegistry:(RCTModuleRegistry *)moduleRegistry
                        bundleManager:(RCTBundleManager *)bundleManager
                    callableJSModules:(RCTCallableJSModules *)callableJSModules
-                  dispatchToJSThread:(void (^)(dispatch_block_t))dispatchToJSThread NS_DESIGNATED_INITIALIZER;
+                  dispatchToJSThread:(void (^)(dispatch_block_t))dispatchToJSThread
+               registerSegmentWithId:(void (^)(NSNumber *, NSString *))registerSegmentWithId NS_DESIGNATED_INITIALIZER;
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)sel;
 - (void)forwardInvocation:(NSInvocation *)invocation;

--- a/packages/react-native/React/Base/RCTBridgeProxy.mm
+++ b/packages/react-native/React/Base/RCTBridgeProxy.mm
@@ -27,6 +27,7 @@ using namespace facebook;
   RCTBundleManager *_bundleManager;
   RCTCallableJSModules *_callableJSModules;
   void (^_dispatchToJSThread)(dispatch_block_t);
+  void (^_registerSegmentWithId)(NSNumber *, NSString *);
 }
 
 - (instancetype)initWithViewRegistry:(RCTViewRegistry *)viewRegistry
@@ -34,6 +35,7 @@ using namespace facebook;
                        bundleManager:(RCTBundleManager *)bundleManager
                    callableJSModules:(RCTCallableJSModules *)callableJSModules
                   dispatchToJSThread:(void (^)(dispatch_block_t))dispatchToJSThread
+               registerSegmentWithId:(void (^)(NSNumber *, NSString *))registerSegmentWithId
 {
   self = [super self];
   if (self) {
@@ -42,6 +44,7 @@ using namespace facebook;
     self->_bundleManager = bundleManager;
     self->_callableJSModules = callableJSModules;
     self->_dispatchToJSThread = dispatchToJSThread;
+    self->_registerSegmentWithId = registerSegmentWithId;
   }
   return self;
 }
@@ -159,7 +162,7 @@ using namespace facebook;
 
 - (void)registerSegmentWithId:(NSUInteger)segmentId path:(NSString *)path
 {
-  [self logError:@"Please migrate to RCTHost registerSegmentWithId. Nooping" cmd:_cmd];
+  self->_registerSegmentWithId(@(segmentId), path);
 }
 
 - (id<RCTBridgeDelegate>)delegate

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -225,17 +225,22 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   timerManager->setRuntimeExecutor(bufferedRuntimeExecutor);
 
   RCTBridgeProxy *bridgeProxy = RCTTurboModuleInteropEnabled() && RCTTurboModuleInteropBridgeProxyEnabled()
-      ? [[RCTBridgeProxy alloc]
-            initWithViewRegistry:_bridgeModuleDecorator.viewRegistry_DEPRECATED
-                  moduleRegistry:_bridgeModuleDecorator.moduleRegistry
-                   bundleManager:_bridgeModuleDecorator.bundleManager
-               callableJSModules:_bridgeModuleDecorator.callableJSModules
-              dispatchToJSThread:^(dispatch_block_t block) {
-                __strong __typeof(self) strongSelf = weakSelf;
-                if (strongSelf && strongSelf->_valid) {
-                  strongSelf->_reactInstance->getBufferedRuntimeExecutor()([=](jsi::Runtime &runtime) { block(); });
-                }
-              }]
+      ? [[RCTBridgeProxy alloc] initWithViewRegistry:_bridgeModuleDecorator.viewRegistry_DEPRECATED
+            moduleRegistry:_bridgeModuleDecorator.moduleRegistry
+            bundleManager:_bridgeModuleDecorator.bundleManager
+            callableJSModules:_bridgeModuleDecorator.callableJSModules
+            dispatchToJSThread:^(dispatch_block_t block) {
+              __strong __typeof(self) strongSelf = weakSelf;
+              if (strongSelf && strongSelf->_valid) {
+                strongSelf->_reactInstance->getBufferedRuntimeExecutor()([=](jsi::Runtime &runtime) { block(); });
+              }
+            }
+            registerSegmentWithId:^(NSNumber *segmentId, NSString *path) {
+              __strong __typeof(self) strongSelf = weakSelf;
+              if (strongSelf && strongSelf->_valid) {
+                [strongSelf registerSegmentWithId:segmentId path:path];
+              }
+            }]
       : nil;
 
   // Set up TurboModules


### PR DESCRIPTION
Summary:
Bridgeless mode replaces RCTCxxBridge registerSegmentWithId with RCTHost registerSegmentWithId.

This diff implements RCTBridgeProxy registerSegmentWithId.

Changelog: [Internal]

Differential Revision: D47349027

