### PR TITLE
Fix typo in hermes-engine.podspec

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -65,7 +65,7 @@ Pod::Spec.new do |spec|
       }
     end
 
-  elsif source_type == HermesEngineSourceType::isFromSource(source_type) then
+  elsif HermesEngineSourceType::isFromSource(source_type) then
 
     spec.subspec 'Hermes' do |ss|
       ss.source_files = ''


### PR DESCRIPTION
Summary:
Changelog: [Internal]
This typo in the condition prevented correspeponding code block form executing ever.

Reviewed By: cipolleschi

Differential Revision: D48648118

