### PR TITLE
cipolleschi/add maven polling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1564,6 +1564,19 @@ jobs:
                     -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${CIRCLE_TAG:1}\" }}"
       # END: Stable releases
 
+  poll_maven:
+    docker:
+      - image: cimg/node:current
+    resource_class: small
+    steps:
+      - checkout_code_with_cache
+      - run_yarn
+      - run:
+          name: Poll Maven for Artifacts
+          command: |
+            node scripts/circleci/poll-maven.js
+
+
   # -------------------------
   #    JOBS: Nightly
   # -------------------------
@@ -1869,6 +1882,9 @@ workflows:
             - build_hermesc_linux
             - build_hermes_macos
             - build_hermesc_windows
+      - poll_maven:
+          requires:
+            -  build_and_publish_npm_package
 
   package_and_publish_release_dryrun:
     jobs:

--- a/scripts/circleci/poll-maven.js
+++ b/scripts/circleci/poll-maven.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const fetch = require('node-fetch');
+const fs = require('fs');
+
+const baseMavenRepo = 'https://repo1.maven.org/maven2/com/facebook/react';
+const artifacts = ['react-native-artifacts', 'react-android', 'hermes-android'];
+const humanNames = {
+  'react-native-artifacts': 'Hermes for iOS',
+  'react-android': 'React Native for Android',
+  'hermes-android': 'Hermes for Android',
+};
+const ping_minutes = 5;
+const max_hours = 5;
+const ping_interval = ping_minutes * 60 * 1000; // 5 minutes
+const max_wait = max_hours * 60 * 60 * 1000; // 5 hours
+
+const startTime = Date.now();
+
+async function pingMaven(artifact, rnVersion) {
+  const url = `${baseMavenRepo}/${artifact}/${rnVersion}`;
+  const response = await fetch(url, {method: 'HEAD'});
+  if (response.status === 200) {
+    console.log(`Found artifact for ${humanNames[artifact]}\n`);
+    return;
+  } else if (response.status !== 404) {
+    throw new Error(
+      `Unexpected response code ${response.status} for ${humanNames[artifact]}`,
+    );
+  }
+
+  const elapsedTime = Date.now() - startTime;
+  if (elapsedTime > max_wait) {
+    throw new Error(`${max_hours} hours has passed. Exiting.`);
+  }
+  // Wait a bit
+  console.log(
+    `${humanNames[artifact]} not available yet. Waiting ${ping_minutes} minutes.\n`,
+  );
+  await new Promise(resolve => setTimeout(resolve, ping_interval));
+  await pingMaven(url);
+}
+
+async function main() {
+  const package = JSON.parse(
+    fs.readFileSync('packages/react-native/package.json', 'utf8'),
+  );
+  const rnVersion = package.version;
+
+  if (rnVersion === '1000.0.0') {
+    console.log(
+      'We are not on a release branch when a release has been initiated. Exiting.',
+    );
+    return;
+  }
+
+  console.log(`Checking artifacts for React Native version ${rnVersion}\n`);
+
+  for (const artifact of artifacts) {
+    console.log(`Start pinging for ${humanNames[artifact]}`);
+    await pingMaven(artifact, rnVersion);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary:

This local change adds a script to poll Maven automatically after the release has happened.
This should allow the Release Crew not to repeatedly and manually refresh Maven urls in order to see whether the artifacts are there or not.
As soon as this job is green, artifacts are out!

Cost wise, we are using a small machine, which costs 5 credits per minute.

## Changelog:

[Internal] -Add script and CI job to poll for maven after a release.

## Test Plan:
Tested locally, running the JS script.
[Verified that the CI job can execute it](https://app.circleci.com/pipelines/github/facebook/react-native/29634/workflows/5966d5f9-12ca-40b1-9185-758fe98d3aee/jobs/944107).

We can only test this for real while doing a proper release.
