### PR TITLE
Change how app startup time is collected from platform side

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/NativePerformance.cpp
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformance.cpp
@@ -60,12 +60,12 @@ ReactNativeStartupTiming NativePerformance::getReactNativeStartupTiming(
 
   ReactMarker::StartupLogger &startupLogger =
       ReactMarker::StartupLogger::getInstance();
-  result.startTime = startupLogger.getAppStartTime();
+  result.startTime = startupLogger.getAppStartupStartTime();
   result.executeJavaScriptBundleEntryPointStart =
       startupLogger.getRunJSBundleStartTime();
   result.executeJavaScriptBundleEntryPointEnd =
       startupLogger.getRunJSBundleEndTime();
-  result.endTime = startupLogger.getRunJSBundleEndTime();
+  result.endTime = startupLogger.getAppStartupEndTime();
 
   return result;
 }

--- a/packages/react-native/React/Base/RCTPLTag.h
+++ b/packages/react-native/React/Base/RCTPLTag.h
@@ -25,5 +25,6 @@ typedef NS_ENUM(NSInteger, RCTPLTag) {
   RCTPLTTI,
   RCTPLBundleSize,
   RCTPLReactInstanceInit,
+  RCTPLAppStartup,
   RCTPLSize // This is used to count the size
 };

--- a/packages/react-native/React/Base/RCTPerformanceLoggerLabels.m
+++ b/packages/react-native/React/Base/RCTPerformanceLoggerLabels.m
@@ -49,6 +49,8 @@ NSString *RCTPLLabelForTag(RCTPLTag tag)
       return @"BundleSize";
     case RCTPLReactInstanceInit:
       return @"ReactInstanceInit";
+    case RCTPLAppStartup:
+      return @"AppStartup";
     case RCTPLSize: // Only used to count enum size
       RCTAssert(NO, @"RCTPLSize should not be used to track performance timestamps.");
       return nil;

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -134,6 +134,12 @@ static void mapReactMarkerToPerformanceLogger(
     const char *tag)
 {
   switch (markerId) {
+    case ReactMarker::APP_STARTUP_START:
+      [performanceLogger markStartForTag:RCTPLAppStartup];
+      break;
+    case ReactMarker::APP_STARTUP_STOP:
+      [performanceLogger markStopForTag:RCTPLAppStartup];
+      break;
     case ReactMarker::RUN_JS_BUNDLE_START:
       [performanceLogger markStartForTag:RCTPLScriptExecution];
       break;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -140,7 +140,14 @@ public class ReactMarker {
     for (MarkerListener listener : sListeners) {
       listener.logMarker(name, tag, instanceKey);
     }
+
+    if (ReactBridge.isInitialized()) {
+      nativeLogMarker(name.name(), SystemClock.uptimeMillis());
+    }
   }
+
+  @DoNotStrip
+  private static native void nativeLogMarker(String markerName, long markerTime);
 
   @DoNotStrip
   public static void setAppStartTime(long appStartTime) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarkerConstants.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarkerConstants.java
@@ -9,6 +9,8 @@ package com.facebook.react.bridge;
 
 /** Constants used by ReactMarker. */
 public enum ReactMarkerConstants {
+  APP_STARTUP_START(true),
+  APP_STARTUP_END(true),
   CREATE_REACT_CONTEXT_START,
   CREATE_REACT_CONTEXT_END(true),
   PROCESS_PACKAGES_START,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarkerConstants.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarkerConstants.java
@@ -10,7 +10,7 @@ package com.facebook.react.bridge;
 /** Constants used by ReactMarker. */
 public enum ReactMarkerConstants {
   CREATE_REACT_CONTEXT_START,
-  CREATE_REACT_CONTEXT_END,
+  CREATE_REACT_CONTEXT_END(true),
   PROCESS_PACKAGES_START,
   PROCESS_PACKAGES_END,
   BUILD_NATIVE_MODULE_REGISTRY_START,
@@ -19,8 +19,8 @@ public enum ReactMarkerConstants {
   CREATE_CATALYST_INSTANCE_END,
   DESTROY_CATALYST_INSTANCE_START,
   DESTROY_CATALYST_INSTANCE_END,
-  RUN_JS_BUNDLE_START,
-  RUN_JS_BUNDLE_END,
+  RUN_JS_BUNDLE_START(true),
+  RUN_JS_BUNDLE_END(true),
   NATIVE_MODULE_INITIALIZE_START,
   NATIVE_MODULE_INITIALIZE_END,
   SETUP_REACT_CONTEXT_START,
@@ -32,8 +32,8 @@ public enum ReactMarkerConstants {
   CREATE_VIEW_MANAGERS_END,
   CREATE_UI_MANAGER_MODULE_CONSTANTS_START,
   CREATE_UI_MANAGER_MODULE_CONSTANTS_END,
-  NATIVE_MODULE_SETUP_START,
-  NATIVE_MODULE_SETUP_END,
+  NATIVE_MODULE_SETUP_START(true),
+  NATIVE_MODULE_SETUP_END(true),
   CREATE_MODULE_START,
   CREATE_MODULE_END,
   PROCESS_CORE_REACT_PACKAGE_START,
@@ -59,8 +59,8 @@ public enum ReactMarkerConstants {
   UNPACKING_JS_BUNDLE_LOADER_CHECK_END,
   UNPACKING_JS_BUNDLE_LOADER_EXTRACTED,
   UNPACKING_JS_BUNDLE_LOADER_BLOCKED,
-  loadApplicationScript_startStringConvert,
-  loadApplicationScript_endStringConvert,
+  loadApplicationScript_startStringConvert(true),
+  loadApplicationScript_endStringConvert(true),
   PRE_SETUP_REACT_CONTEXT_START,
   PRE_SETUP_REACT_CONTEXT_END,
   PRE_RUN_JS_BUNDLE_START,
@@ -86,8 +86,8 @@ public enum ReactMarkerConstants {
   CREATE_MC_MODULE_END,
   CREATE_MC_MODULE_GET_METADATA_START,
   CREATE_MC_MODULE_GET_METADATA_END,
-  REGISTER_JS_SEGMENT_START,
-  REGISTER_JS_SEGMENT_STOP,
+  REGISTER_JS_SEGMENT_START(true),
+  REGISTER_JS_SEGMENT_STOP(true),
   VM_INIT,
   ON_FRAGMENT_CREATE,
   JAVASCRIPT_EXECUTOR_FACTORY_INJECT_START,
@@ -121,5 +121,19 @@ public enum ReactMarkerConstants {
   REACT_BRIDGELESS_LOADING_START,
   REACT_BRIDGELESS_LOADING_END,
   LOAD_REACT_NATIVE_MAPBUFFER_SO_FILE_START,
-  LOAD_REACT_NATIVE_MAPBUFFER_SO_FILE_END,
+  LOAD_REACT_NATIVE_MAPBUFFER_SO_FILE_END;
+
+  private boolean mHasMatchingNameMarker;
+
+  ReactMarkerConstants() {
+    this(false);
+  }
+
+  ReactMarkerConstants(boolean hasMatchingNameMarker) {
+    mHasMatchingNameMarker = hasMatchingNameMarker;
+  }
+
+  public boolean hasMatchingNameMarker() {
+    return mHasMatchingNameMarker;
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
@@ -63,7 +63,7 @@ void JReactMarker::logPerfMarkerBridgeless(
 }
 
 void JReactMarker::logPerfMarkerWithInstanceKey(
-    const facebook::react::ReactMarker::ReactMarkerId markerId,
+    const ReactMarker::ReactMarkerId markerId,
     const char *tag,
     const int instanceKey) {
   switch (markerId) {
@@ -107,6 +107,48 @@ double JReactMarker::getAppStartTime() {
   static auto cls = javaClassStatic();
   static auto meth = cls->getStaticMethod<double()>("getAppStartTime");
   return meth(cls);
+}
+
+void JReactMarker::nativeLogMarker(
+    jni::alias_ref<jclass> /* unused */,
+    std::string markerNameStr,
+    jlong markerTime) {
+  // TODO: refactor this to a bidirectional map along with
+  // logPerfMarkerWithInstanceKey
+  if (markerNameStr == "RUN_JS_BUNDLE_START") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::RUN_JS_BUNDLE_START, (double)markerTime);
+  } else if (markerNameStr == "RUN_JS_BUNDLE_END") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::RUN_JS_BUNDLE_STOP, (double)markerTime);
+  } else if (markerNameStr == "CREATE_REACT_CONTEXT_END") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::CREATE_REACT_CONTEXT_STOP, (double)markerTime);
+  } else if (markerNameStr == "loadApplicationScript_startStringConvert") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::JS_BUNDLE_STRING_CONVERT_START, (double)markerTime);
+  } else if (markerNameStr == "loadApplicationScript_endStringConvert") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::JS_BUNDLE_STRING_CONVERT_STOP, (double)markerTime);
+  } else if (markerNameStr == "NATIVE_MODULE_SETUP_START") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::NATIVE_MODULE_SETUP_START, (double)markerTime);
+  } else if (markerNameStr == "NATIVE_MODULE_SETUP_END") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::NATIVE_MODULE_SETUP_STOP, (double)markerTime);
+  } else if (markerNameStr == "REGISTER_JS_SEGMENT_START") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::REGISTER_JS_SEGMENT_START, (double)markerTime);
+  } else if (markerNameStr == "REGISTER_JS_SEGMENT_STOP") {
+    ReactMarker::logMarkerDone(
+        ReactMarker::REGISTER_JS_SEGMENT_STOP, (double)markerTime);
+  }
+}
+
+void JReactMarker::registerNatives() {
+  javaClassLocal()->registerNatives({
+      makeNativeMethod("nativeLogMarker", JReactMarker::nativeLogMarker),
+  });
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
@@ -18,6 +18,7 @@ class JReactMarker : public facebook::jni::JavaClass<JReactMarker> {
  public:
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/bridge/ReactMarker;";
+  static void registerNatives();
   static void setLogPerfMarkerIfNeeded();
 
  private:
@@ -38,6 +39,10 @@ class JReactMarker : public facebook::jni::JavaClass<JReactMarker> {
       const char *tag,
       const int instanceKey);
   static double getAppStartTime();
+  static void nativeLogMarker(
+      jni::alias_ref<jclass> /* unused */,
+      std::string markerNameStr,
+      jlong markerTime);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
@@ -38,7 +38,6 @@ class JReactMarker : public facebook::jni::JavaClass<JReactMarker> {
       const ReactMarker::ReactMarkerId markerId,
       const char *tag,
       const int instanceKey);
-  static double getAppStartTime();
   static void nativeLogMarker(
       jni::alias_ref<jclass> /* unused */,
       std::string markerNameStr,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -16,6 +16,7 @@
 #include "CatalystInstanceImpl.h"
 #include "CxxModuleWrapper.h"
 #include "JCallback.h"
+#include "JReactMarker.h"
 #include "JavaScriptExecutorHolder.h"
 #include "ProxyExecutor.h"
 #include "WritableNativeArray.h"
@@ -85,6 +86,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     NativeMap::registerNatives();
     ReadableNativeMap::registerNatives();
     WritableNativeMap::registerNatives();
+    JReactMarker::registerNatives();
 
 #ifdef WITH_INSPECTOR
     JInspector::registerNatives();

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
@@ -29,7 +29,6 @@ void logMarker(const ReactMarkerId markerId) {
 }
 
 void logTaggedMarker(const ReactMarkerId markerId, const char *tag) {
-  StartupLogger::getInstance().logStartupEvent(markerId);
   logTaggedMarkerImpl(markerId, tag);
 }
 
@@ -38,8 +37,11 @@ void logMarkerBridgeless(const ReactMarkerId markerId) {
 }
 
 void logTaggedMarkerBridgeless(const ReactMarkerId markerId, const char *tag) {
-  StartupLogger::getInstance().logStartupEvent(markerId);
   logTaggedMarkerBridgelessImpl(markerId, tag);
+}
+
+void logMarkerDone(const ReactMarkerId markerId, double markerTime) {
+  StartupLogger::getInstance().logStartupEvent(markerId, markerTime);
 }
 
 StartupLogger &StartupLogger::getInstance() {
@@ -47,18 +49,19 @@ StartupLogger &StartupLogger::getInstance() {
   return instance;
 }
 
-void StartupLogger::logStartupEvent(const ReactMarkerId markerId) {
-  auto now = JSExecutor::performanceNow();
+void StartupLogger::logStartupEvent(
+    const ReactMarkerId markerId,
+    double markerTime) {
   switch (markerId) {
     case ReactMarkerId::RUN_JS_BUNDLE_START:
       if (runJSBundleStartTime == 0) {
-        runJSBundleStartTime = now;
+        runJSBundleStartTime = markerTime;
       }
       return;
 
     case ReactMarkerId::RUN_JS_BUNDLE_STOP:
       if (runJSBundleEndTime == 0) {
-        runJSBundleEndTime = now;
+        runJSBundleEndTime = markerTime;
       }
       return;
 

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
@@ -18,7 +18,6 @@ namespace ReactMarker {
 
 LogTaggedMarker logTaggedMarkerImpl = nullptr;
 LogTaggedMarker logTaggedMarkerBridgelessImpl = nullptr;
-GetAppStartTime getAppStartTimeImpl = nullptr;
 
 #if __clang__
 #pragma clang diagnostic pop
@@ -53,6 +52,18 @@ void StartupLogger::logStartupEvent(
     const ReactMarkerId markerId,
     double markerTime) {
   switch (markerId) {
+    case ReactMarkerId::APP_STARTUP_START:
+      if (appStartupStartTime == 0) {
+        appStartupStartTime = markerTime;
+      }
+      return;
+
+    case ReactMarkerId::APP_STARTUP_STOP:
+      if (appStartupEndTime == 0) {
+        appStartupEndTime = markerTime;
+      }
+      return;
+
     case ReactMarkerId::RUN_JS_BUNDLE_START:
       if (runJSBundleStartTime == 0) {
         runJSBundleStartTime = markerTime;
@@ -70,12 +81,8 @@ void StartupLogger::logStartupEvent(
   }
 }
 
-double StartupLogger::getAppStartTime() {
-  if (getAppStartTimeImpl == nullptr) {
-    return 0;
-  }
-
-  return getAppStartTimeImpl();
+double StartupLogger::getAppStartupStartTime() {
+  return appStartupStartTime;
 }
 
 double StartupLogger::getRunJSBundleStartTime() {
@@ -84,6 +91,10 @@ double StartupLogger::getRunJSBundleStartTime() {
 
 double StartupLogger::getRunJSBundleEndTime() {
   return runJSBundleEndTime;
+}
+
+double StartupLogger::getAppStartupEndTime() {
+  return appStartupEndTime;
 }
 
 } // namespace ReactMarker

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
@@ -71,7 +71,7 @@ class StartupLogger {
  public:
   static StartupLogger &getInstance();
 
-  void logStartupEvent(const ReactMarker::ReactMarkerId markerId);
+  void logStartupEvent(const ReactMarkerId markerName, double markerTime);
   double getAppStartTime();
   double getRunJSBundleStartTime();
   double getRunJSBundleEndTime();
@@ -84,6 +84,13 @@ class StartupLogger {
   double runJSBundleStartTime;
   double runJSBundleEndTime;
 };
+
+// When the marker got logged from the platform, it will notify here. This is
+// used to collect react markers that are logged in the platform instead of in
+// C++.
+extern RN_EXPORT void logMarkerDone(
+    const ReactMarkerId markerId,
+    double markerTime);
 
 } // namespace ReactMarker
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
@@ -15,6 +15,8 @@ namespace facebook::react {
 namespace ReactMarker {
 
 enum ReactMarkerId {
+  APP_STARTUP_START,
+  APP_STARTUP_STOP,
   NATIVE_REQUIRE_START,
   NATIVE_REQUIRE_STOP,
   RUN_JS_BUNDLE_START,
@@ -35,12 +37,10 @@ using LogTaggedMarker =
     std::function<void(const ReactMarkerId, const char *tag)>; // Bridge only
 using LogTaggedMarkerBridgeless =
     std::function<void(const ReactMarkerId, const char *tag)>;
-using GetAppStartTime = std::function<double()>;
 #else
 typedef void (
     *LogTaggedMarker)(const ReactMarkerId, const char *tag); // Bridge only
 typedef void (*LogTaggedMarkerBridgeless)(const ReactMarkerId, const char *tag);
-typedef double (*GetAppStartTime)();
 #endif
 
 #ifndef RN_EXPORT
@@ -49,7 +49,6 @@ typedef double (*GetAppStartTime)();
 
 extern RN_EXPORT LogTaggedMarker logTaggedMarkerImpl; // Bridge only
 extern RN_EXPORT LogTaggedMarker logTaggedMarkerBridgelessImpl;
-extern RN_EXPORT GetAppStartTime getAppStartTimeImpl;
 
 extern RN_EXPORT void logMarker(const ReactMarkerId markerId); // Bridge only
 extern RN_EXPORT void logTaggedMarker(
@@ -59,7 +58,6 @@ extern RN_EXPORT void logMarkerBridgeless(const ReactMarkerId markerId);
 extern RN_EXPORT void logTaggedMarkerBridgeless(
     const ReactMarkerId markerId,
     const char *tag);
-extern RN_EXPORT double getAppStartTime();
 
 struct ReactMarkerEvent {
   const ReactMarkerId markerId;
@@ -72,15 +70,18 @@ class StartupLogger {
   static StartupLogger &getInstance();
 
   void logStartupEvent(const ReactMarkerId markerName, double markerTime);
-  double getAppStartTime();
+  double getAppStartupStartTime();
   double getRunJSBundleStartTime();
   double getRunJSBundleEndTime();
+  double getAppStartupEndTime();
 
  private:
   StartupLogger() = default;
   StartupLogger(const StartupLogger &) = delete;
   StartupLogger &operator=(const StartupLogger &) = delete;
 
+  double appStartupStartTime;
+  double appStartupEndTime;
   double runJSBundleStartTime;
   double runJSBundleEndTime;
 };

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTPerformanceLoggerUtils.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTPerformanceLoggerUtils.mm
@@ -17,6 +17,12 @@ static void mapReactMarkerToPerformanceLogger(
     RCTPerformanceLogger *performanceLogger)
 {
   switch (markerId) {
+    case ReactMarker::APP_STARTUP_START:
+      [performanceLogger markStartForTag:RCTPLAppStartup];
+      break;
+    case ReactMarker::APP_STARTUP_STOP:
+      [performanceLogger markStopForTag:RCTPLAppStartup];
+      break;
     case ReactMarker::RUN_JS_BUNDLE_START:
       [performanceLogger markStartForTag:RCTPLScriptExecution];
       break;


### PR DESCRIPTION
Summary:
This diff changed how we log app startup time by leveraging ReactMarker `logMarker` API, instead of the custom `setAppStartTime` API.

Changelog:
[Android][Internal] - Refactor how app should notify C++ about the app startup time.

Reviewed By: mdvacca

Differential Revision: D43863975

