### PR TITLE
C++ Cleanup 8/N: Yoga-internal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -15,6 +15,8 @@
 #include <memory>
 #include "YogaJniException.h"
 
+#include <yoga/Yoga-internal.h>
+
 // TODO: Reconcile missing layoutContext functionality from callbacks in the C
 // API and use that
 #include <yoga/node/Node.h>

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga-internal.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga-internal.h
@@ -8,13 +8,10 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <vector>
 
 #include <yoga/Yoga.h>
-
-#include <yoga/style/CompactValue.h>
 
 YG_EXTERN_C_BEGIN
 
@@ -30,120 +27,3 @@ void YGNodeCalculateLayoutWithContext(
 void YGNodeDeallocate(YGNodeRef node);
 
 YG_EXTERN_C_END
-
-namespace facebook::yoga {
-
-inline bool isUndefined(float value) {
-  return std::isnan(value);
-}
-
-inline bool isUndefined(double value) {
-  return std::isnan(value);
-}
-
-} // namespace facebook::yoga
-
-extern const std::array<YGEdge, 4> trailing;
-extern const std::array<YGEdge, 4> leading;
-extern const YGValue YGValueUndefined;
-extern const YGValue YGValueAuto;
-extern const YGValue YGValueZero;
-
-struct YGCachedMeasurement {
-  float availableWidth;
-  float availableHeight;
-  YGMeasureMode widthMeasureMode;
-  YGMeasureMode heightMeasureMode;
-
-  float computedWidth;
-  float computedHeight;
-
-  YGCachedMeasurement()
-      : availableWidth(-1),
-        availableHeight(-1),
-        widthMeasureMode(YGMeasureModeUndefined),
-        heightMeasureMode(YGMeasureModeUndefined),
-        computedWidth(-1),
-        computedHeight(-1) {}
-
-  bool operator==(YGCachedMeasurement measurement) const {
-    using namespace facebook;
-
-    bool isEqual = widthMeasureMode == measurement.widthMeasureMode &&
-        heightMeasureMode == measurement.heightMeasureMode;
-
-    if (!yoga::isUndefined(availableWidth) ||
-        !yoga::isUndefined(measurement.availableWidth)) {
-      isEqual = isEqual && availableWidth == measurement.availableWidth;
-    }
-    if (!yoga::isUndefined(availableHeight) ||
-        !yoga::isUndefined(measurement.availableHeight)) {
-      isEqual = isEqual && availableHeight == measurement.availableHeight;
-    }
-    if (!yoga::isUndefined(computedWidth) ||
-        !yoga::isUndefined(measurement.computedWidth)) {
-      isEqual = isEqual && computedWidth == measurement.computedWidth;
-    }
-    if (!yoga::isUndefined(computedHeight) ||
-        !yoga::isUndefined(measurement.computedHeight)) {
-      isEqual = isEqual && computedHeight == measurement.computedHeight;
-    }
-
-    return isEqual;
-  }
-};
-
-// This value was chosen based on empirical data:
-// 98% of analyzed layouts require less than 8 entries.
-#define YG_MAX_CACHED_RESULT_COUNT 8
-
-namespace facebook::yoga::detail {
-
-template <size_t Size>
-class Values {
-private:
-  std::array<CompactValue, Size> values_;
-
-public:
-  Values() = default;
-  Values(const Values& other) = default;
-
-  explicit Values(const YGValue& defaultValue) noexcept {
-    values_.fill(defaultValue);
-  }
-
-  const CompactValue& operator[](size_t i) const noexcept { return values_[i]; }
-  CompactValue& operator[](size_t i) noexcept { return values_[i]; }
-
-  template <size_t I>
-  YGValue get() const noexcept {
-    return std::get<I>(values_);
-  }
-
-  template <size_t I>
-  void set(YGValue& value) noexcept {
-    std::get<I>(values_) = value;
-  }
-
-  template <size_t I>
-  void set(YGValue&& value) noexcept {
-    set<I>(value);
-  }
-
-  bool operator==(const Values& other) const noexcept {
-    for (size_t i = 0; i < Size; ++i) {
-      if (values_[i] != other.values_[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  Values& operator=(const Values& other) = default;
-};
-
-} // namespace facebook::yoga::detail
-
-static const float kDefaultFlexGrow = 0.0f;
-static const float kDefaultFlexShrink = 0.0f;
-static const float kWebDefaultFlexShrink = 1.0f;

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexDirection.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexDirection.h
@@ -43,4 +43,42 @@ inline YGFlexDirection resolveCrossDirection(
       : YGFlexDirectionColumn;
 }
 
+inline YGEdge leadingEdge(const YGFlexDirection flexDirection) {
+  switch (flexDirection) {
+    case YGFlexDirectionColumn:
+      return YGEdgeTop;
+    case YGFlexDirectionColumnReverse:
+      return YGEdgeBottom;
+    case YGFlexDirectionRow:
+      return YGEdgeLeft;
+    case YGFlexDirectionRowReverse:
+      return YGEdgeRight;
+  }
+
+  YGAssert(false, "Invalid YGFlexDirection");
+
+  // Avoid "not all control paths return a value" warning until next diff adds
+  // assert with [[noreturn]]
+  return YGEdgeTop;
+}
+
+inline YGEdge trailingEdge(const YGFlexDirection flexDirection) {
+  switch (flexDirection) {
+    case YGFlexDirectionColumn:
+      return YGEdgeBottom;
+    case YGFlexDirectionColumnReverse:
+      return YGEdgeTop;
+    case YGFlexDirectionRow:
+      return YGEdgeRight;
+    case YGFlexDirectionRowReverse:
+      return YGEdgeLeft;
+  }
+
+  YGAssert(false, "Invalid YGFlexDirection");
+
+  // Avoid "not all control paths return a value" warning until next diff adds
+  // assert with [[noreturn]]
+  return YGEdgeTop;
+}
+
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/ResolveValue.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/ResolveValue.h
@@ -8,7 +8,9 @@
 #pragma once
 
 #include <yoga/Yoga.h>
+
 #include <yoga/numeric/FloatOptional.h>
+#include <yoga/style/CompactValue.h>
 
 namespace facebook::yoga {
 

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
@@ -8,9 +8,7 @@
 #pragma once
 
 #include <yoga/Yoga.h>
-
 #include <yoga/bits/EnumBitset.h>
-#include <yoga/Yoga-internal.h>
 
 // Tag struct used to form the opaque YGConfigRef for the public C API
 struct YGConfig {};

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -13,7 +13,6 @@
 
 #include <yoga/debug/NodeToString.h>
 #include <yoga/numeric/Comparison.h>
-#include <yoga/Yoga-internal.h>
 
 namespace facebook::yoga {
 

--- a/packages/react-native/ReactCommon/yoga/yoga/node/CachedMeasurement.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/CachedMeasurement.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cmath>
+
+#include <yoga/Yoga.h>
+#include <yoga/numeric/Comparison.h>
+
+namespace facebook::yoga {
+
+struct CachedMeasurement {
+  float availableWidth{-1};
+  float availableHeight{-1};
+  YGMeasureMode widthMeasureMode{YGMeasureModeUndefined};
+  YGMeasureMode heightMeasureMode{YGMeasureModeUndefined};
+
+  float computedWidth{-1};
+  float computedHeight{-1};
+
+  bool operator==(CachedMeasurement measurement) const {
+    bool isEqual = widthMeasureMode == measurement.widthMeasureMode &&
+        heightMeasureMode == measurement.heightMeasureMode;
+
+    if (!yoga::isUndefined(availableWidth) ||
+        !yoga::isUndefined(measurement.availableWidth)) {
+      isEqual = isEqual && availableWidth == measurement.availableWidth;
+    }
+    if (!yoga::isUndefined(availableHeight) ||
+        !yoga::isUndefined(measurement.availableHeight)) {
+      isEqual = isEqual && availableHeight == measurement.availableHeight;
+    }
+    if (!yoga::isUndefined(computedWidth) ||
+        !yoga::isUndefined(measurement.computedWidth)) {
+      isEqual = isEqual && computedWidth == measurement.computedWidth;
+    }
+    if (!yoga::isUndefined(computedHeight) ||
+        !yoga::isUndefined(measurement.computedHeight)) {
+      isEqual = isEqual && computedHeight == measurement.computedHeight;
+    }
+
+    return isEqual;
+  }
+};
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cmath>
+
 #include <yoga/node/LayoutResults.h>
 #include <yoga/numeric/Comparison.h>
 
@@ -23,7 +25,8 @@ bool LayoutResults::operator==(LayoutResults layout) const {
       cachedLayout == layout.cachedLayout &&
       computedFlexBasis == layout.computedFlexBasis;
 
-  for (uint32_t i = 0; i < YG_MAX_CACHED_RESULT_COUNT && isEqual; ++i) {
+  for (uint32_t i = 0; i < LayoutResults::MaxCachedMeasurements && isEqual;
+       ++i) {
     isEqual = isEqual && cachedMeasurements[i] == layout.cachedMeasurements[i];
   }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
@@ -7,13 +7,19 @@
 
 #pragma once
 
+#include <array>
+
 #include <yoga/bits/NumericBitfield.h>
 #include <yoga/numeric/FloatOptional.h>
-#include <yoga/Yoga-internal.h>
+#include <yoga/node/CachedMeasurement.h>
 
 namespace facebook::yoga {
 
 struct LayoutResults {
+  // This value was chosen based on empirical data:
+  // 98% of analyzed layouts require less than 8 entries.
+  static constexpr int32_t MaxCachedMeasurements = 8;
+
   std::array<float, 4> position = {};
   std::array<float, 2> dimensions = {{YGUndefined, YGUndefined}};
   std::array<float, 4> margin = {};
@@ -36,11 +42,10 @@ public:
   YGDirection lastOwnerDirection = YGDirectionInherit;
 
   uint32_t nextCachedMeasurementsIndex = 0;
-  std::array<YGCachedMeasurement, YG_MAX_CACHED_RESULT_COUNT>
-      cachedMeasurements = {};
+  std::array<CachedMeasurement, MaxCachedMeasurements> cachedMeasurements = {};
   std::array<float, 2> measuredDimensions = {{YGUndefined, YGUndefined}};
 
-  YGCachedMeasurement cachedLayout = YGCachedMeasurement();
+  CachedMeasurement cachedLayout{};
 
   YGDirection direction() const {
     return getEnumData<YGDirection>(flags, directionOffset);

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -9,10 +9,10 @@
 
 #include <cstdint>
 #include <stdio.h>
+#include <vector>
+
 #include <yoga/config/Config.h>
 #include <yoga/node/LayoutResults.h>
-#include <yoga/Yoga-internal.h>
-
 #include <yoga/style/CompactValue.h>
 #include <yoga/style/Style.h>
 

--- a/packages/react-native/ReactCommon/yoga/yoga/numeric/Comparison.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/numeric/Comparison.h
@@ -15,19 +15,24 @@
 
 namespace facebook::yoga {
 
+template <typename FloatT>
+inline bool isUndefined(FloatT value) {
+  return std::isnan(value);
+}
+
 inline float maxOrDefined(const float a, const float b) {
-  if (!std::isnan(a) && !std::isnan(b)) {
+  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return fmaxf(a, b);
   }
-  return std::isnan(a) ? b : a;
+  return yoga::isUndefined(a) ? b : a;
 }
 
 inline float minOrDefined(const float a, const float b) {
-  if (!std::isnan(a) && !std::isnan(b)) {
+  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return fminf(a, b);
   }
 
-  return std::isnan(a) ? b : a;
+  return yoga::isUndefined(a) ? b : a;
 }
 
 inline FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
@@ -43,17 +48,17 @@ inline FloatOptional maxOrDefined(FloatOptional op1, FloatOptional op2) {
 // Custom equality functions using a hardcoded epsilon of 0.0001f, or returning
 // true if both floats are NaN.
 inline bool inexactEquals(const float a, const float b) {
-  if (!std::isnan(a) && !std::isnan(b)) {
+  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return fabs(a - b) < 0.0001f;
   }
-  return std::isnan(a) && std::isnan(b);
+  return yoga::isUndefined(a) && yoga::isUndefined(b);
 }
 
 inline bool inexactEquals(const double a, const double b) {
-  if (!std::isnan(a) && !std::isnan(b)) {
+  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
     return fabs(a - b) < 0.0001;
   }
-  return std::isnan(a) && std::isnan(b);
+  return yoga::isUndefined(a) && yoga::isUndefined(b);
 }
 
 inline bool inexactEquals(const YGValue& a, const YGValue& b) {
@@ -62,7 +67,7 @@ inline bool inexactEquals(const YGValue& a, const YGValue& b) {
   }
 
   if (a.unit == YGUnitUndefined ||
-      (std::isnan(a.value) && std::isnan(b.value))) {
+      (yoga::isUndefined(a.value) && yoga::isUndefined(b.value))) {
     return true;
   }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/numeric/FloatOptional.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/numeric/FloatOptional.h
@@ -9,7 +9,6 @@
 
 #include <cmath>
 #include <limits>
-#include <yoga/Yoga-internal.h>
 
 namespace facebook::yoga {
 

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -13,7 +13,6 @@
 #include <type_traits>
 
 #include <yoga/Yoga.h>
-#include <yoga/Yoga-internal.h>
 
 #include <yoga/bits/NumericBitfield.h>
 #include <yoga/numeric/FloatOptional.h>
@@ -23,12 +22,16 @@ namespace facebook::yoga {
 
 class YOGA_EXPORT Style {
   template <typename Enum>
-  using Values = detail::Values<enums::count<Enum>()>;
+  using Values = std::array<CompactValue, enums::count<Enum>()>;
 
 public:
   using Dimensions = Values<YGDimension>;
   using Edges = Values<YGEdge>;
   using Gutters = Values<YGGutter>;
+
+  static constexpr float DefaultFlexGrow = 0.0f;
+  static constexpr float DefaultFlexShrink = 0.0f;
+  static constexpr float WebDefaultFlexShrink = 1.0f;
 
   template <typename T>
   struct BitfieldRef {
@@ -112,7 +115,7 @@ private:
   Edges padding_ = {};
   Edges border_ = {};
   Gutters gap_ = {};
-  Dimensions dimensions_{CompactValue::ofAuto()};
+  Dimensions dimensions_{CompactValue::ofAuto(), CompactValue::ofAuto()};
   Dimensions minDimensions_ = {};
   Dimensions maxDimensions_ = {};
   // Yoga specific properties, not compatible with flexbox specification


### PR DESCRIPTION
Summary:
## This diff

This splits up `Yoga-internal.h` which has become a grab bag. The actual header is left, with the purpose of being a private C ABI for bindings, but everything else is moved to a place more appropriate or removed.

A few notes:
1. `yoga::isUndefined` is replaced with `std::isnan` to avoid a layer of indirection (we will never be able to change its representation anyway). Internal usages of `YGFloatIsUndefined` are also replaced with `std::isnan` since the previous being at a library boundary means I'm not sure it can be inlined/.
2. `leading`, `trailing` arrays are factored into proper functions
3. `Values` is replaced entirely with `std::array`, since most of it was unused.

## This stack

The organization of the C++ internals of Yoga are in need of attention.
1. Some of the C++ internals are namespaced, but others not.
2. Some of the namespaces include `detail`, but are meant to be used outside of the translation unit (FB Clang Tidy rules warn on any usage of these)
2. Most of the files are in a flat hierarchy, except for event tracing in its own folder
3. Some files and functions begin with YG, others don’t
4. Some functions are uppercase, others are not
5. Almost all of the interesting logic is in Yoga.cpp, and the file is too large to reason about
6. There are multiple grab bag files where folks put random functions they need in (Utils, BitUtils, Yoga-Internal.h)
7. There is no clear indication from file structure or type naming what is private vs not
8. Handles like `YGNodeRef` and `YGConfigRef` can be used to access internals just by importing headers

This stack does some much needed spring cleaning:
1. All non-public headers and C++ implementation details are in separate folders from the root level `yoga`. This will give us room to split up logic and add more files without too large a flat hierarchy
3. All private C++ internals are under the `facebook::yoga` namespace. Details namespaces are only ever used within the same header, as they are intended
4. Utils files are split
5. Most C++ internals drop the YG prefix
6. Most C++ internal function names are all lower camel case
7. We start to split up Yoga.cpp
8. Every header beginning with YG or at the top-level directory is public and C only, with the exception of Yoga-Internal.h which has non-public functions for bindings
9. It is not possible to use private APIs without static casting handles to internal classes

This will give us more leeway to continue splitting monolithic files, and consistent guidelines for style in new files as well.

These changes should not be breaking to any project using only public Yoga headers. This includes every usage of Yoga in fbsource except for RN Fabric which is currently tied to internals. This refactor should make that boundary clearer.

Reviewed By: rshest

Differential Revision: D48769241

