### PR TITLE
Introduce react.internal.useHermesNightly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,3 +112,28 @@ tasks.register("publishAllToSonatype") {
   dependsOn(":packages:react-native:ReactAndroid:flipper-integration:publishToSonatype")
   dependsOn(":packages:react-native:ReactAndroid:hermes-engine:publishToSonatype")
 }
+
+if (project.findProperty("react.internal.useHermesNightly")?.toString()?.toBoolean() == true) {
+  logger.warn(
+      """
+      ********************************************************************************
+      INFO: You're using Hermes from nightly as you set
+      
+      react.internal.useHermesNightly=true
+      
+      in the ./gradle.properties file.
+      
+      That's fine for local development, but you should not commit this change.
+      ********************************************************************************
+  """
+          .trimIndent())
+  allprojects {
+    configurations.all {
+      resolutionStrategy.dependencySubstitution {
+        substitute(project(":packages:react-native:ReactAndroid:hermes-engine"))
+            .using(module("com.facebook.react:hermes-android:0.0.0-+"))
+            .because("Users opted to use hermes from nightly")
+      }
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,7 @@ android.useAndroidX=true
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
 reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+
+# Controls whether to use Hermes from nightly builds. This will speed up builds
+# but should NOT be turned on for CI or release builds.
+react.internal.useHermesNightly=false

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -10,6 +10,7 @@ package com.facebook.react.utils
 import com.facebook.react.utils.PropertyUtils.DEFAULT_INTERNAL_PUBLISHING_GROUP
 import com.facebook.react.utils.PropertyUtils.INTERNAL_PUBLISHING_GROUP
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO
+import com.facebook.react.utils.PropertyUtils.INTERNAL_USE_HERMES_NIGHTLY
 import com.facebook.react.utils.PropertyUtils.INTERNAL_VERSION_NAME
 import java.io.File
 import java.net.URI
@@ -70,9 +71,13 @@ internal object DependencyUtils {
         }
         configuration.resolutionStrategy.force(
             "${groupString}:react-android:${versionString}",
-            "${groupString}:hermes-android:${versionString}",
             "${groupString}:flipper-integration:${versionString}",
         )
+        if (!(eachProject.findProperty(INTERNAL_USE_HERMES_NIGHTLY) as? String).toBoolean()) {
+          // Contributors only: The hermes-engine version is forced only if the user has
+          // not opted into using nightlies for local development.
+          configuration.resolutionStrategy.force("${groupString}:hermes-android:${versionString}")
+        }
       }
     }
   }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -40,6 +40,12 @@ object PropertyUtils {
    */
   const val INTERNAL_REACT_WINDOWS_BASH = "react.internal.windowsBashPath"
 
+  /**
+   * Internal property to force the build to use Hermes from the latest nightly. This speeds up the
+   * build at the cost of not testing the latest integration against Hermes.
+   */
+  const val INTERNAL_USE_HERMES_NIGHTLY = "react.internal.useHermesNightly"
+
   /** Internal property used to override the publishing group for the React Native artifacts. */
   const val INTERNAL_PUBLISHING_GROUP = "react.internal.publishingGroup"
   const val DEFAULT_INTERNAL_PUBLISHING_GROUP = "com.facebook.react"

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -180,9 +180,11 @@ android {
 }
 
 afterEvaluate {
-    // As we're consuming Hermes from source, we want to make sure
-    // `hermesc` is built before we actually invoke the `emit*HermesResource` task
-    createBundleHermesReleaseJsAndAssets.dependsOn(":packages:react-native:ReactAndroid:hermes-engine:buildHermesC")
+    if (project.findProperty("react.internal.useHermesNightly") == null || project.findProperty("react.internal.useHermesNightly").toString() == "false") {
+        // As we're consuming Hermes from source, we want to make sure
+        // `hermesc` is built before we actually invoke the `emit*HermesResource` task
+        createBundleHermesReleaseJsAndAssets.dependsOn(":packages:react-native:ReactAndroid:hermes-engine:buildHermesC")
+    }
 
     // As we're building 4 native flavors in parallel, there is clash on the `.cxx/Debug` and
     // `.cxx/Release` folder where the CMake intermediates are stored.


### PR DESCRIPTION
Summary:
This change introduces a property called `react.internal.useHermesNightly`

This allows users building RN-Tester or just ReactAndroid to fetch Hermes from the latest
nightly, without having to build it from source.

The change could be useful to speedup local development, but it should not be enabled on CI or when doing releases.

Changelog:
[Internal] [Changed] - Introduce react.internal.useHermesNightly

Differential Revision: D48188769

