### PR TITLE
Call C++ ReactMarker from android side to log platform specific timing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -140,7 +140,14 @@ public class ReactMarker {
     for (MarkerListener listener : sListeners) {
       listener.logMarker(name, tag, instanceKey);
     }
+
+    if (ReactBridge.isInitialized()) {
+      nativeLogMarker(name.name(), SystemClock.uptimeMillis());
+    }
   }
+
+  @DoNotStrip
+  private static native void nativeLogMarker(String markerName, long markerTime);
 
   @DoNotStrip
   public static void setAppStartTime(long appStartTime) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
@@ -63,7 +63,7 @@ void JReactMarker::logPerfMarkerBridgeless(
 }
 
 void JReactMarker::logPerfMarkerWithInstanceKey(
-    const facebook::react::ReactMarker::ReactMarkerId markerId,
+    const ReactMarker::ReactMarkerId markerId,
     const char *tag,
     const int instanceKey) {
   switch (markerId) {
@@ -107,6 +107,48 @@ double JReactMarker::getAppStartTime() {
   static auto cls = javaClassStatic();
   static auto meth = cls->getStaticMethod<double()>("getAppStartTime");
   return meth(cls);
+}
+
+void JReactMarker::nativeLogMarker(
+    jni::alias_ref<jclass> /* unused */,
+    std::string markerNameStr,
+    jlong markerTime) {
+  // TODO: refactor this to a bidirectional map along with
+  // logPerfMarkerWithInstanceKey
+  if (markerNameStr == "RUN_JS_BUNDLE_START") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::RUN_JS_BUNDLE_START, (double)markerTime);
+  } else if (markerNameStr == "RUN_JS_BUNDLE_END") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::RUN_JS_BUNDLE_STOP, (double)markerTime);
+  } else if (markerNameStr == "CREATE_REACT_CONTEXT_END") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::CREATE_REACT_CONTEXT_STOP, (double)markerTime);
+  } else if (markerNameStr == "loadApplicationScript_startStringConvert") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::JS_BUNDLE_STRING_CONVERT_START, (double)markerTime);
+  } else if (markerNameStr == "loadApplicationScript_endStringConvert") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::JS_BUNDLE_STRING_CONVERT_STOP, (double)markerTime);
+  } else if (markerNameStr == "NATIVE_MODULE_SETUP_START") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::NATIVE_MODULE_SETUP_START, (double)markerTime);
+  } else if (markerNameStr == "NATIVE_MODULE_SETUP_END") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::NATIVE_MODULE_SETUP_STOP, (double)markerTime);
+  } else if (markerNameStr == "REGISTER_JS_SEGMENT_START") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::REGISTER_JS_SEGMENT_START, (double)markerTime);
+  } else if (markerNameStr == "REGISTER_JS_SEGMENT_STOP") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::REGISTER_JS_SEGMENT_STOP, (double)markerTime);
+  }
+}
+
+void JReactMarker::registerNatives() {
+  javaClassLocal()->registerNatives({
+      makeNativeMethod("nativeLogMarker", JReactMarker::nativeLogMarker),
+  });
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
@@ -18,6 +18,7 @@ class JReactMarker : public facebook::jni::JavaClass<JReactMarker> {
  public:
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/bridge/ReactMarker;";
+  static void registerNatives();
   static void setLogPerfMarkerIfNeeded();
 
  private:
@@ -38,6 +39,10 @@ class JReactMarker : public facebook::jni::JavaClass<JReactMarker> {
       const char *tag,
       const int instanceKey);
   static double getAppStartTime();
+  static void nativeLogMarker(
+      jni::alias_ref<jclass> /* unused */,
+      std::string markerNameStr,
+      jlong markerTime);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -16,6 +16,7 @@
 #include "CatalystInstanceImpl.h"
 #include "CxxModuleWrapper.h"
 #include "JCallback.h"
+#include "JReactMarker.h"
 #include "JavaScriptExecutorHolder.h"
 #include "ProxyExecutor.h"
 #include "WritableNativeArray.h"
@@ -85,6 +86,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     NativeMap::registerNatives();
     ReadableNativeMap::registerNatives();
     WritableNativeMap::registerNatives();
+    JReactMarker::registerNatives();
 
 #ifdef WITH_INSPECTOR
     JInspector::registerNatives();

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
@@ -29,7 +29,6 @@ void logMarker(const ReactMarkerId markerId) {
 }
 
 void logTaggedMarker(const ReactMarkerId markerId, const char *tag) {
-  StartupLogger::getInstance().logStartupEvent(markerId);
   logTaggedMarkerImpl(markerId, tag);
 }
 
@@ -38,8 +37,11 @@ void logMarkerBridgeless(const ReactMarkerId markerId) {
 }
 
 void logTaggedMarkerBridgeless(const ReactMarkerId markerId, const char *tag) {
-  StartupLogger::getInstance().logStartupEvent(markerId);
   logTaggedMarkerBridgelessImpl(markerId, tag);
+}
+
+void logMarkerDone(const ReactMarkerId markerId, double markerTime) {
+  StartupLogger::getInstance().logStartupEvent(markerId, markerTime);
 }
 
 StartupLogger &StartupLogger::getInstance() {
@@ -47,18 +49,19 @@ StartupLogger &StartupLogger::getInstance() {
   return instance;
 }
 
-void StartupLogger::logStartupEvent(const ReactMarkerId markerId) {
-  auto now = JSExecutor::performanceNow();
+void StartupLogger::logStartupEvent(
+    const ReactMarkerId markerId,
+    double markerTime) {
   switch (markerId) {
     case ReactMarkerId::RUN_JS_BUNDLE_START:
       if (runJSBundleStartTime == 0) {
-        runJSBundleStartTime = now;
+        runJSBundleStartTime = markerTime;
       }
       return;
 
     case ReactMarkerId::RUN_JS_BUNDLE_STOP:
       if (runJSBundleEndTime == 0) {
-        runJSBundleEndTime = now;
+        runJSBundleEndTime = markerTime;
       }
       return;
 

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
@@ -71,7 +71,7 @@ class StartupLogger {
  public:
   static StartupLogger &getInstance();
 
-  void logStartupEvent(const ReactMarker::ReactMarkerId markerId);
+  void logStartupEvent(const ReactMarkerId markerName, double markerTime);
   double getAppStartTime();
   double getRunJSBundleStartTime();
   double getRunJSBundleEndTime();
@@ -84,6 +84,13 @@ class StartupLogger {
   double runJSBundleStartTime;
   double runJSBundleEndTime;
 };
+
+// When the marker got logged from the platform, it will notify here. This is
+// used to collect react markers that are logged in the platform instead of in
+// C++.
+extern RN_EXPORT void logMarkerDone(
+    const ReactMarkerId markerId,
+    double markerTime);
 
 } // namespace ReactMarker
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
This diff adds the native method in `ReactMarker.java` file so that any logs in the android side will call into C++. Given that currently the C++ uses the native implementation from hosting platforms, this allows any call (either from C++ or android) will end up calling the C++ method after logging is done.

The motivation of this change is to allow us to collect timing information from  hosting platforms, and report back to JS performance startup API. We will have items that are logged before the JNI part is loaded, and those will be cached and sent over in the next diff.

Changelog:
[Android][Internal] - Implemented native method for Android LogMarker API to report timing values to C++.

Reviewed By: mdvacca

Differential Revision: D43806115

