### PR TITLE
Fix: Reloading React Native after a destroy shows a "blank screen"

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
@@ -667,7 +667,7 @@ public class ReactHostImpl implements ReactHost {
   private @Nullable Task<Void> mStartTask = null;
 
   private Task<Void> oldStart() {
-    final String method = "oldPreload()";
+    final String method = "oldStart()";
     return Task.call(
             () -> {
               if (mStartTask == null) {
@@ -678,7 +678,7 @@ public class ReactHostImpl implements ReactHost {
                             task -> {
                               if (task.isFaulted()) {
                                 destroy(
-                                    "oldPreload() failure: " + task.getError().getMessage(),
+                                    "oldStart() failure: " + task.getError().getMessage(),
                                     task.getError());
                                 mReactHostDelegate.handleInstanceException(task.getError());
                               }
@@ -695,7 +695,7 @@ public class ReactHostImpl implements ReactHost {
   }
 
   private Task<Void> newStart() {
-    final String method = "newPreload()";
+    final String method = "newStart()";
     return Task.call(
             () -> {
               if (mStartTask == null) {
@@ -708,7 +708,7 @@ public class ReactHostImpl implements ReactHost {
                                 mReactHostDelegate.handleInstanceException(task.getError());
                                 // Wait for destroy to finish
                                 return newGetOrCreateDestroyTask(
-                                        "newPreload() failure: " + task.getError().getMessage(),
+                                        "newStart() failure: " + task.getError().getMessage(),
                                         task.getError())
                                     .continueWithTask(destroyTask -> Task.forError(task.getError()))
                                     .makeVoid();


### PR DESCRIPTION
Summary:
After React Native tears down, a RedBox can appear, prompting the user to reload.

**Problem:** After React Native reloads, the React Native screen wouldn't show up.

**Cause:** ReactContext.onHostResume() wasn't executed.

Why:
- React Native teardown moves the React manager into the **onHostDestroy()** state.
- During initialization, React Native only calls ReactContext.onHostResume(), if the React manager was *already* in the **onHostResume()** state.

https://www.internalfb.com/code/fbsource/[f82938c7cc9a0ee722c85c33d1027f326049d37c]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java?lines=924-925

**Question:** Why does React Native only call ReactContext.onHostResume(), **if the React manager was already in the onHostResume() state?**

This ensures that the application only calls ReactContext.onHostResume() state, **when the user navigates to their *first* React Native screen** (both with and without preload).

(React Native only puts the React manager into the onHostResume() state (from other states), when the user navigates to their first React Native screen).

## The fix
If we're initializing React Native during a reload, just always call ReactContext.onHostResume().

If React Native is reloading, it seems reasonable to assume that:
1. We must have navigated to a React Native screen in the past, or
2. We must be on a React Native screen.

Changelog: [Internal]

Differential Revision: D48076895

