### PR TITLE
Honor custom name when TM is registered with the legacy mode.

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -794,9 +794,25 @@ static Class getFallbackClassFromName(const char *name)
     moduleClass = [_delegate getModuleClassFromName:moduleName];
   }
 
-  if (!moduleClass) {
-    moduleClass = getFallbackClassFromName(moduleName);
+  if (moduleClass != nil) {
+    return moduleClass;
   }
+
+  moduleClass = getFallbackClassFromName(moduleName);
+  if (moduleClass != nil) {
+    return moduleClass;
+  }
+
+  // fallback on modules registered throught RCT_EXPORT_MODULE with custom names
+  NSString *objcModuleName = [NSString stringWithUTF8String:moduleName];
+  NSArray<Class> *modules = RCTGetModuleClasses();
+  for (Class current in modules) {
+    NSString *currentModuleName = [current moduleName];
+    if ([objcModuleName isEqualToString:currentModuleName]) {
+      return current;
+    }
+  }
+
   return moduleClass;
 }
 


### PR DESCRIPTION
Summary:
Before this change, when a turbomodule was registered using the `RCT_EXPORT_MODULE()` function using a custom name, the TM was not found in the registry.

With this change, we are adding a fallback that looks in the list of registered TM, asking for the name used by the user to register it.

This fallback is executed only if no other method was successful before as it is more expensive.

## CHANGELOG
[iOS][Fixed] - Honor the custom name choosen by the user to register the module.

Differential Revision: D47666848

