### PR TITLE
Fabric Interop - Also normalize direct events

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -145,7 +145,6 @@ import java.util.Set;
 
     Map viewManagerBubblingEvents = viewManager.getExportedCustomBubblingEventTypeConstants();
     if (viewManagerBubblingEvents != null) {
-
       if (ReactFeatureFlags.enableFabricRenderer && ReactFeatureFlags.unstable_useFabricInterop) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
@@ -162,6 +161,12 @@ import java.util.Set;
     Map viewManagerDirectEvents = viewManager.getExportedCustomDirectEventTypeConstants();
     validateDirectEventNames(viewManager.getName(), viewManagerDirectEvents);
     if (viewManagerDirectEvents != null) {
+      if (ReactFeatureFlags.enableFabricRenderer && ReactFeatureFlags.unstable_useFabricInterop) {
+        // For Fabric, events needs to be fired with a "top" prefix.
+        // For the sake of Fabric Interop, here we normalize events adding "top" in their
+        // name if the user hasn't provided it.
+        normalizeEventTypes(viewManagerDirectEvents);
+      }
       recursiveMerge(cumulativeDirectEventTypes, viewManagerDirectEvents);
       recursiveMerge(viewManagerDirectEvents, defaultDirectEvents);
       viewManagerConstants.put(DIRECT_EVENTS_KEY, viewManagerDirectEvents);


### PR DESCRIPTION
Summary:
This change is making sure we normalize both bubbling and direct events for the sake of Fabric Interop.
This is currently required as some libraries have reported incompatiblities with Fabric Interop
(see https://github.com/react-native-maps/react-native-maps/issues/4383)

Also this is has been reported by the WG here:
https://github.com/reactwg/react-native-new-architecture/discussions/135#discussioncomment-6443294

Changelog:
[Android] [Fixed] - Fabric Interop - Fix support for direct events on Paper components

Differential Revision: D47472050

