### PR TITLE
delete RCT_EXPORT_PRE_REGISTERED_MODULE

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -94,19 +94,6 @@ RCT_EXTERN_C_END
     RCTRegisterModule([objc_name class]);                                       \
   }
 
-/**
- * To improve startup performance users may want to generate their module lists
- * at build time and hook the delegate to merge with the runtime list. This
- * macro takes the place of the above for those cases by omitting the +load
- * generation.
- *
- */
-#define RCT_EXPORT_PRE_REGISTERED_MODULE(js_name) \
-  +(NSString *)moduleName                         \
-  {                                               \
-    return @ #js_name;                            \
-  }
-
 // Implemented by RCT_EXPORT_MODULE
 + (NSString *)moduleName;
 


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

seemed like a confusing api, so getting rid of it

also did not see any libraries using this in GH: https://github.com/search?q=RCT_EXPORT_PRE_REGISTERED_MODULE&type=code, so can just delete this safely

Differential Revision: D47919116

