### PR TITLE
Enable local caching for Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+org.gradle.caching=true
 
 android.useAndroidX=true
 

--- a/packages/react-native-gradle-plugin/gradle.properties
+++ b/packages/react-native-gradle-plugin/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.caching=true
+


### PR DESCRIPTION
Summary:
This turns on local caching for Gradle builds.
From now on, some of the tasks of the build will be cached inside the `.gradle` folder.

This will benefit 'clean builds' and builds happening after branch/context switch.
CI will also benefit from this improvement as we're storing the cache folder on CircleCI.

After this we'll have to follow-up and enabling `Cacheable` on each of our task as
they're currently all disabled.

Changelog:
[Internal] [Changed] - Enable local caching for Gradle

Differential Revision: D48187656

