### PR TITLE
Update startup perf api to accept undefined/null values

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/MemoryInfo.js
+++ b/packages/react-native/Libraries/WebPerformance/MemoryInfo.js
@@ -11,7 +11,7 @@
 
 // flowlint unsafe-getters-setters:off
 
-export type MemoryInfoLike = {
+type MemoryInfoLike = {
   jsHeapSizeLimit: ?number,
   totalJSHeapSize: ?number,
   usedJSHeapSize: ?number,

--- a/packages/react-native/Libraries/WebPerformance/NativePerformance.cpp
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformance.cpp
@@ -54,23 +54,41 @@ std::unordered_map<std::string, double> NativePerformance::getSimpleMemoryInfo(
   return heapInfoToJs;
 }
 
-ReactNativeStartupTiming NativePerformance::getReactNativeStartupTiming(
-    jsi::Runtime &rt) {
-  ReactNativeStartupTiming result = {0, 0, 0, 0, 0, 0};
+std::unordered_map<std::string, double>
+NativePerformance::getReactNativeStartupTiming(jsi::Runtime &rt) {
+  std::unordered_map<std::string, double> result;
 
   ReactMarker::StartupLogger &startupLogger =
       ReactMarker::StartupLogger::getInstance();
-  result.startTime = startupLogger.getAppStartupStartTime();
-  if (result.startTime == 0) {
-    result.startTime = startupLogger.getInitReactRuntimeStartTime();
+  if (!std::isnan(startupLogger.getAppStartupStartTime())) {
+    result["startTime"] = startupLogger.getAppStartupStartTime();
+  } else if (!std::isnan(startupLogger.getInitReactRuntimeStartTime())) {
+    result["startTime"] = startupLogger.getInitReactRuntimeStartTime();
   }
-  result.initializeRuntimeStart = startupLogger.getInitReactRuntimeStartTime();
-  result.executeJavaScriptBundleEntryPointStart =
-      startupLogger.getRunJSBundleStartTime();
-  result.executeJavaScriptBundleEntryPointEnd =
-      startupLogger.getRunJSBundleEndTime();
-  result.initializeRuntimeEnd = startupLogger.getInitReactRuntimeEndTime();
-  result.endTime = startupLogger.getAppStartupEndTime();
+
+  if (!std::isnan(startupLogger.getInitReactRuntimeStartTime())) {
+    result["initializeRuntimeStart"] =
+        startupLogger.getInitReactRuntimeStartTime();
+  }
+
+  if (!std::isnan(startupLogger.getRunJSBundleStartTime())) {
+    result["executeJavaScriptBundleEntryPointStart"] =
+        startupLogger.getRunJSBundleStartTime();
+  }
+
+  if (!std::isnan(startupLogger.getRunJSBundleEndTime())) {
+    result["executeJavaScriptBundleEntryPointEnd"] =
+        startupLogger.getRunJSBundleEndTime();
+  }
+
+  if (!std::isnan(startupLogger.getInitReactRuntimeEndTime())) {
+    result["initializeRuntimeEnd"] = startupLogger.getInitReactRuntimeEndTime();
+  }
+
+  if (!std::isnan(startupLogger.getAppStartupEndTime())) {
+    result["endTime"] = startupLogger.getAppStartupEndTime();
+  }
+
   return result;
 }
 

--- a/packages/react-native/Libraries/WebPerformance/NativePerformance.h
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformance.h
@@ -18,25 +18,6 @@ class PerformanceEntryReporter;
 
 #pragma mark - Structs
 
-using ReactNativeStartupTiming =
-    NativePerformanceCxxBaseReactNativeStartupTiming<
-        int32_t,
-        int32_t,
-        int32_t,
-        int32_t,
-        int32_t,
-        int32_t>;
-
-template <>
-struct Bridging<ReactNativeStartupTiming>
-    : NativePerformanceCxxBaseReactNativeStartupTimingBridging<
-          int32_t,
-          int32_t,
-          int32_t,
-          int32_t,
-          int32_t,
-          int32_t> {};
-
 #pragma mark - implementation
 
 class NativePerformance : public NativePerformanceCxxSpec<NativePerformance>,
@@ -70,7 +51,8 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance>,
 
   // Collect and return the RN app startup timing information for performance
   // tracking.
-  ReactNativeStartupTiming getReactNativeStartupTiming(jsi::Runtime &rt);
+  std::unordered_map<std::string, double> getReactNativeStartupTiming(
+      jsi::Runtime &rt);
 
  private:
 };

--- a/packages/react-native/Libraries/WebPerformance/NativePerformance.js
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformance.js
@@ -12,16 +12,9 @@ import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-export type NativeMemoryInfo = {[key: string]: number};
+export type NativeMemoryInfo = {[key: string]: ?number};
 
-export type ReactNativeStartupTiming = {|
-  startTime: number,
-  endTime: number,
-  initializeRuntimeStart: number,
-  initializeRuntimeEnd: number,
-  executeJavaScriptBundleEntryPointStart: number,
-  executeJavaScriptBundleEntryPointEnd: number,
-|};
+export type ReactNativeStartupTiming = {[key: string]: ?number};
 
 export interface Spec extends TurboModule {
   +mark: (name: string, startTime: number) => void;

--- a/packages/react-native/Libraries/WebPerformance/Performance.js
+++ b/packages/react-native/Libraries/WebPerformance/Performance.js
@@ -143,9 +143,22 @@ export default class Performance {
   // Startup metrics is not used in web, but only in React Native.
   get reactNativeStartupTiming(): ReactNativeStartupTiming {
     if (NativePerformance?.getReactNativeStartupTiming) {
-      return new ReactNativeStartupTiming(
-        NativePerformance.getReactNativeStartupTiming(),
-      );
+      const {
+        startTime,
+        endTime,
+        initializeRuntimeStart,
+        initializeRuntimeEnd,
+        executeJavaScriptBundleEntryPointStart,
+        executeJavaScriptBundleEntryPointEnd,
+      } = NativePerformance.getReactNativeStartupTiming();
+      return new ReactNativeStartupTiming({
+        startTime,
+        endTime,
+        initializeRuntimeStart,
+        initializeRuntimeEnd,
+        executeJavaScriptBundleEntryPointStart,
+        executeJavaScriptBundleEntryPointEnd,
+      });
     }
     return new ReactNativeStartupTiming();
   }

--- a/packages/react-native/Libraries/WebPerformance/ReactNativeStartupTiming.js
+++ b/packages/react-native/Libraries/WebPerformance/ReactNativeStartupTiming.js
@@ -11,22 +11,30 @@
 
 // flowlint unsafe-getters-setters:off
 
-import type {ReactNativeStartupTiming as ReactNativeStartupTimingType} from './NativePerformance';
+type ReactNativeStartupTimingLike = {
+  startTime: ?number,
+  endTime: ?number,
+  initializeRuntimeStart: ?number,
+  initializeRuntimeEnd: ?number,
+  executeJavaScriptBundleEntryPointStart: ?number,
+  executeJavaScriptBundleEntryPointEnd: ?number,
+};
 
 // Read-only object with RN startup timing information.
 // This is returned by the performance.reactNativeStartup API.
 export default class ReactNativeStartupTiming {
-  // All time information here are in ms. To match web spec,
-  // the default value for timings are zero if not present.
-  // See https://www.w3.org/TR/performance-timeline/#performancetiming-interface
-  _startTime = 0;
-  _endTime = 0;
-  _initializeRuntimeStart = 0;
-  _initializeRuntimeEnd = 0;
-  _executeJavaScriptBundleEntryPointStart = 0;
-  _executeJavaScriptBundleEntryPointEnd = 0;
+  // All time information here are in ms. The values may be null if not provided.
+  // We do NOT match web spect here for two reasons:
+  // 1. The `ReactNativeStartupTiming` is non-standard API
+  // 2. The timing information is relative to the time origin, which means `0` has valid meaning
+  _startTime: ?number;
+  _endTime: ?number;
+  _initializeRuntimeStart: ?number;
+  _initializeRuntimeEnd: ?number;
+  _executeJavaScriptBundleEntryPointStart: ?number;
+  _executeJavaScriptBundleEntryPointEnd: ?number;
 
-  constructor(startUpTiming: ?ReactNativeStartupTimingType) {
+  constructor(startUpTiming: ?ReactNativeStartupTimingLike) {
     if (startUpTiming != null) {
       this._startTime = startUpTiming.startTime;
       this._endTime = startUpTiming.endTime;
@@ -42,42 +50,42 @@ export default class ReactNativeStartupTiming {
   /**
    * Start time of the RN app startup process. This is provided by the platform by implementing the `ReactMarker.setAppStartTime` API in the native platform code.
    */
-  get startTime(): number {
+  get startTime(): ?number {
     return this._startTime;
   }
 
   /**
    * End time of the RN app startup process. This is equal to `executeJavaScriptBundleEntryPointEnd`.
    */
-  get endTime(): number {
+  get endTime(): ?number {
     return this._endTime;
   }
 
   /**
    * Start time when RN runtime get initialized. This is when RN infra first kicks in app startup process.
    */
-  get initializeRuntimeStart(): number {
+  get initializeRuntimeStart(): ?number {
     return this._initializeRuntimeStart;
   }
 
   /**
    * End time when RN runtime get initialized. This is the last marker before ends of the app startup process.
    */
-  get initializeRuntimeEnd(): number {
+  get initializeRuntimeEnd(): ?number {
     return this._initializeRuntimeEnd;
   }
 
   /**
    * Start time of JS bundle being executed. This indicates the RN JS bundle is loaded and start to be evaluated.
    */
-  get executeJavaScriptBundleEntryPointStart(): number {
+  get executeJavaScriptBundleEntryPointStart(): ?number {
     return this._executeJavaScriptBundleEntryPointStart;
   }
 
   /**
    * End time of JS bundle being executed. This indicates all the synchronous entry point jobs are finished.
    */
-  get executeJavaScriptBundleEntryPointEnd(): number {
+  get executeJavaScriptBundleEntryPointEnd(): ?number {
     return this._executeJavaScriptBundleEntryPointEnd;
   }
 }

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
@@ -53,37 +53,37 @@ void StartupLogger::logStartupEvent(
     double markerTime) {
   switch (markerId) {
     case ReactMarkerId::APP_STARTUP_START:
-      if (appStartupStartTime == 0) {
+      if (std::isnan(appStartupStartTime)) {
         appStartupStartTime = markerTime;
       }
       return;
 
     case ReactMarkerId::APP_STARTUP_STOP:
-      if (appStartupEndTime == 0) {
+      if (std::isnan(appStartupEndTime)) {
         appStartupEndTime = markerTime;
       }
       return;
 
     case ReactMarkerId::INIT_REACT_RUNTIME_START:
-      if (initReactRuntimeStartTime == 0) {
+      if (std::isnan(initReactRuntimeStartTime)) {
         initReactRuntimeStartTime = markerTime;
       }
       return;
 
     case ReactMarkerId::INIT_REACT_RUNTIME_STOP:
-      if (initReactRuntimeEndTime == 0) {
+      if (std::isnan(initReactRuntimeEndTime)) {
         initReactRuntimeEndTime = markerTime;
       }
       return;
 
     case ReactMarkerId::RUN_JS_BUNDLE_START:
-      if (runJSBundleStartTime == 0) {
+      if (std::isnan(runJSBundleStartTime)) {
         runJSBundleStartTime = markerTime;
       }
       return;
 
     case ReactMarkerId::RUN_JS_BUNDLE_STOP:
-      if (runJSBundleEndTime == 0) {
+      if (std::isnan(runJSBundleEndTime)) {
         runJSBundleEndTime = markerTime;
       }
       return;

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #ifdef __APPLE__
 #include <functional>
 #endif
@@ -84,12 +86,12 @@ class RN_EXPORT StartupLogger {
   StartupLogger(const StartupLogger &) = delete;
   StartupLogger &operator=(const StartupLogger &) = delete;
 
-  double appStartupStartTime;
-  double appStartupEndTime;
-  double initReactRuntimeStartTime;
-  double initReactRuntimeEndTime;
-  double runJSBundleStartTime;
-  double runJSBundleEndTime;
+  double appStartupStartTime = std::nan("");
+  double appStartupEndTime = std::nan("");
+  double initReactRuntimeStartTime = std::nan("");
+  double initReactRuntimeEndTime = std::nan("");
+  double runJSBundleStartTime = std::nan("");
+  double runJSBundleEndTime = std::nan("");
 };
 
 // When the marker got logged from the platform, it will notify here. This is

--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -70,30 +70,22 @@ function StartupTimingExample(): React.Node {
           title="Click to update React startup timing"
         />
         <View>
-          <Text>{`startTime: ${
-            startUpTiming == null ? 'N/A' : startUpTiming.startTime
-          } ms`}</Text>
-          <Text>{`initializeRuntimeStart: ${
-            startUpTiming == null ? 'N/A' : startUpTiming.initializeRuntimeStart
-          } ms`}</Text>
+          <Text>{`startTime: ${String(startUpTiming?.startTime)} ms`}</Text>
+          <Text>{`initializeRuntimeStart: ${String(
+            startUpTiming?.initializeRuntimeStart,
+          )} ms`}</Text>
           <Text>
-            {`executeJavaScriptBundleEntryPointStart: ${
-              startUpTiming == null
-                ? 'N/A'
-                : startUpTiming.executeJavaScriptBundleEntryPointStart
-            } ms`}
+            {`executeJavaScriptBundleEntryPointStart: ${String(
+              startUpTiming?.executeJavaScriptBundleEntryPointStart,
+            )} ms`}
           </Text>
-          <Text>{`executeJavaScriptBundleEntryPointEnd: ${
-            startUpTiming == null
-              ? 'N/A'
-              : startUpTiming.executeJavaScriptBundleEntryPointEnd
-          } ms`}</Text>
-          <Text>{`initializeRuntimeEnd: ${
-            startUpTiming == null ? 'N/A' : startUpTiming.initializeRuntimeEnd
-          } ms`}</Text>
-          <Text>{`endTime: ${
-            startUpTiming == null ? 'N/A' : startUpTiming.endTime
-          } ms`}</Text>
+          <Text>{`executeJavaScriptBundleEntryPointEnd: ${String(
+            startUpTiming?.executeJavaScriptBundleEntryPointEnd,
+          )} ms`}</Text>
+          <Text>{`initializeRuntimeEnd: ${String(
+            startUpTiming?.initializeRuntimeEnd,
+          )} ms`}</Text>
+          <Text>{`endTime: ${String(startUpTiming?.endTime)} ms`}</Text>
         </View>
       </View>
     </RNTesterPage>


### PR DESCRIPTION
Summary:
This change makes the returned values from `performance.reactNativeStartupTiming` to accept null or undefined. This is done as some platforms may not have certain startup timing information, and as a default value, it's discussed that null/undefined is better than zero.

- Use `unorderedMap` instead of custom timing object for the C++ native module return value
- Use `std::nan` as initialized value for unset doubles
- Update examples to reflect the latest changes

Changelog:
[General][Internal] - Make the return values for `reactNativeStartupTiming` possible to be null or undefined

Reviewed By: mdvacca

Differential Revision: D43885535

