### PR TITLE
Replace JS public api from performance.reactNativeStartupTiming to performance.rnStartupTiming

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/Performance.js
+++ b/packages/react-native/Libraries/WebPerformance/Performance.js
@@ -141,7 +141,7 @@ export default class Performance {
   }
 
   // Startup metrics is not used in web, but only in React Native.
-  get reactNativeStartupTiming(): ReactNativeStartupTiming {
+  get rnStartupTiming(): ReactNativeStartupTiming {
     if (NativePerformance?.getReactNativeStartupTiming) {
       const {
         startTime,
@@ -161,6 +161,12 @@ export default class Performance {
       });
     }
     return new ReactNativeStartupTiming();
+  }
+
+  // Backward compatible with rnStartupTiming
+  // TODO(T161756740): Remove this once we migrate to the new API.
+  get reactNativeStartupTiming(): ReactNativeStartupTiming {
+    return this.rnStartupTiming;
   }
 
   mark(

--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -56,14 +56,14 @@ function StartupTimingExample(): React.Node {
   const [startUpTiming, setStartUpTiming] =
     useState<?ReactNativeStartupTiming>(null);
   const onGetStartupTiming = useCallback(() => {
-    // performance.reactNativeStartupTiming is not included in bom.js yet.
+    // performance.rnStartupTiming is not included in bom.js yet.
     // Once we release the change in flow this can be removed.
     // $FlowFixMe[prop-missing]
     // $FlowFixMe[incompatible-call]
-    setStartUpTiming(performance.reactNativeStartupTiming);
+    setStartUpTiming(performance.rnStartupTiming);
   }, []);
   return (
-    <RNTesterPage noScroll={true} title="performance.reactNativeStartupTiming">
+    <RNTesterPage noScroll={true} title="performance.rnStartupTiming">
       <View style={styles.container}>
         <Button
           onPress={onGetStartupTiming}
@@ -109,7 +109,7 @@ exports.examples = [
     },
   },
   {
-    title: 'performance.reactNativeStartupTiming',
+    title: 'performance.rnStartupTiming',
     render: function (): React.Element<typeof StartupTimingExample> {
       return <StartupTimingExample />;
     },


### PR DESCRIPTION
Summary:
Per conversation internally we would like to use `rn` instead of `reactNative` to prefix RN specific API that matches web.

Changelog:
[General][Fixed] - Update performance API to use new API name and created backward compatible ones before deprecating.

Reviewed By: rubennorte, rshest

Differential Revision: D47683637

