### PR TITLE
[RN][iOS] Add Caching to e2e tests to save time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,35 +891,37 @@ jobs:
       - setup_ruby:
           ruby_version: << parameters.ruby_version >>
       - run:
-          name: Install Bundler
-          command: |
-            cd packages/rn-tester
-            bundle check || bundle install
-            bundle exec pod setup
-            RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --verbose
-      - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
-      - run:
-          name: Build app
-          command: |
-              xcodebuild build \
-                -workspace packages/rn-tester/RNTesterPods.xcworkspace \
-                -configuration Debug \
-                -scheme RNTester \
-                -sdk iphonesimulator \
-                -derivedDataPath /tmp/e2e/
-      - run:
-          name: Move app to correct directory
-          command: mv /tmp/e2e/Build/Products/Debug-iphonesimulator/RNTester.app packages/rn-tester-e2e/apps/rn-tester.app
-      - run:
-          name: Check Appium server status
-          command: scripts/circleci/check_appium_server_status.sh
-      - run:
-          name: Run E2E tests
-          command: |
-            cd packages/rn-tester-e2e
-            yarn test-e2e ios
+      - with_xcodebuild_cache:
+          steps:
+            - run:
+                name: Install Bundler
+                command: |
+                  cd packages/rn-tester
+                  bundle check || bundle install
+                  bundle exec pod setup
+                  RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --verbose
+            - run:
+                name: Build app
+                command: |
+                    xcodebuild build \
+                      -workspace packages/rn-tester/RNTesterPods.xcworkspace \
+                      -configuration Debug \
+                      -scheme RNTester \
+                      -sdk iphonesimulator \
+                      -derivedDataPath /tmp/e2e/
+            - run:
+                name: Move app to correct directory
+                command: mv /tmp/e2e/Build/Products/Debug-iphonesimulator/RNTester.app packages/rn-tester-e2e/apps/rn-tester.app
+            - run:
+                name: Check Appium server status
+                command: scripts/circleci/check_appium_server_status.sh
+            - run:
+                name: Run E2E tests
+                command: |
+                  cd packages/rn-tester-e2e
+                  yarn test-e2e ios
 
   # -------------------------
   #     JOBS: Android E2E Tests


### PR DESCRIPTION
## Summary:
The iOS e2e testing is not caching the cocoapods properly. With this change, we are adding the cache to save some time. 

## Changelog:

[Internal] - Add caching to iOS e2e jobs

## Test Plan:

CircleCI stays green; the job that is using the cache runs faster.

| BEFORE | AFTER | 
| --- | --- | 
| <img width="554" alt="Screenshot 2023-08-09 at 09 38 48" src="https://github.com/facebook/react-native/assets/11162307/5f175d5d-7dd2-4a55-acab-2063356d2a71"> | <img width="555" alt="Screenshot 2023-08-09 at 09 39 03" src="https://github.com/facebook/react-native/assets/11162307/7058b1eb-6d94-4659-a220-da2f81a9e833"> |  
