### PR TITLE
Interop: Fix regression test

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleLegacyModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleLegacyModule.mm
@@ -41,12 +41,9 @@ RCT_EXPORT_MODULE()
 {
   __block NSDictionary *constants;
   RCTUnsafeExecuteOnMainQueueSync(^{
-    UIScreen *mainScreen = UIScreen.mainScreen;
-    CGSize screenSize = mainScreen.bounds.size;
-
     constants = @{
       @"const1" : @YES,
-      @"const2" : @(screenSize.width),
+      @"const2" : @(390),
       @"const3" : @"something",
     };
   });


### PR DESCRIPTION
Summary:
The TurboModule interop layer test asserts that SampleLegacyModule.const2 == 390.

But SampleLegacyModule.const2 was actually the screen size of device, which is different locally vs sandcastle.

So, while the test passed locally (b/c screen size = 390), it failed on Sandcastle (b/c screen size = 375).

So, this diff hardcodes const2 to be 390.

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: christophpurrer

Differential Revision: D47379531

