### PR TITLE
Downscale test_js & find_and_publish_bumped_packages jobs to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ executors:
     docker:
       # Note: Version set separately for Windows builds, see below.
       - image: *nodelts_image
-    resource_class: "xlarge"
+    resource_class: "large"
   nodeprevlts:
     <<: *defaults
     docker:


### PR DESCRIPTION
Summary:
For the `test_js` and `find_and_publish_bumped_packages` jobs we don't need xlarge resources.

The current average usage for `test_js` and `find_and_publish_bumped_packages` is around 25%.

We can also downscale to medium in few days if this scales well.

**Insights Dashboard:**

`test_js`

{F1065742668}

`find_and_publish_bumped_packages`

{F1065742888}

Changelog:
[Internal] [Changed] - Downscale test_js and find_and_publish_bumped_packages` jobs to Large

Differential Revision: D48125531

