### PR TITLE
[iOS] Move `kRCTPlatformName` to RCTConstants.h

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -7,6 +7,7 @@
 
 #import "RCTBundleURLProvider.h"
 
+#import "RCTConstants.h"
 #import "RCTConvert.h"
 #import "RCTDefines.h"
 #import "RCTLog.h"
@@ -22,7 +23,6 @@ void RCTBundleURLProviderAllowPackagerServerAccess(BOOL allowed)
   kRCTAllowPackagerAccess = allowed;
 }
 #endif
-static NSString *const kRCTPlatformName = @"ios";
 static NSString *const kRCTPackagerSchemeKey = @"RCT_packager_scheme";
 static NSString *const kRCTJsLocationKey = @"RCT_jsLocation";
 static NSString *const kRCTEnableDevKey = @"RCT_enableDev";
@@ -307,7 +307,7 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
   NSString *path = [NSString stringWithFormat:@"/%@.bundle", bundleRoot];
   BOOL lazy = enableDev;
   NSArray<NSURLQueryItem *> *queryItems = @[
-    [[NSURLQueryItem alloc] initWithName:@"platform" value:kRCTPlatformName],
+    [[NSURLQueryItem alloc] initWithName:@"platform" value:RCTPlatformName],
     [[NSURLQueryItem alloc] initWithName:@"dev" value:enableDev ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"lazy" value:lazy ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"minify" value:enableMinification ? @"true" : @"false"],

--- a/packages/react-native/React/Base/RCTConstants.h
+++ b/packages/react-native/React/Base/RCTConstants.h
@@ -7,6 +7,8 @@
 
 #import <React/RCTDefines.h>
 
+RCT_EXTERN NSString *const RCTPlatformName;
+
 RCT_EXTERN NSString *const RCTUserInterfaceStyleDidChangeNotification;
 RCT_EXTERN NSString *const RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey;
 

--- a/packages/react-native/React/Base/RCTConstants.m
+++ b/packages/react-native/React/Base/RCTConstants.m
@@ -7,6 +7,8 @@
 
 #import "RCTConstants.h"
 
+NSString *const RCTPlatformName = @"ios";
+
 NSString *const RCTUserInterfaceStyleDidChangeNotification = @"RCTUserInterfaceStyleDidChangeNotification";
 NSString *const RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey = @"traitCollection";
 

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -481,7 +481,7 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
     BOOL isHotLoadingEnabled = self.isHotLoadingEnabled;
     [self.callableJSModules invokeModule:@"HMRClient"
                                   method:@"setup"
-                                withArgs:@[ @"ios", path, host, RCTNullIfNil(port), @(isHotLoadingEnabled), scheme ]];
+                                withArgs:@[ RCTPlatformName, path, host, RCTNullIfNil(port), @(isHotLoadingEnabled), scheme ]];
   }
 }
 

--- a/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
+++ b/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
@@ -14,6 +14,7 @@
 #import <React/RCTAssert.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
+#import <React/RCTConstants.h>
 #import <React/RCTConvert.h>
 #import <React/RCTDefines.h>
 #import <React/RCTLog.h>
@@ -100,7 +101,7 @@ static RCTReconnectingWebSocket *socketForLocation(NSString *const serverHostPor
   components.scheme = scheme;
   components.port = serverPort ? @(serverPort.integerValue) : @(kRCTBundleURLProviderDefaultPort);
   components.path = @"/message";
-  components.queryItems = @[ [NSURLQueryItem queryItemWithName:@"role" value:@"ios"] ];
+  components.queryItems = @[ [NSURLQueryItem queryItemWithName:@"role" value:RCTPlatformName] ];
   static dispatch_queue_t queue;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{

--- a/packages/rn-tester/RCTTest/RCTTestRunner.m
+++ b/packages/rn-tester/RCTTest/RCTTestRunner.m
@@ -9,6 +9,7 @@
 
 #import <React/RCTAssert.h>
 #import <React/RCTBridge+Private.h>
+#import <React/RCTConstants.h>
 #import <React/RCTDevSettings.h>
 #import <React/RCTLog.h>
 #import <React/RCTRootView.h>
@@ -88,7 +89,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 {
   if (getenv("CI_USE_PACKAGER") || _useBundler) {
     return [NSURL
-        URLWithString:[NSString stringWithFormat:@"http://localhost:8081/%@.bundle?platform=ios&dev=true", _appPath]];
+        URLWithString:[NSString stringWithFormat:@"http://localhost:8081/%@.bundle?platform=%@&dev=true", _appPath, RCTPlatformName]];
   } else {
     return [[NSBundle bundleForClass:[RCTBridge class]] URLForResource:@"main" withExtension:@"jsbundle"];
   }

--- a/packages/rn-tester/RNTesterIntegrationTests/RCTLoggingTests.m
+++ b/packages/rn-tester/RNTesterIntegrationTests/RCTLoggingTests.m
@@ -9,6 +9,7 @@
 
 #import <React/RCTAssert.h>
 #import <React/RCTBridge.h>
+#import <React/RCTConstants.h>
 #import <React/RCTLog.h>
 
 // Time to wait for an expected log statement to show before failing the test
@@ -33,7 +34,7 @@ const int64_t LOGGER_TIMEOUT = 10 * NSEC_PER_SEC;
   if (getenv("CI_USE_PACKAGER")) {
     NSString *app = @"IntegrationTests/IntegrationTestsApp";
     scriptURL =
-        [NSURL URLWithString:[NSString stringWithFormat:@"http://localhost:8081/%@.bundle?platform=ios&dev=true", app]];
+        [NSURL URLWithString:[NSString stringWithFormat:@"http://localhost:8081/%@.bundle?platform=%@&dev=true", app, RCTPlatformName]];
   } else {
     scriptURL = [[NSBundle bundleForClass:[RCTBridge class]] URLForResource:@"main" withExtension:@"jsbundle"];
   }

--- a/packages/rn-tester/RNTesterUnitTests/RCTBundleURLProviderTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTBundleURLProviderTests.m
@@ -8,6 +8,7 @@
 #import <XCTest/XCTest.h>
 
 #import <React/RCTBundleURLProvider.h>
+#import <React/RCTConstants.h>
 #import <React/RCTUtils.h>
 
 #import "OCMock/OCMock.h"
@@ -26,8 +27,9 @@ static NSURL *localhostBundleURL(void)
       URLWithString:
           [NSString
               stringWithFormat:
-                  @"http://localhost:8081/%@.bundle?platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
-                  testFile]];
+                  @"http://localhost:8081/%@.bundle?platform=%@s&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
+                  testFile,
+                  RCTPlatformName]];
 }
 
 static NSURL *ipBundleURL(void)
@@ -36,8 +38,9 @@ static NSURL *ipBundleURL(void)
       URLWithString:
           [NSString
               stringWithFormat:
-                  @"http://192.168.1.1:8081/%@.bundle?platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
-                  testFile]];
+                  @"http://192.168.1.1:8081/%@.bundle?platform=%@&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
+                  testFile,
+                  RCTPlatformName]];
 }
 
 @implementation NSBundle (RCTBundleURLProviderTests)

--- a/packages/rn-tester/RNTesterUnitTests/RCTBundleURLProviderTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTBundleURLProviderTests.m
@@ -27,7 +27,7 @@ static NSURL *localhostBundleURL(void)
       URLWithString:
           [NSString
               stringWithFormat:
-                  @"http://localhost:8081/%@.bundle?platform=%@s&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
+                  @"http://localhost:8081/%@.bundle?platform=%@&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
                   testFile,
                   RCTPlatformName]];
 }


### PR DESCRIPTION
## Summary:

This PR is another one made with the intent to reduce the number of diffs between React Native and React Native macOS.

In https://github.com/facebook/react-native/commit/f7219ec02d71d2f0f6c71af4d5c3d4850a898fd8 , we introduced `kRCTPlatformName`, which had already been in React Native macOS for a while (since we ifdef to either "ios" or "macos" in a number of places). This change moves the string up to a common header (dropping the "k" prefix) so we can refactor other strings that currently have a hardcoded "platform=ios" inside them. 

## Changelog:

[IOS] [CHANGED] - Add RCTPlatformName to RCTConstants.h

## Test Plan:

CI should pass
