### PR TITLE
Throw ReactNoCrashSoftException when handle memeory pressure to avoid crash

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -24,6 +24,7 @@ import com.facebook.react.bridge.JSBundleLoaderDelegate;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.NativeArray;
 import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.bridge.RuntimeScheduler;
@@ -436,7 +437,7 @@ final class ReactInstance {
     } catch (NullPointerException e) {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
-          new IllegalViewOperationException(
+          new ReactNoCrashSoftException(
               "Native method handleMemoryPressureJs is called earlier than librninstance.so got ready."));
     }
   }


### PR DESCRIPTION
Summary:
As title

Changelog:
[Android][Changed] - Throw ReactNoCrashSoftException when handle memeory pressure to avoid crash

Reviewed By: jacdebug

Differential Revision: D47596577

