### PR TITLE
RNTester: Remove extra padding on RNTesterPage affecting e2e test

### DIFF
--- a/packages/rn-tester/js/components/RNTesterPage.js
+++ b/packages/rn-tester/js/components/RNTesterPage.js
@@ -52,7 +52,6 @@ const styles = StyleSheet.create({
   },
   noscrollWrapper: {
     flex: 1,
-    paddingVertical: 10,
     rowGap: 30,
   },
   scrollWrapper: {


### PR DESCRIPTION
Summary: Changelog: [Internal] - Remove padding in RNTesterPage

Reviewed By: makovkastar

Differential Revision: D48205648

