### PR TITLE
Flow: Cleanup Platform Suffix Ignore Patterns

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,6 @@
 [ignore]
-; We fork some components by platform
-.*/*[.]android.js
+; Ignore other platform suffixes
+.*\.android\.js$
 
 ; Ignore templates for 'react-native init'
 <PROJECT_ROOT>/packages/react-native/template/.*

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -1,6 +1,6 @@
 [ignore]
-; We fork some components by platform
-.*/*[.]ios.js
+; Ignore other platform suffixes
+.*\.ios\.js$
 
 ; Ignore templates for 'react-native init'
 <PROJECT_ROOT>/packages/react-native/template/.*


### PR DESCRIPTION
Summary:
The regular expressions that we use to ignore other platform suffixes are wrong or unnecessarily complicated.

This diff cleans them up to be idiomatic regular expressions without any extra constructs.

Changelog:
[Internal]

Reviewed By: samwgoldman

Differential Revision: D48377329

