### PR TITLE
Remove the package_and_publish_release_dryrun workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1628,6 +1628,11 @@ workflows:
         - equal: [ false, << pipeline.parameters.run_release_workflow >> ]
         - equal: [ false, << pipeline.parameters.run_nightly_workflow >> ]
     jobs:
+      - prepare_package_for_release:
+          name: prepare_package_for_release
+          version: ''
+          latest : false
+          dryrun: true
       - prepare_hermes_workspace
       - test_ios_rntester_hermes_xcode_integration
       - build_hermesc_linux:
@@ -1866,40 +1871,6 @@ workflows:
           name: build_and_publish_npm_package
           release_type: "release"
           filters: *only_release_tags
-          requires:
-            - build_hermesc_linux
-            - build_hermes_macos
-            - build_hermesc_windows
-
-  package_and_publish_release_dryrun:
-    when:
-      and:
-        - equal: [ false, << pipeline.parameters.run_release_workflow >> ]
-        - equal: [ false, << pipeline.parameters.run_nightly_workflow >> ]
-    jobs:
-      - prepare_package_for_release:
-          name: prepare_package_for_release
-          version: ''
-          latest : false
-          dryrun: true
-      - prepare_hermes_workspace:
-          requires:
-            - prepare_package_for_release
-      - build_hermesc_linux:
-          requires:
-            - prepare_hermes_workspace
-      - build_hermes_macos:
-          requires:
-            - prepare_hermes_workspace
-          matrix:
-            parameters:
-              flavor: ["Debug", "Release"]
-      - build_hermesc_windows:
-          requires:
-            - prepare_hermes_workspace
-      - build_npm_package:
-          name: build_and_publish_npm_package
-          release_type: "dry-run"
           requires:
             - build_hermesc_linux
             - build_hermes_macos

--- a/scripts/circle-ci-artifacts-utils.js
+++ b/scripts/circle-ci-artifacts-utils.js
@@ -26,16 +26,8 @@ async function initialize(circleCIToken, baseTempPath, branchName) {
   baseTemporaryPath = baseTempPath;
   exec(`mkdir -p ${baseTemporaryPath}`);
   const pipeline = await _getLastCircleCIPipelineID(branchName);
-  const packageAndReleaseWorkflow = await _getPackageAndReleaseWorkflow(
-    pipeline.id,
-  );
   const testsWorkflow = await _getTestsWorkflow(pipeline.id);
-  const jobsPromises = [
-    _getCircleCIJobs(packageAndReleaseWorkflow.id),
-    _getCircleCIJobs(testsWorkflow.id),
-  ];
-
-  const jobsResults = await Promise.all(jobsPromises);
+  const jobsResults = await _getCircleCIJobs(testsWorkflow.id);
 
   jobs = jobsResults.flatMap(j => j);
 }
@@ -94,10 +86,6 @@ function _throwIfWorkflowNotFound(workflow, name) {
       `Can't find a workflow named ${name}. Please check whether that workflow has started.`,
     );
   }
-}
-
-async function _getPackageAndReleaseWorkflow(pipelineId) {
-  return _getSpecificWorkflow(pipelineId, 'package_and_publish_release_dryrun');
 }
 
 async function _getTestsWorkflow(pipelineId) {
@@ -165,7 +153,7 @@ async function artifactURLHermesDebug() {
 }
 
 async function artifactURLForMavenLocal() {
-  return _findUrlForJob('build_and_publish_npm_package-2', 'maven-local.zip');
+  return _findUrlForJob('build_npm_package', 'maven-local.zip');
 }
 
 async function artifactURLForHermesRNTesterAPK(emulatorArch) {


### PR DESCRIPTION
## Summary:

The `package_and_publish_release_dryrun` workflow does the same steps that we are actually already doing in the `tests` workflow.
Both workflows are triggered when `run_nightly_workflow == false && run_release_workflow == false` so the triggering condition **is the same**

The following table highlights and compares the steps performed by the two workflows:

| Package_and_publish_release_dryrun | Tests |
| --- | --- |
| `prepare_package_for_release(version: ‘’, latest: false, dryrun: true)` | |
| `prepare_hermes_workspace` | `prepare_hermes_workspace` |
| `build_hermesc_linux` | `build_hermesc_linux` |
| `build_hermes_macos(flavor: Debug | Release)` | `build_hermes_macos(flavor: Debug | Release)` |
| `build_hermesc_windows` | `build_hermesc_windows` |
| `build_npm_package (release_type: dry-run)` | `build_npm_package(release_type: dry-run)` |


The only missing job in `tests` workflow is `prepare_package_for_release`. This job has the following features:
1. It invokes the `prepare-package-for-release.js` scripts, actually testing it.
2. It doesn’t cache anything, 
3. it doesn’t attach any workspace

Due to 2 and 3, it means that it does not influence any job that follow it in the pipeline as they won't access any of the results from this job.

So, we are adding this job in the Test pipeline, so we exercise the `prepare-package-for-release.js` making sure that it works,  and remove 
the whole `package_and_publish_release_dryrun` wroflow as it will now be completely duplicated

## Changelog:

[Internal] - Remove the `package_and_publish_release_dryrun` workflow

## Test Plan:

CircleCI stays green
