### PR TITLE
Add missing constants to fallback implementation of ToastAndroid

### DIFF
--- a/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.js
+++ b/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.js
@@ -5,12 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @noflow
+ * @flow strict-local
  */
 
 'use strict';
 
 const ToastAndroid = {
+  // Dummy fallback toast duration constants
+  SHORT: (0: number),
+  LONG: (0: number),
+  // Dummy fallback toast gravity constants
+  TOP: (0: number),
+  BOTTOM: (0: number),
+  CENTER: (0: number),
+
   show: function (message: string, duration: number): void {
     console.warn('ToastAndroid is not supported on this platform.');
   },


### PR DESCRIPTION
Summary:
The d.ts file says these constant must exist, but they only exist in the android implementation. This diff stops lying and adds some dummy constants, so that the type will match-up.

Changelog: [Internal]

Differential Revision: D48085126

