### PR TITLE
Fix null crash when using maintainVisibleContentPosition on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
@@ -103,6 +103,10 @@ public class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup &
     }
 
     View firstVisibleView = mFirstVisibleView.get();
+    if (firstVisibleView == null) {
+      return;
+    }
+
     Rect newFrame = new Rect();
     firstVisibleView.getHitRect(newFrame);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

`mFirstVisibleView` is a weak ref so it can also be null when dereferencing.

This was reported on the original PR here https://github.com/facebook/react-native/pull/35049#discussion_r1288195469

## Changelog:

[ANDROID] [FIXED] - Fix null crash when using maintainVisibleContentPosition on Android

## Test Plan:

Not sure exactly in what cases this can happen, but the fix is trivial and makes sense.
