### PR TITLE
Clear bundler banner messages after a certain delay during development.

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -83,6 +83,14 @@ RCT_EXPORT_MODULE()
       dispatch_time(DISPATCH_TIME_NOW, 0.2 * NSEC_PER_SEC), dispatch_get_main_queue(), self->_initialMessageBlock);
 }
 
+- (void)hideBannerAfter:(CGFloat)delay
+{
+  // Cancel previous hide call after the delay.
+  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hide) object:nil];
+  // Set new hide call after a delay.
+  [self performSelector:@selector(hide) withObject:nil afterDelay:delay];
+}
+
 - (void)showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor
 {
   if (!RCTDevLoadingViewGetEnabled() || _hiding) {
@@ -132,6 +140,8 @@ RCT_EXPORT_MODULE()
     UIWindowScene *scene = (UIWindowScene *)RCTSharedApplication().connectedScenes.anyObject;
     self->_window.windowScene = scene;
   });
+
+  [self hideBannerAfter:15.0];
 }
 
 RCT_EXPORT_METHOD(showMessage


### PR DESCRIPTION
Summary: Changelog: [General] [iOS] Clear bundler banner messages after a certain delay during development.

Differential Revision: D47478373

