### PR TITLE
iOS: don't override EXCLUDED_ARCHS when installing Hermes

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -220,7 +220,7 @@ class UtilsTests < Test::Unit::TestCase
     # ============================ #
     # Test - Exclude Architectures #
     # ============================ #
-    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_excludeNothing
+    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_withNoValue_leaveUnset
         # Arrange
         user_project_mock = prepare_empty_user_project_mock()
         pods_projects_mock = PodsProjectMock.new()
@@ -233,13 +233,36 @@ class UtilsTests < Test::Unit::TestCase
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "")
+            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], nil)
         end
-        assert_equal(user_project_mock.save_invocation_count, 1)
+        assert_equal(user_project_mock.save_invocation_count, 0)
+        assert_equal(pods_projects_mock.save_invocation_count, 0)
+    end
+    
+    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_withExistingValue_preserveExistingValue
+        # Arrange
+        user_project_mock = prepare_empty_user_project_mock()
+        user_project_mock.build_configurations.each do |config|
+            config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+        end
+        pods_projects_mock = PodsProjectMock.new()
+        installer = InstallerMock.new(pods_projects_mock, [
+            AggregatedProjectMock.new(user_project_mock)
+        ])
+
+        # Act
+        ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
+
+        # Assert
+        user_project_mock.build_configurations.each do |config|
+            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "arm64")
+        end
+
+        assert_equal(user_project_mock.save_invocation_count, 0)
         assert_equal(pods_projects_mock.save_invocation_count, 0)
     end
 
-    def test_excludeArchitectures_whenHermesEngineIsIncluded_excludeI386
+    def test_excludeArchitectures_whenHermesEngineIsIncluded_withNoValue_onlyExcludeI386
         # Arrange
         user_project_mock = prepare_empty_user_project_mock()
         pods_projects_mock = PodsProjectMock.new([], {"hermes-engine" => {}})
@@ -259,30 +282,7 @@ class UtilsTests < Test::Unit::TestCase
         assert_equal(pods_projects_mock.save_invocation_count, 1)
     end
 
-    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_preserveExistingValue
-        # Arrange
-        user_project_mock = prepare_empty_user_project_mock()
-        user_project_mock.build_configurations.each do |config|
-            config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
-        end
-        pods_projects_mock = PodsProjectMock.new()
-        installer = InstallerMock.new(pods_projects_mock, [
-            AggregatedProjectMock.new(user_project_mock)
-        ])
-
-        # Act
-        ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
-
-        # Assert
-        user_project_mock.build_configurations.each do |config|
-            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "arm64")
-        end
-
-        assert_equal(user_project_mock.save_invocation_count, 1)
-        assert_equal(pods_projects_mock.save_invocation_count, 1)
-    end
-
-    def test_excludeArchitectures_whenHermesEngineIsIncluded_appendI386
+    def test_excludeArchitectures_whenHermesEngineIsIncluded_withExistingValue_appendI386
         # Arrange
         user_project_mock = prepare_empty_user_project_mock()
         user_project_mock.build_configurations.each do |config|

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -59,15 +59,23 @@ class ReactNativePodsUtils
     end
 
     def self.exclude_i386_architecture_while_using_hermes(installer)
+        isUsingHermes = self.has_pod(installer, 'hermes-engine')
+        key = "EXCLUDED_ARCHS[sdk=iphonesimulator*]"
+
         projects = self.extract_projects(installer)
 
         projects.each do |project|
             project.build_configurations.each do |config|
-                currentValue = config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] || ""
+                current_setting = config.build_settings[key] || ""
 
-                unless currentValue.include?("i386")
+                excludesI386 = current_setting.include?("i386")
+
+                if isUsingHermes and !excludesI386
                     # Hermes does not support `i386` architecture
-                    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "#{currentValue} i386".strip
+                    config.build_settings[key] = "#{current_setting} i386".strip
+                else
+                    # leave EXCLUDED_ARCHS unchanged or set it to "" if it doesn't already exist
+                    config.build_settings[key] = current_setting
                 end
             end
 

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -59,27 +59,27 @@ class ReactNativePodsUtils
     end
 
     def self.exclude_i386_architecture_while_using_hermes(installer)
-        isUsingHermes = self.has_pod(installer, 'hermes-engine')
-        key = "EXCLUDED_ARCHS[sdk=iphonesimulator*]"
+        is_using_hermes = self.has_pod(installer, 'hermes-engine')
+        
+        if is_using_hermes
+            key = "EXCLUDED_ARCHS[sdk=iphonesimulator*]"
 
-        projects = self.extract_projects(installer)
+            projects = self.extract_projects(installer)
 
-        projects.each do |project|
-            project.build_configurations.each do |config|
-                current_setting = config.build_settings[key] || ""
+            projects.each do |project|
+                project.build_configurations.each do |config|
+                    current_setting = config.build_settings[key] || ""
 
-                excludesI386 = current_setting.include?("i386")
+                    build_will_skip_I386 = current_setting.include?("i386")
 
-                if isUsingHermes and !excludesI386
-                    # Hermes does not support `i386` architecture
-                    config.build_settings[key] = "#{current_setting} i386".strip
-                else
-                    # leave EXCLUDED_ARCHS unchanged or set it to "" if it doesn't already exist
-                    config.build_settings[key] = current_setting
+                    unless build_will_skip_I386
+                        # Hermes does not support `i386` architecture
+                        config.build_settings[key] = "#{current_setting} i386".strip
+                    end
                 end
-            end
 
-            project.save()
+                project.save()
+            end
         end
     end
 

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -61,12 +61,14 @@ class ReactNativePodsUtils
     def self.exclude_i386_architecture_while_using_hermes(installer)
         projects = self.extract_projects(installer)
 
-        # Hermes does not support `i386` architecture
-        excluded_archs_default = self.has_pod(installer, 'hermes-engine') ? "i386" : ""
-
         projects.each do |project|
             project.build_configurations.each do |config|
-                config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = excluded_archs_default
+                currentValue = config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] || ""
+
+                unless currentValue.include?("i386")
+                    # Hermes does not support `i386` architecture
+                    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "#{currentValue} i386".strip
+                end
             end
 
             project.save()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- if an existing iOS project specifies `EXCLUDED_ARCHS`, these settings are overwritten by the `react_native_post_install` step as part of the Cocoapods install
- this can break the build of existing iOS apps that want to include React Native
- a previous PR (https://github.com/facebook/react-native/pull/38132) updated the Cocoapods utils to that we only update `EXCLUDED_ARCHS` when using Hermes
- this worked around the issue for apps that opted to use JSC
- however if you _do_ want to use Hermes (the default) this problem persists

### Existing Behaviour

- one of the functions called as part of the `react_native_post_install` step is `exclude_i386_architecture_while_using_hermes`
  - see [/packages/react-native/scripts/cocoapods/utils.rb](https://github.com/facebook/react-native/blob/v0.72.1/packages/react-native/scripts/cocoapods/utils.rb#L56-L69)
```
    def self.exclude_i386_architecture_while_using_hermes(installer)
        projects = self.extract_projects(installer)

        # Hermes does not support `i386` architecture
        excluded_archs_default = self.has_pod(installer, 'hermes-engine') ? "i386" : ""

        projects.each do |project|
            project.build_configurations.each do |config|
                config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = excluded_archs_default
            end

            project.save()
        end
    end
```

🐛 **However** 🐛

- this means existing projects that have `EXCLUDED_ARCHS` set, the existing value will be overwritten either to `"i386"` or a blank string

### Changed Behaviour

- appends `"i386"` to existing string if set, or just sets the value to `"i386"` if there is no existing value

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] don't override `EXCLUDED_ARCHS` when installing Hermes

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
