### PR TITLE
Fix compilation warnings related to YogaShadowNode

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -251,7 +251,7 @@ void YogaLayoutableShadowNode::appendChild(
 void YogaLayoutableShadowNode::replaceChild(
     ShadowNode const &oldChild,
     ShadowNode::Shared const &newChild,
-    size_t suggestedIndex) {
+    int32_t suggestedIndex) {
   LayoutableShadowNode::replaceChild(oldChild, newChild, suggestedIndex);
 
   ensureUnsealed();

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -55,7 +55,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   void replaceChild(
       ShadowNode const &oldChild,
       ShadowNode::Shared const &newChild,
-      size_t suggestedIndex = -1) override;
+      int32_t suggestedIndex = -1) override;
 
   void updateYogaChildren();
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -105,6 +105,7 @@ void YogaStylableProps::setProp(
     const char *propName,
     RawValue const &value) {
   static const auto ygDefaults = YGStyle{};
+  static const auto defaults = YogaStylableProps{};
 
   Props::setProp(context, hash, propName, value);
 
@@ -132,8 +133,6 @@ void YogaStylableProps::setProp(
     REBUILD_FIELD_YG_EDGES(margin, "margin", "");
     REBUILD_FIELD_YG_EDGES(padding, "padding", "");
     REBUILD_FIELD_YG_EDGES(border, "border", "Width");
-
-    static const auto defaults = YogaStylableProps{};
 
     // Aliases
     RAW_SET_PROP_SWITCH_CASE(inset, "inset");

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -236,7 +236,7 @@ void ShadowNode::appendChild(const ShadowNode::Shared &child) {
 void ShadowNode::replaceChild(
     ShadowNode const &oldChild,
     ShadowNode::Shared const &newChild,
-    size_t suggestedIndex) {
+    int32_t suggestedIndex) {
   ensureUnsealed();
 
   cloneChildrenIfShared();

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -168,7 +168,7 @@ class ShadowNode : public Sealable,
   virtual void replaceChild(
       ShadowNode const &oldChild,
       Shared const &newChild,
-      size_t suggestedIndex = -1);
+      int32_t suggestedIndex = -1);
 
   /*
    * Performs all side effects associated with mounting/unmounting in one place.


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

These pop up when compiling with `/Wall`, fixes two legitimate warnings around using YogaShadowNode/Props in RN.

The `suggestedIndex` in `ShadowNode::replaceChild` (and the overriden one in `YogaLayoutableShadowNode`) is used in a way around the code that suggests that it **is** expected to be negative (checking for non-negativity, assigning -1 as default etc), so having it as a `size_t` type argument both makes things confusing and generates the warning.

I believe it's a good idea to be consistent and use the same type for the index throughout. In majority of the cases it's `int32_t` as of now.

Differential Revision: D48059620

