### PR TITLE
Make the e2e Tests actually not blocking

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -280,7 +280,7 @@ jobs:
                 name: Run E2E tests
                 command: |
                   cd packages/rn-tester-e2e
-                  yarn test-e2e ios 2>&1 | tee /tmp/test_log
+                  (yarn test-e2e ios 2>&1 | tee /tmp/test_log) || true
             - store_artifacts:
                 path: /tmp/test_log
 
@@ -343,7 +343,7 @@ jobs:
           name: Run E2E tests
           command: |
             cd packages/rn-tester-e2e
-            yarn test-e2e android 2>&1 | tee /tmp/test_log
+            (yarn test-e2e android 2>&1 | tee /tmp/test_log) || true
       - store_artifacts:
           path: /tmp/test_log
 


### PR DESCRIPTION
Summary:
Just `tee`-ing the e2e tests command into a log is not enough to make the command non-failing.
I'm wrapping it into a single command and `or`-int to true to ensure that it never fails.

## Changelog:
[Internal] - Make e2e tests not failing in CI

Differential Revision: D48720827

