### PR TITLE
Remove need for platform overrides in SafeAreaView.js

### DIFF
--- a/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -25,10 +25,9 @@ let exported: React.AbstractComponent<ViewProps, React.ElementRef<typeof View>>;
  * limitation of the screen, such as rounded corners or camera notches (aka
  * sensor housing area on iPhone X).
  */
-if (Platform.OS === 'android') {
-  exported = View;
-} else {
-  exported = require('./RCTSafeAreaViewNativeComponent').default;
-}
+exported = Platform.select({
+  ios: require('./RCTSafeAreaViewNativeComponent').default,
+  default: View,
+});
 
 export default exported;


### PR DESCRIPTION
Summary:
This file is forked in out of tree platforms as:

- macOS > https://github.com/microsoft/react-native-macos/blob/main/Libraries/Components/SafeAreaView/SafeAreaView.js#L28-L33
- Windows > https://github.com/microsoft/react-native-windows/blob/0.71-stable/vnext/src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js#L30-L36

The change here removes the need of forking this file

Changelog:
[General] [Fixed] - [SafeAreaView] Remove need for platform overrides in SafeAreaView.js

Differential Revision: D47734944

