### PR TITLE
Fixes regression of prop parsing for elevation

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -72,8 +72,6 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
   LayoutConformance experimental_layoutConformance{};
 
-  Float elevation{}; /* Android-only */
-
 #pragma mark - Convenience Methods
 
   BorderMetrics resolveBorderMetrics(LayoutMetrics const &layoutMetrics) const;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -23,6 +23,14 @@ HostPlatformViewProps::HostPlatformViewProps(
     RawProps const &rawProps,
     bool shouldSetRawProps)
     : BaseViewProps(context, sourceProps, rawProps, shouldSetRawProps),
+      elevation(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.elevation
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "elevation",
+                                                       sourceProps.elevation,
+                                                       {})),
       nativeBackground(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.nativeBackground

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -40,6 +40,8 @@ class HostPlatformViewProps : public BaseViewProps {
 
 #pragma mark - Props
 
+  Float elevation{};
+
   std::optional<NativeDrawable> nativeBackground{};
   std::optional<NativeDrawable> nativeForeground{};
 

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -164,9 +164,11 @@ static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(
                                                  : Transform::Perspective(42);
   }
 
+#ifdef ANDROID
   if (entropy.random<bool>(0.1)) {
     viewProps.elevation = entropy.random<bool>() ? 1 : 0;
   }
+#endif
 
   return shadowNode.clone({newProps});
 }
@@ -195,7 +197,9 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
     viewProps.zIndex = {};
     viewProps.pointerEvents = PointerEventsMode::Auto;
     viewProps.transform = Transform::Identity();
+#ifdef ANDROID
     viewProps.elevation = 0;
+#endif
   } else {
     viewProps.nativeId = "42";
     viewProps.backgroundColor = whiteColor();
@@ -204,7 +208,9 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
     viewProps.zIndex = {entropy.random<int>()};
     viewProps.pointerEvents = PointerEventsMode::None;
     viewProps.transform = Transform::Perspective(entropy.random<int>());
+#ifdef ANDROID
     viewProps.elevation = entropy.random<int>();
+#endif
   }
 
   return shadowNode.clone({newProps});


### PR DESCRIPTION
Summary:
When refactoring ViewProps in D47492635, `elevation` prop parsing was dropped. This restores it.

## Changelog:
[General] [Fixed] - Fabric regression for elevation prop in Android

Differential Revision: D48269510

