### PR TITLE
Back out "Fixes regression of prop parsing for elevation"

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -72,6 +72,8 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
   LayoutConformance experimental_layoutConformance{};
 
+  Float elevation{}; /* Android-only */
+
 #pragma mark - Convenience Methods
 
   BorderMetrics resolveBorderMetrics(LayoutMetrics const &layoutMetrics) const;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -23,14 +23,6 @@ HostPlatformViewProps::HostPlatformViewProps(
     RawProps const &rawProps,
     bool shouldSetRawProps)
     : BaseViewProps(context, sourceProps, rawProps, shouldSetRawProps),
-      elevation(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.elevation
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "elevation",
-                                                       sourceProps.elevation,
-                                                       {})),
       nativeBackground(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.nativeBackground

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -40,8 +40,6 @@ class HostPlatformViewProps : public BaseViewProps {
 
 #pragma mark - Props
 
-  Float elevation{};
-
   std::optional<NativeDrawable> nativeBackground{};
   std::optional<NativeDrawable> nativeForeground{};
 

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -164,11 +164,9 @@ static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(
                                                  : Transform::Perspective(42);
   }
 
-#ifdef ANDROID
   if (entropy.random<bool>(0.1)) {
     viewProps.elevation = entropy.random<bool>() ? 1 : 0;
   }
-#endif
 
   return shadowNode.clone({newProps});
 }
@@ -197,9 +195,7 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
     viewProps.zIndex = {};
     viewProps.pointerEvents = PointerEventsMode::Auto;
     viewProps.transform = Transform::Identity();
-#ifdef ANDROID
     viewProps.elevation = 0;
-#endif
   } else {
     viewProps.nativeId = "42";
     viewProps.backgroundColor = whiteColor();
@@ -208,9 +204,7 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
     viewProps.zIndex = {entropy.random<int>()};
     viewProps.pointerEvents = PointerEventsMode::None;
     viewProps.transform = Transform::Perspective(entropy.random<int>());
-#ifdef ANDROID
     viewProps.elevation = entropy.random<int>();
-#endif
   }
 
   return shadowNode.clone({newProps});


### PR DESCRIPTION
Summary:
Original commit changeset: 91867a668985

Original Phabricator Diff: D48269510

## Changelog:
[General] [Fixed] - Rolling back change that broke e2e tests until we can figure out why the e2e tests are broken

Differential Revision: D48288415

