### PR TITLE
Cleanup and scope all the Gradle Properties

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1087,7 +1087,7 @@ jobs:
                   else
                     export ORG_GRADLE_PROJECT_hermesEnabled=false
                   fi
-                  ./gradlew assemble<< parameters.flavor >> -PREACT_NATIVE_MAVEN_LOCAL_REPO=/root/react-native/maven-local
+                  ./gradlew assemble<< parameters.flavor >> -Preact.internal.mavenLocalRepo=/root/react-native/maven-local
 
       - store_artifacts:
           path: /tmp/AndroidTemplateProject/android/app/build/outputs/apk/

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -7,13 +7,15 @@
 
 package com.facebook.react.utils
 
+import com.facebook.react.utils.PropertyUtils.DEFAULT_INTERNAL_PUBLISHING_GROUP
+import com.facebook.react.utils.PropertyUtils.INTERNAL_PUBLISHING_GROUP
+import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO
+import com.facebook.react.utils.PropertyUtils.INTERNAL_VERSION_NAME
 import java.io.File
 import java.net.URI
 import java.util.*
 import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-
-internal const val DEFAULT_GROUP_STRING = "com.facebook.react"
 
 internal object DependencyUtils {
 
@@ -24,8 +26,8 @@ internal object DependencyUtils {
   fun configureRepositories(project: Project, reactNativeDir: File) {
     project.rootProject.allprojects { eachProject ->
       with(eachProject) {
-        if (hasProperty("REACT_NATIVE_MAVEN_LOCAL_REPO")) {
-          val mavenLocalRepoPath = property("REACT_NATIVE_MAVEN_LOCAL_REPO") as String
+        if (hasProperty(INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO)) {
+          val mavenLocalRepoPath = property(INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO) as String
           mavenRepoFromURI(File(mavenLocalRepoPath).toURI())
         }
         // We add the snapshot for users on nightlies.
@@ -52,7 +54,7 @@ internal object DependencyUtils {
   fun configureDependencies(
       project: Project,
       versionString: String,
-      groupString: String = DEFAULT_GROUP_STRING
+      groupString: String = DEFAULT_INTERNAL_PUBLISHING_GROUP
   ) {
     if (versionString.isBlank()) return
     project.rootProject.allprojects { eachProject ->
@@ -77,7 +79,7 @@ internal object DependencyUtils {
 
   internal fun getDependencySubstitutions(
       versionString: String,
-      groupString: String = DEFAULT_GROUP_STRING
+      groupString: String = DEFAULT_INTERNAL_PUBLISHING_GROUP
   ): List<Triple<String, String, String>> {
     val dependencySubstitution = mutableListOf<Triple<String, String, String>>()
     dependencySubstitution.add(
@@ -90,7 +92,7 @@ internal object DependencyUtils {
             "com.facebook.react:hermes-engine",
             "${groupString}:hermes-android:${versionString}",
             "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210."))
-    if (groupString != DEFAULT_GROUP_STRING) {
+    if (groupString != DEFAULT_INTERNAL_PUBLISHING_GROUP) {
       dependencySubstitution.add(
           Triple(
               "com.facebook.react:react-android",
@@ -108,7 +110,7 @@ internal object DependencyUtils {
   fun readVersionAndGroupStrings(propertiesFile: File): Pair<String, String> {
     val reactAndroidProperties = Properties()
     propertiesFile.inputStream().use { reactAndroidProperties.load(it) }
-    val versionStringFromFile = reactAndroidProperties["VERSION_NAME"] as? String ?: ""
+    val versionStringFromFile = reactAndroidProperties[INTERNAL_VERSION_NAME] as? String ?: ""
     // If on a nightly, we need to fetch the -SNAPSHOT artifact from Sonatype.
     val versionString =
         if (versionStringFromFile.startsWith("0.0.0") || "-nightly-" in versionStringFromFile) {
@@ -117,7 +119,9 @@ internal object DependencyUtils {
           versionStringFromFile
         }
     // Returns Maven group for repos using different group for Maven artifacts
-    val groupString = reactAndroidProperties["GROUP"] as? String ?: DEFAULT_GROUP_STRING
+    val groupString =
+        reactAndroidProperties[INTERNAL_PUBLISHING_GROUP] as? String
+            ?: DEFAULT_INTERNAL_PUBLISHING_GROUP
     return Pair(versionString, groupString)
   }
 

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -7,12 +7,43 @@
 
 package com.facebook.react.utils
 
-/** Collection of all the Gradle Propreties that are accepted by React Native Gradle Plugin. */
+/** Collection of all the Gradle Properties that are accepted by React Native Gradle Plugin. */
 object PropertyUtils {
+
+  /** Public property that toggles the New Architecture */
+  const val NEW_ARCH_ENABLED = "newArchEnabled"
+  const val SCOPED_NEW_ARCH_ENABLED = "react.newArchEnabled"
+
+  /** Public property that toggles the New Architecture */
+  const val HERMES_ENABLED = "hermesEnabled"
+  const val SCOPED_HERMES_ENABLED = "react.hermesEnabled"
+
+  /** Public property that allows to control which architectures to build for React Native. */
+  const val REACT_NATIVE_ARCHITECTURES = "reactNativeArchitectures"
+  const val SCOPED_REACT_NATIVE_ARCHITECTURES = "react.nativeArchitectures"
 
   /**
    * Internal Property that acts as a killswitch to configure the JDK version and align it for app
    * and all the libraries.
    */
   const val INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT = "react.internal.disableJavaVersionAlignment"
+
+  /**
+   * Internal Property that allows to specify a local Maven repository to use for React Native
+   * artifacts It's used on CI to test templates against a version of React Native built on the fly.
+   */
+  const val INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO = "react.internal.mavenLocalRepo"
+
+  /**
+   * Internal property used to specify where the Windows Bash executable is located. This is useful
+   * for contributors who are running Windows on their machine.
+   */
+  const val INTERNAL_REACT_WINDOWS_BASH = "react.internal.windowsBashPath"
+
+  /** Internal property used to override the publishing group for the React Native artifacts. */
+  const val INTERNAL_PUBLISHING_GROUP = "react.internal.publishingGroup"
+  const val DEFAULT_INTERNAL_PUBLISHING_GROUP = "com.facebook.react"
+
+  /** Internal property used to control the version name of React Native */
+  const val INTERNAL_VERSION_NAME = "VERSION_NAME"
 }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -31,7 +31,7 @@ class DependencyUtilsTest {
     val localMaven = tempFolder.newFolder("m2")
     val localMavenURI = localMaven.toURI()
     val project = createProject()
-    project.extensions.extraProperties.set("REACT_NATIVE_MAVEN_LOCAL_REPO", localMaven.absolutePath)
+    project.extensions.extraProperties.set("react.internal.mavenLocalRepo", localMaven.absolutePath)
 
     configureRepositories(project, tempFolder.root)
 
@@ -115,7 +115,7 @@ class DependencyUtilsTest {
     val localMavenURI = localMaven.toURI()
     val mavenCentralURI = URI.create("https://repo.maven.apache.org/maven2/")
     val project = createProject()
-    project.extensions.extraProperties.set("REACT_NATIVE_MAVEN_LOCAL_REPO", localMaven.absolutePath)
+    project.extensions.extraProperties.set("react.internal.mavenLocalRepo", localMaven.absolutePath)
 
     configureRepositories(project, tempFolder.root)
 
@@ -358,7 +358,7 @@ class DependencyUtilsTest {
         tempFolder.newFile("gradle.properties").apply {
           writeText(
               """
-        GROUP=io.github.test
+        react.internal.publishingGroup=io.github.test
         ANOTHER_PROPERTY=true
       """
                   .trimIndent())

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -396,7 +396,7 @@ task downloadNdkBuildDependencies {
 // This is not the case for users of React Native, as we ship a compiled version of the codegen.
 final def buildCodegenCLITask = tasks.register('buildCodegenCLI', BuildCodegenCLITask) {
     it.codegenDir.set(file("$rootDir/node_modules/@react-native/codegen"))
-    it.bashWindowsHome.set(project.findProperty("REACT_WINDOWS_BASH"))
+    it.bashWindowsHome.set(project.findProperty("react.internal.windowsBashPath"))
 }
 
 /**

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -1,5 +1,5 @@
 VERSION_NAME=1000.0.0
-GROUP=com.facebook.react
+react.internal.publishingGroup=com.facebook.react
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -249,7 +249,7 @@ async function testRNTestProject(circleCIArtifacts) {
 
   // need to do this here so that Android will be properly setup either way
   exec(
-    `echo "REACT_NATIVE_MAVEN_LOCAL_REPO=${mavenLocalPath}" >> android/gradle.properties`,
+    `echo "react.internal.mavenLocalRepo=${mavenLocalPath}" >> android/gradle.properties`,
   );
 
   // doing the pod install here so that it's easier to play around RNTestProject


### PR DESCRIPTION
Summary:
We do have several Gradle Properties that are used to configure the build.

I've refactored them all and moved them inside the PropertyUtils file:
https://github.com/facebook/react-native/blob/main/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt

Specifically properties should be 'scoped' under `react.` if public, and `react.internal.` if for internal usage.

Property that I cleaned up are:
- REACT_NATIVE_MAVEN_LOCAL_REPO becomes react.internal.mavenLocalRepo
- REACT_WINDOWS_BASH becomes react.internal.windowsBashPath
- GROUP becomes react.internal.publishingGroup

I've also added support for scoping for public properties with backward compat (so both the scoped and unscoped properties are accepted):
- react.newArchEnabled
- react.hermesEnabled
- react.nativeArchitectures

Changelog:
[Android] [Changed] - Cleanup and scope all the Gradle Properties

Differential Revision: D48188310

