### PR TITLE
Fix incorrect pointer coordinates caching

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -387,6 +387,16 @@ public class JSPointerDispatcher {
             "Motion Event was ignored. Action=" + action + " Target=" + activeTargetTag);
         return;
     }
+
+    // Update "previous" pointer coordinates and button state
+    Map<Integer, float[]> nextEventCoordinatesByPointerId =
+        new HashMap<>(eventState.getEventCoordinatesByPointerId());
+    mLastEventCoordinatesByPointerId = nextEventCoordinatesByPointerId;
+    mLastButtonState = motionEvent.getButtonState();
+
+    // Clean up any stale pointerIds
+    Set<Integer> allPointerIds = mLastEventCoordinatesByPointerId.keySet();
+    mHoveringPointerIds.retainAll(allPointerIds);
   }
 
   private static boolean isAnyoneListeningForBubblingEvent(
@@ -562,21 +572,11 @@ public class JSPointerDispatcher {
 
     Map<Integer, List<TouchTargetHelper.ViewTarget>> nextHitPathByPointerId =
         new HashMap<>(eventState.getHitPathByPointerId());
-    Map<Integer, float[]> nextEventCoordinatesByPointerId =
-        new HashMap<>(eventState.getEventCoordinatesByPointerId());
 
     if (targetTag == UNSELECTED_VIEW_TAG) {
       nextHitPathByPointerId.remove(activePointerId);
-      nextEventCoordinatesByPointerId.remove(activePointerId);
     }
-
     mLastHitPathByPointerId = nextHitPathByPointerId;
-    mLastEventCoordinatesByPointerId = nextEventCoordinatesByPointerId;
-    mLastButtonState = motionEvent.getButtonState();
-
-    // Clean up any stale pointerIds
-    Set<Integer> allPointerIds = mLastEventCoordinatesByPointerId.keySet();
-    mHoveringPointerIds.retainAll(allPointerIds);
   }
 
   private void onMove(


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Fix incorrect pointer coordinates caching

In D48472486 I moved the updating of "previous" fields into the `handleHitStateDivergence` method which made sense considering that it's run on every event regardless but what I didn't take into account was the updating of the `mLastEventCoordinatesByPointerId` field. On `ACTION_HOVER_MOVE` events there's a filter that ensures that only move events that have a large enough distance are emitted (something that isn't done on iOS, hence why I didn't think of it), but after my changes in D48472486 it was updating `mLastEventCoordinatesByPointerId` **before** that hover move check, making the distance always 0 and never firing move events.

This diff fixes this by moving the updating of `mLastEventCoordinatesByPointerId` and `mLastButtonState` back to the end of `handleMotionEvent`.

Differential Revision: D48756372

