### PR TITLE
[Codegen-135] add `getPaperTopLevelNameDeprecated` to parsers

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -189,9 +189,7 @@ function findEventArgumentsAndType(
   } else if (name === 'BubblingEventHandler' || name === 'DirectEventHandler') {
     const eventType = name === 'BubblingEventHandler' ? 'bubble' : 'direct';
     const paperTopLevelNameDeprecated =
-      typeAnnotation.typeParameters.params.length > 1
-        ? typeAnnotation.typeParameters.params[1].value
-        : null;
+      parser.getPaperTopLevelNameDeprecated(typeAnnotation);
     if (
       typeAnnotation.typeParameters.params[0].type ===
       parser.nullLiteralTypeAnnotation

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -543,6 +543,12 @@ class FlowParser implements Parser {
   getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
     return typeAnnotation.properties;
   }
+
+  getPaperTopLevelNameDeprecated(typeAnnotation: $FlowFixMe): $FlowFixMe {
+    return typeAnnotation.typeParameters.params.length > 1
+      ? typeAnnotation.typeParameters.params[1].value
+      : null;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -414,4 +414,11 @@ export interface Parser {
    * @returns: the properties of an object represented by a type annotation.
    */
   getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe;
+
+  /**
+   * Given a type annotation, it returns top level name in the AST if it exists else returns null.
+   * @parameter typeAnnotation: the annotation for a type in the AST.
+   * @returns: the top level name properties in the AST if it exists else null.
+   */
+  getPaperTopLevelNameDeprecated(typeAnnotation: $FlowFixMe): $FlowFixMe;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -482,4 +482,10 @@ export class MockedParser implements Parser {
   getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
     return typeAnnotation.properties;
   }
+
+  getPaperTopLevelNameDeprecated(typeAnnotation: $FlowFixMe): $FlowFixMe {
+    return typeAnnotation.typeParameters.params.length > 1
+      ? typeAnnotation.typeParameters.params[1].value
+      : null;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -198,9 +198,7 @@ function findEventArgumentsAndType(
   } else if (name === 'BubblingEventHandler' || name === 'DirectEventHandler') {
     const eventType = name === 'BubblingEventHandler' ? 'bubble' : 'direct';
     const paperTopLevelNameDeprecated =
-      typeAnnotation.typeParameters.params.length > 1
-        ? typeAnnotation.typeParameters.params[1].literal.value
-        : null;
+      parser.getPaperTopLevelNameDeprecated(typeAnnotation);
 
     switch (typeAnnotation.typeParameters.params[0].type) {
       case parser.nullLiteralTypeAnnotation:

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -557,6 +557,12 @@ class TypeScriptParser implements Parser {
   getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
     return typeAnnotation.members;
   }
+
+  getPaperTopLevelNameDeprecated(typeAnnotation: $FlowFixMe): $FlowFixMe {
+    return typeAnnotation.typeParameters.params.length > 1
+      ? typeAnnotation.typeParameters.params[1].literal.value
+      : null;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary:

[Codegen 135] This PR introduces `getPaperTopLevelNameDeprecated` to parser base class and abstracts the logic out of typescript and parser events as requested on https://github.com/facebook/react-native/issues/34872

## Changelog:

[Internal] [Changed] - Add `getPaperTopLevelNameDeprecated` to parser base class and update usages.

## Test Plan:

Run `yarn jest react-native-codegen` locally and ensure CI is green

## Screenshot of test passing locally:
<img width="1060" alt="Screenshot 2023-07-30 at 10 04 24 AM" src="https://github.com/facebook/react-native/assets/64726664/3f61377b-9f44-45e8-bece-d4fd6bcc4567">


