### PR TITLE
Fix bad comparison in RCTScrollViewComponentView RTL

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -675,16 +675,16 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 - (void)scrollToOffset:(CGPoint)offset animated:(BOOL)animated
 {
+  if (_layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
+    // Adjusting offset.x in right to left layout direction.
+    offset.x = self.contentSize.width - _scrollView.frame.size.width - offset.x;
+  }
+
   if (CGPointEqualToPoint(_scrollView.contentOffset, offset)) {
     return;
   }
 
   [self _forceDispatchNextScrollEvent];
-
-  if (_layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
-    // Adjusting offset.x in right to left layout direction.
-    offset.x = self.contentSize.width - _scrollView.frame.size.width - offset.x;
-  }
 
   [_scrollView setContentOffset:offset animated:animated];
 


### PR DESCRIPTION
Summary:
D29164056 fixed `scrollTo` coordinate space in RTL, but D38499666 regressed it by adding a comparison before the RTL conversion happens.

This makes `scrollTo` no-op if we are scrolling from the beginning to the end of the list, since the end of the list is `x: 0` in cartesian coordinates, and the start of the list is `x: 0` in flow-relative coordinates.

Do coordinate conversion before the early exit check.

Changelog:
[iOS][Fixed] - Fix bad comparison in RCTScrollViewComponentView RTL

Differential Revision: D48378414

