### PR TITLE
Fix no support Schemes names contain spaces

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -62,7 +62,7 @@ describe('generateCode', () => {
     expect(child_process.execSync).toHaveBeenCalledTimes(1);
     expect(child_process.execSync).toHaveBeenNthCalledWith(
       1,
-      `cp -R ${tmpOutputDir}/* ${iosOutputDir}`,
+      `cp -R ${tmpOutputDir}/* "${iosOutputDir}"`,
     );
 
     expect(fs.mkdirSync).toHaveBeenCalledTimes(2);

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -372,7 +372,7 @@ function generateCode(iosOutputDir, library, tmpDir, node, pathToSchema) {
   const outputDir =
     CORE_LIBRARIES_WITH_OUTPUT_FOLDER[library.config.name] ?? iosOutputDir;
   fs.mkdirSync(outputDir, {recursive: true});
-  execSync(`cp -R ${tmpOutputDir}/* ${outputDir}`);
+  execSync(`cp -R ${tmpOutputDir}/* "${outputDir}"`);
   console.log(`[Codegen] Generated artifacts: ${iosOutputDir}`);
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

i just moved to the new react native 0.72.1 with the new Architecture and I encountered a problem when tried to archive my develop version(i have 2 Schemes one for prod and one for dev).

so i did some digging and got to the problem that was found in script file named "generate-artifacts-executor.js".

i found that after generating lib content into the temp directory(tmpOutputDir)
it copy all the content into the real output directory(iosOutputDir).

the problem was that the real output directory(iosOutputDir) containing the selected scheme name and mine was with backspace(AppTest Develop) so the cp -r command was failing.

in order to fix that i wrapped the real output directory(iosOutputDir) with double quotes.

Also updated the related test ("executeNodes with the right arguments") to include the double quotes.

## Changelog:

[GENERAL] [FIXED] - Add support to archive Schemes names with backspaces

## Test Plan:

1. After updating the related test ("executeNodes with the right arguments") to include the double quotes i run all tests by 
run yarn test and yarn flow and All tests passed.

2. Also after i changed locally the script file in my project from the node_modules
    i successfully Archived both my Schemes dev and prod (one with backspace and one without).

