### PR TITLE
Gate Platform.isTesting via __DEV__ on the native level

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -54,11 +54,8 @@ const Platform = {
   },
   // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean {
-    if (__DEV__) {
-      // $FlowFixMe[object-this-reference]
-      return this.constants.isTesting;
-    }
-    return false;
+    // $FlowFixMe[object-this-reference]
+    return this.constants.isTesting;
   },
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean {

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -59,11 +59,8 @@ const Platform = {
   },
   // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean {
-    if (__DEV__) {
-      // $FlowFixMe[object-this-reference]
-      return this.constants.isTesting;
-    }
-    return false;
+    // $FlowFixMe[object-this-reference]
+    return this.constants.isTesting;
   },
   select: <T>(spec: PlatformSelectSpec<T>): T =>
     // $FlowFixMe[incompatible-return]

--- a/packages/react-native/React/CoreModules/RCTPlatform.mm
+++ b/packages/react-native/React/CoreModules/RCTPlatform.mm
@@ -69,7 +69,7 @@ RCT_EXPORT_MODULE(PlatformConstants)
         .osVersion = [device systemVersion],
         .systemName = [device systemName],
         .interfaceIdiom = interfaceIdiom([device userInterfaceIdiom]),
-        .isTesting = RCTRunningInTestEnvironment() ? true : false,
+        .isTesting = (RCT_DEV && RCTRunningInTestEnvironment()) ? true : false,
         .reactNativeVersion = JS::NativePlatformConstantsIOS::ConstantsReactNativeVersion::Builder(
             {.minor = [versions[@"minor"] doubleValue],
              .major = [versions[@"major"] doubleValue],

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -28,6 +28,7 @@ import java.util.Map;
 @SuppressLint("HardwareIds")
 public class AndroidInfoModule extends NativePlatformConstantsAndroidSpec implements TurboModule {
   private static final String IS_TESTING = "IS_TESTING";
+  private static final boolean DEV = ReactBuildConfig.DEBUG;
 
   public AndroidInfoModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -74,7 +75,8 @@ public class AndroidInfoModule extends NativePlatformConstantsAndroidSpec implem
           AndroidInfoHelpers.getServerHost(getReactApplicationContext().getApplicationContext()));
     }
     constants.put(
-        "isTesting", "true".equals(System.getProperty(IS_TESTING)) || isRunningScreenshotTest());
+        "isTesting",
+        DEV && ("true".equals(System.getProperty(IS_TESTING)) || isRunningScreenshotTest()));
     constants.put("reactNativeVersion", ReactNativeVersion.VERSION);
     constants.put("uiMode", uiMode());
     return constants;


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

In D13050583, the `Platform.isTesting` was unconditionally forced to `false` in `__DEV__` on JS side.

On some platforms, we may want to run tests in the release mode.

This hoists these gatings down to the corresponding platforms' native modules.

Differential Revision: D47438069

