### PR TITLE
[Codegen-119] add `emitBuildEventSchema` to parser commons

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -27,6 +27,7 @@ const {
   getEventArgument,
   buildPropertiesForEvent,
   handleEventHandler,
+  emitBuildEventSchema,
 } = require('../../parsers-commons');
 const {
   emitBoolProp,
@@ -245,36 +246,19 @@ function buildEventSchema(
   );
   const nonNullableBubblingType = throwIfBubblingTypeIsNull(bubblingType, name);
 
-  if (paperTopLevelNameDeprecated != null) {
-    return {
-      name,
-      optional,
-      bubblingType: nonNullableBubblingType,
-      paperTopLevelNameDeprecated,
-      typeAnnotation: {
-        type: 'EventTypeAnnotation',
-        argument: getEventArgument(
-          nonNullableArgumentProps,
-          parser,
-          getPropertyType,
-        ),
-      },
-    };
-  }
+  const argument = getEventArgument(
+    nonNullableArgumentProps,
+    parser,
+    getPropertyType,
+  );
 
-  return {
+  return emitBuildEventSchema(
+    paperTopLevelNameDeprecated,
     name,
     optional,
-    bubblingType: nonNullableBubblingType,
-    typeAnnotation: {
-      type: 'EventTypeAnnotation',
-      argument: getEventArgument(
-        nonNullableArgumentProps,
-        parser,
-        getPropertyType,
-      ),
-    },
-  };
+    nonNullableBubblingType,
+    argument,
+  );
 }
 
 // $FlowFixMe[unclear-type] there's no flowtype for ASTs

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -26,6 +26,7 @@ import type {
   PropTypeAnnotation,
   EventTypeAnnotation,
   ObjectTypeAnnotation,
+  EventTypeShape,
 } from '../CodegenSchema.js';
 
 import type {Parser} from './parser';
@@ -1125,6 +1126,37 @@ function handleEventHandler(
   }
 }
 
+function emitBuildEventSchema(
+  paperTopLevelNameDeprecated: $FlowFixMe,
+  name: $FlowFixMe,
+  optional: $FlowFixMe,
+  nonNullableBubblingType: 'direct' | 'bubble',
+  argument: ObjectTypeAnnotation<EventTypeAnnotation>,
+): ?EventTypeShape {
+  if (paperTopLevelNameDeprecated != null) {
+    return {
+      name,
+      optional,
+      bubblingType: nonNullableBubblingType,
+      paperTopLevelNameDeprecated,
+      typeAnnotation: {
+        type: 'EventTypeAnnotation',
+        argument: argument,
+      },
+    };
+  }
+
+  return {
+    name,
+    optional,
+    bubblingType: nonNullableBubblingType,
+    typeAnnotation: {
+      type: 'EventTypeAnnotation',
+      argument: argument,
+    },
+  };
+}
+
 module.exports = {
   wrapModuleSchema,
   unwrapNullable,
@@ -1154,4 +1186,5 @@ module.exports = {
   buildPropertiesForEvent,
   verifyPropNotAlreadyDefined,
   handleEventHandler,
+  emitBuildEventSchema,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -28,6 +28,7 @@ const {
   getEventArgument,
   buildPropertiesForEvent,
   handleEventHandler,
+  emitBuildEventSchema,
 } = require('../../parsers-commons');
 const {
   emitBoolProp,
@@ -259,36 +260,19 @@ function buildEventSchema(
   );
   const nonNullableBubblingType = throwIfBubblingTypeIsNull(bubblingType, name);
 
-  if (paperTopLevelNameDeprecated != null) {
-    return {
-      name,
-      optional,
-      bubblingType: nonNullableBubblingType,
-      paperTopLevelNameDeprecated,
-      typeAnnotation: {
-        type: 'EventTypeAnnotation',
-        argument: getEventArgument(
-          nonNullableArgumentProps,
-          parser,
-          getPropertyType,
-        ),
-      },
-    };
-  }
+  const argument = getEventArgument(
+    nonNullableArgumentProps,
+    parser,
+    getPropertyType,
+  );
 
-  return {
+  return emitBuildEventSchema(
+    paperTopLevelNameDeprecated,
     name,
     optional,
-    bubblingType: nonNullableBubblingType,
-    typeAnnotation: {
-      type: 'EventTypeAnnotation',
-      argument: getEventArgument(
-        nonNullableArgumentProps,
-        parser,
-        getPropertyType,
-      ),
-    },
-  };
+    nonNullableBubblingType,
+    argument,
+  );
 }
 
 function getEvents(


### PR DESCRIPTION
## Summary:

[Codegen 119] This PR introduces `emitBuildEventSchema` to parser commons and abstracts the logic out of typescript and parser events as requested on https://github.com/facebook/react-native/issues/34872

## Changelog:

[Internal] [Changed] - Add `emitBuildEventSchema` to parser commons and update usages.

## Test Plan:

Run `yarn jest react-native-codegen` locally and ensure CI is green

## Screenshot of test passing locally:

<img width="1047" alt="Screenshot 2023-08-07 at 8 03 49 AM" src="https://github.com/facebook/react-native/assets/64726664/ab87f004-d9f8-4b5f-800b-0e724430301f">

