### PR TITLE
Add Microsoft Edge support for opening debugger

### DIFF
--- a/flow-typed/npm/chromium-edge-launcher_v1.x.x.js
+++ b/flow-typed/npm/chromium-edge-launcher_v1.x.x.js
@@ -9,18 +9,18 @@
  * @oncall react_native
  */
 
-declare module 'chrome-launcher' {
+declare module 'chromium-edge-launcher' {
   import typeof fs from 'fs';
   import typeof childProcess from 'child_process';
   import type {ChildProcess} from 'child_process';
 
   declare export type Options = {
     startingUrl?: string,
-    chromeFlags?: Array<string>,
+    edgeFlags?: Array<string>,
     prefs?: mixed,
     port?: number,
     handleSIGINT?: boolean,
-    chromePath?: string,
+    edgePath?: string,
     userDataDir?: string | boolean,
     logLevel?: 'verbose' | 'info' | 'error' | 'warn' | 'silent',
     ignoreDefaultFlags?: boolean,
@@ -29,7 +29,7 @@ declare module 'chrome-launcher' {
     envVars?: {[key: string]: ?string},
   };
 
-  declare export type LaunchedChrome = {
+  declare export type LaunchedEdge = {
     pid: number,
     port: number,
     process: ChildProcess,
@@ -42,9 +42,12 @@ declare module 'chrome-launcher' {
   };
 
   declare class Launcher {
-    getChromePath(): string;
-    launch(options: Options): Promise<LaunchedChrome>;
+    getFirstInstallation(): string;
+    launch(options: Options): Promise<LaunchedEdge>;
   }
 
-  declare module.exports: Launcher;
+  declare module.exports: {
+    default: Launcher,
+    Launcher: Launcher,
+  };
 }

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@isaacs/ttlcache": "^1.4.1",
     "chrome-launcher": "^0.15.2",
+    "chromium-edge-launcher": "^1.0.0",
     "connect": "^3.6.5",
     "debug": "^2.2.0",
     "node-fetch": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4665,6 +4665,18 @@ chrome-launcher@^0.15.0, chrome-launcher@^0.15.2:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
+chromium-edge-launcher@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz#0443083074715a13c669530b35df7bfea33b1509"
+  integrity sha512-pgtgjNKZ7i5U++1g1PWv75umkHvhVTDOQIZ+sjeUX9483S7Y6MUvO0lrd7ShGlQlFHMN4SwKTCq/X8hWrbv2KA==
+  dependencies:
+    "@types/node" "*"
+    escape-string-regexp "^4.0.0"
+    is-wsl "^2.2.0"
+    lighthouse-logger "^1.0.0"
+    mkdirp "^1.0.4"
+    rimraf "^3.0.2"
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -8698,7 +8710,7 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   dependencies:
     minimist "^1.2.6"
 
-mkdirp@^1.0.3:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==


### PR DESCRIPTION
Summary:
Adds Microsoft Edge fallback for the `/open-debugger` endpoint when no Chrome installation is found.

Changelog: [Internal]

Differential Revision: D48563386

