### PR TITLE
Fix condition to detect use of Paper renderer in TextInput on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -924,7 +924,7 @@ public class ReactEditText extends AppCompatEditText {
     // view, we don't need to construct one or apply it at all - it provides no use in Fabric.
     ReactContext reactContext = getReactContext(this);
 
-    if (mStateWrapper != null && !reactContext.isBridgeless()) {
+    if (mStateWrapper == null && !reactContext.isBridgeless()) {
 
       final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
       UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);


### PR DESCRIPTION
Summary:
changelog: [internal]

In D47993140 I removed FabricViewStateManager but made a mistake during refactoring. This fixes it.

Differential Revision: D48390478

