### PR TITLE
Ensure consistent usage of the RN_DEBUG_STRING_CONVERTIBLE flag in C++

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -81,7 +81,7 @@ struct LayoutMetrics {
 static LayoutMetrics const EmptyLayoutMetrics = {
     /* .frame = */ {{0, 0}, {-1.0, -1.0}}};
 
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
 
 std::string getDebugName(LayoutMetrics const &object);
 std::vector<DebugStringConvertibleObject> getDebugProps(

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -81,6 +81,7 @@ class DebugStringConvertible {
 
 #else
 
+struct DebugStringConvertibleOptions {};
 class DebugStringConvertible {};
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/debug/flags.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/flags.h
@@ -36,6 +36,10 @@
 #define RN_DEBUG_STRING_CONVERTIBLE 1
 #endif
 
+#ifndef RN_DEBUG_STRING_CONVERTIBLE
+#define RN_DEBUG_STRING_CONVERTIBLE 0
+#endif
+
 // Enables *very* verbose, noisy logs in the differ. Useful for debugging
 // specifically the differ, but not much else.
 //#define DEBUG_LOGS_DIFFER

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
@@ -14,7 +14,7 @@
 
 namespace facebook::react {
 
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
 void Transform::print(Transform const &t, std::string prefix) {
   LOG(ERROR) << prefix << "[ " << t.matrix[0] << " " << t.matrix[1] << " "
              << t.matrix[2] << " " << t.matrix[3] << " ]";

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -62,7 +62,7 @@ struct Transform {
   /**
    * For debugging only. Prints out the matrix.
    */
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
   static void print(Transform const &t, std::string prefix);
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.cpp
@@ -55,7 +55,7 @@ bool ShadowView::operator!=(const ShadowView &rhs) const {
   return !(*this == rhs);
 }
 
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
 
 std::string getDebugName(ShadowView const &object) {
   return object.componentHandle == 0 ? "Invalid" : object.componentName;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.cpp
@@ -75,7 +75,7 @@ void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
               << std::hash<ShadowView>{}((ShadowView)*stubView)
               << " old mutation hash: ##"
               << std::hash<ShadowView>{}(mutation.oldChildShadowView);
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
           LOG(ERROR) << "StubView: "
                      << getDebugPropsDescription((ShadowView)*stubView, {});
           LOG(ERROR) << "OldChildShadowView: "
@@ -161,7 +161,7 @@ void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
                 << std::hash<ShadowView>{}((ShadowView)*childStubView)
                 << " old mutation hash: ##"
                 << std::hash<ShadowView>{}(mutation.oldChildShadowView);
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
             LOG(ERROR) << "ChildStubView: "
                        << getDebugPropsDescription(
                               (ShadowView)*childStubView, {});
@@ -228,7 +228,7 @@ void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
               << std::hash<ShadowView>{}((ShadowView)*oldStubView)
               << " old mutation hash: ##"
               << std::hash<ShadowView>{}(mutation.oldChildShadowView);
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
           LOG(ERROR) << "OldStubView: "
                      << getDebugPropsDescription((ShadowView)*oldStubView, {});
           LOG(ERROR) << "OldChildShadowView: "

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
@@ -148,7 +148,7 @@ static void testShadowNodeTreeLifeCycle(
 
         // There are some issues getting `getDebugDescription` to compile
         // under test on Android for now.
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
         LOG(ERROR) << "Shadow Tree before: \n"
                    << currentRootNode->getDebugDescription();
         LOG(ERROR) << "Shadow Tree after: \n"
@@ -300,7 +300,7 @@ static void testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
 
         // There are some issues getting `getDebugDescription` to compile
         // under test on Android for now.
-#ifdef RN_DEBUG_STRING_CONVERTIBLE
+#if RN_DEBUG_STRING_CONVERTIBLE
         LOG(ERROR) << "Shadow Tree before: \n"
                    << currentRootNode->getDebugDescription();
         LOG(ERROR) << "Shadow Tree after: \n"


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

The `RN_DEBUG_STRING_CONVERTIBLE` was interchangeably used via both `#if` and `#ifdef` (the latter being incorrect), which led to both inconsistency, or even the code plain not compiling it `RN_DEBUG_STRING_CONVERTIBLE=0` explicitly.

Furthermore there was no guarantee it's defined, which can generate warnings with `-Wundef`/`-Wall` (or even errors with `-Werror` on top of that).

This fixes all the usages to be uniform and makes sure the flag is defined when it's used to prevent compiler warnings.

Differential Revision: D48021565

