### PR TITLE
Attempt to enable the Gradle Daemon for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,9 +136,7 @@ executors:
     resource_class: "xlarge"
     environment:
       - TERM: "dumb"
-      - ADB_INSTALL_TIMEOUT: 10
-      - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dfile.encoding=utf-8 -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
-      - BUILD_THREADS: 2
+      - GRADLE_OPTS: '-Dfile.encoding=utf-8 -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
       # Repeated here, as the environment key in this executor will overwrite the one in defaults
       - PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A: *github_analysisbot_token_a
       - PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B: *github_analysisbot_token_b
@@ -1272,7 +1270,6 @@ jobs:
       - ANDROID_NDK: "C:\\Android\\android-sdk\\ndk\\20.1.5948944"
       - ANDROID_BUILD_VERSION: 33
       - ANDROID_TOOLS_VERSION: 33.0.1
-      - GRADLE_OPTS: -Dorg.gradle.daemon=false
       - CHOCO_CACHE_DIR: "C:\\ChocoCache"
     steps:
       - checkout_code_with_cache

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,3 @@
-# This is causing issue with dependencies task: https://github.com/gradle/gradle/issues/9645#issuecomment-530746758
-# org.gradle.configureondemand=true
-org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 


### PR DESCRIPTION
Summary:
This change enables the Gradle Daemon on CI.
We noticed some flakyness with the Daemon disabled, so we'll give it a try with the daemon enabled which is the default for Gradle.

Changelog:
[Internal] [Changed] - Enable the Gradle Daemon for CI

Differential Revision: D48112363

