### PR TITLE
Reduce visibility of JavaMethodWrapper and JavaModuleWrapper to package only

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
@@ -12,7 +12,6 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate;
-import com.facebook.soloader.SoLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -20,8 +19,6 @@ import java.util.List;
 @DoNotStrip
 public class CompositeReactPackageTurboModuleManagerDelegate
     extends ReactPackageTurboModuleManagerDelegate {
-
-  private static volatile boolean sIsSoLibraryLoaded;
 
   protected native HybridData initHybrid();
 
@@ -51,14 +48,6 @@ public class CompositeReactPackageTurboModuleManagerDelegate
         delegates.add(delegatesBuilder.build(context, Collections.<ReactPackage>emptyList()));
       }
       return new CompositeReactPackageTurboModuleManagerDelegate(context, packages, delegates);
-    }
-  }
-
-  protected synchronized void maybeLoadOtherSoLibraries() {
-    // Prevents issues with initializer interruptions. See T38996825 and D13793825 for more context.
-    if (!sIsSoLibraryLoaded) {
-      SoLoader.loadLibrary("turbomodulejsijni");
-      sIsSoLibraryLoaded = true;
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -119,12 +119,7 @@ public class CoreModulesPackage extends TurboReactPackage implements ReactPackag
                 TurboModule.class.isAssignableFrom(moduleClass)));
       }
 
-      return new ReactModuleInfoProvider() {
-        @Override
-        public Map<String, ReactModuleInfo> getReactModuleInfos() {
-          return reactModuleInfoMap;
-        }
-      };
+      return () -> reactModuleInfoMap;
     } catch (InstantiationException e) {
       throw new RuntimeException(
           "No ReactModuleInfoProvider for CoreModulesPackage$$ReactModuleInfoProvider", e);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
@@ -18,7 +18,7 @@ import com.facebook.systrace.SystraceMessage;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-public class JavaMethodWrapper implements NativeModule.NativeMethod {
+class JavaMethodWrapper implements NativeModule.NativeMethod {
 
   private abstract static class ArgumentExtractor<T> {
     public int getJSArgumentsNeeded() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * read and means fewer JNI calls.
  */
 @DoNotStrip
-public class JavaModuleWrapper {
+class JavaModuleWrapper {
   @DoNotStrip
   public class MethodDescriptor {
     @DoNotStrip Method method;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.java
@@ -18,7 +18,7 @@ public class ReactModuleInfo {
   private final boolean mNeedsEagerInit;
   private final boolean mHasConstants;
   private final boolean mIsCxxModule;
-  private String mClassName;
+  private final String mClassName;
   private final boolean mIsTurboModule;
 
   public ReactModuleInfo(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
@@ -23,7 +23,6 @@ import javax.annotation.Nullable;
 @ReactModule(name = NativeAppStateSpec.NAME)
 public class AppStateModule extends NativeAppStateSpec
     implements LifecycleEventListener, WindowFocusChangeListener {
-  public static final String TAG = AppStateModule.class.getSimpleName();
 
   public static final String APP_STATE_ACTIVE = "active";
   public static final String APP_STATE_BACKGROUND = "background";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/CallInvokerHolderImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/CallInvokerHolderImpl.java
@@ -9,7 +9,6 @@ package com.facebook.react.turbomodule.core;
 
 import com.facebook.jni.HybridData;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
-import com.facebook.soloader.SoLoader;
 
 /**
  * JSCallInvoker is created at a different time/place (i.e: in CatalystInstance) than
@@ -17,20 +16,13 @@ import com.facebook.soloader.SoLoader;
  * pass it from CatalystInstance, through Java, to TurboModuleManager::initHybrid.
  */
 public class CallInvokerHolderImpl implements CallInvokerHolder {
-  private static volatile boolean sIsSoLibraryLoaded;
-
   private final HybridData mHybridData;
 
-  private CallInvokerHolderImpl(HybridData hd) {
-    maybeLoadSoLibrary();
-    mHybridData = hd;
+  static {
+    NativeModuleSoLoader.maybeLoadSoLibrary();
   }
 
-  // Prevents issues with initializer interruptions. See T38996825 and D13793825 for more context.
-  private static synchronized void maybeLoadSoLibrary() {
-    if (!sIsSoLibraryLoaded) {
-      SoLoader.loadLibrary("turbomodulejsijni");
-      sIsSoLibraryLoaded = true;
-    }
+  private CallInvokerHolderImpl(HybridData hd) {
+    mHybridData = hd;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl.java
@@ -9,7 +9,6 @@ package com.facebook.react.turbomodule.core;
 
 import com.facebook.jni.HybridData;
 import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder;
-import com.facebook.soloader.SoLoader;
 
 /**
  * NativeMethodCallInvokerHolder is created at a different time/place (i.e: in CatalystInstance)
@@ -18,20 +17,14 @@ import com.facebook.soloader.SoLoader;
  * TurboModuleManager::initHybrid.
  */
 public class NativeMethodCallInvokerHolderImpl implements NativeMethodCallInvokerHolder {
-  private static volatile boolean sIsSoLibraryLoaded;
 
   private final HybridData mHybridData;
 
-  private NativeMethodCallInvokerHolderImpl(HybridData hd) {
-    maybeLoadSoLibrary();
-    mHybridData = hd;
+  static {
+    NativeModuleSoLoader.maybeLoadSoLibrary();
   }
 
-  // Prevents issues with initializer interruptions. See T38996825 and D13793825 for more context.
-  private static synchronized void maybeLoadSoLibrary() {
-    if (!sIsSoLibraryLoaded) {
-      SoLoader.loadLibrary("turbomodulejsijni");
-      sIsSoLibraryLoaded = true;
-    }
+  private NativeMethodCallInvokerHolderImpl(HybridData hd) {
+    mHybridData = hd;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeModuleSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeModuleSoLoader.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core
+
+import com.facebook.soloader.SoLoader
+
+internal class NativeModuleSoLoader {
+  companion object {
+    private var isSoLibraryLoaded = false
+
+    @Synchronized
+    @JvmStatic
+    fun maybeLoadSoLibrary() {
+      if (!isSoLibraryLoaded) {
+        SoLoader.loadLibrary("turbomodulejsijni")
+        isSoLibraryLoaded = true
+      }
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
@@ -12,7 +12,6 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-import com.facebook.soloader.SoLoader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,13 +20,14 @@ public abstract class TurboModuleManagerDelegate {
   @SuppressWarnings("unused")
   private final HybridData mHybridData;
 
-  private static volatile boolean sIsSoLibraryLoaded;
+  static {
+    NativeModuleSoLoader.maybeLoadSoLibrary();
+  }
 
   protected abstract HybridData initHybrid();
 
   protected TurboModuleManagerDelegate() {
     maybeLoadOtherSoLibraries();
-    maybeLoadSoLibrary();
     mHybridData = initHybrid();
   }
 
@@ -55,14 +55,6 @@ public abstract class TurboModuleManagerDelegate {
 
   public List<String> getEagerInitModuleNames() {
     return new ArrayList<>();
-  }
-
-  // Prevents issues with initializer interruptions. See T38996825 and D13793825 for more context.
-  private static synchronized void maybeLoadSoLibrary() {
-    if (!sIsSoLibraryLoaded) {
-      SoLoader.loadLibrary("turbomodulejsijni");
-      sIsSoLibraryLoaded = true;
-    }
   }
 
   protected synchronized void maybeLoadOtherSoLibraries() {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModulePerfLogger.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModulePerfLogger.java
@@ -9,13 +9,16 @@ package com.facebook.react.turbomodule.core;
 
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.perflogger.NativeModulePerfLogger;
-import com.facebook.soloader.SoLoader;
 import javax.annotation.Nullable;
 
 @DoNotStrip
 public class TurboModulePerfLogger {
+
   @Nullable private static NativeModulePerfLogger sNativeModulePerfLogger = null;
-  private static boolean sIsSoLibraryLoaded = false;
+
+  static {
+    NativeModuleSoLoader.maybeLoadSoLibrary();
+  }
 
   public static void moduleDataCreateStart(String moduleName, int id) {
     if (sNativeModulePerfLogger != null) {
@@ -79,17 +82,9 @@ public class TurboModulePerfLogger {
 
   private static native void jniEnableCppLogging(NativeModulePerfLogger perfLogger);
 
-  private static synchronized void maybeLoadSoLibrary() {
-    if (!sIsSoLibraryLoaded) {
-      SoLoader.loadLibrary("turbomodulejsijni");
-      sIsSoLibraryLoaded = true;
-    }
-  }
-
   public static void enableLogging(NativeModulePerfLogger perfLogger) {
     if (perfLogger != null) {
       sNativeModulePerfLogger = perfLogger;
-      maybeLoadSoLibrary();
       jniEnableCppLogging(perfLogger);
     }
   }


### PR DESCRIPTION
Summary:
Reduce visibility of JavaMethodWrapper and JavaModuleWrapper to package only

changelog: [internal] internal

Reviewed By: christophpurrer, cortinico

Differential Revision: D47449525

