### PR TITLE
Sync `@pkgjs/parseargs` Flow types with Node types

### DIFF
--- a/flow-typed/npm/parseargs_v0.11.x.js
+++ b/flow-typed/npm/parseargs_v0.11.x.js
@@ -10,31 +10,30 @@
  */
 
 declare module '@pkgjs/parseargs' {
-  declare type ParseArgsOptionConfig = {
-    type: 'string' | 'boolean',
-    short?: string,
-    multiple?: boolean,
-  };
-
-  declare type ParseArgsOptionsConfig = {
-    [longOption: string]: ParseArgsOptionConfig,
-  };
-
-  declare export type ParseArgsConfig = {
+  declare export function parseArgs<
+    TOptions: {[string]: util$ParseArgsOption} = {},
+  >(config: {
+    args?: Array<string>,
+    options?: TOptions,
     strict?: boolean,
     allowPositionals?: boolean,
-    tokens?: boolean,
-    options?: ParseArgsOptionsConfig,
-    args?: string[],
+    tokens?: false,
+  }): {
+    values: util$ParseArgsOptionsToValues<TOptions>,
+    positionals: Array<string>,
   };
 
-  declare type ParsedResults = {
-    values: {
-      [longOption: string]: void | string | boolean | Array<string | boolean>,
-    },
-    positionals: string[],
-    ...
+  declare export function parseArgs<
+    TOptions: {[string]: util$ParseArgsOption} = {},
+  >(config: {
+    args?: Array<string>,
+    options?: TOptions,
+    strict?: boolean,
+    allowPositionals?: boolean,
+    tokens: true,
+  }): {
+    values: util$ParseArgsOptionsToValues<TOptions>,
+    positionals: Array<string>,
+    tokens: Array<util$ParseArgsToken>,
   };
-
-  declare export function parseArgs(config: ParseArgsConfig): ParsedResults;
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Flow knows about `util.parseArgs` now and has [really nice types for it](https://github.com/facebook/flow/commit/dc5c06a7cbf4b326bd1582b91c5cd0ed65a705bb), so let's update the type definitions for the `pkgjs/parseargs` shim to use those. The updated types use conditional and mapped types to generate a more precise return type for `parseArgs`, based directly on the provided config object.

Reviewed By: huntie

Differential Revision: D48683091

