### PR TITLE
Enable 'allWarningsAsErrors' for CI android build

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -441,6 +441,11 @@ def reactNativeArchitectures() {
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
+def enableWarningsAsErrors() {
+    def value = project.getProperties().get("enableWarningsAsErrors")
+    return value != null ? value : false
+}
+
 task packageReactNdkLibsForBuck(type: Copy) {
     dependsOn("mergeDebugNativeLibs")
     // Shared libraries (.so) are copied from the merged_native_libs folder instead
@@ -484,6 +489,8 @@ android {
     kotlinOptions {
         // Using '-Xjvm-default=all' to generate default java methods for interfaces
         freeCompilerArgs = ['-Xjvm-default=all']
+        // Using -PenableWarningsAsErrors=true prop to enable allWarningsAsErrors
+        kotlinOptions.allWarningsAsErrors = enableWarningsAsErrors()
     }
 
     defaultConfig {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/CompositeReactPackageTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/CompositeReactPackageTest.kt
@@ -28,7 +28,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 @PowerMockIgnore("org.mockito.*", "org.robolectric.*", "androidx.*", "android.*")
 class CompositeReactPackageTest {
-  @get:Rule var rule = PowerMockRule()
+  @get:Rule val rule = PowerMockRule()
 
   @Mock lateinit var packageNo1: ReactPackage
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
@@ -33,7 +33,7 @@ class BaseViewManagerTest {
   private lateinit var viewManager: BaseViewManager<ReactViewGroup, *>
   private lateinit var view: ReactViewGroup
 
-  @get:Rule var rule = PowerMockRule()
+  @get:Rule val rule = PowerMockRule()
 
   @Before
   fun setUp() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/JSPointerDispatcherTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/JSPointerDispatcherTest.kt
@@ -42,7 +42,7 @@ class JSPointerDispatcherTest {
 
   @Before
   fun setupViewHierarchy() {
-    val ctx: Context = RuntimeEnvironment.application
+    val ctx: Context = RuntimeEnvironment.getApplication()
     root = LinearLayout(ctx)
     val childView = TextView(ctx)
     childView.append("Hello, world!")

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.kt
@@ -34,9 +34,11 @@ class SimpleViewPropertyTest {
   @get:Rule var rule = PowerMockRule()
 
   private class ConcreteViewManager : SimpleViewManager<View?>() {
-    @ReactProp(name = "foo") fun setFoo(view: View, foo: Boolean) {}
+    @Suppress("UNUSED_PARAMETER") @ReactProp(name = "foo") fun setFoo(view: View, foo: Boolean) {}
 
-    @ReactProp(name = "bar") fun setBar(view: View, bar: ReadableMap?) {}
+    @Suppress("UNUSED_PARAMETER")
+    @ReactProp(name = "bar")
+    fun setBar(view: View, bar: ReadableMap?) {}
 
     override fun createViewInstance(reactContext: ThemedReactContext): View {
       return View(reactContext)
@@ -57,7 +59,7 @@ class SimpleViewPropertyTest {
     context = ReactApplicationContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
     context.initializeWithInstance(catalystInstanceMock)
-    themedContext = ThemedReactContext(context, context)
+    themedContext = ThemedReactContext(context, context, null, surfaceId)
     manager = ConcreteViewManager()
   }
 
@@ -96,5 +98,6 @@ class SimpleViewPropertyTest {
 
   companion object {
     private const val viewTag = 2
+    private const val surfaceId = 1
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
@@ -59,7 +59,7 @@ class ReactImagePropertyTest {
     context = ReactApplicationContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
     context!!.initializeWithInstance(catalystInstanceMock)
-    themeContext = ThemedReactContext(context, context)
+    themeContext = ThemedReactContext(context, context, null, -1)
     Fresco.initialize(context)
     DisplayMetricsHolder.setWindowDisplayMetrics(DisplayMetrics())
   }

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-androidx-annotation = "1.3.0"
-androidx-appcompat = "1.4.1"
+androidx-annotation = "1.6.0"
+androidx-appcompat = "1.6.1"
 androidx-autofill = "1.1.0"
-androidx-swiperefreshlayout = "1.0.0"
-androidx-test = "1.4.0"
+androidx-swiperefreshlayout = "1.1.0"
+androidx-test = "1.5.0"
 androidx-tracing = "1.1.0"
 assertj = "3.21.0"
 fbjni = "0.5.1"


### PR DESCRIPTION
Summary:
As we migrate java to kotlin I noticed that we've introduced few warnings here and there.
I'm introducing a way to configure allWarningsAsErrors in gradle

changelog: [internal] internal

Differential Revision: D48238321

