### PR TITLE
[RN] Make prettier ignore generated folders

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+# Ignore Pods
+**/Pods
+
+# Ignore hermes as it is downloaded from the react_native_pods
+**/sdks/hermes
+**/sdks/downloads


### PR DESCRIPTION
## Summary:

This change introduce the `.prettierignore` file to skip some generated folders.
Prettier was checking that the JS files inside the Pods/ and the sdks/ folders were properly formatted.
However, we don't control those folders.

Running prettier in those folders was taking extra 10s to 30s on average, some time we can now save.

## Changelog:

[Internal] - Make prettier skip generated folders

## Test Plan:

Tested locally

| Before | After |
| --- | --- |
| <img width="593" alt="Screenshot 2023-08-18 at 11 28 51" src="https://github.com/facebook/react-native/assets/11162307/65eb773b-1966-49cd-bd51-6310fe48cf3b"> | <img width="515" alt="Screenshot 2023-08-18 at 11 29 09" src="https://github.com/facebook/react-native/assets/11162307/969ff9e4-f05b-43bf-9a95-7b37dea7d3d0"> |


