### PR TITLE
Show RedBox when reloads fail

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessDevSupportManager.java
@@ -121,7 +121,7 @@ class BridgelessDevSupportManager extends DevSupportManagerBase {
       @androidx.annotation.Nullable
       @Override
       public Activity getCurrentActivity() {
-        return reactHost.getCurrentActivity();
+        return reactHost.getLastUsedActivity();
       }
 
       @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
@@ -1180,6 +1180,61 @@ public class ReactHostImpl implements ReactHost {
   @ThreadConfined("ReactHost")
   private @Nullable Task<ReactInstance> mReloadTask = null;
 
+  private interface ReactInstanceTaskUnwrapper {
+    @Nullable
+    ReactInstance unwrap(Task<ReactInstance> task, String stage);
+  }
+
+  private ReactInstanceTaskUnwrapper createReactInstanceUnwraper(
+      String tag, String method, String reason) {
+
+    return (task, stage) -> {
+      final ReactInstance reactInstance = task.getResult();
+      final ReactInstance currentReactInstance = mReactInstanceTaskRef.get().getResult();
+
+      final String stageLabel = "Stage: " + stage;
+      final String reasonLabel = tag + " reason: " + reason;
+      if (task.isFaulted()) {
+        final Exception ex = task.getError();
+        final String faultLabel = "Fault reason: " + ex.getMessage();
+        raiseSoftException(
+            method,
+            tag
+                + ": ReactInstance task faulted. "
+                + stageLabel
+                + ". "
+                + faultLabel
+                + ". "
+                + reasonLabel);
+        return currentReactInstance;
+      }
+
+      if (task.isCancelled()) {
+        raiseSoftException(
+            method, tag + ": ReactInstance task cancelled. " + stageLabel + ". " + reasonLabel);
+        return currentReactInstance;
+      }
+
+      if (reactInstance == null) {
+        raiseSoftException(
+            method, tag + ": ReactInstance task returned null. " + stageLabel + ". " + reasonLabel);
+        return currentReactInstance;
+      }
+
+      if (currentReactInstance != null && reactInstance != currentReactInstance) {
+        raiseSoftException(
+            method,
+            tag
+                + ": Detected two different ReactInstances. Returning old. "
+                + stageLabel
+                + ". "
+                + reasonLabel);
+      }
+
+      return reactInstance;
+    };
+  }
+
   /**
    * The ReactInstance is loaded. Tear it down, and re-create it.
    *
@@ -1197,30 +1252,18 @@ public class ReactHostImpl implements ReactHost {
     // TODO(T136397487): Remove after Venice is shipped to 100%
     raiseSoftException(method, reason);
 
+    ReactInstanceTaskUnwrapper reactInstanceTaskUnwrapper =
+        createReactInstanceUnwraper("Reload", method, reason);
+
     if (mReloadTask == null) {
       mReloadTask =
           mReactInstanceTaskRef
               .get()
               .continueWithTask(
                   (task) -> {
-                    log(method, "Starting on UI thread");
-
-                    if (task.isFaulted()) {
-                      raiseSoftException(
-                          method,
-                          "ReactInstance task faulted. Reload reason: " + reason,
-                          task.getError());
-                    }
-
-                    if (task.isCancelled()) {
-                      raiseSoftException(
-                          method, "ReactInstance task cancelled. Reload reason: " + reason);
-                    }
-
-                    final ReactInstance reactInstance = task.getResult();
-                    if (reactInstance == null) {
-                      raiseSoftException(method, "ReactInstance is null. Reload reason: " + reason);
-                    }
+                    log(method, "Starting React Native reload");
+                    final ReactInstance reactInstance =
+                        reactInstanceTaskUnwrapper.unwrap(task, "1: Starting reload");
 
                     final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
                     if (reactContext == null) {
@@ -1234,13 +1277,16 @@ public class ReactHostImpl implements ReactHost {
                       reactContext.onHostPause();
                     }
 
-                    return task;
+                    return Task.forResult(reactInstance);
                   },
                   mUIExecutor)
               .continueWithTask(
                   task -> {
-                    final ReactInstance reactInstance = task.getResult();
+                    final ReactInstance reactInstance =
+                        reactInstanceTaskUnwrapper.unwrap(task, "2: Surface shutdown");
+
                     if (reactInstance == null) {
+                      raiseSoftException(method, "Skipping surface shutdown: ReactInstance null");
                       return task;
                     }
 
@@ -1250,6 +1296,8 @@ public class ReactHostImpl implements ReactHost {
                   mBGExecutor)
               .continueWithTask(
                   task -> {
+                    reactInstanceTaskUnwrapper.unwrap(task, "3: Destroying ReactContext");
+
                     log(method, "Removing memory pressure listener");
                     mMemoryPressureRouter.removeMemoryPressureListener(mMemoryPressureListener);
 
@@ -1271,10 +1319,14 @@ public class ReactHostImpl implements ReactHost {
                   mUIExecutor)
               .continueWithTask(
                   task -> {
-                    final ReactInstance reactInstance = task.getResult();
+                    final ReactInstance reactInstance =
+                        reactInstanceTaskUnwrapper.unwrap(task, "4: Destroying ReactInstance");
 
-                    log(method, "Destroying ReactInstance");
-                    if (reactInstance != null) {
+                    if (reactInstance == null) {
+                      raiseSoftException(
+                          method, "Skipping ReactInstance.destroy(): ReactInstance null");
+                    } else {
+                      log(method, "Destroying ReactInstance");
                       reactInstance.destroy();
                     }
 
@@ -1291,23 +1343,30 @@ public class ReactHostImpl implements ReactHost {
                     return newGetOrCreateReactInstanceTask();
                   },
                   mBGExecutor)
-              .onSuccess(
+              .continueWithTask(
                   task -> {
-                    final ReactInstance reactInstance = task.getResult();
+                    final ReactInstance reactInstance =
+                        reactInstanceTaskUnwrapper.unwrap(task, "5: Restarting surfaces");
+
                     if (reactInstance == null) {
-                      return null;
+                      raiseSoftException(method, "Skipping surface restart: ReactInstance null");
+                      return task;
                     }
 
                     startAttachedSurfaces(method, reactInstance);
-                    return reactInstance;
+
+                    return task;
                   },
                   mBGExecutor)
               .continueWithTask(
                   task -> {
                     if (task.isFaulted()) {
+                      Exception fault = task.getError();
                       raiseSoftException(
                           method,
-                          "Failed to re-created ReactInstance. Task faulted. Reload reason: "
+                          "Error during reload. ReactInstance task faulted. Fault reason: "
+                              + fault.getMessage()
+                              + ". Reload reason: "
                               + reason,
                           task.getError());
                     }
@@ -1315,7 +1374,7 @@ public class ReactHostImpl implements ReactHost {
                     if (task.isCancelled()) {
                       raiseSoftException(
                           method,
-                          "Failed to re-created ReactInstance. Task cancelled. Reload reason: "
+                          "Error during reload. ReactInstance task cancelled. Reload reason: "
                               + reason);
                     }
 
@@ -1349,31 +1408,19 @@ public class ReactHostImpl implements ReactHost {
     // TODO(T136397487): Remove after Venice is shipped to 100%
     raiseSoftException(method, reason, ex);
 
+    ReactInstanceTaskUnwrapper reactInstanceTaskUnwrapper =
+        createReactInstanceUnwraper("Destroy", method, reason);
+
     if (mDestroyTask == null) {
       mDestroyTask =
           mReactInstanceTaskRef
               .get()
               .continueWithTask(
                   task -> {
-                    log(method, "Destroying ReactInstance on UI Thread");
+                    log(method, "Starting React Native destruction");
 
-                    if (task.isFaulted()) {
-                      raiseSoftException(
-                          method,
-                          "ReactInstance task faulted. Destroy reason: " + reason,
-                          task.getError());
-                    }
-
-                    if (task.isCancelled()) {
-                      raiseSoftException(
-                          method, "ReactInstance task cancelled. Destroy reason: " + reason);
-                    }
-
-                    final ReactInstance reactInstance = task.getResult();
-                    if (reactInstance == null) {
-                      raiseSoftException(
-                          method, "ReactInstance is null. Destroy reason: " + reason);
-                    }
+                    final ReactInstance reactInstance =
+                        reactInstanceTaskUnwrapper.unwrap(task, "1: Starting destroy");
 
                     // Step 1: Destroy DevSupportManager
                     if (mUseDevSupport) {
@@ -1392,13 +1439,16 @@ public class ReactHostImpl implements ReactHost {
                     log(method, "Move ReactHost to onHostDestroy()");
                     mReactLifecycleStateManager.moveToOnHostDestroy(reactContext);
 
-                    return task;
+                    return Task.forResult(reactInstance);
                   },
                   mUIExecutor)
               .continueWithTask(
                   task -> {
-                    final ReactInstance reactInstance = task.getResult();
+                    final ReactInstance reactInstance =
+                        reactInstanceTaskUnwrapper.unwrap(task, "2: Stopping surfaces");
+
                     if (reactInstance == null) {
+                      raiseSoftException(method, "Skipping surface shutdown: ReactInstance null");
                       return task;
                     }
 
@@ -1413,6 +1463,8 @@ public class ReactHostImpl implements ReactHost {
                   mBGExecutor)
               .continueWithTask(
                   task -> {
+                    reactInstanceTaskUnwrapper.unwrap(task, "3: Destroying ReactContext");
+
                     final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
 
                     if (reactContext == null) {
@@ -1437,10 +1489,15 @@ public class ReactHostImpl implements ReactHost {
                     return task;
                   },
                   mUIExecutor)
-              .continueWith(
+              .continueWithTask(
                   task -> {
-                    final ReactInstance reactInstance = task.getResult();
-                    if (reactInstance != null) {
+                    final ReactInstance reactInstance =
+                        reactInstanceTaskUnwrapper.unwrap(task, "3: Destroying ReactInstance");
+
+                    if (reactInstance == null) {
+                      raiseSoftException(
+                          method, "Skipping ReactInstance.destroy(): ReactInstance null");
+                    } else {
                       log(method, "Destroying ReactInstance");
                       reactInstance.destroy();
                     }
@@ -1456,9 +1513,30 @@ public class ReactHostImpl implements ReactHost {
 
                     log(method, "Resetting destroy task ref");
                     mDestroyTask = null;
-                    return null;
+                    return task;
                   },
-                  mBGExecutor);
+                  mBGExecutor)
+              .continueWith(
+                  task -> {
+                    if (task.isFaulted()) {
+                      Exception fault = task.getError();
+                      raiseSoftException(
+                          method,
+                          "React destruction failed. ReactInstance task faulted. Fault reason: "
+                              + fault.getMessage()
+                              + ". Destroy reason: "
+                              + reason,
+                          task.getError());
+                    }
+
+                    if (task.isCancelled()) {
+                      raiseSoftException(
+                          method,
+                          "React destruction failed. ReactInstance task cancelled. Destroy reason: "
+                              + reason);
+                    }
+                    return null;
+                  });
     }
 
     return mDestroyTask;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
@@ -667,7 +667,7 @@ public class ReactHostImpl implements ReactHost {
   private @Nullable Task<Void> mStartTask = null;
 
   private Task<Void> oldStart() {
-    final String method = "oldPreload()";
+    final String method = "oldStart()";
     return Task.call(
             () -> {
               if (mStartTask == null) {
@@ -678,7 +678,7 @@ public class ReactHostImpl implements ReactHost {
                             task -> {
                               if (task.isFaulted()) {
                                 destroy(
-                                    "oldPreload() failure: " + task.getError().getMessage(),
+                                    "oldStart() failure: " + task.getError().getMessage(),
                                     task.getError());
                                 mReactHostDelegate.handleInstanceException(task.getError());
                               }
@@ -695,7 +695,7 @@ public class ReactHostImpl implements ReactHost {
   }
 
   private Task<Void> newStart() {
-    final String method = "newPreload()";
+    final String method = "newStart()";
     return Task.call(
             () -> {
               if (mStartTask == null) {
@@ -708,7 +708,7 @@ public class ReactHostImpl implements ReactHost {
                                 mReactHostDelegate.handleInstanceException(task.getError());
                                 // Wait for destroy to finish
                                 return newGetOrCreateDestroyTask(
-                                        "newPreload() failure: " + task.getError().getMessage(),
+                                        "newStart() failure: " + task.getError().getMessage(),
                                         task.getError())
                                     .continueWithTask(destroyTask -> Task.forError(task.getError()))
                                     .makeVoid();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
@@ -276,11 +276,11 @@ public class ReactHostImpl implements ReactHost {
     final String method = "onHostResume(activity)";
     log(method);
 
-    mActivity.set(activity);
+    setCurrentActivity(activity);
     ReactContext currentContext = getCurrentReactContext();
 
     // TODO(T137233065): Enable DevSupportManager here
-    mReactLifecycleStateManager.moveToOnHostResume(currentContext, mActivity.get());
+    mReactLifecycleStateManager.moveToOnHostResume(currentContext, getCurrentActivity());
   }
 
   @ThreadConfined(UI)
@@ -291,7 +291,7 @@ public class ReactHostImpl implements ReactHost {
 
     ReactContext currentContext = getCurrentReactContext();
 
-    Activity currentActivity = mActivity.get();
+    Activity currentActivity = getCurrentActivity();
     if (currentActivity != null) {
       String currentActivityClass = currentActivity.getClass().getSimpleName();
       String activityClass = activity == null ? "null" : activity.getClass().getSimpleName();
@@ -321,7 +321,7 @@ public class ReactHostImpl implements ReactHost {
 
     // TODO(T137233065): Disable DevSupportManager here
     mDefaultHardwareBackBtnHandler = null;
-    mReactLifecycleStateManager.moveToOnHostPause(currentContext, mActivity.get());
+    mReactLifecycleStateManager.moveToOnHostPause(currentContext, getCurrentActivity());
   }
 
   /** To be called when the host activity is destroyed. */
@@ -341,7 +341,7 @@ public class ReactHostImpl implements ReactHost {
     final String method = "onHostDestroy(activity)";
     log(method);
 
-    Activity currentActivity = mActivity.get();
+    Activity currentActivity = getCurrentActivity();
 
     // TODO(T137233065): Disable DevSupportManager here
     if (currentActivity == activity) {
@@ -502,6 +502,10 @@ public class ReactHostImpl implements ReactHost {
   @Nullable
   /* package */ Activity getCurrentActivity() {
     return mActivity.get();
+  }
+
+  private void setCurrentActivity(@Nullable Activity activity) {
+    mActivity.set(activity);
   }
 
   /**
@@ -726,7 +730,7 @@ public class ReactHostImpl implements ReactHost {
   @ThreadConfined(UI)
   private void moveToHostDestroy(@Nullable ReactContext currentContext) {
     mReactLifecycleStateManager.moveToOnHostDestroy(currentContext);
-    mActivity.set(null);
+    setCurrentActivity(null);
   }
 
   private void raiseSoftException(String method, String message) {
@@ -946,14 +950,15 @@ public class ReactHostImpl implements ReactHost {
                      * screen in the past, or (2) We must be on a React Native screen.
                      */
                     if (isReloading && !isManagerResumed) {
-                      mReactLifecycleStateManager.moveToOnHostResume(reactContext, mActivity.get());
+                      mReactLifecycleStateManager.moveToOnHostResume(
+                          reactContext, getCurrentActivity());
                     } else {
                       /**
                        * Call ReactContext.onHostResume() only when already in the resumed state
                        * which aligns with the bridge https://fburl.com/diffusion/2qhxmudv.
                        */
                       mReactLifecycleStateManager.resumeReactContextIfHostResumed(
-                          reactContext, mActivity.get());
+                          reactContext, getCurrentActivity());
                     }
 
                     ReactInstanceEventListener[] listeners =
@@ -1033,7 +1038,7 @@ public class ReactHostImpl implements ReactHost {
                      aligns with the bridge https://fburl.com/diffusion/2qhxmudv.
                     */
                     mReactLifecycleStateManager.resumeReactContextIfHostResumed(
-                        reactContext, mActivity.get());
+                        reactContext, getCurrentActivity());
 
                     ReactInstanceEventListener[] listeners =
                         new ReactInstanceEventListener[mReactInstanceEventListeners.size()];
@@ -1410,7 +1415,7 @@ public class ReactHostImpl implements ReactHost {
                     }
 
                     // Reset current activity
-                    mActivity.set(null);
+                    setCurrentActivity(null);
 
                     // Clear ResourceIdleDrawableIdMap
                     ResourceDrawableIdHelper.getInstance().clear();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
@@ -16,6 +16,7 @@ import static java.lang.Boolean.TRUE;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
@@ -71,6 +72,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
 
 /**
  * A ReactHost is an object that manages a single {@link ReactInstance}. A ReactHost can be
@@ -127,6 +130,9 @@ public class ReactHostImpl implements ReactHost {
   private @Nullable JSEngineResolutionAlgorithm mJSEngineResolutionAlgorithm = null;
   private MemoryPressureListener mMemoryPressureListener;
   private @Nullable DefaultHardwareBackBtnHandler mDefaultHardwareBackBtnHandler;
+
+  private final Set<Function0<Unit>> mBeforeDestroyListeners =
+      Collections.synchronizedSet(new HashSet<>());
 
   public ReactHostImpl(
       Context context,
@@ -674,6 +680,20 @@ public class ReactHostImpl implements ReactHost {
         }
       }
       return false;
+    }
+  }
+
+  @Override
+  public void addBeforeDestroyListener(@NonNull Function0<Unit> onBeforeDestroy) {
+    synchronized (mBeforeDestroyListeners) {
+      mBeforeDestroyListeners.add(onBeforeDestroy);
+    }
+  }
+
+  @Override
+  public void removeBeforeDestroyListener(@NonNull Function0<Unit> onBeforeDestroy) {
+    synchronized (mBeforeDestroyListeners) {
+      mBeforeDestroyListeners.remove(onBeforeDestroy);
     }
   }
 
@@ -1295,8 +1315,24 @@ public class ReactHostImpl implements ReactHost {
                   },
                   mBGExecutor)
               .continueWithTask(
+                  (task) -> {
+                    reactInstanceTaskUnwrapper.unwrap(
+                        task, "3: Executing Before Destroy Listeners");
+
+                    Set<Function0<Unit>> beforeDestroyListeners;
+                    synchronized (mBeforeDestroyListeners) {
+                      beforeDestroyListeners = new HashSet<>(mBeforeDestroyListeners);
+                    }
+
+                    for (Function0<Unit> destroyListener : beforeDestroyListeners) {
+                      destroyListener.invoke();
+                    }
+                    return task;
+                  },
+                  mUIExecutor)
+              .continueWithTask(
                   task -> {
-                    reactInstanceTaskUnwrapper.unwrap(task, "3: Destroying ReactContext");
+                    reactInstanceTaskUnwrapper.unwrap(task, "4: Destroying ReactContext");
 
                     log(method, "Removing memory pressure listener");
                     mMemoryPressureRouter.removeMemoryPressureListener(mMemoryPressureListener);
@@ -1320,7 +1356,7 @@ public class ReactHostImpl implements ReactHost {
               .continueWithTask(
                   task -> {
                     final ReactInstance reactInstance =
-                        reactInstanceTaskUnwrapper.unwrap(task, "4: Destroying ReactInstance");
+                        reactInstanceTaskUnwrapper.unwrap(task, "5: Destroying ReactInstance");
 
                     if (reactInstance == null) {
                       raiseSoftException(
@@ -1346,7 +1382,7 @@ public class ReactHostImpl implements ReactHost {
               .continueWithTask(
                   task -> {
                     final ReactInstance reactInstance =
-                        reactInstanceTaskUnwrapper.unwrap(task, "5: Restarting surfaces");
+                        reactInstanceTaskUnwrapper.unwrap(task, "7: Restarting surfaces");
 
                     if (reactInstance == null) {
                       raiseSoftException(method, "Skipping surface restart: ReactInstance null");
@@ -1463,7 +1499,23 @@ public class ReactHostImpl implements ReactHost {
                   mBGExecutor)
               .continueWithTask(
                   task -> {
-                    reactInstanceTaskUnwrapper.unwrap(task, "3: Destroying ReactContext");
+                    reactInstanceTaskUnwrapper.unwrap(
+                        task, "3: Executing Before Destroy Listeners");
+
+                    Set<Function0<Unit>> beforeDestroyListeners;
+                    synchronized (mBeforeDestroyListeners) {
+                      beforeDestroyListeners = new HashSet<>(mBeforeDestroyListeners);
+                    }
+
+                    for (Function0<Unit> destroyListener : beforeDestroyListeners) {
+                      destroyListener.invoke();
+                    }
+                    return task;
+                  },
+                  mUIExecutor)
+              .continueWithTask(
+                  task -> {
+                    reactInstanceTaskUnwrapper.unwrap(task, "4: Destroying ReactContext");
 
                     final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
 
@@ -1492,7 +1544,7 @@ public class ReactHostImpl implements ReactHost {
               .continueWithTask(
                   task -> {
                     final ReactInstance reactInstance =
-                        reactInstanceTaskUnwrapper.unwrap(task, "3: Destroying ReactInstance");
+                        reactInstanceTaskUnwrapper.unwrap(task, "5: Destroying ReactInstance");
 
                     if (reactInstance == null) {
                       raiseSoftException(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostImpl.java
@@ -117,6 +117,8 @@ public class ReactHostImpl implements ReactHost {
       new BridgelessAtomicRef<>();
 
   private final AtomicReference<Activity> mActivity = new AtomicReference<>();
+  private final AtomicReference<WeakReference<Activity>> mLastUsedActivity =
+      new AtomicReference<>(new WeakReference<>(null));
   private final BridgelessReactStateTracker mBridgelessReactStateTracker =
       new BridgelessReactStateTracker(DEV);
   private final ReactLifecycleStateManager mReactLifecycleStateManager =
@@ -504,8 +506,20 @@ public class ReactHostImpl implements ReactHost {
     return mActivity.get();
   }
 
+  @Nullable
+  /* package */ Activity getLastUsedActivity() {
+    @Nullable WeakReference<Activity> lastUsedActivityWeakRef = mLastUsedActivity.get();
+    if (lastUsedActivityWeakRef != null) {
+      return lastUsedActivityWeakRef.get();
+    }
+    return null;
+  }
+
   private void setCurrentActivity(@Nullable Activity activity) {
     mActivity.set(activity);
+    if (activity != null) {
+      mLastUsedActivity.set(new WeakReference<>(activity));
+    }
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/internal/bolts/Task.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.bridgeless.internal.bolts;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.interfaces.TaskInterface;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -187,7 +188,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
 
   /** Creates a completed task with the given value. */
   @SuppressWarnings("unchecked")
-  public static <TResult> Task<TResult> forResult(TResult value) {
+  public static <TResult> Task<TResult> forResult(@Nullable TResult value) {
     if (value == null) {
       return (Task<TResult>) TASK_NULL;
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/ReactHost.kt
@@ -101,4 +101,8 @@ interface ReactHost {
    * @return A task that completes when React Native gets destroyed.
    */
   fun destroy(reason: String, ex: Exception?): TaskInterface<Void>
+
+  fun addBeforeDestroyListener(onBeforeDestroy: () -> Unit)
+
+  fun removeBeforeDestroyListener(onBeforeDestroy: () -> Unit)
 }


### PR DESCRIPTION
Summary:
When reloads fail, React Native currently just renders a blank screen.

We should provde some sort of feedback to the developer. Hence, this diff makes the RedBox show up.

Changelog: [Internal]

Differential Revision: D48335851

