### PR TITLE
refactor(codegen): add getLiteralValue in parser

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -430,6 +430,22 @@ describe('FlowParser', () => {
       expect(parser.getObjectProperties(declaration)).toEqual(undefined);
     });
   });
+  describe('getLiteralValue', () => {
+    it('returns value of an union represented, given an option', () => {
+      const option = {
+        value: 'LiteralValue',
+      };
+      const expected = option.value;
+
+      expect(parser.getLiteralValue(option)).toEqual(expected);
+    });
+
+    it('returns undefined if option does not have value', () => {
+      const option = {};
+
+      expect(parser.getLiteralValue(option)).toEqual(undefined);
+    });
+  });
 });
 
 describe('TypeScriptParser', () => {
@@ -819,6 +835,28 @@ describe('TypeScriptParser', () => {
       };
 
       expect(parser.getObjectProperties(declaration)).toEqual(undefined);
+    });
+  });
+
+  describe('getLiteralValue', () => {
+    it('returns literal value of an union represented, given an option', () => {
+      const literal = {
+        value: 'LiteralValue',
+      };
+      const option = {
+        literal,
+      };
+      const expected = literal.value;
+
+      expect(parser.getLiteralValue(option)).toEqual(expected);
+    });
+
+    it('returns undefined if literal does not have value', () => {
+      const option = {
+        literal: {},
+      };
+
+      expect(parser.getLiteralValue(option)).toEqual(undefined);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -78,7 +78,9 @@ function getPropertyType(
         optional,
         typeAnnotation: {
           type: 'StringEnumTypeAnnotation',
-          options: typeAnnotation.types.map(option => option.value),
+          options: typeAnnotation.types.map(option =>
+            parser.getLiteralValue(option),
+          ),
         },
       };
     case 'UnsafeMixed':
@@ -119,7 +121,9 @@ function extractArrayElementType(
     case 'UnionTypeAnnotation':
       return {
         type: 'StringEnumTypeAnnotation',
-        options: typeAnnotation.types.map(option => option.value),
+        options: typeAnnotation.types.map(option =>
+          parser.getLiteralValue(option),
+        ),
       };
     case 'UnsafeMixed':
       return {type: 'MixedTypeAnnotation'};

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -543,6 +543,10 @@ class FlowParser implements Parser {
   getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
     return typeAnnotation.properties;
   }
+
+  getLiteralValue(option: $FlowFixMe): $FlowFixMe {
+    return option.value;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -414,4 +414,11 @@ export interface Parser {
    * @returns: the properties of an object represented by a type annotation.
    */
   getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe;
+
+  /**
+   * Given a option return the literal value.
+   * @parameter option
+   * @returns: the literal value of an union represented.
+   */
+  getLiteralValue(option: $FlowFixMe): $FlowFixMe;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -482,4 +482,8 @@ export class MockedParser implements Parser {
   getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
     return typeAnnotation.properties;
   }
+
+  getLiteralValue(option: $FlowFixMe): $FlowFixMe {
+    return option.value;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -77,7 +77,9 @@ function getPropertyType(
         optional,
         typeAnnotation: {
           type: 'StringEnumTypeAnnotation',
-          options: typeAnnotation.types.map(option => option.literal.value),
+          options: typeAnnotation.types.map(option =>
+            parser.getLiteralValue(option),
+          ),
         },
       };
     case 'UnsafeMixed':
@@ -127,7 +129,9 @@ function extractArrayElementType(
     case 'TSUnionType':
       return {
         type: 'StringEnumTypeAnnotation',
-        options: typeAnnotation.types.map(option => option.literal.value),
+        options: typeAnnotation.types.map(option =>
+          parser.getLiteralValue(option),
+        ),
       };
     case 'TSTypeLiteral':
       return {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -557,6 +557,10 @@ class TypeScriptParser implements Parser {
   getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
     return typeAnnotation.members;
   }
+
+  getLiteralValue(option: $FlowFixMe): $FlowFixMe {
+    return option.literal.value;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary:

[Codegen 130] This PR add a `getLiteralValue` function to the Parser interface, which returns the literal value of an union represented, given an option. as requested on https://github.com/facebook/react-native/issues/34872

## Changelog:

[INTERNAL] [ADDED] - Add `getLiteralValue` function to codegen Parser

## Test Plan:

Run `yarn jest react-native-codegen` and ensure CI is green
