### PR TITLE
Change use of nativeId to collapsable

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -1700,7 +1700,6 @@ class ScrollView extends React.Component<Props, State> {
           return (
             <StickyHeaderComponent
               key={key}
-              nativeID={'StickyHeader-' + key} /* TODO: T68258846. */
               ref={ref => this._setStickyHeaderRef(key, ref)}
               nextHeaderLayoutY={this._headerLayoutYs.get(
                 this._getKeyForIndex(nextIndex, childArray),


### PR DESCRIPTION
Summary:
changelog: [internal]

nativeID was used to fix broken behaviour of collapsable. Now, collapsable is fixed, let's remove that.

Reviewed By: rozele

Differential Revision: D48349235

