### PR TITLE
fix[AppContainer]: mount react devtools overlay only when devtools are attached

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppContainer.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer.js
@@ -17,6 +17,8 @@ import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import {RootTagContext, createRootTag} from './RootTag';
 import * as React from 'react';
 
+const reactDevToolsHook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+
 type Props = $ReadOnly<{|
   children?: React.Node,
   fabric?: boolean,
@@ -47,8 +49,20 @@ class AppContainer extends React.Component<Props, State> {
   };
   _mainRef: ?React.ElementRef<typeof View>;
   _subscription: ?EventSubscription = null;
+  _reactDevToolsAgentListener: ?() => void = null;
 
   static getDerivedStateFromError: any = undefined;
+
+  mountReactDevToolsOverlays(): void {
+    const DevtoolsOverlay = require('../Inspector/DevtoolsOverlay').default;
+    const devtoolsOverlay = <DevtoolsOverlay inspectedView={this._mainRef} />;
+
+    const TraceUpdateOverlay =
+      require('../Components/TraceUpdateOverlay/TraceUpdateOverlay').default;
+    const traceUpdateOverlay = <TraceUpdateOverlay />;
+
+    this.setState({devtoolsOverlay, traceUpdateOverlay});
+  }
 
   componentDidMount(): void {
     if (__DEV__) {
@@ -71,16 +85,21 @@ class AppContainer extends React.Component<Props, State> {
             this.setState({inspector});
           },
         );
-        if (window.__REACT_DEVTOOLS_GLOBAL_HOOK__ != null) {
-          const DevtoolsOverlay =
-            require('../Inspector/DevtoolsOverlay').default;
-          const devtoolsOverlay = (
-            <DevtoolsOverlay inspectedView={this._mainRef} />
+
+        if (reactDevToolsHook != null) {
+          if (reactDevToolsHook.reactDevtoolsAgent) {
+            // In case if this is not the first AppContainer rendered and React DevTools are already attached
+            this.mountReactDevToolsOverlays();
+            return;
+          }
+
+          this._reactDevToolsAgentListener = () =>
+            this.mountReactDevToolsOverlays();
+
+          reactDevToolsHook.on(
+            'react-devtools',
+            this._reactDevToolsAgentListener,
           );
-          const TraceUpdateOverlay =
-            require('../Components/TraceUpdateOverlay/TraceUpdateOverlay').default;
-          const traceUpdateOverlay = <TraceUpdateOverlay />;
-          this.setState({devtoolsOverlay, traceUpdateOverlay});
         }
       }
     }
@@ -89,6 +108,10 @@ class AppContainer extends React.Component<Props, State> {
   componentWillUnmount(): void {
     if (this._subscription != null) {
       this._subscription.remove();
+    }
+
+    if (reactDevToolsHook != null && this._reactDevToolsAgentListener != null) {
+      reactDevToolsHook.off('react-devtools', this._reactDevToolsAgentListener);
     }
   }
 


### PR DESCRIPTION
Cherry-picking https://github.com/facebook/react-native/pull/38727 into 0.72