### PR TITLE
Return right edge in RTL Cell metrics

### DIFF
--- a/packages/virtualized-lists/Lists/ListMetricsAggregator.js
+++ b/packages/virtualized-lists/Lists/ListMetricsAggregator.js
@@ -256,8 +256,8 @@ export default class ListMetricsAggregator {
   }
 
   /**
-   * Converts a cartesian offset along the x or y axis to a flow-relative
-   * offset, (e.g. starting from the left in LTR, but right in RTL).
+   * Finds the flow-relative offset (e.g. starting from the left in LTR, but
+   * right in RTL) from a layout box.
    */
   flowRelativeOffset(layout: Layout, referenceContentLength?: ?number): number {
     const {horizontal, rtl} = this._orientation;
@@ -268,7 +268,10 @@ export default class ListMetricsAggregator {
         contentLength != null,
         'ListMetricsAggregator must be notified of list content layout before resolving offsets',
       );
-      return contentLength - this._selectOffset(layout);
+      return (
+        contentLength -
+        (this._selectOffset(layout) + this._selectLength(layout))
+      );
     } else {
       return this._selectOffset(layout);
     }


### PR DESCRIPTION
Summary:
Returned measurements from the measurements cache in RTL calculate offset as distance from the left edge of the cell to the right edge of the content, when it should instead be the distance from the right edge of the cell (the logical beginning).

Changelog:
[General][Fixed] - Return right edge in RTL cell metrics

Differential Revision: D47978631

