### PR TITLE
ListMetricAggregator UTs - cell measurement

### DIFF
--- a/packages/virtualized-lists/Lists/ListMetricsAggregator.js
+++ b/packages/virtualized-lists/Lists/ListMetricsAggregator.js
@@ -256,8 +256,8 @@ export default class ListMetricsAggregator {
   }
 
   /**
-   * Converts a cartesian offset along the x or y axis to a flow-relative
-   * offset, (e.g. starting from the left in LTR, but right in RTL).
+   * Finds the flow-relative offset (e.g. starting from the left in LTR, but
+   * right in RTL) from a layout box.
    */
   flowRelativeOffset(layout: Layout, referenceContentLength?: ?number): number {
     const {horizontal, rtl} = this._orientation;
@@ -268,7 +268,10 @@ export default class ListMetricsAggregator {
         contentLength != null,
         'ListMetricsAggregator must be notified of list content layout before resolving offsets',
       );
-      return contentLength - this._selectOffset(layout);
+      return (
+        contentLength -
+        (this._selectOffset(layout) + this._selectLength(layout))
+      );
     } else {
       return this._selectOffset(layout);
     }

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -276,8 +276,21 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
 
     scrollRef.scrollTo({
       animated,
-      ...this._cartesianScrollOffset(offset),
+      ...this._scrollToParamsFromOffset(offset),
     });
+  }
+
+  _scrollToParamsFromOffset(offset: number): {x?: number, y?: number} {
+    const {horizontal, rtl} = this._orientation();
+    if (horizontal && rtl) {
+      // Add the visible length of the scrollview so that the offset is right-aligned
+      const cartOffset = this._listMetrics.cartesianOffset(
+        offset + this._scrollMetrics.visibleLength,
+      );
+      return horizontal ? {x: cartOffset} : {y: cartOffset};
+    } else {
+      return horizontal ? {x: offset} : {y: offset};
+    }
   }
 
   recordInteraction() {
@@ -1480,39 +1493,6 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       : metrics.width;
   }
 
-  _flowRelativeScrollOffset(
-    metrics: $ReadOnly<{
-      x: number,
-      y: number,
-      ...
-    }>,
-    contentSize: $ReadOnly<{
-      width: number,
-      height: number,
-      ...
-    }>,
-  ): number {
-    let offset = this._selectOffset(metrics);
-
-    const {horizontal, rtl} = this._orientation();
-    if (horizontal && rtl && Platform.OS !== 'ios') {
-      offset = this._selectLength(contentSize) - offset;
-    }
-
-    return offset;
-  }
-
-  _cartesianScrollOffset(offset: number): {x?: number, y?: number} {
-    const {horizontal, rtl} = this._orientation();
-    const normalizedOffset =
-      horizontal && rtl && Platform.OS !== 'ios'
-        ? this._listMetrics.getContentLength() - offset
-        : offset;
-
-    const cartOffset = this._listMetrics.cartesianOffset(normalizedOffset);
-    return horizontal ? {x: cartOffset} : {y: cartOffset};
-  }
-
   _selectOffset({x, y}: $ReadOnly<{x: number, y: number, ...}>): number {
     return this._orientation().horizontal ? x : y;
   }
@@ -1688,7 +1668,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     const timestamp = e.timeStamp;
     let visibleLength = this._selectLength(e.nativeEvent.layoutMeasurement);
     let contentLength = this._selectLength(e.nativeEvent.contentSize);
-    let offset = this._flowRelativeScrollOffset(
+    let offset = this._offsetFromScrollEvent(
       e.nativeEvent.contentOffset,
       e.nativeEvent.contentSize,
     );
@@ -1754,6 +1734,26 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     this._computeBlankness();
     this._scheduleCellsToRenderUpdate();
   };
+
+  _offsetFromScrollEvent(
+    contentOffset: $ReadOnly<{
+      x: number,
+      y: number,
+      ...
+    }>,
+    contentSize: $ReadOnly<{
+      width: number,
+      height: number,
+      ...
+    }>,
+  ): number {
+    const {horizontal, rtl} = this._orientation();
+    if (Platform.OS === 'ios' || !(horizontal && rtl)) {
+      return this._selectOffset(contentOffset);
+    }
+
+    return this._selectLength(contentSize) - this._selectOffset(contentOffset);
+  }
 
   _scheduleCellsToRenderUpdate(opts?: {allowImmediateExecution?: boolean}) {
     const allowImmediateExecution = opts?.allowImmediateExecution ?? true;

--- a/packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {CellMetricProps} from '../ListMetricsAggregator';
+
+import ListMetricsAggregator from '../ListMetricsAggregator';
+
+import nullthrows from 'nullthrows';
+
+describe('ListMetricsAggregator', () => {
+  it('keeps a running average length of measured cells', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: false};
+
+    expect(listMetrics.getAverageCellLength()).toEqual(0);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+    expect(listMetrics.getAverageCellLength()).toEqual(10);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+    expect(listMetrics.getAverageCellLength()).toEqual(15);
+  });
+
+  it('adjusts the average cell length when layout changes', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: false};
+
+    expect(listMetrics.getAverageCellLength()).toEqual(0);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+    expect(listMetrics.getAverageCellLength()).toEqual(10);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+    expect(listMetrics.getAverageCellLength()).toEqual(15);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+    expect(listMetrics.getAverageCellLength()).toEqual(20);
+  });
+
+  it('keeps track of the highest measured cell index', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: false};
+
+    expect(listMetrics.getHighestMeasuredCellIndex()).toEqual(0);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+    expect(listMetrics.getHighestMeasuredCellIndex()).toEqual(0);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+    expect(listMetrics.getHighestMeasuredCellIndex()).toEqual(1);
+  });
+});

--- a/packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js
@@ -126,4 +126,590 @@ describe('ListMetricsAggregator', () => {
     });
     expect(listMetrics.getHighestMeasuredCellIndex()).toEqual(1);
   });
+
+  it('resets measurements if list orientation changes', () => {
+    const listMetrics = new ListMetricsAggregator();
+    expect(listMetrics.getAverageCellLength()).toEqual(0);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation: {horizontal: false, rtl: false},
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+    expect(listMetrics.getAverageCellLength()).toEqual(10);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation: {horizontal: true, rtl: false},
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+    expect(listMetrics.getAverageCellLength()).toEqual(5);
+  });
+
+  it('resolves metrics of already measured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: false};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(1, props)).toEqual({
+      index: 1,
+      length: 20,
+      offset: 10,
+      isMounted: true,
+    });
+    expect(listMetrics.getCellMetricsApprox(1, props)).toEqual({
+      index: 1,
+      length: 20,
+      offset: 10,
+      isMounted: true,
+    });
+  });
+
+  it('estimates metrics of unmeasured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: false};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(2, props)).toBeNull();
+    expect(listMetrics.getCellMetricsApprox(2, props)).toEqual({
+      index: 2,
+      length: 15,
+      offset: 30,
+      isMounted: false,
+    });
+  });
+
+  it('uses getItemLayout for metrics of unmeasured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: false};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+      getItemLayout: () => ({index: 2, length: 40, offset: 30}),
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(2, props)).toMatchObject({
+      index: 2,
+      length: 40,
+      offset: 30,
+    });
+    expect(listMetrics.getCellMetricsApprox(2, props)).toMatchObject({
+      index: 2,
+      length: 40,
+      offset: 30,
+    });
+  });
+
+  it('resolves horizontal metrics of already measured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: true, rtl: false};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 5,
+        width: 10,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 5,
+        width: 20,
+        x: 10,
+        y: 0,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(1, props)).toEqual({
+      index: 1,
+      length: 20,
+      offset: 10,
+      isMounted: true,
+    });
+    expect(listMetrics.getCellMetricsApprox(1, props)).toEqual({
+      index: 1,
+      length: 20,
+      offset: 10,
+      isMounted: true,
+    });
+  });
+
+  it('estimates horizontal metrics of unmeasured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: true, rtl: false};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 5,
+        width: 10,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 5,
+        width: 20,
+        x: 10,
+        y: 0,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(2, props)).toBeNull();
+    expect(listMetrics.getCellMetricsApprox(2, props)).toEqual({
+      index: 2,
+      length: 15,
+      offset: 30,
+      isMounted: false,
+    });
+  });
+
+  it('uses getItemLayout for horizontal metrics of unmeasured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: true, rtl: false};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+      getItemLayout: () => ({index: 2, length: 40, offset: 30}),
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 5,
+        width: 10,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 5,
+        width: 20,
+        x: 10,
+        y: 0,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(2, props)).toMatchObject({
+      index: 2,
+      length: 40,
+      offset: 30,
+    });
+    expect(listMetrics.getCellMetricsApprox(2, props)).toMatchObject({
+      index: 2,
+      length: 40,
+      offset: 30,
+    });
+  });
+
+  it('resolves RTL metrics of already measured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: true, rtl: true};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 5,
+        width: 10,
+        x: 90,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 5,
+        width: 20,
+        x: 70,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyListContentLayout({
+      layout: {width: 100, height: 5},
+      orientation,
+    });
+
+    expect(listMetrics.getCellMetrics(1, props)).toEqual({
+      index: 1,
+      length: 20,
+      offset: 10,
+      isMounted: true,
+    });
+    expect(listMetrics.getCellMetricsApprox(1, props)).toEqual({
+      index: 1,
+      length: 20,
+      offset: 10,
+      isMounted: true,
+    });
+  });
+
+  it('estimates RTL metrics of unmeasured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: true, rtl: false};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 5,
+        width: 10,
+        x: 90,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 5,
+        width: 20,
+        x: 70,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyListContentLayout({
+      layout: {width: 100, height: 5},
+      orientation,
+    });
+
+    expect(listMetrics.getCellMetrics(2, props)).toBeNull();
+    expect(listMetrics.getCellMetricsApprox(2, props)).toEqual({
+      index: 2,
+      length: 15,
+      offset: 30,
+      isMounted: false,
+    });
+  });
+
+  it('uses getItemLayout for RTL metrics of unmeasured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: true, rtl: false};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+      getItemLayout: () => ({index: 2, length: 40, offset: 30}),
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 5,
+        width: 10,
+        x: 90,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 5,
+        width: 20,
+        x: 70,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyListContentLayout({
+      layout: {width: 100, height: 5},
+      orientation,
+    });
+
+    expect(listMetrics.getCellMetrics(2, props)).toMatchObject({
+      index: 2,
+      length: 40,
+      offset: 30,
+    });
+    expect(listMetrics.getCellMetricsApprox(2, props)).toMatchObject({
+      index: 2,
+      length: 40,
+      offset: 30,
+    });
+  });
+
+  it('resolves vertical rtl metrics of already measured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: true};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(1, props)).toEqual({
+      index: 1,
+      length: 20,
+      offset: 10,
+      isMounted: true,
+    });
+    expect(listMetrics.getCellMetricsApprox(1, props)).toEqual({
+      index: 1,
+      length: 20,
+      offset: 10,
+      isMounted: true,
+    });
+  });
+
+  it('estimates vertical RTL metrics of unmeasured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: true};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(2, props)).toBeNull();
+    expect(listMetrics.getCellMetricsApprox(2, props)).toEqual({
+      index: 2,
+      length: 15,
+      offset: 30,
+      isMounted: false,
+    });
+  });
+
+  it('uses getItemLayout for vertical RTL metrics of unmeasured cell', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const orientation = {horizontal: false, rtl: true};
+    const props: CellMetricProps = {
+      data: [1, 2, 3, 4, 5],
+      getItemCount: () => nullthrows(props.data).length,
+      getItem: (i: number) => nullthrows(props.data)[i],
+      getItemLayout: () => ({index: 2, length: 40, offset: 30}),
+    };
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation,
+      layout: {
+        height: 10,
+        width: 5,
+        x: 0,
+        y: 0,
+      },
+    });
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 1,
+      cellKey: '1',
+      orientation,
+      layout: {
+        height: 20,
+        width: 5,
+        x: 0,
+        y: 10,
+      },
+    });
+
+    expect(listMetrics.getCellMetrics(2, props)).toMatchObject({
+      index: 2,
+      length: 40,
+      offset: 30,
+    });
+    expect(listMetrics.getCellMetricsApprox(2, props)).toMatchObject({
+      index: 2,
+      length: 40,
+      offset: 30,
+    });
+  });
 });


### PR DESCRIPTION
Summary:
UTs around cell measurement results through `getCellMetrics` and `getCellMetricsApprox`. For each orientation, validate basic scenarios for approximation, cached measurement, or measurement by user-provided `getItemLayout`.

Changelog: [Internal]

Differential Revision: D47978630

