### PR TITLE
Mitigate a corner case of ReactNativeFeatureFlags late initialization order

### DIFF
--- a/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
@@ -38,9 +38,10 @@ export type FeatureFlags = {|
   animatedShouldUseSingleOp: () => boolean,
   /**
    * Enables GlobalPerformanceLogger replacement with a WebPerformance API based
-   * implementation
+   * implementation. Tri-state due to being sensitive to initialization order
+   * vs the platform-specific ReactNativeFeatureFlags implementation.
    */
-  isGlobalWebPerformanceLoggerEnabled: () => boolean,
+  isGlobalWebPerformanceLoggerEnabled: () => ?boolean,
   /**
    * Enables access to the host tree in Fabric using DOM-compatible APIs.
    */
@@ -69,7 +70,7 @@ const ReactNativeFeatureFlags: FeatureFlags = {
   shouldPressibilityUseW3CPointerEventsForHover: () => false,
   animatedShouldDebounceQueueFlush: () => false,
   animatedShouldUseSingleOp: () => false,
-  isGlobalWebPerformanceLoggerEnabled: () => false,
+  isGlobalWebPerformanceLoggerEnabled: () => undefined,
   enableAccessToHostTreeInFabric: () => false,
   shouldUseAnimatedObjectForTransform: () => false,
   shouldUseSetNativePropsInFabric: () => false,

--- a/packages/react-native/Libraries/Utilities/GlobalPerformanceLogger.js
+++ b/packages/react-native/Libraries/Utilities/GlobalPerformanceLogger.js
@@ -10,16 +10,7 @@
 
 import type {IPerformanceLogger} from './createPerformanceLogger';
 
-import ReactNativeFeatureFlags from '../ReactNative/ReactNativeFeatureFlags';
-import NativePerformance from '../WebPerformance/NativePerformance';
 import createPerformanceLogger from './createPerformanceLogger';
-
-function isLoggingForWebPerformance(): boolean {
-  return (
-    NativePerformance != null &&
-    ReactNativeFeatureFlags.isGlobalWebPerformanceLoggerEnabled()
-  );
-}
 
 /**
  * This is a global shared instance of IPerformanceLogger that is created with
@@ -28,8 +19,7 @@ function isLoggingForWebPerformance(): boolean {
  * that are logged during loading bundle. If you want to log something from your
  * React component you should use PerformanceLoggerContext instead.
  */
-const GlobalPerformanceLogger: IPerformanceLogger = createPerformanceLogger(
-  isLoggingForWebPerformance(),
-);
+const GlobalPerformanceLogger: IPerformanceLogger =
+  createPerformanceLogger(true);
 
 module.exports = GlobalPerformanceLogger;


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

`ReactNativeFeatureFlags` are not guaranteed to be initialized before everything else, and one case popped up with this being a problem, in particular when creating `GlobalPerformanceLogger` instance (which may be created quite early on).

If the order of initialization of `ReactNativeFeatureFlags` and reading a value from there is flipped, then we'd just get a default value, without using any `MobileConfig` backing or anything.

This diff works this around for the particular case of `GlobalPerformanceLogger` initialization by making the corresponding flag tri-state (unititalized/true/false) and making sure that its value is only really taken into account after its initialized.

Differential Revision: D48559981

