### PR TITLE
Remove Flipper actions in Dev Menu, add new Open Debugger action

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -260,29 +260,16 @@ RCT_EXPORT_MODULE()
   if (!devSettings.isProfilingEnabled) {
 #if RCT_ENABLE_INSPECTOR
     if (devSettings.isDeviceDebuggingAvailable) {
-      // For on-device debugging we link out to Flipper.
-      // Since we're assuming Flipper is available, also include the DevTools.
-      // Note: For parity with the Android code.
+      // On-device JS debugging (Hermes). Render actions to open Chrome
+      // DevTools and React DevTools.
       [items addObject:[RCTDevMenuItem
                            buttonItemWithTitleBlock:^NSString * {
                              return @"Open Debugger";
                            }
                            handler:^{
                              [RCTInspectorDevServerHelper
-                                          openURL:@"flipper://null/Hermesdebuggerrn?device=React%20Native"
-                                    withBundleURL:bundleManager.bundleURL
-                                 withErrorMessage:@"Failed to open Flipper. Please check that Metro is running."];
-                           }]];
-
-      [items addObject:[RCTDevMenuItem
-                           buttonItemWithTitleBlock:^NSString * {
-                             return @"Open React DevTools";
-                           }
-                           handler:^{
-                             [RCTInspectorDevServerHelper
-                                          openURL:@"flipper://null/React?device=React%20Native"
-                                    withBundleURL:bundleManager.bundleURL
-                                 withErrorMessage:@"Failed to open Flipper. Please check that Metro is running."];
+                                     openDebugger:bundleManager.bundleURL
+                                 withErrorMessage:@"Failed to open debugger. Please check that Metro is running."];
                            }]];
     }
 #endif

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.h
@@ -18,6 +18,7 @@
 + (RCTInspectorPackagerConnection *)connectWithBundleURL:(NSURL *)bundleURL;
 + (void)disableDebugger;
 + (void)openURL:(NSString *)url withBundleURL:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage;
++ (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage;
 @end
 
 #endif

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -89,6 +89,26 @@ static void sendEventToAllConnections(NSString *event)
         }] resume];
 }
 
++ (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage
+{
+  NSString *appId = [[[NSBundle mainBundle] bundleIdentifier]
+      stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
+
+  NSURL *url = [NSURL
+      URLWithString:[NSString stringWithFormat:@"http://%@/open-debugger?appId=%@", getServerHost(bundleURL), appId]];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+  [request setHTTPMethod:@"POST"];
+
+  [[[NSURLSession sharedSession]
+      dataTaskWithRequest:request
+        completionHandler:^(
+            __unused NSData *_Nullable data, __unused NSURLResponse *_Nullable response, NSError *_Nullable error) {
+          if (error != nullptr) {
+            RCTLogWarn(@"%@", errorMessage);
+          }
+        }] resume];
+}
+
 + (void)disableDebugger
 {
   sendEventToAllConnections(kDebuggerMsgDisable);


### PR DESCRIPTION
Summary:
## Context

RFC: Decoupling Flipper from React Native core: https://github.com/react-native-community/discussions-and-proposals/pull/641

## Changes

- Removes Flipper-backed "Launch Debugger" and "Launch React DevTools" actions from the Dev Menu.
- Adds replacement "Launch Debugger" action triggering the new one-click Hermes debugger flow for 0.73.

Changelog:
[iOS][Changed] Remove Flipper actions in Dev Menu, add new Open Debugger action

Differential Revision: D46220076

