### PR TITLE
Enable 'allWarningsAsErrors' for CI android build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1022,7 +1022,7 @@ jobs:
           steps:
             - run:
                 name: Build & Test React Native using Gradle
-                command: ./gradlew build
+                command: ./gradlew build -PenableWarningsAsErrors=true
 
       - report_bundle_size:
           platform: android


### PR DESCRIPTION
Summary:
As we migrate java to kotlin I noticed that we've introduced few warnings here and there.
In this diff I'm enabling allWarningsAsErrors in the CI

The reasoning is that we are just starting with Kotlin and I believe we should enable 'allWarningsAsErrors' for CI android builds to make sure the codebase grow healthy, this will also help us to cleanup apis. e.g. create APIs for
deprecated java APIs.

changelog: [internal] internal

Reviewed By: NickGerleman

Differential Revision: D48239603

