### PR TITLE
Do not import java Collections from Kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.kt
@@ -8,7 +8,6 @@
 package com.facebook.react.turbomodule.core.interfaces
 
 import com.facebook.react.bridge.NativeModule
-import java.util.Collection
 
 /**
  * Interface to allow for creating and retrieving NativeModules. Why is this this class prefixed


### PR DESCRIPTION
Summary:
We should not attempt to import `java.util.Collections` in a Kotlin file
as we should use the Kotlin's equivalent class instead.

Changelog:
[Internal] [Changed] - Do not import java Collections from Kotlin

Differential Revision: D48117940

