### PR TITLE
Add .cpplsp-buck-out to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ buck-out
 /packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/
 /packages/react-native/ReactAndroid/src/main/gen
 /.cpplsp.buckd
+/.cpplsp-buck-out
 
 # Android Studio
 .project


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

Add a buck-specific (on Windows) non-source file type to .gitignore.

Differential Revision: D47957053

