### PR TITLE
Reenable scrollEventThrottle prop for ScrollView and HorizontalScrollView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -101,6 +101,15 @@ public class ReactScrollViewHelper {
   private static <T extends ViewGroup & HasScrollEventThrottle> void emitScrollEvent(
       T scrollView, ScrollEventType scrollEventType, float xVelocity, float yVelocity) {
     long now = System.currentTimeMillis();
+    // Throttle the scroll event if scrollEventThrottle is set to be equal or more than 17 ms.
+    // We limit the delta to 17ms so that small throttles intended to enable 60fps updates will not
+    // inadvertently filter out any scroll events.
+    if (scrollView.getScrollEventThrottle()
+        >= Math.max(17, now - scrollView.getLastScrollDispatchTime())) {
+      // Scroll events are throttled.
+      return;
+    }
+
     View contentView = scrollView.getChildAt(0);
 
     if (contentView == null) {


### PR DESCRIPTION
Summary:
We added `scrollEventThrottle` for android in D35735978, but the experiment was never executed and the flag got removed in D39449184.

Since the same feature is on iOS and the implementation here is the same to iOS (https://fburl.com/code/htcuhq4w), it should be safe to support.

Reviewed By: cortinico

Differential Revision: D47492259

