### PR TITLE
Make Glog defines modules

### DIFF
--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -29,8 +29,11 @@ Pod::Spec.new do |spec|
                         'src/base/*.h'
   spec.exclude_files       = "src/windows/**/*"
   spec.compiler_flags      = '-Wno-shorten-64-to-32'
-  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
-                               "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
+  spec.pod_target_xcconfig = {
+    "USE_HEADERMAP" => "NO",
+    "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src",
+    "DEFINES_MODULE" => "YES"
+  }
 
   # Pinning to the same version as React.podspec.
   spec.platforms = { :ios => min_ios_version_supported }


### PR DESCRIPTION
Summary:
This changes updates the Glog pod to defines module.
This makes it easier to work with Glog using Swift and to work on React Native Modules

## Changelog:
[Internal] - Make Glog define modules

Reviewed By: dmytrorykun

Differential Revision: D48564026

