### PR TITLE
Populate Platform.isDisableAnimations for the Android mobile platform

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -28,6 +28,7 @@ import java.util.Map;
 @SuppressLint("HardwareIds")
 public class AndroidInfoModule extends NativePlatformConstantsAndroidSpec implements TurboModule {
   private static final String IS_TESTING = "IS_TESTING";
+  private static final String IS_DISABLE_ANIMATIONS = "IS_DISABLE_ANIMATIONS";
 
   public AndroidInfoModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -75,6 +76,10 @@ public class AndroidInfoModule extends NativePlatformConstantsAndroidSpec implem
     }
     constants.put(
         "isTesting", "true".equals(System.getProperty(IS_TESTING)) || isRunningScreenshotTest());
+    String isDisableAnimations = System.getProperty(IS_DISABLE_ANIMATIONS);
+    if (isDisableAnimations != null) {
+      constants.put("isDisableAnimations", "true".equals(isDisableAnimations));
+    }
     constants.put("reactNativeVersion", ReactNativeVersion.VERSION);
     constants.put("uiMode", uiMode());
     return constants;


### PR DESCRIPTION
Summary:
## Changelog
[Internal] -

This allows to override `Platform.isDisableAnimations` for the Android platform, in the same way as it's done with `IS_TESTING` (but similarly optionally doing `IS_DISABLE_ANIMATIONS` in addition to/instead).

See for more context: https://github.com/facebook/react-native/pull/38490

Differential Revision: D47530731

