### PR TITLE
Fix concurrent consumers issue with ReactMarker

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -193,8 +193,8 @@ public class ReactMarker {
       nativeLogMarker(name.name(), now);
 
       // Then send all cached native ReactMarkers
-      while (!sNativeReactMarkerQueue.isEmpty()) {
-        ReactMarkerRecord record = sNativeReactMarkerQueue.poll();
+      ReactMarkerRecord record;
+      while ((record = sNativeReactMarkerQueue.poll()) != null) {
         nativeLogMarker(record.getMarkerName(), record.getMarkerTime());
       }
     } else {


### PR DESCRIPTION
Summary:
Fix a race condition when multiple consumers try to access ReactMarker and trigger calls to native module. Even though ReactMarker uses `ConcurrentLinkedQueue`, the loop itself could race and cause NPE.

Changelog:
[Android][Fixed] - Fix race condition with ReactMarker calls to its native module

Differential Revision: D47933993

