### PR TITLE
Fix react_native_pods_utils copy step under Eden

### DIFF
--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -104,7 +104,7 @@ moveOutputs () {
     mkdir -p "$RCT_SCRIPT_OUTPUT_DIR"
 
     # Copy all output to output_dir
-    cp -R "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
+    cp -R -X "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
     echo "$LIBRARY_NAME output has been written to $RCT_SCRIPT_OUTPUT_DIR:" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
     ls -1 "$RCT_SCRIPT_OUTPUT_DIR" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
 }


### PR DESCRIPTION
Summary:
This removes a point of friction where the `moveOutputs` script step would fail to copy extended file attributes under [EdenFS](https://github.com/facebook/sapling/blob/29362eb4fd06b63a2184f5cce729c304c70b0582/eden/fs/docs/Overview.md).

Changelog: [Internal]

Reviewed By: dmytrorykun

Differential Revision: D47951246

