### PR TITLE
fix(Modal): Prevent unnecessary dialog creations

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -13,6 +13,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Build;
+import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
@@ -197,18 +198,21 @@ public class ReactModalHostView extends ViewGroup
   }
 
   protected void setStatusBarTranslucent(boolean statusBarTranslucent) {
+    mPropertyRequiresNewDialog =
+        mPropertyRequiresNewDialog || (statusBarTranslucent != mStatusBarTranslucent);
     mStatusBarTranslucent = statusBarTranslucent;
-    mPropertyRequiresNewDialog = true;
   }
 
   protected void setAnimationType(String animationType) {
+    mPropertyRequiresNewDialog =
+        mPropertyRequiresNewDialog || !TextUtils.equals(animationType, mAnimationType);
     mAnimationType = animationType;
-    mPropertyRequiresNewDialog = true;
   }
 
   protected void setHardwareAccelerated(boolean hardwareAccelerated) {
+    mPropertyRequiresNewDialog =
+        mPropertyRequiresNewDialog || (hardwareAccelerated != mHardwareAccelerated);
     mHardwareAccelerated = hardwareAccelerated;
-    mPropertyRequiresNewDialog = true;
   }
 
   void setEventDispatcher(EventDispatcher eventDispatcher) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

 ## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The current `<Modal />` implementation on Android attempts to reuse the existing Dialog and only recreate it if necessary. However, there are some false-positives -- if a flagged prop is updated to the same value, it'll be treated as if the dialog needs to be recreated.

The fix for this is to only set the "recreate the dialog" (`mPropertyRequiresNewDialog`) if the property value _changes_.

 ## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests -->

[ANDROID] [FIXED] - Only recreate Modal when necessary

 ## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This is testable with the RN Tester app, with some modifications. The easiest way to demonstrate this is to change the value of `transparent` after the dialog has been created -- this shouldn't recreate the dialog and should instead update the existing dialog.