### PR TITLE
Update facebook::react::kNumberOfPropsPerComponentSoftCap

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
@@ -40,7 +40,7 @@ constexpr static RawPropsValueIndex kRawPropsValueIndexEmpty =
  * about twenty. It's okay if some `*Props` class has more than this amount of
  * props but the majority of those classes should be below this cap.
  */
-constexpr static auto kNumberOfPropsPerComponentSoftCap = 150;
+constexpr static auto kNumberOfPropsPerComponentSoftCap = 250;
 
 /*
  * The maximum length of the prop name.


### PR DESCRIPTION
Summary:
`butter::small_vector` is backed by a `folly:small_vector` on non-Android platforms in release mode.

It uses the small vector optimization, keeping a fixed size buffer, then falling back to heap allocation.

When I was debugging through props parsing code to figure out a prop not getting passed to Fabric (was being filtered in ViewConfig), I noticed this vector is filled with 199 elements for ViewProps. So It always overflows the current capacity and falls back to heap allocation. This bumps the capacity basde on what I observed with some more headroom.

Changelog:
[Internal]

Reviewed By: sammy-SC

Differential Revision: D47981105

