### PR TITLE
Add dispatchEvent API to EventEmitter that accepts an EventPayload directly (and use it for Pointer Events)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -79,7 +79,7 @@ void TouchEventEmitter::dispatchPointerEvent(
     RawEvent::Category category) const {
   dispatchEvent(
       std::move(type),
-      [event](jsi::Runtime &runtime) { return event.asJSIValue(runtime); },
+      std::make_shared<PointerEvent>(event),
       priority,
       category);
 }
@@ -139,9 +139,7 @@ void TouchEventEmitter::onPointerDown(const PointerEvent &event) const {
 }
 
 void TouchEventEmitter::onPointerMove(const PointerEvent &event) const {
-  dispatchUniqueEvent("pointerMove", [event](jsi::Runtime &runtime) {
-    return event.asJSIValue(runtime);
-  });
+  dispatchUniqueEvent("pointermove", std::make_shared<PointerEvent>(event));
 }
 
 void TouchEventEmitter::onPointerUp(const PointerEvent &event) const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -74,6 +74,18 @@ void EventEmitter::dispatchEvent(
     const ValueFactory &payloadFactory,
     EventPriority priority,
     RawEvent::Category category) const {
+  dispatchEvent(
+      std::move(type),
+      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
+      priority,
+      category);
+}
+
+void EventEmitter::dispatchEvent(
+    std::string type,
+    SharedEventPayload payload,
+    EventPriority priority,
+    RawEvent::Category category) const {
   SystraceSection s("EventEmitter::dispatchEvent", "type", type);
 
   auto eventDispatcher = eventDispatcher_.lock();
@@ -84,7 +96,7 @@ void EventEmitter::dispatchEvent(
   eventDispatcher->dispatchEvent(
       RawEvent(
           normalizeEventType(std::move(type)),
-          std::make_shared<ValueFactoryEventPayload>(payloadFactory),
+          std::move(payload),
           eventTarget_,
           category),
       priority);
@@ -93,6 +105,14 @@ void EventEmitter::dispatchEvent(
 void EventEmitter::dispatchUniqueEvent(
     std::string type,
     const ValueFactory &payloadFactory) const {
+  dispatchUniqueEvent(
+      std::move(type),
+      std::make_shared<ValueFactoryEventPayload>(payloadFactory));
+}
+
+void EventEmitter::dispatchUniqueEvent(
+    std::string type,
+    SharedEventPayload payload) const {
   SystraceSection s("EventEmitter::dispatchUniqueEvent");
 
   auto eventDispatcher = eventDispatcher_.lock();
@@ -102,7 +122,7 @@ void EventEmitter::dispatchUniqueEvent(
 
   eventDispatcher->dispatchUniqueEvent(RawEvent(
       normalizeEventType(std::move(type)),
-      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
+      std::move(payload),
       eventTarget_,
       RawEvent::Category::Continuous));
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -80,6 +80,12 @@ class EventEmitter {
       EventPriority priority = EventPriority::AsynchronousBatched,
       RawEvent::Category category = RawEvent::Category::Unspecified) const;
 
+  void dispatchEvent(
+      std::string type,
+      SharedEventPayload payload,
+      EventPriority priority = EventPriority::AsynchronousBatched,
+      RawEvent::Category category = RawEvent::Category::Unspecified) const;
+
   void dispatchUniqueEvent(std::string type, const folly::dynamic &payload)
       const;
 
@@ -87,6 +93,8 @@ class EventEmitter {
       std::string type,
       const ValueFactory &payloadFactory =
           EventEmitter::defaultPayloadFactory()) const;
+
+  void dispatchUniqueEvent(std::string type, SharedEventPayload payload) const;
 
  private:
   void toggleEventTargetOwnership_() const;


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Add dispatchEvent API to EventEmitter that accepts an EventPayload directly

This diff adds a deeper overload of dispatchEvent to EventEmitter which accepts a caller-provided EventPayload subclass, and modifies TouchEventEmitter's dispatchPointerEvent method to use it so that the typed PointerEvent is actually sent through the event pipeline.

Differential Revision: D47351851

