### PR TITLE
Include accessibilityValue prop values in accessibilityValue

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -766,6 +766,13 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     [valueComponents addObject:RCTLocalizedString("busy", "an element currently being updated or modified")];
   }
 
+  // Using super.accessibilityValue:
+  // 1. to access the value that is set to accessibilityValue in updateProps
+  // 2. can't access from self.accessibilityElement because it resolves to self
+  if (super.accessibilityValue) {
+    [valueComponents addObject:super.accessibilityValue];
+  }
+
   if (valueComponents.count > 0) {
     return [valueComponents componentsJoinedByString:@", "];
   }


### PR DESCRIPTION
Summary:
Previously, when `props.accessibilityValue` was enabled and other props were enabled, like `props.accessibilityRole`, that are used in the accessibilityValue for iOS, the value from `props.accessibilityValue` wasn't announced.

This is a problem for cases like radio button, which also needs to announce the placement of the radio button within a group, e.g. "[label], radio button, checked, 1 out of 3".

This diff fixes this problem by including the value from `props.acessibilityValue` within the method that builds the `accessibiityValue` for VoiceOver.

Reviewed By: cipolleschi

Differential Revision: D48534155

