### PR TITLE
Resolve absolute paths of Babel presets/plugins in Node build config

### DIFF
--- a/scripts/build/babel/node.config.js
+++ b/scripts/build/babel/node.config.js
@@ -17,9 +17,9 @@ const TARGET_NODE_VERSION = '18';
 
 const config /*: BabelCoreOptions */ = {
   presets: [
-    '@babel/preset-flow',
+    require.resolve('@babel/preset-flow'),
     [
-      '@babel/preset-env',
+      require.resolve('@babel/preset-env'),
       {
         targets: {
           node: TARGET_NODE_VERSION,
@@ -29,13 +29,13 @@ const config /*: BabelCoreOptions */ = {
   ],
   plugins: [
     [
-      'transform-define',
+      require.resolve('babel-plugin-transform-define'),
       {
         'process.env.BUILD_EXCLUDE_BABEL_REGISTER': true,
       },
     ],
     [
-      'minify-dead-code-elimination',
+      require.resolve('babel-plugin-minify-dead-code-elimination'),
       {keepFnName: true, keepFnArgs: true, keepClassName: true},
     ],
   ],


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The Babel config for Node packages in the RN repo, added in D47760330 / D48312463, relies on [name normalization](https://babeljs.io/docs/options#name-normalization) to resolve the Babel presets and plugins that it references. This works for OSS but can cause other integrations to fail to resolve the packages, depending on the details of how they're installed. Here we eagerly resolve the packages when constructing the Babel config.

Reviewed By: huntie

Differential Revision: D48469386

