### PR TITLE
Add ability to get ShadowNodeFamily's ancestors as shared pointers

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -396,28 +396,6 @@ static void UpdateActivePointerWithUITouch(
   activePointer.modifierFlags = uiEvent.modifierFlags;
 }
 
-static BOOL IsViewListeningToEvent(RCTReactTaggedView *taggedView, ViewEvents::Offset eventType)
-{
-  UIView *view = taggedView.view;
-  if (view && [view.class conformsToProtocol:@protocol(RCTComponentViewProtocol)]) {
-    auto props = ((id<RCTComponentViewProtocol>)view).props;
-    if (SharedViewProps viewProps = std::dynamic_pointer_cast<ViewProps const>(props)) {
-      return viewProps->events[eventType];
-    }
-  }
-  return NO;
-}
-
-static BOOL IsAnyViewInPathListeningToEvent(NSOrderedSet<RCTReactTaggedView *> *viewPath, ViewEvents::Offset eventType)
-{
-  for (RCTReactTaggedView *taggedView in viewPath) {
-    if (IsViewListeningToEvent(taggedView, eventType)) {
-      return YES;
-    }
-  }
-  return NO;
-}
-
 /**
  * Given an ActivePointer determine if it is still within the same event target tree as
  * the one which initiated the pointer gesture.
@@ -634,8 +612,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 {
   for (const auto &activePointer : activePointers) {
     PointerEvent pointerEvent = CreatePointerEventFromActivePointer(activePointer, eventType, _rootComponentView);
-    NSOrderedSet<RCTReactTaggedView *> *eventPathViews = [self handleIncomingPointerEvent:pointerEvent
-                                                                                   onView:activePointer.componentView];
+    [self handleIncomingPointerEvent:pointerEvent onView:activePointer.componentView];
 
     SharedTouchEventEmitter eventEmitter = GetTouchEmitterFromView(
         activePointer.componentView,
@@ -648,12 +625,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
           break;
         }
         case RCTPointerEventTypeMove: {
-          BOOL hasMoveEventListeners =
-              IsAnyViewInPathListeningToEvent(eventPathViews, ViewEvents::Offset::PointerMove) ||
-              IsAnyViewInPathListeningToEvent(eventPathViews, ViewEvents::Offset::PointerMoveCapture);
-          if (hasMoveEventListeners) {
-            eventEmitter->onPointerMove(pointerEvent);
-          }
+          eventEmitter->onPointerMove(pointerEvent);
           break;
         }
         case RCTPointerEventTypeEnd: {
@@ -792,11 +764,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   PointerEvent event = CreatePointerEventFromIncompleteHoverData(
       pointerId, pointerType, clientLocation, screenLocation, offsetLocation, modifierFlags);
 
-  NSOrderedSet<RCTReactTaggedView *> *eventPathViews = [self handleIncomingPointerEvent:event onView:targetView];
+  [self handleIncomingPointerEvent:event onView:targetView];
   SharedTouchEventEmitter eventEmitter = GetTouchEmitterFromView(targetView, offsetLocation);
-  BOOL hasMoveEventListeners = IsAnyViewInPathListeningToEvent(eventPathViews, ViewEvents::Offset::PointerMove) ||
-      IsAnyViewInPathListeningToEvent(eventPathViews, ViewEvents::Offset::PointerMoveCapture);
-  if (eventEmitter != nil && hasMoveEventListeners) {
+  if (eventEmitter != nil) {
     eventEmitter->onPointerMove(event);
   }
 }
@@ -831,10 +801,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 
   // Out
   if (prevTargetView != nil && prevTargetTaggedView.tag != targetTaggedView.tag) {
-    BOOL shouldEmitOutEvent = IsAnyViewInPathListeningToEvent(currentlyHoveredViews, ViewEvents::Offset::PointerOut);
     SharedTouchEventEmitter eventEmitter =
         GetTouchEmitterFromView(prevTargetView, [_rootComponentView convertPoint:clientLocation toView:prevTargetView]);
-    if (shouldEmitOutEvent && eventEmitter != nil) {
+    if (eventEmitter != nil) {
       eventEmitter->onPointerOut(event);
     }
   }
@@ -847,19 +816,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   // we reverse iterate (now from target to root), actually emitting the events.
   NSMutableOrderedSet<UIView *> *viewsToEmitLeaveEventsTo = [NSMutableOrderedSet orderedSet];
 
-  BOOL hasParentLeaveListener = NO;
   for (RCTReactTaggedView *taggedView in [currentlyHoveredViews reverseObjectEnumerator]) {
     UIView *componentView = taggedView.view;
 
-    BOOL shouldEmitEvent = componentView != nil &&
-        (hasParentLeaveListener || IsViewListeningToEvent(taggedView, ViewEvents::Offset::PointerLeave));
+    BOOL shouldEmitEvent = componentView != nil;
 
     if (shouldEmitEvent && ![eventPathViews containsObject:taggedView]) {
       [viewsToEmitLeaveEventsTo addObject:componentView];
-    }
-
-    if (shouldEmitEvent && !hasParentLeaveListener) {
-      hasParentLeaveListener = YES;
     }
   }
 
@@ -873,10 +836,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 
   // Over
   if (targetView != nil && prevTargetTaggedView.tag != targetTaggedView.tag) {
-    BOOL shouldEmitOverEvent = IsAnyViewInPathListeningToEvent(eventPathViews, ViewEvents::Offset::PointerOver);
     SharedTouchEventEmitter eventEmitter =
         GetTouchEmitterFromView(targetView, [_rootComponentView convertPoint:clientLocation toView:targetView]);
-    if (shouldEmitOverEvent && eventEmitter != nil) {
+    if (eventEmitter != nil) {
       eventEmitter->onPointerOver(event);
     }
   }
@@ -888,12 +850,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   // or if one of its parents is listening in case those listeners care about the capturing phase. Adding the ability
   // for native to distinguish between capturing listeners and not could be an optimization to further reduce the number
   // of events we send to JS
-  BOOL hasParentEnterListener = NO;
   for (RCTReactTaggedView *taggedView in [eventPathViews reverseObjectEnumerator]) {
     UIView *componentView = taggedView.view;
 
-    BOOL shouldEmitEvent = componentView != nil &&
-        (hasParentEnterListener || IsViewListeningToEvent(taggedView, ViewEvents::Offset::PointerEnter));
+    BOOL shouldEmitEvent = componentView != nil;
 
     if (shouldEmitEvent && ![currentlyHoveredViews containsObject:taggedView]) {
       SharedTouchEventEmitter eventEmitter =
@@ -901,10 +861,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
       if (eventEmitter != nil) {
         eventEmitter->onPointerEnter(event);
       }
-    }
-
-    if (shouldEmitEvent && !hasParentEnterListener) {
-      hasParentEnterListener = YES;
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -62,6 +62,10 @@ struct ViewEvents {
     ClickCapture = 31,
     GotPointerCapture = 32,
     LostPointerCapture = 33,
+    PointerDown = 34,
+    PointerDownCapture = 35,
+    PointerUp = 36,
+    PointerUpCapture = 37,
   };
 
   constexpr bool operator[](const Offset offset) const {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -616,18 +616,31 @@ static inline ViewEvents convertRawProp(
       "onClickCapture",
       sourceValue[Offset::ClickCapture],
       defaultValue[Offset::ClickCapture]);
-  result[Offset::GotPointerCapture] = convertRawProp(
+  result[Offset::PointerDown] = convertRawProp(
       context,
       rawProps,
-      "onGotPointerCapture",
-      sourceValue[Offset::GotPointerCapture],
-      defaultValue[Offset::GotPointerCapture]);
-  result[Offset::LostPointerCapture] = convertRawProp(
+      "onPointerDown",
+      sourceValue[Offset::PointerDown],
+      defaultValue[Offset::PointerDown]);
+  result[Offset::PointerDownCapture] = convertRawProp(
       context,
       rawProps,
-      "onLostPointerCapture",
-      sourceValue[Offset::LostPointerCapture],
-      defaultValue[Offset::LostPointerCapture]);
+      "onPointerDownCapture",
+      sourceValue[Offset::PointerDownCapture],
+      defaultValue[Offset::PointerDownCapture]);
+  result[Offset::PointerUp] = convertRawProp(
+      context,
+      rawProps,
+      "onPointerUp",
+      sourceValue[Offset::PointerUp],
+      defaultValue[Offset::PointerUp]);
+  result[Offset::PointerUpCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onPointerUpCapture",
+      sourceValue[Offset::PointerUpCapture],
+      defaultValue[Offset::PointerUpCapture]);
+  // TODO: gotPointerCapture & lostPointerCapture
 
   // PanResponder callbacks
   result[Offset::MoveShouldSetResponder] = convertRawProp(

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -49,6 +49,9 @@ class ShadowNode : public Sealable,
           std::reference_wrapper<ShadowNode const> /* parentNode */,
           int /* childIndex */>,
       64>;
+  using AncestorListOfShared = butter::small_vector<
+      std::pair<ShadowNode::Shared /* parentNode */, int /* childIndex */>,
+      64>;
 
   static SharedListOfShared emptySharedShadowNodeSharedList();
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -54,6 +54,11 @@ class ShadowNodeFamily final {
           std::reference_wrapper<ShadowNode const> /* parentNode */,
           int /* childIndex */>,
       64>;
+  using AncestorListOfShared = butter::small_vector<
+      std::pair<
+          std::shared_ptr<ShadowNode const> /* parentNode */,
+          int /* childIndex */>,
+      64>;
 
   ShadowNodeFamily(
       ShadowNodeFamilyFragment const &fragment,
@@ -88,6 +93,13 @@ class ShadowNodeFamily final {
    * The theoretical complexity of the algorithm is `O(ln(n))`. Use it wisely.
    */
   AncestorList getAncestors(ShadowNode const &ancestorShadowNode) const;
+
+  /*
+   * Same method as getAncestors but gives you shared pointers of the ancestors
+   * instead of reference wrappers.
+   */
+  AncestorListOfShared getSharedAncestors(
+      std::shared_ptr<ShadowNode const> ancestorShadowNode) const;
 
   SurfaceId getSurfaceId() const;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeFamilyTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeFamilyTest.cpp
@@ -76,4 +76,14 @@ TEST(ShadowNodeFamilyTest, sealObjectCorrectly) {
   EXPECT_EQ(ancestors2.size(), 2);
   EXPECT_EQ(&ancestors2[0].first.get(), shadowNodeA.get());
   EXPECT_EQ(&ancestors2[1].first.get(), shadowNodeAA.get());
+
+  // Negative shared case:
+  auto ancestors3 = shadowNodeB->getFamily().getSharedAncestors(shadowNodeA);
+  EXPECT_EQ(ancestors3.size(), 0);
+
+  // Positive shared case:
+  auto ancestors4 = shadowNodeAAA->getFamily().getSharedAncestors(shadowNodeA);
+  EXPECT_EQ(ancestors4.size(), 2);
+  EXPECT_EQ(ancestors4[0].first, shadowNodeA);
+  EXPECT_EQ(ancestors4[1].first, shadowNodeAA);
 }

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
@@ -222,6 +222,16 @@ void PointerEventsProcessor::interceptPointerEvent(
     eventTarget = retargeted.target.get();
   }
 
+  if (type == "topPointerDown") {
+    registerActivePointer(pointerEvent);
+  } else if (type == "topPointerMove") {
+    // TODO: Remove the need for this check by properly handling
+    // pointerenter/pointerleave events emitted from the native platform
+    if (getActivePointer(pointerEvent.pointerId) != nullptr) {
+      updateActivePointer(pointerEvent);
+    }
+  }
+
   eventTarget->retain(runtime);
   auto shadowNode = getShadowNodeFromEventTarget(runtime, *eventTarget);
   if (shadowNode != nullptr &&
@@ -237,30 +247,45 @@ void PointerEventsProcessor::interceptPointerEvent(
     processPendingPointerCapture(
         pointerEvent, runtime, eventDispatcher, uiManager);
   }
+
+  if (type == "topPointerUp" || type == "topPointerCancel") {
+    unregisterActivePointer(pointerEvent);
+  }
 }
 
 void PointerEventsProcessor::setPointerCapture(
     PointerIdentifier pointerId,
     ShadowNode::Shared const &shadowNode) {
-  // TODO: Throw DOMException with name "NotFoundError" when pointerId does not
-  // match any of the active pointers
-  pendingPointerCaptureTargetOverrides_[pointerId] = shadowNode;
+  if (auto activePointer = getActivePointer(pointerId)) {
+    // As per the spec this method should silently fail if the pointer in
+    // question does not have any active buttons
+    if (activePointer->event.buttons == 0) {
+      return;
+    }
+
+    pendingPointerCaptureTargetOverrides_[pointerId] = shadowNode;
+  } else {
+    // TODO: Throw DOMException with name "NotFoundError" when pointerId does
+    // not match any of the active pointers
+  }
 }
 
 void PointerEventsProcessor::releasePointerCapture(
     PointerIdentifier pointerId,
     ShadowNode const *shadowNode) {
-  // TODO: Throw DOMException with name "NotFoundError" when pointerId does not
-  // match any of the active pointers
-
-  // We only clear the pointer's capture target override if release was called
-  // on the shadowNode which has the capture override, otherwise the result
-  // should no-op
-  auto pendingTarget = getCaptureTargetOverride(
-      pointerId, pendingPointerCaptureTargetOverrides_);
-  if (pendingTarget != nullptr &&
-      pendingTarget->getTag() == shadowNode->getTag()) {
-    pendingPointerCaptureTargetOverrides_.erase(pointerId);
+  if (getActivePointer(pointerId) != nullptr) {
+    // We only clear the pointer's capture target override if release was called
+    // on the shadowNode which has the capture override, otherwise the result
+    // should no-op
+    auto pendingTarget = getCaptureTargetOverride(
+        pointerId, pendingPointerCaptureTargetOverrides_);
+    if (pendingTarget != nullptr &&
+        pendingTarget->getTag() == shadowNode->getTag()) {
+      pendingPointerCaptureTargetOverrides_.erase(pointerId);
+    }
+  } else {
+    // TODO: Throw DOMException with name "NotFoundError" when pointerId does
+    // not match any of the active pointers
   }
 }
 
@@ -273,6 +298,38 @@ bool PointerEventsProcessor::hasPointerCapture(
     return pendingTarget->getTag() == shadowNode->getTag();
   }
   return false;
+}
+
+ActivePointer *PointerEventsProcessor::getActivePointer(
+    PointerIdentifier pointerId) {
+  auto it = activePointers_.find(pointerId);
+  return (it == activePointers_.end()) ? nullptr : &it->second;
+}
+
+void PointerEventsProcessor::registerActivePointer(PointerEvent const &event) {
+  ActivePointer activePointer = {};
+  activePointer.event = event;
+
+  activePointers_[event.pointerId] = activePointer;
+}
+
+void PointerEventsProcessor::updateActivePointer(PointerEvent const &event) {
+  if (auto activePointer = getActivePointer(event.pointerId)) {
+    activePointer->event = event;
+  } else {
+    LOG(WARNING)
+        << "Inconsistency between local and platform pointer registries";
+  }
+}
+
+void PointerEventsProcessor::unregisterActivePointer(
+    PointerEvent const &event) {
+  if (getActivePointer(event.pointerId) != nullptr) {
+    activePointers_.erase(event.pointerId);
+  } else {
+    LOG(WARNING)
+        << "Inconsistency between local and platform pointer registries";
+  }
 }
 
 void PointerEventsProcessor::processPendingPointerCapture(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -15,6 +15,18 @@
 
 namespace facebook::react {
 
+// Helper struct to package a PointerEvent and SharedEventTarget together
+struct PointerEventTarget {
+  PointerEvent event;
+  SharedEventTarget target;
+};
+
+// Helper struct to contain an active pointer's event data along with additional
+// metadata
+struct ActivePointer {
+  PointerEvent event;
+};
+
 using DispatchEvent = std::function<void(
     jsi::Runtime &runtime,
     const EventTarget *eventTarget,
@@ -26,11 +38,8 @@ using PointerIdentifier = int32_t;
 using CaptureTargetOverrideRegistry =
     std::unordered_map<PointerIdentifier, ShadowNode::Weak>;
 
-// Helper struct to package a PointerEvent and SharedEventTarget together
-struct PointerEventTarget {
-  PointerEvent event;
-  SharedEventTarget target;
-};
+using ActivePointerRegistry =
+    std::unordered_map<PointerIdentifier, ActivePointer>;
 
 class PointerEventsProcessor final {
  public:
@@ -54,11 +63,19 @@ class PointerEventsProcessor final {
       ShadowNode const *shadowNode);
 
  private:
+  ActivePointer *getActivePointer(PointerIdentifier pointerId);
+
+  void registerActivePointer(PointerEvent const &event);
+  void updateActivePointer(PointerEvent const &event);
+  void unregisterActivePointer(PointerEvent const &event);
+
   void processPendingPointerCapture(
       PointerEvent const &event,
       jsi::Runtime &runtime,
       DispatchEvent const &eventDispatcher,
       UIManager const &uiManager);
+
+  ActivePointerRegistry activePointers_;
 
   CaptureTargetOverrideRegistry pendingPointerCaptureTargetOverrides_;
   CaptureTargetOverrideRegistry activePointerCaptureTargetOverrides_;


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Add ability to get ShadowNodeFamily's ancestors as shared pointers

While working on the hover tracking logic I've found the need to recieve a node's ancestor list to contain shared pointers to ShadowNodes instead of references to them. This isn't necessarily to get ownership of the ancestors but instead will allow me to store those shadow node lists as weak pointers so I have a mechanism to know when they've been deallocated.

RFC: This effectively just adds a copy of the existing `getAncestors` method with minor changes. This creates some code duplication but I'm unsure of a more elegant way to do this so I'm open to ideas.

Differential Revision: D48170045

