### PR TITLE
Make TurboReactPackage.getModule no nullable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -37,6 +37,7 @@ public abstract class LazyReactPackage implements ReactPackage {
       LazyReactPackage lazyReactPackage) {
     return Collections::emptyMap;
   }
+
   /**
    * We return an iterable
    *
@@ -44,8 +45,8 @@ public abstract class LazyReactPackage implements ReactPackage {
    * @return {@link Iterable<ModuleHolder>} that contains all native modules registered for the
    *     context
    */
-  public Iterable<ModuleHolder> getNativeModuleIterator(
-      final ReactApplicationContext reactContext) {
+  /** package */
+  Iterable<ModuleHolder> getNativeModuleIterator(final ReactApplicationContext reactContext) {
     final Map<String, ReactModuleInfo> reactModuleInfoMap =
         getReactModuleInfoProvider().getReactModuleInfos();
     final List<ModuleSpec> nativeModules = getNativeModules(reactContext);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageHelper.java
@@ -25,7 +25,8 @@ public class ReactPackageHelper {
    * @param reactInstanceManager
    * @return
    */
-  public static Iterable<ModuleHolder> getNativeModuleIterator(
+  /** package */
+  static Iterable<ModuleHolder> getNativeModuleIterator(
       ReactPackage reactPackage,
       ReactApplicationContext reactApplicationContext,
       ReactInstanceManager reactInstanceManager) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
@@ -55,8 +55,8 @@ public abstract class TurboReactPackage implements ReactPackage {
    * @param reactContext
    * @return
    */
-  public Iterable<ModuleHolder> getNativeModuleIterator(
-      final ReactApplicationContext reactContext) {
+  /** package */
+  Iterable<ModuleHolder> getNativeModuleIterator(final ReactApplicationContext reactContext) {
     final Set<Map.Entry<String, ReactModuleInfo>> entrySet =
         getReactModuleInfoProvider().getReactModuleInfos().entrySet();
     final Iterator<Map.Entry<String, ReactModuleInfo>> entrySetIterator = entrySet.iterator();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
@@ -41,8 +41,7 @@ public abstract class TurboReactPackage implements ReactPackage {
    * @param name name of the Native Module
    * @param reactContext {@link ReactApplicationContext} context for this
    */
-  public abstract @Nullable NativeModule getModule(
-      String name, final ReactApplicationContext reactContext);
+  public abstract NativeModule getModule(String name, final ReactApplicationContext reactContext);
 
   /**
    * This is a temporary method till we implement TurboModules. Once we implement TurboModules, we

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ModuleHolder;
 import com.facebook.react.bridge.ModuleSpec;
@@ -39,9 +38,8 @@ public abstract class TurboReactPackage implements ReactPackage {
    * The API needed for TurboModules. Given a module name, it returns an instance of {@link
    * NativeModule} for the name
    *
-   * @param name
-   * @param reactContext
-   * @return
+   * @param name name of the Native Module
+   * @param reactContext {@link ReactApplicationContext} context for this
    */
   public abstract @Nullable NativeModule getModule(
       String name, final ReactApplicationContext reactContext);
@@ -60,13 +58,10 @@ public abstract class TurboReactPackage implements ReactPackage {
     final Set<Map.Entry<String, ReactModuleInfo>> entrySet =
         getReactModuleInfoProvider().getReactModuleInfos().entrySet();
     final Iterator<Map.Entry<String, ReactModuleInfo>> entrySetIterator = entrySet.iterator();
-    return new Iterable<ModuleHolder>() {
-      @NonNull
-      @Override
-      // This should ideally be an IteratorConvertor, but we don't have any internal library for it
-      public Iterator<ModuleHolder> iterator() {
-        return new Iterator<ModuleHolder>() {
-          Map.Entry<String, ReactModuleInfo> nextEntry = null;
+    // This should ideally be an IteratorConvertor, but we don't have any internal library for it
+    return () ->
+        new Iterator<ModuleHolder>() {
+          @Nullable Map.Entry<String, ReactModuleInfo> nextEntry = null;
 
           private void findNext() {
             while (entrySetIterator.hasNext()) {
@@ -118,8 +113,6 @@ public abstract class TurboReactPackage implements ReactPackage {
             throw new UnsupportedOperationException("Cannot remove native modules from the list");
           }
         };
-      }
-    };
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -104,7 +104,7 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
   }
 
   @Override
-  public @Nullable NativeModule getModule(String name, ReactApplicationContext context) {
+  public NativeModule getModule(String name, ReactApplicationContext context) {
     switch (name) {
       case AccessibilityInfoModule.NAME:
         return new AccessibilityInfoModule(context);
@@ -151,7 +151,8 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
       case DevToolsSettingsManagerModule.NAME:
         return new DevToolsSettingsManagerModule(context);
       default:
-        return null;
+        throw new IllegalArgumentException(
+            "Could not find Native module for " + name + " in MainReactPackage.");
     }
   }
 


### PR DESCRIPTION
Summary:
TurboReactPackage.getModule is nullable, although the internals of ReactNative requires this method to be non null (otherwise there will a NPEs)
I'm making TurboReactPackage.getModule no nullable, this is important to simplify API and future migration to kotlin

changelog: [internal] internal/

Reviewed By: cortinico

Differential Revision: D48588375

