### PR TITLE
Fix regression with NativeSyntheticEvent and add test.

### DIFF
--- a/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
@@ -8,7 +8,6 @@
  */
 
 import type * as React from 'react';
-import {NodeHandle} from '../ReactNative/RendererProxy';
 import {HostComponent} from '../../types/public/ReactNativeTypes';
 
 export interface LayoutRectangle {
@@ -42,7 +41,11 @@ export interface TextLayoutEventData extends TargetedEvent {
 
 // Similar to React.SyntheticEvent except for nativeEvent
 export interface NativeSyntheticEvent<T>
-  extends React.BaseSyntheticEvent<T, NodeHandle, NodeHandle> {}
+  extends React.BaseSyntheticEvent<
+    T,
+    React.ElementRef<HostComponent<unknown>>,
+    React.ElementRef<HostComponent<unknown>>
+  > {}
 
 export interface NativeTouchEvent {
   /**

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -386,6 +386,7 @@ const testNativeSyntheticEvent = <T extends {}>(
   e.isTrusted;
   e.nativeEvent;
   e.target;
+  e.target.measure(() => {});
   e.timeStamp;
   e.type;
   e.nativeEvent;


### PR DESCRIPTION
## Summary:

With moving the TypeScript declarations into the repo, the NativeSyntheticEvent type was copied incorrectly from DefinitelyTyped.

This was the old one: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/v0.70/index.d.ts#L355

## Changelog:

[GENERAL] [FIXED] - Correct the NativeSyntheticEvent type


## Test Plan:

Added a test and ran `yarn test-typescript`