### PR TITLE
Notify ReactMarker C++ from iOS when we log perf markers

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -328,6 +328,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   RCT_PROFILE_BEGIN_EVENT(0, @"-[RCTBridge setUp]", nil);
 
   _performanceLogger = [RCTPerformanceLogger new];
+  [_performanceLogger markStartForTag:RCTPLInitReactRuntime];
   [_performanceLogger markStartForTag:RCTPLBridgeStartup];
   [_performanceLogger markStartForTag:RCTPLTTI];
 

--- a/packages/react-native/React/Base/RCTPerformanceLogger.mm
+++ b/packages/react-native/React/Base/RCTPerformanceLogger.mm
@@ -6,12 +6,16 @@
  */
 
 #import <QuartzCore/QuartzCore.h>
+#import <cxxreact/ReactMarker.h>
+#include <unordered_map>
 
 #import "RCTLog.h"
 #import "RCTPerformanceLogger.h"
 #import "RCTPerformanceLoggerLabels.h"
 #import "RCTProfile.h"
 #import "RCTRootView.h"
+
+using namespace facebook::react;
 
 @interface RCTPerformanceLogger () {
   int64_t _data[RCTPLSize][2];
@@ -22,6 +26,24 @@
 
 @implementation RCTPerformanceLogger
 
+static const std::unordered_map<RCTPLTag, ReactMarker::ReactMarkerId> &getStartTagToReactMarkerIdMap()
+{
+  static std::unordered_map<RCTPLTag, ReactMarker::ReactMarkerId> StartTagToReactMarkerIdMap = {
+      {RCTPLAppStartup, ReactMarker::APP_STARTUP_START},
+      {RCTPLInitReactRuntime, ReactMarker::INIT_REACT_RUNTIME_START},
+      {RCTPLScriptExecution, ReactMarker::RUN_JS_BUNDLE_START}};
+  return StartTagToReactMarkerIdMap;
+}
+
+static const std::unordered_map<RCTPLTag, ReactMarker::ReactMarkerId> &getStopTagToReactMarkerIdMap()
+{
+  static std::unordered_map<RCTPLTag, ReactMarker::ReactMarkerId> StopTagToReactMarkerIdMap = {
+      {RCTPLAppStartup, ReactMarker::APP_STARTUP_STOP},
+      {RCTPLInitReactRuntime, ReactMarker::INIT_REACT_RUNTIME_STOP},
+      {RCTPLScriptExecution, ReactMarker::RUN_JS_BUNDLE_STOP}};
+  return StopTagToReactMarkerIdMap;
+}
+
 - (void)markStartForTag:(RCTPLTag)tag
 {
 #if RCT_PROFILE
@@ -30,8 +52,15 @@
     _cookies[tag] = RCTProfileBeginAsyncEvent(RCTProfileTagAlways, label, nil);
   }
 #endif
-  _data[tag][0] = CACurrentMediaTime() * 1000;
+  const NSTimeInterval currentTime = CACurrentMediaTime() * 1000;
+  _data[tag][0] = currentTime;
   _data[tag][1] = 0;
+
+  // Notify RN ReactMarker when hosting platform log for markers
+  const auto &startTagToReactMarkerIdMap = getStartTagToReactMarkerIdMap();
+  if (startTagToReactMarkerIdMap.find(tag) != startTagToReactMarkerIdMap.end()) {
+    ReactMarker::logMarkerDone(startTagToReactMarkerIdMap.at(tag), currentTime);
+  }
 }
 
 - (void)markStopForTag:(RCTPLTag)tag
@@ -42,10 +71,17 @@
     RCTProfileEndAsyncEvent(RCTProfileTagAlways, @"native", _cookies[tag], label, @"RCTPerformanceLogger");
   }
 #endif
+  const NSTimeInterval currentTime = CACurrentMediaTime() * 1000;
   if (_data[tag][0] != 0 && _data[tag][1] == 0) {
-    _data[tag][1] = CACurrentMediaTime() * 1000;
+    _data[tag][1] = currentTime;
   } else {
     RCTLogInfo(@"Unbalanced calls start/end for tag %li", (unsigned long)tag);
+  }
+
+  // Notify RN ReactMarker when hosting platform log for markers
+  const auto &stopTagToReactMarkerIdMap = getStopTagToReactMarkerIdMap();
+  if (stopTagToReactMarkerIdMap.find(tag) != stopTagToReactMarkerIdMap.end()) {
+    ReactMarker::logMarkerDone(stopTagToReactMarkerIdMap.at(tag), currentTime);
   }
 }
 


### PR DESCRIPTION
Summary:
This diff adds the iOS side of changes that the platform would notify `ReactMarker` in C++ for selected list of events. This helps us collect and send startup performance timing values via the `performance.reactNativeStartupTiming` API.

Changelog:
[iOS][Internal] - Notify ReactMarker in C++ from iOS platform for startup perf API

Reviewed By: rshest

Differential Revision: D43931719

