### PR TITLE
Align jsdoc to external doc for `id` prop of `View`

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -569,7 +569,7 @@ export type ViewProps = $ReadOnly<{|
   collapsable?: ?boolean,
 
   /**
-   * Used to locate this view from native classes.
+   * Used to locate this view from native classes. Has precedence over `nativeID` prop.
    *
    * > This disables the 'layout-only view removal' optimization for this view!
    *


### PR DESCRIPTION
Summary:
Changelog:
[Internal][Changed] - Align jsdoc to external doc for `id` prop of `View`

Differential Revision: D47433958

