### PR TITLE
Fix bad formatting of generated C++ code

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -320,7 +320,8 @@ struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
     }
   }
 };
-  #pragma mark - NativeEnumTurboModuleBaseStateType
+  
+#pragma mark - NativeEnumTurboModuleBaseStateType
 
 template <typename P0>
 struct NativeEnumTurboModuleBaseStateType {
@@ -348,14 +349,15 @@ struct NativeEnumTurboModuleBaseStateTypeBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const NativeEnumTurboModuleBaseStateType<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const NativeEnumTurboModuleBaseStateType<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
+    return result;
+  }
+};
+
 
 
 #pragma mark - NativeEnumTurboModuleBaseStateTypeWithEnums
@@ -391,33 +393,37 @@ struct NativeEnumTurboModuleBaseStateTypeWithEnumsBridging {
   static jsi::String stateToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String regularToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String strToJs(jsi::Runtime &rt, P2 value) {
     return bridging::toJs(rt, value);
   }
+
   static int numToJs(jsi::Runtime &rt, P3 value) {
     return bridging::toJs(rt, value);
   }
+
   static double fractionToJs(jsi::Runtime &rt, P4 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const NativeEnumTurboModuleBaseStateTypeWithEnums<P0, P1, P2, P3, P4> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
+      jsi::Runtime &rt,
+      const NativeEnumTurboModuleBaseStateTypeWithEnums<P0, P1, P2, P3, P4> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
     result.setProperty(rt, \\"regular\\", bridging::toJs(rt, value.regular, jsInvoker));
     result.setProperty(rt, \\"str\\", bridging::toJs(rt, value.str, jsInvoker));
     result.setProperty(rt, \\"num\\", bridging::toJs(rt, value.num, jsInvoker));
     result.setProperty(rt, \\"fraction\\", bridging::toJs(rt, value.fraction, jsInvoker));
-          return result;
-        }
-      };
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeEnumTurboModuleCxxSpecJSI : public TurboModule {
 protected:
@@ -784,7 +790,8 @@ private:
 };
 
 
-  #pragma mark - NativePartialAnnotationTurboModuleBaseSomeObj
+  
+#pragma mark - NativePartialAnnotationTurboModuleBaseSomeObj
 
 template <typename P0, typename P1>
 struct NativePartialAnnotationTurboModuleBaseSomeObj {
@@ -811,23 +818,24 @@ struct NativePartialAnnotationTurboModuleBaseSomeObjBridging {
   static jsi::String aToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static bool bToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const NativePartialAnnotationTurboModuleBaseSomeObj<P0, P1> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"a\\", bridging::toJs(rt, value.a, jsInvoker));
+      jsi::Runtime &rt,
+      const NativePartialAnnotationTurboModuleBaseSomeObj<P0, P1> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"a\\", bridging::toJs(rt, value.a, jsInvoker));
     if (value.b) {
-            result.setProperty(rt, \\"b\\", bridging::toJs(rt, value.b.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      result.setProperty(rt, \\"b\\", bridging::toJs(rt, value.b.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT NativePartialAnnotationTurboModuleCxxSpecJSI : public TurboModule {
 protected:
@@ -957,7 +965,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleBaseAnimal
+  
+#pragma mark - SampleTurboModuleBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleBaseAnimal {
@@ -985,14 +994,14 @@ struct SampleTurboModuleBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleCxxSpecJSI : public TurboModule {
 protected:
@@ -1148,7 +1157,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleArraysBaseAnimal
+  
+#pragma mark - SampleTurboModuleArraysBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleArraysBaseAnimal {
@@ -1176,14 +1186,14 @@ struct SampleTurboModuleArraysBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleArraysBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleArraysBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleArraysCxxSpecJSI : public TurboModule {
 protected:
@@ -1339,7 +1349,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleNullableBaseAnimal
+  
+#pragma mark - SampleTurboModuleNullableBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleNullableBaseAnimal {
@@ -1367,14 +1378,14 @@ struct SampleTurboModuleNullableBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleNullableBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleNullableBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleNullableCxxSpecJSI : public TurboModule {
 protected:
@@ -1530,7 +1541,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleNullableAndOptionalBaseAnimal
+  
+#pragma mark - SampleTurboModuleNullableAndOptionalBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleNullableAndOptionalBaseAnimal {
@@ -1558,16 +1570,16 @@ struct SampleTurboModuleNullableAndOptionalBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleNullableAndOptionalBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          if (value.name) {
-            result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleNullableAndOptionalBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.name) {
+      result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI : public TurboModule {
 protected:
@@ -1723,7 +1735,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleOptionalBaseAnimal
+  
+#pragma mark - SampleTurboModuleOptionalBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleOptionalBaseAnimal {
@@ -1751,16 +1764,16 @@ struct SampleTurboModuleOptionalBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleOptionalBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          if (value.name) {
-            result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleOptionalBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.name) {
+      result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleOptionalCxxSpecJSI : public TurboModule {
 protected:
@@ -2295,7 +2308,8 @@ struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
     }
   }
 };
-  #pragma mark - NativeEnumTurboModuleBaseStateType
+  
+#pragma mark - NativeEnumTurboModuleBaseStateType
 
 template <typename P0>
 struct NativeEnumTurboModuleBaseStateType {
@@ -2323,14 +2337,15 @@ struct NativeEnumTurboModuleBaseStateTypeBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const NativeEnumTurboModuleBaseStateType<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const NativeEnumTurboModuleBaseStateType<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
+    return result;
+  }
+};
+
 
 
 #pragma mark - NativeEnumTurboModuleBaseStateTypeWithEnums
@@ -2366,33 +2381,37 @@ struct NativeEnumTurboModuleBaseStateTypeWithEnumsBridging {
   static jsi::String stateToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String regularToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String strToJs(jsi::Runtime &rt, P2 value) {
     return bridging::toJs(rt, value);
   }
+
   static int numToJs(jsi::Runtime &rt, P3 value) {
     return bridging::toJs(rt, value);
   }
+
   static double fractionToJs(jsi::Runtime &rt, P4 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const NativeEnumTurboModuleBaseStateTypeWithEnums<P0, P1, P2, P3, P4> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
+      jsi::Runtime &rt,
+      const NativeEnumTurboModuleBaseStateTypeWithEnums<P0, P1, P2, P3, P4> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
     result.setProperty(rt, \\"regular\\", bridging::toJs(rt, value.regular, jsInvoker));
     result.setProperty(rt, \\"str\\", bridging::toJs(rt, value.str, jsInvoker));
     result.setProperty(rt, \\"num\\", bridging::toJs(rt, value.num, jsInvoker));
     result.setProperty(rt, \\"fraction\\", bridging::toJs(rt, value.fraction, jsInvoker));
-          return result;
-        }
-      };
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeEnumTurboModuleCxxSpecJSI : public TurboModule {
 protected:
@@ -2759,7 +2778,8 @@ private:
 };
 
 
-  #pragma mark - NativePartialAnnotationTurboModuleBaseSomeObj
+  
+#pragma mark - NativePartialAnnotationTurboModuleBaseSomeObj
 
 template <typename P0, typename P1>
 struct NativePartialAnnotationTurboModuleBaseSomeObj {
@@ -2786,23 +2806,24 @@ struct NativePartialAnnotationTurboModuleBaseSomeObjBridging {
   static jsi::String aToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static bool bToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const NativePartialAnnotationTurboModuleBaseSomeObj<P0, P1> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"a\\", bridging::toJs(rt, value.a, jsInvoker));
+      jsi::Runtime &rt,
+      const NativePartialAnnotationTurboModuleBaseSomeObj<P0, P1> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"a\\", bridging::toJs(rt, value.a, jsInvoker));
     if (value.b) {
-            result.setProperty(rt, \\"b\\", bridging::toJs(rt, value.b.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      result.setProperty(rt, \\"b\\", bridging::toJs(rt, value.b.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT NativePartialAnnotationTurboModuleCxxSpecJSI : public TurboModule {
 protected:
@@ -2932,7 +2953,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleBaseAnimal
+  
+#pragma mark - SampleTurboModuleBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleBaseAnimal {
@@ -2960,14 +2982,14 @@ struct SampleTurboModuleBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleCxxSpecJSI : public TurboModule {
 protected:
@@ -3123,7 +3145,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleArraysBaseAnimal
+  
+#pragma mark - SampleTurboModuleArraysBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleArraysBaseAnimal {
@@ -3151,14 +3174,14 @@ struct SampleTurboModuleArraysBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleArraysBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleArraysBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleArraysCxxSpecJSI : public TurboModule {
 protected:
@@ -3314,7 +3337,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleNullableBaseAnimal
+  
+#pragma mark - SampleTurboModuleNullableBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleNullableBaseAnimal {
@@ -3342,14 +3366,14 @@ struct SampleTurboModuleNullableBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleNullableBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleNullableBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleNullableCxxSpecJSI : public TurboModule {
 protected:
@@ -3505,7 +3529,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleNullableAndOptionalBaseAnimal
+  
+#pragma mark - SampleTurboModuleNullableAndOptionalBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleNullableAndOptionalBaseAnimal {
@@ -3533,16 +3558,16 @@ struct SampleTurboModuleNullableAndOptionalBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleNullableAndOptionalBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          if (value.name) {
-            result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleNullableAndOptionalBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.name) {
+      result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI : public TurboModule {
 protected:
@@ -3698,7 +3723,8 @@ private:
 };
 
 
-  #pragma mark - SampleTurboModuleOptionalBaseAnimal
+  
+#pragma mark - SampleTurboModuleOptionalBaseAnimal
 
 template <typename P0>
 struct SampleTurboModuleOptionalBaseAnimal {
@@ -3726,16 +3752,16 @@ struct SampleTurboModuleOptionalBaseAnimalBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleOptionalBaseAnimal<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          if (value.name) {
-            result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleOptionalBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.name) {
+      result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleOptionalCxxSpecJSI : public TurboModule {
 protected:

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -296,7 +296,8 @@ struct Bridging<SampleTurboModuleCxxStringEnum> {
     }
   }
 };
-  #pragma mark - SampleTurboModuleCxxBaseObjectAlias
+  
+#pragma mark - SampleTurboModuleCxxBaseObjectAlias
 
 template <typename P0>
 struct SampleTurboModuleCxxBaseObjectAlias {
@@ -324,14 +325,14 @@ struct SampleTurboModuleCxxBaseObjectAliasBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const SampleTurboModuleCxxBaseObjectAlias<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"x\\", bridging::toJs(rt, value.x, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const SampleTurboModuleCxxBaseObjectAlias<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"x\\", bridging::toJs(rt, value.x, jsInvoker));
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeSampleTurboModuleCxxSpecJSI : public TurboModule {
 protected:
@@ -504,7 +505,8 @@ namespace facebook {
 namespace react {
 
 
-  #pragma mark - AliasTurboModuleBaseOptions
+  
+#pragma mark - AliasTurboModuleBaseOptions
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct AliasTurboModuleBaseOptions {
@@ -537,39 +539,43 @@ struct AliasTurboModuleBaseOptionsBridging {
   static jsi::Object offsetToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::Object sizeToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::Object displaySizeToJs(jsi::Runtime &rt, P2 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String resizeModeToJs(jsi::Runtime &rt, P3 value) {
     return bridging::toJs(rt, value);
   }
+
   static bool allowExternalStorageToJs(jsi::Runtime &rt, P4 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const AliasTurboModuleBaseOptions<P0, P1, P2, P3, P4> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"offset\\", bridging::toJs(rt, value.offset, jsInvoker));
+      jsi::Runtime &rt,
+      const AliasTurboModuleBaseOptions<P0, P1, P2, P3, P4> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"offset\\", bridging::toJs(rt, value.offset, jsInvoker));
     result.setProperty(rt, \\"size\\", bridging::toJs(rt, value.size, jsInvoker));
     if (value.displaySize) {
-            result.setProperty(rt, \\"displaySize\\", bridging::toJs(rt, value.displaySize.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"displaySize\\", bridging::toJs(rt, value.displaySize.value(), jsInvoker));
+    }
     if (value.resizeMode) {
-            result.setProperty(rt, \\"resizeMode\\", bridging::toJs(rt, value.resizeMode.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"resizeMode\\", bridging::toJs(rt, value.resizeMode.value(), jsInvoker));
+    }
     if (value.allowExternalStorage) {
-            result.setProperty(rt, \\"allowExternalStorage\\", bridging::toJs(rt, value.allowExternalStorage.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      result.setProperty(rt, \\"allowExternalStorage\\", bridging::toJs(rt, value.allowExternalStorage.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT AliasTurboModuleCxxSpecJSI : public TurboModule {
 protected:
@@ -651,7 +657,8 @@ namespace facebook {
 namespace react {
 
 
-  #pragma mark - CameraRollManagerBasePhotoIdentifierImage
+  
+#pragma mark - CameraRollManagerBasePhotoIdentifierImage
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
 struct CameraRollManagerBasePhotoIdentifierImage {
@@ -686,39 +693,45 @@ struct CameraRollManagerBasePhotoIdentifierImageBridging {
   static jsi::String uriToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static double playableDurationToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
+
   static double widthToJs(jsi::Runtime &rt, P2 value) {
     return bridging::toJs(rt, value);
   }
+
   static double heightToJs(jsi::Runtime &rt, P3 value) {
     return bridging::toJs(rt, value);
   }
+
   static bool isStoredToJs(jsi::Runtime &rt, P4 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String filenameToJs(jsi::Runtime &rt, P5 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const CameraRollManagerBasePhotoIdentifierImage<P0, P1, P2, P3, P4, P5> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"uri\\", bridging::toJs(rt, value.uri, jsInvoker));
+      jsi::Runtime &rt,
+      const CameraRollManagerBasePhotoIdentifierImage<P0, P1, P2, P3, P4, P5> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"uri\\", bridging::toJs(rt, value.uri, jsInvoker));
     result.setProperty(rt, \\"playableDuration\\", bridging::toJs(rt, value.playableDuration, jsInvoker));
     result.setProperty(rt, \\"width\\", bridging::toJs(rt, value.width, jsInvoker));
     result.setProperty(rt, \\"height\\", bridging::toJs(rt, value.height, jsInvoker));
     if (value.isStored) {
-            result.setProperty(rt, \\"isStored\\", bridging::toJs(rt, value.isStored.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"isStored\\", bridging::toJs(rt, value.isStored.value(), jsInvoker));
+    }
     result.setProperty(rt, \\"filename\\", bridging::toJs(rt, value.filename, jsInvoker));
-          return result;
-        }
-      };
+    return result;
+  }
+};
+
 
 
 #pragma mark - CameraRollManagerBasePhotoIdentifier
@@ -749,14 +762,15 @@ struct CameraRollManagerBasePhotoIdentifierBridging {
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const CameraRollManagerBasePhotoIdentifier<P0> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"node\\", bridging::toJs(rt, value.node, jsInvoker));
-          return result;
-        }
-      };
+      jsi::Runtime &rt,
+      const CameraRollManagerBasePhotoIdentifier<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"node\\", bridging::toJs(rt, value.node, jsInvoker));
+    return result;
+  }
+};
+
 
 
 #pragma mark - CameraRollManagerBasePhotoIdentifiersPage
@@ -786,21 +800,23 @@ struct CameraRollManagerBasePhotoIdentifiersPageBridging {
   static jsi::Array edgesToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::Object page_infoToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const CameraRollManagerBasePhotoIdentifiersPage<P0, P1> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"edges\\", bridging::toJs(rt, value.edges, jsInvoker));
+      jsi::Runtime &rt,
+      const CameraRollManagerBasePhotoIdentifiersPage<P0, P1> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"edges\\", bridging::toJs(rt, value.edges, jsInvoker));
     result.setProperty(rt, \\"page_info\\", bridging::toJs(rt, value.page_info, jsInvoker));
-          return result;
-        }
-      };
+    return result;
+  }
+};
+
 
 
 #pragma mark - CameraRollManagerBaseGetPhotosParams
@@ -840,53 +856,59 @@ struct CameraRollManagerBaseGetPhotosParamsBridging {
   static double firstToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String afterToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String groupNameToJs(jsi::Runtime &rt, P2 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String groupTypesToJs(jsi::Runtime &rt, P3 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String assetTypeToJs(jsi::Runtime &rt, P4 value) {
     return bridging::toJs(rt, value);
   }
+
   static double maxSizeToJs(jsi::Runtime &rt, P5 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::Array mimeTypesToJs(jsi::Runtime &rt, P6 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const CameraRollManagerBaseGetPhotosParams<P0, P1, P2, P3, P4, P5, P6> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"first\\", bridging::toJs(rt, value.first, jsInvoker));
+      jsi::Runtime &rt,
+      const CameraRollManagerBaseGetPhotosParams<P0, P1, P2, P3, P4, P5, P6> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"first\\", bridging::toJs(rt, value.first, jsInvoker));
     if (value.after) {
-            result.setProperty(rt, \\"after\\", bridging::toJs(rt, value.after.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"after\\", bridging::toJs(rt, value.after.value(), jsInvoker));
+    }
     if (value.groupName) {
-            result.setProperty(rt, \\"groupName\\", bridging::toJs(rt, value.groupName.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"groupName\\", bridging::toJs(rt, value.groupName.value(), jsInvoker));
+    }
     if (value.groupTypes) {
-            result.setProperty(rt, \\"groupTypes\\", bridging::toJs(rt, value.groupTypes.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"groupTypes\\", bridging::toJs(rt, value.groupTypes.value(), jsInvoker));
+    }
     if (value.assetType) {
-            result.setProperty(rt, \\"assetType\\", bridging::toJs(rt, value.assetType.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"assetType\\", bridging::toJs(rt, value.assetType.value(), jsInvoker));
+    }
     if (value.maxSize) {
-            result.setProperty(rt, \\"maxSize\\", bridging::toJs(rt, value.maxSize.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"maxSize\\", bridging::toJs(rt, value.maxSize.value(), jsInvoker));
+    }
     if (value.mimeTypes) {
-            result.setProperty(rt, \\"mimeTypes\\", bridging::toJs(rt, value.mimeTypes.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      result.setProperty(rt, \\"mimeTypes\\", bridging::toJs(rt, value.mimeTypes.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeCameraRollManagerCxxSpecJSI : public TurboModule {
 protected:
@@ -961,7 +983,8 @@ private:
 };
 
 
-  #pragma mark - ExceptionsManagerBaseStackFrame
+  
+#pragma mark - ExceptionsManagerBaseStackFrame
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct ExceptionsManagerBaseStackFrame {
@@ -994,39 +1017,44 @@ struct ExceptionsManagerBaseStackFrameBridging {
   static double columnToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String fileToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
+
   static double lineNumberToJs(jsi::Runtime &rt, P2 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String methodNameToJs(jsi::Runtime &rt, P3 value) {
     return bridging::toJs(rt, value);
   }
+
   static bool collapseToJs(jsi::Runtime &rt, P4 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const ExceptionsManagerBaseStackFrame<P0, P1, P2, P3, P4> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          if (value.column) {
-            result.setProperty(rt, \\"column\\", bridging::toJs(rt, value.column.value(), jsInvoker));
-          }
+      jsi::Runtime &rt,
+      const ExceptionsManagerBaseStackFrame<P0, P1, P2, P3, P4> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.column) {
+      result.setProperty(rt, \\"column\\", bridging::toJs(rt, value.column.value(), jsInvoker));
+    }
     result.setProperty(rt, \\"file\\", bridging::toJs(rt, value.file, jsInvoker));
     if (value.lineNumber) {
-            result.setProperty(rt, \\"lineNumber\\", bridging::toJs(rt, value.lineNumber.value(), jsInvoker));
-          }
+      result.setProperty(rt, \\"lineNumber\\", bridging::toJs(rt, value.lineNumber.value(), jsInvoker));
+    }
     result.setProperty(rt, \\"methodName\\", bridging::toJs(rt, value.methodName, jsInvoker));
     if (value.collapse) {
-            result.setProperty(rt, \\"collapse\\", bridging::toJs(rt, value.collapse.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      result.setProperty(rt, \\"collapse\\", bridging::toJs(rt, value.collapse.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
 
 
 #pragma mark - ExceptionsManagerBaseExceptionData
@@ -1068,35 +1096,42 @@ struct ExceptionsManagerBaseExceptionDataBridging {
   static jsi::String messageToJs(jsi::Runtime &rt, P0 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String originalMessageToJs(jsi::Runtime &rt, P1 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String nameToJs(jsi::Runtime &rt, P2 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::String componentStackToJs(jsi::Runtime &rt, P3 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::Array stackToJs(jsi::Runtime &rt, P4 value) {
     return bridging::toJs(rt, value);
   }
+
   static double idToJs(jsi::Runtime &rt, P5 value) {
     return bridging::toJs(rt, value);
   }
+
   static bool isFatalToJs(jsi::Runtime &rt, P6 value) {
     return bridging::toJs(rt, value);
   }
+
   static jsi::Object extraDataToJs(jsi::Runtime &rt, P7 value) {
     return bridging::toJs(rt, value);
   }
 #endif
 
   static jsi::Object toJs(
-    jsi::Runtime &rt,
-    const ExceptionsManagerBaseExceptionData<P0, P1, P2, P3, P4, P5, P6, P7> &value,
-    const std::shared_ptr<CallInvoker> &jsInvoker) {
-      auto result = facebook::jsi::Object(rt);
-          result.setProperty(rt, \\"message\\", bridging::toJs(rt, value.message, jsInvoker));
+      jsi::Runtime &rt,
+      const ExceptionsManagerBaseExceptionData<P0, P1, P2, P3, P4, P5, P6, P7> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"message\\", bridging::toJs(rt, value.message, jsInvoker));
     result.setProperty(rt, \\"originalMessage\\", bridging::toJs(rt, value.originalMessage, jsInvoker));
     result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
     result.setProperty(rt, \\"componentStack\\", bridging::toJs(rt, value.componentStack, jsInvoker));
@@ -1104,11 +1139,11 @@ struct ExceptionsManagerBaseExceptionDataBridging {
     result.setProperty(rt, \\"id\\", bridging::toJs(rt, value.id, jsInvoker));
     result.setProperty(rt, \\"isFatal\\", bridging::toJs(rt, value.isFatal, jsInvoker));
     if (value.extraData) {
-            result.setProperty(rt, \\"extraData\\", bridging::toJs(rt, value.extraData.value(), jsInvoker));
-          }
-          return result;
-        }
-      };
+      result.setProperty(rt, \\"extraData\\", bridging::toJs(rt, value.extraData.value(), jsInvoker));
+    }
+    return result;
+  }
+};
 
 class JSI_EXPORT NativeExceptionsManagerCxxSpecJSI : public TurboModule {
 protected:


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

Some of the generated C++ code was badly formatted - even though it's normally not supposed to be read by humans, sometimes it's still useful/needed, so it helps when it's more readable.

Differential Revision: D48827010

