### PR TITLE
Use modern timers in monorepo Jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
   setupFiles: ['./packages/react-native/jest/local-setup.js'],
   fakeTimers: {
     enableGlobally: true,
-    legacyFakeTimers: true,
+    legacyFakeTimers: false,
   },
   snapshotFormat: {
     escapeString: true,

--- a/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
+++ b/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
@@ -11,6 +11,9 @@
 
 'use strict';
 
+// TODO(legacy-fake-timers): Fix these tests to work with modern timers.
+jest.useFakeTimers({legacyFakeTimers: true});
+
 jest.mock('react-native/Libraries/Utilities/HMRClient');
 
 jest.mock('react-native/Libraries/Core/Devtools/getDevServer', () =>

--- a/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -166,13 +166,8 @@ describe('promise tasks', () => {
   }
   beforeEach(() => {
     jest.resetModules();
-    jest.useFakeTimers({legacyFakeTimers: true});
     InteractionManager = require('../InteractionManager');
     sequenceId = 0;
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
   });
 
   it('should run a basic promise task', () => {

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -10,6 +10,10 @@
  */
 
 'use strict';
+
+// TODO(legacy-fake-timers): Fix these tests to work with modern timers.
+jest.useFakeTimers({legacyFakeTimers: true});
+
 jest.mock('../../../Core/Devtools/parseErrorStack', () => {
   return {__esModule: true, default: jest.fn(() => [])};
 });

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -9,6 +9,9 @@
  * @oncall react_native
  */
 
+// TODO(legacy-fake-timers): Fix these tests to work with modern timers.
+jest.useFakeTimers({legacyFakeTimers: true});
+
 import type {PressEvent} from '../../Types/CoreEventTypes';
 
 const UIManager = require('../../ReactNative/UIManager');

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-test.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-test.js
@@ -9,6 +9,9 @@
  * @oncall react_native
  */
 
+// TODO(legacy-fake-timers): Fix these tests to work with modern timers.
+jest.useFakeTimers({legacyFakeTimers: true});
+
 import type {HostComponent} from '../../../Renderer/shims/ReactNativeTypes';
 
 import * as React from 'react';

--- a/scripts/__tests__/publish-npm-test.js
+++ b/scripts/__tests__/publish-npm-test.js
@@ -45,11 +45,7 @@ let consoleError;
 
 describe('publish-npm', () => {
   beforeAll(() => {
-    jest.useFakeTimers({legacyFakeTimers: false});
     jest.setSystemTime(date);
-  });
-  afterAll(() => {
-    jest.useRealTimers();
   });
   beforeEach(() => {
     consoleError = console.error;


### PR DESCRIPTION
Summary:
Jest introduced "modern" timers based on `sinon/fake-timers` in Jest 26 ([release announcement](https://jestjs.io/blog/2020/05/05/jest-26#new-fake-timers)), and they became the default in Jest 27, in May 2021.

Modern timers have more capabilities - they were introduced with support for `queueMicrotask`, mocking `Date`, etc., and they've continued to receive more attention from the Jest team since - they're now much more comprehensive and more configurable than legacy timers.

Importantly, because they're not based on Jest mocks, they're not affected in surprising ways by eg `jest.resetAllMocks()` (a particularly confusing side-effect when fake timers are enabled globally, as in our setup).

This migrates RN's own tests and config to modern fake timers, or real timers where that's more appropriate.

NOTE: In cases where non-trivial changes to the tests are required, four test files are individually opted-in to `legacyFakeTimers` with a `TODO(legacy-fake-timers)`. I'll open these up for community contributions to fix.

Changelog: [Internal]

Differential Revision: D48189907

