### PR TITLE
Re-enable LayoutableShadowNodeTest inversion tests

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
@@ -9,12 +9,25 @@
 #include <react/renderer/element/Element.h>
 #include <react/renderer/element/testUtils.h>
 
-#include "TestComponent.h"
-
 using namespace facebook::react;
 
-// TODO: T127619309 re-enable CalculateTransformedFrames
-bool enableCalculateTransformedFrames = false;
+class LayoutableShadowNodeTest : public ::testing::TestWithParam<bool> {
+ public:
+  LayoutableShadowNodeTest()
+      : builder_(simpleComponentBuilder(createContextContainer())) {}
+
+  ContextContainer::Shared createContextContainer() {
+    auto contextContainer = std::make_shared<ContextContainer>();
+    contextContainer->insert("CalculateTransformedFramesEnabled", GetParam());
+    return contextContainer;
+  }
+
+  bool getCalculateTransformedFramesEnabled() {
+    return GetParam();
+  }
+
+  ComponentBuilder builder_;
+};
 
 /*
  * ┌────────┐
@@ -27,9 +40,7 @@ bool enableCalculateTransformedFrames = false;
  *     │        │
  *     └────────┘
  */
-TEST(LayoutableShadowNodeTest, relativeLayoutMetrics) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, relativeLayoutMetrics) {
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
   // clang-format off
   auto element =
@@ -52,7 +63,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetrics) {
     });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -73,9 +84,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetrics) {
  * │                   │
  * └───────────────────┘
  */
-TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnNodeWithDisplayNone) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, relativeLayoutMetricsOnNodeWithDisplayNone) {
   // clang-format off
   auto element =
     Element<ViewShadowNode>()
@@ -88,7 +97,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnNodeWithDisplayNone) {
     });
   // clang-format on
 
-  auto shadowNode = builder.build(element);
+  auto shadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -109,11 +118,9 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnNodeWithDisplayNone) {
  *     │                   │
  *     └───────────────────┘
  */
-TEST(
+TEST_P(
     LayoutableShadowNodeTest,
     relativeLayoutMetricsOnChildrenOfParentWithDisplayNone) {
-  auto builder = simpleComponentBuilder();
-
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
   // clang-format off
   auto element =
@@ -137,7 +144,7 @@ TEST(
     });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -161,11 +168,9 @@ TEST(
  *         |                  |
  *         └──────────────────┘
  */
-TEST(
+TEST_P(
     LayoutableShadowNodeTest,
     relativeLayoutMetricsOnOuterParentWithDisplayNone) {
-  auto builder = simpleComponentBuilder();
-
   auto parentShadowNode = std::shared_ptr<ViewShadowNode>{};
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
   // clang-format off
@@ -199,7 +204,7 @@ TEST(
     });
   // clang-format on
 
-  auto outerParentShadowNode = builder.build(element);
+  auto outerParentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -223,9 +228,7 @@ TEST(
  *          │         │
  *          └─────────┘
  */
-TEST(LayoutableShadowNodeTest, contentOriginOffset) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, contentOriginOffset) {
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
   // clang-format off
   auto element =
@@ -251,17 +254,21 @@ TEST(LayoutableShadowNodeTest, contentOriginOffset) {
     });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
-          childShadowNode->getFamily(), *parentShadowNode, {});
+          childShadowNode->getFamily(),
+          *parentShadowNode,
+          {/* includeTransform = */ true});
 
   EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 0);
   EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 10);
 
   relativeLayoutMetrics = LayoutableShadowNode::computeRelativeLayoutMetrics(
-      childShadowNode->getFamily(), *parentShadowNode, {false});
+      childShadowNode->getFamily(),
+      *parentShadowNode,
+      {/* includeTransform = */ false});
 
   EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 10);
   EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 20);
@@ -276,9 +283,7 @@ TEST(LayoutableShadowNodeTest, contentOriginOffset) {
  * │      └────────────────┘│
  * └────────────────────────┘
  */
-TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedNode) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedNode) {
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
   // clang-format off
   auto element =
@@ -305,7 +310,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedNode) {
     });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -333,9 +338,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedNode) {
  * │ └─────────────────────┘│
  * └────────────────────────┘
  */
-TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedParent) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedParent) {
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
   // clang-format off
   auto element =
@@ -371,7 +374,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedParent) {
     });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -400,9 +403,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedParent) {
  * │ └─────────────────────┘│
  * └────────────────────────┘
  */
-TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnParentWithClipping) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, relativeLayoutMetricsOnParentWithClipping) {
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
   // clang-format off
   auto element =
@@ -433,7 +434,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnParentWithClipping) {
     });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -468,11 +469,9 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnParentWithClipping) {
  * │ └─────────────────────┘│
  * └────────────────────────┘
  */
-TEST(
+TEST_P(
     LayoutableShadowNodeTest,
     relativeLayoutMetricsOnTransformedParentWithClipping) {
-  auto builder = simpleComponentBuilder();
-
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
   // clang-format off
   auto element =
@@ -508,7 +507,7 @@ TEST(
     });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -533,9 +532,7 @@ TEST(
  * │                │
  * └────────────────┘
  */
-TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameNode) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameNode) {
   // clang-format off
   auto element =
     Element<ViewShadowNode>()
@@ -547,7 +544,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameNode) {
     });
   // clang-format on
 
-  auto shadowNode = builder.build(element);
+  auto shadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -565,9 +562,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameNode) {
  * │                │
  * └────────────────┘
  */
-TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameTransformedNode) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameTransformedNode) {
   // clang-format off
   auto element =
     Element<ViewShadowNode>()
@@ -584,7 +579,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameTransformedNode) {
     });
   // clang-format on
 
-  auto shadowNode = builder.build(element);
+  auto shadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
@@ -605,9 +600,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnSameTransformedNode) {
  * │      └────────────────┘│
  * └────────────────────────┘
  */
-TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnClonedNode) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, relativeLayoutMetricsOnClonedNode) {
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
 
   // clang-format off
@@ -619,7 +612,7 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnClonedNode) {
       });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto clonedChildShadowNode =
       std::static_pointer_cast<ViewShadowNode>(childShadowNode->clone({}));
@@ -648,11 +641,9 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnClonedNode) {
  * │ └──────────────────────┘│
  * └─────────────────────────┘
  */
-TEST(
+TEST_P(
     LayoutableShadowNodeTest,
     relativeLayoutMetricsOnNodesCrossingRootKindNode) {
-  auto builder = simpleComponentBuilder();
-
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
 
   // clang-format off
@@ -676,18 +667,17 @@ TEST(
           })
       });
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics = LayoutableShadowNode::computeRelativeLayoutMetrics(childShadowNode->getFamily(), *parentShadowNode, {});
 
-  // relativeLayoutMetrics do not include offsset of nodeAA_ because it is a
+  // relativeLayoutMetrics do not include offset of nodeAA_ because it is a
   // RootKindNode.
   EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 10);
   EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 10);
 }
 
-TEST(LayoutableShadowNodeTest, includeViewportOffset) {
-  auto builder = simpleComponentBuilder();
+TEST_P(LayoutableShadowNodeTest, includeViewportOffset) {
 
   auto viewShadowNode = std::shared_ptr<ViewShadowNode>{};
 
@@ -705,7 +695,7 @@ TEST(LayoutableShadowNodeTest, includeViewportOffset) {
         });
   // clang-format on
 
-  auto rootShadowNode = builder.build(element);
+  auto rootShadowNode = builder_.build(element);
 
   // `includeViewportOffset` has to work with `includeTransform` enabled and
   // disabled.
@@ -738,14 +728,9 @@ TEST(LayoutableShadowNodeTest, includeViewportOffset) {
  * │└─────────────────────────────┘│
  * └───────────────────────────────┘
  */
-TEST(LayoutableShadowNodeTest, invertedVerticalView) {
-  auto builder = simpleComponentBuilder();
+TEST_P(LayoutableShadowNodeTest, invertedVerticalView) {
   auto childShadowNode1 = std::shared_ptr<ViewShadowNode>{};
   auto childShadowNode2 = std::shared_ptr<ViewShadowNode>{};
-
-  if (!enableCalculateTransformedFrames) {
-    return;
-  }
 
   // clang-format off
   auto element =
@@ -779,14 +764,19 @@ TEST(LayoutableShadowNodeTest, invertedVerticalView) {
         });
   // clang-format on
 
-  auto scrollShadowNode = builder.build(element);
+  auto scrollShadowNode = builder_.build(element);
 
   auto firstItemRelativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode1->getFamily(), *scrollShadowNode, {});
 
+  if (getCalculateTransformedFramesEnabled()) {
+    EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.y, 0);
+  } else {
+    EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.y, 100);
+  }
+
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.x, 0);
-  EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.y, 100);
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.size.width, 100);
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.size.height, 100);
 
@@ -794,8 +784,13 @@ TEST(LayoutableShadowNodeTest, invertedVerticalView) {
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode2->getFamily(), *scrollShadowNode, {});
 
+  if (getCalculateTransformedFramesEnabled()) {
+    EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.origin.y, 100);
+  } else {
+    EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.origin.y, 0);
+  }
+
   EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.origin.x, 0);
-  EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.origin.y, 0);
   EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.size.width, 100);
   EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.size.height, 100);
 }
@@ -818,14 +813,9 @@ TEST(LayoutableShadowNodeTest, invertedVerticalView) {
  * │ └───────────────────────────────┘  │
  * └────────────────────────────────────┘
  */
-TEST(LayoutableShadowNodeTest, nestedInvertedVerticalView) {
-  auto builder = simpleComponentBuilder();
+TEST_P(LayoutableShadowNodeTest, nestedInvertedVerticalView) {
   auto childShadowNode1 = std::shared_ptr<ViewShadowNode>{};
   auto childShadowNode2 = std::shared_ptr<ViewShadowNode>{};
-
-  if (!enableCalculateTransformedFrames) {
-    return;
-  }
 
   // clang-format off
   auto element =
@@ -868,14 +858,19 @@ TEST(LayoutableShadowNodeTest, nestedInvertedVerticalView) {
       });
   // clang-format on
 
-  auto scrollShadowNode = builder.build(element);
+  auto scrollShadowNode = builder_.build(element);
 
   auto firstItemRelativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode1->getFamily(), *scrollShadowNode, {});
 
+  if (getCalculateTransformedFramesEnabled()) {
+    EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.y, 50);
+  } else {
+    EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.y, 250);
+  }
+
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.x, 100);
-  EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.y, 250);
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.size.width, 100);
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.size.height, 100);
 
@@ -899,14 +894,9 @@ TEST(LayoutableShadowNodeTest, nestedInvertedVerticalView) {
  * │└─────────────────┘└─────────────────┘│
  * └──────────────────────────────────────┘
  */
-TEST(LayoutableShadowNodeTest, invertedHorizontalView) {
-  auto builder = simpleComponentBuilder();
+TEST_P(LayoutableShadowNodeTest, invertedHorizontalView) {
   auto childShadowNode1 = std::shared_ptr<ViewShadowNode>{};
   auto childShadowNode2 = std::shared_ptr<ViewShadowNode>{};
-
-  if (!enableCalculateTransformedFrames) {
-    return;
-  }
 
   // clang-format off
   auto element =
@@ -940,13 +930,19 @@ TEST(LayoutableShadowNodeTest, invertedHorizontalView) {
         });
   // clang-format on
 
-  auto scrollShadowNode = builder.build(element);
+  auto scrollShadowNode = builder_.build(element);
 
   auto firstItemRelativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode1->getFamily(), *scrollShadowNode, {});
 
-  EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.x, 100);
+  if (getCalculateTransformedFramesEnabled()) {
+    EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.x, 0);
+  } else {
+    // Incorrect legacy behaviour
+    EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.x, 100);
+  }
+
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.y, 0);
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.size.width, 100);
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.size.height, 100);
@@ -954,8 +950,12 @@ TEST(LayoutableShadowNodeTest, invertedHorizontalView) {
   auto secondItemRelativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode2->getFamily(), *scrollShadowNode, {});
-
-  EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.origin.x, 0);
+  if (getCalculateTransformedFramesEnabled()) {
+    EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.origin.x, 100);
+  } else {
+    // Incorrect legacy behaviour
+    EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.origin.x, 0);
+  }
   EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.origin.y, 0);
   EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.size.width, 100);
   EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.size.height, 100);
@@ -975,14 +975,9 @@ TEST(LayoutableShadowNodeTest, invertedHorizontalView) {
  * │ └──────────────────────────────────────┘ │
  * └──────────────────────────────────────────┘
  */
-TEST(LayoutableShadowNodeTest, nestedInvertedHorizontalView) {
-  auto builder = simpleComponentBuilder();
+TEST_P(LayoutableShadowNodeTest, nestedInvertedHorizontalView) {
   auto childShadowNode1 = std::shared_ptr<ViewShadowNode>{};
   auto childShadowNode2 = std::shared_ptr<ViewShadowNode>{};
-
-  if (!enableCalculateTransformedFrames) {
-    return;
-  }
 
   // clang-format off
   auto element =
@@ -1025,13 +1020,18 @@ TEST(LayoutableShadowNodeTest, nestedInvertedHorizontalView) {
       });
   // clang-format on
 
-  auto scrollShadowNode = builder.build(element);
+  auto scrollShadowNode = builder_.build(element);
 
   auto firstItemRelativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode1->getFamily(), *scrollShadowNode, {});
 
-  EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.x, 250);
+  if (getCalculateTransformedFramesEnabled()) {
+    EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.x, 50);
+  } else {
+    // Incorrect legacy behaviour
+    EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.x, 250);
+  }
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.origin.y, 100);
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.size.width, 100);
   EXPECT_EQ(firstItemRelativeLayoutMetrics.frame.size.height, 100);
@@ -1046,14 +1046,8 @@ TEST(LayoutableShadowNodeTest, nestedInvertedHorizontalView) {
   EXPECT_EQ(secondItemRelativeLayoutMetrics.frame.size.height, 100);
 }
 
-TEST(LayoutableShadowNodeTest, inversedContentOriginOffset) {
-  auto builder = simpleComponentBuilder();
-
+TEST_P(LayoutableShadowNodeTest, inversedContentOriginOffset) {
   auto childShadowNode = std::shared_ptr<ViewShadowNode>{};
-
-  if (!enableCalculateTransformedFrames) {
-    return;
-  }
 
   // clang-format off
   auto element =
@@ -1083,12 +1077,23 @@ TEST(LayoutableShadowNodeTest, inversedContentOriginOffset) {
     });
   // clang-format on
 
-  auto parentShadowNode = builder.build(element);
+  auto parentShadowNode = builder_.build(element);
 
   auto relativeLayoutMetrics =
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode->getFamily(), *parentShadowNode, {});
 
-  EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 180);
-  EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 130);
+  if (getCalculateTransformedFramesEnabled()) {
+    EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 20);
+    EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 20);
+  } else {
+    // Incorrect legacy behaviour
+    EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 160);
+    EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 90);
+  }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    CalculateTransformedFrames,
+    LayoutableShadowNodeTest,
+    testing::Values(false, true));

--- a/packages/react-native/ReactCommon/react/renderer/element/testUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/testUtils.h
@@ -19,12 +19,14 @@
 
 namespace facebook::react {
 
-inline ComponentBuilder simpleComponentBuilder() {
+inline ComponentBuilder simpleComponentBuilder(
+    ContextContainer::Shared contextContainer = nullptr) {
   ComponentDescriptorProviderRegistry componentDescriptorProviderRegistry{};
   auto eventDispatcher = EventDispatcher::Shared{};
   auto componentDescriptorRegistry =
       componentDescriptorProviderRegistry.createComponentDescriptorRegistry(
-          ComponentDescriptorParameters{eventDispatcher, nullptr, nullptr});
+          ComponentDescriptorParameters{
+              eventDispatcher, std::move(contextContainer), nullptr});
 
   componentDescriptorProviderRegistry.add(
       concreteComponentDescriptorProvider<RootComponentDescriptor>());


### PR DESCRIPTION
Summary:
Some tests were not running because they were disabled when experiment with `enableCalculateTransformedFrames`. Instead, run tests against both variants of the experiment so differences can be better understood.

Changelog: [Internal]

Differential Revision: D48826739

