### PR TITLE
Fix crash in CompositeTurboModuleManagerDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/CompositeTurboModuleManagerDelegate.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/CompositeTurboModuleManagerDelegate.cpp
@@ -29,7 +29,8 @@ CompositeTurboModuleManagerDelegate::getTurboModule(
     const std::string &moduleName,
     const std::shared_ptr<CallInvoker> &jsInvoker) {
   for (auto delegate : mDelegates_) {
-    if (auto turboModule = delegate->getTurboModule(moduleName, jsInvoker)) {
+    if (auto turboModule =
+            delegate->cthis()->getTurboModule(moduleName, jsInvoker)) {
       return turboModule;
     }
   }
@@ -41,7 +42,8 @@ CompositeTurboModuleManagerDelegate::getTurboModule(
     const std::string &moduleName,
     const JavaTurboModule::InitParams &params) {
   for (auto delegate : mDelegates_) {
-    if (auto turboModule = delegate->getTurboModule(moduleName, params)) {
+    if (auto turboModule =
+            delegate->cthis()->getTurboModule(moduleName, params)) {
       return turboModule;
     }
   }
@@ -49,9 +51,8 @@ CompositeTurboModuleManagerDelegate::getTurboModule(
 }
 
 void CompositeTurboModuleManagerDelegate::addTurboModuleManagerDelegate(
-    jni::alias_ref<TurboModuleManagerDelegate::javaobject>
-        turboModuleManagerDelegate) {
-  mDelegates_.insert(turboModuleManagerDelegate->cthis());
+    jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate) {
+  mDelegates_.push_back(jni::make_global(delegate));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/CompositeTurboModuleManagerDelegate.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/CompositeTurboModuleManagerDelegate.h
@@ -11,7 +11,7 @@
 #include <fbjni/fbjni.h>
 #include <memory>
 #include <string>
-#include <unordered_set>
+#include <vector>
 
 namespace facebook::react {
 
@@ -30,6 +30,7 @@ class CompositeTurboModuleManagerDelegate
   std::shared_ptr<TurboModule> getTurboModule(
       const std::string &moduleName,
       const std::shared_ptr<CallInvoker> &jsInvoker) override;
+
   std::shared_ptr<TurboModule> getTurboModule(
       const std::string &moduleName,
       const JavaTurboModule::InitParams &params) override;
@@ -37,11 +38,11 @@ class CompositeTurboModuleManagerDelegate
  private:
   friend HybridBase;
   using HybridBase::HybridBase;
-  std::unordered_set<TurboModuleManagerDelegate *> mDelegates_;
+  std::vector<jni::global_ref<TurboModuleManagerDelegate::javaobject>>
+      mDelegates_;
 
   void addTurboModuleManagerDelegate(
-      jni::alias_ref<TurboModuleManagerDelegate::javaobject>
-          turboModuleManagerDelegate);
+      jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
[Changelog]: [Android][Fixed] Fix crash in CompositeTurboModuleManagerDelegate

CompositeTurboModuleManagerDelegate.cpp crashes as we pass in one or multiple
```
jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate
```
but don't retain a global reference to them. Fix use:
```
jni::make_global(delegate)
```

Differential Revision: D48670217

