### PR TITLE
delete unused RCTSurfaceHostingProxyRootView initializers

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -87,10 +87,8 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
     RCTFabricSurface *surface = [_reactHost createSurfaceWithModuleName:self.moduleName
                                                       initialProperties:launchOptions];
 
-    RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView = [[RCTSurfaceHostingProxyRootView alloc]
-        initWithSurface:surface
-        sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact
-         moduleRegistry:[_reactHost getModuleRegistry]];
+    RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView =
+        [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface moduleRegistry:[_reactHost getModuleRegistry]];
 
     rootView = (RCTRootView *)surfaceHostingProxyRootView;
 #endif

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
@@ -42,15 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSTimeInterval loadingViewFadeDuration;
 @property (nonatomic, assign) CGSize minimumSize;
 
-- (instancetype)initWithBridge:(RCTBridge *)bridge
-                    moduleName:(NSString *)moduleName
-             initialProperties:(NSDictionary *)initialProperties NS_DESIGNATED_INITIALIZER;
-
-- (instancetype)initWithBundleURL:(NSURL *)bundleURL
-                       moduleName:(NSString *)moduleName
-                initialProperties:(NSDictionary *)initialProperties
-                    launchOptions:(NSDictionary *)launchOptions;
-
 /**
  * Bridgeless mode initializer
  */

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
@@ -54,9 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Bridgeless mode initializer
  */
-- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
-                sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
-                 moduleRegistry:(RCTModuleRegistry *)moduleRegistry;
+- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface moduleRegistry:(RCTModuleRegistry *)moduleRegistry;
 
 - (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface;
 

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -53,46 +53,6 @@ static RCTRootViewSizeFlexibility convertToRootViewSizeFlexibility(RCTSurfaceSiz
   RCTModuleRegistry *_moduleRegistry;
 }
 
-- (instancetype)initWithBridge:(RCTBridge *)bridge
-                    moduleName:(NSString *)moduleName
-             initialProperties:(NSDictionary *)initialProperties
-{
-  RCTAssertMainQueue();
-  RCTAssert(bridge, @"A bridge instance is required to create an RCTSurfaceHostingProxyRootView");
-  RCTAssert(moduleName, @"A moduleName is required to create an RCTSurfaceHostingProxyRootView");
-
-  RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"-[RCTSurfaceHostingProxyRootView init]", nil);
-
-  _bridge = bridge;
-  _minimumSize = CGSizeZero;
-
-  if (!bridge.isLoading) {
-    [bridge.performanceLogger markStartForTag:RCTPLTTI];
-  }
-
-  // `RCTRootViewSizeFlexibilityNone` is the RCTRootView's default.
-  RCTSurfaceSizeMeasureMode sizeMeasureMode = convertToSurfaceSizeMeasureMode(RCTRootViewSizeFlexibilityNone);
-
-  self = [super initWithBridge:bridge
-                    moduleName:moduleName
-             initialProperties:initialProperties
-               sizeMeasureMode:sizeMeasureMode];
-
-  RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
-
-  return self;
-}
-
-- (instancetype)initWithBundleURL:(NSURL *)bundleURL
-                       moduleName:(NSString *)moduleName
-                initialProperties:(NSDictionary *)initialProperties
-                    launchOptions:(NSDictionary *)launchOptions
-{
-  RCTBridge *bridge = [[RCTBridge alloc] initWithBundleURL:bundleURL moduleProvider:nil launchOptions:launchOptions];
-
-  return [self initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
-}
-
 - (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface moduleRegistry:(RCTModuleRegistry *)moduleRegistry
 {
   if (self = [self initWithSurface:surface]) {

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -93,11 +93,9 @@ static RCTRootViewSizeFlexibility convertToRootViewSizeFlexibility(RCTSurfaceSiz
   return [self initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
 }
 
-- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
-                sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
-                 moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface moduleRegistry:(RCTModuleRegistry *)moduleRegistry
 {
-  if (self = [super initWithSurface:surface sizeMeasureMode:sizeMeasureMode]) {
+  if (self = [self initWithSurface:surface]) {
     _moduleRegistry = moduleRegistry;
   }
 


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

after D48139820, these are not needed anymore. there's some logic with the bridge, but since we're treating new arch as one piece moving forward, i don't really think they're that important. plus that logic is like really old.

Differential Revision: D48140101

