### PR TITLE
Android deprecate JSCJavaScriptExecutorFactory and JSCJavaScriptExecutor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutor.java
@@ -10,7 +10,9 @@ package com.facebook.react.bridge;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 
+/** @deprecated use {@link com.facebook.react.jscexecutor.JSCExecutor} instead. */
 @DoNotStrip
+@Deprecated
 /* package */ class JSCJavaScriptExecutor extends JavaScriptExecutor {
   static {
     ReactBridge.staticInit();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutorFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutorFactory.java
@@ -7,6 +7,8 @@
 
 package com.facebook.react.bridge;
 
+/** @deprecated use {@link com.facebook.react.jscexecutor.JSCExecutorFactory} instead. */
+@Deprecated
 public class JSCJavaScriptExecutorFactory implements JavaScriptExecutorFactory {
   private final String mAppName;
   private final String mDeviceName;


### PR DESCRIPTION
Summary:
These classes are deprecated in favor of com.facebook.react.jscexecutor instead

changelog: [Android][Changed] Deprecate JSCJavaScriptExecutorFactory and JSCJavaScriptExecutor, use com.facebook.react.jscexecutor instead

Reviewed By: christophpurrer, cortinico

Differential Revision: D47483650

