### PR TITLE
Add retry mechanism to test_e2e_android to reduce flakyness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1014,7 +1014,7 @@ jobs:
           name: Run E2E tests
           command: |
             cd packages/rn-tester-e2e
-            yarn test-e2e android
+            node ../../scripts/circleci/run_with_retry.js 3 "yarn test-e2e android"
 
   # -------------------------
   #    JOBS: Build Android

--- a/scripts/circleci/retry.js
+++ b/scripts/circleci/retry.js
@@ -20,7 +20,7 @@ async function retry(command, options, maxRetries, delay, args) {
       return true;
     }
 
-    console.log(`Command failed on attempt ${i}`);
+    console.warn(`Command failed on attempt ${i}`);
 
     if (i >= maxRetries) {
       console.log('Maximum retries reached. Exiting.');
@@ -32,7 +32,7 @@ async function retry(command, options, maxRetries, delay, args) {
       await new Promise(resolve => setTimeout(resolve, delay));
     }
 
-    console.log('Retrying...');
+    console.log('Retrying...\n\n');
   }
 }
 


### PR DESCRIPTION
## Summary:

We figured that android e2e tests are a bit flakier than needed. This change add a retry mechanism to rerun the tests up to 3 times in order to try and reduce the flakyness there.

## Changelog:

[Internal] - Add retry to Android e2e tests

## Test Plan:

CircleCI stays green
