### PR TITLE
Add detection of logical assignment operators to `react-native-babel-preset`

### DIFF
--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -19,6 +19,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.0",
     "@babel/plugin-proposal-export-default-from": "^7.0.0",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
+    "@babel/plugin-proposal-logical-assignment-operators":  "^7.18.0",
     "@babel/plugin-proposal-numeric-separator": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
     "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -146,6 +146,18 @@ const getPreset = (src, options) => {
       {loose: true},
     ]);
   }
+  if (
+    !isHermes &&
+    (isNull ||
+      src.indexOf('??=') !== -1 ||
+      src.indexOf('||=') !== -1 ||
+      src.indexOf('&&=') !== -1)
+  ) {
+    extraPlugins.push([
+      require('@babel/plugin-proposal-logical-assignment-operators'),
+      {loose: true},
+    ]);
+  }
 
   if (options && options.dev && !options.useTransformReactJSXExperimental) {
     extraPlugins.push([require('@babel/plugin-transform-react-jsx-source')]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -734,6 +734,14 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-json-strings" "^7.8.3"
 
+"@babel/plugin-proposal-logical-assignment-operators@^7.18.0":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz#dfbcaa8f7b4d37b51e8bfb46d94a5aea2bb89d83"
+  integrity sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+
 "@babel/plugin-proposal-logical-assignment-operators@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.18.9.tgz#8148cbb350483bf6220af06fa6db3690e14b2e23"


### PR DESCRIPTION
## Summary:

Though not currently in use in the RN code, when `react-native-windows` tried to integrate changes up to 7/28/23 (see PR https://github.com/microsoft/react-native-windows/pull/11970) there happened to be a `??=` operator in the `virtualized-lists` package (see [diff here](https://github.com/facebook/react-native/compare/ccc50ddd2...c168a4f88#diff-abeff2daf5909e54a23562e43569de1d5b8db1d7170119eed485b618cdf04ec7R322)). (The offending line was removed in a later commit).

The default RNW engine is still Chakra and it couldn't handle the syntax. It looks like the `@babel/plugin-proposal-nullish-coalescing-operator` plugin only handles `??`, so to handle `??=` I've added `@babel/plugin-proposal-logical-assignment-operators`, which also happens to handle the logical assignment operators `||=` and `&&=`.

Closes #31704

## Changelog:

[GENERAL] [FIXED] - Add detection of logical assignment operators to `react-native-babel-preset`

## Test Plan:

We started using these plugins in RNW's babel config to resolve the issue in our integrate PR.
