### PR TITLE
Add thread idle indicator

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -441,6 +441,18 @@ public class ReactContext extends ContextWrapper {
     return Assertions.assertNotNull(mJSMessageQueueThread).runOnQueue(runnable);
   }
 
+  public @Nullable MessageQueueThread getJSMessageQueueThread() {
+    return mJSMessageQueueThread;
+  }
+
+  public @Nullable MessageQueueThread getNativeModulesMessageQueueThread() {
+    return mNativeModulesMessageQueueThread;
+  }
+
+  public @Nullable MessageQueueThread getUiMessageQueueThread() {
+    return mUiMessageQueueThread;
+  }
+
   /**
    * Passes the given exception to the current {@link JSExceptionHandler} if one exists, rethrowing
    * otherwise.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.java
@@ -69,4 +69,8 @@ public interface MessageQueueThread {
    */
   @DoNotStrip
   void resetPerfStats();
+
+  /** Returns true if the message queue is idle */
+  @DoNotStrip
+  boolean isIdle();
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadImpl.java
@@ -156,6 +156,12 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
         });
   }
 
+  @DoNotStrip
+  @Override
+  public boolean isIdle() {
+    return mLooper.getQueue().isIdle();
+  }
+
   private static void assignToPerfStats(MessageQueueThreadPerfStats stats, long wall, long cpu) {
     stats.wallTime = wall;
     stats.cpuTime = cpu;


### PR DESCRIPTION
Summary:
Add thread idle indicator to UI, JS and native modules threads to the RN perf monitor.

Changelog:
[Internal] - Add thread idle state to perf monitor

Differential Revision: D48673070

