### PR TITLE
Consoliate Native deps version inside the Version Catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,11 +6,11 @@
  */
 
 plugins {
-  id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
-  id("com.android.library") version "8.1.0" apply false
-  id("com.android.application") version "8.1.0" apply false
-  id("de.undercouch.download") version "5.4.0" apply false
-  kotlin("android") version "1.8.0" apply false
+  alias(libs.plugins.nexus.publish)
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.download) apply false
+  alias(libs.plugins.kotlin.android) apply false
 }
 
 val reactAndroidProperties = java.util.Properties()

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -11,7 +11,7 @@ import org.gradle.configurationcache.extensions.serviceOf
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.8.0"
+  alias(libs.plugins.kotlin.jvm)
   id("java-gradle-plugin")
 }
 

--- a/packages/react-native-gradle-plugin/gradle/libs.versions.toml
+++ b/packages/react-native-gradle-plugin/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-junit = "4.13.2"
-kotlin = "1.8.0"
 agp = "8.1.0"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"
+junit = "4.13.2"
+kotlin = "1.8.0"
 
 [libraries]
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -13,3 +13,6 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 javapoet = { module = "com.squareup:javapoet", version.ref = "javapoet" }
 junit = {module = "junit:junit", version.ref = "junit" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -61,6 +61,15 @@ def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
 def skipPrefabPublishing = System.getenv("REACT_NATIVE_SKIP_PREFAB") != null
 def prefabHeadersDir = project.file("$buildDir/prefab-headers")
 
+// Native versions which are defined inside the version catalog (libs.versions.toml)
+def BOOST_VERSION = libs.versions.boost.get()
+def DOUBLE_CONVERSION_VERSION = libs.versions.doubleconversion.get()
+def FMT_VERSION = libs.versions.fmt.get()
+def FOLLY_VERSION = libs.versions.folly.get()
+def GLOG_VERSION = libs.versions.glog.get()
+def LIBEVENT_VERSION = libs.versions.libevent.get()
+def GTEST_VERSION = libs.versions.gtest.get()
+
 final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTask) {
     dependsOn(prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog)
     dependsOn("generateCodegenArtifactsFromSchema")

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -468,8 +468,8 @@ repositories {
 }
 
 android {
-    compileSdk 33
-    buildToolsVersion = "33.0.1"
+    compileSdk libs.versions.compileSdk.get().toInteger()
+    buildToolsVersion = libs.versions.buildTools.get()
     namespace "com.facebook.react"
 
     // Used to override the NDK path/version on internal CI or by allowing
@@ -494,8 +494,8 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
-        targetSdk = 33
+        minSdk = libs.versions.minSdk.get().toInteger()
+        targetSdk = libs.versions.targetSdk.get().toInteger()
         versionCode(1)
         versionName("1.0")
 

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -6,11 +6,11 @@
  */
 
 plugins {
-    id("com.android.library")
-    id("com.facebook.react")
-    id("de.undercouch.download")
     id("maven-publish")
-    id("org.jetbrains.kotlin.android")
+    id("com.facebook.react")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.download)
+    alias(libs.plugins.kotlin.android)
 }
 
 import com.facebook.react.tasks.internal.*

--- a/packages/react-native/ReactAndroid/flipper-integration/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/flipper-integration/build.gradle.kts
@@ -29,11 +29,11 @@ repositories {
 }
 
 android {
-  compileSdk = 33
-  buildToolsVersion = "33.0.1"
+  compileSdk = libs.versions.compileSdk.get().toInt()
+  buildToolsVersion = libs.versions.buildTools.get()
   namespace = "com.facebook.react.flipper"
 
-  defaultConfig { minSdk = 21 }
+  defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/react-native/ReactAndroid/flipper-integration/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/flipper-integration/build.gradle.kts
@@ -8,10 +8,10 @@
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
 plugins {
-  id("com.android.library")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
   id("maven-publish")
   id("signing")
-  id("org.jetbrains.kotlin.android")
 }
 
 group = "com.facebook.react"

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -1,15 +1,6 @@
 VERSION_NAME=1000.0.0
 GROUP=com.facebook.react
 
-# Native Dependency Versions
-BOOST_VERSION=1_76_0
-DOUBLE_CONVERSION_VERSION=1.1.6
-FMT_VERSION=6.2.1
-FOLLY_VERSION=2021.07.22.00
-GLOG_VERSION=0.3.5
-LIBEVENT_VERSION=2.1.12
-GTEST_VERSION=1.12.1
-
 android.useAndroidX=true
 android.enableJetifier=true
 

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -161,8 +161,8 @@ repositories {
 }
 
 android {
-    compileSdk 33
-    buildToolsVersion = "33.0.1"
+    compileSdk libs.versions.compileSdk.get().toInteger()
+    buildToolsVersion = libs.versions.buildTools.get()
     namespace "com.facebook.hermes"
 
     // Used to override the NDK path/version on internal CI or by allowing
@@ -175,7 +175,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
+        minSdk = libs.versions.minSdk.get().toInteger()
 
         externalNativeBuild {
             cmake {

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -9,9 +9,9 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
     id("de.undercouch.download")
-    id("com.android.library")
     id("maven-publish")
     id("signing")
+    alias(libs.plugins.android.library)
 }
 
 group = "com.facebook.react"

--- a/packages/react-native/build.gradle.kts
+++ b/packages/react-native/build.gradle.kts
@@ -11,8 +11,8 @@
 // their settings.gradle.kts file.
 // More on this here: https://reactnative.dev/contributing/how-to-build-from-source
 plugins {
-  id("com.android.library") version "8.1.0" apply false
-  id("com.android.application") version "8.1.0" apply false
-  id("de.undercouch.download") version "5.4.0" apply false
-  kotlin("android") version "1.8.0" apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.download) apply false
+  alias(libs.plugins.kotlin.android) apply false
 }

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,4 +1,10 @@
 [versions]
+# Android versions
+minSdk = "21"
+targetSdk = "33"
+compileSdk = "33"
+buildTools = "33.0.1"
+# Dependencies versions
 agp = "8.1.0"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.6.1"

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+agp = "8.1.0"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.6.1"
 androidx-autofill = "1.1.0"
@@ -6,6 +7,7 @@ androidx-swiperefreshlayout = "1.1.0"
 androidx-test = "1.5.0"
 androidx-tracing = "1.1.0"
 assertj = "3.21.0"
+download = "5.4.0"
 fbjni = "0.5.1"
 flipper = "0.201.0"
 fresco = "3.0.0"
@@ -13,7 +15,9 @@ infer-annotation = "0.18.0"
 javax-inject = "1"
 jsr305 = "3.0.2"
 junit = "4.13.2"
+kotlin = "1.8.0"
 mockito = "2.28.2"
+nexus-publish = "1.3.0"
 okhttp = "4.9.2"
 okio = "2.9.0"
 powermock = "2.0.9"
@@ -59,8 +63,8 @@ robolectric = {module = "org.robolectric:robolectric", version.ref = "robolectri
 thoughtworks = {module = "com.thoughtworks.xstream:xstream", version.ref = "xstream" }
 
 [plugins]
-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }
-download = { id = "de.undercouch.download", version = "5.4.0" }
-gradleVersions = { id = "com.github.ben-manes.versions", version = "0.47.0" }
-pluginPublishing = { id = "com.gradle.plugin-publish", version = "1.2.0" }
-shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+download = { id = "de.undercouch.download", version.ref = "download" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -31,6 +31,14 @@ robolectric = "4.9.2"
 soloader = "0.10.5"
 xstream = "1.4.20"
 yoga-proguard-annotations = "1.19.0"
+# Native Dependencies
+boost="1_76_0"
+doubleconversion="1.1.6"
+fmt="6.2.1"
+folly="2021.07.22.00"
+glog="0.3.5"
+libevent="2.1.12"
+gtest="1.12.1"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -90,8 +90,8 @@ repositories {
 }
 
 android {
-    compileSdk 33
-    buildToolsVersion = "33.0.1"
+    compileSdk libs.versions.compileSdk.get().toInteger()
+    buildToolsVersion = libs.versions.buildTools.get()
     namespace "com.facebook.react.uiapp"
 
     // Used to override the NDK path/version on internal CI or by allowing
@@ -117,8 +117,8 @@ android {
 
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
-        minSdk = 21
-        targetSdk = 33
+        minSdk = libs.versions.minSdk.get().toInteger()
+        targetSdk = libs.versions.targetSdk.get().toInteger()
         versionCode 1
         versionName "1.0"
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -6,9 +6,9 @@
  */
 
 plugins {
-    id("com.android.application")
     id("com.facebook.react")
-    id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
 }
 
 /**


### PR DESCRIPTION
Summary:
Another pass of moving version numbers into a single place.
This time I've moved all the native dependencies from gradle.properties to the version catalog

Changelog:
[Internal] [Changed] - Consoliate Native deps version inside the Version Catalog

Differential Revision: D48263910

