### PR TITLE
fix: add signal to `Request` type

### DIFF
--- a/packages/react-native/types/modules/globals.d.ts
+++ b/packages/react-native/types/modules/globals.d.ts
@@ -187,6 +187,7 @@ declare interface Request extends Object, Body {
   readonly mode: RequestMode_;
   readonly referrer: string;
   readonly url: string;
+  readonly signal: AbortSignal | undefined;
   clone(): Request;
 }
 


### PR DESCRIPTION
## Summary:

The `Request` interface provided by `@types/react-native` doesn't have a `signal` property when it should as this is something that is accessible on the `Request` object.

![image](https://github.com/facebook/react-native/assets/10697889/f2d75973-61ff-4874-ad8e-2c0898b82d27)

For example, running the following:

#### Without providing a `signal`

```ts
console.log(new Request('https://www.facebook.com'));
```

will result in the following:

```ts
{"_bodyInit": undefined, "_bodyText": "", "bodyUsed": false, "credentials": "same-origin", "headers": {"map": {}}, "method": "GET", "mode": null, "referrer": null, "signal": undefined, "url": "https://www.facebook.com"}
```

## Changelog:

[GENERAL] [FIXED] - Add missing property `signal` for the `Request` interface

## Reproduce

1. Add `new Request('https://www.facebook.com').signal` to a typescript file
2. TS will error `Property 'signal' does not exist on type 'Request'`

## Test Plan:

Adding to `global.d.ts` in a file will resolve the problem, demonstrating that this works.

```ts
interface Request {
    readonly signal: AbortSignal | undefined
}
```
