### PR TITLE
Build iOS app in New Architecture when running E2E tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -878,7 +878,7 @@ jobs:
             cd packages/rn-tester
             bundle check || bundle install
             bundle exec pod setup
-            bundle exec pod install --verbose
+            RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --verbose
       - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Right now we're building by default Android app in New Architecture, so to align this behaviour between platforms - I added `RCT_NEW_ARCH_ENABLED=1` when installing Pods when running E2E tests, to also build iOS app in New Arch.

## Changelog:

[IOS] [CHANGED] - Build iOS app in New Architecture when running E2E tests.

## Test Plan:

App in `test_e2e_ios` job should build in New Architecture