### PR TITLE
Adds `isPressable` prop to TextAttributes

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -95,6 +95,14 @@ void TextAttributes::apply(TextAttributes textAttributes) {
   isHighlighted = textAttributes.isHighlighted.has_value()
       ? textAttributes.isHighlighted
       : isHighlighted;
+
+  // If an ancestor text component has set `isPressable`, this text component
+  // should not reset `isPressable` to false.
+  isPressable =
+      textAttributes.isPressable.has_value() && *textAttributes.isPressable
+      ? textAttributes.isPressable
+      : isPressable;
+
   layoutDirection = textAttributes.layoutDirection.has_value()
       ? textAttributes.layoutDirection
       : layoutDirection;
@@ -125,6 +133,7 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              textShadowOffset,
              textShadowColor,
              isHighlighted,
+             isPressable,
              layoutDirection,
              accessibilityRole,
              role,
@@ -147,6 +156,7 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              rhs.textShadowOffset,
              rhs.textShadowColor,
              rhs.isHighlighted,
+             rhs.isPressable,
              rhs.layoutDirection,
              rhs.accessibilityRole,
              rhs.role,
@@ -216,6 +226,7 @@ SharedDebugStringConvertibleList TextAttributes::getDebugProps() const {
 
       // Special
       debugStringConvertibleItem("isHighlighted", isHighlighted),
+      debugStringConvertibleItem("isPressable", isPressable),
       debugStringConvertibleItem("layoutDirection", layoutDirection),
       debugStringConvertibleItem("accessibilityRole", accessibilityRole),
       debugStringConvertibleItem("role", role),

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -74,6 +74,7 @@ class TextAttributes : public DebugStringConvertible {
 
   // Special
   std::optional<bool> isHighlighted{};
+  std::optional<bool> isPressable{};
 
   // TODO T59221129: document where this value comes from and how it is set.
   // It's not clear if this is being used properly, or if it's being set at all.
@@ -132,6 +133,7 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.textShadowRadius,
         textAttributes.textShadowColor,
         textAttributes.isHighlighted,
+        textAttributes.isPressable,
         textAttributes.layoutDirection,
         textAttributes.accessibilityRole,
         textAttributes.role);

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -165,6 +165,12 @@ static TextAttributes convertRawProp(
       "isHighlighted",
       sourceTextAttributes.isHighlighted,
       defaultTextAttributes.isHighlighted);
+  textAttributes.isPressable = convertRawProp(
+      context,
+      rawProps,
+      "isPressable",
+      sourceTextAttributes.isPressable,
+      defaultTextAttributes.isPressable);
 
   // In general, we want this class to access props in the same order
   // that ViewProps accesses them in, so that RawPropParser can optimize
@@ -294,6 +300,8 @@ void BaseTextProps::setProp(
         defaults, value, textAttributes, textShadowColor, "textShadowColor");
     REBUILD_FIELD_SWITCH_CASE(
         defaults, value, textAttributes, isHighlighted, "isHighlighted");
+    REBUILD_FIELD_SWITCH_CASE(
+        defaults, value, textAttributes, isPressable, "isPressable");
     REBUILD_FIELD_SWITCH_CASE(
         defaults,
         value,


### PR DESCRIPTION
Summary:
Although we don't currently use this for iOS and Android, platforms with less performant text hit testing algorithms or input devices like a mouse may wish to only hit test text on mouse move if there are pressable inline spans.

This change adds the `isPressable` prop, which has been wired up in JS since https://github.com/facebook/react-native/commit/f3bf2e4f51897f1bb71e37002c288ebf3b23cf78 to Fabric TextAttributes.

Differential Revision: D47722096

