### PR TITLE
Add affected layoutable nodes counter in telemetry

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -52,6 +52,15 @@ public class ReactMarker {
   public interface FabricMarkerListener {
     void logFabricMarker(
         ReactMarkerConstants name, @Nullable String tag, int instanceKey, long timestamp);
+
+    default void logFabricMarker(
+        ReactMarkerConstants name,
+        @Nullable String tag,
+        int instanceKey,
+        long timestamp,
+        int counter) {
+      logFabricMarker(name, tag, instanceKey, timestamp);
+    }
   };
 
   // Use a list instead of a set here because we expect the number of listeners
@@ -105,9 +114,21 @@ public class ReactMarker {
   // Specific to Fabric marker listeners
   @DoNotStrip
   public static void logFabricMarker(
+      ReactMarkerConstants name,
+      @Nullable String tag,
+      int instanceKey,
+      long timestamp,
+      int counter) {
+    for (FabricMarkerListener listener : sFabricMarkerListeners) {
+      listener.logFabricMarker(name, tag, instanceKey, timestamp, counter);
+    }
+  }
+
+  @DoNotStrip
+  public static void logFabricMarker(
       ReactMarkerConstants name, @Nullable String tag, int instanceKey, long timestamp) {
     for (FabricMarkerListener listener : sFabricMarkerListeners) {
-      listener.logFabricMarker(name, tag, instanceKey, timestamp);
+      listener.logFabricMarker(name, tag, instanceKey, timestamp, 0);
     }
   }
 
@@ -115,7 +136,7 @@ public class ReactMarker {
   @DoNotStrip
   public static void logFabricMarker(
       ReactMarkerConstants name, @Nullable String tag, int instanceKey) {
-    logFabricMarker(name, tag, instanceKey, SystemClock.uptimeMillis());
+    logFabricMarker(name, tag, instanceKey, SystemClock.uptimeMillis(), 0);
   }
 
   @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.java
@@ -111,21 +111,44 @@ public class DevToolsReactPerfLogger implements ReactMarker.FabricMarkerListener
     void onFabricCommitEnd(FabricCommitPoint commitPoint);
   }
 
+  public static class FabricCommitPointData {
+    private final long mTimeStamp;
+    private final int mCounter;
+
+    public FabricCommitPointData(long timeStamp, int counter) {
+      this.mTimeStamp = timeStamp;
+      this.mCounter = counter;
+    }
+
+    public long getTimeStamp() {
+      return mTimeStamp;
+    }
+
+    public int getCounter() {
+      return mCounter;
+    }
+  }
+
   public static class FabricCommitPoint {
     private final long mCommitNumber;
-    private final Map<ReactMarkerConstants, Long> mPoints = new HashMap<>();
+    private final Map<ReactMarkerConstants, FabricCommitPointData> mPoints = new HashMap<>();
 
     private FabricCommitPoint(int commitNumber) {
       this.mCommitNumber = commitNumber;
     }
 
-    private void addPoint(ReactMarkerConstants key, long time) {
-      mPoints.put(key, time);
+    private void addPoint(ReactMarkerConstants key, FabricCommitPointData data) {
+      mPoints.put(key, data);
     }
 
-    private long getValue(ReactMarkerConstants marker) {
-      Long value = mPoints.get(marker);
-      return value != null ? value : -1;
+    private long getTimestamp(ReactMarkerConstants marker) {
+      FabricCommitPointData data = mPoints.get(marker);
+      return data != null ? data.getTimeStamp() : -1;
+    }
+
+    private int getCounter(ReactMarkerConstants marker) {
+      FabricCommitPointData data = mPoints.get(marker);
+      return data != null ? data.getCounter() : 0;
     }
 
     public long getCommitNumber() {
@@ -133,51 +156,55 @@ public class DevToolsReactPerfLogger implements ReactMarker.FabricMarkerListener
     }
 
     public long getCommitStart() {
-      return getValue(FABRIC_COMMIT_START);
+      return getTimestamp(FABRIC_COMMIT_START);
     }
 
     public long getCommitEnd() {
-      return getValue(FABRIC_COMMIT_END);
+      return getTimestamp(FABRIC_COMMIT_END);
     }
 
     public long getFinishTransactionStart() {
-      return getValue(FABRIC_FINISH_TRANSACTION_START);
+      return getTimestamp(FABRIC_FINISH_TRANSACTION_START);
     }
 
     public long getFinishTransactionEnd() {
-      return getValue(FABRIC_FINISH_TRANSACTION_END);
+      return getTimestamp(FABRIC_FINISH_TRANSACTION_END);
     }
 
     public long getDiffStart() {
-      return getValue(FABRIC_DIFF_START);
+      return getTimestamp(FABRIC_DIFF_START);
     }
 
     public long getDiffEnd() {
-      return getValue(FABRIC_DIFF_END);
+      return getTimestamp(FABRIC_DIFF_END);
     }
 
     public long getLayoutStart() {
-      return getValue(FABRIC_LAYOUT_START);
+      return getTimestamp(FABRIC_LAYOUT_START);
     }
 
     public long getLayoutEnd() {
-      return getValue(FABRIC_LAYOUT_END);
+      return getTimestamp(FABRIC_LAYOUT_END);
+    }
+
+    public int getAffectedLayoutNodesCount() {
+      return getCounter(FABRIC_LAYOUT_END);
     }
 
     public long getBatchExecutionStart() {
-      return getValue(FABRIC_BATCH_EXECUTION_START);
+      return getTimestamp(FABRIC_BATCH_EXECUTION_START);
     }
 
     public long getBatchExecutionEnd() {
-      return getValue(FABRIC_BATCH_EXECUTION_END);
+      return getTimestamp(FABRIC_BATCH_EXECUTION_END);
     }
 
     public long getUpdateUIMainThreadStart() {
-      return getValue(FABRIC_UPDATE_UI_MAIN_THREAD_START);
+      return getTimestamp(FABRIC_UPDATE_UI_MAIN_THREAD_START);
     }
 
     public long getUpdateUIMainThreadEnd() {
-      return getValue(FABRIC_UPDATE_UI_MAIN_THREAD_END);
+      return getTimestamp(FABRIC_UPDATE_UI_MAIN_THREAD_END);
     }
 
     // Duration calculations
@@ -221,6 +248,16 @@ public class DevToolsReactPerfLogger implements ReactMarker.FabricMarkerListener
   @Override
   public void logFabricMarker(
       ReactMarkerConstants name, @Nullable String tag, int instanceKey, long timestamp) {
+    logFabricMarker(name, tag, instanceKey, timestamp, 0);
+  }
+
+  @Override
+  public void logFabricMarker(
+      ReactMarkerConstants name,
+      @Nullable String tag,
+      int instanceKey,
+      long timestamp,
+      int counter) {
 
     if (isFabricCommitMarker(name)) {
       FabricCommitPoint commitPoint = mFabricCommitMarkers.get(instanceKey);
@@ -228,7 +265,7 @@ public class DevToolsReactPerfLogger implements ReactMarker.FabricMarkerListener
         commitPoint = new FabricCommitPoint(instanceKey);
         mFabricCommitMarkers.put(instanceKey, commitPoint);
       }
-      commitPoint.addPoint(name, timestamp);
+      commitPoint.addPoint(name, new FabricCommitPointData(timestamp, counter));
 
       if (name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_END && timestamp > 0) {
         onFabricCommitEnd(commitPoint);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -764,7 +764,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       long layoutStartTime,
       long layoutEndTime,
       long finishTransactionStartTime,
-      long finishTransactionEndTime) {
+      long finishTransactionEndTime,
+      int affectedLayoutNodesCount) {
     // When Binding.cpp calls scheduleMountItems during a commit phase, it always calls with
     // a BatchMountItem. No other sites call into this with a BatchMountItem, and Binding.cpp only
     // calls scheduleMountItems with a BatchMountItem.
@@ -837,7 +838,11 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       ReactMarker.logFabricMarker(
           ReactMarkerConstants.FABRIC_LAYOUT_START, null, commitNumber, layoutStartTime);
       ReactMarker.logFabricMarker(
-          ReactMarkerConstants.FABRIC_LAYOUT_END, null, commitNumber, layoutEndTime);
+          ReactMarkerConstants.FABRIC_LAYOUT_END,
+          null,
+          commitNumber,
+          layoutEndTime,
+          affectedLayoutNodesCount);
       ReactMarker.logFabricMarker(ReactMarkerConstants.FABRIC_COMMIT_END, null, commitNumber);
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -512,7 +512,8 @@ void FabricMountingManager::executeMount(
                                           jlong,
                                           jlong,
                                           jlong,
-                                          jlong)>("scheduleMountItem");
+                                          jlong,
+                                          jint)>("scheduleMountItem");
 
   if (batchMountItemIntsSize == 0) {
     auto finishTransactionEndTime = telemetryTimePointNow();
@@ -527,7 +528,8 @@ void FabricMountingManager::executeMount(
         telemetryTimePointToMilliseconds(telemetry.getLayoutStartTime()),
         telemetryTimePointToMilliseconds(telemetry.getLayoutEndTime()),
         telemetryTimePointToMilliseconds(finishTransactionStartTime),
-        telemetryTimePointToMilliseconds(finishTransactionEndTime));
+        telemetryTimePointToMilliseconds(finishTransactionEndTime),
+        telemetry.getAffectedLayoutNodesCount());
     return;
   }
 
@@ -814,7 +816,8 @@ void FabricMountingManager::executeMount(
       telemetryTimePointToMilliseconds(telemetry.getLayoutStartTime()),
       telemetryTimePointToMilliseconds(telemetry.getLayoutEndTime()),
       telemetryTimePointToMilliseconds(finishTransactionStartTime),
-      telemetryTimePointToMilliseconds(finishTransactionEndTime));
+      telemetryTimePointToMilliseconds(finishTransactionEndTime),
+      telemetry.getAffectedLayoutNodesCount());
 
   env->DeleteLocalRef(intBufferArray);
 }

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -369,7 +369,7 @@ CommitStatus ShadowTree::tryCommit(
   telemetry.setAsThreadLocal();
   newRootShadowNode->layoutIfNeeded(&affectedLayoutableNodes);
   telemetry.unsetAsThreadLocal();
-  telemetry.didLayout();
+  telemetry.didLayout(affectedLayoutableNodes.size());
 
   // Seal the shadow node so it can no longer be mutated
   newRootShadowNode->sealRecursive();

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/TransactionTelemetry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/TransactionTelemetry.cpp
@@ -84,6 +84,11 @@ void TransactionTelemetry::didLayout() {
   layoutEndTime_ = now_();
 }
 
+void TransactionTelemetry::didLayout(int affectedLayoutNodesCount) {
+  didLayout();
+  affectedLayoutNodesCount_ = affectedLayoutNodesCount;
+}
+
 void TransactionTelemetry::willMount() {
   react_native_assert(mountStartTime_ == kTelemetryUndefinedTimePoint);
   react_native_assert(mountEndTime_ == kTelemetryUndefinedTimePoint);
@@ -158,6 +163,10 @@ int TransactionTelemetry::getNumberOfTextMeasurements() const {
 
 int TransactionTelemetry::getRevisionNumber() const {
   return revisionNumber_;
+}
+
+int TransactionTelemetry::getAffectedLayoutNodesCount() const {
+  return affectedLayoutNodesCount_;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/TransactionTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/TransactionTelemetry.h
@@ -43,6 +43,7 @@ class TransactionTelemetry final {
   void willMeasureText();
   void didMeasureText();
   void didLayout();
+  void didLayout(int affectedLayoutNodesCount);
   void willMount();
   void didMount();
 
@@ -64,6 +65,8 @@ class TransactionTelemetry final {
   int getNumberOfTextMeasurements() const;
   int getRevisionNumber() const;
 
+  int getAffectedLayoutNodesCount() const;
+
  private:
   TelemetryTimePoint diffStartTime_{kTelemetryUndefinedTimePoint};
   TelemetryTimePoint diffEndTime_{kTelemetryUndefinedTimePoint};
@@ -80,6 +83,8 @@ class TransactionTelemetry final {
   int numberOfTextMeasurements_{0};
   int revisionNumber_{0};
   std::function<TelemetryTimePoint()> now_;
+
+  int affectedLayoutNodesCount_{0};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
This diff adds affected layoutable nodes count from Yoga in the telemetry for commit revision. This is used for performance monitoring next to the timestamp information we already have.

Changelog:
[Internal] - Add affected layoutable nodes count information in Fabric commit telemetry.

Differential Revision: D48671209

