### PR TITLE
Enable Kotlin for RN Tester

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -35,13 +35,8 @@ abstract class GenerateCodegenSchemaTask : Exec() {
       project.fileTree(jsRootDir) {
         it.include("**/*.js")
         it.include("**/*.ts")
-        // Those are known build paths where the source map or other
-        // .js files could be stored/generated. We want to make sure we don't pick them up
-        // for execution avoidance.
-        it.exclude("**/build/ASSETS/**/*")
-        it.exclude("**/build/RES/**/*")
-        it.exclude("**/build/generated/**/*")
-        it.exclude("**/build/intermediates/**/*")
+        // We want to exclude the build directory, to don't pick them up for execution avoidance.
+        it.exclude("**/build/**/*")
       }
 
   @get:OutputFile

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -68,10 +68,7 @@ class GenerateCodegenSchemaTaskTest {
     assertEquals(jsRootDir, task.jsInputFiles.dir)
     assertEquals(
         setOf(
-            "**/build/ASSETS/**/*",
-            "**/build/RES/**/*",
-            "**/build/generated/**/*",
-            "**/build/intermediates/**/*",
+            "**/build/**/*",
         ),
         task.jsInputFiles.excludes)
     assertEquals(1, task.jsInputFiles.files.size)

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -8,6 +8,7 @@
 plugins {
     id("com.android.application")
     id("com.facebook.react")
+    id("org.jetbrains.kotlin.android")
 }
 
 /**


### PR DESCRIPTION
Summary:
This is needed if we want to allow users to write Kotlin code inside RN Tester

Changelog:
[Internal] [Changed] - Enable Kotlin for RN Tester

Differential Revision: D48117203

