### PR TITLE
feat: Resolve gradle files dynamically

### DIFF
--- a/packages/react-native/template/android/app/build.gradle
+++ b/packages/react-native/template/android/app/build.gradle
@@ -116,4 +116,8 @@ dependencies {
     }
 }
 
-apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: file('../utils.gradle')
+
+def nativeModulesPath = resolveJSModule('@react-native-community/cli-platform-android/native_modules.gradle')
+
+apply from: file(nativeModulesPath); applyNativeModulesAppBuildGradle(project)

--- a/packages/react-native/template/android/settings.gradle
+++ b/packages/react-native/template/android/settings.gradle
@@ -1,4 +1,11 @@
 rootProject.name = 'HelloWorld'
-apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+
+apply from: file('./utils.gradle')
+
+def nativeModulesPath = resolveJSModule('@react-native-community/cli-platform-android/native_modules.gradle')
+def gradlePluginPath = resolveJSModule('@react-native/gradle-plugin/package.json').replace('/package.json', '')
+
+apply from: file(nativeModulesPath); applyNativeModulesSettingsGradle(settings)
+
 include ':app'
-includeBuild('../node_modules/@react-native/gradle-plugin')
+includeBuild(gradlePluginPath)

--- a/packages/react-native/template/android/utils.gradle
+++ b/packages/react-native/template/android/utils.gradle
@@ -1,0 +1,5 @@
+ext.resolveJSModule = { String path ->
+  def js = "require.resolve('$path');"
+
+  return "node -p $js".execute().text.trim()
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Files inside `node_modules` aren't always present in exact locations specified in `gradle` configuration. Impacted projects:
- Projects using package managers like `pnpm`
- Might be the case for projects with non-standard directory structures

To fix this issue we can simply use Node mechanism to resolve modules (`require.resolve`).

This PR is blocking https://github.com/react-native-community/cli/pull/2036

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - Fixed file resolution in gradle configuration

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

1. Initialise a new project using this template
2. Build `android` project

