### PR TITLE
remove RCTSurfaceSizeMeasureMode from public contract of RCTSurfaceHostingProxyRootView

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -87,10 +87,8 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
     RCTFabricSurface *surface = [_reactHost createSurfaceWithModuleName:self.moduleName
                                                       initialProperties:launchOptions];
 
-    RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView = [[RCTSurfaceHostingProxyRootView alloc]
-        initWithSurface:surface
-        sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact
-         moduleRegistry:[_reactHost getModuleRegistry]];
+    RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView =
+        [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface moduleRegistry:[_reactHost getModuleRegistry]];
 
     rootView = (RCTRootView *)surfaceHostingProxyRootView;
 #endif

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
@@ -54,9 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Bridgeless mode initializer
  */
-- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
-                sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
-                 moduleRegistry:(RCTModuleRegistry *)moduleRegistry;
+- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface moduleRegistry:(RCTModuleRegistry *)moduleRegistry;
 
 - (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface;
 

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -93,11 +93,9 @@ static RCTRootViewSizeFlexibility convertToRootViewSizeFlexibility(RCTSurfaceSiz
   return [self initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
 }
 
-- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
-                sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
-                 moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface moduleRegistry:(RCTModuleRegistry *)moduleRegistry
 {
-  if (self = [super initWithSurface:surface sizeMeasureMode:sizeMeasureMode]) {
+  if (self = [self initWithSurface:surface]) {
     _moduleRegistry = moduleRegistry;
   }
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

All callsites to `initWithSurface:sizeMeasureMode:moduleRegistry` pass down `RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact`. since that's the case, let's simplify the constructor since `initWithSurface:` passes that value by default.

Differential Revision: D48140102

