### PR TITLE
Introduce FrameworkAPI annotation to document APIs that are provided ONLY for frameworks

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -82,13 +82,11 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
 
       if (shouldSupportLegacyPackages() && reactPackage instanceof ReactInstancePackage) {
         // TODO(T145105887): Output error that ReactPackage was used
-
         continue;
       }
 
       if (shouldSupportLegacyPackages()) {
         // TODO(T145105887): Output warnings that ReactPackage was used
-
         final List<NativeModule> nativeModules =
             reactPackage.createNativeModules(reactApplicationContext);
 
@@ -151,11 +149,11 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
         }
 
       } catch (IllegalArgumentException ex) {
-        /**
-         * TurboReactPackages can throw an IllegalArgumentException when a module isn't found. If
-         * this happens, it's safe to ignore the exception because a later TurboReactPackage could
-         * provide the module.
-         */
+        /*
+         TurboReactPackages can throw an IllegalArgumentException when a module isn't found. If
+         this happens, it's safe to ignore the exception because a later TurboReactPackage could
+         provide the module.
+        */
       }
     }
 
@@ -213,7 +211,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
         }
 
       } catch (IllegalArgumentException ex) {
-        /**
+        /*
          * TurboReactPackages can throw an IllegalArgumentException when a module isn't found. If
          * this happens, it's safe to ignore the exception because a later TurboReactPackage could
          * provide the module.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -168,6 +168,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
     return (TurboModule) resolvedModule;
   }
 
+  @Override
   public boolean unstable_isModuleRegistered(String moduleName) {
     for (final ModuleProvider moduleProvider : mModuleProviders) {
       final ReactModuleInfo moduleInfo = mPackageModuleInfos.get(moduleProvider).get(moduleName);
@@ -178,6 +179,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
     return false;
   }
 
+  @Override
   public boolean unstable_isLegacyModuleRegistered(String moduleName) {
     for (final ModuleProvider moduleProvider : mModuleProviders) {
       final ReactModuleInfo moduleInfo = mPackageModuleInfos.get(moduleProvider).get(moduleName);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutor.java
@@ -10,7 +10,9 @@ package com.facebook.react.bridge;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 
+/** @deprecated use {@link com.facebook.react.jscexecutor.JSCExecutor} instead. */
 @DoNotStrip
+@Deprecated
 /* package */ class JSCJavaScriptExecutor extends JavaScriptExecutor {
   static {
     ReactBridge.staticInit();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutorFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutorFactory.java
@@ -7,6 +7,8 @@
 
 package com.facebook.react.bridge;
 
+/** @deprecated use {@link com.facebook.react.jscexecutor.JSCExecutorFactory} instead. */
+@Deprecated
 public class JSCJavaScriptExecutorFactory implements JavaScriptExecutorFactory {
   private final String mAppName;
   private final String mDeviceName;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -476,12 +476,12 @@ final class ReactInstance {
   /**
    * @return The {@link EventDispatcher} used by {@link FabricUIManager} to emit UI events to JS.
    */
-  /* protected */ EventDispatcher getEventDispatcher() {
+  /* package */ EventDispatcher getEventDispatcher() {
     return mFabricUIManager.getEventDispatcher();
   }
 
   /** @return The {@link FabricUIManager} if it's been initialized. */
-  /* protected */ FabricUIManager getUIManager() {
+  /* package */ FabricUIManager getUIManager() {
     return mFabricUIManager;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/FrameworkAPI.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/FrameworkAPI.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message =
+        "This API is provided only for React Native frameworks and not intended for general users. " +
+            "This API can change between minor versions in alignment with React Native frameworks " +
+            "and won't be considered a breaking change.")
+annotation class FrameworkAPI

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
@@ -119,6 +119,8 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
         && ReactFeatureFlags.unstable_useTurboModuleInteropForAllTurboModules;
   }
 
+  @Override
+  @NonNull
   public List<String> getEagerInitModuleNames() {
     return mEagerInitModuleNames;
   }


### PR DESCRIPTION
Summary:
In this diff I'm introducing the FrameworkAPI annotation to document APIs that are provided ONLY for frameworks

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D47839411

