### PR TITLE
Do not store Hermes debug symbols on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1896,11 +1896,6 @@ jobs:
 
               node ./scripts/publish-npm.js --<< parameters.release_type >>
       - run:
-          name: Zip Hermes Native Symbols
-          command: zip -r /tmp/hermes-native-symbols.zip ~/react-native/packages/react-native/ReactAndroid/hermes-engine/build/intermediates/cmake/
-      - store_artifacts:
-          path: /tmp/hermes-native-symbols.zip
-      - run:
           name: Zip Maven Artifacts from /tmp/maven-local
           command: zip -r /tmp/maven-local.zip /tmp/maven-local
       - store_artifacts:


### PR DESCRIPTION
Summary:
As now we distribute libraries on Maven Central,
users should be able to use those instead of having to download them from the
React Native CI automatically.

This is already available since React Native 0.71, so we can probably remove this extra step.

Changelog:
[Internal] [Changed] - Do not store Hermes debug symbols on CircleCI

Reviewed By: mdvacca

Differential Revision: D48197732

