### PR TITLE
Fix build errors when a native module includes Swift

### DIFF
--- a/packages/react-native/React/CxxBridge/NSDataBigString.h
+++ b/packages/react-native/React/CxxBridge/NSDataBigString.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+#ifdef __cplusplus
+
 #include <cxxreact/JSBigString.h>
 
 namespace facebook::react {
@@ -38,3 +40,5 @@ class NSDataBigString : public JSBigString {
 };
 
 } // namespace facebook::react
+
+#endif // __cplusplus

--- a/packages/react-native/React/CxxBridge/RCTCxxBridgeDelegate.h
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridgeDelegate.h
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <memory>
+#ifdef __cplusplus
 
-#import <React/RCTBridgeDelegate.h>
+#include <memory>
 
 namespace facebook::react {
 
@@ -15,11 +15,16 @@ class JSExecutorFactory;
 
 } // namespace facebook::react
 
+#endif // __cplusplus
+
+#import <React/RCTBridgeDelegate.h>
+
 // This is a separate class so non-C++ implementations don't need to
 // take a C++ dependency.
 
 @protocol RCTCxxBridgeDelegate <RCTBridgeDelegate>
 
+#ifdef __cplusplus
 /**
  * In the RCTCxxBridge, if this method is implemented, return a
  * ExecutorFactory instance which can be used to create the executor.
@@ -27,5 +32,6 @@ class JSExecutorFactory;
  * will be used with a JSCRuntime.
  */
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge;
+#endif // __cplusplus
 
 @end

--- a/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.h
+++ b/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#ifdef __cplusplus
 
 #include <jsireact/JSIExecutor.h>
 
@@ -19,3 +20,5 @@ JSIExecutor::RuntimeInstaller RCTJSIExecutorRuntimeInstaller(
     JSIExecutor::RuntimeInstaller runtimeInstallerToWrap);
 
 } // namespace facebook::react
+
+#endif // __cplusplus

--- a/packages/react-native/React/CxxBridge/RCTMessageThread.h
+++ b/packages/react-native/React/CxxBridge/RCTMessageThread.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef __cplusplus
+
 #import <memory>
 #import <string>
 
@@ -37,3 +39,5 @@ class RCTMessageThread : public MessageQueueThread,
 };
 
 } // namespace facebook::react
+
+#endif // __cplusplus

--- a/packages/react-native/React/CxxBridge/RCTObjcExecutor.h
+++ b/packages/react-native/React/CxxBridge/RCTObjcExecutor.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef __cplusplus
+
 #include <functional>
 #include <memory>
 
@@ -29,3 +31,5 @@ class RCTObjcExecutorFactory : public JSExecutorFactory {
 };
 
 } // namespace facebook::react
+
+#endif // __cplusplus

--- a/packages/react-native/React/CxxModule/DispatchMessageQueueThread.h
+++ b/packages/react-native/React/CxxModule/DispatchMessageQueueThread.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef __cplusplus
+
 #include <glog/logging.h>
 
 #include <React/RCTLog.h>
@@ -43,3 +45,5 @@ class DispatchMessageQueueThread : public MessageQueueThread {
 };
 
 } // namespace facebook::react
+
+#endif // __cplusplus

--- a/packages/react-native/React/CxxModule/RCTCxxMethod.h
+++ b/packages/react-native/React/CxxModule/RCTCxxMethod.h
@@ -8,10 +8,15 @@
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeMethod.h>
+
+#ifdef __cplusplus
 #import <cxxreact/CxxModule.h>
+#endif // __cplusplus
 
 @interface RCTCxxMethod : NSObject <RCTBridgeMethod>
 
+#ifdef __cplusplus
 - (instancetype)initWithCxxMethod:(const facebook::xplat::module::CxxModule::Method &)cxxMethod;
+#endif // __cplusplus
 
 @end

--- a/packages/react-native/React/CxxModule/RCTCxxModule.h
+++ b/packages/react-native/React/CxxModule/RCTCxxModule.h
@@ -5,15 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <memory>
-
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>
 
+#ifdef __cplusplus
+
+#import <memory>
+
 namespace facebook::xplat::module {
 class CxxModule;
 } // namespace facebook::react::module
+
+#endif // __cplusplus
 
 /**
  * Subclass RCTCxxModule to use cross-platform CxxModule on iOS.
@@ -23,7 +27,9 @@ class CxxModule;
  */
 @interface RCTCxxModule : NSObject <RCTBridgeModule>
 
+#ifdef __cplusplus
 // To be implemented by subclasses
 - (std::unique_ptr<facebook::xplat::module::CxxModule>)createModule;
+#endif // __cplusplus
 
 @end

--- a/packages/react-native/React/CxxModule/RCTCxxUtils.h
+++ b/packages/react-native/React/CxxModule/RCTCxxUtils.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef __cplusplus
+
 #include <functional>
 #include <memory>
 
@@ -25,3 +27,5 @@ NSError *tryAndReturnError(const std::function<void()> &func);
 NSString *deriveSourceURL(NSURL *url);
 
 } // namespace facebook::react
+
+#endif // __cplusplus

--- a/packages/react-native/React/CxxModule/RCTNativeModule.h
+++ b/packages/react-native/React/CxxModule/RCTNativeModule.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifdef __cplusplus
+
 #import <React/RCTModuleData.h>
 #import <cxxreact/NativeModule.h>
 
@@ -30,3 +32,5 @@ class RCTNativeModule : public NativeModule {
 };
 
 } // namespace facebook::react
+
+#endif // __cplusplus

--- a/packages/react-native/React/CxxUtils/RCTFollyConvert.h
+++ b/packages/react-native/React/CxxUtils/RCTFollyConvert.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+#ifdef __cplusplus
+
 #include <folly/dynamic.h>
 
 namespace facebook::react {
@@ -15,3 +17,5 @@ folly::dynamic convertIdToFollyDynamic(id json);
 id convertFollyDynamicToId(const folly::dynamic &dyn);
 
 } // namespace facebook::react
+
+#endif // __cplusplus


### PR DESCRIPTION
## Summary:

Similar to https://github.com/facebook/react-native/pull/34527, but covers much more Objective-C++ headers that are now included in the autogenerated `React-Core-umbrella.h`.

<img width="908" alt="Screenshot 2023-08-05 at 22 34 34" src="https://github.com/facebook/react-native/assets/1714764/f9243010-7d15-4473-80bb-4d9c42a67a5e">

## Changelog:

[IOS] [FIXED] - Fixed build errors when a native module includes Swift

## Test Plan:

RNTester builds without errors after adding a Swift file to https://github.com/facebook/react-native/tree/main/packages/rn-tester/NativeModuleExample and running `USE_FRAMEWORKS=static pod install`.