### PR TITLE
fix: prevent iOS modal to be presented multiple times

### DIFF
--- a/packages/react-native/React/Views/RCTModalHostView.m
+++ b/packages/react-native/React/Views/RCTModalHostView.m
@@ -168,7 +168,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 
 - (void)ensurePresentedOnlyIfNeeded
 {
-  BOOL shouldBePresented = !_isPresented && _visible && self.window;
+  BOOL shouldBePresented = !_isPresented && _visible && self.window && !_modalViewController.view.window;
   if (shouldBePresented) {
     RCTAssert(self.reactViewController, @"Can't present modal view controller without a presenting view controller");
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Got crash when navigating to other screen while modal is being closed, it throws `NSInvalidArgumentException', reason: 'Application tried to present modally a view controller <RCTModalHostViewController: 0x125fb63d0> that is already being presented by <UIViewController: 0x125f152e0>.`, similar with https://github.com/react-navigation/react-navigation/issues/11201. It seems the `RCTModalHostViewController` is already presented and the other VC (when navigating to new screen) tried to present it again.

To fix this issue, I added validation before presenting the modal to check if the it's already presented.
The other alternative is to adjust this [validation](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTModalHostView.m#L129-L133) to not present the modal if `RCTModalHostView` instance is exists in `self.superview.reactSubviews`.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Prevent iOS modal to be presented multiple times

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Repro can be found [here](https://github.com/adrianha/react-native-ios-modal-repro), using `react-native 0.72.3`

After:

https://github.com/facebook/react-native/assets/5382429/e8f00fbf-9a8d-4550-93b6-9ed80f813ae9


