### PR TITLE
[IOS] [FIXED] - Fix TextInput's maxLength limit when use a non-English input method

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -464,7 +464,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 
         // Collapse selection at end of insert to match normal paste behavior.
         UITextPosition *insertEnd = [backedTextInputView positionFromPosition:backedTextInputView.beginningOfDocument
-                                                                       offset:(range.location + allowedLength)];
                                                                        offset:newAttributedText.length >= _maxLength.intValue?_maxLength.intValue : (range.location + allowedLength)];
         [backedTextInputView setSelectedTextRange:[backedTextInputView textRangeFromPosition:insertEnd
                                                                                   toPosition:insertEnd]

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -427,6 +427,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
         0);
 
     if (text.length > allowedLength) {
+      // Gets the marked text when using a non-English input method. Such as Chinese, Simplified - Pinyin
+      UITextRange *selectedRange = [backedTextInputView markedTextRange];
+      UITextPosition *position = [backedTextInputView positionFromPosition:selectedRange.start offset:0];
+      // Max length should not work if there are marked literals.
+      if (position) {
+        return text;
+      }
       // If we typed/pasted more than one character, limit the text inputted.
       if (text.length > 1) {
         if (allowedLength > 0) {
@@ -446,7 +453,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
               initWithString:[self.textAttributes applyTextAttributesToText:limitedString]
                   attributes:self.textAttributes.effectiveTextAttributes];
         } else {
-          [newAttributedText replaceCharactersInRange:range withString:limitedString];
+          if(newAttributedText.length > _maxLength.intValue){
+            [newAttributedText replaceCharactersInRange:NSMakeRange(_maxLength.intValue, newAttributedText.length - _maxLength.intValue) withString:@""];
+          }else{
+            [newAttributedText replaceCharactersInRange:range withString:limitedString];
+          }
         }
         backedTextInputView.attributedText = newAttributedText;
         _predictedText = newAttributedText.string;
@@ -454,6 +465,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
         // Collapse selection at end of insert to match normal paste behavior.
         UITextPosition *insertEnd = [backedTextInputView positionFromPosition:backedTextInputView.beginningOfDocument
                                                                        offset:(range.location + allowedLength)];
+                                                                       offset:newAttributedText.length >= _maxLength.intValue?_maxLength.intValue : (range.location + allowedLength)];
         [backedTextInputView setSelectedTextRange:[backedTextInputView textRangeFromPosition:insertEnd
                                                                                   toPosition:insertEnd]
                                    notifyDelegate:YES];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When using a non-English input method, and the TextInput’s maxLength is set, some temporary characters are also added to the maximum length, which should not be the case.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [FIXED] - Fix TextInput's maxLength limit when use a non-English input method.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

### Before fixed I can't input '65432黄'. 'huang' is the Chinese word for '黄'.

![253845058-16a40b35-95a3-4814-ba9c-481e02633f4e](https://github.com/facebook/react-native/assets/12185078/b6c76041-ff62-4af3-8eb5-749e0b3fe306)

### After fixed TextInput's maxLength can work for English input and a non-English input:

![253845168-974162ae-7d0e-4840-8143-3a8bf617655d](https://github.com/facebook/react-native/assets/12185078/b0af5f85-a4f5-4ce6-89a3-3e94b9944576)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
