### PR TITLE
Break circular dependency between renderer/core and renderer/components/view

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -19,6 +19,7 @@
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/components/image/ImageProps.h>
 #include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/components/view/ViewPropsInterpolation.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/Props.h>
@@ -1152,8 +1153,13 @@ ShadowView LayoutAnimationKeyFrameManager::createInterpolatedShadowView(
   // Animate opacity or scale/transform
   PropsParserContext propsParserContext{
       finalView.surfaceId, *contextContainer_};
-  mutatedShadowView.props = componentDescriptor.interpolateProps(
-      propsParserContext, progress, startingView.props, finalView.props);
+  mutatedShadowView.props = interpolateProps(
+      componentDescriptor,
+      propsParserContext,
+      progress,
+      startingView.props,
+      finalView.props);
+
   react_native_assert(mutatedShadowView.props != nullptr);
   if (mutatedShadowView.props == nullptr) {
     return finalView;
@@ -1655,5 +1661,33 @@ void LayoutAnimationKeyFrameManager::deleteAnimationsForStoppedSurfaces()
     }
   }
 }
+
+Props::Shared LayoutAnimationKeyFrameManager::interpolateProps(
+    const ComponentDescriptor &componentDescriptor,
+    const PropsParserContext &context,
+    Float animationProgress,
+    const Props::Shared &props,
+    const Props::Shared &newProps) const {
+#ifdef ANDROID
+  // On Android only, the merged props should have the same RawProps as the
+  // final props struct
+  Props::Shared interpolatedPropsShared =
+      (newProps != nullptr
+           ? componentDescriptor.cloneProps(
+                 context, newProps, newProps->rawProps)
+           : componentDescriptor.cloneProps(context, newProps, {}));
+#else
+  Props::Shared interpolatedPropsShared =
+      componentDescriptor.cloneProps(context, newProps, {});
+#endif
+
+  if (componentDescriptor.getTraits().check(
+          ShadowNodeTraits::Trait::ViewKind)) {
+    interpolateViewProps(
+        animationProgress, props, newProps, interpolatedPropsShared);
+  }
+
+  return interpolatedPropsShared;
+};
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
@@ -173,6 +173,16 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
 
   void simulateImagePropsMemoryAccess(
       ShadowViewMutationList const &mutations) const;
+
+  /**
+   * Interpolates the props values.
+   */
+  Props::Shared interpolateProps(
+      const ComponentDescriptor &componentDescriptor,
+      const PropsParserContext &context,
+      Float animationProgress,
+      const Props::Shared &props,
+      const Props::Shared &newProps) const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -109,16 +109,6 @@ class ComponentDescriptor {
       const RawProps &rawProps) const = 0;
 
   /*
-   * Creates a new `Props` of a particular type with all values interpolated
-   * between `props` and `newProps`.
-   */
-  virtual Props::Shared interpolateProps(
-      const PropsParserContext &context,
-      Float animationProgress,
-      const Props::Shared &props,
-      const Props::Shared &newProps) const = 0;
-
-  /*
    * Create an initial State object that represents (and contains) an initial
    * State's data which can be constructed based on initial Props.
    */

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -11,7 +11,6 @@
 #include <memory>
 
 #include <react/debug/react_native_assert.h>
-#include <react/renderer/components/view/ViewPropsInterpolation.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventDispatcher.h>
 #include <react/renderer/core/Props.h>
@@ -123,30 +122,6 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     }
 
     return shadowNodeProps;
-  };
-
-  Props::Shared interpolateProps(
-      const PropsParserContext &context,
-      Float animationProgress,
-      const Props::Shared &props,
-      const Props::Shared &newProps) const override {
-#ifdef ANDROID
-    // On Android only, the merged props should have the same RawProps as the
-    // final props struct
-    Props::Shared interpolatedPropsShared =
-        (newProps != nullptr ? cloneProps(context, newProps, newProps->rawProps)
-                             : cloneProps(context, newProps, {}));
-#else
-    Props::Shared interpolatedPropsShared = cloneProps(context, newProps, {});
-#endif
-
-    if (ConcreteShadowNode::BaseTraits().check(
-            ShadowNodeTraits::Trait::ViewKind)) {
-      interpolateViewProps(
-          animationProgress, props, newProps, interpolatedPropsShared);
-    }
-
-    return interpolatedPropsShared;
   };
 
   virtual State::Shared createInitialState(


### PR DESCRIPTION
Summary:
ComponentDescriptor and ConcreteComponentDescriptor expose a virtual method to interpolate props for LayoutAnimation. The implementation of this virtual method in ConcreteComponentDescriptor calls ViewPropsInterpolation, creating a circular dependency between react/renderer/core and react/renderer/components/view.

To break this circular dependency, this change lifts the props interpolation functionality out of ComponentDescriptor into LayoutAnimationKeyFrameManager.

Differential Revision: D47797967

