### PR TITLE
Pressability: Replace `cancelable` Change w/ `blockNativeResponder`

### DIFF
--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -132,6 +132,12 @@ export type PressabilityConfig = $ReadOnly<{|
   onPressOut?: ?(event: PressEvent) => mixed,
 
   /**
+   * Whether to prevent any other native components from becoming responder
+   * while this pressable is responder.
+   */
+  blockNativeResponder?: ?boolean,
+
+  /**
    * Returns whether a long press gesture should cancel the press gesture.
    * Defaults to true.
    *
@@ -495,7 +501,7 @@ export default class Pressability {
           this._handleLongPress(event);
         }, delayLongPress + delayPressIn);
 
-        return this._config.cancelable === false;
+        return this._config.blockNativeResponder === true;
       },
 
       onResponderMove: (event: PressEvent): void => {


### PR DESCRIPTION
Summary:
{D47225928} introduced a bug affecting `TextInput` on iOS that prevented native text editing capabilities. This reverts the change to a previous incarnation of the diff where javache created a new `blockNativeResponder` option instead of piggybacking off the existing `cancelable` option.

Changelog:
[iOS][Changed] - Restored `cancelable` option in `Pressability` configuration to not block native responder, and instead introduced a new optional `blockNativeResponder` boolean option to accomplish the same thing.

Reviewed By: mdvacca

Differential Revision: D48246530

