### PR TITLE
configure turbomodule main queue setup logic

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -111,15 +111,13 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
   [bridge setRCTTurboModuleRegistry:turboModuleManager];
 
 #if RCT_DEV
-  if (!RCTTurboModuleEagerInitEnabled()) {
-    /**
-     * Instantiating DevMenu has the side-effect of registering
-     * shortcuts for CMD + d, CMD + i,  and CMD + n via RCTDevMenu.
-     * Therefore, when TurboModules are enabled, we must manually create this
-     * NativeModule.
-     */
-    [turboModuleManager moduleForName:"RCTDevMenu"];
-  }
+  /**
+   * Instantiating DevMenu has the side-effect of registering
+   * shortcuts for CMD + d, CMD + i,  and CMD + n via RCTDevMenu.
+   * Therefore, when TurboModules are enabled, we must manually create this
+   * NativeModule.
+   */
+  [turboModuleManager moduleForName:"RCTDevMenu"];
 #endif
 
 #if RCT_USE_HERMES

--- a/packages/react-native/React/Base/RCTBridge+Private.h
+++ b/packages/react-native/React/Base/RCTBridge+Private.h
@@ -70,9 +70,6 @@ RCT_EXTERN void RCTRegisterModule(Class);
  */
 @property (nonatomic, strong, readonly) RCTModuleRegistry *moduleRegistry;
 
-@property (nonatomic, copy, readwrite) NSArray<NSString *> *eagerInitModuleNames_DO_NOT_USE;
-@property (nonatomic, copy, readwrite) NSArray<NSString *> *eagerInitMainQueueModuleNames_DO_NOT_USE;
-
 @end
 
 @interface RCTBridge (RCTCxxBridge)

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -53,10 +53,6 @@ RCT_EXTERN void RCTEnableTurboModule(BOOL enabled);
 RCT_EXTERN BOOL RCTTurboModuleEagerInitEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleEagerInit(BOOL enabled);
 
-// Turn off TurboModule delegate locking
-RCT_EXTERN BOOL RCTTurboModuleManagerDelegateLockingDisabled(void);
-RCT_EXTERN void RCTDisableTurboModuleManagerDelegateLocking(BOOL enabled);
-
 // Turn on TurboModule interop
 RCT_EXTERN BOOL RCTTurboModuleInteropEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleInterop(BOOL enabled);

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -32,12 +32,6 @@
 typedef NSArray<id<RCTBridgeModule>> * (^RCTBridgeModuleListProvider)(void);
 
 /**
- * These blocks are used to report whether an additional bundle
- * fails or succeeds loading.
- */
-typedef void (^RCTLoadAndExecuteErrorBlock)(NSError *error);
-
-/**
  * This function returns the module name for a given class.
  */
 RCT_EXTERN NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
@@ -48,10 +42,6 @@ RCT_EXTERN NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
  */
 RCT_EXTERN BOOL RCTTurboModuleEnabled(void);
 RCT_EXTERN void RCTEnableTurboModule(BOOL enabled);
-
-// Turn on TurboModule eager initialization
-RCT_EXTERN BOOL RCTTurboModuleEagerInitEnabled(void);
-RCT_EXTERN void RCTEnableTurboModuleEagerInit(BOOL enabled);
 
 // Turn on TurboModule interop
 RCT_EXTERN BOOL RCTTurboModuleInteropEnabled(void);

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -31,25 +31,27 @@
  */
 typedef NSArray<id<RCTBridgeModule>> * (^RCTBridgeModuleListProvider)(void);
 
+RCT_EXTERN_C_BEGIN
+
 /**
  * This function returns the module name for a given class.
  */
-RCT_EXTERN NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
+NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
 
 /**
  * Experimental.
  * Check/set if JSI-bound NativeModule is enabled. By default it's off.
  */
-RCT_EXTERN BOOL RCTTurboModuleEnabled(void);
-RCT_EXTERN void RCTEnableTurboModule(BOOL enabled);
+BOOL RCTTurboModuleEnabled(void);
+void RCTEnableTurboModule(BOOL enabled);
 
 // Turn on TurboModule interop
-RCT_EXTERN BOOL RCTTurboModuleInteropEnabled(void);
-RCT_EXTERN void RCTEnableTurboModuleInterop(BOOL enabled);
+BOOL RCTTurboModuleInteropEnabled(void);
+void RCTEnableTurboModuleInterop(BOOL enabled);
 
 // Turn on TurboModule interop's Bridge proxy
-RCT_EXTERN BOOL RCTTurboModuleInteropBridgeProxyEnabled(void);
-RCT_EXTERN void RCTEnableTurboModuleInteropBridgeProxy(BOOL enabled);
+BOOL RCTTurboModuleInteropBridgeProxyEnabled(void);
+void RCTEnableTurboModuleInteropBridgeProxy(BOOL enabled);
 
 typedef enum {
   kRCTBridgeProxyLoggingLevelNone,
@@ -57,12 +59,12 @@ typedef enum {
   kRCTBridgeProxyLoggingLevelError,
 } RCTBridgeProxyLoggingLevel;
 
-RCT_EXTERN RCTBridgeProxyLoggingLevel RCTTurboModuleInteropBridgeProxyLogLevel(void);
-RCT_EXTERN void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logLevel);
+RCTBridgeProxyLoggingLevel RCTTurboModuleInteropBridgeProxyLogLevel(void);
+void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logLevel);
 
 // Route all TurboModules through TurboModule interop
-RCT_EXTERN BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void);
-RCT_EXTERN void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled);
+BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void);
+void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled);
 
 typedef enum {
   kRCTGlobalScope,
@@ -70,8 +72,16 @@ typedef enum {
   kRCTTurboModuleManagerScope,
 } RCTTurboModuleCleanupMode;
 
-RCT_EXTERN RCTTurboModuleCleanupMode RCTGetTurboModuleCleanupMode(void);
-RCT_EXTERN void RCTSetTurboModuleCleanupMode(RCTTurboModuleCleanupMode mode);
+RCTTurboModuleCleanupMode RCTGetTurboModuleCleanupMode(void);
+void RCTSetTurboModuleCleanupMode(RCTTurboModuleCleanupMode mode);
+
+void RCTSetEnableMainQueueSetupIfConstantsToExport(BOOL val);
+BOOL RCTEnableMainQueueSetupIfConstantsToExport(void);
+
+void RCTSetEnableMainQueueSetupIfCustomInit(BOOL val);
+BOOL RCTEnableMainQueueSetupIfCustomInit(void);
+
+RCT_EXTERN_C_END
 
 /**
  * Async batched bridge used to communicate with the JavaScript application.

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -108,18 +108,6 @@ void RCTEnableTurboModuleEagerInit(BOOL enabled)
   turboModuleEagerInitEnabled = enabled;
 }
 
-// Turn off TurboModule delegate locking
-static BOOL turboModuleManagerDelegateLockingDisabled = YES;
-BOOL RCTTurboModuleManagerDelegateLockingDisabled(void)
-{
-  return turboModuleManagerDelegateLockingDisabled;
-}
-
-void RCTDisableTurboModuleManagerDelegateLocking(BOOL disabled)
-{
-  turboModuleManagerDelegateLockingDisabled = disabled;
-}
-
 static BOOL turboModuleInteropEnabled = NO;
 BOOL RCTTurboModuleInteropEnabled(void)
 {

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -97,17 +97,6 @@ void RCTEnableTurboModule(BOOL enabled)
   turboModuleEnabled = enabled;
 }
 
-static BOOL turboModuleEagerInitEnabled = NO;
-BOOL RCTTurboModuleEagerInitEnabled(void)
-{
-  return turboModuleEagerInitEnabled;
-}
-
-void RCTEnableTurboModuleEagerInit(BOOL enabled)
-{
-  turboModuleEagerInitEnabled = enabled;
-}
-
 static BOOL turboModuleInteropEnabled = NO;
 BOOL RCTTurboModuleInteropEnabled(void)
 {

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -139,6 +139,30 @@ void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled)
   useTurboModuleInteropForAllTurboModules = enabled;
 }
 
+static BOOL enableMainQueueSetupIfConstantsToExport = YES;
+
+void RCTSetEnableMainQueueSetupIfConstantsToExport(BOOL val)
+{
+  enableMainQueueSetupIfConstantsToExport = val;
+}
+
+BOOL RCTEnableMainQueueSetupIfConstantsToExport(void)
+{
+  return enableMainQueueSetupIfConstantsToExport;
+}
+
+static BOOL enableMainQueueSetupIfCustomInit = YES;
+
+void RCTSetEnableMainQueueSetupIfCustomInit(BOOL val)
+{
+  enableMainQueueSetupIfCustomInit = val;
+}
+
+BOOL RCTEnableMainQueueSetupIfCustomInit(void)
+{
+  return enableMainQueueSetupIfCustomInit;
+}
+
 @interface RCTBridge () <RCTReloadListener>
 @end
 

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -432,27 +432,6 @@ struct RCTInstanceCallback : public InstanceCallback {
     }));
   }
 
-  /**
-   * id<RCTCxxBridgeDelegate> jsExecutorFactory may create and assign an id<RCTTurboModuleRegistry> object to
-   * RCTCxxBridge If id<RCTTurboModuleRegistry> is assigned by this time, eagerly initialize all TurboModules
-   */
-  if (_turboModuleRegistry && RCTTurboModuleEagerInitEnabled()) {
-    for (NSString *moduleName in [_parentBridge eagerInitModuleNames_DO_NOT_USE]) {
-      [_turboModuleRegistry moduleForName:[moduleName UTF8String]];
-    }
-
-    for (NSString *moduleName in [_parentBridge eagerInitMainQueueModuleNames_DO_NOT_USE]) {
-      if (RCTIsMainQueue()) {
-        [_turboModuleRegistry moduleForName:[moduleName UTF8String]];
-      } else {
-        id<RCTTurboModuleRegistry> turboModuleRegistry = _turboModuleRegistry;
-        dispatch_group_async(prepareBridge, dispatch_get_main_queue(), ^{
-          [turboModuleRegistry moduleForName:[moduleName UTF8String]];
-        });
-      }
-    }
-  }
-
   // Dispatch the instance initialization as soon as the initial module metadata has
   // been collected (see initModules)
   dispatch_group_enter(prepareBridge);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -558,17 +558,6 @@ static Class getFallbackClassFromName(const char *name)
       };
 
       if ([self _requiresMainQueueSetup:moduleClass]) {
-        /**
-         * When TurboModule eager initialization is enabled, there shouldn't be any TurboModule initializations on the
-         * main queue.
-         * TODO(T69449176) Roll out TurboModule eager initialization, and remove this check.
-         */
-        if (RCTTurboModuleEagerInitEnabled() && !RCTIsMainQueue()) {
-          RCTLogWarn(
-              @"TurboModule \"%@\" requires synchronous dispatch onto the main queue to be initialized. This may lead to deadlock.",
-              moduleClass);
-        }
-
         RCTUnsafeExecuteOnMainQueueSync(work);
       } else {
         work();

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -786,10 +786,8 @@ static Class getFallbackClassFromName(const char *name)
     return _legacyEagerlyRegisteredModuleClasses[moduleNameStr];
   }
 
-  Class moduleClass;
-  if (RCTTurboModuleManagerDelegateLockingDisabled()) {
-    moduleClass = [_delegate getModuleClassFromName:moduleName];
-  } else {
+  Class moduleClass = nil;
+  {
     std::lock_guard<std::mutex> delegateGuard(_turboModuleManagerDelegateMutex);
     moduleClass = [_delegate getModuleClassFromName:moduleName];
   }
@@ -828,12 +826,11 @@ static Class getFallbackClassFromName(const char *name)
   }
 
   id<RCTBridgeModule> module = nil;
-  if (RCTTurboModuleManagerDelegateLockingDisabled()) {
-    module = (id<RCTBridgeModule>)[_delegate getModuleInstanceFromClass:moduleClass];
-  } else {
+  {
     std::lock_guard<std::mutex> delegateGuard(_turboModuleManagerDelegateMutex);
     module = (id<RCTBridgeModule>)[_delegate getModuleInstanceFromClass:moduleClass];
   }
+
   if (!module) {
     module = [moduleClass new];
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this change, i'm setting up the logic where we can disable the behavior that triggers the main queue init of a turbomodule even if it's not explicitly set by the consumer.

the reason i'm looking to do this is because i ultimately want to get rid of this logic. i find the assumptions that this code makes are incorrect, also the behavior is not documented, so it's an opportunity to simplify.

Differential Revision: D47622456

