### PR TITLE
Add missing type for TextInput.setSelection in Typescript

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -948,5 +948,5 @@ export class TextInput extends TextInputBase {
   /**
    * Sets the start and end positions of text selection.
    */
-  setSelection: (start: number, end: number) => void
+  setSelection: (start: number, end: number) => void;
 }

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -944,4 +944,9 @@ export class TextInput extends TextInputBase {
    * Removes all text from the input.
    */
   clear: () => void;
+
+  /**
+   * Sets the start and end positions of text selection.
+   */
+  setSelection: (start: number, end: number) => void
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The `setSelection` method is available in the `TextInput` implementation [here](https://github.com/blazejkustra/react-native/blob/316c19a91d2548124b04a97427cf7a13e06fca4e/packages/react-native/Libraries/Components/TextInput/TextInput.js#L1256), but the corresponding TypeScript type is currently missing. Notably, this method is included in the Flow types [here](https://github.com/blazejkustra/react-native/blob/316c19a91d2548124b04a97427cf7a13e06fca4e/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js#L944). It would be beneficial to have this method included in TypeScript types for consistency and comprehensive type support.

## Changelog:

[GENERAL] [ADDED] - Add missing type for TextInput.setSelection in Typescript

## Test Plan:

N/A
