### PR TITLE
Introduce a build_android step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ references:
   cache_keys:
     checkout_cache_key: &checkout_cache_key v1-checkout
     gems_cache_key: &gems_cache_key v1-gems-{{ checksum "Gemfile.lock" }}
-    gradle_cache_key: &gradle_cache_key v2-gradle-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "packages/react-native/ReactAndroid/gradle.properties" }}
+    gradle_cache_key: &gradle_cache_key v3-gradle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "packages/react-native/ReactAndroid/gradle.properties" }}
     yarn_cache_key: &yarn_cache_key v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}
     rbenv_cache_key: &rbenv_cache_key v1-rbenv-{{ checksum "/tmp/required_ruby" }}
     hermes_workspace_cache_key: &hermes_workspace_cache_key v5-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
@@ -300,17 +300,22 @@ commands:
             - packages/rn-tester/Pods
           key: *pods_cache_key
 
-  download_gradle_dependencies:
+  with_gradle_cache:
+    parameters:
+      steps:
+        type: steps
     steps:
       - restore_cache:
           keys:
             - *gradle_cache_key
-      - run:
-          name: Download Dependencies Using Gradle
-          command: ./gradlew downloadAll
+            - v3-gradle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-
+            - v3-gradle-{{ .Environment.CIRCLE_JOB }}-
+            - v3-gradle-
+      - steps: << parameters.steps >>
       - save_cache:
           paths:
-            - ~/.gradle
+            - ~/.gradle/caches
+            - ~/.gradle/wrapper
             - packages/react-native/ReactAndroid/build/downloads
             - packages/react-native/ReactAndroid/build/third-party-ndk
           key: *gradle_cache_key
@@ -430,18 +435,18 @@ commands:
       - run:
           name: Print Hermes version
           command: |
-              HERMES_TARBALL_ARTIFACTS_DIR=<< parameters.hermes_tarball_artifacts_dir >>
-              TARBALL_FILENAME=$(node ~/react-native/packages/react-native/scripts/hermes/get-tarball-name.js --buildType "<< parameters.flavor >>")
-              TARBALL_PATH=$HERMES_TARBALL_ARTIFACTS_DIR/$TARBALL_FILENAME
-              if [[ -e $TARBALL_PATH ]]; then
-                tar -xf $TARBALL_PATH
-                echo 'print(HermesInternal?.getRuntimeProperties?.()["OSS Release Version"])' > test.js
-                ./destroot/bin/hermes test.js
-                rm test.js
-                rm -rf destroot
-              else
-                echo 'No Hermes tarball found.'
-              fi
+            HERMES_TARBALL_ARTIFACTS_DIR=<< parameters.hermes_tarball_artifacts_dir >>
+            TARBALL_FILENAME=$(node ~/react-native/packages/react-native/scripts/hermes/get-tarball-name.js --buildType "<< parameters.flavor >>")
+            TARBALL_PATH=$HERMES_TARBALL_ARTIFACTS_DIR/$TARBALL_FILENAME
+            if [[ -e $TARBALL_PATH ]]; then
+              tar -xf $TARBALL_PATH
+              echo 'print(HermesInternal?.getRuntimeProperties?.()["OSS Release Version"])' > test.js
+              ./destroot/bin/hermes test.js
+              rm test.js
+              rm -rf destroot
+            else
+              echo 'No Hermes tarball found.'
+            fi
       - steps: << parameters.steps >>
       - when:
           condition:
@@ -924,8 +929,8 @@ jobs:
   # -------------------------
   test_e2e_android:
     executor:
-        name: android/android-machine
-        tag: 2023.07.1
+      name: android/android-machine
+      tag: 2023.07.1
     steps:
       - checkout_code_with_cache
       - run_yarn
@@ -958,10 +963,12 @@ jobs:
           background: true
       - attach_workspace:
           at: .
-      - run:
-          name: Build app
-          command: |
-            ./gradlew :packages:rn-tester:android:app:assembleHermesDebug -PreactNativeArchitectures=x86_64
+      - with_gradle_cache:
+          steps:
+            - run:
+                name: Build app
+                command: |
+                  ./gradlew :packages:rn-tester:android:app:assembleHermesDebug -PreactNativeArchitectures=x86_64
       - run:
           name: Move app to correct directory
           command: mv packages/rn-tester/android/app/build/outputs/apk/hermes/debug/app-hermes-x86_64-debug.apk packages/rn-tester-e2e/apps/rn-tester.apk
@@ -977,6 +984,57 @@ jobs:
           command: |
             cd packages/rn-tester-e2e
             yarn test-e2e android
+
+  # -------------------------
+  #    JOBS: Build Android
+  # -------------------------
+  build_android:
+    executor: reactnativeandroid-xlarge
+    parameters:
+      release_type:
+        description: The type of release to build. Must be one of "nightly", "release", "dry-run".
+        type: enum
+        enum: ["nightly", "release", "dry-run"]
+        default: "dry-run"
+    steps:
+      - checkout
+      - setup_artifacts
+      - run_yarn
+      - run:
+          name: Set React Native Version
+          command: node ./scripts/set-rn-version.js --build-type << parameters.release_type >>
+
+      - with_gradle_cache:
+          steps:
+            - run:
+                name: Build and publish all the Android Artifacts to /tmp/maven-local
+                command: |
+                  if [[ << parameters.release_type >> == "dry-run" ]]; then
+                    export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a"
+                  else
+                    export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
+                  fi
+                  ./gradlew publishAllToMavenTempLocal
+
+      - persist_to_workspace:
+          root: /root/react-native/
+          paths:
+            - build/
+            - .gradle/
+            - packages/rn-tester/android/app/.cxx/
+            - packages/rn-tester/android/app/build/
+            - packages/react-native/sdks/download/
+            - packages/react-native/sdks/hermes/
+            - packages/react-native/ReactAndroid/.cxx/
+            - packages/react-native/ReactAndroid/build/
+            - packages/react-native/ReactAndroid/hermes-engine/.cxx/
+            - packages/react-native/ReactAndroid/hermes-engine/build/
+            - packages/react-native/ReactAndroid/flipper-integration/build/
+            - packages/react-native/ReactAndroid/src/main/jni/prebuilt/
+            - packages/react-native-gradle-plugin/.gradle/
+            - packages/react-native-gradle-plugin/build/
+            - packages/react-native-codegen/lib/
+
   # -------------------------
   #    JOBS: Test Android
   # -------------------------
@@ -986,11 +1044,19 @@ jobs:
       - checkout
       - setup_artifacts
       - run_yarn
-      - download_gradle_dependencies
-
       - run:
-          name: Build & Test React Native using Gradle
-          command: ./gradlew build
+          name: Set React Native Version to "dry-run"
+          # test_android executes only for dry-run builds. We need to bump the version for caching
+          # reasons otherwise we won't reuse the artifacts from the build_android job.
+          command: node ./scripts/set-rn-version.js --build-type "dry-run"
+      - attach_workspace:
+          at: .
+
+      - with_gradle_cache:
+          steps:
+            - run:
+                name: Build & Test React Native using Gradle
+                command: ./gradlew build
 
       - report_bundle_size:
           platform: android
@@ -1039,21 +1105,23 @@ jobs:
             REPO_ROOT=$(pwd)
             node ./scripts/update-template-package.js "{\"react-native\":\"file:$REPO_ROOT/build/$(cat build/react-native-package-version)\"}"
             node ./scripts/template/initialize.js --reactNativeRootPath $REPO_ROOT --templateName $PROJECT_NAME --templateConfigPath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME"
-      - run:
-          name: Build the template application for << parameters.flavor >> with Architecture set to << parameters.architecture >>, and using the << parameters.jsengine>> JS engine.
-          command: |
-            cd /tmp/$PROJECT_NAME/android/
-            if [[ << parameters.architecture >> == "NewArch" ]]; then
-              export ORG_GRADLE_PROJECT_newArchEnabled=true
-            else
-              export ORG_GRADLE_PROJECT_newArchEnabled=false
-            fi
-            if [[ << parameters.jsengine >> == "Hermes" ]]; then
-              export ORG_GRADLE_PROJECT_hermesEnabled=true
-            else
-              export ORG_GRADLE_PROJECT_hermesEnabled=false
-            fi
-            ./gradlew assemble<< parameters.flavor >> -PREACT_NATIVE_MAVEN_LOCAL_REPO=/root/react-native/maven-local
+      - with_gradle_cache:
+          steps:
+            - run:
+                name: Build the template application for << parameters.flavor >> with Architecture set to << parameters.architecture >>, and using the << parameters.jsengine>> JS engine.
+                command: |
+                  cd /tmp/$PROJECT_NAME/android/
+                  if [[ << parameters.architecture >> == "NewArch" ]]; then
+                    export ORG_GRADLE_PROJECT_newArchEnabled=true
+                  else
+                    export ORG_GRADLE_PROJECT_newArchEnabled=false
+                  fi
+                  if [[ << parameters.jsengine >> == "Hermes" ]]; then
+                    export ORG_GRADLE_PROJECT_hermesEnabled=true
+                  else
+                    export ORG_GRADLE_PROJECT_hermesEnabled=false
+                  fi
+                  ./gradlew assemble<< parameters.flavor >> -PREACT_NATIVE_MAVEN_LOCAL_REPO=/root/react-native/maven-local
 
       - store_artifacts:
           path: /tmp/AndroidTemplateProject/android/app/build/outputs/apk/
@@ -1182,8 +1250,8 @@ jobs:
   # build toolchain. The `test_ios_rntester` job, instead, takes the
   # same prebuilt for Hermes that we are going to use in the Release.
   test_ios_rntester_hermes_xcode_integration:
-     executor: reactnativeios
-     steps:
+    executor: reactnativeios
+    steps:
       - checkout_code_with_cache
       - run_yarn
       - brew_install:
@@ -1525,30 +1593,30 @@ jobs:
       - HERMES_WS_DIR: *hermes_workspace_root
       - HERMES_TARBALL_ARTIFACTS_DIR: *hermes_tarball_artifacts_dir
     steps:
-        - *attach_hermes_workspace
-        - stop_job_if_apple_artifacts_are_there:
-            flavor: "All"
-        - checkout_code_with_cache
-        - get_react_native_version
-        - setup_hermes_workspace
-        - restore_cache:
-            key: *hermesc_apple_cache_key
-        - brew_install:
-            package: cmake
-        - run:
-            name: "Build HermesC Apple"
-            command: |
-              cd ./packages/react-native/sdks/hermes || exit 1
-              . ./utils/build-apple-framework.sh
-              build_host_hermesc_if_needed
-        - save_cache:
-            key: *hermesc_apple_cache_key
-            paths:
-              - ./packages/react-native/sdks/hermes/build_host_hermesc
-        - persist_to_workspace:
-            root: ./packages/react-native/sdks/hermes/
-            paths:
-              - build_host_hermesc
+      - *attach_hermes_workspace
+      - stop_job_if_apple_artifacts_are_there:
+          flavor: "All"
+      - checkout_code_with_cache
+      - get_react_native_version
+      - setup_hermes_workspace
+      - restore_cache:
+          key: *hermesc_apple_cache_key
+      - brew_install:
+          package: cmake
+      - run:
+          name: "Build HermesC Apple"
+          command: |
+            cd ./packages/react-native/sdks/hermes || exit 1
+            . ./utils/build-apple-framework.sh
+            build_host_hermesc_if_needed
+      - save_cache:
+          key: *hermesc_apple_cache_key
+          paths:
+            - ./packages/react-native/sdks/hermes/build_host_hermesc
+      - persist_to_workspace:
+          root: ./packages/react-native/sdks/hermes/
+          paths:
+            - build_host_hermesc
 
   build_apple_slices_hermes:
     parameters:
@@ -1571,46 +1639,46 @@ jobs:
       - HERMES_TARBALL_ARTIFACTS_DIR: *hermes_tarball_artifacts_dir
       - HERMES_OSXBIN_ARTIFACTS_DIR: *hermes_osxbin_artifacts_dir
     steps:
-        - *attach_hermes_workspace
-        - stop_job_if_apple_artifacts_are_there:
-            flavor: << parameters.flavor >>
-        - checkout_code_with_cache
-        - get_react_native_version
-        - setup_hermes_workspace
-        - restore_cache:
-            key: *hermesc_apple_cache_key
-        - brew_install:
-            package: cmake
-        - restore_cache:
-            key: << parameters.slice_base_cache_key >>-<< parameters.slice >>-<< parameters.flavor >>
-        - run:
-            name: Build the Hermes << parameters.slice >> frameworks
-            command: |
-              cd ./packages/react-native/sdks/hermes || exit 1
-              SLICE=<< parameters.slice >>
-              FLAVOR=<< parameters.flavor >>
-              FINAL_PATH=build_"$SLICE"_"$FLAVOR"
-              echo "Final path for this slice is: $FINAL_PATH"
+      - *attach_hermes_workspace
+      - stop_job_if_apple_artifacts_are_there:
+          flavor: << parameters.flavor >>
+      - checkout_code_with_cache
+      - get_react_native_version
+      - setup_hermes_workspace
+      - restore_cache:
+          key: *hermesc_apple_cache_key
+      - brew_install:
+          package: cmake
+      - restore_cache:
+          key: << parameters.slice_base_cache_key >>-<< parameters.slice >>-<< parameters.flavor >>
+      - run:
+          name: Build the Hermes << parameters.slice >> frameworks
+          command: |
+            cd ./packages/react-native/sdks/hermes || exit 1
+            SLICE=<< parameters.slice >>
+            FLAVOR=<< parameters.flavor >>
+            FINAL_PATH=build_"$SLICE"_"$FLAVOR"
+            echo "Final path for this slice is: $FINAL_PATH"
 
-              if [[ -d "$FINAL_PATH" ]]; then
-                echo "[HERMES] Skipping! Found the requested slice at $FINAL_PATH".
-                exit 0
-              fi
+            if [[ -d "$FINAL_PATH" ]]; then
+              echo "[HERMES] Skipping! Found the requested slice at $FINAL_PATH".
+              exit 0
+            fi
 
-              if [[ "$SLICE" == "macosx" ]]; then
-                echo "[HERMES] Building Hermes for MacOS"
-                BUILD_TYPE="<< parameters.flavor >>" ./utils/build-mac-framework.sh
-              else
-                echo "[HERMES] Building Hermes for iOS: $SLICE"
-                BUILD_TYPE="<< parameters.flavor >>" ./utils/build-ios-framework.sh "$SLICE"
-              fi
+            if [[ "$SLICE" == "macosx" ]]; then
+              echo "[HERMES] Building Hermes for MacOS"
+              BUILD_TYPE="<< parameters.flavor >>" ./utils/build-mac-framework.sh
+            else
+              echo "[HERMES] Building Hermes for iOS: $SLICE"
+              BUILD_TYPE="<< parameters.flavor >>" ./utils/build-ios-framework.sh "$SLICE"
+            fi
 
-              echo "Moving from build_$SLICE to $FINAL_PATH"
-              mv build_"$SLICE" "$FINAL_PATH"
-        - save_cache:
-            key: << parameters.slice_base_cache_key >>-<< parameters.slice >>-<< parameters.flavor >>
-            paths:
-              - ./packages/react-native/sdks/hermes/build_<< parameters.slice >>_<< parameters.flavor >>
+            echo "Moving from build_$SLICE to $FINAL_PATH"
+            mv build_"$SLICE" "$FINAL_PATH"
+      - save_cache:
+          key: << parameters.slice_base_cache_key >>-<< parameters.slice >>-<< parameters.flavor >>
+          paths:
+            - ./packages/react-native/sdks/hermes/build_<< parameters.slice >>_<< parameters.flavor >>
 
   build_hermes_macos:
     parameters:
@@ -1869,7 +1937,8 @@ jobs:
 
       - run_yarn
       - build_packages
-      - download_gradle_dependencies
+      - attach_workspace:
+          at: .
 
       # START: Stables and nightlies
       # This conditional step sets up the necessary credentials for publishing react-native to npm.
@@ -1882,19 +1951,20 @@ jobs:
             - run: echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc
       # END: Stables and nightlies
 
-      - run:
-          name: "Publish NPM"
-          command: |
-              # We can't have a separate step because each command is executed in a separate shell
-              # so variables exported in a command are not visible in another.
+      - with_gradle_cache:
+          steps:
+            - run:
+                name: Publish NPM
+                command: |
+                  # We can't have a separate step because each command is executed in a separate shell
+                  # so variables exported in a command are not visible in another.
+                  if [[ << parameters.release_type >> == "dry-run" ]]; then
+                    export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a"
+                  else
+                    export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
+                  fi
+                  node ./scripts/publish-npm.js --<< parameters.release_type >>
 
-              if [[ << parameters.release_type >> == "dry-run" ]]; then
-                export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a"
-              else
-                export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
-              fi
-
-              node ./scripts/publish-npm.js --<< parameters.release_type >>
       - run:
           name: Zip Maven Artifacts from /tmp/maven-local
           command: zip -r /tmp/maven-local.zip /tmp/maven-local
@@ -2022,6 +2092,8 @@ workflows:
           dryrun: true
       - prepare_hermes_workspace
       - test_ios_rntester_hermes_xcode_integration
+      - build_android:
+          release_type: "dry-run"
       - build_hermesc_linux:
           requires:
             - prepare_hermes_workspace
@@ -2048,12 +2120,15 @@ workflows:
           # Build a release package on every untagged commit, but do not publish to npm.
           release_type: "dry-run"
           requires:
+            - build_android
             - build_hermesc_linux
             - build_hermes_macos
             - build_hermesc_windows
       - test_js:
           run_disabled_tests: false
-      - test_android
+      - test_android:
+          requires:
+            - build_android
       - test_e2e_ios:
           ruby_version: "2.7.7"
       - test_e2e_android
@@ -2191,6 +2266,10 @@ workflows:
     jobs:
       - prepare_hermes_workspace:
           filters: *only_release_tags
+      - build_android:
+          filters: *only_release_tags
+          name: build_android_for_release
+          release_type: "release"
       - build_hermesc_linux:
           filters: *only_release_tags
           requires:
@@ -2219,6 +2298,7 @@ workflows:
           release_type: "release"
           filters: *only_release_tags
           requires:
+            - build_android_for_release
             - build_hermesc_linux
             - build_hermes_macos
             - build_hermesc_windows
@@ -2240,6 +2320,8 @@ workflows:
     jobs:
       - nightly_job
       - prepare_hermes_workspace
+      - build_android:
+          release_type: "nightly"
       - build_hermesc_linux:
           requires:
             - prepare_hermes_workspace
@@ -2262,6 +2344,7 @@ workflows:
       - build_npm_package:
           release_type: "nightly"
           requires:
+            - build_android
             - build_hermesc_linux
             - build_hermes_macos
             - build_hermesc_windows

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -43,15 +43,17 @@ def overrideHermesDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") != nul
 def hermesDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") ?: new File(reactNativeRootDir, "sdks/hermes")
 def hermesBuildDir = new File("$buildDir/hermes")
 def hermesCOutputBinary = new File("$buildDir/hermes/bin/hermesc")
+
 // This filetree represents the file of the Hermes build that we want as input/output
 // of the buildHermesC task. Gradle will compute the hash of files in the file tree
 // and won't rebuilt hermesc unless those files are changing.
 def hermesBuildOutputFileTree = fileTree(hermesBuildDir.toString())
-                    .exclude('**/*.make')
-                    .exclude('**/*.internal')
-                    .exclude('**/external/**')
-                    .exclude('**/hermes.framework/**')
-                    .exclude('**/bin/hermesc')
+                    .include('**/*.make')
+                    .include('**/*.cmake')
+                    .include('**/*.marks')
+                    .include('**/compiler_depends.ts')
+                    .include('**/Makefile')
+                    .include('**/link.txt')
 
 def hermesVersion = "main"
 def hermesVersionFile = new File(reactNativeRootDir, "sdks/.hermesversion")

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -10,6 +10,67 @@
 'use strict';
 
 const {exec} = require('shelljs');
+const {parseVersion} = require('./version-utils');
+const {
+  exitIfNotOnGit,
+  getCurrentCommit,
+  isTaggedLatest,
+} = require('./scm-utils');
+
+// Get `next` version from npm and +1 on the minor for `main` version
+function getMainVersion() {
+  const versionStr = getPackageVersionStrByTag('react-native', 'next');
+  const {major, minor} = parseVersion(versionStr, 'release');
+  return `${major}.${parseInt(minor, 10) + 1}.0`;
+}
+
+function getNpmInfo(buildType) {
+  const currentCommit = getCurrentCommit();
+  const shortCommit = currentCommit.slice(0, 9);
+
+  if (buildType === 'dry-run') {
+    return {
+      version: `1000.0.0-${shortCommit}`,
+      tag: null, // We never end up publishing this
+    };
+  }
+
+  if (buildType === 'nightly') {
+    const mainVersion = getMainVersion();
+    const dateIdentifier = new Date()
+      .toISOString()
+      .slice(0, -14)
+      .replace(/[-]/g, '');
+    return {
+      version: `${mainVersion}-nightly-${dateIdentifier}-${shortCommit}`,
+      tag: 'nightly',
+    };
+  }
+
+  const {version, major, minor, prerelease} = parseVersion(
+    process.env.CIRCLE_TAG,
+    buildType,
+  );
+
+  // See if releaser indicated that this version should be tagged "latest"
+  // Set in `trigger-react-native-release`
+  const isLatest = exitIfNotOnGit(
+    () => isTaggedLatest(currentCommit),
+    'Not in git. We do not want to publish anything',
+  );
+
+  const releaseBranchTag = `${major}.${minor}-stable`;
+
+  // npm will automatically tag the version as `latest` if no tag is set when we publish
+  // To prevent this, use `releaseBranchTag` when we don't want that (ex. releasing a patch on older release)
+  const tag =
+    prerelease != null ? 'next' : isLatest ? 'latest' : releaseBranchTag;
+
+  return {
+    version,
+    tag,
+  };
+}
 
 function getPackageVersionStrByTag(packageName, tag) {
   const result = exec(`npm view ${packageName}@${tag} version`, {silent: true});
@@ -85,6 +146,7 @@ function applyPackageVersions(originalPackageJson, packageVersions) {
 
 module.exports = {
   applyPackageVersions,
+  getNpmInfo,
   getPackageVersionStrByTag,
   publishPackage,
   diffPackages,

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -10,13 +10,7 @@
 'use strict';
 
 const {echo, exit} = require('shelljs');
-const {parseVersion} = require('./version-utils');
-const {getPackageVersionStrByTag, publishPackage} = require('./npm-utils');
-const {
-  exitIfNotOnGit,
-  getCurrentCommit,
-  isTaggedLatest,
-} = require('./scm-utils');
+const {publishPackage, getNpmInfo} = require('./npm-utils');
 const getAndUpdateNightlies = require('./monorepo/get-and-update-nightlies');
 const setReactNativeVersion = require('./set-rn-version');
 const {
@@ -75,61 +69,6 @@ if (require.main === module) {
     : 'dry-run';
 
   publishNpm(buildType);
-}
-
-// Get `next` version from npm and +1 on the minor for `main` version
-function getMainVersion() {
-  const versionStr = getPackageVersionStrByTag('react-native', 'next');
-  const {major, minor} = parseVersion(versionStr, 'release');
-  return `${major}.${parseInt(minor, 10) + 1}.0`;
-}
-
-function getNpmInfo(buildType) {
-  const currentCommit = getCurrentCommit();
-  const shortCommit = currentCommit.slice(0, 9);
-
-  if (buildType === 'dry-run') {
-    return {
-      version: `1000.0.0-${shortCommit}`,
-      tag: null, // We never end up publishing this
-    };
-  }
-
-  if (buildType === 'nightly') {
-    const mainVersion = getMainVersion();
-    const dateIdentifier = new Date()
-      .toISOString()
-      .slice(0, -14)
-      .replace(/[-]/g, '');
-    return {
-      version: `${mainVersion}-nightly-${dateIdentifier}-${shortCommit}`,
-      tag: 'nightly',
-    };
-  }
-
-  const {version, major, minor, prerelease} = parseVersion(
-    process.env.CIRCLE_TAG,
-    buildType,
-  );
-
-  // See if releaser indicated that this version should be tagged "latest"
-  // Set in `trigger-react-native-release`
-  const isLatest = exitIfNotOnGit(
-    () => isTaggedLatest(currentCommit),
-    'Not in git. We do not want to publish anything',
-  );
-
-  const releaseBranchTag = `${major}.${minor}-stable`;
-
-  // npm will automatically tag the version as `latest` if no tag is set when we publish
-  // To prevent this, use `releaseBranchTag` when we don't want that (ex. releasing a patch on older release)
-  const tag =
-    prerelease != null ? 'next' : isLatest ? 'latest' : releaseBranchTag;
-
-  return {
-    version,
-    tag,
-  };
 }
 
 function publishNpm(buildType) {

--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -14,7 +14,7 @@ const {cat, echo, exit, sed} = require('shelljs');
 const yargs = require('yargs');
 const {parseVersion, validateBuildType} = require('./version-utils');
 const updateTemplatePackage = require('./update-template-package');
-const {applyPackageVersions} = require('./npm-utils');
+const {applyPackageVersions, getNpmInfo} = require('./npm-utils');
 
 /**
  * This script updates relevant React Native files with supplied version:
@@ -28,7 +28,7 @@ if (require.main === module) {
     .option('v', {
       alias: 'to-version',
       type: 'string',
-      required: true,
+      required: false,
     })
     .option('d', {
       alias: 'dependency-versions',
@@ -145,6 +145,10 @@ function setPackage({version}, dependencyVersions) {
 }
 
 function setReactNativeVersion(argVersion, dependencyVersions, buildType) {
+  if (!argVersion) {
+    const {version} = getNpmInfo(buildType);
+    argVersion = version;
+  }
   validateBuildType(buildType);
 
   const version = parseVersion(argVersion, buildType);


### PR DESCRIPTION
Summary:
In order to parallelize the Android CI, I've moved most of the building to a `build_android` step which executes before the `build_npm_package` step.

As currently, building Hermes for Android is on the critical path, this should reduce much of the execution time on CI.

Changelog:
[Internal] [Changed] - Introduce a build_android step

Differential Revision: D48148418

