### PR TITLE
WIP: Use all relative paths for `header_mappings_dir` option in podspecs

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
                             "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir     = File.absolute_path('./')
+    s.header_mappings_dir     = './'
     s.module_name             = 'React_Fabric'
   end
 

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
                                "GCC_WARN_PEDANTIC" => "YES" }
   if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir     = File.absolute_path("./")
+    s.header_mappings_dir     = './'
   end
 
   # TODO (T48588859): Restructure this target to align with dir structure: "react/nativemodule/..."

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_debug"
-    s.header_mappings_dir  = File.absolute_path("../..")
+    s.header_mappings_dir  = "../.."
   end
 end

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_debug"
-    s.header_mappings_dir  = "../.."
+    s.header_mappings_dir  = "./"
   end
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
                                 "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
                                 "GCC_WARN_PEDANTIC" => "YES" }
     if ENV['USE_FRAMEWORKS']
-        s.header_mappings_dir     = File.absolute_path('./')
+        s.header_mappings_dir     = './'
     end
 
     s.source_files = "ReactCommon/**/*.{mm,cpp,h}"

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
                                "GCC_WARN_PEDANTIC" => "YES" }
   if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir     = File.absolute_path('./')
+    s.header_mappings_dir     = './'
   end
 
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_graphics"
-    s.header_mappings_dir  =  File.absolute_path("../../..")
+    s.header_mappings_dir  = "../../.."
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
   end
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_graphics"
-    s.header_mappings_dir  = "../../.."
+    s.header_mappings_dir  = "./"
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
   end
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_ImageManager"
-    s.header_mappings_dir  = File.absolute_path("./")
+    s.header_mappings_dir  = "./"
     header_search_paths = header_search_paths + [
       "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\"",
       "\"$(PODS_ROOT)/DoubleConversion\"",

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_runtimescheduler"
-    s.header_mappings_dir  = File.absolute_path("../../..")
+    s.header_mappings_dir  = "../../.."
   end
 
   s.dependency "React-jsi"

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_runtimescheduler"
-    s.header_mappings_dir  = "../../.."
+    s.header_mappings_dir  = "./"
   end
 
   s.dependency "React-jsi"

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_utils"
-    s.header_mappings_dir  = File.absolute_path("../..")
+    s.header_mappings_dir  = "../.."
   end
 
   s.dependency "RCT-Folly", folly_version

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_utils"
-    s.header_mappings_dir  = "../.."
+    s.header_mappings_dir  = "./"
   end
 
   s.dependency "RCT-Folly", folly_version


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Possible follow-up for https://github.com/facebook/react-native/pull/39177

From what I understand from the `header_mappings_dir` is that it basically a relative path from the pods source root, and since all previous paths pointed to the root level of the pod's source roots I think having them all use `./` should result in all header structures being preserved. 

https://www.rubydoc.info/gems/cocoapods-core/0.38.2/Pod%2FSpecification%2FDSL:header_mappings_dir=

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
