### PR TITLE
Bump Android compile-sdk to 34

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ references:
   android-defaults: &android-defaults
     working_directory: ~/react-native
     docker:
-      - image: reactnativecommunity/react-native-android:v10.0
+      - image: reactnativecommunity/react-native-android:v11.0
     environment:
       - TERM: "dumb"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false'
@@ -929,7 +929,7 @@ jobs:
       - run_yarn
       - android/create-avd:
           avd-name: e2e_emulator
-          system-image: system-images;android-33;google_apis;x86_64
+          system-image: system-images;android-34;google_apis;x86_64
           install: true
       - android/start-emulator:
           avd-name: e2e_emulator
@@ -1311,15 +1311,7 @@ jobs:
   test_windows:
     executor:
       name: win/default
-    parameters:
-      run_disabled_tests:
-        type: boolean
-        default: false
     environment:
-      - ANDROID_HOME: "C:\\Android\\android-sdk"
-      - ANDROID_NDK: "C:\\Android\\android-sdk\\ndk\\20.1.5948944"
-      - ANDROID_BUILD_VERSION: 33
-      - ANDROID_TOOLS_VERSION: 33.0.1
       - CHOCO_CACHE_DIR: "C:\\ChocoCache"
     steps:
       - checkout_code_with_cache
@@ -1374,24 +1366,10 @@ jobs:
           paths:
             - C:\Users\circleci\AppData\Local\Yarn
 
-      - run:
-          name: Install Android SDK Tools
-          command: choco install android-sdk;
-
       - save_cache:
           key: *windows_choco_cache_key
           paths:
             - $env:CHOCO_CACHE_DIR
-
-      - run:
-          name: Setup Android SDKs
-          command: |
-            sdkmanager --licenses
-            sdkmanager "system-images;android-21;google_apis;armeabi-v7a"
-            sdkmanager "platforms;android-%ANDROID_BUILD_VERSION%"
-            sdkmanager "build-tools;%ANDROID_TOOLS_VERSION%"
-            sdkmanager "add-ons;addon-google_apis-google-23"
-            sdkmanager "extras;android;m2repository"
 
       # -------------------------
       # Run Tests
@@ -1404,15 +1382,6 @@ jobs:
       - run:
           name: "Run Tests: JavaScript Tests"
           command: yarn test
-
-      # Optionally, run disabled tests
-      - when:
-          condition: << parameters.run_disabled_tests >>
-          steps:
-            - run: echo "Failing tests may be moved here temporarily."
-            - run:
-                name: Android Build
-                command: ./gradlew.bat packages:rn-tester:android:app:assembleRelease
 
   # -------------------------
   #      JOBS: Build Hermes
@@ -2219,8 +2188,7 @@ workflows:
       - test_js:
           name: test_js_prev_lts
           executor: nodeprevlts
-      - test_windows:
-          run_disabled_tests: false
+      - test_windows
 
   # This workflow should only be triggered by release script
   package_release:

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 # Android versions
 minSdk = "21"
 targetSdk = "33"
-compileSdk = "33"
-buildTools = "33.0.1"
+compileSdk = "34"
+buildTools = "34.0.0"
 # Dependencies versions
 agp = "8.1.0"
 androidx-annotation = "1.6.0"

--- a/packages/rn-tester-e2e/e2e-config.js
+++ b/packages/rn-tester-e2e/e2e-config.js
@@ -23,7 +23,7 @@ let capabilities: Capabilities;
 
 const android = {
   platformName: 'Android',
-  'appium:platformVersion': '13.0',
+  'appium:platformVersion': '14.0',
   'appium:deviceName': 'Android Emulator',
   'appium:app': path.join(process.cwd(), '/apps/rn-tester.apk'),
   'appium:automationName': 'UiAutomator2',


### PR DESCRIPTION
Summary:
As now we do have the buildTools version 34 in the docker container,
I'm bumping compileSdkVersion for all the targets to 34.

I'm also cleaning up the `test_windows` setup as it had old references
of NDK 20, build tools 33 and was installing the Android SDK but not
actually using it.

Changelog:
[Android] [Changed] - Bump Android compile-sdk to 34

Differential Revision: D48311828

