### PR TITLE
Add PerformanceStatsHistory to perf monitor overlay

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.java
@@ -200,6 +200,14 @@ public class DevToolsReactPerfLogger implements ReactMarker.FabricMarkerListener
     public long getBatchExecutionDuration() {
       return getBatchExecutionEnd() - getBatchExecutionStart();
     }
+
+    public String toString() {
+      StringBuilder builder = new StringBuilder("FabricCommitPoint{");
+      builder.append("mCommitNumber=").append(mCommitNumber);
+      builder.append(", mPoints=").append(mPoints);
+      builder.append('}');
+      return builder.toString();
+    }
   }
 
   public void addDevToolsReactPerfLoggerListener(DevToolsReactPerfLoggerListener listener) {
@@ -222,7 +230,7 @@ public class DevToolsReactPerfLogger implements ReactMarker.FabricMarkerListener
       }
       commitPoint.addPoint(name, timestamp);
 
-      if (name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_END) {
+      if (name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_END && timestamp > 0) {
         onFabricCommitEnd(commitPoint);
         mFabricCommitMarkers.remove(instanceKey);
       }


### PR DESCRIPTION
Summary:
This diff adds `PerformanceStatsHistory.kt` which is used to track performance stat in buckets with resolution (in ms) and size. This is to help group perf stats in a time series data structure that we can adapt to any visualization in the future.

Changelog:
[Internal] - Performance monitoring overlay improvements

Differential Revision: D48657874

