### PR TITLE
Define modules and use modular headers to simplify Swift integration

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -57,7 +57,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig  = {
     "USE_HEADERMAP" => "NO",
     "HEADER_SEARCH_PATHS" => header_search_paths.join(" "),
-    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+    "DEFINES_MODULE" => "YES",
   }
 
   s.dependency "RCT-Folly/Fabric"

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -144,7 +144,7 @@ def use_react_native! (
   pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
 
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
-  pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
+  pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec", :modular_headers => true
   pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
   pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
 


### PR DESCRIPTION
Summary:
This change adds another `DEFINES_MODULE` which is required to integrate with Swift.
It also make glog use modular headers. The `DEFINES_MODULE` directive is somehow ignored by glog and I don't know why.

## Changelog:
[Internal] - Defines modules for React-ImageManager and use modular headers for glog

## Facebook:
This work is required to collaborate with Expo on ExpoModules

Differential Revision: D48648153

