### PR TITLE
reuse existing source URL for bridgeless

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -279,6 +279,12 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 - (NSURL *)getBundleURL
 {
+  // Fallback to legacy API
+  NSURL *bundleURL = [self sourceURLForBridge:nil];
+  if (bundleURL) {
+    return bundleURL;
+  }
+
   [NSException raise:@"RCTAppDelegate::getBundleURL not implemented"
               format:@"Subclasses must implement a valid getBundleURL method"];
   return nullptr;


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

so i was thinking that the `getBundleURL` API that we added on the app delegate is redundant since all working apps will have the source url provided in `sourceURLForBridge:`. i briefly perused GH: https://github.com/search?q=sourceURLForBridge&type=code, and it seems no one actually needs the bridge to generate this url.

i think there's an opportunity to remove a step from the upgrade flow by either:
1) getting rid of `getBundleURL` and reuse `sourceURLForBridge:`
2) fallback to `sourceURLForBridge:` in `getBundleURL`

in this diff, i ended up going with 1), but i'm open to options. the tricky thing is that `sourceURLForBridge:` implies the old architecture.

Differential Revision: D48141201

