### PR TITLE
Temporarily back out "[RN] Gate Platform.isTesting via __DEV__ on the native level"

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -54,8 +54,11 @@ const Platform = {
   },
   // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean {
-    // $FlowFixMe[object-this-reference]
-    return this.constants.isTesting;
+    if (__DEV__) {
+      // $FlowFixMe[object-this-reference]
+      return this.constants.isTesting;
+    }
+    return false;
   },
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean {

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -59,8 +59,11 @@ const Platform = {
   },
   // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean {
-    // $FlowFixMe[object-this-reference]
-    return this.constants.isTesting;
+    if (__DEV__) {
+      // $FlowFixMe[object-this-reference]
+      return this.constants.isTesting;
+    }
+    return false;
   },
   select: <T>(spec: PlatformSelectSpec<T>): T =>
     // $FlowFixMe[incompatible-return]

--- a/packages/react-native/React/CoreModules/RCTPlatform.mm
+++ b/packages/react-native/React/CoreModules/RCTPlatform.mm
@@ -69,7 +69,7 @@ RCT_EXPORT_MODULE(PlatformConstants)
         .osVersion = [device systemVersion],
         .systemName = [device systemName],
         .interfaceIdiom = interfaceIdiom([device userInterfaceIdiom]),
-        .isTesting = (RCT_DEV && RCTRunningInTestEnvironment()) ? true : false,
+        .isTesting = RCTRunningInTestEnvironment() ? true : false,
         .reactNativeVersion = JS::NativePlatformConstantsIOS::ConstantsReactNativeVersion::Builder(
             {.minor = [versions[@"minor"] doubleValue],
              .major = [versions[@"major"] doubleValue],

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -28,7 +28,6 @@ import java.util.Map;
 @SuppressLint("HardwareIds")
 public class AndroidInfoModule extends NativePlatformConstantsAndroidSpec implements TurboModule {
   private static final String IS_TESTING = "IS_TESTING";
-  private static final boolean DEV = ReactBuildConfig.DEBUG;
 
   public AndroidInfoModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -75,8 +74,7 @@ public class AndroidInfoModule extends NativePlatformConstantsAndroidSpec implem
           AndroidInfoHelpers.getServerHost(getReactApplicationContext().getApplicationContext()));
     }
     constants.put(
-        "isTesting",
-        DEV && ("true".equals(System.getProperty(IS_TESTING)) || isRunningScreenshotTest()));
+        "isTesting", "true".equals(System.getProperty(IS_TESTING)) || isRunningScreenshotTest());
     constants.put("reactNativeVersion", ReactNativeVersion.VERSION);
     constants.put("uiMode", uiMode());
     return constants;


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] -

This backs out an earlier commit because we have two separate internal tests' setups that broke as a side effect of it.

In both cases the setup was arguably inconsistent, however the plan is to temporarily revert this nevertheless, fix the tests first and then resubmit.

Reviewed By: javache

Differential Revision: D47469176

