### PR TITLE
Add `experimental_layoutConformance` prop

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -98,6 +98,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           focusable: true,
           overflow: true,
           backfaceVisibility: true,
+          experimental_layoutConformance: true,
         },
       }
     : {

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -569,6 +569,15 @@ export type ViewProps = $ReadOnly<{|
   collapsable?: ?boolean,
 
   /**
+   * Contols whether this view, and its transitive children, are laid in a way
+   * consistent with web browsers ('strict'), or consistent with existing
+   * React Native code which may rely on incorrect behavior ('classic').
+   *
+   * This prop only works when using Fabric.
+   */
+  experimental_layoutConformance?: ?('strict' | 'classic'),
+
+  /**
    * Used to locate this view from native classes. Has precedence over `nativeID` prop.
    *
    * > This disables the 'layout-only view removal' optimization for this view!

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -273,6 +273,8 @@ const validAttributesForNonEventProps = {
   position: true,
 
   style: ReactNativeStyleAttributes,
+
+  experimental_layoutConformance: true,
 };
 
 // Props for bubbling and direct events

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -335,6 +335,8 @@ const validAttributesForNonEventProps = {
   direction: true,
 
   style: ReactNativeStyleAttributes,
+
+  experimental_layoutConformance: true,
 };
 
 // Props for bubbling and direct events

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -398,6 +398,13 @@ RCT_CUSTOM_VIEW_PROPERTY(collapsable, BOOL, RCTView)
   // filtered by view configs.
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(experimental_layoutConformance, NSString *, RCTView)
+{
+  // Property is only to be used in the new renderer.
+  // It is necessary to add it here, otherwise it gets
+  // filtered by view configs.
+}
+
 #define RCT_VIEW_BORDER_PROPERTY(SIDE)                                                               \
   RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Width, float, RCTView)                                      \
   {                                                                                                  \

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -151,6 +151,12 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     view.setBorderStyle(borderStyle);
   }
 
+  // This is unused by the view manager, and not wired to be sent to Java, but
+  // must be present for the prop to show up in the view config.
+  @ReactProp(name = "experimental_layoutConformance")
+  public void setexperimental_layoutConformance(
+      ReactViewGroup view, @Nullable String layoutConformance) {}
+
   @ReactProp(name = "hitSlop")
   public void setHitSlop(final ReactViewGroup view, Dynamic hitSlop) {
     switch (hitSlop.getType()) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -190,7 +190,16 @@ BaseViewProps::BaseViewProps(
                     rawProps,
                     "removeClippedSubviews",
                     sourceProps.removeClippedSubviews,
-                    false)) {}
+                    false)),
+      experimental_layoutConformance(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.experimental_layoutConformance
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "experimental_layoutConformance",
+                    sourceProps.experimental_layoutConformance,
+                    {})) {}
 
 #define VIEW_EVENT_CASE(eventType)                      \
   case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): { \
@@ -233,6 +242,7 @@ void BaseViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(onLayout);
     RAW_SET_PROP_SWITCH_CASE_BASIC(collapsable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(removeClippedSubviews);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(experimental_layoutConformance);
     // events field
     VIEW_EVENT_CASE(PointerEnter);
     VIEW_EVENT_CASE(PointerEnterCapture);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -70,6 +70,8 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
   bool removeClippedSubviews{false};
 
+  LayoutConformance experimental_layoutConformance{};
+
   Float elevation{}; /* Android-only */
 
 #pragma mark - Convenience Methods

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -132,6 +132,27 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    */
   void adoptYogaChild(size_t index);
 
+  /**
+   * Applies contextual values to the ShadowNode's Yoga tree after the
+   * ShadowTree has been constructed, but before it has been is laid out or
+   * commited.
+   */
+  void configureYogaTree(
+      float pointScaleFactor,
+      YGErrata defaultErrata,
+      bool swapLeftAndRight);
+
+  /**
+   * Return an errata based on a `layoutConformance` prop if given, otherwise
+   * the passed default
+   */
+  YGErrata resolveErrata(YGErrata defaultErrata) const;
+
+  /**
+   * Replcaes a child with a mutable clone of itself, returning the clone.
+   */
+  YogaLayoutableShadowNode &cloneChildInPlace(size_t layoutableChildIndex);
+
   static YGConfig &initializeYogaConfig(
       YGConfig &config,
       YGConfigRef previousConfig = nullptr);
@@ -150,7 +171,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
 #pragma mark - RTL Legacy Autoflip
 
   /*
-   * Walks though shadow node hierarchy and reassign following values:
+   * Reassigns the following values:
    * - (left|right) → (start|end)
    * - margin(Left|Right) → margin(Start|End)
    * - padding(Left|Right) → padding(Start|End)
@@ -161,8 +182,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    * This is neccesarry to be backwards compatible with old renderer, it swaps
    * the values as well in https://fburl.com/diffusion/kl7bjr3h
    */
-  static void swapLeftAndRightInTree(
-      YogaLayoutableShadowNode const &shadowNode);
+  void swapStyleLeftAndRight();
   /*
    * In shadow node passed as argument, reassigns following values
    * - borderTop(Left|Right)Radius → borderTop(Start|End)Radius

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -660,6 +660,28 @@ inline void fromRawValue(
   react_native_expect(false);
 }
 
+inline void fromRawValue(
+    const PropsParserContext & /*context*/,
+    const RawValue &value,
+    LayoutConformance &result) {
+  result = LayoutConformance::Classic;
+  react_native_expect(value.hasType<std::string>());
+  if (!value.hasType<std::string>()) {
+    return;
+  }
+  auto stringValue = (std::string)value;
+  if (stringValue == "classic") {
+    result = LayoutConformance::Classic;
+    return;
+  }
+  if (stringValue == "strict") {
+    result = LayoutConformance::Strict;
+    return;
+  }
+  LOG(ERROR) << "Could not parse LayoutConformance:" << stringValue;
+  react_native_expect(false);
+}
+
 inline std::string toString(
     const std::array<float, yoga::enums::count<YGDimension>()> &dimensions) {
   return "{" + folly::to<std::string>(dimensions[0]) + ", " +
@@ -836,6 +858,17 @@ inline std::string toString(const YGStyle::Edges &value) {
   }
 
   return "{" + result + "}";
+}
+
+inline std::string toString(const LayoutConformance &value) {
+  switch (value) {
+    case LayoutConformance::Undefined:
+      return "undefined";
+    case LayoutConformance::Classic:
+      return "classic";
+    case LayoutConformance::Strict:
+      return "strict";
+  }
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -87,6 +87,8 @@ enum class BorderCurve : uint8_t { Circular, Continuous };
 
 enum class BorderStyle : uint8_t { Solid, Dotted, Dashed };
 
+enum class LayoutConformance : uint8_t { Undefined, Classic, Strict };
+
 template <typename T>
 struct CascadedRectangleEdges {
   using Counterpart = RectangleEdges<T>;

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -31,6 +31,10 @@ struct LayoutMetrics {
   DisplayType displayType{DisplayType::Flex};
   // See `LayoutDirection` for all possible options.
   LayoutDirection layoutDirection{LayoutDirection::Undefined};
+  // Whether React Native treated cardinal directions as flow-relative
+  // directions due to being laid out in RTL with `doLeftAndRightSwapInRTL`
+  // enabled.
+  bool wasLeftAndRightSwapped{false};
   // Pixel density. Number of device pixels per density-independent pixel.
   Float pointScaleFactor{1.0};
   // How much the children of the node actually overflow in each direction.

--- a/packages/react-native/types/experimental.d.ts
+++ b/packages/react-native/types/experimental.d.ts
@@ -133,4 +133,13 @@ declare module '.' {
      */
     paddingInlineStart?: DimensionValue | undefined;
   }
+
+  export interface ViewProps {
+    /**
+     * Contols whether this view, and its transitive children, are laid in a way
+     * consistent with web browsers ('strict'), or consistent with existing
+     * React Native code which may rely on incorrect behavior ('classic').
+     */
+    experimental_layoutConformance?: 'strict' | 'classic' | undefined;
+  }
 }

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -342,6 +342,51 @@ class FlexGapExample extends React.Component<$ReadOnly<{|testID?: ?string|}>> {
   }
 }
 
+function LayoutConformanceExample(): React.Node {
+  return (
+    <View style={{flexDirection: 'row', gap: 10}}>
+      <View>
+        <Text>Unset</Text>
+        <LayoutConformanceBox />
+      </View>
+      <View experimental_layoutConformance="classic">
+        <Text>Classic</Text>
+        <LayoutConformanceBox />
+      </View>
+      <View experimental_layoutConformance="strict">
+        <Text>Strict</Text>
+        <LayoutConformanceBox />
+      </View>
+    </View>
+  );
+}
+
+function LayoutConformanceBox(): React.Node {
+  return (
+    <View
+      style={{
+        backgroundColor: 'blue',
+        width: 100,
+        height: 100,
+        flexDirection: 'row',
+        alignItems: 'center',
+      }}>
+      <View
+        style={{
+          flexDirection: 'row',
+        }}>
+        <View
+          style={{
+            height: 50,
+            backgroundColor: 'red',
+            flexGrow: 1,
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
 export default ({
   title: 'View',
   documentationURL: 'https://reactnative.dev/docs/view',
@@ -846,6 +891,11 @@ export default ({
           </View>
         );
       },
+    },
+    {
+      title: 'Layout conformance',
+      name: 'layout-conformance',
+      render: LayoutConformanceExample,
     },
   ],
 }: RNTesterModule);


### PR DESCRIPTION
Summary:
This adds a view prop which controls the layout conformance of it and its transitive children (including non-view ShadowNodes).

The implementation here is to traverse down before layout, updating any context-specific configuration. Normally at the time of layout, some child ShadowNodes are already sealed. These were previously cloned via Yoga node clone callback, when Yoga layout observes a Yoga node owned by the previous ShadowNode. We replicate this cloning during this down-propagation step, and remove the clone callback.

This gives us a hook to more generically mutate the final Yoga tree, after the ShadowTree is constructed, but before layout.

`Errata` and `PointScaleFactor` (DPI) are threaded to each Node's per-node config. The same values are retained when Yoga nodes are cloned (by cloning the ShadowNode). Since these are set before the first layout, config setting should only ever dirty layout [when layout-effecting values change](https://www.internalfb.com/code/fbsource/[1c95e981c740]/xplat/yoga/yoga/YGConfig.cpp?lines=13). But we do need to traverse every layoutable ShadowNode nodes before each layout pass. But we were already traversing many for cloning, and layout itself is likely to be more expensive.

The prop is prefixed with `experimental` because we are likely to make more breaking conformance fixes in the strict mode, and I'm not sure this is the final API yet. I was previously looking at a context-like component which is more challenging to implement.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D47940100

