### PR TITLE
Remove module debug info logging

### DIFF
--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -30,9 +30,8 @@ function isTurboModuleInteropEnabled() {
   return global.RN$TurboInterop === true;
 }
 
-// TODO(154308585): Remove "module not found" debug info logging
-function shouldReportDebugInfo() {
-  return true;
+function shouldReportLoadedModules() {
+  return isTurboModuleInteropEnabled();
 }
 
 // TODO(148943970): Consider reversing the lookup here:
@@ -42,7 +41,7 @@ function requireModule<T: TurboModule>(name: string): ?T {
     // Backward compatibility layer during migration.
     const legacyModule = NativeModules[name];
     if (legacyModule != null) {
-      if (shouldReportDebugInfo()) {
+      if (shouldReportLoadedModules()) {
         moduleLoadHistory.NativeModules.push(name);
       }
       return ((legacyModule: $FlowFixMe): T);
@@ -52,14 +51,14 @@ function requireModule<T: TurboModule>(name: string): ?T {
   if (turboModuleProxy != null) {
     const module: ?T = turboModuleProxy(name);
     if (module != null) {
-      if (shouldReportDebugInfo()) {
+      if (shouldReportLoadedModules()) {
         moduleLoadHistory.TurboModules.push(name);
       }
       return module;
     }
   }
 
-  if (shouldReportDebugInfo()) {
+  if (shouldReportLoadedModules()) {
     moduleLoadHistory.NotFound.push(name);
   }
   return null;
@@ -75,12 +74,7 @@ export function getEnforcing<T: TurboModule>(name: string): T {
     `TurboModuleRegistry.getEnforcing(...): '${name}' could not be found. ` +
     'Verify that a module by this name is registered in the native binary.';
 
-  if (shouldReportDebugInfo()) {
-    message += 'Bridgeless mode: ' + (isBridgeless() ? 'true' : 'false') + '. ';
-    message +=
-      'TurboModule interop: ' +
-      (isTurboModuleInteropEnabled() ? 'true' : 'false') +
-      '. ';
+  if (shouldReportLoadedModules()) {
     message += 'Modules loaded: ' + JSON.stringify(moduleLoadHistory);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -37,6 +37,7 @@ public abstract class LazyReactPackage implements ReactPackage {
       LazyReactPackage lazyReactPackage) {
     return Collections::emptyMap;
   }
+
   /**
    * We return an iterable
    *
@@ -44,8 +45,8 @@ public abstract class LazyReactPackage implements ReactPackage {
    * @return {@link Iterable<ModuleHolder>} that contains all native modules registered for the
    *     context
    */
-  public Iterable<ModuleHolder> getNativeModuleIterator(
-      final ReactApplicationContext reactContext) {
+  /** package */
+  Iterable<ModuleHolder> getNativeModuleIterator(final ReactApplicationContext reactContext) {
     final Map<String, ReactModuleInfo> reactModuleInfoMap =
         getReactModuleInfoProvider().getReactModuleInfos();
     final List<ModuleSpec> nativeModules = getNativeModules(reactContext);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageHelper.java
@@ -25,7 +25,8 @@ public class ReactPackageHelper {
    * @param reactInstanceManager
    * @return
    */
-  public static Iterable<ModuleHolder> getNativeModuleIterator(
+  /** package */
+  static Iterable<ModuleHolder> getNativeModuleIterator(
       ReactPackage reactPackage,
       ReactApplicationContext reactApplicationContext,
       ReactInstanceManager reactInstanceManager) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
@@ -55,8 +55,8 @@ public abstract class TurboReactPackage implements ReactPackage {
    * @param reactContext
    * @return
    */
-  public Iterable<ModuleHolder> getNativeModuleIterator(
-      final ReactApplicationContext reactContext) {
+  /** package */
+  Iterable<ModuleHolder> getNativeModuleIterator(final ReactApplicationContext reactContext) {
     final Set<Map.Entry<String, ReactModuleInfo>> entrySet =
         getReactModuleInfoProvider().getReactModuleInfos().entrySet();
     final Iterator<Map.Entry<String, ReactModuleInfo>> entrySetIterator = entrySet.iterator();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ModuleHolder;
 import com.facebook.react.bridge.ModuleSpec;
@@ -39,9 +38,8 @@ public abstract class TurboReactPackage implements ReactPackage {
    * The API needed for TurboModules. Given a module name, it returns an instance of {@link
    * NativeModule} for the name
    *
-   * @param name
-   * @param reactContext
-   * @return
+   * @param name name of the Native Module
+   * @param reactContext {@link ReactApplicationContext} context for this
    */
   public abstract @Nullable NativeModule getModule(
       String name, final ReactApplicationContext reactContext);
@@ -60,13 +58,10 @@ public abstract class TurboReactPackage implements ReactPackage {
     final Set<Map.Entry<String, ReactModuleInfo>> entrySet =
         getReactModuleInfoProvider().getReactModuleInfos().entrySet();
     final Iterator<Map.Entry<String, ReactModuleInfo>> entrySetIterator = entrySet.iterator();
-    return new Iterable<ModuleHolder>() {
-      @NonNull
-      @Override
-      // This should ideally be an IteratorConvertor, but we don't have any internal library for it
-      public Iterator<ModuleHolder> iterator() {
-        return new Iterator<ModuleHolder>() {
-          Map.Entry<String, ReactModuleInfo> nextEntry = null;
+    // This should ideally be an IteratorConvertor, but we don't have any internal library for it
+    return () ->
+        new Iterator<ModuleHolder>() {
+          @Nullable Map.Entry<String, ReactModuleInfo> nextEntry = null;
 
           private void findNext() {
             while (entrySetIterator.hasNext()) {
@@ -118,8 +113,6 @@ public abstract class TurboReactPackage implements ReactPackage {
             throw new UnsupportedOperationException("Cannot remove native modules from the list");
           }
         };
-      }
-    };
   }
 
   /**


### PR DESCRIPTION
Summary:
Module debug info logging was added temporarily, cleaning this up while analyzing TurboModuleRegistry API

changelog: [internal] internal

Reviewed By: arushikesarwani94

Differential Revision: D48691697

