### PR TITLE
Fix typo App.test.tsx

### DIFF
--- a/packages/react-native/template/__tests__/App.test.tsx
+++ b/packages/react-native/template/__tests__/App.test.tsx
@@ -6,7 +6,7 @@ import 'react-native';
 import React from 'react';
 import App from '../App';
 
-// Note: import explicitly to use the types shiped with jest.
+// Note: import explicitly to use the types shipped with jest.
 import {it} from '@jest/globals';
 
 // Note: test renderer must be required after react-native.


### PR DESCRIPTION
## Summary:

There was a typo in App.test.tsx, that I noticed when tried to upgrade from 0.71 to 0.72

## Changelog:

Fixed small typo from *shiped* to *shipped*

Pick one each for the category and type tags:

[GENERAL] [FIXED]
