### PR TITLE
chore(releases): improve bump oss script to allow less human errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test-ios": "./scripts/objc-test.sh test",
     "test-typescript": "dtslint packages/react-native/types",
     "test-typescript-offline": "dtslint --localTs node_modules/typescript/lib  packages/react-native/types",
-    "bump-all-updated-packages": "node ./scripts/monorepo/bump-all-updated-packages"
+    "bump-all-updated-packages": "node ./scripts/monorepo/bump-all-updated-packages",
+    "bump-oss-version": "node ./scripts/bump-oss-version.js"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test-typescript": "dtslint packages/react-native/types",
     "test-typescript-offline": "dtslint --localTs node_modules/typescript/lib  packages/react-native/types",
     "bump-all-updated-packages": "node ./scripts/monorepo/bump-all-updated-packages",
-    "bump-oss-version": "node ./scripts/bump-oss-version.js"
+    "trigger-react-native-release": "node ./scripts/trigger-react-native-release.js"
   },
   "workspaces": [
     "packages/*"

--- a/scripts/monorepo/bump-all-updated-packages/bump-utils.js
+++ b/scripts/monorepo/bump-all-updated-packages/bump-utils.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const chalk = require('chalk');
+const {echo, exec} = require('shelljs');
+
+const detectPackageUnreleasedChanges = (
+  packageRelativePathFromRoot,
+  packageName,
+  ROOT_LOCATION,
+) => {
+  const hashOfLastCommitInsidePackage = exec(
+    `git log -n 1 --format=format:%H -- ${packageRelativePathFromRoot}`,
+    {cwd: ROOT_LOCATION, silent: true},
+  ).stdout.trim();
+
+  const hashOfLastCommitThatChangedVersion = exec(
+    `git log -G\\"version\\": --format=format:%H -n 1 -- ${packageRelativePathFromRoot}/package.json`,
+    {cwd: ROOT_LOCATION, silent: true},
+  ).stdout.trim();
+
+  if (hashOfLastCommitInsidePackage === hashOfLastCommitThatChangedVersion) {
+    echo(
+      `\uD83D\uDD0E No changes for package ${chalk.green(
+        packageName,
+      )} since last version bump`,
+    );
+    return false;
+  } else {
+    echo(`\uD83D\uDCA1 Found changes for ${chalk.yellow(packageName)}:`);
+    exec(
+      `git log --pretty=oneline ${hashOfLastCommitThatChangedVersion}..${hashOfLastCommitInsidePackage} ${packageRelativePathFromRoot}`,
+      {
+        cwd: ROOT_LOCATION,
+      },
+    );
+    echo();
+
+    return true;
+  }
+};
+
+module.exports = detectPackageUnreleasedChanges;

--- a/scripts/monorepo/bump-all-updated-packages/index.js
+++ b/scripts/monorepo/bump-all-updated-packages/index.js
@@ -25,6 +25,7 @@ const {
 const forEachPackage = require('../for-each-package');
 const checkForGitChanges = require('../check-for-git-changes');
 const bumpPackageVersion = require('./bump-package-version');
+const detectPackageUnreleasedChanges = require('./bump-utils');
 
 const ROOT_LOCATION = path.join(__dirname, '..', '..', '..');
 
@@ -62,34 +63,15 @@ const buildExecutor =
       return;
     }
 
-    const hashOfLastCommitInsidePackage = exec(
-      `git log -n 1 --format=format:%H -- ${packageRelativePathFromRoot}`,
-      {cwd: ROOT_LOCATION, silent: true},
-    ).stdout.trim();
-
-    const hashOfLastCommitThatChangedVersion = exec(
-      `git log -G\\"version\\": --format=format:%H -n 1 -- ${packageRelativePathFromRoot}/package.json`,
-      {cwd: ROOT_LOCATION, silent: true},
-    ).stdout.trim();
-
-    if (hashOfLastCommitInsidePackage === hashOfLastCommitThatChangedVersion) {
-      echo(
-        `\uD83D\uDD0E No changes for package ${chalk.green(
-          packageName,
-        )} since last version bump`,
-      );
-
+    if (
+      !detectPackageUnreleasedChanges(
+        packageRelativePathFromRoot,
+        packageName,
+        ROOT_LOCATION,
+      )
+    ) {
       return;
     }
-
-    echo(`\uD83D\uDCA1 Found changes for ${chalk.yellow(packageName)}:`);
-    exec(
-      `git log --pretty=oneline ${hashOfLastCommitThatChangedVersion}..${hashOfLastCommitInsidePackage} ${packageRelativePathFromRoot}`,
-      {
-        cwd: ROOT_LOCATION,
-      },
-    );
-    echo();
 
     await inquirer
       .prompt([

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -113,7 +113,7 @@ function getNpmInfo(buildType) {
   );
 
   // See if releaser indicated that this version should be tagged "latest"
-  // Set in `bump-oss-version`
+  // Set in `trigger-react-native-release`
   const isLatest = exitIfNotOnGit(
     () => isTaggedLatest(currentCommit),
     'Not in git. We do not want to publish anything',

--- a/scripts/trigger-react-native-release.js
+++ b/scripts/trigger-react-native-release.js
@@ -49,7 +49,7 @@ let argv = yargs
   .check(() => {
     const branch = exitIfNotOnGit(
       () => getBranchName(),
-      "Not in git. You can't invoke bump-oss-versions.js from outside a git repo.",
+      "Not in git. You can't invoke trigger-react-native-release from outside a git repo.",
     );
     exitIfNotOnReleaseBranch(branch);
     return true;
@@ -125,7 +125,7 @@ function triggerReleaseWorkflow(options) {
 async function main() {
   const branch = exitIfNotOnGit(
     () => getBranchName(),
-    "Not in git. You can't invoke bump-oss-versions.js from outside a git repo.",
+    "Not in git. You can't invoke trigger-react-native-release from outside a git repo.",
   );
 
   // check for uncommitted changes


### PR DESCRIPTION
## Summary:

One of the limitations of the existing flow for the release crew is that they need to manually remember to publish all the other packages in the monorepo ahead of a new patch release - this PR modifies the logic for the bump-oss-version script (and makes it available via yarn) so that it will not run if:
* there are git changes lying around
* if some of the packages need a new release

it required a bit of refactoring to extract some portions of the logic from the bump-all-package-versions script, but I think the end result is pretty decent.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [CHANGED] - improve bump oss script to allow less human errors

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
* checkout this branch
* comment L54 of bump-oss-version.js (to remove the check on the branch name)
* run `yarn bump-all-updated-packages`, verify that it works and that it detects that some packages have unreleased code
* run `yarn bump-oss-version -t asd -v asd` (the "fake" parameters are needed to pass the yargs check), verify that it will throw an error because it finds a package that has unreleased code
