### PR TITLE
Use runtime scheduler in the old architecture

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -11,7 +11,7 @@
 
 #ifdef __cplusplus
 
-#if RCT_NEW_ARCH_ENABLED
+#import <memory>
 
 #ifndef RCT_USE_HERMES
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
@@ -27,20 +27,26 @@
 #import <React/JSCExecutorFactory.h>
 #endif
 
+#if RCT_NEW_ARCH_ENABLED
 #import <ReactCommon/RCTTurboModuleManager.h>
 #endif
 
-#if RCT_NEW_ARCH_ENABLED
 // Forward declaration to decrease compilation coupling
 namespace facebook::react {
 class RuntimeScheduler;
 }
+
+#if RCT_NEW_ARCH_ENABLED
 
 RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass);
 
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutorFactory(
     RCTBridge *bridge,
     RCTTurboModuleManager *turboModuleManager,
+    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler);
+#else
+std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactoryForOldArch(
+    RCTBridge *bridge,
     std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler);
 #endif
 

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -93,6 +93,7 @@ Pod::Spec.new do |s|
   s.dependency "React-CoreModules"
   s.dependency "React-nativeconfig"
   s.dependency "React-runtimescheduler"
+  s.dependency "React-RCTFabric"
 
   if is_new_arch_enabled
     s.dependency "React-BridgelessCore"
@@ -110,7 +111,6 @@ Pod::Spec.new do |s|
 
   if is_new_arch_enabled
     s.dependency "React-Fabric"
-    s.dependency "React-RCTFabric"
     s.dependency "React-graphics"
     s.dependency "React-utils"
     s.dependency "React-debug"

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -92,6 +92,7 @@ Pod::Spec.new do |s|
   s.dependency "React-NativeModulesApple"
   s.dependency "React-CoreModules"
   s.dependency "React-nativeconfig"
+  s.dependency "React-runtimescheduler"
 
   if is_new_arch_enabled
     s.dependency "React-BridgelessCore"

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -126,12 +126,13 @@ Pod::Spec.new do |s|
   end
 
   s.dependency "RCT-Folly", folly_version
-  s.dependency "React-cxxreact", version
-  s.dependency "React-perflogger", version
-  s.dependency "React-jsi", version
-  s.dependency "React-jsiexecutor", version
+  s.dependency "React-cxxreact"
+  s.dependency "React-perflogger"
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
   s.dependency "React-utils"
   s.dependency "SocketRocket", socket_rocket_version
+  s.dependency "React-runtimescheduler"
   s.dependency "Yoga"
   s.dependency "glog"
 

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -30,7 +30,6 @@ header_search_paths = [
   "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
   "\"$(PODS_ROOT)/Headers/Public/React-Codegen\"",
   "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Codegen/React_Codegen.framework/Headers\"",
-
 ]
 
 if ENV['USE_FRAMEWORKS']
@@ -48,6 +47,7 @@ if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\""
   header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\""
   header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererdebug/React_rendererdebug.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimescheduler/React_runtimescheduler.framework/Headers\""
 end
 
 Pod::Spec.new do |s|
@@ -88,6 +88,7 @@ Pod::Spec.new do |s|
   s.dependency "React-utils"
   s.dependency "React-rendererdebug"
   s.dependency "React-nativeconfig"
+  s.dependency "React-runtimescheduler"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency "React-debug"
   s.dependency "React-utils"
-  # s.dependency "React-runtimescheduler"
+  s.dependency "React-runtimescheduler"
   s.dependency "React-rendererdebug"
   s.dependency "React-cxxreact"
 
@@ -296,15 +296,6 @@ Pod::Spec.new do |s|
     ss.source_files         = "react/renderer/leakchecker/**/*.{cpp,h}"
     ss.exclude_files        = "react/renderer/leakchecker/tests"
     ss.header_dir           = "react/renderer/leakchecker"
-    ss.pod_target_xcconfig  = { "GCC_WARN_PEDANTIC" => "YES" }
-  end
-
-  s.subspec "runtimescheduler" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/runtimescheduler/**/*.{cpp,h}"
-    ss.exclude_files        = "react/renderer/runtimescheduler/tests"
-    ss.header_dir           = "react/renderer/runtimescheduler"
     ss.pod_target_xcconfig  = { "GCC_WARN_PEDANTIC" => "YES" }
   end
 end

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.exclude_files          = "SampleCxxModule.*"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = {
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\"",
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
   }
   s.header_dir             = "cxxreact"

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -61,8 +61,6 @@ Pod::Spec.new do |s|
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsi"
   end
 
 end

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
@@ -7,6 +7,7 @@
 
 #include "RuntimeSchedulerBinding.h"
 #include <ReactCommon/SchedulerPriority.h>
+#include "RuntimeScheduler.h"
 #include "SchedulerPriorityUtils.h"
 #include "primitives.h"
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
@@ -8,9 +8,10 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
 namespace facebook::react {
+
+class RuntimeScheduler;
 
 /*
  * Exposes RuntimeScheduler to JavaScript realm.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RuntimeSchedulerCallInvoker.h"
+#include "RuntimeScheduler.h"
 
 #include <utility>
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <ReactCommon/CallInvoker.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
 namespace facebook::react {
 
+class RuntimeScheduler;
 /*
  * Exposes RuntimeScheduler to native modules. All calls invoked on JavaScript
  * queue from native modules will be funneled through RuntimeScheduler.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/renderer/runtimescheduler/Task.h>
 #include <react/utils/CoreFeatures.h>

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
@@ -13,7 +13,6 @@
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/EventBeat.h>
 #include <react/renderer/leakchecker/LeakChecker.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <react/renderer/uimanager/primitives.h>
 #include <react/utils/ContextContainer.h>

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
@@ -47,8 +47,8 @@ class CodegenTests < Test::Unit::TestCase
 
         # Arrange
         FileMock.mocked_existing_files([
-            @prefix + "/React/Fabric/" + @third_party_provider_header,
-            @prefix + "/React/Fabric/" + @third_party_provider_implementation,
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header,
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_implementation,
         ])
 
         # Act
@@ -58,8 +58,8 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
-            @prefix + "/React/Fabric/" + @third_party_provider_header,
-            @prefix + "/React/Fabric/" + @third_party_provider_implementation,
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header,
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_implementation,
         ])
         assert_equal(DirMock.exist_invocation_params, [])
         assert_equal(Pod::UI.collected_messages, [])
@@ -84,7 +84,7 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
-            @prefix + "/React/Fabric/" + @third_party_provider_header
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header
         ])
         assert_equal(DirMock.exist_invocation_params, [
             @base_path + "/"+ @prefix + "/../react-native-codegen",
@@ -100,8 +100,8 @@ class CodegenTests < Test::Unit::TestCase
 
         # Arrange
         FileMock.mocked_existing_files([
-            @prefix + "/React/Fabric/" + @third_party_provider_header,
-            @prefix + "/React/Fabric/tmpSchemaList.txt"
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header,
+            @base_path + "/" + @prefix + "/React/Fabric/tmpSchemaList.txt"
         ])
 
         DirMock.mocked_existing_dirs([
@@ -116,9 +116,9 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
-            @prefix + "/React/Fabric/" + @third_party_provider_header,
-            @prefix + "/React/Fabric/" + @third_party_provider_implementation,
-            @prefix + "/React/Fabric/tmpSchemaList.txt",
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header,
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_implementation,
+            @base_path + "/" + @prefix + "/React/Fabric/tmpSchemaList.txt",
         ])
         assert_equal(DirMock.exist_invocation_params, [
             @base_path + "/"+ @prefix + "/../react-native-codegen",
@@ -127,7 +127,7 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pod::UI.collected_messages, ["[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"])
         assert_equal($collected_commands, [])
         assert_equal(FileMock.open_invocation_count, 1)
-        assert_equal(FileMock.open_files_with_mode[@prefix + "/React/Fabric/tmpSchemaList.txt"], 'w')
+        assert_equal(FileMock.open_files_with_mode[@prefix + "/React/Fabric/tmpSchemaList.txt"], nil)
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
         assert_equal(Pod::Executable.executed_commands[0], {
@@ -135,12 +135,12 @@ class CodegenTests < Test::Unit::TestCase
             "arguments" => [
                 @base_path + "/" + @prefix + "/scripts/generate-provider-cli.js",
                 "--platform", 'ios',
-                "--schemaListPath", @prefix + "/React/Fabric/tmpSchemaList.txt",
-                "--outputDir", @prefix + "/React/Fabric"
+                "--schemaListPath", @base_path + "/" + @prefix + "/React/Fabric/tmpSchemaList.txt",
+                "--outputDir", @base_path + "/" + @prefix + "/React/Fabric"
             ]
         })
         assert_equal(FileMock.delete_invocation_count, 1)
-        assert_equal(FileMock.deleted_files, [ @prefix + "/React/Fabric/tmpSchemaList.txt"])
+        assert_equal(FileMock.deleted_files, [ @base_path + "/" + @prefix + "/React/Fabric/tmpSchemaList.txt"])
     end
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenBothMissing_buildCodegen()
@@ -156,8 +156,8 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
-            @prefix + "/React/Fabric/" + @third_party_provider_header,
-            @prefix + "/React/Fabric/" + @tmp_schema_list_file
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header,
+            @base_path + "/" + @prefix + "/React/Fabric/" + @tmp_schema_list_file
         ])
         assert_equal(DirMock.exist_invocation_params, [
             @base_path + "/" + @prefix + "/../react-native-codegen",
@@ -176,18 +176,18 @@ class CodegenTests < Test::Unit::TestCase
             "arguments" => [
                 @base_path + "/" + @prefix + "/scripts/generate-provider-cli.js",
                 "--platform", 'ios',
-                "--schemaListPath", @prefix + "/React/Fabric/" + @tmp_schema_list_file,
-                "--outputDir", @prefix + "/React/Fabric"
+                "--schemaListPath", @base_path + "/" + @prefix + "/React/Fabric/" + @tmp_schema_list_file,
+                "--outputDir", @base_path + "/" + @prefix + "/React/Fabric"
             ]
         })
     end
 
     def testCheckAndGenerateEmptyThirdPartyProvider_withAbsoluteReactNativePath_buildCodegen()
         # Arrange
-        rn_path = '/Users/distiller/react-native/packages/react-native'
+        rn_path = 'packages/react-native'
         codegen_cli_path = rn_path + "/../@react-native/codegen"
         DirMock.mocked_existing_dirs([
-            codegen_cli_path,
+            @base_path + "/" + codegen_cli_path,
         ])
 
         # Act
@@ -197,28 +197,28 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
-            rn_path + "/React/Fabric/" + @third_party_provider_header,
-            rn_path + "/React/Fabric/" + @tmp_schema_list_file
+            @base_path + "/" + rn_path + "/React/Fabric/" + @third_party_provider_header,
+            @base_path + "/" + rn_path + "/React/Fabric/" + @tmp_schema_list_file
         ])
         assert_equal(DirMock.exist_invocation_params, [
-            rn_path + "/../react-native-codegen",
-            codegen_cli_path,
-            codegen_cli_path + "/lib",
+            @base_path + "/" + rn_path + "/../react-native-codegen",
+            @base_path + "/" + codegen_cli_path,
+            @base_path + "/" + codegen_cli_path + "/lib",
         ])
         assert_equal(Pod::UI.collected_messages, [
-            "[Codegen] building #{codegen_cli_path}.",
+            "[Codegen] building #{@base_path + "/" + codegen_cli_path}.",
             "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
         ])
-        assert_equal($collected_commands, [rn_path + "/../@react-native/codegen/scripts/oss/build.sh"])
+        assert_equal($collected_commands, [@base_path + "/" + rn_path + "/../@react-native/codegen/scripts/oss/build.sh"])
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
         assert_equal(Pod::Executable.executed_commands[0], {
             "command" => "node",
             "arguments" => [
-                rn_path + "/scripts/generate-provider-cli.js",
+                @base_path + "/" + rn_path + "/scripts/generate-provider-cli.js",
                 "--platform", 'ios',
-                "--schemaListPath", rn_path + "/React/Fabric/" + @tmp_schema_list_file,
-                "--outputDir", rn_path + "/React/Fabric"
+                "--schemaListPath", @base_path + "/" + rn_path + "/React/Fabric/" + @tmp_schema_list_file,
+                "--outputDir", @base_path + "/" + rn_path + "/React/Fabric"
             ]
         })
     end

--- a/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
@@ -22,24 +22,12 @@ class FabricTest < Test::Unit::TestCase
     # ================== #
     # TEST - setupFabric #
     # ================== #
-    def test_setupFabric_whenNewArchDisabled_installsPods
+    def test_setupFabric_installsPods
         # Arrange
         prefix = "../.."
 
         # Act
         setup_fabric!(:react_native_path => prefix)
-
-        # Assert
-        check_installed_pods(prefix)
-    end
-
-    def test_setupFabric_whenNewArchEnabled_installPods
-        # Arrange
-        prefix = "../.."
-        ENV['RCT_NEW_ARCH_ENABLED'] = "1"
-
-        # Act
-        setup_fabric!(:react_native_path => prefix, new_arch_enabled: true)
 
         # Assert
         check_installed_pods(prefix)

--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -41,7 +41,7 @@ def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled
 
     relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
 
-    output_dir = "#{react_native_path}/React/Fabric"
+    output_dir = "#{relative_installation_root}/#{react_native_path}/React/Fabric"
 
     provider_h_path = "#{output_dir}/RCTThirdPartyFabricComponentsProvider.h"
     provider_cpp_path ="#{output_dir}/RCTThirdPartyFabricComponentsProvider.mm"

--- a/packages/react-native/scripts/cocoapods/fabric.rb
+++ b/packages/react-native/scripts/cocoapods/fabric.rb
@@ -7,7 +7,7 @@
 # It sets up the Fabric dependencies.
 #
 # @parameter react_native_path: relative path to react-native
-def setup_fabric!(react_native_path: "../node_modules/react-native", new_arch_enabled: false)
+def setup_fabric!(react_native_path: "../node_modules/react-native")
     pod 'React-Fabric', :path => "#{react_native_path}/ReactCommon"
     pod 'React-graphics', :path => "#{react_native_path}/ReactCommon/react/renderer/graphics"
     pod 'React-RCTFabric', :path => "#{react_native_path}/React", :modular_headers => true

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -135,6 +135,7 @@ def use_react_native! (
 
   pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
   pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
+  pod 'React-runtimescheduler', :path => "#{prefix}/ReactCommon/react/renderer/runtimescheduler"
   pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
   pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
   pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -163,10 +163,13 @@ def use_react_native! (
 
   pod 'React-Codegen', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
 
-  if fabric_enabled
-    checkAndGenerateEmptyThirdPartyProvider!(prefix, new_arch_enabled)
-    setup_fabric!(:react_native_path => prefix, new_arch_enabled: new_arch_enabled)
-  else
+  # Always need fabric to access the RCTSurfacePresenterBridgeAdapter which allow to enable the RuntimeScheduler
+  # If the New Arch is turned off, we will use the Old Renderer, though.
+  # RNTester always installed Fabric, this change is required to make the template work.
+  setup_fabric!(:react_native_path => prefix)
+  checkAndGenerateEmptyThirdPartyProvider!(prefix, new_arch_enabled)
+
+  if !fabric_enabled
     relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
     build_codegen!(prefix, relative_installation_root)
   end

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -19,7 +19,7 @@ end
 def pods(target_name, options = {}, use_flipper: !IN_CI && !USE_FRAMEWORKS)
   project 'RNTesterPods.xcodeproj'
 
-  fabric_enabled = ENV['USE_FRAMEWORKS'] == 'dynamic' ? false : true
+  fabric_enabled = true
 
   # Hermes is now enabled by default.
   # The following line will only disable Hermes if the USE_HERMES envvar is SET to a value other than 1 (e.g. USE_HERMES=0).


### PR DESCRIPTION
Summary:
## Changelog:
[iOS][Changed] - Use the runtime scheduler in the old Architecture

## Facebook

Differential Revision: D48430129

