### PR TITLE
Remove StaticLibraries job of RNTester as they are duplicated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2170,6 +2170,15 @@ workflows:
               architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
+            exclude:
+              # Tested by test_ios-Hermes
+              - architecture: "OldArch"
+                jsengine: "Hermes"
+                use_frameworks: "StaticLibraries"
+              # Tested by test_ios-JSC
+              - architecture: "OldArch"
+                jsengine: "JSC"
+                use_frameworks: "StaticLibraries"
       - test_ios:
           name: "Test iOS with Ruby 3.2.0"
           run_unit_tests: true


### PR DESCRIPTION
## Summary:

Removing the test_ios_rntester jobs for the following config:
- (OldArch, JSC, StaticLibraries)
- (OldArch, Hermes, StaticLibraries)

As this job just test that this configuration can be built and we have two other jobs (test_ios-Hermes and test_ios-JSC) which builds the same configs (so the test is duplicated) and they run 
unit and integration tests on top of these.

## Changelog:
[Internal] - Remove duplicated test_ios_rntester jobs

## Test Plan:

CircleCI stays green
