### PR TITLE
Fix builds with C++20

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.cpp
@@ -17,7 +17,12 @@ using Fragments = AttributedString::Fragments;
 #pragma mark - Fragment
 
 std::string Fragment::AttachmentCharacter() {
-  return u8"\uFFFC"; // Unicode `OBJECT REPLACEMENT CHARACTER`
+  // C++20 makes char8_t a distinct type from char, and u8 string literals
+  // consist of char8_t instead of char, which in turn requires std::u8string,
+  // etc. Here we were assuming char was UTF-8 anyway, so just cast to that
+  // (which is valid because char* is allowed to alias anything).
+  return reinterpret_cast<const char *>(
+      u8"\uFFFC"); // Unicode `OBJECT REPLACEMENT CHARACTER`
 }
 
 bool Fragment::isAttachment() const {


### PR DESCRIPTION
Summary:
char8_t is a distinct type in C++20, which would need to be propagated
everywhere else (e.g. using `std::u8string` instead of `std::string`).
The code was already assuming that char is UTF-8, so we can just cast
accordingly (which works on all compilers: https://godbolt.org/z/9cv4c48o4).

Reviewed By: javache

Differential Revision: D47537998

