### PR TITLE
[Codegen 112] - Extract the content into `handleEventHandler`

### DIFF
--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -27,6 +27,7 @@ const {
 const {
   getEventArgument,
   buildPropertiesForEvent,
+  handleEventHandler,
 } = require('../../parsers-commons');
 const {
   emitBoolProp,
@@ -204,27 +205,13 @@ function findEventArgumentsAndType(
       paperName,
     );
   } else if (name === 'BubblingEventHandler' || name === 'DirectEventHandler') {
-    const eventType = name === 'BubblingEventHandler' ? 'bubble' : 'direct';
-    const paperTopLevelNameDeprecated =
-      parser.getPaperTopLevelNameDeprecated(typeAnnotation);
-
-    switch (typeAnnotation.typeParameters.params[0].type) {
-      case parser.nullLiteralTypeAnnotation:
-      case parser.undefinedLiteralTypeAnnotation:
-        return {
-          argumentProps: [],
-          bubblingType: eventType,
-          paperTopLevelNameDeprecated,
-        };
-      default:
-        return findEventArgumentsAndType(
-          parser,
-          typeAnnotation.typeParameters.params[0],
-          types,
-          eventType,
-          paperTopLevelNameDeprecated,
-        );
-    }
+    return handleEventHandler(
+      name,
+      typeAnnotation,
+      parser,
+      types,
+      findEventArgumentsAndType,
+    );
   } else if (types[name]) {
     let elementType = types[name];
     if (elementType.type === 'TSTypeAliasDeclaration') {


### PR DESCRIPTION
## Summary:

Part of #34872 
> Extract the content of the if branches that handle the EventHandlers ([Flow](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/flow/components/events.js#L131-L151), [TypeScript](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/typescript/components/events.js#L150-L171)) into a handleEventHandler function in parsers-commons.js. This will take a name, a typeAnnotation, a parser and a findEventArgumentsAndType function as parameters. Use the switch based approach from TypeScript.

## Changelog:

[Internal][Changed]: Extract the content into handleEventHandler

## Test Plan:

`yarn test react-native-codegen`
