### PR TITLE
cleanup installJSBindingWithRuntimeExecutor

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -53,10 +53,6 @@ RCT_EXTERN void RCTEnableTurboModule(BOOL enabled);
 RCT_EXTERN BOOL RCTTurboModuleEagerInitEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleEagerInit(BOOL enabled);
 
-// Turn off TurboModule delegate locking
-RCT_EXTERN BOOL RCTTurboModuleManagerDelegateLockingDisabled(void);
-RCT_EXTERN void RCTDisableTurboModuleManagerDelegateLocking(BOOL enabled);
-
 // Turn on TurboModule interop
 RCT_EXTERN BOOL RCTTurboModuleInteropEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleInterop(BOOL enabled);

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -108,18 +108,6 @@ void RCTEnableTurboModuleEagerInit(BOOL enabled)
   turboModuleEagerInitEnabled = enabled;
 }
 
-// Turn off TurboModule delegate locking
-static BOOL turboModuleManagerDelegateLockingDisabled = YES;
-BOOL RCTTurboModuleManagerDelegateLockingDisabled(void)
-{
-  return turboModuleManagerDelegateLockingDisabled;
-}
-
-void RCTDisableTurboModuleManagerDelegateLocking(BOOL disabled)
-{
-  turboModuleManagerDelegateLockingDisabled = disabled;
-}
-
 static BOOL turboModuleInteropEnabled = NO;
 BOOL RCTTurboModuleInteropEnabled(void)
 {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -65,11 +65,6 @@
 
 - (void)installJSBindings:(facebook::jsi::Runtime &)runtime;
 
-/**
- * @deprecated: use installJSBindings instead
- */
-- (void)installJSBindingWithRuntimeExecutor:(facebook::react::RuntimeExecutor &)runtimeExecutor;
-
 - (void)invalidate;
 
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -800,10 +800,8 @@ static Class getFallbackClassFromName(const char *name)
     return _legacyEagerlyRegisteredModuleClasses[moduleNameStr];
   }
 
-  Class moduleClass;
-  if (RCTTurboModuleManagerDelegateLockingDisabled()) {
-    moduleClass = [_delegate getModuleClassFromName:moduleName];
-  } else {
+  Class moduleClass = nil;
+  {
     std::lock_guard<std::mutex> delegateGuard(_turboModuleManagerDelegateMutex);
     moduleClass = [_delegate getModuleClassFromName:moduleName];
   }
@@ -826,12 +824,11 @@ static Class getFallbackClassFromName(const char *name)
   }
 
   id<RCTBridgeModule> module = nil;
-  if (RCTTurboModuleManagerDelegateLockingDisabled()) {
-    module = (id<RCTBridgeModule>)[_delegate getModuleInstanceFromClass:moduleClass];
-  } else {
+  {
     std::lock_guard<std::mutex> delegateGuard(_turboModuleManagerDelegateMutex);
     module = (id<RCTBridgeModule>)[_delegate getModuleInstanceFromClass:moduleClass];
   }
+
   if (!module) {
     module = [moduleClass new];
   }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -959,17 +959,6 @@ static Class getFallbackClassFromName(const char *name)
   }
 }
 
-/**
- * @deprecated: use installJSBindings instead
- */
-- (void)installJSBindingWithRuntimeExecutor:(facebook::react::RuntimeExecutor &)runtimeExecutor
-{
-  // jsi::Runtime doesn't exist when attached to Chrome debugger.
-  if (runtimeExecutor) {
-    runtimeExecutor([self](facebook::jsi::Runtime &runtime) { [self installJSBindings:runtime]; });
-  }
-}
-
 #pragma mark RCTTurboModuleRegistry
 
 - (id)moduleForName:(const char *)moduleName


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

we can just delete this, replacing the callsite w/ `installJSBindings` is straightforward

Reviewed By: mdvacca, cipolleschi

Differential Revision: D47620027

