### PR TITLE
Cache android react marker before the JNI load C++ libraries

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarkerConstants.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarkerConstants.java
@@ -10,7 +10,7 @@ package com.facebook.react.bridge;
 /** Constants used by ReactMarker. */
 public enum ReactMarkerConstants {
   CREATE_REACT_CONTEXT_START,
-  CREATE_REACT_CONTEXT_END,
+  CREATE_REACT_CONTEXT_END(true),
   PROCESS_PACKAGES_START,
   PROCESS_PACKAGES_END,
   BUILD_NATIVE_MODULE_REGISTRY_START,
@@ -19,8 +19,8 @@ public enum ReactMarkerConstants {
   CREATE_CATALYST_INSTANCE_END,
   DESTROY_CATALYST_INSTANCE_START,
   DESTROY_CATALYST_INSTANCE_END,
-  RUN_JS_BUNDLE_START,
-  RUN_JS_BUNDLE_END,
+  RUN_JS_BUNDLE_START(true),
+  RUN_JS_BUNDLE_END(true),
   NATIVE_MODULE_INITIALIZE_START,
   NATIVE_MODULE_INITIALIZE_END,
   SETUP_REACT_CONTEXT_START,
@@ -32,8 +32,8 @@ public enum ReactMarkerConstants {
   CREATE_VIEW_MANAGERS_END,
   CREATE_UI_MANAGER_MODULE_CONSTANTS_START,
   CREATE_UI_MANAGER_MODULE_CONSTANTS_END,
-  NATIVE_MODULE_SETUP_START,
-  NATIVE_MODULE_SETUP_END,
+  NATIVE_MODULE_SETUP_START(true),
+  NATIVE_MODULE_SETUP_END(true),
   CREATE_MODULE_START,
   CREATE_MODULE_END,
   PROCESS_CORE_REACT_PACKAGE_START,
@@ -59,8 +59,8 @@ public enum ReactMarkerConstants {
   UNPACKING_JS_BUNDLE_LOADER_CHECK_END,
   UNPACKING_JS_BUNDLE_LOADER_EXTRACTED,
   UNPACKING_JS_BUNDLE_LOADER_BLOCKED,
-  loadApplicationScript_startStringConvert,
-  loadApplicationScript_endStringConvert,
+  loadApplicationScript_startStringConvert(true),
+  loadApplicationScript_endStringConvert(true),
   PRE_SETUP_REACT_CONTEXT_START,
   PRE_SETUP_REACT_CONTEXT_END,
   PRE_RUN_JS_BUNDLE_START,
@@ -86,8 +86,8 @@ public enum ReactMarkerConstants {
   CREATE_MC_MODULE_END,
   CREATE_MC_MODULE_GET_METADATA_START,
   CREATE_MC_MODULE_GET_METADATA_END,
-  REGISTER_JS_SEGMENT_START,
-  REGISTER_JS_SEGMENT_STOP,
+  REGISTER_JS_SEGMENT_START(true),
+  REGISTER_JS_SEGMENT_STOP(true),
   VM_INIT,
   ON_FRAGMENT_CREATE,
   JAVASCRIPT_EXECUTOR_FACTORY_INJECT_START,
@@ -121,5 +121,19 @@ public enum ReactMarkerConstants {
   REACT_BRIDGELESS_LOADING_START,
   REACT_BRIDGELESS_LOADING_END,
   LOAD_REACT_NATIVE_MAPBUFFER_SO_FILE_START,
-  LOAD_REACT_NATIVE_MAPBUFFER_SO_FILE_END,
+  LOAD_REACT_NATIVE_MAPBUFFER_SO_FILE_END;
+
+  private boolean mHasMatchingNameMarker;
+
+  ReactMarkerConstants() {
+    this(false);
+  }
+
+  ReactMarkerConstants(boolean hasMatchingNameMarker) {
+    mHasMatchingNameMarker = hasMatchingNameMarker;
+  }
+
+  public boolean hasMatchingNameMarker() {
+    return mHasMatchingNameMarker;
+  }
 }


### PR DESCRIPTION
Summary:
This diff caches the react marker sent from the android host platform before JNI library is loaded and sent out once it's ready. This way the C++ side will receive those markers as expecetd.

Changelog:
[Android][Internal] - Cache react marker timings before JNI library is loaded.

Reviewed By: mdvacca

Differential Revision: D43863973

