### PR TITLE
Remove default 50ms Scroll Event Throttling in VirtualizedList

### DIFF
--- a/packages/react-native/Libraries/Animated/components/AnimatedFlatList.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedFlatList.js
@@ -23,7 +23,7 @@ const FlatListWithEventThrottle = React.forwardRef(
     ref:
       | ((null | FlatList<mixed>) => mixed)
       | {current: null | FlatList<mixed>, ...},
-  ) => <FlatList scrollEventThrottle={0.0001} {...props} ref={ref} />,
+  ) => <FlatList {...props} ref={ref} />,
 );
 
 export default (createAnimatedComponent(

--- a/packages/react-native/Libraries/Animated/components/AnimatedSectionList.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedSectionList.js
@@ -27,7 +27,7 @@ const SectionListWithEventThrottle = React.forwardRef(
           current: null | SectionList<SectionBase<$FlowFixMe>>,
           ...
         },
-  ) => <SectionList scrollEventThrottle={0.0001} {...props} ref={ref} />,
+  ) => <SectionList {...props} ref={ref} />,
 );
 
 export default (createAnimatedComponent(

--- a/packages/react-native/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
+++ b/packages/react-native/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
@@ -28,7 +28,7 @@ exports[`FlatList ignores invalid data 1`] = `
   pagingEnabled={false}
   removeClippedSubviews={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   scrollViewRef={[Function]}
   sendMomentumEvents={true}
   snapToEnd={true}
@@ -104,7 +104,7 @@ exports[`FlatList renders all the bells and whistles 1`] = `
   refreshing={false}
   removeClippedSubviews={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   viewabilityConfigCallbackPairs={Array []}
 >
@@ -222,7 +222,7 @@ exports[`FlatList renders array-like data 1`] = `
   pagingEnabled={false}
   removeClippedSubviews={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   scrollViewRef={[Function]}
   sendMomentumEvents={true}
   snapToEnd={true}
@@ -295,7 +295,7 @@ exports[`FlatList renders empty list 1`] = `
   onScrollEndDrag={[Function]}
   removeClippedSubviews={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   viewabilityConfigCallbackPairs={Array []}
 >
@@ -317,7 +317,7 @@ exports[`FlatList renders null list 1`] = `
   onScrollEndDrag={[Function]}
   removeClippedSubviews={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   viewabilityConfigCallbackPairs={Array []}
 >
@@ -352,7 +352,7 @@ exports[`FlatList renders simple list (multiple columns) 1`] = `
   onScrollEndDrag={[Function]}
   removeClippedSubviews={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   viewabilityConfigCallbackPairs={Array []}
 >
@@ -425,7 +425,7 @@ exports[`FlatList renders simple list 1`] = `
   onScrollEndDrag={[Function]}
   removeClippedSubviews={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   viewabilityConfigCallbackPairs={Array []}
 >
@@ -488,7 +488,7 @@ exports[`FlatList renders simple list using ListItemComponent (multiple columns)
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   removeClippedSubviews={false}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   viewabilityConfigCallbackPairs={Array []}
 >
@@ -561,7 +561,7 @@ exports[`FlatList renders simple list using ListItemComponent 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   removeClippedSubviews={false}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   viewabilityConfigCallbackPairs={Array []}
 >

--- a/packages/react-native/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
+++ b/packages/react-native/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
@@ -28,7 +28,7 @@ exports[`SectionList rendering empty section headers is fine 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -89,7 +89,7 @@ exports[`SectionList renders a footer when there is no data 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -140,7 +140,7 @@ exports[`SectionList renders a footer when there is no data and no header 1`] = 
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -231,7 +231,7 @@ exports[`SectionList renders all the bells and whistles 1`] = `
   }
   refreshing={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       1,
@@ -422,7 +422,7 @@ exports[`SectionList renders empty list 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View />

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -62,7 +62,6 @@ import {
   maxToRenderPerBatchOrDefault,
   onStartReachedThresholdOrDefault,
   onEndReachedThresholdOrDefault,
-  scrollEventThrottleOrDefault,
   windowSizeOrDefault,
 } from './VirtualizedListProps';
 
@@ -1073,9 +1072,9 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       onScrollEndDrag: this._onScrollEndDrag,
       onMomentumScrollBegin: this._onMomentumScrollBegin,
       onMomentumScrollEnd: this._onMomentumScrollEnd,
-      scrollEventThrottle: scrollEventThrottleOrDefault(
-        this.props.scrollEventThrottle,
-      ), // TODO: Android support
+      // iOS/macOS requires a non-zero scrollEventThrottle to fire more than a
+      // single notification while scrolling. This will otherwise no-op.
+      scrollEventThrottle: this.props.scrollEventThrottle ?? 0.0001,
       invertStickyHeaders:
         this.props.invertStickyHeaders !== undefined
           ? this.props.invertStickyHeaders

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -331,13 +331,6 @@ export function onEndReachedThresholdOrDefault(
   return onEndReachedThreshold ?? 2;
 }
 
-// scrollEventThrottleOrDefault(this.props.scrollEventThrottle)
-export function scrollEventThrottleOrDefault(
-  scrollEventThrottle: ?number,
-): number {
-  return scrollEventThrottle ?? 50;
-}
-
 // windowSizeOrDefault(this.props.windowSize)
 export function windowSizeOrDefault(windowSize: ?number): number {
   return windowSize ?? 21;

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -53,7 +53,7 @@ exports[`VirtualizedList forwards correct stickyHeaderIndices when ListHeaderCom
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -210,7 +210,7 @@ exports[`VirtualizedList forwards correct stickyHeaderIndices when all in initia
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -361,7 +361,7 @@ exports[`VirtualizedList forwards correct stickyHeaderIndices when partially in 
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -445,7 +445,7 @@ exports[`VirtualizedList handles nested lists 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -476,7 +476,7 @@ exports[`VirtualizedList handles nested lists 1`] = `
         onScrollBeginDrag={[Function]}
         onScrollEndDrag={[Function]}
         renderItem={[Function]}
-        scrollEventThrottle={50}
+        scrollEventThrottle={0.0001}
         stickyHeaderIndices={Array []}
       >
         <View
@@ -526,7 +526,7 @@ exports[`VirtualizedList handles nested lists 1`] = `
         onScrollBeginDrag={[Function]}
         onScrollEndDrag={[Function]}
         renderItem={[Function]}
-        scrollEventThrottle={50}
+        scrollEventThrottle={0.0001}
         stickyHeaderIndices={Array []}
       >
         <View>
@@ -595,7 +595,7 @@ exports[`VirtualizedList handles separators correctly 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -672,7 +672,7 @@ exports[`VirtualizedList handles separators correctly 2`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -749,7 +749,7 @@ exports[`VirtualizedList handles separators correctly 3`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -886,7 +886,7 @@ exports[`VirtualizedList keeps sticky headers above viewport visualized 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -1032,7 +1032,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   }
   refreshing={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   style={
     Array [
@@ -1204,7 +1204,7 @@ exports[`VirtualizedList renders empty list 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View />
@@ -1224,7 +1224,7 @@ exports[`VirtualizedList renders empty list after batch 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View />
@@ -1247,7 +1247,7 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -1287,7 +1287,7 @@ exports[`VirtualizedList renders list with empty component 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -1316,7 +1316,7 @@ exports[`VirtualizedList renders null list 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View />
@@ -1348,7 +1348,7 @@ exports[`VirtualizedList renders simple list 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -1408,7 +1408,7 @@ exports[`VirtualizedList renders simple list using ListItemComponent 1`] = `
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -1495,7 +1495,7 @@ exports[`VirtualizedList renders sticky headers in viewport on batched render 1`
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -1577,7 +1577,7 @@ exports[`VirtualizedList test getItem functionality where data is not an Array 1
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -1614,7 +1614,7 @@ exports[`VirtualizedList warns if both renderItem or ListItemComponent are speci
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -1712,7 +1712,7 @@ exports[`adjusts render area with non-zero initialScrollIndex 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={10}
 >
@@ -1912,7 +1912,7 @@ exports[`clamps render area when items removed for initialScrollIndex > 0 and sc
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={10}
 >
@@ -2050,7 +2050,7 @@ exports[`constrains batch render region when an item is removed 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -2177,7 +2177,7 @@ exports[`discards intitial render if initialScrollIndex != 0 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -2319,7 +2319,7 @@ exports[`does not adjust render area until content area layed out 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={10}
 >
@@ -2454,7 +2454,7 @@ exports[`does not move render area when initialScrollIndex is > 0 and offset not
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={10}
 >
@@ -2566,7 +2566,7 @@ exports[`does not over-render when there is less than initialNumToRender cells 1
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -2680,7 +2680,7 @@ exports[`eventually renders all items when virtualization disabled 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -2819,7 +2819,7 @@ exports[`expands first in viewport to render up to maxToRenderPerBatch on initia
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -2936,7 +2936,7 @@ exports[`expands render area by maxToRenderPerBatch on tick 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -3056,7 +3056,7 @@ exports[`gracefully handles negative initialScrollIndex 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -3227,7 +3227,7 @@ exports[`handles maintainVisibleContentPosition 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -3396,7 +3396,7 @@ exports[`handles maintainVisibleContentPosition 2`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -3580,7 +3580,7 @@ exports[`handles maintainVisibleContentPosition 3`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -3742,7 +3742,7 @@ exports[`handles maintainVisibleContentPosition when anchor moves before minInde
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -3878,7 +3878,7 @@ exports[`handles maintainVisibleContentPosition when anchor moves before minInde
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -3974,7 +3974,7 @@ exports[`initially renders nothing when initialNumToRender is 0 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -4067,7 +4067,7 @@ exports[`keeps viewport above last focused rendered 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -4265,7 +4265,7 @@ exports[`keeps viewport below last focused rendered 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -4448,7 +4448,7 @@ exports[`renders a zero-height tail spacer on initial render if getItemLayout no
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -4538,7 +4538,7 @@ exports[`renders full tail spacer if all cells measured 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -4649,7 +4649,7 @@ exports[`renders initialNumToRender cells when virtualization disabled 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -4748,7 +4748,7 @@ exports[`renders items before initialScrollIndex on first batch tick when virtua
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -4844,7 +4844,7 @@ exports[`renders new items when data is updated with non-zero initialScrollIndex
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={10}
 >
@@ -4927,7 +4927,7 @@ exports[`renders no spacers up to initialScrollIndex on first render when virtua
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -5000,7 +5000,7 @@ exports[`renders offset cells in initial render when initialScrollIndex set 1`] 
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -5102,7 +5102,7 @@ exports[`renders tail spacer up to last measured index if getItemLayout not defi
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -5211,7 +5211,7 @@ exports[`renders tail spacer up to last measured with irregular layout when getI
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -5312,7 +5312,7 @@ exports[`renders windowSize derived region at bottom 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={3}
 >
@@ -5425,7 +5425,7 @@ exports[`renders windowSize derived region at top 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={3}
 >
@@ -5522,7 +5522,7 @@ exports[`renders windowSize derived region in middle 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={3}
 >
@@ -5657,7 +5657,7 @@ exports[`renders zero-height tail spacer on batch render if cells not yet measur
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -5752,7 +5752,7 @@ exports[`retains batch render region when an item is appended 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -5898,7 +5898,7 @@ exports[`retains initial render region when an item is appended 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -6016,7 +6016,7 @@ exports[`retains intitial render if initialScrollIndex == 0 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -6205,7 +6205,7 @@ exports[`unmounts sticky headers moved below viewport 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={
     Array [
       0,
@@ -6343,7 +6343,7 @@ exports[`virtualizes away last focused index if item removed 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >
@@ -6533,7 +6533,7 @@ exports[`virtualizes away last focused item if focus changes to a new cell 1`] =
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   windowSize={1}
 >

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
@@ -28,7 +28,7 @@ exports[`VirtualizedSectionList handles nested lists 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -70,7 +70,7 @@ exports[`VirtualizedSectionList handles nested lists 1`] = `
         onScrollBeginDrag={[Function]}
         onScrollEndDrag={[Function]}
         renderItem={[Function]}
-        scrollEventThrottle={50}
+        scrollEventThrottle={0.0001}
         stickyHeaderIndices={Array []}
       >
         <View
@@ -136,7 +136,7 @@ exports[`VirtualizedSectionList handles nested lists 1`] = `
         onScrollBeginDrag={[Function]}
         onScrollEndDrag={[Function]}
         renderItem={[Function]}
-        scrollEventThrottle={50}
+        scrollEventThrottle={0.0001}
         stickyHeaderIndices={Array []}
       >
         <View>
@@ -239,7 +239,7 @@ exports[`VirtualizedSectionList handles separators correctly 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -377,7 +377,7 @@ exports[`VirtualizedSectionList handles separators correctly 2`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -515,7 +515,7 @@ exports[`VirtualizedSectionList handles separators correctly 3`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -654,7 +654,7 @@ exports[`VirtualizedSectionList handles separators correctly 4`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -814,7 +814,7 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
   }
   refreshing={false}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
   style={
     Array [
@@ -1029,7 +1029,7 @@ exports[`VirtualizedSectionList renders empty list 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View />
@@ -1053,7 +1053,7 @@ exports[`VirtualizedSectionList renders empty list with empty component 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -1099,7 +1099,7 @@ exports[`VirtualizedSectionList renders list with empty component 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>
@@ -1157,7 +1157,7 @@ exports[`VirtualizedSectionList renders simple list 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   renderItem={[Function]}
-  scrollEventThrottle={50}
+  scrollEventThrottle={0.0001}
   stickyHeaderIndices={Array []}
 >
   <View>


### PR DESCRIPTION
Summary:
This is specific to the scenario, and device, and time-based sampling as implemented on Android may inherently create stutters because we may not proess events at a consistent cadence (and we may never process the last events).

https://github.com/facebook/react-native/pull/38475 made this code no longer no-op on Android, which caused scroll regressions documented in https://github.com/facebook/react-native/issues/38470

We are already coalescing scroll events on both Android and iOS, which will ensure we are not flooded with events.  VirtualizedList also already inserts an artificial 50ms delay by default when high priority work is not happening (see `updateCellsBatchingPeriod`). This limits the heavy work done by VirtualizedList (no new renders or expensive math on scroll events), while letting the list still have the most recent events.

We can eventually remove this once VirtualizedList is able to use OffScreen universally.

Changelog:
[General][Changed] - Remove default 50ms Scroll Event Throttling in VirtualizedList

Differential Revision: D47823772

