### PR TITLE
Fix setting array elements through JSI

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -478,6 +478,20 @@ TEST_P(JSITest, ArrayTest) {
   Array alpha2 = Array(rt, 1);
   alpha2 = std::move(alpha);
   EXPECT_EQ(alpha2.size(rt), 4);
+
+  // Test getting/setting an element that is an accessor.
+  auto arrWithAccessor =
+      eval(
+          "Object.defineProperty([], '0', {set(){ throw 72 }, get(){ return 45 }});")
+          .getObject(rt)
+          .getArray(rt);
+  try {
+    arrWithAccessor.setValueAtIndex(rt, 0, 1);
+    FAIL() << "Expected exception";
+  } catch (const JSError& err) {
+    EXPECT_EQ(err.value().getNumber(), 72);
+  }
+  EXPECT_EQ(arrWithAccessor.getValueAtIndex(rt, 0).getNumber(), 45);
 }
 
 TEST_P(JSITest, FunctionTest) {


### PR DESCRIPTION
Summary:
`HermesRuntimeImpl::setValueAtIndexImpl` directly called
`setElementAt`, which meant that it would not handle index-like
properties properly. Use `putComputed_RJS` instead, which will check
for such properties.

Differential Revision: D47617445

