### PR TITLE
Fix building Android on Windows

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -8,6 +8,11 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 project(ReactAndroid)
 
+# Convert input paths to CMake format (with forward slashes)
+file(TO_CMAKE_PATH "${REACT_ANDROID_DIR}" REACT_ANDROID_DIR)
+file(TO_CMAKE_PATH "${REACT_BUILD_DIR}" REACT_BUILD_DIR)
+file(TO_CMAKE_PATH "${REACT_COMMON_DIR}" REACT_COMMON_DIR)
+
 # If you have ccache installed, we're going to honor it.
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)


### PR DESCRIPTION
## Summary:

Currently Android fails to build on Windows, because CMake cannot work with
native Windows paths that are passed to it as build arguments. This change
converts the input paths to the CMake format.

## Changelog:

[Android] [Fixed] - Fix building Android on Windows.

## Test Plan:

Build the React Native Android project on Windows. It should complete successfully.
