### PR TITLE
[Android] Fix issue#11068 of duplicating characters when replacing letters to lowercase or uppercase in TextInput (Adjusted)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -166,6 +166,9 @@ public class ReactFeatureFlags {
   /** Enables Stable API for TurboModule (removal of ReactModule, ReactModuleInfoProvider). */
   public static boolean enableTurboModuleStableAPI = false;
 
+  /** Enable keeping Composing Spans on Text input change if the new text has the same length. */
+  public static boolean enableComposingSpanRestorationOnSameLength = false;
+
   /**
    * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with
    * priorities from any thread.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -167,7 +167,7 @@ public class ReactFeatureFlags {
   public static boolean enableTurboModuleStableAPI = false;
 
   /** Enable keeping Composing Spans on Text input change if the new text has the same length. */
-  public static boolean enableComposingSpanRestorationOnSameLength = false;
+  public static boolean enableComposingSpanRestorationOnSameLength = true;
 
   /**
    * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -676,6 +676,8 @@ public class ReactEditText extends AppCompatEditText {
       // try to update state if the wrapper is available. Temporarily disable
       // to prevent an infinite loop.
       getText().replace(0, length(), spannableStringBuilder);
+
+      attachCompositeSpansToTextFrom(spannableStringBuilder);
     }
     mDisableTextDiffing = false;
 
@@ -688,18 +690,24 @@ public class ReactEditText extends AppCompatEditText {
   }
 
   /**
-   * Remove and/or add {@link Spanned.SPAN_EXCLUSIVE_EXCLUSIVE} spans, since they should only exist
-   * as long as the text they cover is the same. All other spans will remain the same, since they
-   * will adapt to the new text, hence why {@link SpannableStringBuilder#replace} never removes
+   * Remove and/or add {@link Spanned#SPAN_EXCLUSIVE_EXCLUSIVE} spans, since they should only exist
+   * as long as the text they cover is the same unless they are {@link Spanned#SPAN_COMPOSING}.
+   * All other spans will remain the same, since they will adapt to the new text, hence why {@link SpannableStringBuilder#replace} never removes
    * them.
+   * Keep copy of {@link Spanned#SPAN_COMPOSING} Spans in {@param spannableStringBuilder}, because they are important for
+   * keyboard suggestions. Without keeping these Spans, suggestions default to be put after the current selection position,
+   * possibly resulting in letter duplication (ex. Samsung Keyboard).
    */
   private void manageSpans(SpannableStringBuilder spannableStringBuilder) {
     Object[] spans = getText().getSpans(0, length(), Object.class);
+    boolean shouldKeepComposingSpans = length() == spannableStringBuilder.length();
     for (int spanIdx = 0; spanIdx < spans.length; spanIdx++) {
       Object span = spans[spanIdx];
       int spanFlags = getText().getSpanFlags(span);
       boolean isExclusiveExclusive =
           (spanFlags & Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) == Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
+      boolean isComposing =
+        (spanFlags & Spanned.SPAN_COMPOSING) == Spanned.SPAN_COMPOSING;
 
       // Remove all styling spans we might have previously set
       if (span instanceof ReactSpan) {
@@ -713,6 +721,12 @@ public class ReactEditText extends AppCompatEditText {
 
       final int spanStart = getText().getSpanStart(span);
       final int spanEnd = getText().getSpanEnd(span);
+
+      // We keep a copy of Composing spans
+      if (shouldKeepComposingSpans && isComposing) {
+        spannableStringBuilder.setSpan(span, spanStart, spanEnd, spanFlags);
+        continue;
+      }
 
       // Make sure the span is removed from existing text, otherwise the spans we set will be
       // ignored or it will cover text that has changed.
@@ -838,6 +852,34 @@ public class ReactEditText extends AppCompatEditText {
     float lineHeight = mTextAttributes.getEffectiveLineHeight();
     if (!Float.isNaN(lineHeight)) {
       workingText.setSpan(new CustomLineHeightSpan(lineHeight), 0, workingText.length(), spanFlags);
+    }
+  }
+
+  /**
+   * Attaches the {@link Spanned#SPAN_COMPOSING} from {@param spannableStringBuilder} to {@link ReactEditText#getText}
+   * if they are the same length.
+   *
+   * See {@link ReactEditText#manageSpans} for more details.
+   * Also https://github.com/facebook/react-native/issues/11068
+   */
+  private void attachCompositeSpansToTextFrom(SpannableStringBuilder spannableStringBuilder) {
+    Editable text = getText();
+    if (text == null || text.length() != spannableStringBuilder.length()) {
+      return;
+    }
+    Object[] spans = spannableStringBuilder.getSpans(0, length(), Object.class);
+    for (Object span : spans) {
+      int spanFlags = spannableStringBuilder.getSpanFlags(span);
+      boolean isComposing = (spanFlags & Spanned.SPAN_COMPOSING) == Spanned.SPAN_COMPOSING;
+
+      if (!isComposing) {
+        continue;
+      }
+
+      final int spanStart = spannableStringBuilder.getSpanStart(span);
+      final int spanEnd = spannableStringBuilder.getSpanEnd(span);
+
+      text.setSpan(span, spanStart, spanEnd, spanFlags);
     }
   }
 

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -135,6 +135,30 @@ class RewriteExample extends React.Component<$FlowFixMeProps, any> {
   }
 }
 
+class RewriteToLowerCaseExample extends React.Component<$FlowFixMeProps, any> {
+  constructor(props: any | void) {
+    super(props);
+    this.state = {text: ''};
+  }
+  render(): React.Node {
+    return (
+      <View style={styles.rewriteContainer}>
+        <TextInput
+          testID="rewrite_to_lowercase_input"
+          autoCorrect={false}
+          multiline={false}
+          onChangeText={text => {
+            text = text.toLowerCase();
+            this.setState({text});
+          }}
+          style={styles.default}
+          value={this.state.text}
+        />
+      </View>
+    );
+  }
+}
+
 class RewriteExampleInvalidCharacters extends React.Component<
   $FlowFixMeProps,
   any,
@@ -852,6 +876,13 @@ module.exports = ([
     title: "Live Re-Write (<sp>  ->  '_') + maxLength",
     render: function (): React.Node {
       return <RewriteExample />;
+    },
+  },
+  {
+    name: 'lowerCase',
+    title: 'Live Re-Write to LowerCase',
+    render: function (): React.Node {
+      return <RewriteToLowerCaseExample />;
     },
   },
   {


### PR DESCRIPTION
## Summary:

These changes are intended to resolve https://github.com/facebook/react-native/issues/11068.
This pull request is an adjustment to https://github.com/facebook/react-native/pull/35929 which had issues with it's implementation and had to be reverted. (commit: c1eec4cc51c15037afea25351ffa0ea3a0f848f0)

## Changelog:

[Android] [Fixed] - Fix letters duplication when using autoCapitalize

## Test Plan:

I have added an example to the `TextInputSharedExamples.js` which can demonstration the fix.

Here is a short video showing the following:
- No duplicate characters
- Characters are updated to be lowercase
- Long pressing delete properly deletes, doesn’t stop after deleting one character
- Suggestions (selected from keyboard) work and are updated to lowercase when it becomes part of the input text
- Moving the cursor and typing works, cursor position is kept as it should
- Moving the cursor and deleting works
- Selection portion and deleting it works, cursor position is kept as it should

https://github.com/facebook/react-native/assets/14225329/f95055b7-bd03-4e88-a2d7-a81e4840d2bc

**Note**: I have tested with latest main, 0.72.3, commit before mine: 3c6dbec23b3267e93695b153bca0d3ebbd58fac9
**Note2**: I have tested on Emulator where I can reproduce the original issue. On real device (Samsung A52s 5G) I could reproduce it using Samsung Keyboard, I could not reproduce it on the same device with Gboard.

Here is a longer version which goes through the TextInput examples: typing, clearing, selection, cut, paste etc.
So to ensure this indeed does not cause the same issues as https://github.com/facebook/react-native/pull/35929 did.
Uploaded to youtube, because it was too big: https://youtu.be/5IEzXYpfa7w

## Possible Future Improvements
As it can be seen the video, the letter duplication is resolved, however since the lowercase modification happens on the Javascript side, it takes a couple milliseconds and the Uppercase can still be shown momentarily while typing.

## Technical details, why the solution works

I've debugged a simple AppCompatEditText with calling the same `getText().replace` in `doAfterTextChanged` with a bit of delay and noticed a difference to the `ReactEditText`.

The ReactEditText removes the `android.view.inputmethod.ComposingText` Span in `manageSpans` before calling replace (ComposingText is `Spanned.SPAN_EXCLUSIVE_EXCLUSIVE`).
That `ComposingText` Span is used in `android.view.inputmethod.BaseInputConnection` `private replaceText` to find from what point the text should be replaced from when applying suggestions or typing new letters. Without that Span, it defaults to the selection position, which is usually the end of the text causing duplication of the old "word".

**In simple terms, while typing with suggestions on the keyboard, each new letter is handled similarly as clicking a suggestion would be, aka replacing the current "word" with the new "word". (let's say "Ar" word with "Are" word)**

Another way to describe it:
While typing with suggestions, with the ComposingText Span the TextView keeps track of what word completions are suggested for on the keyboard UI. When receiving a new letter input, it replaces the current "word" with a new "word", and without the Span, it replaces nothing at the end (selection point) with the new word which results in character duplication.

It also seems to make sense then why without suggestions (like password-visible and secureTextEntry) the issue hasn't occurred.

### Examples

How the issue happened:
> - User types: A (ComposingText Span becomes (0,1), composingWord: "A")
> - Javascript replaced A with a, ComposingText Span was removed from getText()
> - User types a new character: r (ComposingText, defaulting to selection, from selection, empty string is replaced with word "Ar")
> => Complete text: aAr => letter duplication.

How it works with the changes applied:
> - User types: A (ComposingText Span becomes (0,1), composingWord: "A")
> - Javascript replaces A with a, (ComposingText Span (0,1) is re-set after replace)
> - User types a new character: r (ComposingText (0,1), "a" word is replaced with word "Ar". ComposingText becomes (0,2) "Ar")
> - Javascript replaced Ar with ar, (ComposingText Span (0,2) is re-set after replace)
> => Complete text: ar => no letter duplication
> - User selects suggestion "Are" (ComposingText Span (0,2) "ar" is replaced with new word and space "Are ")
> - CompleteText: "Are "
> - Javascript replaces "Are " with "are " (ComposingText Span doesn't exist, no string after space " ")

Note: the Editable.replace also removes the ComposingText, if it doesn't cover the whole text, that's why we need to re-setSpan them even if we wouldn't remove them in `manageSpans`.
