### PR TITLE
reduce visibility of getNativeModuleIterator

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -37,6 +37,7 @@ public abstract class LazyReactPackage implements ReactPackage {
       LazyReactPackage lazyReactPackage) {
     return Collections::emptyMap;
   }
+
   /**
    * We return an iterable
    *
@@ -44,8 +45,8 @@ public abstract class LazyReactPackage implements ReactPackage {
    * @return {@link Iterable<ModuleHolder>} that contains all native modules registered for the
    *     context
    */
-  public Iterable<ModuleHolder> getNativeModuleIterator(
-      final ReactApplicationContext reactContext) {
+  /** package */
+  Iterable<ModuleHolder> getNativeModuleIterator(final ReactApplicationContext reactContext) {
     final Map<String, ReactModuleInfo> reactModuleInfoMap =
         getReactModuleInfoProvider().getReactModuleInfos();
     final List<ModuleSpec> nativeModules = getNativeModules(reactContext);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageHelper.java
@@ -25,7 +25,8 @@ public class ReactPackageHelper {
    * @param reactInstanceManager
    * @return
    */
-  public static Iterable<ModuleHolder> getNativeModuleIterator(
+  /** package */
+  static Iterable<ModuleHolder> getNativeModuleIterator(
       ReactPackage reactPackage,
       ReactApplicationContext reactApplicationContext,
       ReactInstanceManager reactInstanceManager) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
@@ -55,8 +55,8 @@ public abstract class TurboReactPackage implements ReactPackage {
    * @param reactContext
    * @return
    */
-  public Iterable<ModuleHolder> getNativeModuleIterator(
-      final ReactApplicationContext reactContext) {
+  /** package */
+  Iterable<ModuleHolder> getNativeModuleIterator(final ReactApplicationContext reactContext) {
     final Set<Map.Entry<String, ReactModuleInfo>> entrySet =
         getReactModuleInfoProvider().getReactModuleInfos().entrySet();
     final Iterator<Map.Entry<String, ReactModuleInfo>> entrySetIterator = entrySet.iterator();


### PR DESCRIPTION
Summary:
getNativeModuleIterator is not required to be public, reducing visibillity to package only

changelog: [internal] intenral

Differential Revision: D48588376

