### PR TITLE
[RN][CI] Store publishing log when publishing a new version of React Native fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1903,6 +1903,9 @@ jobs:
           command: zip -r /tmp/maven-local.zip /tmp/maven-local
       - store_artifacts:
           path: /tmp/maven-local.zip
+      - store_artifacts:
+          when: on_fail
+          path: /root/.npm/_logs
       - persist_to_workspace:
           root: /tmp
           paths:


### PR DESCRIPTION
## Summary:

This change adds a step to store the publishing logs as artifacts when the publishing fails, so that we can analyze what happened without relaunching the job

## Changelog:

[Internal] - Add step to upload publishing logs

## Test Plan:
CircleCI stays green
