### PR TITLE
Mitigate flakiness in iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -812,7 +812,7 @@ jobs:
           steps:
             - run:
                 name: "Run Tests: iOS Unit and Integration Tests"
-                command: yarn test-ios
+                command: node ./scripts/circleci/run_with_retry.js 3 yarn test-ios
             - run:
                 name: Zip Derived data folder
                 when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -736,10 +736,6 @@ jobs:
         description: Specifies whether unit tests should run.
         type: boolean
         default: false
-      run_disabled_tests:
-        description: Specifies whether disabled tests should run. Set this to true to debug failing tests.
-        type: boolean
-        default: false
       jsengine:
         default: "Hermes"
         description: Which JavaScript engine to use. Must be one of "Hermes", "JSC".
@@ -827,26 +823,7 @@ jobs:
                   tar -zcvf xcresults.tar.gz $XCRESULT_PATH
             - store_artifacts:
                 path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
-
-      # Optionally, run disabled tests
-      - when:
-          condition: << parameters.run_disabled_tests >>
-          steps:
-            - run: echo "Failing tests may be moved here temporarily."
-            - run:
-                name: "Run Tests: CocoaPods"
-                command: ./scripts/process-podspecs.sh
-            - run:
-                name: Free up port 8081 for iOS End-to-End Tests
-                command: |
-                  # free up port 8081 for the packager before running tests
-                  set +eo pipefail
-                  lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
-                  set -eo pipefail
-            - run_e2e:
-                platform: ios
       # -------------------------
-
       # Collect Results
       - report_bundle_size:
           platform: ios

--- a/scripts/circleci/run_with_retry.js
+++ b/scripts/circleci/run_with_retry.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const {spawnSync} = require('child_process');
+
+function retryCommand(maxRetries, command) {
+  for (let i = 1; i <= maxRetries; i++) {
+    console.log(`Attempt ${i}: ${command}`);
+    const result = spawnSync(command, {shell: true, stdio: 'inherit'});
+
+    if (result.status === 0) {
+      console.log(`Command succeeded on attempt ${i}`);
+      process.exit(0);
+    } else {
+      console.log(`Command failed on attempt ${i}`);
+      if (i < maxRetries) {
+        console.log('Retrying...');
+      } else {
+        console.log('Maximum retries reached. Exiting.');
+        process.exit(1);
+      }
+    }
+  }
+}
+
+const maxRetries = process.argv[2];
+const command = process.argv.slice(3).join(' ');
+
+if (!maxRetries || !command) {
+  console.log('Usage: node retry_script.js <max_retries> <command>');
+  process.exit(1);
+}
+
+retryCommand(maxRetries, command);


### PR DESCRIPTION
Summary:
This diff introduces a script `run_with_retry` that we can apply to single commands in order to mitigate the flakiness.

This can be useful when networking is involved, to retry installing some dependencies, or for example with some e2e/integration tests.

The diff applies this rerun to the iOS tests so we mitigate failures in CI.

## Changelog:
[Internal] - Add script to retry CI steps and mitigate iOS flakyness.

Differential Revision: D48189365

