### PR TITLE
[RN][iOS] Persist different dSYM folders depending on the flavor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1800,8 +1800,8 @@ jobs:
           root: /tmp/hermes/
           paths:
             - hermes-runtime-darwin
-            - osx-bin
-            - dSYM
+            - osx-bin/<< parameters.flavor >>
+            - dSYM/<< parameters.flavor >>
 
   build_hermesc_windows:
     executor:
@@ -1950,7 +1950,8 @@ jobs:
             mkdir -p ./packages/react-native/ReactAndroid/external-artifacts/artifacts/
             cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-debug.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-debug.tar.gz
             cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-release.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-release.tar.gz
-
+            cp $HERMES_WS_DIR/dSYM/Debug/hermes.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-debug.tar.gz
+            cp $HERMES_WS_DIR/dSYM/Release/hermes.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-release.tar.gz
       - run_yarn
       - build_packages
       - attach_workspace:

--- a/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
@@ -35,6 +35,24 @@ val hermesiOSReleaseArtifact: PublishArtifact =
       classifier = "hermes-ios-release"
     }
 
+// Those artifacts should be placed inside the `artifacts/hermes-*.framework.dSYM` location
+val hermesDSYMDebugArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/hermes-framework-dSYM-debug.tar.gz")
+val hermesDSYMDebugArtifact: PublishArtifact =
+    artifacts.add("default", hermesDSYMDebugArtifactFile) {
+      type = "tgz"
+      extension = "tar.gz"
+      classifier = "hermes-framework-dSYM-debug"
+    }
+val hermesDSYMReleaseArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/hermes-framework-dSYM-release.tar.gz")
+val hermesDSYMReleaseArtifact: PublishArtifact =
+    artifacts.add("default", hermesDSYMReleaseArtifactFile) {
+      type = "tgz"
+      extension = "tar.gz"
+      classifier = "hermes-framework-dSYM-release"
+    }
+
 apply(from = "../publish.gradle")
 
 publishing {
@@ -43,6 +61,8 @@ publishing {
       artifactId = "react-native-artifacts"
       artifact(hermesiOSDebugArtifact)
       artifact(hermesiOSReleaseArtifact)
+      artifact(hermesDSYMDebugArtifact)
+      artifact(hermesDSYMReleaseArtifact)
     }
   }
 }


### PR DESCRIPTION
## Summary:

CI is failing due to the attach workspace trying to attach the same file twice. Let's try to be more selective.

## Changelog:

[Internal] - Fix CI

## Test Plan:

CircleCI must be green
