### PR TITLE
Enable Kotlin for RN Tester

### DIFF
--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -8,6 +8,7 @@
 plugins {
     id("com.android.application")
     id("com.facebook.react")
+    id("org.jetbrains.kotlin.android")
 }
 
 /**


### PR DESCRIPTION
Summary:
This is needed if we want to allow users to write Kotlin code inside RN Tester

Changelog:
[Internal] [Changed] - Enable Kotlin for RN Tester

Reviewed By: cipolleschi

Differential Revision: D48066316

