### PR TITLE
Better Incremental build for :ReactAndroid:hermes-engine

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -42,6 +42,16 @@ def downloadsDir = customDownloadDir ? new File(customDownloadDir) : new File(re
 def overrideHermesDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") != null
 def hermesDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") ?: new File(reactNativeRootDir, "sdks/hermes")
 def hermesBuildDir = new File("$buildDir/hermes")
+def hermesCOutputBinary = new File("$buildDir/hermes/bin/hermesc")
+// This filetree represents the file of the Hermes build that we want as input/output
+// of the buildHermesC task. Gradle will compute the hash of files in the file tree
+// and won't rebuilt hermesc unless those files are changing.
+def hermesBuildOutputFileTree = fileTree(hermesBuildDir.toString())
+                    .exclude('**/*.make')
+                    .exclude('**/*.internal')
+                    .exclude('**/external/**')
+                    .exclude('**/hermes.framework/**')
+                    .exclude('**/bin/hermesc')
 
 def hermesVersion = "main"
 def hermesVersionFile = new File(reactNativeRootDir, "sdks/.hermesversion")
@@ -86,12 +96,36 @@ task unzipHermes(dependsOn: downloadHermes, type: Copy) {
 
 task configureBuildForHermes(type: Exec) {
     workingDir(hermesDir)
-    commandLine(windowsAwareCommandLine(findCmakePath(cmakeVersion), Os.isFamily(Os.FAMILY_WINDOWS) ? "-GNMake Makefiles" : "", "-S", ".", "-B", hermesBuildDir.toString(), "-DJSI_DIR=" + jsiDir.absolutePath))
+    inputs.dir(hermesDir)
+    outputs.files(hermesBuildOutputFileTree)
+    commandLine(
+        windowsAwareCommandLine(
+            findCmakePath(cmakeVersion),
+            Os.isFamily(Os.FAMILY_WINDOWS) ? "-GNMake Makefiles" : "",
+            "-S",
+            ".",
+            "-B",
+            hermesBuildDir.toString(),
+            "-DJSI_DIR=" + jsiDir.absolutePath
+        )
+    )
 }
 
-task buildHermes(dependsOn: configureBuildForHermes, type: Exec) {
+task buildHermesC(dependsOn: configureBuildForHermes, type: Exec) {
     workingDir(hermesDir)
-    commandLine(windowsAwareCommandLine(findCmakePath(cmakeVersion), "--build", hermesBuildDir.toString(), "--target", "hermesc", "-j", ndkBuildJobs))
+    inputs.files(hermesBuildOutputFileTree)
+    outputs.file(hermesCOutputBinary)
+    commandLine(
+        windowsAwareCommandLine(
+            findCmakePath(cmakeVersion),
+            "--build",
+            hermesBuildDir.toString(),
+            "--target",
+            "hermesc",
+            "-j",
+            ndkBuildJobs,
+        )
+    )
 }
 
 task prepareHeadersForPrefab(type: Copy) {
@@ -258,9 +292,9 @@ afterEvaluate {
         configureBuildForHermes.dependsOn(unzipHermes)
         prepareHeadersForPrefab.dependsOn(unzipHermes)
     }
-    preBuild.dependsOn(buildHermes)
+    preBuild.dependsOn(buildHermesC)
     preBuild.dependsOn(prepareHeadersForPrefab)
-    prepareHeadersForPrefab.dependsOn(buildHermes)
+    prepareHeadersForPrefab.dependsOn(buildHermesC)
 }
 
 /* Publishing Configuration */

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -181,7 +181,7 @@ android {
 afterEvaluate {
     // As we're consuming Hermes from source, we want to make sure
     // `hermesc` is built before we actually invoke the `emit*HermesResource` task
-    createBundleHermesReleaseJsAndAssets.dependsOn(":packages:react-native:ReactAndroid:hermes-engine:buildHermes")
+    createBundleHermesReleaseJsAndAssets.dependsOn(":packages:react-native:ReactAndroid:hermes-engine:buildHermesC")
 
     // As we're building 4 native flavors in parallel, there is clash on the `.cxx/Debug` and
     // `.cxx/Release` folder where the CMake intermediates are stored.


### PR DESCRIPTION
## Summary:

This fixes an issue we had with incremental compilation of `:ReactAndroid:hermes-engine`
Practically the `buildHermesC` and `configureBuildForHermes` would re-run every time as they had no input/output configured.

This breaks incremental compilation, meaning that when you want to rebuild RN-Tester, you would rebuild hermesc every time.

This fixes it for good, so we won't be rebuilding `hermesc` unless needed. 

## Changelog:

[INTERNAL] - Better Incremental build for :ReactAndroid:hermes-engine

## Test Plan:

Will wait for CI to be green. Plus I've verified that those tasks don't get re-executed on subsequent builds:

```bash
$ gw :packages:rn-tester:android:app:assembleHermesDebug --console=plain
> Task :react-native-gradle-plugin:compileKotlin UP-TO-DATE
> Task :react-native-gradle-plugin:compileJava NO-SOURCE
> Task :react-native-gradle-plugin:pluginDescriptors UP-TO-DATE
> Task :react-native-gradle-plugin:processResources UP-TO-DATE
> Task :react-native-gradle-plugin:classes UP-TO-DATE
> Task :react-native-gradle-plugin:jar UP-TO-DATE
> Task :react-native-gradle-plugin:inspectClassesForKotlinIC UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:preBuild UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:preDebugBuild UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:generateDebugResValues UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:generateDebugResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:buildCodegenCLI SKIPPED
> Task :packages:react-native:ReactAndroid:flipper-integration:packageDebugResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:parseDebugLocalResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:processDebugManifest UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:generateDebugRFile UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:javaPreCompileDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:compileDebugLibraryResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:writeDebugAarMetadata UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:extractDeepLinksDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:mergeDebugShaders UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:compileDebugShaders NO-SOURCE
> Task :packages:react-native:ReactAndroid:flipper-integration:generateDebugAssets UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:packageDebugAssets UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:processDebugJavaRes NO-SOURCE
> Task :packages:react-native:ReactAndroid:flipper-integration:mergeDebugJniLibFolders UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:mergeDebugNativeLibs NO-SOURCE
> Task :packages:react-native:ReactAndroid:flipper-integration:copyDebugJniLibsProjectOnly UP-TO-DATE
> Task :packages:rn-tester:android:app:buildCodegenCLI SKIPPED
> Task :packages:react-native:ReactAndroid:generateCodegenSchemaFromJavaScript UP-TO-DATE
> Task :packages:react-native:ReactAndroid:generateCodegenArtifactsFromSchema UP-TO-DATE
> Task :packages:react-native:ReactAndroid:createNativeDepsDirectories UP-TO-DATE
> Task :packages:rn-tester:android:app:generateCodegenSchemaFromJavaScript UP-TO-DATE
> Task :packages:rn-tester:android:app:generateCodegenArtifactsFromSchema UP-TO-DATE
> Task :packages:rn-tester:android:app:preBuild UP-TO-DATE
> Task :packages:rn-tester:android:app:preHermesDebugBuild UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeHermesDebugNativeDebugMetadata NO-SOURCE

> Task :packages:react-native:ReactAndroid:downloadBoost UP-TO-DATE
Download https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz

> Task :packages:rn-tester:android:app:generateHermesDebugBuildConfig UP-TO-DATE
> Task :packages:rn-tester:android:app:javaPreCompileHermesDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:prepareBoost UP-TO-DATE
> Task :packages:rn-tester:android:app:generateHermesDebugResValues UP-TO-DATE

> Task :packages:react-native:ReactAndroid:downloadDoubleConversion UP-TO-DATE
Download https://github.com/google/double-conversion/archive/v1.1.6.tar.gz

> Task :packages:rn-tester:android:app:generateHermesDebugResources UP-TO-DATE
> Task :packages:rn-tester:android:app:packageHermesDebugResources UP-TO-DATE
> Task :packages:rn-tester:android:app:parseHermesDebugLocalResources UP-TO-DATE
> Task :packages:rn-tester:android:app:createHermesDebugCompatibleScreenManifests UP-TO-DATE
> Task :packages:rn-tester:android:app:extractDeepLinksHermesDebug UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeHermesDebugShaders UP-TO-DATE
> Task :packages:rn-tester:android:app:compileHermesDebugShaders NO-SOURCE
> Task :packages:rn-tester:android:app:generateHermesDebugAssets UP-TO-DATE
> Task :packages:react-native:ReactAndroid:prepareDoubleConversion UP-TO-DATE

> Task :packages:react-native:ReactAndroid:downloadFmt UP-TO-DATE
Download https://github.com/fmtlib/fmt/archive/6.2.1.tar.gz

> Task :packages:react-native:ReactAndroid:downloadFolly UP-TO-DATE
Download https://github.com/facebook/folly/archive/v2021.07.22.00.tar.gz

> Task :packages:rn-tester:android:app:checkHermesDebugDuplicateClasses UP-TO-DATE
> Task :packages:rn-tester:android:app:desugarHermesDebugFileDependencies UP-TO-DATE
> Task :packages:react-native:ReactAndroid:prepareFmt UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeExtDexHermesDebug UP-TO-DATE
> Task :packages:rn-tester:android:app:processHermesDebugJavaRes NO-SOURCE
> Task :packages:rn-tester:android:app:preJscDebugBuild UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeHermesDebugJniLibFolders UP-TO-DATE
> Task :packages:rn-tester:android:app:validateSigningHermesDebug UP-TO-DATE
> Task :packages:rn-tester:android:app:writeHermesDebugAppMetadata UP-TO-DATE
> Task :packages:react-native:ReactAndroid:prepareFolly UP-TO-DATE
> Task :packages:rn-tester:android:app:writeHermesDebugSigningConfigVersions UP-TO-DATE

> Task :packages:react-native:ReactAndroid:downloadGlog UP-TO-DATE
Download https://github.com/google/glog/archive/v0.3.5.tar.gz

> Task :packages:react-native:ReactAndroid:downloadGtest UP-TO-DATE
Download https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz

> Task :packages:react-native:ReactAndroid:prepareGlog UP-TO-DATE
> Task :packages:react-native:ReactAndroid:prepareGtest UP-TO-DATE
> Task :packages:react-native:ReactAndroid:prepareJSC UP-TO-DATE

> Task :packages:react-native:ReactAndroid:downloadLibevent UP-TO-DATE
Download https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz

> Task :packages:react-native:ReactAndroid:preparePrefab UP-TO-DATE
> Task :packages:react-native:ReactAndroid:prepareLibevent UP-TO-DATE
> Task :packages:react-native:ReactAndroid:preBuild UP-TO-DATE
> Task :packages:react-native:ReactAndroid:preDebugBuild UP-TO-DATE
> Task :packages:react-native:ReactAndroid:generateDebugBuildConfig UP-TO-DATE
> Task :packages:react-native:ReactAndroid:generateDebugResValues UP-TO-DATE
> Task :packages:react-native:ReactAndroid:generateDebugResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:packageDebugResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:parseDebugLocalResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:processDebugManifest UP-TO-DATE
> Task :packages:react-native:ReactAndroid:generateDebugRFile UP-TO-DATE
> Task :packages:react-native:ReactAndroid:javaPreCompileDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:compileDebugLibraryResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:writeDebugAarMetadata UP-TO-DATE
> Task :packages:react-native:ReactAndroid:extractDeepLinksDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:mergeDebugShaders UP-TO-DATE
> Task :packages:react-native:ReactAndroid:compileDebugShaders NO-SOURCE
> Task :packages:react-native:ReactAndroid:generateDebugAssets UP-TO-DATE
> Task :packages:react-native:ReactAndroid:packageDebugAssets UP-TO-DATE
> Task :packages:react-native:ReactAndroid:processDebugJavaRes NO-SOURCE
> Task :packages:react-native:ReactAndroid:mergeDebugJniLibFolders UP-TO-DATE

> Task :packages:react-native:ReactAndroid:hermes-engine:downloadHermes UP-TO-DATE
Download https://github.com/facebook/hermes/tarball/main

> Task :packages:react-native:ReactAndroid:hermes-engine:unzipHermes UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:configureBuildForHermes UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:buildHermesC UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:prepareHeadersForPrefab UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:preBuild UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:preDebugBuild UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:generateDebugResValues UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:generateDebugResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:packageDebugResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:parseDebugLocalResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:processDebugManifest UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:generateDebugRFile UP-TO-DATE
> Task :packages:rn-tester:android:app:mapHermesDebugSourceSetPaths UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:javaPreCompileDebug UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeHermesDebugResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:compileDebugJavaWithJavac UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:bundleLibCompileToJarDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:compileDebugLibraryResources UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:writeDebugAarMetadata UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:extractDeepLinksDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:mergeDebugShaders UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:compileDebugShaders NO-SOURCE
> Task :packages:react-native:ReactAndroid:hermes-engine:generateDebugAssets UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:packageDebugAssets UP-TO-DATE
> Task :packages:rn-tester:android:app:checkHermesDebugAarMetadata UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:processDebugJavaRes NO-SOURCE
> Task :packages:react-native:ReactAndroid:hermes-engine:bundleLibResDebug NO-SOURCE
> Task :packages:rn-tester:android:app:processHermesDebugMainManifest UP-TO-DATE
> Task :packages:rn-tester:android:app:processHermesDebugManifest UP-TO-DATE
> Task :packages:rn-tester:android:app:processHermesDebugManifestForPackage UP-TO-DATE
> Task :packages:rn-tester:android:app:processHermesDebugResources UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeHermesDebugAssets UP-TO-DATE
> Task :packages:rn-tester:android:app:compressHermesDebugAssets UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:configureCMakeRelease[arm64-v8a]
> Task :packages:react-native:ReactAndroid:hermes-engine:generateJsonModelDebug
> Task :packages:react-native:ReactAndroid:hermes-engine:prefabDebugConfigurePackage UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:buildCMakeRelease[arm64-v8a][libhermes]
> Task :packages:react-native:ReactAndroid:compileDebugKotlin UP-TO-DATE
> Task :packages:react-native:ReactAndroid:compileDebugJavaWithJavac UP-TO-DATE
> Task :packages:react-native:ReactAndroid:bundleLibCompileToJarDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:bundleLibResDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:compileDebugKotlin UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:compileDebugJavaWithJavac NO-SOURCE
> Task :packages:react-native:ReactAndroid:flipper-integration:bundleLibCompileToJarDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:flipper-integration:bundleLibResDebug UP-TO-DATE
> Task :packages:rn-tester:android:app:compileHermesDebugJavaWithJavac UP-TO-DATE
> Task :packages:rn-tester:android:app:dexBuilderHermesDebug UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeHermesDebugGlobalSynthetics UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeHermesDebugJavaResource UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeLibDexHermesDebug UP-TO-DATE
> Task :packages:rn-tester:android:app:mergeProjectDexHermesDebug UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:externalNativeBuildDebug
> Task :packages:react-native:ReactAndroid:hermes-engine:prefabDebugPackage UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:mergeDebugJniLibFolders UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:mergeDebugNativeLibs UP-TO-DATE
> Task :packages:react-native:ReactAndroid:hermes-engine:copyDebugJniLibsProjectOnly UP-TO-DATE
> Task :packages:react-native:ReactAndroid:configureCMakeDebug[arm64-v8a]
> Task :packages:react-native:ReactAndroid:buildCMakeDebug[arm64-v8a][bridgeless,fabricjni,etc]
> Task :packages:react-native:ReactAndroid:mergeDebugNativeLibs UP-TO-DATE
> Task :packages:react-native:ReactAndroid:copyDebugJniLibsProjectOnly UP-TO-DATE
> Task :packages:react-native:ReactAndroid:externalNativeBuildDebug
> Task :packages:react-native:ReactAndroid:generateJsonModelDebug
> Task :packages:react-native:ReactAndroid:prefabDebugConfigurePackage UP-TO-DATE
> Task :packages:react-native:ReactAndroid:prefabDebugPackage UP-TO-DATE
> Task :packages:rn-tester:android:app:configureCMakeDebug[arm64-v8a]
> Task :packages:rn-tester:android:app:buildCMakeDebug[arm64-v8a]
> Task :packages:rn-tester:android:app:mergeHermesDebugNativeLibs UP-TO-DATE
> Task :packages:rn-tester:android:app:stripHermesDebugDebugSymbols UP-TO-DATE
> Task :packages:rn-tester:android:app:packageHermesDebug UP-TO-DATE
> Task :packages:rn-tester:android:app:createHermesDebugApkListingFileRedirect UP-TO-DATE
> Task :packages:rn-tester:android:app:assembleHermesDebug UP-TO-DATE

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 3s
130 actionable tasks: 8 executed, 122 up-to-date
```