### PR TITLE
Return NONE accessibility role if `null` is passed.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -295,6 +295,10 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
     }
 
     public static AccessibilityRole fromValue(@Nullable String value) {
+      if (value == null) {
+        return NONE;
+      }
+
       for (AccessibilityRole role : AccessibilityRole.values()) {
         if (role.name().equalsIgnoreCase(value)) {
           return role;


### PR DESCRIPTION
Summary:
The `value` string of the ReactAccessibilityDelegate's `fromValue` method is marked as `Nullable`, however the `null` case is not handled.

This change handle the `null` case setting the accesssibility role to NONE.

## Changelog:
[Android][Fixed] - Set the accessibility role to `NONE` when a `null` string is passed to `fromValue`

Differential Revision: D47752098

