### PR TITLE
Let check-for-reproducer run only on newly created issues.

### DIFF
--- a/.github/workflows/check-for-reproducer.yml
+++ b/.github/workflows/check-for-reproducer.yml
@@ -3,9 +3,7 @@ name: Check for reproducer
 # Also, when a comment is added, edited or deleted.
 on:
   issues:
-    types: [opened, edited]
-  issue_comment:
-    types: [created, edited, deleted]
+    types: [opened]
 
 jobs:
   check-for-reproducer:


### PR DESCRIPTION
Summary:
To reduce the noise of the `check-for-reproducer` bot, this restricts the event
that trigger the bot to only the issue creation.

Changelog:
[Internal] [Changed] - Let check-for-reproducer run only on newly created issues

Reviewed By: cipolleschi

Differential Revision: D47792374

