### PR TITLE
feat: add showsScrollIndex prop

### DIFF
--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.h
@@ -48,6 +48,7 @@
 @property (nonatomic, assign) BOOL snapToEnd;
 @property (nonatomic, copy) NSString *snapToAlignment;
 @property (nonatomic, assign) BOOL inverted;
+@property (nonatomic, assign) BOOL showsScrollIndex;
 
 // NOTE: currently these event props are only declared so we can export the
 // event names to JS - we don't call the blocks directly because scroll events

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -453,6 +453,18 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
   if ([changedProps containsObject:@"contentSize"]) {
     [self updateContentSizeIfNeeded];
   }
+  if ([changedProps containsObject:@"showsScrollIndex"]) {
+    [self updateScrollIndex];
+  }
+}
+
+- (void)updateScrollIndex
+{
+  if (!self.showsScrollIndex) {
+      self.scrollView.indexDisplayMode = UIScrollViewIndexDisplayModeAlwaysHidden;
+  } else {
+      self.scrollView.indexDisplayMode = UIScrollViewIndexDisplayModeAutomatic;
+  }
 }
 
 - (BOOL)centerContent

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
@@ -100,6 +100,7 @@ RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustsScrollIndicatorInsets, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
+RCT_EXPORT_VIEW_PROPERTY(showsScrollIndex, BOOL)
 
 // overflow is used both in css-layout as well as by react-native. In css-layout
 // we always want to treat overflow as scroll but depending on what the overflow

--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -390,4 +390,9 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
     | React.ComponentType<CellRendererProps<ItemT>>
     | null
     | undefined;
+
+  /**
+   * *(Apple TV only)* Defines if UIScrollView index should be shown when fast scrolling.
+   */
+  showsScrollIndex?: boolean | undefined;
 }

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -285,6 +285,10 @@ type OptionalProps = {|
    * The legacy implementation is no longer supported.
    */
   legacyImplementation?: empty,
+  /**
+   * *(Apple TV only)* Defines if UIScrollView index should be shown when fast scrolling.
+   */
+  showsScrollIndex?: ?boolean,
 |};
 
 export type Props = {|


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Add new prop to ScrollView that allows to hide the fast scrolling indicator for tvOS. Reference: https://developer.apple.com/documentation/uikit/uiscrollviewindexdisplaymode?language=objc

This property is also available for iOS but I didn't find any use for it. Orignially I've created a PR to `react-native-tvos` here: https://github.com/react-native-tvos/react-native-tvos/pull/553 and @douglowder suggested I should open a PR to the core repo.


## Recordings

Before (default behaviour): 

https://github.com/react-native-tvos/react-native-tvos/assets/52801365/319898ed-b874-4822-a8bb-b4165e085130

After: 

https://github.com/react-native-tvos/react-native-tvos/assets/52801365/51e5fc82-e209-41ff-9d97-b2a4f027ad56

## Changelog:

[IOS] [ADDED] - showsScrollIndex prop to manage the manner in which the index appears while the user is scrolling


## Test Plan:

Pass `showsScrollIndex={false}` to flat list and check that there is no scrolling index displayed.
