### PR TITLE
[Codegen 131]: add emitUnionProp to parser primitives

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -43,6 +43,7 @@ const {
   Visitor,
   emitStringProp,
   emitObjectProp,
+  emitUnionProp,
 } = require('../parsers-primitives.js');
 const {MockedParser} = require('../parserMock');
 const {emitUnion} = require('../parsers-primitives');
@@ -1769,6 +1770,74 @@ describe('emitObjectProp', () => {
             },
           ],
           type: 'ObjectTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitUnionProp', () => {
+  describe('when property is optional', () => {
+    it('returns optional type annotation with Flow parser', () => {
+      const typeAnnotation = {
+        types: [
+          {
+            value: 'someValue1',
+          },
+          {
+            value: 'someValue2',
+          },
+        ],
+      };
+      const result = emitUnionProp(
+        'someProp',
+        true,
+        flowParser,
+        typeAnnotation,
+      );
+      const expected = {
+        name: 'someProp',
+        optional: true,
+        typeAnnotation: {
+          type: 'StringEnumTypeAnnotation',
+          options: ['someValue1', 'someValue2'],
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when property is required', () => {
+    it('returns required type annotation with TypeScript parser', () => {
+      const typeAnnotation = {
+        types: [
+          {
+            literal: {
+              value: 'someValue1',
+            },
+          },
+          {
+            literal: {
+              value: 'someValue2',
+            },
+          },
+        ],
+      };
+      const result = emitUnionProp(
+        'someProp',
+        false,
+        typeScriptParser,
+        typeAnnotation,
+      );
+
+      const expected = {
+        name: 'someProp',
+        optional: false,
+        typeAnnotation: {
+          type: 'StringEnumTypeAnnotation',
+          options: ['someValue1', 'someValue2'],
         },
       };
 

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -34,6 +34,7 @@ const {
   emitStringProp,
   emitInt32Prop,
   emitObjectProp,
+  emitUnionProp,
 } = require('../../parsers-primitives');
 
 function getPropertyType(
@@ -73,16 +74,7 @@ function getPropertyType(
         extractArrayElementType,
       );
     case 'UnionTypeAnnotation':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'StringEnumTypeAnnotation',
-          options: typeAnnotation.types.map(option =>
-            parser.getLiteralValue(option),
-          ),
-        },
-      };
+      return emitUnionProp(name, optional, parser, typeAnnotation);
     case 'UnsafeMixed':
       return emitMixedProp(name, optional);
     case 'ArrayTypeAnnotation':

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -675,6 +675,24 @@ function emitObjectProp(
   };
 }
 
+function emitUnionProp(
+  name: string,
+  optional: boolean,
+  parser: Parser,
+  typeAnnotation: $FlowFixMe,
+): NamedShape<EventTypeAnnotation> {
+  return {
+    name,
+    optional,
+    typeAnnotation: {
+      type: 'StringEnumTypeAnnotation',
+      options: typeAnnotation.types.map(option =>
+        parser.getLiteralValue(option),
+      ),
+    },
+  };
+}
+
 module.exports = {
   emitArrayType,
   emitBoolean,
@@ -706,4 +724,5 @@ module.exports = {
   translateArrayTypeAnnotation,
   Visitor,
   emitObjectProp,
+  emitUnionProp,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -36,6 +36,7 @@ const {
   emitStringProp,
   emitInt32Prop,
   emitObjectProp,
+  emitUnionProp,
 } = require('../../parsers-primitives');
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
@@ -72,16 +73,7 @@ function getPropertyType(
         extractArrayElementType,
       );
     case 'TSUnionType':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'StringEnumTypeAnnotation',
-          options: typeAnnotation.types.map(option =>
-            parser.getLiteralValue(option),
-          ),
-        },
-      };
+      return emitUnionProp(name, optional, parser, typeAnnotation);
     case 'UnsafeMixed':
       return emitMixedProp(name, optional);
     case 'TSArrayType':


### PR DESCRIPTION
## Summary:

[Codegen 131] This PR add a function `emitUnionProp` to the parser-primitives, as requested on https://github.com/facebook/react-native/issues/34872

## Changelog:

[INTERNAL] [ADDED] - Add `emitUnionProp` function to parser-primitives

## Test Plan:

`yarn test react-native-codegen`
