### PR TITLE
Create unstable API for event logging

### DIFF
--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -10,6 +10,7 @@
  */
 
 import type {NextHandleFunction} from 'connect';
+import type {EventReporter} from './types/EventReporter';
 import type {Logger} from './types/Logger';
 
 import connect from 'connect';
@@ -21,6 +22,7 @@ type Options = $ReadOnly<{
   port: number,
   projectRoot: string,
   logger?: Logger,
+  unstable_eventReporter?: EventReporter,
 }>;
 
 type DevMiddlewareAPI = $ReadOnly<{
@@ -33,11 +35,21 @@ export default function createDevMiddleware({
   port,
   projectRoot,
   logger,
+  unstable_eventReporter,
 }: Options): DevMiddlewareAPI {
-  const inspectorProxy = new InspectorProxy(projectRoot);
+  const inspectorProxy = new InspectorProxy(
+    projectRoot,
+    unstable_eventReporter,
+  );
 
   const middleware = connect()
-    .use('/open-debugger', openDebuggerMiddleware({logger}))
+    .use(
+      '/open-debugger',
+      openDebuggerMiddleware({
+        logger,
+        eventReporter: unstable_eventReporter,
+      }),
+    )
     .use((...args) => inspectorProxy.processRequest(...args));
 
   return {

--- a/packages/dev-middleware/src/index.flow.js
+++ b/packages/dev-middleware/src/index.flow.js
@@ -10,3 +10,5 @@
  */
 
 export {default as createDevMiddleware} from './createDevMiddleware';
+
+export type {EventReporter, ReportableEvent} from './types/EventReporter';

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -24,6 +24,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import fetch from 'node-fetch';
 import WS from 'ws';
+import type {EventReporter} from '../types/EventReporter';
 
 const debug = require('debug')('Metro:InspectorProxy');
 
@@ -89,12 +90,15 @@ export default class Device {
   // Root of the project used for relative to absolute source path conversion.
   _projectRoot: string;
 
+  _eventReporter: ?EventReporter;
+
   constructor(
     id: string,
     name: string,
     app: string,
     socket: WS,
     projectRoot: string,
+    eventReporter: ?EventReporter,
   ) {
     this._id = id;
     this._name = name;
@@ -102,6 +106,7 @@ export default class Device {
     this._pages = [];
     this._deviceSocket = socket;
     this._projectRoot = projectRoot;
+    this._eventReporter = eventReporter;
 
     // $FlowFixMe[incompatible-call]
     this._deviceSocket.on('message', (message: string) => {
@@ -158,6 +163,10 @@ export default class Device {
   // 2. Forwards all messages from the debugger to device as wrappedEvent
   // 3. Sends disconnect event to device when debugger connection socket closes.
   handleDebuggerConnection(socket: WS, pageId: string) {
+    this._eventReporter?.logEvent({
+      type: 'connect_debugger_frontend',
+      status: 'success',
+    });
     // Disconnect current debugger if we already have debugger connected.
     if (this._debuggerConnection) {
       this._debuggerConnection.socket.close();

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+type SuccessResult<Props: {...} | void = {}> = {
+  status: 'success',
+  ...Props,
+};
+
+type ErrorResult<ErrorT = mixed> = {
+  status: 'error',
+  error: ErrorT,
+};
+
+type CodedErrorResult<ErrorCode: string> = {
+  status: 'coded_error',
+  errorCode: ErrorCode,
+  errorDetails?: string,
+};
+
+export type ReportableEvent =
+  | {
+      type: 'launch_debugger_frontend',
+      ...
+        | SuccessResult<{appId: string}>
+        | ErrorResult<mixed>
+        | CodedErrorResult<'MISSING_APP_ID' | 'NO_APPS_FOUND'>,
+    }
+  | {
+      type: 'connect_debugger_frontend',
+      ...SuccessResult<void> | ErrorResult<mixed>,
+    };
+
+/**
+ * A simple interface for logging events, to be implemented by integrators of
+ * `dev-middleware`.
+ *
+ * This is an unstable API with no semver guarantees.
+ */
+export interface EventReporter {
+  logEvent(event: ReportableEvent): void;
+}


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a simple typed logging hook to `react-native/dev-middleware`. This is intended to allow integrators to receive events from the dev server, apply any relevant sampling/processing, and log them to a backend. (To be clear, the open source version of React Native does not and will not collect any data.)

WARNING: The API will evolve over the coming weeks/months and is *not guaranteed to be stable* - it might even break between patch releases.

Reviewed By: huntie

Differential Revision: D48466760

