### PR TITLE
Override `canScrollHorizontally()` to expose when scrolling is disabled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -145,6 +145,11 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     return mScrollEnabled;
   }
 
+  @Override
+  public boolean canScrollHorizontally(int direction) {
+    return mScrollEnabled && super.canScrollHorizontally(direction);
+  }
+
   @Nullable
   private OverScroller getOverScrollerFromParent() {
     OverScroller scroller;


### PR DESCRIPTION
Summary:
**Context**
We have a bug where a ReactHorizontalScrollView is set to scrollEnabled = false. However, it still has a "scrollable width." When other components evaluate how to handle touches, they assume this view wants it...but `onInterceptTouch()` will return NO. To fix this in the most generic way and without making the other code aware of this class, I'm overriding `View.canScrollHorizontally()`.

**Notes**
- I also considered making the other code invoke onInterceptTouch(), but I don't want to have non-OS code invoking that and messing up state. The order of the input events matters.
- The [docs explicitly state](https://developer.android.com/reference/android/view/View#canScrollHorizontally(int)) "this is without regard to whether the view is enabled or not, or if it will scroll in response to user input or not"
  - I'm not so sure this is useful.
  - Other Android OS classes disregard it. :)
    - https://cs.android.com/android/platform/superproject/+/master:packages/apps/Messaging/src/com/android/messaging/ui/PagingAwareViewPager.java;l=91?q=%20canScrollHorizontally%5C(&start=21
    - https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/packages/SystemUI/src/com/android/systemui/qs/NonInterceptingScrollView.java;l=107?q=canScrollHorizontal

Reviewed By: NickGerleman

Differential Revision: D48343681

