### PR TITLE
Move script checking Appium server status to separate file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,11 +785,7 @@ jobs:
           command: mv /tmp/e2e/Build/Products/Debug-iphonesimulator/RNTester.app packages/rn-tester-e2e/apps/rn-tester.app
       - run:
           name: Check Appium server status
-          command: |
-            if ! nc -z 127.0.0.1 4723; then
-              echo Could not find Appium server!
-              exit 1
-            fi
+          command: scripts/circleci/check_appium_server_status.sh
       - run:
           name: Run E2E tests
           command: |

--- a/scripts/circleci/check_appium_server_status.sh
+++ b/scripts/circleci/check_appium_server_status.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This script checks if Appium server is running on default port (which is 4723).
+if ! nc -z 127.0.0.1 4723; then
+  echo Could not find Appium server.
+  exit 1
+fi


### PR DESCRIPTION
## Summary:
This PR is small cleanup in `.circleci/config.yml` file. Request here: https://github.com/facebook/react-native/pull/36267#discussion_r1272050735

## Changelog:
[INTERNAL] [CHANGED] - move script checking Appium server status to separate file 

## Test Plan:

CI Green ✅