### PR TITLE
Adjust RawPropsPropNameLength's type to account for increased number of props

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
@@ -38,6 +38,8 @@ void RawPropsKeyMap::insert(
   item.value = value;
   key.render(item.name, &item.length);
   items_.push_back(item);
+  react_native_assert(
+      items_.size() < std::numeric_limits<RawPropsPropNameLength>::max());
 }
 
 void RawPropsKeyMap::reindex() noexcept {

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -42,6 +42,7 @@ RawValue const *RawPropsParser::at(
     // This is not thread-safe part; this happens only during initialization of
     // a `ComponentDescriptor` where it is actually safe.
     keys_.push_back(key);
+    react_native_assert(size < std::numeric_limits<RawPropsValueIndex>::max());
     nameToIndex_.insert(key, static_cast<RawPropsValueIndex>(size));
     return nullptr;
   }

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
@@ -15,11 +15,11 @@ namespace facebook::react {
 /*
  * Type used to represent an index of some stored values in small arrays.
  */
-using RawPropsValueIndex = uint8_t;
+using RawPropsValueIndex = uint16_t;
 static_assert(
-    sizeof(RawPropsValueIndex) == 1,
-    "RawPropsValueIndex must be one byte size.");
-using RawPropsPropNameLength = uint8_t;
+    sizeof(RawPropsValueIndex) == 2,
+    "RawPropsValueIndex must be two byte size.");
+using RawPropsPropNameLength = uint16_t;
 using RawPropsPropNameHash = uint32_t;
 
 /*


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Adjust RawPropsPropNameLength's type to account for increased number of props

While investigating why we needed to back out D48288752 I discovered that the root cause was that the `items_` vector in `RawProsKeyMap` was now a size greater than 255 which becomes an issue because `items_`'s indices are statically cast to `RawPropsPropNameLength` (previously alias to `uint8_t`).

This diff updates `RawPropsPropNameLength` to be an alias to `uint16_t` so the current issue is resolved as well as adding an assert to ensure (however unlikely) that this happens again.

Differential Revision: D48331909

