### PR TITLE
Optimize arg conversion in SurfaceRegistryBinding

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/SurfaceRegistryBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/SurfaceRegistryBinding.cpp
@@ -36,10 +36,11 @@ void SurfaceRegistryBinding::startSurface(
     folly::dynamic const &initialProps,
     DisplayMode displayMode) {
   SystraceSection s("SurfaceRegistryBinding::startSurface");
-  folly::dynamic parameters = folly::dynamic::object();
-  parameters["rootTag"] = surfaceId;
-  parameters["initialProps"] = initialProps;
-  parameters["fabric"] = true;
+  jsi::Object parameters(runtime);
+  parameters.setProperty(runtime, "rootTag", surfaceId);
+  parameters.setProperty(
+      runtime, "initialProps", jsi::valueFromDynamic(runtime, initialProps));
+  parameters.setProperty(runtime, "fabric", true);
 
   auto global = runtime.global();
   auto registry = global.getProperty(runtime, "RN$AppRegistry");
@@ -49,7 +50,7 @@ void SurfaceRegistryBinding::startSurface(
     method.call(
         runtime,
         {jsi::String::createFromUtf8(runtime, moduleName),
-         jsi::valueFromDynamic(runtime, parameters),
+         std::move(parameters),
          jsi::Value(runtime, displayModeToInt(displayMode))});
   } else {
     throwIfBridgeless(runtime, global, "startSurface");
@@ -58,7 +59,7 @@ void SurfaceRegistryBinding::startSurface(
         "AppRegistry",
         "runApplication",
         {jsi::String::createFromUtf8(runtime, moduleName),
-         jsi::valueFromDynamic(runtime, parameters),
+         std::move(parameters),
          jsi::Value(runtime, displayModeToInt(displayMode))});
   }
 }
@@ -70,10 +71,11 @@ void SurfaceRegistryBinding::setSurfaceProps(
     folly::dynamic const &initialProps,
     DisplayMode displayMode) {
   SystraceSection s("UIManagerBinding::setSurfaceProps");
-  folly::dynamic parameters = folly::dynamic::object();
-  parameters["rootTag"] = surfaceId;
-  parameters["initialProps"] = initialProps;
-  parameters["fabric"] = true;
+  jsi::Object parameters(runtime);
+  parameters.setProperty(runtime, "rootTag", surfaceId);
+  parameters.setProperty(
+      runtime, "initialProps", jsi::valueFromDynamic(runtime, initialProps));
+  parameters.setProperty(runtime, "fabric", true);
 
   auto global = runtime.global();
   auto registry = global.getProperty(runtime, "RN$AppRegistry");
@@ -83,7 +85,7 @@ void SurfaceRegistryBinding::setSurfaceProps(
     method.call(
         runtime,
         {jsi::String::createFromUtf8(runtime, moduleName),
-         jsi::valueFromDynamic(runtime, parameters),
+         std::move(parameters),
          jsi::Value(runtime, displayModeToInt(displayMode))});
   } else {
     throwIfBridgeless(runtime, global, "setSurfaceProps");
@@ -92,7 +94,7 @@ void SurfaceRegistryBinding::setSurfaceProps(
         "AppRegistry",
         "setSurfaceProps",
         {jsi::String::createFromUtf8(runtime, moduleName),
-         jsi::valueFromDynamic(runtime, parameters),
+         std::move(parameters),
          jsi::Value(runtime, displayModeToInt(displayMode))});
   }
 }


### PR DESCRIPTION
Summary:
We can construct the outer jsi::Object directly instead of going through `valueFromDynamic` for the whole thing.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D48519751

