### PR TITLE
Align usage of JSPointerDispatcher across ReactSurfaceView and ReactRootView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -194,20 +194,14 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   }
 
   @Override
-  public void onChildStartedNativeGesture(MotionEvent ev) {
-    onChildStartedNativeGesture(null, ev);
-  }
-
-  @Override
   public void onChildStartedNativeGesture(View childView, MotionEvent ev) {
     if (!isDispatcherReady()) {
       return;
     }
-    ReactContext reactContext = getCurrentReactContext();
-    UIManager uiManager = UIManagerHelper.getUIManager(reactContext, getUIManagerType());
 
-    if (uiManager != null) {
-      EventDispatcher eventDispatcher = uiManager.getEventDispatcher();
+    EventDispatcher eventDispatcher =
+        UIManagerHelper.getEventDispatcher(getCurrentReactContext(), getUIManagerType());
+    if (eventDispatcher != null) {
       mJSTouchDispatcher.onChildStartedNativeGesture(ev, eventDispatcher);
       if (childView != null && mJSPointerDispatcher != null) {
         mJSPointerDispatcher.onChildStartedNativeGesture(childView, ev, eventDispatcher);
@@ -220,11 +214,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     if (!isDispatcherReady()) {
       return;
     }
-    ReactContext reactContext = getCurrentReactContext();
-    UIManager uiManager = UIManagerHelper.getUIManager(reactContext, getUIManagerType());
 
-    if (uiManager != null) {
-      EventDispatcher eventDispatcher = uiManager.getEventDispatcher();
+    EventDispatcher eventDispatcher =
+        UIManagerHelper.getEventDispatcher(getCurrentReactContext(), getUIManagerType());
+    if (eventDispatcher != null) {
       mJSTouchDispatcher.onChildEndedNativeGesture(ev, eventDispatcher);
       if (mJSPointerDispatcher != null) {
         mJSPointerDispatcher.onChildEndedNativeGesture();
@@ -347,11 +340,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       FLog.w(TAG, "Unable to dispatch pointer events to JS before the dispatcher is available");
       return;
     }
-    ReactContext reactContext = getCurrentReactContext();
-    UIManager uiManager = UIManagerHelper.getUIManager(reactContext, getUIManagerType());
 
-    if (uiManager != null) {
-      EventDispatcher eventDispatcher = uiManager.getEventDispatcher();
+    EventDispatcher eventDispatcher =
+        UIManagerHelper.getEventDispatcher(getCurrentReactContext(), getUIManagerType());
+    if (eventDispatcher != null) {
       mJSPointerDispatcher.handleMotionEvent(event, eventDispatcher, isCapture);
     }
   }
@@ -365,11 +357,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       FLog.w(TAG, "Unable to dispatch touch to JS before the dispatcher is available");
       return;
     }
-    ReactContext reactContext = getCurrentReactContext();
-    UIManager uiManager = UIManagerHelper.getUIManager(reactContext, getUIManagerType());
 
-    if (uiManager != null) {
-      EventDispatcher eventDispatcher = uiManager.getEventDispatcher();
+    EventDispatcher eventDispatcher =
+        UIManagerHelper.getEventDispatcher(getCurrentReactContext(), getUIManagerType());
+    if (eventDispatcher != null) {
       mJSTouchDispatcher.handleTouchEvent(event, eventDispatcher);
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurfaceView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurfaceView.java
@@ -33,7 +33,7 @@ public class ReactSurfaceView extends ReactRootView {
 
   private static final String TAG = "ReactSurfaceView";
 
-  private ReactSurface mSurface;
+  private final ReactSurface mSurface;
 
   private final JSTouchDispatcher mJSTouchDispatcher;
   private @Nullable JSPointerDispatcher mJSPointerDispatcher;
@@ -138,25 +138,32 @@ public class ReactSurfaceView extends ReactRootView {
    * from the child's onTouchIntercepted implementation.
    */
   @Override
-  public void onChildStartedNativeGesture(MotionEvent ev) {
-    if (mJSTouchDispatcher != null && mSurface.getEventDispatcher() != null) {
-      mJSTouchDispatcher.onChildStartedNativeGesture(ev, mSurface.getEventDispatcher());
-    }
-  }
-
-  /**
-   * Called when a child starts a native gesture (e.g. a scroll in a ScrollView). Should be called
-   * from the child's onTouchIntercepted implementation.
-   */
-  @Override
   public void onChildStartedNativeGesture(View childView, MotionEvent ev) {
-    onChildStartedNativeGesture(ev);
+    EventDispatcher eventDispatcher = mSurface.getEventDispatcher();
+    if (eventDispatcher == null) {
+      return;
+    }
+
+    if (mJSTouchDispatcher != null) {
+      mJSTouchDispatcher.onChildStartedNativeGesture(ev, eventDispatcher);
+    }
+    if (childView != null && mJSPointerDispatcher != null) {
+      mJSPointerDispatcher.onChildStartedNativeGesture(childView, ev, eventDispatcher);
+    }
   }
 
   @Override
   public void onChildEndedNativeGesture(View childView, MotionEvent ev) {
+    EventDispatcher eventDispatcher = mSurface.getEventDispatcher();
+    if (eventDispatcher == null) {
+      return;
+    }
+
     if (mJSTouchDispatcher != null && mSurface.getEventDispatcher() != null) {
       mJSTouchDispatcher.onChildEndedNativeGesture(ev, mSurface.getEventDispatcher());
+    }
+    if (mJSPointerDispatcher != null) {
+      mJSPointerDispatcher.onChildStartedNativeGesture(childView, ev, eventDispatcher);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
@@ -21,7 +21,9 @@ public interface RootView {
 
   /** @deprecated */
   @Deprecated
-  void onChildStartedNativeGesture(MotionEvent ev);
+  default void onChildStartedNativeGesture(MotionEvent ev) {
+    onChildStartedNativeGesture(null, ev);
+  }
 
   /**
    * Called when a child ends a native gesture. Should be called from the child's onTouchIntercepted

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -568,11 +568,6 @@ public class ReactModalHostView extends ViewGroup
     }
 
     @Override
-    public void onChildStartedNativeGesture(MotionEvent ev) {
-      this.onChildStartedNativeGesture(null, ev);
-    }
-
-    @Override
     public void onChildStartedNativeGesture(View childView, MotionEvent ev) {
       mJSTouchDispatcher.onChildStartedNativeGesture(ev, mEventDispatcher);
       if (mJSPointerDispatcher != null) {


### PR DESCRIPTION
Summary:
Found subtle differences between how JSPointerDispatcher is configured across bridgeless.

Changelog: [Internal]

Differential Revision: D47468666

