### PR TITLE
Fix Main by removing the last setup_artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -966,7 +966,6 @@ jobs:
         default: "dry-run"
     steps:
       - checkout
-      - setup_artifacts
       - run_yarn
       - run:
           name: Set React Native Version


### PR DESCRIPTION
## Summary:

CircleCI is broken because we deleted a command but forgot to remove one last usage of it.

## Changelog:

[Internal] - Remove last usage of setup_artifacts

## Test Plan:

CircleCI is green
