### PR TITLE
Set android.suppressUnsupportedCompileSdk=34 for the root project

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,9 @@ org.gradle.caching=true
 
 android.useAndroidX=true
 
+# Can be removed once we bump to AGP 8.2.0
+android.suppressUnsupportedCompileSdk=34
+
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64


### PR DESCRIPTION
Summary:
Android is currently raising a warning as we're using AGP 8.1 with SDK 34.
I'm suppressing this warning that we can remove once we bump to AGP 8.2

Changelog:
[Internal] [Changed] - Set android.suppressUnsupportedCompileSdk=34 for the root project

Reviewed By: mdvacca

Differential Revision: D48437747

