### PR TITLE
[LOCAL] Fix broken Android tests for 0.72

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowSoLoader.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.testutils.shadows
+
+import android.content.Context
+import com.facebook.soloader.SoLoader
+import kotlin.jvm.JvmStatic
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Suppress("UNUSED_PARAMETER")
+@Implements(SoLoader::class)
+class ShadowSoLoader {
+  companion object {
+    @JvmStatic @Implementation fun init(context: Context?, flags: Int) {}
+
+    @JvmStatic @Implementation fun loadLibrary(shortName: String?): Boolean = true
+  }
+}


### PR DESCRIPTION
## Summary:

JVM Tests for 0.72 are failing to compile due to a missing `ShadowSoLoader` class which exists in main. I'm adding it here.

## Changelog:

[INTERNAL] - [LOCAL] Fix broken Android tests for 0.72

## Test Plan:

Tests are green locally, so should they be on CI