### PR TITLE
Bump AGP to 8.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1158,7 +1158,7 @@ jobs:
       - ANDROID_HOME: "C:\\Android\\android-sdk"
       - ANDROID_NDK: "C:\\Android\\android-sdk\\ndk\\20.1.5948944"
       - ANDROID_BUILD_VERSION: 33
-      - ANDROID_TOOLS_VERSION: 33.0.0
+      - ANDROID_TOOLS_VERSION: 33.0.1
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
       - CHOCO_CACHE_DIR: "C:\\ChocoCache"
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@
 
 plugins {
   id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-  id("com.android.library") version "8.0.2" apply false
-  id("com.android.application") version "8.0.2" apply false
+  id("com.android.library") version "8.1.0" apply false
+  id("com.android.application") version "8.1.0" apply false
   id("de.undercouch.download") version "5.0.1" apply false
   kotlin("android") version "1.8.0" apply false
 }

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   // The KGP/AGP version is defined by React Native Gradle plugin.
   // Therefore we specify an implementation dep rather than a compileOnly.
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
-  implementation("com.android.tools.build:gradle:8.0.2")
+  implementation("com.android.tools.build:gradle:8.1.0")
 
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.google.guava:guava:31.0.1-jre")
@@ -54,21 +54,18 @@ dependencies {
               .first()))
 }
 
-java {
-  // We intentionally don't build for Java 17 as users will see a cryptic bytecode version
-  // error first. Instead we produce a Java 11-compatible Gradle Plugin, so that AGP can print their
-  // nice message showing that JDK 11 (or 17) is required first
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
-}
+// We intentionally don't build for Java 17 as users will see a cryptic bytecode version
+// error first. Instead we produce a Java 11-compatible Gradle Plugin, so that AGP can print their
+// nice message showing that JDK 11 (or 17) is required first
+java { targetCompatibility = JavaVersion.VERSION_11 }
 
 kotlin { jvmToolchain(17) }
 
-tasks.withType<KotlinCompile> {
+tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
     apiVersion = "1.5"
-    languageVersion = "1.5"
+    // See comment above on JDK 11 support
+    jvmTarget = "11"
   }
 }
 

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -453,8 +453,8 @@ repositories {
 }
 
 android {
-    buildToolsVersion = "33.0.0"
-    compileSdkVersion 33
+    compileSdk 33
+    buildToolsVersion = "33.0.1"
     namespace "com.facebook.react"
 
     // Used to override the NDK path/version on internal CI or by allowing

--- a/packages/react-native/ReactAndroid/flipper-integration/build.gradle
+++ b/packages/react-native/ReactAndroid/flipper-integration/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 android {
     compileSdk 33
-    buildToolsVersion = "33.0.0"
+    buildToolsVersion = "33.0.1"
     namespace "com.facebook.react.flipper"
 
     defaultConfig {

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -159,8 +159,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion = "33.0.0"
+    compileSdk 33
+    buildToolsVersion = "33.0.1"
     namespace "com.facebook.hermes"
 
     // Used to override the NDK path/version on internal CI or by allowing
@@ -230,17 +230,6 @@ android {
                 }
             }
         }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlin {
-        // We intentionally don't build on JDK 17 to keep this version aligned with
-        // the JVM toolchain of :ReactAndroid
-        jvmToolchain(11)
     }
 
     sourceSets {

--- a/packages/react-native/build.gradle.kts
+++ b/packages/react-native/build.gradle.kts
@@ -11,8 +11,8 @@
 // their settings.gradle.kts file.
 // More on this here: https://reactnative.dev/contributing/how-to-build-from-source
 plugins {
-  id("com.android.library") version "8.0.2" apply false
-  id("com.android.application") version "8.0.2" apply false
+  id("com.android.library") version "8.1.0" apply false
+  id("com.android.application") version "8.1.0" apply false
   id("de.undercouch.download") version "5.0.1" apply false
   kotlin("android") version "1.8.0" apply false
 }

--- a/packages/react-native/template/android/app/build.gradle
+++ b/packages/react-native/template/android/app/build.gradle
@@ -72,7 +72,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 android {
     ndkVersion rootProject.ext.ndkVersion
 
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     namespace "com.helloworld"
     defaultConfig {

--- a/packages/react-native/template/android/build.gradle
+++ b/packages/react-native/template/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "33.0.0"
+        buildToolsVersion = "33.0.1"
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -89,8 +89,8 @@ repositories {
 }
 
 android {
-    buildToolsVersion = "33.0.0"
-    compileSdkVersion 33
+    compileSdk 33
+    buildToolsVersion = "33.0.1"
     namespace "com.facebook.react.uiapp"
 
     // Used to override the NDK path/version on internal CI or by allowing

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -4,7 +4,7 @@
 
 ## ANDROID ##
 # Android SDK Build Tools revision
-export ANDROID_SDK_BUILD_TOOLS_REVISION=33.0.0
+export ANDROID_SDK_BUILD_TOOLS_REVISION=33.0.1
 # Android API Level we build with
 export ANDROID_SDK_BUILD_API_LEVEL="33"
 # Google APIs for Android level


### PR DESCRIPTION
Summary:
A new stable version of Android Gradle Plugin has just been released which I'm bumping over here, and applying all the required changes.

Changelog:
[Internal] [Changed] - Bump AGP to 8.1.0

Reviewed By: cipolleschi

Differential Revision: D47798273

