### PR TITLE
Build only arm64 when building PRs. All archs for nightlies and releases.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ references:
       # Homebrew currently breaks while updating:
       # https://discuss.circleci.com/t/brew-install-fails-while-updating/32992
       - HOMEBREW_NO_AUTO_UPDATE: 1
+  android-defaults: &android-defaults
+    working_directory: ~/react-native
+    docker:
+      - image: reactnativecommunity/react-native-android:v10.0
+    environment:
+      - TERM: "dumb"
+      - GRADLE_OPTS: '-Dorg.gradle.daemon=false'
+      # Repeated here, as the environment key in this executor will overwrite the one in defaults
+      - PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A: *github_analysisbot_token_a
+      - PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B: *github_analysisbot_token_b
+      - PUBLIC_PULLBOT_GITHUB_TOKEN_A: *github_pullbot_token_a
+      - PUBLIC_PULLBOT_GITHUB_TOKEN_B: *github_pullbot_token_b
 
   hermes_workspace_root: &hermes_workspace_root
     /tmp/hermes
@@ -122,7 +134,6 @@ executors:
   nodelts:
     <<: *defaults
     docker:
-      # Note: Version set separately for Windows builds, see below.
       - image: *nodelts_image
     resource_class: "xlarge"
   nodeprevlts:
@@ -136,19 +147,12 @@ executors:
     docker:
       - image: *nodelts_browser_image
     resource_class: "small"
-  reactnativeandroid:
-    <<: *defaults
-    docker:
-      - image: reactnativecommunity/react-native-android:v10.0
+  reactnativeandroid-xlarge:
+    <<: *android-defaults
     resource_class: "xlarge"
-    environment:
-      - TERM: "dumb"
-      - GRADLE_OPTS: '-Dfile.encoding=utf-8 -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
-      # Repeated here, as the environment key in this executor will overwrite the one in defaults
-      - PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A: *github_analysisbot_token_a
-      - PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B: *github_analysisbot_token_b
-      - PUBLIC_PULLBOT_GITHUB_TOKEN_A: *github_pullbot_token_a
-      - PUBLIC_PULLBOT_GITHUB_TOKEN_B: *github_pullbot_token_b
+  reactnativeandroid-large:
+    <<: *android-defaults
+    resource_class: "large"
   reactnativeios:
     <<: *defaults
     macos:
@@ -977,7 +981,7 @@ jobs:
   #    JOBS: Test Android
   # -------------------------
   test_android:
-    executor: reactnativeandroid
+    executor: reactnativeandroid-xlarge
     steps:
       - checkout
       - setup_artifacts
@@ -1005,7 +1009,7 @@ jobs:
   #    JOBS: Test Android Template
   # -------------------------
   test_android_template:
-    executor: reactnativeandroid
+    executor: reactnativeandroid-large
     parameters:
       flavor:
         default: "Debug"
@@ -1831,7 +1835,7 @@ jobs:
         type: enum
         enum: ["nightly", "release", "dry-run"]
         default: "dry-run"
-    executor: reactnativeandroid
+    executor: reactnativeandroid-xlarge
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ references:
     environment:
       - TERM: "dumb"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false'
+      # By default we only build ARM64 to save time/resources. For release/nightlies, we override this value to build all archs.
+      - ORG_GRADLE_PROJECT_reactNativeArchitectures: "arm64-v8a"
       # Repeated here, as the environment key in this executor will overwrite the one in defaults
       - PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A: *github_analysisbot_token_a
       - PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B: *github_analysisbot_token_b
@@ -1844,6 +1846,14 @@ jobs:
           command: |
             mkdir -p ~/.ssh
             echo '|1|If6MU203eXTaaWL678YEfWkVMrw=|kqLeIAyTy8pzpj8x8Ae4Fr8Mtlc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
+      - run:
+          name: Set the reactNativeArchitectures to build only required architectures
+          command: |
+            if [ "${release_type}" = "dry-run" ]; then
+              export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a"
+            else
+              export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
+            fi
       - checkout
       - *attach_hermes_workspace
       - run:


### PR DESCRIPTION
Summary:
To save resources, we should build only arm64 for PRs and commits to mains.
Our Android ABIs are really similar and we should just build the most popular. For nightlies/releases
instead we'll have to build all the archs.

Changelog:
[Internal] [Changed] - Build only arm64 when building PRs. All archs for nightlies and releases.

Differential Revision: D48112361

