### PR TITLE
Cleanup BUCK setup for our JVM tests

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/interop/InteropEventEmitterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/interop/InteropEventEmitterTest.kt
@@ -10,6 +10,7 @@ package com.facebook.react.fabric.interop
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContext
+import com.facebook.testutils.fakes.FakeEventDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -21,7 +22,7 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class InteropEventEmitterTest {
   lateinit var reactContext: ReactContext
-  lateinit var eventDispatcher: FakeEventDispatcher
+  private lateinit var eventDispatcher: FakeEventDispatcher
 
   @Before
   fun setup() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.kt
@@ -30,13 +30,11 @@ class ReactPropConstantsTest {
     }
 
     override fun createShadowNodeInstance(): ReactShadowNode<*>? {
-      Assertions.fail<Any>("This method should not be executed as a part of this test")
-      return null
+      error("This method should not be executed as a part of this test")
     }
 
     override fun createViewInstance(reactContext: ThemedReactContext): View {
-      Assertions.fail<Any>("This method should not be executed as a part of this test")
-      return View(reactContext)
+      error("This method should not be executed as a part of this test")
     }
 
     override fun getShadowNodeClass(): Class<out ReactShadowNode<*>> {
@@ -44,7 +42,7 @@ class ReactPropConstantsTest {
     }
 
     override fun updateExtraData(root: View, extraData: Any) {
-      Assertions.fail<Any>("This method should not be executed as a part of this test")
+      error("This method should not be executed as a part of this test")
     }
 
     @ReactProp(name = "boolProp") fun setBoolProp(v: View?, value: Boolean) {}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeEventDispatcher.kt
@@ -6,7 +6,7 @@
  */
 
 @file:Suppress("DEPRECATION") // Suppressing as RCTEventEmitter is part of the API
-package com.facebook.react.fabric.interop
+package com.facebook.testutils.fakes
 
 import com.facebook.react.uimanager.events.BatchEventDispatchedListener
 import com.facebook.react.uimanager.events.Event


### PR DESCRIPTION
Summary:
We're suppressing JVM tests using BUCK which is causing misalignment between which tests we run on Buck vs Gradle.
Instead we should be using the Ignore annotation (which we already do) to decide which tests to skip, so that Buck can just pick all the Java/Kotlin file in this folder.

Changelog:
[Internal] [Changed] - Cleanup BUCK setup for our JVM tests

Reviewed By: cipolleschi

Differential Revision: D48433432

