### PR TITLE
decouple root views from native modules

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -93,8 +93,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
     RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView = [[RCTSurfaceHostingProxyRootView alloc]
         initWithSurface:surface
-        sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact
-         moduleRegistry:[_reactHost getModuleRegistry]];
+        sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact];
 
     rootView = (RCTRootView *)surfaceHostingProxyRootView;
 #endif

--- a/packages/react-native/React/Base/RCTRootView.h
+++ b/packages/react-native/React/Base/RCTRootView.h
@@ -78,14 +78,6 @@ extern
                     launchOptions:(nullable NSDictionary *)launchOptions;
 
 /**
- * This API allows users of RCTRootView to access other NativeModules, without
- * directly accessing the bridge.
- */
-@property (nonatomic, strong, readonly) RCTModuleRegistry *moduleRegistry;
-
-@property (nonatomic, strong, readonly) id<RCTEventDispatcherProtocol> eventDispatcher;
-
-/**
  * The name of the JavaScript module to execute within the
  * specified scriptURL (required). Setting this will not have
  * any immediate effect, but it must be done prior to loading

--- a/packages/react-native/React/Base/RCTRootView.m
+++ b/packages/react-native/React/Base/RCTRootView.m
@@ -121,16 +121,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   return self;
 }
 
-- (RCTModuleRegistry *)moduleRegistry
-{
-  return _bridge.moduleRegistry;
-}
-
-- (id<RCTEventDispatcherProtocol>)eventDispatcher
-{
-  return [self.moduleRegistry moduleForName:"EventDispatcher"];
-}
-
 #pragma mark - passThroughTouches
 
 - (BOOL)passThroughTouches

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
@@ -27,8 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, readonly) NSString *moduleName;
 @property (nonatomic, strong, readonly) RCTBridge *bridge;
-@property (nonatomic, strong, readonly) RCTModuleRegistry *moduleRegistry;
-@property (nonatomic, strong, readonly) id<RCTEventDispatcherProtocol> eventDispatcher;
 @property (nonatomic, copy, readwrite) NSDictionary *appProperties;
 @property (nonatomic, assign) RCTRootViewSizeFlexibility sizeFlexibility;
 @property (nonatomic, weak) id<RCTRootViewDelegate> delegate;
@@ -41,14 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSTimeInterval loadingViewFadeDuration;
 @property (nonatomic, assign) CGSize minimumSize;
 
-/**
- * Bridgeless mode initializer
- */
-- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
-                sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
-                 moduleRegistry:(RCTModuleRegistry *)moduleRegistry;
-
-- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface;
+- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface NS_DESIGNATED_INITIALIZER;
 
 - (void)cancelTouches;
 

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -49,20 +49,7 @@ static RCTRootViewSizeFlexibility convertToRootViewSizeFlexibility(RCTSurfaceSiz
   }
 }
 
-@implementation RCTSurfaceHostingProxyRootView {
-  RCTModuleRegistry *_moduleRegistry;
-}
-
-- (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
-                sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
-                 moduleRegistry:(RCTModuleRegistry *)moduleRegistry
-{
-  if (self = [super initWithSurface:surface sizeMeasureMode:sizeMeasureMode]) {
-    _moduleRegistry = moduleRegistry;
-  }
-
-  return self;
-}
+@implementation RCTSurfaceHostingProxyRootView
 
 - (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
 {
@@ -71,21 +58,6 @@ static RCTRootViewSizeFlexibility convertToRootViewSizeFlexibility(RCTSurfaceSiz
     [surface start];
   }
   return self;
-}
-
-- (RCTModuleRegistry *)moduleRegistry
-{
-  // In bridgeless mode, RCTSurfaceHostingProxyRootView is created with an RCTModuleRegistry
-  if (_moduleRegistry) {
-    return _moduleRegistry;
-  }
-
-  return _bridge.moduleRegistry;
-}
-
-- (id<RCTEventDispatcherProtocol>)eventDispatcher
-{
-  return [self.moduleRegistry moduleForName:"EventDispatcher"];
 }
 
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

now after all the diffs in this stack, we can finally decouple the root views from the module registry, and remove the dependency from fabric root views on bridge.

for what i'm breaking, i only found this module library: https://github.com/flyskywhy/react-native-blob-util/blob/3d5155e11426fa458a9e2dbf7fe691cf9863ff01/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm#L45. they can replace this with synthesize moduleRegistry API to get access.

for eventDispatcher, i didn't see anyone using this.

Differential Revision: D48179428

