### PR TITLE
Remove systrace from recursive function

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -1037,7 +1037,6 @@ static void calculateShadowViewMutationsV2(
     ShadowViewNodePair::NonOwningList &&oldChildPairs,
     ShadowViewNodePair::NonOwningList &&newChildPairs,
     bool isRecursionRedundant) {
-  SystraceSection s("Differentiator::calculateShadowViewMutationsV2");
   if (oldChildPairs.empty() && newChildPairs.empty()) {
     return;
   }


### PR DESCRIPTION
Summary:
changelog: [internal]

Remove systrace from recursive function. This causes visual noise in perf tooling.

Reviewed By: rshest

Differential Revision: D48066562

