### PR TITLE
On setting the same state for ShadowNodeFamily, don't mark it as obsolete

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
@@ -116,7 +116,7 @@ void ShadowNodeFamily::setMostRecentState(State::Shared const &state) const {
    * Nodes (the evolution of nodes is not linear), however, we never back out
    * states (they progress linearly).
    */
-  if (state && state->isObsolete_) {
+  if (state && (state->isObsolete_ || state == mostRecentState_)) {
     return;
   }
 


### PR DESCRIPTION
## Summary:

During investigation of impact of PR https://github.com/facebook/react-native/pull/38706 on `reanimated` I found out that when:
- state reconciliation is turned on
- `progressState` in `ShadowTree::tryCommit` quite often returns a new pointer to updated shadow tree
- above happened due to `newState->getMostRecentStateIfObsolete()` returning precisely the same ptr as `newState` in `progressState`
- this is caused by calling `ShadowNodeFamily::setMostRecentState` with the same state as currently held and marking those states as obsolete

This PR adds additional check whether `ShadowNodeFamily::setMostRecentState` is called with the same `state` as currently set and skips setting obsolete flag if that happens.

## Changelog:

[INTERNAL][FIXED] Setting the same most recent state for ShadowNodeFamily, doesn't mark it as obsolete

## Test Plan:

None
