### PR TITLE
Add @react-native/babel-plugin-codegen to the preset if src is null

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -57,7 +57,7 @@ const getPreset = (src, options) => {
 
   if (
     !options.disableStaticViewConfigsCodegen &&
-    /\bcodegenNativeComponent</.test(src)
+    (src === null || /\bcodegenNativeComponent</.test(src))
   ) {
     extraPlugins.push([require('@react-native/babel-plugin-codegen')]);
   }


### PR DESCRIPTION
Summary:
Source is not required for `getPreset` of `react-native/babel-preset`. There is a codition that adds `react-native/babel-plugin-codegen` to the preset only if source is passing certain regex. This condition fails if source is null, but that's wrong because the plugin may still be requred for this transformation even though source is not provided.
This diff changes the condition so the regexp tests source only if it is not null, and `react-native/babel-plugin-codegen` automatically added to the preset otherwise.
Changelog: [Internal]

Differential Revision: D48684443

