### PR TITLE
RN: Change Source Package Versions to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-native/monorepo",
   "private": true,
-  "version": "1000.0.0",
+  "version": "0.0.0",
   "description": "A framework for building native apps using React",
   "license": "MIT",
   "repository": "github:facebook/react-native",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "1000.0.0",
+  "version": "0.0.0",
   "description": "A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Summary:
Changes the `package.json` for `react-native/monorepo` and `react-native` to 0.0.0 (instead of 1000.0.0).

This reduces the risk of either human or automation error accidentally publishing a v1000.0.0 of the `react-native` package to npm, which would be very problematic.

This should have no visible impact to any existing processes, though.

Changelog:
[Internal]

Differential Revision: D48450601

