### PR TITLE
Fix build errors when importing React-Core module from Swift

### DIFF
--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -99,7 +99,7 @@ Pod::Spec.new do |s|
       exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
     end
     ss.exclude_files = exclude_files
-    ss.private_header_files   = "React/CxxLogUtils/*.h"
+    ss.private_header_files   = "React/Cxx*/*.h"
   end
 
   s.subspec "DevSupport" do |ss|

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/React-BridgelessApple.podspec
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/React-BridgelessApple.podspec
@@ -23,6 +23,7 @@ boost_compiler_flags = '-Wno-documentation'
 
 header_search_paths = [
   "$(PODS_ROOT)/boost",
+  "$(PODS_ROOT)/Headers/Private/React-Core",
   "$(PODS_TARGET_SRCROOT)/../../../..",
   "$(PODS_TARGET_SRCROOT)/../../../../..",
 ]

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1284,11 +1284,11 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: a0b90ce379cb01df2495a908c5f8a795fe08c25d
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  FBLazyVector: a210a18fb92dc884212883f04194a5d18c6838da
-  FBReactNativeSpec: d7cc6f223b0e88500446becd3c3630a8526d698b
+  FBLazyVector: e90249ae24be56ea6e88388a4a4661edf743943d
+  FBReactNativeSpec: cd940591855af3dd507f3eb73cd346842689dd79
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -1299,56 +1299,56 @@ SPEC CHECKSUMS:
   FlipperKit: 37525a5d056ef9b93d1578e04bc3ea1de940094f
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 99bd064df01718db56b8f75e6b5ea3051c7dad0a
-  hermes-engine: 82f64b365ab2d21a7d625ef139681ab4080cbd8e
+  hermes-engine: 8aab9ea62682b28a1839ced11c2fcdb330fe47c8
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: b0d1393cb3763d71efca99db314c65f0072eb0fe
-  RCTRequired: 554ec6d43fbff1a7a407bb42f94e1f192c69fcca
-  RCTTypeSafety: 3e70b6ee70ff524aa5bfe3fa025c514d6fbc16ce
-  React: 10e424c0fe8032b69381045243a2de17e6152701
-  React-callinvoker: f1075644170d5bf21f0541aadee6f632c35d63b0
+  RCTRequired: 35346305cc1b0c74538ca19e2465010fee0f3415
+  RCTTypeSafety: aa6aefe0dcdc11082715ab8196a0ba54f17a89bb
+  React: 1e6a6c52ae0eeff4fb79237859a127ad6e151ce0
+  React-callinvoker: 6969b0f75c7384823baa7df2172778f94d9bce8c
   React-Codegen: 4ac0cb84d358edd26db783a441cade433333eb93
-  React-Core: 58a1092471d9171b36eb425f1b3f30f1e9d0da30
-  React-CoreModules: 9197e32fa0126df35ef1f65b8007ecf3b783a586
-  React-cxxreact: 2f53a93de74b827b170a3684166385aa44b47e24
-  React-debug: 3ec6fc905dbf2bdc2bb643ae4ac35d0548bc75d7
-  React-Fabric: a6e018bd0dca346f986db21463215430513b9cff
-  React-FabricImage: 85b8c7dcf0fd6be93ecdc028553c829882e5a280
-  React-graphics: a5f50138fbce82f646b26ec20f863e00926c6d1b
-  React-hermes: 4be9a63a8ebae2b2f15206411a1d77b7665bff6c
-  React-ImageManager: d58778b31303e487217a584f2cb6bf3b8f1a9a96
-  React-jserrorhandler: 3f471b26b10279d88e9f1632616e8e02b9ccda1f
-  React-jsi: 3cd9b89ee261bb27e3fcc74441c266ff571b22db
-  React-jsiexecutor: 12ae077b19f537eefa7bbc441f4fa12e007eef88
-  React-jsinspector: afb98d73dbeea95e49ae456b9b40722e831c4116
-  React-logger: f047d39539ec7e4b5b4d70ba093680af914a23d5
-  React-Mapbuffer: 521278e1d20c5ce9b0d6bdd421d23a388212c08a
-  React-nativeconfig: bf01e79a2dc6ef911a0485fbcc6a72b8921a9c64
-  React-NativeModulesApple: e169b541a9296af7da487f864c7b3978f47ee6d6
-  React-perflogger: 4f6c2fb86cb04ad127fe07ab5ab4a231674a7111
-  React-RCTActionSheet: aebd047f5f1a7804b9029672ffe312b0d436f13f
-  React-RCTAnimation: 0e8b646e86a664a12809bf5f3c92d661bb6a8bb2
-  React-RCTAppDelegate: 8a33016954836883f8c6143572d1ffc80e07200d
-  React-RCTBlob: 00a130b39b63ac5e8d8e8b925987266cee3e694c
-  React-RCTFabric: cdd9aae986e50f8a253fdeb510a19c4d074d248f
-  React-RCTImage: cc4f65e4ecbad1b80a77592832fd6e4874f3a1c4
-  React-RCTLinking: 5526511fde9952d490ef69641f7f92178748707d
-  React-RCTNetwork: 722554188394a4154a893d1a22a6a631e1bc03fa
-  React-RCTPushNotification: 5b4621889cfe1635ded31d1361dff21df059faa9
-  React-RCTSettings: a4e23b62cbeebef79c1359486bf0f85f61716430
-  React-RCTTest: daa4f97ad7c030be590501512159f901200e5888
-  React-RCTText: 608e82645fd725c11d25cf27d71b28b4389ad264
-  React-RCTVibration: 0a83ae8d0493d94c9b9be12aec6f41944a4a0e21
-  React-rendererdebug: d21ce728c66c75f3a1dd93ab3d069393819201da
-  React-rncore: ba1b9b0715967eb5460c126d9b36899035ddf071
-  React-runtimeexecutor: 2cca33c8d993e1be6179fb0a9d8aae9120b399c5
-  React-utils: ba27d9ce9aa1cc3de9c500a8043b64a2f4bcc50c
-  ReactCommon: 6c13f234b0404ffa144e081f652db40c8ca14b17
-  ReactCommon-Samples: 4d8f10b2717c24fb6712e78e2b380c097aa62e95
+  React-Core: 6d23e06babf0832e46991f1e843a5f6538405f12
+  React-CoreModules: bf7cdd0f5eb8b3f6847477ae560787e4053e34b5
+  React-cxxreact: 5a1469f7604c81bb30fd2efaffbc25ad9d42b015
+  React-debug: ef8242f7a53d3d399db22c6ac7387e6ce986a009
+  React-Fabric: 43dd241d2ebcc848d1edc2b2d79de9a3d1081067
+  React-FabricImage: 507eb024c3b0826fc857490282c2e2f16a1831bb
+  React-graphics: a6fff8ef141b649f24eb5df3b978b7ee3fe963eb
+  React-hermes: 356c84840fc6dbee9f31bacd2bd1536db4b54fcf
+  React-ImageManager: 33ea5e5b4ac693734fe0ae8c3ca2941c9e57935a
+  React-jserrorhandler: bdba0867a02c9ddb4dc3a8ff84c0038a253c2430
+  React-jsi: 6401739576c620873c852678213cf58bb48d8243
+  React-jsiexecutor: 491706b9fafc15e1a4333a9bae6a615f980e0e78
+  React-jsinspector: 8c65260015b22902d0f12d9620f41ad39523c9e0
+  React-logger: 7fe9e08e9ef1d0cdc670c06e1cc035773a06290d
+  React-Mapbuffer: bae22bf5900b519b9fdcb59cf3d1e29828622bb8
+  React-nativeconfig: 8ddffdf5118c97e663417b2890073a49e6ea4045
+  React-NativeModulesApple: 2eb2721d3782e82cbc06a093c7727bacbf5f1ed3
+  React-perflogger: 7553d4d1d44e4d926cc6f3d811902dd7fc9adc82
+  React-RCTActionSheet: 18462159c1294c943cdc036ea108d498a458992c
+  React-RCTAnimation: 420760559f70fb40bd8a9d3be089534a4c7894a7
+  React-RCTAppDelegate: 5022068f4239260c890e9952fe4d661d9523444c
+  React-RCTBlob: de281c7467d0b0dab01a00f275b81ab05509a57d
+  React-RCTFabric: dc8922d2f0dba9746ea70bcc6e2b693ed11ccfd7
+  React-RCTImage: 6b534ecd845884c2a47420926428e63be81bf445
+  React-RCTLinking: 08af98efaefda10c6dbffeaa5645299804cdf293
+  React-RCTNetwork: 8252248955c1a8ede4bf6cbe2a504b1308e2fc82
+  React-RCTPushNotification: 38631ec5a801b1769e4eb559836d3b01cdfe082c
+  React-RCTSettings: da22aa6543805596c658a6d87381cc958c460708
+  React-RCTTest: 7cd42f25b947437ae9234994945a5c2e95948333
+  React-RCTText: 5a0617985b16b31595116ff71a48e34b81f02c00
+  React-RCTVibration: a7cc6305aa427091b3514ec399d33a2aa2e15ae9
+  React-rendererdebug: 25ec73683d7298af4fa740b5d75daa65ee5d695c
+  React-rncore: a62b9d13a35ad6f2d16358a98a3aacc085333a16
+  React-runtimeexecutor: d2c2d923e9f87a0c7970c57a9a0c35502f7b323f
+  React-utils: d6eef3429c57d51ca4fa7c603b48956145b4210d
+  ReactCommon: caad0c97cf7f7bfb9e6fbcd5821c3eee0abf909e
+  ReactCommon-Samples: 55a53451d8f4dba8de91954c00a86cd8b793571d
   ScreenshotManager: d39b964a374e5012e2b8c143e29ead86b1da6a3c
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 8d612ba703f51053b25a27dd6a18c0f96a507625
+  Yoga: bb053cf51d69bab01c4c21cc3ab2f6037376cad4
 
 PODFILE CHECKSUM: e220946495183a79874329aff76ec197027be224
 

--- a/packages/rn-tester/RNTester/SwiftTest.swift
+++ b/packages/rn-tester/RNTester/SwiftTest.swift
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// The SwiftTest here in rn-tester acts as a guard to make sure that we can build React-Core clang module and import from Swift.
+import React
+
+func getReactNativeVersion() -> String {
+  let version = RCTGetReactNativeVersion()
+  guard let major = version?[RCTVersionMajor],
+        let minor = version?[RCTVersionMinor],
+        let patch = version?[RCTVersionPatch] else {
+    fatalError()
+  }
+  var result = "\(major).\(minor).\(patch)"
+  if let prerelease = version?[RCTVersionPrerelease] {
+    result += "-\(prerelease)"
+  }
+  return result
+}

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3D2AFAF51D646CF80089D1A3 /* legacy_image@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3D2AFAF41D646CF80089D1A3 /* legacy_image@2x.png */; };
 		5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C60EB1B226440DB0018C04F /* AppDelegate.mm */; };
 		8145AE06241172D900A3F8DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */; };
+		832F45BB2A8A6E1F0097B4E6 /* SwiftTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */; };
 		953D44E0A849F5064163EA24 /* libPods-RNTesterIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F4A7C4C85AB0198A25D51E4 /* libPods-RNTesterIntegrationTests.a */; };
 		BE3BEE3556275C62F33864C8 /* libPods-RNTesterUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6144DEEE56C6C17B301A90E4 /* libPods-RNTesterUnitTests.a */; };
 		CD10C7A5290BD4EB0033E1ED /* RCTEventEmitterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD10C7A4290BD4EB0033E1ED /* RCTEventEmitterTests.m */; };
@@ -98,6 +99,7 @@
 		6144DEEE56C6C17B301A90E4 /* libPods-RNTesterUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7FC437025B5EE3899315628B /* Pods-RNTester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester.release.xcconfig"; path = "Target Support Files/Pods-RNTester/Pods-RNTester.release.xcconfig"; sourceTree = "<group>"; };
 		8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = RNTester/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwiftTest.swift; path = RNTester/SwiftTest.swift; sourceTree = "<group>"; };
 		AC474BFB29BBD4A1002BDAED /* RNTester.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RNTester.xctestplan; path = RNTester/RNTester.xctestplan; sourceTree = "<group>"; };
 		B8219B8DAB1CDD38543E30A4 /* Pods-RNTesterUnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterUnitTests.release.xcconfig"; path = "Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		BD6F35F6C79ACF7496CBC337 /* Pods-RNTesterIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -228,6 +230,7 @@
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				5C60EB1B226440DB0018C04F /* AppDelegate.mm */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */,
 				2DDEF00F1F84BF7B00DBDF73 /* Images.xcassets */,
 				8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */,
 				680759612239798500290469 /* Fabric */,
@@ -473,6 +476,9 @@
 				LastUpgradeCheck = 1210;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1430;
+					};
 					E7DB209E22B2BA84005AC45F = {
 						CreatedOnToolsVersion = 10.2.1;
 					};
@@ -742,6 +748,7 @@
 			files = (
 				E62F11842A5C6584000BF1C8 /* UpdatePropertiesExampleView.mm in Sources */,
 				E62F11832A5C6580000BF1C8 /* FlexibleSizeExampleView.mm in Sources */,
+				832F45BB2A8A6E1F0097B4E6 /* SwiftTest.swift in Sources */,
 				5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
@@ -818,6 +825,7 @@
 			baseConfigurationReference = 3CC2F16A3AEB8D7102722AD5 /* Pods-RNTester.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = RNTester/RNTester.entitlements;
 				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = (
@@ -845,6 +853,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.meta.RNTester.localDevelopment;
 				PRODUCT_NAME = RNTester;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -854,6 +864,7 @@
 			baseConfigurationReference = 7FC437025B5EE3899315628B /* Pods-RNTester.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = RNTester/RNTester.entitlements;
 				DEVELOPMENT_TEAM = "";
 				EXCLUDED_ARCHS = "";
@@ -881,6 +892,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.meta.RNTester.localDevelopment;
 				PRODUCT_NAME = RNTester;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1062,6 +1074,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C4CEC47A71A2AEE236833CDF /* Pods-RNTesterUnitTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -1103,6 +1116,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B8219B8DAB1CDD38543E30A4 /* Pods-RNTesterUnitTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -1144,6 +1158,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3485A25B916F57284634B78A /* Pods-RNTesterIntegrationTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -1186,6 +1201,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BD6F35F6C79ACF7496CBC337 /* Pods-RNTesterIntegrationTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;


### PR DESCRIPTION
## Summary:

supersedes #38806 
the errors are actually coming from https://github.com/facebook/react-native/commit/42d67452eb9a#diff-226ff5f87f146abfebd14a69eeb7d95c358d53da30533321e3ae9281c8acc6f0L102. we should keep c++ headers as cocoapods private headers, so that those headers will not expose into the umbrella header.

this pr also adds a swift test file to rn-tester, so we can verify the fix and prevent the similar build errors in the future.

## Changelog:

[IOS] [FIXED] - Fix build errors when importing React-Core module from Swift

## Test Plan:

add a swift file in rn-tester and make sure it builds successfully
