### PR TITLE
Add RuntimeScheduler dependency properly

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -92,6 +92,7 @@ Pod::Spec.new do |s|
   s.dependency "React-NativeModulesApple"
   s.dependency "React-CoreModules"
   s.dependency "React-nativeconfig"
+  s.dependency "React-runtimescheduler"
 
   if is_new_arch_enabled
     s.dependency "React-BridgelessCore"

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -126,12 +126,13 @@ Pod::Spec.new do |s|
   end
 
   s.dependency "RCT-Folly", folly_version
-  s.dependency "React-cxxreact", version
-  s.dependency "React-perflogger", version
-  s.dependency "React-jsi", version
-  s.dependency "React-jsiexecutor", version
+  s.dependency "React-cxxreact"
+  s.dependency "React-perflogger"
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
   s.dependency "React-utils"
   s.dependency "SocketRocket", socket_rocket_version
+  s.dependency "React-runtimescheduler"
   s.dependency "Yoga"
   s.dependency "glog"
 

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -30,7 +30,6 @@ header_search_paths = [
   "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
   "\"$(PODS_ROOT)/Headers/Public/React-Codegen\"",
   "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Codegen/React_Codegen.framework/Headers\"",
-
 ]
 
 if ENV['USE_FRAMEWORKS']
@@ -48,6 +47,7 @@ if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\""
   header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\""
   header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererdebug/React_rendererdebug.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimescheduler/React_runtimescheduler.framework/Headers\""
 end
 
 Pod::Spec.new do |s|
@@ -88,6 +88,7 @@ Pod::Spec.new do |s|
   s.dependency "React-utils"
   s.dependency "React-rendererdebug"
   s.dependency "React-nativeconfig"
+  s.dependency "React-runtimescheduler"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency "React-debug"
   s.dependency "React-utils"
-  # s.dependency "React-runtimescheduler"
+  s.dependency "React-runtimescheduler"
   s.dependency "React-rendererdebug"
   s.dependency "React-cxxreact"
 
@@ -296,15 +296,6 @@ Pod::Spec.new do |s|
     ss.source_files         = "react/renderer/leakchecker/**/*.{cpp,h}"
     ss.exclude_files        = "react/renderer/leakchecker/tests"
     ss.header_dir           = "react/renderer/leakchecker"
-    ss.pod_target_xcconfig  = { "GCC_WARN_PEDANTIC" => "YES" }
-  end
-
-  s.subspec "runtimescheduler" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/runtimescheduler/**/*.{cpp,h}"
-    ss.exclude_files        = "react/renderer/runtimescheduler/tests"
-    ss.header_dir           = "react/renderer/runtimescheduler"
     ss.pod_target_xcconfig  = { "GCC_WARN_PEDANTIC" => "YES" }
   end
 end

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.exclude_files          = "SampleCxxModule.*"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = {
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\"",
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
   }
   s.header_dir             = "cxxreact"

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -61,8 +61,6 @@ Pod::Spec.new do |s|
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsi"
   end
 
 end

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
@@ -7,6 +7,7 @@
 
 #include "RuntimeSchedulerBinding.h"
 #include <ReactCommon/SchedulerPriority.h>
+#include "RuntimeScheduler.h"
 #include "SchedulerPriorityUtils.h"
 #include "primitives.h"
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
@@ -8,9 +8,10 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
 namespace facebook::react {
+
+class RuntimeScheduler;
 
 /*
  * Exposes RuntimeScheduler to JavaScript realm.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RuntimeSchedulerCallInvoker.h"
+#include "RuntimeScheduler.h"
 
 #include <utility>
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <ReactCommon/CallInvoker.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
 namespace facebook::react {
 
+class RuntimeScheduler;
 /*
  * Exposes RuntimeScheduler to native modules. All calls invoked on JavaScript
  * queue from native modules will be funneled through RuntimeScheduler.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/renderer/runtimescheduler/Task.h>
 #include <react/utils/CoreFeatures.h>

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
@@ -13,7 +13,6 @@
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/EventBeat.h>
 #include <react/renderer/leakchecker/LeakChecker.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <react/renderer/uimanager/primitives.h>
 #include <react/utils/ContextContainer.h>

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -135,6 +135,7 @@ def use_react_native! (
 
   pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
   pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
+  pod 'React-runtimescheduler', :path => "#{prefix}/ReactCommon/react/renderer/runtimescheduler"
   pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
   pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
   pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -19,7 +19,7 @@ end
 def pods(target_name, options = {}, use_flipper: !IN_CI && !USE_FRAMEWORKS)
   project 'RNTesterPods.xcodeproj'
 
-  fabric_enabled = ENV['USE_FRAMEWORKS'] == 'dynamic' ? false : true
+  fabric_enabled = true
 
   # Hermes is now enabled by default.
   # The following line will only disable Hermes if the USE_HERMES envvar is SET to a value other than 1 (e.g. USE_HERMES=0).


### PR DESCRIPTION
Summary:
## Changelog:
[iOS][Changed] - Extract RuntimeScheduler as separate cocoapod dependency

## Facebook:

Differential Revision: D48429964

