### PR TITLE
Fix: React Native teardown crashes app

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
@@ -667,7 +667,7 @@ public class ReactHostImpl implements ReactHost {
   private @Nullable Task<Void> mStartTask = null;
 
   private Task<Void> oldStart() {
-    final String method = "oldPreload()";
+    final String method = "oldStart()";
     return Task.call(
             () -> {
               if (mStartTask == null) {
@@ -678,7 +678,7 @@ public class ReactHostImpl implements ReactHost {
                             task -> {
                               if (task.isFaulted()) {
                                 destroy(
-                                    "oldPreload() failure: " + task.getError().getMessage(),
+                                    "oldStart() failure: " + task.getError().getMessage(),
                                     task.getError());
                                 mReactHostDelegate.handleInstanceException(task.getError());
                               }
@@ -695,7 +695,7 @@ public class ReactHostImpl implements ReactHost {
   }
 
   private Task<Void> newStart() {
-    final String method = "newPreload()";
+    final String method = "newStart()";
     return Task.call(
             () -> {
               if (mStartTask == null) {
@@ -708,7 +708,7 @@ public class ReactHostImpl implements ReactHost {
                                 mReactHostDelegate.handleInstanceException(task.getError());
                                 // Wait for destroy to finish
                                 return newGetOrCreateDestroyTask(
-                                        "newPreload() failure: " + task.getError().getMessage(),
+                                        "newStart() failure: " + task.getError().getMessage(),
                                         task.getError())
                                     .continueWithTask(destroyTask -> Task.forError(task.getError()))
                                     .makeVoid();


### PR DESCRIPTION
Summary:
During React Native teardown, we should stop all React surfaces. Otherwise, the app could crash with this error:

```
08-06 14:54:08.644 14843 14843 F DEBUG   : Abort message: 'xplat/js/react-native-github/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp:171: function ~Scheduler: assertion failed (surfaceIds.empty() && "Scheduler was destroyed with outstanding Surfaces.")'
```

When can teardown occur? One case: an exception occurs on the NativeModules thread.

NOTE: This diff impacts the **new** Bridgeless mode lifecycle methods.

Differential Revision: D47926966

