### PR TITLE
delete unused selectors from hosting views

### DIFF
--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -53,46 +53,6 @@ static RCTRootViewSizeFlexibility convertToRootViewSizeFlexibility(RCTSurfaceSiz
   RCTModuleRegistry *_moduleRegistry;
 }
 
-- (instancetype)initWithBridge:(RCTBridge *)bridge
-                    moduleName:(NSString *)moduleName
-             initialProperties:(NSDictionary *)initialProperties
-{
-  RCTAssertMainQueue();
-  RCTAssert(bridge, @"A bridge instance is required to create an RCTSurfaceHostingProxyRootView");
-  RCTAssert(moduleName, @"A moduleName is required to create an RCTSurfaceHostingProxyRootView");
-
-  RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"-[RCTSurfaceHostingProxyRootView init]", nil);
-
-  _bridge = bridge;
-  _minimumSize = CGSizeZero;
-
-  if (!bridge.isLoading) {
-    [bridge.performanceLogger markStartForTag:RCTPLTTI];
-  }
-
-  // `RCTRootViewSizeFlexibilityNone` is the RCTRootView's default.
-  RCTSurfaceSizeMeasureMode sizeMeasureMode = convertToSurfaceSizeMeasureMode(RCTRootViewSizeFlexibilityNone);
-
-  self = [super initWithBridge:bridge
-                    moduleName:moduleName
-             initialProperties:initialProperties
-               sizeMeasureMode:sizeMeasureMode];
-
-  RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
-
-  return self;
-}
-
-- (instancetype)initWithBundleURL:(NSURL *)bundleURL
-                       moduleName:(NSString *)moduleName
-                initialProperties:(NSDictionary *)initialProperties
-                    launchOptions:(NSDictionary *)launchOptions
-{
-  RCTBridge *bridge = [[RCTBridge alloc] initWithBundleURL:bundleURL moduleProvider:nil launchOptions:launchOptions];
-
-  return [self initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
-}
-
 - (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
                 sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
                  moduleRegistry:(RCTModuleRegistry *)moduleRegistry

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -28,29 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTSurfaceHostingView : UIView <RCTSurfaceDelegate>
 
 /**
- * Create an instance of RCTSurface to be hosted.
- */
-+ (RCTSurface *)createSurfaceWithBridge:(RCTBridge *)bridge
-                             moduleName:(NSString *)moduleName
-                      initialProperties:(NSDictionary *)initialProperties;
-
-/**
  * Designated initializer.
  * Instantiates a view with given Surface object.
  * Note: The view retains the surface object.
  */
 - (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
                 sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode NS_DESIGNATED_INITIALIZER;
-
-/**
- * Convenience initializer.
- * Instantiates a Surface object with given `bridge`, `moduleName`, and
- * `initialProperties`, and then use it to instantiate a view.
- */
-- (instancetype)initWithBridge:(RCTBridge *)bridge
-                    moduleName:(NSString *)moduleName
-             initialProperties:(NSDictionary *)initialProperties
-               sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode;
 
 /**
  * Surface object which is currently using to power the view.

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -26,30 +26,9 @@
   RCTSurfaceStage _stage;
 }
 
-+ (id<RCTSurfaceProtocol>)createSurfaceWithBridge:(RCTBridge *)bridge
-                                       moduleName:(NSString *)moduleName
-                                initialProperties:(NSDictionary *)initialProperties
-{
-  return [[RCTSurface alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
-}
-
 RCT_NOT_IMPLEMENTED(-(instancetype)init)
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 RCT_NOT_IMPLEMENTED(-(nullable instancetype)initWithCoder : (NSCoder *)coder)
-
-- (instancetype)initWithBridge:(RCTBridge *)bridge
-                    moduleName:(NSString *)moduleName
-             initialProperties:(NSDictionary *)initialProperties
-               sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
-{
-  id<RCTSurfaceProtocol> surface = [[self class] createSurfaceWithBridge:bridge
-                                                              moduleName:moduleName
-                                                       initialProperties:initialProperties];
-  if (self = [self initWithSurface:surface sizeMeasureMode:sizeMeasureMode]) {
-    [surface start];
-  }
-  return self;
-}
 
 - (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface
                 sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode


### PR DESCRIPTION
Summary:
## Changelog:

[iOS][Breaking]- After [#38866](https://github.com/facebook/react-native/pull/38866) and [#38868](https://github.com/facebook/react-native/pull/38868), these are not needed anymore. instead of depending on the host view and overriding `createSurfaceWithBridge:` in a subclass create a specialized surface, we just rely on composition instead and provide a surface to the hosting view.

Differential Revision: D48577192

