### PR TITLE
Fix OSS gradle build for ReactCommon/react/renderer/graphics

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -109,7 +109,7 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
                 "react_render_graphics",
                 [
                     new Pair("../ReactCommon/react/renderer/graphics/", "react/renderer/graphics/"),
-                    new Pair("../ReactCommon/react/renderer/graphics/platform/cxx/", ""),
+                    new Pair("../ReactCommon/react/renderer/graphics/platform/android/", ""),
                 ]
             ),
             new PrefabPreprocessingEntry(


### PR DESCRIPTION
Summary:
It's likely that some components consuming react/renderer/graphics headers are consuming the wrong PlatformColorParser header, since the implementation under platform/android is quite different from the implementation under platform/cxx.

This change should hoist the correct headers to react/renderer/graphics when building Fabric in OSS.

## Changelog:
[General] [Fixed] - Fix headers for react/renderer/graphics for Fabric Android

Differential Revision: D47821848

