### PR TITLE
Add basic active pointer tracking to the pointer event processor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -15,6 +15,18 @@
 
 namespace facebook::react {
 
+// Helper struct to package a PointerEvent and SharedEventTarget together
+struct PointerEventTarget {
+  PointerEvent event;
+  SharedEventTarget target;
+};
+
+// Helper struct to contain an active pointer's event data along with additional
+// metadata
+struct ActivePointer {
+  PointerEvent event;
+};
+
 using DispatchEvent = std::function<void(
     jsi::Runtime &runtime,
     const EventTarget *eventTarget,
@@ -26,11 +38,8 @@ using PointerIdentifier = int32_t;
 using CaptureTargetOverrideRegistry =
     std::unordered_map<PointerIdentifier, ShadowNode::Weak>;
 
-// Helper struct to package a PointerEvent and SharedEventTarget together
-struct PointerEventTarget {
-  PointerEvent event;
-  SharedEventTarget target;
-};
+using ActivePointerRegistry =
+    std::unordered_map<PointerIdentifier, ActivePointer>;
 
 class PointerEventsProcessor final {
  public:
@@ -54,11 +63,19 @@ class PointerEventsProcessor final {
       ShadowNode const *shadowNode);
 
  private:
+  ActivePointer *getActivePointer(PointerIdentifier pointerId);
+
+  void registerActivePointer(PointerEvent const &event);
+  void updateActivePointer(PointerEvent const &event);
+  void unregisterActivePointer(PointerEvent const &event);
+
   void processPendingPointerCapture(
       PointerEvent const &event,
       jsi::Runtime &runtime,
       DispatchEvent const &eventDispatcher,
       UIManager const &uiManager);
+
+  ActivePointerRegistry activePointers_;
 
   CaptureTargetOverrideRegistry pendingPointerCaptureTargetOverrides_;
   CaptureTargetOverrideRegistry activePointerCaptureTargetOverrides_;


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Add basic active pointer tracking to the pointer event processor

This diff lays the groundwork for keeping track of all the "active" pointers. The ActivePointer struct right now only contains a copy of the PointerEvent data but in future diffs this will be extended to include additional stateful metadata.

It's important to note that the code as written in this diff only "tracks" pointers when they are down and won't track pointers that are only hovering. I do want to include this in future diffs but I couldn't include that handling here as it requires changes to the iOS native pointer handling to stop deriving its own hover events which ends up snowballing even more changes. I will be making this change in (hopefully) the next diff where I refactor the hover event derivation to the fabric C++ layer.

Differential Revision: D48167438

