### PR TITLE
Restore checking shadow tree commit cancellation after commit hook execution 

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -351,6 +351,11 @@ CommitStatus ShadowTree::tryCommit(
   newRootShadowNode = delegate_.shadowTreeWillCommit(
       *this, oldRootShadowNode, newRootShadowNode);
 
+  if (!newRootShadowNode ||
+      (commitOptions.shouldYield && commitOptions.shouldYield())) {
+    return CommitStatus::Cancelled;
+  }
+
   // Layout nodes.
   std::vector<LayoutableShadowNode const *> affectedLayoutableNodes{};
   affectedLayoutableNodes.reserve(1024);
@@ -373,11 +378,6 @@ CommitStatus ShadowTree::tryCommit(
     }
 
     auto newRevisionNumber = oldRevision.number + 1;
-
-    if (!newRootShadowNode ||
-        (commitOptions.shouldYield && commitOptions.shouldYield())) {
-      return CommitStatus::Cancelled;
-    }
 
     {
       std::lock_guard<std::mutex> dispatchLock(EventEmitter::DispatchMutex());

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -373,6 +373,10 @@ CommitStatus ShadowTree::tryCommit(
     // Updating `currentRevision_` in unique manner if it hasn't changed.
     std::unique_lock lock(commitMutex_);
 
+    if (commitOptions.shouldYield && commitOptions.shouldYield()) {
+      return CommitStatus::Cancelled;
+    }
+
     if (currentRevision_.number != oldRevision.number) {
       return CommitStatus::Failed;
     }


### PR DESCRIPTION
## Summary:

Hello! This PR is a fix for one merged some time ago (https://github.com/facebook/react-native/pull/36216). In the PR check for `nullptr` value of `newRootShadowNode` just after performing commit hooks was overlooked. This PR restores previous behaviour of conditional commit cancellation after commit hook execution.

## Changelog:

[INTERNAL] [FIXED] - Restore checking shadow tree commit cancellation after commit hook execution 

## Test Plan:

Just register a commit hook that return `nullptr`. In that case current code crashes due to `nullptr` dereference.
