### PR TITLE
Interop: Introduce bridge proxy log levels

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -65,6 +65,15 @@ RCT_EXTERN void RCTEnableTurboModuleInterop(BOOL enabled);
 RCT_EXTERN BOOL RCTTurboModuleInteropBridgeProxyEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleInteropBridgeProxy(BOOL enabled);
 
+typedef enum {
+  kRCTBridgeProxyLoggingLevelNone,
+  kRCTBridgeProxyLoggingLevelWarning,
+  kRCTBridgeProxyLoggingLevelError,
+} RCTBridgeProxyLoggingLevel;
+
+RCT_EXTERN RCTBridgeProxyLoggingLevel RCTTurboModuleInteropBridgeProxyLogLevel(void);
+RCT_EXTERN void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logLevel);
+
 // Route all TurboModules through TurboModule interop
 RCT_EXTERN BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled);

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -141,6 +141,17 @@ void RCTEnableTurboModuleInteropBridgeProxy(BOOL enabled)
   turboModuleInteropBridgeProxyEnabled = enabled;
 }
 
+static RCTBridgeProxyLoggingLevel bridgeProxyLoggingLevel = kRCTBridgeProxyLoggingLevelNone;
+RCTBridgeProxyLoggingLevel RCTTurboModuleInteropBridgeProxyLogLevel(void)
+{
+  return bridgeProxyLoggingLevel;
+}
+
+void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logLevel)
+{
+  bridgeProxyLoggingLevel = logLevel;
+}
+
 static BOOL useTurboModuleInteropForAllTurboModules = NO;
 BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void)
 {

--- a/packages/react-native/React/Base/RCTBridgeProxy.mm
+++ b/packages/react-native/React/Base/RCTBridgeProxy.mm
@@ -371,12 +371,17 @@ using namespace facebook;
  */
 - (void)logWarning:(NSString *)message cmd:(SEL)cmd
 {
-  RCTLogWarn(@"RCTBridgeProxy: Calling [bridge %@]. %@", NSStringFromSelector(cmd), message);
+  if (RCTTurboModuleInteropBridgeProxyLogLevel() == kRCTBridgeProxyLoggingLevelWarning) {
+    RCTLogWarn(@"RCTBridgeProxy: Calling [bridge %@]. %@", NSStringFromSelector(cmd), message);
+  }
 }
 
 - (void)logError:(NSString *)message cmd:(SEL)cmd
 {
-  RCTLogError(@"RCTBridgeProxy: Calling [bridge %@]. %@", NSStringFromSelector(cmd), message);
+  if (RCTTurboModuleInteropBridgeProxyLogLevel() == kRCTBridgeProxyLoggingLevelWarning ||
+      RCTTurboModuleInteropBridgeProxyLogLevel() == kRCTBridgeProxyLoggingLevelError) {
+    RCTLogError(@"RCTBridgeProxy: Calling [bridge %@]. %@", NSStringFromSelector(cmd), message);
+  }
 }
 
 @end
@@ -437,14 +442,19 @@ using namespace facebook;
  */
 - (void)logWarning:(NSString *)message cmd:(SEL)cmd
 {
-  RCTLogWarn(
-      @"RCTBridgeProxy (RCTUIManagerProxy): Calling [bridge.uiManager %@]. %@", NSStringFromSelector(cmd), message);
+  if (RCTTurboModuleInteropBridgeProxyLogLevel() == kRCTBridgeProxyLoggingLevelWarning) {
+    RCTLogWarn(
+        @"RCTBridgeProxy (RCTUIManagerProxy): Calling [bridge.uiManager %@]. %@", NSStringFromSelector(cmd), message);
+  }
 }
 
 - (void)logError:(NSString *)message cmd:(SEL)cmd
 {
-  RCTLogError(
-      @"RCTBridgeProxy (RCTUIManagerProxy): Calling [bridge.uiManager %@]. %@", NSStringFromSelector(cmd), message);
+  if (RCTTurboModuleInteropBridgeProxyLogLevel() == kRCTBridgeProxyLoggingLevelWarning ||
+      RCTTurboModuleInteropBridgeProxyLogLevel() == kRCTBridgeProxyLoggingLevelError) {
+    RCTLogError(
+        @"RCTBridgeProxy (RCTUIManagerProxy): Calling [bridge.uiManager %@]. %@", NSStringFromSelector(cmd), message);
+  }
 }
 
 @end


### PR DESCRIPTION
Summary:
The TurboModule interop layer's bridge proxy emits logs.

These logs aren't very actionable (yet). (We will make them more useful eventually).

So, this diff adds bridge proxy log-levels (backed by a server-side flag).

Longer term, **all of** React Native's backwards compatibility layers will output logs (not just the bridge proxy). So, we might replace this specific control with something more general.

Changelog: [Internal]

Differential Revision: D47407548

