### PR TITLE
Bump template @types/react to 18.2.6

### DIFF
--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -21,7 +21,7 @@
     "@react-native/eslint-config": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",
     "@react-native/typescript-config": "^0.73.0",
-    "@types/react": "^18.0.24",
+    "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.2.1",
     "eslint": "^8.19.0",


### PR DESCRIPTION
Match the `react` dependency minor of `18.2` and specify a min version of `18.2.6`, which is the first version which includes `React.JSX` namespace. This enables usage of `React.JSX.Element`, now default as part of the template.

Note that `18.2.6` satisfied the previous semver, so new templates are already pulling in a version even newer than this, but updating projects may not do this automatically.

Changelog:
[General][Fixed] - Bump template @types/react to 18.2.6