### PR TITLE
Replace `JSX.Element` with `React.JSX.Element`

### DIFF
--- a/packages/react-native/template/App.tsx
+++ b/packages/react-native/template/App.tsx
@@ -29,7 +29,7 @@ type SectionProps = PropsWithChildren<{
   title: string;
 }>;
 
-function Section({children, title}: SectionProps): JSX.Element {
+function Section({children, title}: SectionProps): React.JSX.Element {
   const isDarkMode = useColorScheme() === 'dark';
   return (
     <View style={styles.sectionContainer}>
@@ -55,7 +55,7 @@ function Section({children, title}: SectionProps): JSX.Element {
   );
 }
 
-function App(): JSX.Element {
+function App(): React.JSX.Element {
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {


### PR DESCRIPTION



## Summary:

the global `JSX` namespace was depreacted in react 18:

```tsx
declare global {
    /**
     * @deprecated Use `React.JSX` instead of the global `JSX` namespace.
     */
    namespace JSX {
```

## Changelog:

[GENERAL] [CHANGED] - Replace `JSX.Element` with `React.JSX.Element` in `App.tsx` template

## Test Plan:

Before

<img width="686" alt="Screenshot 2023-07-25 at 14 11 59" src="https://github.com/facebook/react-native/assets/4661784/531a4f88-8090-43aa-86d6-4af595d4cb5d">


After

<img width="445" alt="Screenshot 2023-07-25 at 14 12 12" src="https://github.com/facebook/react-native/assets/4661784/3b427938-2768-4131-b77a-62045e5b8d08">
