### PR TITLE
FlatList example fixes

### DIFF
--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -248,7 +248,9 @@ class FlatListExample extends React.PureComponent<Props, State> {
           <SeparatorComponent />
           <Animated.FlatList
             fadingEdgeLength={this.state.fadingEdgeLength}
-            ItemSeparatorComponent={ItemSeparatorComponent}
+            ItemSeparatorComponent={
+              this.state.horizontal ? null : ItemSeparatorComponent
+            }
             ListHeaderComponent={
               this.state.previousLoading ? LoadingComponent : HeaderComponent
             }
@@ -280,6 +282,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
             onScroll={
               this.state.horizontal ? this._scrollSinkX : this._scrollSinkY
             }
+            onScrollToIndexFailed={this._onScrollToIndexFailed}
             onViewableItemsChanged={this._onViewableItemsChanged}
             ref={this._captureRef}
             refreshing={false}
@@ -369,6 +372,19 @@ class FlatListExample extends React.PureComponent<Props, State> {
         }
       : {renderItem: renderProp};
   };
+
+  _onScrollToIndexFailed = ({
+    index,
+    highestMeasuredFrameIndex,
+  }: {
+    index: number,
+    highestMeasuredFrameIndex: number,
+  }) => {
+    console.warn(
+      `failed to scroll to index: ${index} (measured up to ${highestMeasuredFrameIndex})`,
+    );
+  };
+
   // This is called when items change viewability by scrolling into or out of
   // the viewable area.
   _onViewableItemsChanged = (info: {


### PR DESCRIPTION
Summary:
1. The separator here adds horizontal width, except when the cell is tapped. This is meant to be a visual effect for vertical FlatList, but makes `getItemLayout` incorrect and results in odd layout shifts. Do not use when horizontal.
2. Disabling "fixed height" leads to a barrage of errors because the example sets `initialScrollIndex` but does not set an `onScrollToIndexFailed` prop.

Changelog: [Internal]

Differential Revision: D47978628

