### PR TITLE
Remove deprecated removeSubscription from the type of NativeEventEmitter

### DIFF
--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.d.ts
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.d.ts
@@ -60,10 +60,4 @@ declare class NativeEventEmitter extends EventEmitter {
    * @param eventType  name of the event whose registered listeners to remove
    */
   removeAllListeners(eventType: string): void;
-
-  /**
-   * Removes a subscription created by the addListener, the EventSubscription#remove()
-   * function actually calls through to this.
-   */
-  removeSubscription(subscription: EmitterSubscription): void;
 }

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -1068,7 +1068,6 @@ const sub2 = androidEventEmitter.addListener(
 androidEventEmitter.listenerCount('event'); // $ExpectType number
 sub2.remove();
 androidEventEmitter.removeAllListeners('event');
-androidEventEmitter.removeSubscription(sub1);
 
 // NativeEventEmitter - IOS
 const nativeModule: NativeModule = {
@@ -1081,7 +1080,6 @@ const sub4 = iosEventEmitter.addListener('event', (event: object) => event, {});
 iosEventEmitter.listenerCount('event');
 sub4.remove();
 iosEventEmitter.removeAllListeners('event');
-iosEventEmitter.removeSubscription(sub3);
 
 class CustomEventEmitter extends NativeEventEmitter {}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Removed deprecated function removeSubscription from the type of NativeEventEmitter, so that it lines up with its implementation. This is a fix for #39111 .

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[General] [Fixed] - Fix a type issue of NativeEventEmitter

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Not applicable 
