### PR TITLE
Pass hitSlop into usePressability

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1380,6 +1380,7 @@ function InternalTextInput(props: Props): React.Node {
 
   const config = React.useMemo(
     () => ({
+      hitSlop: props.hitSlop,
       onPress: (event: PressEvent) => {
         if (props.editable !== false) {
           if (inputRef.current != null) {
@@ -1394,6 +1395,7 @@ function InternalTextInput(props: Props): React.Node {
     }),
     [
       props.editable,
+      props.hitSlop,
       props.onPressIn,
       props.onPressOut,
       props.rejectResponderTermination,


### PR DESCRIPTION
Summary: `hitSlop` must be passed into the `usePressability` hook in order for it to take effect. It's a no-op if no hit slop is present

Reviewed By: NickGerleman

Differential Revision: D48124538

