### PR TITLE
Revert D47915065

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
@@ -128,8 +128,7 @@ public class ReactSurface implements ReactSurfaceInterface {
     mReactHost.set(null);
   }
 
-  /** package */
-  SurfaceHandler getSurfaceHandler() {
+  public SurfaceHandler getSurfaceHandler() {
     return mSurfaceHandler;
   }
 


### PR DESCRIPTION
Summary: In order to expose getSurfaceHandler() from an interface ReactSurface we need this to be public.

Differential Revision: D48003816

