### PR TITLE
Make Runtime a friend of all pointer types

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -924,6 +924,7 @@ class JSI_EXPORT Array : public Object {
  private:
   friend class Object;
   friend class Value;
+  friend class Runtime;
 
   void setValueAtIndexImpl(Runtime& runtime, size_t i, const Value& value)
       const {
@@ -959,6 +960,7 @@ class JSI_EXPORT ArrayBuffer : public Object {
  private:
   friend class Object;
   friend class Value;
+  friend class Runtime;
 
   ArrayBuffer(Runtime::PointerValue* value) : Object(value) {}
 };
@@ -1067,6 +1069,7 @@ class JSI_EXPORT Function : public Object {
  private:
   friend class Object;
   friend class Value;
+  friend class Runtime;
 
   Function(Runtime::PointerValue* value) : Object(value) {}
 };


### PR DESCRIPTION
Summary:
Make Runtime a friend of these types so we can use `Runtime::make` with
all of them. Simplify the Hermes API code to do this.

Differential Revision: D47373807

