### PR TITLE
Fix issue bot triggering on PRs and closed issues

### DIFF
--- a/.github/workflows/check-for-reproducer.yml
+++ b/.github/workflows/check-for-reproducer.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check-for-reproducer:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native' && github.event.issue.pull_request == null
+    if: github.repository == 'facebook/react-native' && github.event.issue.pull_request == null && github.event.issue.state == 'open'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6

--- a/.github/workflows/check-for-reproducer.yml
+++ b/.github/workflows/check-for-reproducer.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check-for-reproducer:
     runs-on: ubuntu-latest
-    if: github.repository == 'facebook/react-native'
+    if: github.repository == 'facebook/react-native' && github.event.issue.pull_request == null
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR fixes a bug with an issue labeling bot issues triggering on comments to pull requests. The action doesn't trigger when a pull request is open (but other actions add comments immediately).

From [GitHub docs](https://docs.github.com/en/webhooks-and-events/events/issue-event-types):

> GitHub's REST API considers every pull request to be an issue, but not every issue is a pull request. [...] Pull requests have a **`pull_request` property in the `issue` object.**

☝️ Which is a way to differentiate between an issue and a pull request

Relates to a bug introduced in https://github.com/facebook/react-native/pull/38338 and links to ☂️https://github.com/facebook/react-native/issues/35591  


## Changelog:

[INTERNAL] [FIXED] - Prevent issue bot triggering on pull requests

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This PR makes use of  `github.event.issue.pull_request` object which is null on issues and comments in issues:

![image](https://github.com/facebook/react-native/assets/39658211/e0a64039-5fb7-4ad3-95aa-65cb7c9f0a4b)

and truthy on comments on pull requests

![image](https://github.com/facebook/react-native/assets/39658211/9df69d00-c792-4c00-bfc2-9ee832551d16)


With a change from PR bot skips execution on comments on pull requests

![image](https://github.com/facebook/react-native/assets/39658211/f02687fb-f81b-4278-8d0e-9b23651229c1)


