### PR TITLE
Move nativePerformanceNow binding call into common core code

### DIFF
--- a/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm
+++ b/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm
@@ -19,7 +19,6 @@ JSIExecutor::RuntimeInstaller RCTJSIExecutorRuntimeInstaller(JSIExecutor::Runtim
       _RCTLogJavaScriptInternal(static_cast<RCTLogLevel>(logLevel), [NSString stringWithUTF8String:message.c_str()]);
     };
     bindNativeLogger(runtime, iosLoggingBinder);
-    bindNativePerformanceNow(runtime);
 
     // Wrap over the original runtimeInstaller
     if (runtimeInstaller) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
@@ -46,7 +46,6 @@ static void installBindings(jsi::Runtime &runtime) {
       static_cast<void (*)(const std::string &, unsigned int)>(
           &reactAndroidLoggingHook);
   react::bindNativeLogger(runtime, androidLogger);
-  react::bindNativePerformanceNow(runtime);
 }
 
 class HermesExecutorHolder

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jscexecutor/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jscexecutor/OnLoad.cpp
@@ -29,7 +29,6 @@ class JSCExecutorFactory : public JSExecutorFactory {
           static_cast<void (*)(const std::string &, unsigned int)>(
               &reactAndroidLoggingHook);
       react::bindNativeLogger(runtime, androidLogger);
-      react::bindNativePerformanceNow(runtime);
     };
     return std::make_unique<JSIExecutor>(
         jsc::makeJSCRuntime(),

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -81,6 +81,9 @@ JSIExecutor::JSIExecutor(
 
 void JSIExecutor::initializeRuntime() {
   SystraceSection s("JSIExecutor::initializeRuntime");
+
+  bindNativePerformanceNow(*runtime_);
+
   runtime_->global().setProperty(
       *runtime_,
       "nativeModuleProxy",
@@ -136,6 +139,7 @@ void JSIExecutor::initializeRuntime() {
   if (runtimeInstaller_) {
     runtimeInstaller_(*runtime_);
   }
+
   bool hasLogger(ReactMarker::logTaggedMarkerImpl);
   if (hasLogger) {
     ReactMarker::logMarker(ReactMarker::CREATE_REACT_CONTEXT_STOP);

--- a/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
@@ -9,10 +9,12 @@
 
 #include <cxxreact/ErrorUtils.h>
 #include <cxxreact/JSBigString.h>
+#include <cxxreact/JSExecutor.h>
 #include <cxxreact/SystraceSection.h>
 #include <glog/logging.h>
 #include <jsi/JSIDynamic.h>
 #include <jsi/instrumentation.h>
+#include <jsireact/JSIExecutor.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 
 #include <cxxreact/ReactMarker.h>
@@ -339,6 +341,9 @@ void ReactInstance::initializeRuntime(
   runtimeScheduler_->scheduleWork([this, options, bindingsInstallFunc](
                                       jsi::Runtime &runtime) {
     SystraceSection s("ReactInstance::initializeRuntime");
+
+    bindNativePerformanceNow(runtime);
+
     RuntimeSchedulerBinding::createAndInstallIfNeeded(
         runtime, runtimeScheduler_);
 


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

This moves the call to bind the `nativePerformanceNow` function to the common place in C++ code (`JSIExecutor::initializeRuntime`), as opposed on relying on calling it from every platform-specific implementation.

I believe the reason why it was don this way, to begin with, was historical, since we did use to have a different implementation of this function on every platform. Now we have a common one in C++, anyway, so there is no reason whatsoever to have this binding platform-specific.

Differential Revision: D48232883

