### PR TITLE
[JSCRuntime] Add runtimeConfig to set debugger options

### DIFF
--- a/packages/react-native/React/CxxBridge/JSCExecutorFactory.h
+++ b/packages/react-native/React/CxxBridge/JSCExecutorFactory.h
@@ -16,12 +16,19 @@ class JSCExecutorFactory : public JSExecutorFactory {
   explicit JSCExecutorFactory(JSIExecutor::RuntimeInstaller runtimeInstaller)
       : runtimeInstaller_(std::move(runtimeInstaller)) {}
 
+  void setEnableDebugger(bool enableDebugger);
+
+  void setDebuggerName(const std::string &debuggerName);
+
   std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
       std::shared_ptr<MessageQueueThread> jsQueue) override;
 
  private:
   JSIExecutor::RuntimeInstaller runtimeInstaller_;
+
+  bool enableDebugger_ = true;
+  std::string debuggerName_ = "JSC React Native";
 };
 
 } // namespace facebook::react

--- a/packages/react-native/React/CxxBridge/JSCExecutorFactory.h
+++ b/packages/react-native/React/CxxBridge/JSCExecutorFactory.h
@@ -27,7 +27,11 @@ class JSCExecutorFactory : public JSExecutorFactory {
  private:
   JSIExecutor::RuntimeInstaller runtimeInstaller_;
 
+#if DEBUG
   bool enableDebugger_ = true;
+#else
+  bool enableDebugger_ = false;
+#endif
   std::string debuggerName_ = "JSC React Native";
 };
 

--- a/packages/react-native/React/CxxBridge/JSCExecutorFactory.mm
+++ b/packages/react-native/React/CxxBridge/JSCExecutorFactory.mm
@@ -13,12 +13,22 @@
 
 namespace facebook::react {
 
+void JSCExecutorFactory::setEnableDebugger(bool enableDebugger) {
+  enableDebugger_ = enableDebugger;
+}
+
+void JSCExecutorFactory::setDebuggerName(const std::string &debuggerName) {
+  debuggerName_ = debuggerName;
+}
+
 std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
     std::shared_ptr<ExecutorDelegate> delegate,
     std::shared_ptr<MessageQueueThread> __unused jsQueue)
 {
-  return std::make_unique<JSIExecutor>(
-      facebook::jsc::makeJSCRuntime(), delegate, JSIExecutor::defaultTimeoutInvoker, runtimeInstaller_);
+  facebook::jsc::RuntimeConfig rc = {
+    .enableDebugger = enableDebugger_,
+    .debuggerName = debuggerName_,
+  };
+  return std::make_unique<JSIExecutor>(facebook::jsc::makeJSCRuntime(std::move(rc)), delegate, JSIExecutor::defaultTimeoutInvoker, runtimeInstaller_);
 }
-
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -36,6 +36,8 @@ class JSCRuntime : public jsi::Runtime {
  public:
   // Creates new context in new context group
   JSCRuntime();
+  // Creates new context in new context group with config
+  JSCRuntime(const facebook::jsc::RuntimeConfig& rc);
   // Retains ctx
   JSCRuntime(JSGlobalContextRef ctx);
   ~JSCRuntime();
@@ -359,6 +361,17 @@ std::string to_string(void* value) {
 JSCRuntime::JSCRuntime()
     : JSCRuntime(JSGlobalContextCreateInGroup(nullptr, nullptr)) {
   JSGlobalContextRelease(ctx_);
+}
+
+JSCRuntime::JSCRuntime(const facebook::jsc::RuntimeConfig& rc)
+	: JSCRuntime() {
+#ifdef _JSC_HAS_INSPECTABLE
+  if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+    JSGlobalContextSetInspectable(ctx_, rc.enableDebugger);
+  }
+#endif
+  JSGlobalContextSetName(ctx_, JSStringCreateWithUTF8CString(rc.debuggerName.c_str()));
+
 }
 
 JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
@@ -1563,6 +1576,10 @@ void JSCRuntime::checkException(
 
 std::unique_ptr<jsi::Runtime> makeJSCRuntime() {
   return std::make_unique<JSCRuntime>();
+}
+
+std::unique_ptr<jsi::Runtime> makeJSCRuntime(const facebook::jsc::RuntimeConfig& rc) {
+  return std::make_unique<JSCRuntime>(rc);
 }
 
 } // namespace jsc

--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.h
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.h
@@ -13,7 +13,14 @@
 namespace facebook {
 namespace jsc {
 
+struct RuntimeConfig {
+  bool enableDebugger;
+  std::string debuggerName;
+};
+
 std::unique_ptr<jsi::Runtime> makeJSCRuntime();
+
+std::unique_ptr<jsi::Runtime> makeJSCRuntime(const facebook::jsc::RuntimeConfig& rc);
 
 } // namespace jsc
 } // namespace facebook


### PR DESCRIPTION
## Summary:

When using React Native with JavascriptCore with a brownfield app, you may have multiple instances of React Native running, each with a JSContext. You attach a debugger to this JSContext via the Safari->Develop menu. To distinguish multiple JSContexts apart, JSContext has a [name](https://developer.apple.com/documentation/javascriptcore/jscontext/1451399-name) property, with a [C style setter](https://developer.apple.com/documentation/javascriptcore/1451703-jsglobalcontextsetname). We currently don't take advantage of that property, meaning that all your React Native instances show in the Develop menu with the default name "JSContext", making them hard to distinguish from each other. 

Let's solve this by adding a `runtimeConfig` parameter to the method `makeJSCRuntime()`, and pass through the properties `enableDebugger` and `debuggerName` to it. These names / the API to set them are heavily inspired by a similar change made to `HermesExecutorFactory`: https://github.com/facebook/react-native/commit/32d12e89f864a106433c8e54c10691d7876333ee

## Changelog:

[IOS] [CHANGED] - Add facebook::jsc::runtimeConfig to set enable debugger and set debugger 


## Test Plan:

Running RNTester with JSC shows the JSContext with the updated name.

![Screenshot 2023-08-16 at 5 48 08 AM](https://github.com/facebook/react-native/assets/6722175/b96aa37a-daa3-4c93-bf1f-4bcc99c57e9b)



