### PR TITLE
Upgrade CLI, restore prev status check value

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -23,8 +23,8 @@
   ],
   "dependencies": {
     "@react-native/dev-middleware": "^0.73.0",
-    "@react-native-community/cli-server-api": "12.0.0-alpha.9",
-    "@react-native-community/cli-tools": "12.0.0-alpha.9",
+    "@react-native-community/cli-server-api": "12.0.0-alpha.11",
+    "@react-native-community/cli-tools": "12.0.0-alpha.11",
     "@react-native/metro-babel-transformer": "^0.73.11",
     "chalk": "^4.0.0",
     "execa": "^5.1.1",

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -107,13 +107,6 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
   dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 
   NSString *status = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-
-  // TODO(huntie): Temporary string match in JSON response. We will revert this
-  // endpoint back to "packager-status:running" in the next CLI alpha.
-  if ([status containsString:@"\"status\":\"running\""]) {
-    return true;
-  }
-
   return [status isEqualToString:@"packager-status:running"];
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.java
@@ -81,15 +81,6 @@ public class PackagerStatusCheck {
                 String bodyString =
                     body.string(); // cannot call body.string() twice, stored it into variable.
                 // https://github.com/square/okhttp/issues/1240#issuecomment-68142603
-
-                // TODO(huntie): Temporary string match in JSON response. We
-                // will revert this endpoint back to "packager-status:running"
-                // in the next CLI alpha.
-                if (bodyString.contains("\"status\":\"running\"")) {
-                  callback.onPackagerStatusFetched(true);
-                  return;
-                }
-
                 if (!PACKAGER_OK_STATUS.equals(bodyString)) {
                   FLog.e(
                       ReactConstants.TAG,

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -92,9 +92,9 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.6.3",
-    "@react-native-community/cli": "12.0.0-alpha.9",
-    "@react-native-community/cli-platform-android": "12.0.0-alpha.9",
-    "@react-native-community/cli-platform-ios": "12.0.0-alpha.9",
+    "@react-native-community/cli": "12.0.0-alpha.11",
+    "@react-native-community/cli-platform-android": "12.0.0-alpha.11",
+    "@react-native-community/cli-platform-ios": "12.0.0-alpha.11",
     "@react-native/assets-registry": "^0.73.0",
     "@react-native/community-cli-plugin": "^0.73.0",
     "@react-native/codegen": "^0.73.0",

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -73,26 +73,6 @@ waitForWebSocketServer() {
   echo "WebSocket Server is ready!"
 }
 
-waitForPackagerAlt() {
-  local -i max_attempts=60
-  local -i attempt_num=1
-
-  # TODO(huntie): Temporary string match in JSON response. We will revert
-  # this endpoint back to "packager-status:running" in the next CLI alpha.
-  until curl -s http://localhost:8081/status | grep "\"status\":\"running\"" -q; do
-    if (( attempt_num == max_attempts )); then
-      echo "Packager did not respond in time. No more attempts left."
-      exit 1
-    else
-      (( attempt_num++ ))
-      echo "Packager did not respond. Retrying for attempt number $attempt_num..."
-      sleep 1
-    fi
-  done
-
-  echo "Packager is ready!"
-}
-
 runTests() {
   # shellcheck disable=SC1091
   source "$ROOT/scripts/.tests.env"
@@ -151,7 +131,7 @@ main() {
 
     # Start the packager
     yarn start --max-workers=1 || echo "Can't start packager automatically" &
-    waitForPackagerAlt
+    waitForPackager
     preloadBundlesRNTester
     preloadBundlesRNIntegrationTests
 

--- a/scripts/testing-utils.js
+++ b/scripts/testing-utils.js
@@ -117,12 +117,6 @@ function isPackagerRunning(
       silent: true,
     }).stdout;
 
-    // TODO(huntie): Temporary string match in JSON response. We will revert
-    // this endpoint back to "packager-status:running" in the next CLI alpha.
-    if (status.includes('"status":"running"')) {
-      return 'running';
-    }
-
     return status === 'packager-status:running' ? 'running' : 'unrecognized';
   } catch (_error) {
     return 'not_running';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,44 +2615,44 @@
   optionalDependencies:
     npmlog "2 || ^3.1.0 || ^4.0.0"
 
-"@react-native-community/cli-clean@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-12.0.0-alpha.9.tgz#f5b9615e65860fec8fdc60d80944bc6f06b76726"
-  integrity sha512-o0lnATX3GNA4MK7aVBpJj5nulPi9BucWlavnVrGpBRLGsNca2js1KrlIVhYYSZaVlCwf71IZsEMYa/1KN8YiRQ==
+"@react-native-community/cli-clean@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-12.0.0-alpha.11.tgz#22a21bf5f937b9a58541612db3a231a5f044acd6"
+  integrity sha512-KU6nrnwAb7LeuPgDapTz/B7nFaII21cg0Dm90gII/+gwjTogsowIaoSAFLxK8DO83wn/vlJlJBxN4Brs/Wby3Q==
   dependencies:
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
     chalk "^4.1.2"
     execa "^5.0.0"
     prompts "^2.4.2"
 
-"@react-native-community/cli-config@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-12.0.0-alpha.9.tgz#bfe992b8abfb3f5e4ef578a5e984d52ef2cc605a"
-  integrity sha512-Kq/cAUITcZKGhA5HoN14ZRZrJen3Y+QWU2Zkyi2ho3nmgjUbCW5Y8AYERKL/uuEkWi8JB14+Ky8LJmfNbO1Rnw==
+"@react-native-community/cli-config@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-12.0.0-alpha.11.tgz#daa7425cc891857f8894d8636f8881933f159f07"
+  integrity sha512-a68/F4queh7MA7Kr/3+92SD2miZ+tmSjFjM8Lg8+3hEAoBi3rRk+6fgXtfJqpqQnaJDviTXIMZZyY0Sn1Ff2gw==
   dependencies:
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
     chalk "^4.1.2"
     cosmiconfig "^5.1.0"
     deepmerge "^4.3.0"
     glob "^7.1.3"
     joi "^17.2.1"
 
-"@react-native-community/cli-debugger-ui@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-12.0.0-alpha.9.tgz#5ac44925cd024882c39b056f62ec8712cf751252"
-  integrity sha512-l7Awe3TlBfnFmMQ2N+JoWSfYMIgHcySk056wI+tskc2OS2JJvnmHkASeHIrl0tnQuFcHluFxpK6nyvgkzcXJ7w==
+"@react-native-community/cli-debugger-ui@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-12.0.0-alpha.11.tgz#d4c5aae29d57291e1b12db40143e5bc8b94acd03"
+  integrity sha512-J45vZXwY5mW7mkHDrFJ3Iz5EDJnqUh0uX+ar+uOW5RdVzJ3aurn9mfmLb5txX04k+ee7+hmqF7OZue1eVrBepg==
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-12.0.0-alpha.9.tgz#d27956902bc81f97e23d5dd15daa2ede668f507a"
-  integrity sha512-rTuCkcmMBmbFzJ9V8/7sipdM2ggjL2I04W5/Xn9OUwKVsHqydRaO9vyqOag+jwDgHMxHZO6OOr41nMQaa32z3w==
+"@react-native-community/cli-doctor@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-12.0.0-alpha.11.tgz#5d7515416a9c8144e4b84afdcb10b27e88b43bd0"
+  integrity sha512-yUPmi2wRcASIomvdUyWqwSo3F7B+EoUeMNFMxhleyIQ3HvnmZQi/kNLhKwjVEIPM7tDBMFi8dSTK27DTl/Pxhg==
   dependencies:
-    "@react-native-community/cli-config" "12.0.0-alpha.9"
-    "@react-native-community/cli-platform-android" "12.0.0-alpha.9"
-    "@react-native-community/cli-platform-ios" "12.0.0-alpha.9"
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
+    "@react-native-community/cli-config" "12.0.0-alpha.11"
+    "@react-native-community/cli-platform-android" "12.0.0-alpha.11"
+    "@react-native-community/cli-platform-ios" "12.0.0-alpha.11"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     envinfo "^7.7.2"
@@ -2668,47 +2668,48 @@
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
-"@react-native-community/cli-hermes@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-12.0.0-alpha.9.tgz#a10b0795e3f29f65d055b480af6284981869bb43"
-  integrity sha512-CSHkkaUsdZpMSFhsCT5Xy6upl3HXB5jk06b8is8XObDHPxQGOt+U7GPuQ8O2O5Doa87mQ9y3uHVhFEmb0ANioQ==
+"@react-native-community/cli-hermes@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-12.0.0-alpha.11.tgz#1b5dd1c5e61f3d4c149cafe9e9c9bfd7b484d6e4"
+  integrity sha512-1DcR76pzp+pFflYUq+sleZedHWt3noK8ledGeRH5MJz9sBpPFD6GmpIa/tQP5gwLPZaHVGAkZs6l6FT6OoBgVA==
   dependencies:
-    "@react-native-community/cli-platform-android" "12.0.0-alpha.9"
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
+    "@react-native-community/cli-platform-android" "12.0.0-alpha.11"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
     ip "^1.1.5"
 
-"@react-native-community/cli-platform-android@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-12.0.0-alpha.9.tgz#609ff08357cbee51540c796f4df1bf6bdbd0cbdc"
-  integrity sha512-Q2eIOQ6iYyVrdjyB4pcSRqKvzp0S9130IIocLjvc/8+YmeU0bMoSLZ/uYAkVAoKD+VFP3Ry6US6CLzNvxFwDzw==
+"@react-native-community/cli-platform-android@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-12.0.0-alpha.11.tgz#550a27017a8909211fb3ad4ecb1d8baac6a66d61"
+  integrity sha512-bffvGJkRwhon5I5fIB1R/rZZlufJXbUddRxEjHi3hn0I0kwQ5ahgEBqRVMKyxtQRzRS5dDdFAm8CLqcSLrapWg==
   dependencies:
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
     chalk "^4.1.2"
     execa "^5.0.0"
+    fast-xml-parser "^4.2.4"
     glob "^7.1.3"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-ios@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-12.0.0-alpha.9.tgz#f0a126c192c1f4188a233e1f51dcf1030bd783ce"
-  integrity sha512-Nl1+MyCcpGKvkv8kxDlN4jvht4bIR8N2mrQwazgtZeOURd3Mn8spOe8cfLexSNKhBaHHcb0JdqWLWyujlQTlyw==
+"@react-native-community/cli-platform-ios@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-12.0.0-alpha.11.tgz#9a24a5bc96e4b1cdb0b80a00427590c932fb6e10"
+  integrity sha512-YMBeYMwcjYyvqimj6fGHtrkqwF83jR9ZaZ/Xovk7udEL1qxs3ktQUW0dWtyzNz7dlhDEEzoC501tty0boTOmBg==
   dependencies:
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-xml-parser "^4.0.12"
     glob "^7.1.3"
     ora "^5.4.1"
 
-"@react-native-community/cli-plugin-metro@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-12.0.0-alpha.9.tgz#83a1906b8e3ad250910896ec450b6215d2dd88fe"
-  integrity sha512-4oQoKPPKRTLfgVKKaVTtJRVBZpyDZh6CfzMeQ1NuobQbf0IzvpypbDJlrVcDz/vzm2DjiZEvlD0D51XvErKpXg==
+"@react-native-community/cli-plugin-metro@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-12.0.0-alpha.11.tgz#bf51d906361e5cc01a211c6dd949dc291d4c7562"
+  integrity sha512-HPVXMNFmYfd3ljY48hQVNKy0scEJqvfhD/sjxAdrDc5H00AE3qr9XBSpCih3LcTLm2pVFrnEHU5dsUtNySR6sQ==
   dependencies:
-    "@react-native-community/cli-server-api" "12.0.0-alpha.9"
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
+    "@react-native-community/cli-server-api" "12.0.0-alpha.11"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
     chalk "^4.1.2"
     execa "^5.0.0"
     metro "0.78.0"
@@ -2716,13 +2717,13 @@
     metro-core "0.78.0"
     readline "^1.3.0"
 
-"@react-native-community/cli-server-api@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-12.0.0-alpha.9.tgz#bde13526941e3f82daeecd264ce3dcc23846ec0b"
-  integrity sha512-z47N3CxYBhv027HN7fBvNAZNORx4VSOE0WHQS78iBc2X9IiJdo/wi6BA3OO3mHA9w9ZCGVE3ejz/89wxx0vbdg==
+"@react-native-community/cli-server-api@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-12.0.0-alpha.11.tgz#34b240d172f6b2d3e64a3e8cdf3ea82e48b88ce0"
+  integrity sha512-XfwiG0W+h5WoVvoXHHoEHtIgOSpWERMOp8CKKMi7c9oAKjUt/ayAn7M9PGcaCUVz2J43DgCaow8jKVZyfTXkxg==
   dependencies:
-    "@react-native-community/cli-debugger-ui" "12.0.0-alpha.9"
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
+    "@react-native-community/cli-debugger-ui" "12.0.0-alpha.11"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.1"
@@ -2731,10 +2732,10 @@
     serve-static "^1.13.1"
     ws "^7.5.1"
 
-"@react-native-community/cli-tools@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-12.0.0-alpha.9.tgz#a8533a19e98696355826751597b7535cd1e70c3c"
-  integrity sha512-77XKc240Uc4wswhoF1bJm9EolX8sziGzz8z+vqgFKUob1igXvJ9oEIX+Tci8ScFgD/duY4/8ydKgYFehGf6KjA==
+"@react-native-community/cli-tools@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-12.0.0-alpha.11.tgz#fe719a8db55b727c90b31079f772a4e024c20d33"
+  integrity sha512-PDAfNUG4e6FpY4rTo0jFQ5p8gwHTZkLlNo/JEQgn3hvQsZk5LN2t0wwtEnaLKzZ9LEu9avZ/7MyiiRdW14fdOg==
   dependencies:
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
@@ -2746,27 +2747,27 @@
     semver "^7.5.2"
     shell-quote "^1.7.3"
 
-"@react-native-community/cli-types@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-12.0.0-alpha.9.tgz#73fc3b709880a60370194e6d0c060e465b945368"
-  integrity sha512-PGE3H+jM73ZugEe3bTCxA2UjI+IyPbdZetXj+4TDkfLU3WTnW/wqo0TeIZTvfBNpKg4PdyLEtdOcQePeywr8Zw==
+"@react-native-community/cli-types@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-12.0.0-alpha.11.tgz#140b96450c3d94cba2cec750f560dfea86350b65"
+  integrity sha512-iG4/Q4WDjJAlt8eeEKhlgnIpEHYcsYDepQClef7hq6mtuzQyn+Qk0LZbIwXBA1xdTp93+NTZJiHUS6iAk0sIOg==
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@12.0.0-alpha.9":
-  version "12.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-12.0.0-alpha.9.tgz#ff0227bafb135a6c91e162bf299e24db39d15274"
-  integrity sha512-MxZ+/mXjvQ88ndo0IaiJ7NDr1P7jO5ZOTtpvxB9xl8HdufZde2pL+xeVTqqN/NVWCSkdDEaP7120OZ9kzXRIKw==
+"@react-native-community/cli@12.0.0-alpha.11":
+  version "12.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-12.0.0-alpha.11.tgz#d8307a7127e200d521e47ee5f1ae1f5d9219ddf4"
+  integrity sha512-iR8MUzxtiuaR9yS2b1F27lWHlOrhzyWNUy/QJUF2Lbi4+yZHPNBR8ICE4L5IyWprKVtT9hkkNeAVtmyNA4CFjQ==
   dependencies:
-    "@react-native-community/cli-clean" "12.0.0-alpha.9"
-    "@react-native-community/cli-config" "12.0.0-alpha.9"
-    "@react-native-community/cli-debugger-ui" "12.0.0-alpha.9"
-    "@react-native-community/cli-doctor" "12.0.0-alpha.9"
-    "@react-native-community/cli-hermes" "12.0.0-alpha.9"
-    "@react-native-community/cli-plugin-metro" "12.0.0-alpha.9"
-    "@react-native-community/cli-server-api" "12.0.0-alpha.9"
-    "@react-native-community/cli-tools" "12.0.0-alpha.9"
-    "@react-native-community/cli-types" "12.0.0-alpha.9"
+    "@react-native-community/cli-clean" "12.0.0-alpha.11"
+    "@react-native-community/cli-config" "12.0.0-alpha.11"
+    "@react-native-community/cli-debugger-ui" "12.0.0-alpha.11"
+    "@react-native-community/cli-doctor" "12.0.0-alpha.11"
+    "@react-native-community/cli-hermes" "12.0.0-alpha.11"
+    "@react-native-community/cli-plugin-metro" "12.0.0-alpha.11"
+    "@react-native-community/cli-server-api" "12.0.0-alpha.11"
+    "@react-native-community/cli-tools" "12.0.0-alpha.11"
+    "@react-native-community/cli-types" "12.0.0-alpha.11"
     chalk "^4.1.2"
     commander "^9.4.1"
     execa "^5.0.0"
@@ -6007,6 +6008,13 @@ fast-xml-parser@^4.0.12:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz#5a98c18238d28a57bbdfa9fe4cda01211fff8f4a"
   integrity sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==
+  dependencies:
+    strnum "^1.0.5"
+
+fast-xml-parser@^4.2.4:
+  version "4.2.7"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.7.tgz#871f2ca299dc4334b29f8da3658c164e68395167"
+  integrity sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
Summary:
Follow-up to https://github.com/facebook/react-native/pull/38988.

- Upgrade to RN CLI `12.0.0-alpha.11`.
- Restore previous value check against `/status` response in test scripts (restored in above CLI alpha).

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D48432629

