### PR TITLE
Back out "RN: Adopt Mapped Types in EventEmitter"

### DIFF
--- a/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
+++ b/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
@@ -35,9 +35,10 @@ interface Registration<TArgs> {
   +remove: () => void;
 }
 
-type Registry<TEventToArgsMap: {...}> = {
-  [key in keyof TEventToArgsMap]?: Set<Registration<TEventToArgsMap[key]>>,
-};
+type Registry<TEventToArgsMap: {...}> = $ObjMap<
+  TEventToArgsMap,
+  <TArgs>(TArgs) => Set<Registration<TArgs>>,
+>;
 
 /**
  * EventEmitter manages listeners and publishes events to them.
@@ -62,7 +63,7 @@ type Registry<TEventToArgsMap: {...}> = {
 export default class EventEmitter<TEventToArgsMap: {...}>
   implements IEventEmitter<TEventToArgsMap>
 {
-  _registry: Registry<TEventToArgsMap> = emptyRegistry<TEventToArgsMap>();
+  _registry: Registry<TEventToArgsMap> = {};
 
   /**
    * Registers a listener that is called when the supplied event is emitted.
@@ -121,7 +122,7 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     eventType?: ?TEvent,
   ): void {
     if (eventType == null) {
-      this._registry = emptyRegistry<TEventToArgsMap>();
+      this._registry = {};
     } else {
       delete this._registry[eventType];
     }
@@ -134,13 +135,6 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     const registrations: ?Set<Registration<mixed>> = this._registry[eventType];
     return registrations == null ? 0 : registrations.size;
   }
-}
-
-function emptyRegistry<TEventToArgsMap: {...}>(): Registry<TEventToArgsMap> {
-  // Flow cannot enforce that `TEventToArgsMap` is an object because, for
-  // example, Flow permits `empty. We have to ignore this error for now.
-  // $FlowIgnore[incompatible-return]
-  return {};
 }
 
 function allocate<


### PR DESCRIPTION
Summary:
Currently, `metro-config` does not have `hermes-parser` enabled by default. This is because `hermes-parser` does not yet support parsing all of TypeScript's syntax nodes.

However, this also means we cannot yet utilize any Flow langauge features that require the use of `hermes-parser` (and are unsupported by Babel). Mapped types falls into this category, so we cannot use them.

This backs out a recent change that tried to adopt Flow mapped types in `EventEmitter`, for now. We can revisit after making the necessary changes to `metro-config`.

Changelog:
[Internal]

Reviewed By: pieterv

Differential Revision: D47729818

