### PR TITLE
Export DeviceInfoConstants type from the native module's specs

### DIFF
--- a/packages/react-native/Libraries/Utilities/NativeDeviceInfo.js
+++ b/packages/react-native/Libraries/Utilities/NativeDeviceInfo.js
@@ -34,6 +34,11 @@ export type DimensionsPayload = {|
   screenPhysicalPixels?: DisplayMetricsAndroid,
 |};
 
+export type DeviceInfoConstants = {|
+  +Dimensions: DimensionsPayload,
+  +isIPhoneX_deprecated?: boolean,
+|};
+
 export interface Spec extends TurboModule {
   +getConstants: () => {|
     +Dimensions: DimensionsPayload,
@@ -42,13 +47,10 @@ export interface Spec extends TurboModule {
 }
 
 const NativeModule: Spec = TurboModuleRegistry.getEnforcing<Spec>('DeviceInfo');
-let constants = null;
+let constants: ?DeviceInfoConstants = null;
 
 const NativeDeviceInfo = {
-  getConstants(): {|
-    +Dimensions: DimensionsPayload,
-    +isIPhoneX_deprecated?: boolean,
-  |} {
+  getConstants(): DeviceInfoConstants {
     if (constants == null) {
       constants = NativeModule.getConstants();
     }


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

Expose constants type from DeviceInfo native module - this makes codegen generate the corresponding data structure, making the native module implementation shorter (in C++ in particular).

Differential Revision: D48620784

