### PR TITLE
Add missing `libreact_utils.so` inside RNGP pickFirst

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -107,6 +107,7 @@ internal object NdkConfiguratorUtils {
               "**/libreact_render_graphics.so",
               "**/libreact_render_imagemanager.so",
               "**/libreact_render_mapbuffer.so",
+              "**/libreact_utils.so",
               "**/librrc_image.so",
               "**/librrc_legacyviewmanagerinterop.so",
               "**/librrc_view.so",


### PR DESCRIPTION
Summary:
When building the template test on CircleCI, I've noticed we fire a warnign for `libreact_utils.so` as we're missing a pickFirst directive.
You can see an example of the warning here:
https://app.circleci.com/pipelines/github/facebook/react-native/28853/workflows/f1808b5e-fb40-4165-8885-694f88037f9f/jobs/904972

This fixes it by adding `libreact_utils.so` to the `pickFirst` list.

Changelog:
[Internal] [Changed] - Add missing `libreact_utils.so` inside RNGP pickFirst

Differential Revision: D48115852

