### PR TITLE
Fix warnings for Gradle 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,10 +6,10 @@
  */
 
 plugins {
-  id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+  id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
   id("com.android.library") version "8.1.0" apply false
   id("com.android.application") version "8.1.0" apply false
-  id("de.undercouch.download") version "5.0.1" apply false
+  id("de.undercouch.download") version "5.4.0" apply false
   kotlin("android") version "1.8.0" apply false
 }
 
@@ -52,7 +52,7 @@ tasks.register("clean", Delete::class.java) {
       dependsOn(it.tasks.named("clean"))
     }
   }
-  delete(allprojects.map { it.buildDir })
+  delete(allprojects.map { it.layout.buildDirectory.asFile })
   delete(rootProject.file("./packages/react-native/ReactAndroid/.cxx"))
   delete(rootProject.file("./packages/react-native/ReactAndroid/hermes-engine/.cxx"))
   delete(rootProject.file("./packages/react-native/sdks/download/"))

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -28,6 +28,8 @@ import kotlin.system.exitProcess
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.internal.jvm.Jvm
 
 class ReactPlugin : Plugin<Project> {
@@ -111,7 +113,8 @@ class ReactPlugin : Plugin<Project> {
       isLibrary: Boolean
   ) {
     // First, we set up the output dir for the codegen.
-    val generatedSrcDir = File(project.buildDir, "generated/source/codegen")
+    val generatedSrcDir: Provider<Directory> =
+        project.layout.buildDirectory.dir("generated/source/codegen")
 
     // We specify the default value (convention) for jsRootDir.
     // It's the root folder for apps (so ../../ from the Gradle project)
@@ -172,7 +175,7 @@ class ReactPlugin : Plugin<Project> {
     //
     // android { sourceSets { main { java { srcDirs += "$generatedSrcDir/java" } } } }
     project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
-      ext.sourceSets.getByName("main").java.srcDir(File(generatedSrcDir, "java"))
+      ext.sourceSets.getByName("main").java.srcDir(generatedSrcDir.get().dir("java").asFile)
     }
 
     // `preBuild` is one of the base tasks automatically registered by AGP.

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -41,7 +41,7 @@ internal object NdkConfiguratorUtils {
         // the user provided, but allow for sensible defaults).
         val cmakeArgs = ext.defaultConfig.externalNativeBuild.cmake.arguments
         if (cmakeArgs.none { it.startsWith("-DPROJECT_BUILD_DIR") }) {
-          cmakeArgs.add("-DPROJECT_BUILD_DIR=${project.buildDir}")
+          cmakeArgs.add("-DPROJECT_BUILD_DIR=${project.layout.buildDirectory.get().asFile}")
         }
         if (cmakeArgs.none { it.startsWith("-DREACT_ANDROID_DIR") }) {
           cmakeArgs.add(

--- a/packages/react-native/build.gradle.kts
+++ b/packages/react-native/build.gradle.kts
@@ -13,6 +13,6 @@
 plugins {
   id("com.android.library") version "8.1.0" apply false
   id("com.android.application") version "8.1.0" apply false
-  id("de.undercouch.download") version "5.0.1" apply false
+  id("de.undercouch.download") version "5.4.0" apply false
   kotlin("android") version "1.8.0" apply false
 }


### PR DESCRIPTION
Summary:
I've done a pass and fixed most of the warnings for Gradle 9:
- project.buildDir is deprecated in favor of project.layout.buildDirectory
- I've updated 3rd party Gradle Plugins that we depend on

There are still two warnings which are outside of our control:
1. One is inside AGP and will be fixed with AGP 8.2 - Source https://issuetracker.google.com/issues/279306626
2. Another one is inside nexus-publish and should ideally be fixed by 2.0 https://github.com/gradle/gradle/issues/25206 Will bump the release once it's out

Changelog:
[Internal] [Changed] - Fix warnings for Gradle 9

Differential Revision: D48231760

