### PR TITLE
Remove need for platform overrides to Settings

### DIFF
--- a/packages/react-native/Libraries/Settings/Settings.js
+++ b/packages/react-native/Libraries/Settings/Settings.js
@@ -12,21 +12,21 @@
 
 const Settings = {
   get(key: string): mixed {
-    console.warn('Settings is not yet supported on Android');
+    console.warn('Settings is not yet supported on this platform.');
     return null;
   },
 
   set(settings: Object) {
-    console.warn('Settings is not yet supported on Android');
+    console.warn('Settings is not yet supported on this platform.');
   },
 
   watchKeys(keys: string | Array<string>, callback: Function): number {
-    console.warn('Settings is not yet supported on Android');
+    console.warn('Settings is not yet supported on this platform.');
     return -1;
   },
 
   clearWatch(watchId: number) {
-    console.warn('Settings is not yet supported on Android');
+    console.warn('Settings is not yet supported on this platform.');
   },
 };
 


### PR DESCRIPTION
Summary:
Today, any host platform implementation of React Native must add Settings.platform.js.

- https://github.com/microsoft/react-native-windows/blob/0.71-stable/vnext/src/Libraries/Settings/Settings.windows.js

Now they don't have to do it anymore.

For this case, macOS actually wants to share the iOS specific logic > https://github.com/microsoft/react-native-macos/blob/main/Libraries/Settings/Settings.macos.js

Changelog:
[General] [Fixed] - [Settings] Remove need for platform overrides to Settings

Differential Revision: D47747018

