### PR TITLE
[RN][Android] set NDEBUG properly

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/fb/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/fb/CMakeLists.txt
@@ -21,7 +21,7 @@ add_compile_options(
         -Wno-error=unused-but-set-variable
         -DHAVE_POSIX_CLOCKS
 )
-if(${CMAKE_BUILD_TYPE} MATCHES Release)
+if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
         add_compile_options(-DNDEBUG)
 endif()
 

--- a/packages/react-native/ReactCommon/jsc/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsc/CMakeLists.txt
@@ -34,6 +34,6 @@ target_link_libraries(jscruntime
 # Android has this enabled by default, but the flag is still needed for iOS.
 target_compile_options(jscruntime PRIVATE -DRN_FABRIC_ENABLED)
 
-if(${CMAKE_BUILD_TYPE} MATCHES Release)
+if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(jscruntime PRIVATE -DNDEBUG)
 endif()

--- a/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
@@ -23,6 +23,6 @@ target_include_directories(react_debug PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_debug log folly_runtime)
 
-if(${CMAKE_BUILD_TYPE} MATCHES Release)
+if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(react_debug PUBLIC -DNDEBUG)
 endif()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

`CMAKE_BUILD_TYPE` is `RelWithDebInfo` while `./gradlew :package:react-native:ReactAndroid:bundleReleaseAar`

## Changelog:

[ANDROID] [FIXED] - Fix `CMAKE_BUILD_TYPE` match condition from #36172 

## Test Plan:

### Release (does contain two `-DNDEBUG`)

```
build ReactCommon/react/renderer/components/view/CMakeFiles/rrc_view.dir/YogaLayoutableShadowNode.cpp.o: CXX_COMPILER__rrc_view_RelWithDebInfo /Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp || cmake_object_order_depends_target_rrc_view
  DEFINES = -Drrc_view_EXPORTS
  DEP_FILE = ReactCommon/react/renderer/components/view/CMakeFiles/rrc_view.dir/YogaLayoutableShadowNode.cpp.o.d
  FLAGS = -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -O2 -g -DNDEBUG -fPIC -Wall -Werror -std=c++17 -fexceptions -frtti -Wpedantic -Wno-gnu-zero-variadic-macro-arguments -DLOG_TAG=\"Fabric\" -DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -DFOLLY_HAVE_RECVMMSG=1 -DFOLLY_HAVE_PTHREAD=1 -DFOLLY_HAVE_XSI_STRERROR_R=1 -DNDEBUG
  INCLUDES = -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactCommon -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/build/third-party-ndk/folly/. -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/build/third-party-ndk/glog/exported -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/build/third-party-ndk/double-conversion/. -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/build/third-party-ndk/boost/boost_1_76_0 -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/build/third-party-ndk/fmt/include -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/src/main/jni/first-party/fbgloginit/. -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactCommon/jsi -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactCommon/logger/. -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactCommon/react/renderer/graphics/platform/android -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/src/main/jni/first-party/fb/include -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni -I/Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactCommon/yoga/yoga/.. -isystem /Users/sunbreak/.gradle/caches/transforms-3/a52d8ada161ee9f7b900e2f4d7543a45/transformed/fbjni-0.4.0/prefab/modules/fbjni/include
  OBJECT_DIR = ReactCommon/react/renderer/components/view/CMakeFiles/rrc_view.dir
  OBJECT_FILE_DIR = ReactCommon/react/renderer/components/view/CMakeFiles/rrc_view.dir
  TARGET_COMPILE_PDB = ReactCommon/react/renderer/components/view/CMakeFiles/rrc_view.dir/
  TARGET_PDB = /Volumes/sunbreak-WD/w/Sunbreak/react-native@Sunbreak/packages/react-native/ReactAndroid/build/intermediates/cxx/RelWithDebInfo/394f413f/obj/arm64-v8a/librrc_view.pdb
```
