### PR TITLE
Refactor/broken text test

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -158,7 +158,7 @@ public class UIImplementation {
               mShadowNodeRegistry.addRootNode(rootCSSNode);
             }
           });
-
+      mShadowNodeRegistry.addRootNode(rootCSSNode);
       // register it within NativeViewHierarchyManager
       mOperationsQueue.addRootView(tag, rootView);
     }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
@@ -33,15 +33,21 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.modules.core.ReactChoreographer;
+import com.facebook.react.uimanager.ReactYogaConfigProvider;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.views.view.ReactViewBackgroundDrawable;
+import com.facebook.testutils.shadows.ShadowSoLoader;
+import com.facebook.yoga.YogaConfig;
+import com.facebook.yoga.YogaNative;
+import com.facebook.yoga.YogaNode;
+import com.facebook.yoga.YogaNodeFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
@@ -49,24 +55,37 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 /** Tests for {@link UIManagerModule} specifically for React Text/RawText. */
+@Config(shadows = {ShadowSoLoader.class})
 @RunWith(RobolectricTestRunner.class)
-@Ignore // TODO T110934492
 public class ReactTextTest {
 
   private MockedStatic<Arguments> arguments;
   private MockedStatic<ReactChoreographer> reactCoreographer;
+  private MockedStatic<ReactYogaConfigProvider> reactYogaConfigProvider;
+  private MockedStatic<YogaNodeFactory> yogaNodeFactory;
   private ArrayList<ChoreographerCompat.FrameCallback> mPendingFrameCallbacks;
 
   @Before
   public void setUp() {
     ReactChoreographer uiDriverMock = mock(ReactChoreographer.class);
+    YogaConfig yogaConfigMock = mock(YogaConfig.class);
+    YogaNode yogaNodeMock = mock(YogaNode.class);
     arguments = mockStatic(Arguments.class);
     arguments.when(Arguments::createMap).thenAnswer(invocation -> new JavaOnlyMap());
 
     reactCoreographer = mockStatic(ReactChoreographer.class);
     reactCoreographer.when(ReactChoreographer::getInstance).thenAnswer(invocation -> uiDriverMock);
+
+    reactYogaConfigProvider = mockStatic(ReactYogaConfigProvider.class);
+    reactYogaConfigProvider.when(ReactYogaConfigProvider::get).thenAnswer(invocation -> yogaConfigMock);
+
+    yogaNodeFactory = mockStatic(YogaNodeFactory.class);
+    yogaNodeFactory.when(() -> YogaNodeFactory.create(any(YogaConfig.class))).thenAnswer(invocation -> yogaNodeMock);
+
+    mockStatic(YogaNative.class);
 
     mPendingFrameCallbacks = new ArrayList<>();
     doAnswer(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

~~This PR fixes ReactTextTest.java and converts it into Kotlin as requested in [the umbrella PR](https://github.com/facebook/react-native/issues/38825)~~

@cortinico @mdvacca I rebased my branch with the latest changes including PowerMock removal. I still have troubles to fix the test:

1) the first commit in that draft PR mocks Yoga related classes that are used when text shadow nodes are created (not sure if it's done the right way)

2) the second commit "workarounds" the issue with not mocked [`context.runOnNativeModulesQueueThread`](https://github.com/facebook/react-native/blob/e44fdfed60c07c4cc10d5cf89fee94653e80ad40/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L428) method inside [`UIImplementation.registerRootView`](https://github.com/facebook/react-native/blob/e44fdfed60c07c4cc10d5cf89fee94653e80ad40/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java#L154) -> it's not executed during the test and without doing it, the following error is displayed:

```sh
java.lang.AssertionError: Root node with tag 11 doesn't exist
	at com.facebook.infer.annotation.Assertions.assertNotNull(Assertions.java:19)
	at com.facebook.react.uimanager.UIImplementation.createView(UIImplementation.java:235)
	at com.facebook.react.uimanager.UIManagerModule.createView(UIManagerModule.java:419)
	at com.facebook.react.views.text.ReactTextTest.createText(ReactTextTest.java:492)
	at com.facebook.react.views.text.ReactTextTest.testFontSizeApplied(ReactTextTest.java:111)
...
```

Definitely, it's not a way to go, but I don't have any idea how it can be mocked (it seems that [ReactTestHelper.createCatalystContextForTest](https://github.com/facebook/react-native/blob/e44fdfed60c07c4cc10d5cf89fee94653e80ad40/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ReactTestHelper.kt#L26) is not mocking it)

3) currently I'm stuck on the following error when the `createText` helper inside a test suite tries to add a virtual text view to the text view:

```sh
java.lang.RuntimeException: Cannot add a child that doesn't have a YogaNode to a parent without a measure function! (Trying to add a 'RCTRawText [text: test text]' to a '[RCTText 12]')
	at com.facebook.react.uimanager.ReactShadowNodeImpl.addChildAt(ReactShadowNodeImpl.java:223)
	at com.facebook.react.uimanager.ReactShadowNodeImpl.addChildAt(ReactShadowNodeImpl.java:56)
	at com.facebook.react.uimanager.UIImplementation.manageChildren(UIImplementation.java:406)
	at com.facebook.react.uimanager.UIManagerModule.manageChildren(UIManagerModule.java:469)
	at com.facebook.react.views.text.ReactTextTest.createText(ReactTextTest.java:495)
	at com.facebook.react.views.text.ReactTextTest.testFontSizeApplied(ReactTextTest.java:111)
...
```

The virtual text view (child) does not have yoga node, so the real text view (parent) should have the measure function set, which idk why is not happening during the test.

Right now, I need some guidance on how should I tackle 2) & 3) point; whether I should mock other parts to make test work (e.g. UIManager class)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [CHANGED] fix & convert ReactTextTest test suite to Kotlin

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Verify that all tests are green with: `./gradlew :packages:react-native:ReactAndroid:test`
