### PR TITLE
Remove Flipper jobs from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2246,6 +2246,21 @@ workflows:
                 jsengine: "JSC"
                 flipper: "WithFlipper"
                 use_frameworks: "DynamicFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticLibraries"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticLibraries"
+              - architecture: "OldArch"
+                flavor: "Debug"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticLibraries"
       - test_ios_rntester:
           requires:
             - build_hermes_macos


### PR DESCRIPTION
Summary:
Flipper is going to be deprecated in 0.73. So we can decide to remove the CircleCI tests that run Flipper:

- test_ios_template-NewArch-Debug-WithFlipper-Hermes-StaticLibraries
- test_ios_template-NewArch-Debug-WithFlipper-JSC-StaticLibraries
- test_ios_template-OldArch-Debug-WithFlipper-Hermes-StaticLibraries
- test_ios_template-OldArch-Debug-WithFlipper-JSC-StaticLibraries

Changelog:

[Internal] [Changed] - Remove Flipper jobs from Circle CI

Differential Revision: D48209184

