### PR TITLE
Fix ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode check

### DIFF
--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -31,7 +31,7 @@ function getCachedConstants(): Object {
 
 module.exports = {
   getViewManagerConfig: (viewManagerName: string): mixed => {
-    if (ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode) {
+    if (ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode()) {
       return getCachedConstants()[viewManagerName];
     } else {
       console.error(
@@ -46,7 +46,7 @@ module.exports = {
     return unstable_hasComponent(viewManagerName);
   },
   getConstants: (): Object => {
-    if (ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode) {
+    if (ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode()) {
       return getCachedConstants();
     } else {
       console.error(errorMessageForMethod('getConstants'));


### PR DESCRIPTION
Summary:
`ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode` is a function, we should call it.
Changelog: [Internal] - Fix ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode check

Differential Revision: D47798910

