### PR TITLE
fix: remove old command for align packages versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "test-ios": "./scripts/objc-test.sh test",
     "test-typescript": "dtslint packages/react-native/types",
     "test-typescript-offline": "dtslint --localTs node_modules/typescript/lib  packages/react-native/types",
-    "bump-all-updated-packages": "node ./scripts/monorepo/bump-all-updated-packages",
-    "align-package-versions": "node -e \"require('./scripts/monorepo/align-package-versions')()\""
+    "bump-all-updated-packages": "node ./scripts/monorepo/bump-all-updated-packages"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While working on a couple things, me Riccardo and Nicola noticed that in main for some reason the old `align-package-versions` command in the root package.json was still there in main branch.

This was "merged into" `bump-all-updated-packages` by @hoxyq all the way back in March; here's the commit for 0.72 branch -> https://github.com/facebook/react-native/commit/a469927c16e175b637b2eaf9a84af94f2e8cb519

We are not sure why, but for some reason the same commit in main was borked in some way, and didn't actually remove the command: PR (https://github.com/facebook/react-native/pull/36568) and commit (https://github.com/facebook/react-native/commit/04df252aa7bff34a02b24f8381b3f2f1dd122c2f)

So this commit just takes care of that.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [REMOVED] - remove old command for align packages versions

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

N/A - it's a removal