### PR TITLE
Consistent QualifierAlignment

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -43,11 +43,11 @@ RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClas
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutorFactory(
     RCTBridge *bridge,
     RCTTurboModuleManager *turboModuleManager,
-    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler);
+    const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler);
 #else
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactoryForOldArch(
     RCTBridge *bridge,
-    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler);
+    const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler);
 #endif
 
 #endif // __cplusplus

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -108,7 +108,7 @@ id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass)
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutorFactory(
     RCTBridge *bridge,
     RCTTurboModuleManager *turboModuleManager,
-    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler)
+    const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler)
 {
   // Necessary to allow NativeModules to lookup TurboModules
   [bridge setRCTTurboModuleRegistry:turboModuleManager];
@@ -144,7 +144,7 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
 
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactoryForOldArch(
     RCTBridge *bridge,
-    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler)
+    const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler)
 {
 #if RCT_USE_HERMES
   return std::make_unique<facebook::react::HermesExecutorFactory>(

--- a/packages/react-native/Libraries/IntersectionObserver/NativeIntersectionObserver.cpp
+++ b/packages/react-native/Libraries/IntersectionObserver/NativeIntersectionObserver.cpp
@@ -66,7 +66,7 @@ NativeIntersectionObserver::takeRecords(jsi::Runtime &runtime) {
   std::vector<NativeIntersectionObserverEntry> nativeModuleEntries;
   nativeModuleEntries.reserve(entries.size());
 
-  for (auto const &entry : entries) {
+  for (const auto &entry : entries) {
     nativeModuleEntries.emplace_back(
         convertToNativeModuleEntry(entry, runtime));
   }

--- a/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.cpp
+++ b/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.cpp
@@ -73,7 +73,7 @@ void NativeMutationObserver::connect(
 
   // This should always be called from the JS thread, as it's unsafe to call
   // into JS otherwise (via `getPublicInstanceFromInstanceHandle`).
-  getPublicInstanceFromShadowNode_ = [&](ShadowNode const &shadowNode) {
+  getPublicInstanceFromShadowNode_ = [&](const ShadowNode &shadowNode) {
     auto instanceHandle = shadowNode.getInstanceHandle(runtime);
     if (!instanceHandle.isObject() ||
         !getPublicInstanceFromInstanceHandle_.isObject() ||
@@ -88,7 +88,7 @@ void NativeMutationObserver::connect(
 
   notifyMutationObservers_ = std::move(notifyMutationObservers);
 
-  auto onMutationsCallback = [&](std::vector<MutationRecord const> &records) {
+  auto onMutationsCallback = [&](std::vector<const MutationRecord> &records) {
     return onMutations(records);
   };
 
@@ -114,11 +114,11 @@ std::vector<NativeMutationRecord> NativeMutationObserver::takeRecords(
 
 std::vector<jsi::Value>
 NativeMutationObserver::getPublicInstancesFromShadowNodes(
-    std::vector<ShadowNode::Shared> const &shadowNodes) const {
+    const std::vector<ShadowNode::Shared> &shadowNodes) const {
   std::vector<jsi::Value> publicInstances;
   publicInstances.reserve(shadowNodes.size());
 
-  for (auto const &shadowNode : shadowNodes) {
+  for (const auto &shadowNode : shadowNodes) {
     publicInstances.push_back(getPublicInstanceFromShadowNode_(*shadowNode));
   }
 
@@ -129,7 +129,7 @@ void NativeMutationObserver::onMutations(
     std::vector<const MutationRecord> &records) {
   SystraceSection s("NativeMutationObserver::onMutations");
 
-  for (auto const &record : records) {
+  for (const auto &record : records) {
     pendingRecords_.emplace_back(NativeMutationRecord{
         record.mutationObserverId,
         // FIXME(T157129303) Instead of assuming we can call into JS from here,

--- a/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.h
+++ b/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.h
@@ -89,7 +89,7 @@ class NativeMutationObserver
   // This is passed to `connect` so we can retain references to public instances
   // when mutation occur, before React cleans up unmounted instances.
   jsi::Value getPublicInstanceFromInstanceHandle_ = jsi::Value::undefined();
-  std::function<jsi::Value(ShadowNode const &)>
+  std::function<jsi::Value(const ShadowNode &)>
       getPublicInstanceFromShadowNode_;
 
   bool notifiedMutationObservers_{};
@@ -99,7 +99,7 @@ class NativeMutationObserver
   void notifyMutationObserversIfNecessary();
 
   std::vector<jsi::Value> getPublicInstancesFromShadowNodes(
-      std::vector<ShadowNode::Shared> const &shadowNodes) const;
+      const std::vector<ShadowNode::Shared> &shadowNodes) const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -68,8 +68,8 @@ constexpr size_t NUM_PERFORMANCE_ENTRY_TYPES =
 
 class PerformanceEntryReporter : public EventLogger {
  public:
-  PerformanceEntryReporter(PerformanceEntryReporter const &) = delete;
-  void operator=(PerformanceEntryReporter const &) = delete;
+  PerformanceEntryReporter(const PerformanceEntryReporter &) = delete;
+  void operator=(const PerformanceEntryReporter &) = delete;
 
   // NOTE: This class is not thread safe, make sure that the calls are made from
   // the same thread.

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -181,10 +181,10 @@ RCT_EXTERN BOOL RCTUIManagerTypeForTagIsFabric(NSNumber *reactTag);
 RCT_EXTERN BOOL RCTValidateTypeOfViewCommandArgument(
     NSObject *obj,
     id expectedClass,
-    NSString const *expectedType,
-    NSString const *componentName,
-    NSString const *commandName,
-    NSString const *argPos);
+    const NSString *expectedType,
+    const NSString *componentName,
+    const NSString *commandName,
+    const NSString *argPos);
 
 RCT_EXTERN BOOL RCTIsAppActive(void);
 

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -1047,10 +1047,10 @@ RCT_EXTERN BOOL RCTUIManagerTypeForTagIsFabric(NSNumber *reactTag)
 RCT_EXTERN BOOL RCTValidateTypeOfViewCommandArgument(
     NSObject *obj,
     id expectedClass,
-    NSString const *expectedType,
-    NSString const *componentName,
-    NSString const *commandName,
-    NSString const *argPos)
+    const NSString *expectedType,
+    const NSString *componentName,
+    const NSString *commandName,
+    const NSString *argPos)
 {
   if (![obj isKindOfClass:expectedClass]) {
     NSString *kindOfClass = RCTHumanReadableType(obj);

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -36,8 +36,8 @@
 
 static NSString *const RCTPerfMonitorCellIdentifier = @"RCTPerfMonitorCellIdentifier";
 
-static CGFloat const RCTPerfMonitorBarHeight = 50;
-static CGFloat const RCTPerfMonitorExpandHeight = 250;
+static const CGFloat RCTPerfMonitorBarHeight = 50;
+static const CGFloat RCTPerfMonitorExpandHeight = 250;
 
 typedef BOOL (*RCTJSCSetOptionType)(const char *);
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
@@ -62,10 +62,10 @@ static UIActivityIndicatorViewStyle convertActivityIndicatorViewStyle(const Acti
   return self;
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldViewProps = static_cast<ActivityIndicatorViewProps const &>(*_props);
-  const auto &newViewProps = static_cast<ActivityIndicatorViewProps const &>(*props);
+  const auto &oldViewProps = static_cast<const ActivityIndicatorViewProps &>(*_props);
+  const auto &newViewProps = static_cast<const ActivityIndicatorViewProps &>(*props);
 
   if (oldViewProps.animating != newViewProps.animating) {
     if (newViewProps.animating) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -28,7 +28,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static auto const defaultProps = std::make_shared<ImageProps const>();
+    static const auto defaultProps = std::make_shared<const ImageProps>();
     _props = defaultProps;
 
     _imageView = [RCTUIImageViewAnimated new];
@@ -52,10 +52,10 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<ImageComponentDescriptor>();
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldImageProps = static_cast<ImageProps const &>(*_props);
-  const auto &newImageProps = static_cast<ImageProps const &>(*props);
+  const auto &oldImageProps = static_cast<const ImageProps &>(*_props);
+  const auto &newImageProps = static_cast<const ImageProps &>(*props);
 
   // `resizeMode`
   if (oldImageProps.resizeMode != newImageProps.resizeMode) {
@@ -70,7 +70,7 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
-- (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
   RCTAssert(state, @"`state` must not be null.");
   RCTAssert(
@@ -88,17 +88,17 @@ using namespace facebook::react;
       (newImageState && newImageState->getData().getImageSource() != oldImageState->getData().getImageSource())) {
     // Loading actually starts a little before this, but this is the first time we know
     // the image is loading and can fire an event from this component
-    static_cast<ImageEventEmitter const &>(*_eventEmitter).onLoadStart();
+    static_cast<const ImageEventEmitter &>(*_eventEmitter).onLoadStart();
 
     // TODO (T58941612): Tracking for visibility should be done directly on this class.
     // For now, we consolidate instrumentation logic in the image loader, so that pre-Fabric gets the same treatment.
   }
 }
 
-- (void)_setStateAndResubscribeImageResponseObserver:(ImageShadowNode::ConcreteState::Shared const &)state
+- (void)_setStateAndResubscribeImageResponseObserver:(const ImageShadowNode::ConcreteState::Shared &)state
 {
   if (_state) {
-    auto const &imageRequest = _state->getData().getImageRequest();
+    const auto &imageRequest = _state->getData().getImageRequest();
     auto &observerCoordinator = imageRequest.getObserverCoordinator();
     observerCoordinator.removeObserver(_imageResponseObserverProxy);
     if (CoreFeatures::cancelImageDownloadsOnRecycle) {
@@ -129,7 +129,7 @@ using namespace facebook::react;
 
 #pragma mark - RCTImageResponseDelegate
 
-- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(void const *)observer
+- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(const void *)observer
 {
   if (!_eventEmitter || !_state) {
     // Notifications are delivered asynchronously and might arrive after the view is already recycled.
@@ -138,10 +138,10 @@ using namespace facebook::react;
     return;
   }
 
-  static_cast<ImageEventEmitter const &>(*_eventEmitter).onLoad();
-  static_cast<ImageEventEmitter const &>(*_eventEmitter).onLoadEnd();
+  static_cast<const ImageEventEmitter &>(*_eventEmitter).onLoad();
+  static_cast<const ImageEventEmitter &>(*_eventEmitter).onLoadEnd();
 
-  const auto &imageProps = static_cast<ImageProps const &>(*_props);
+  const auto &imageProps = static_cast<const ImageProps &>(*_props);
 
   if (imageProps.tintColor) {
     image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -170,16 +170,16 @@ using namespace facebook::react;
   }
 }
 
-- (void)didReceiveProgress:(float)progress fromObserver:(void const *)observer
+- (void)didReceiveProgress:(float)progress fromObserver:(const void *)observer
 {
   if (!_eventEmitter) {
     return;
   }
 
-  static_cast<ImageEventEmitter const &>(*_eventEmitter).onProgress(progress);
+  static_cast<const ImageEventEmitter &>(*_eventEmitter).onProgress(progress);
 }
 
-- (void)didReceiveFailureFromObserver:(void const *)observer
+- (void)didReceiveFailureFromObserver:(const void *)observer
 {
   _imageView.image = nil;
 
@@ -187,8 +187,8 @@ using namespace facebook::react;
     return;
   }
 
-  static_cast<ImageEventEmitter const &>(*_eventEmitter).onError();
-  static_cast<ImageEventEmitter const &>(*_eventEmitter).onLoadEnd();
+  static_cast<const ImageEventEmitter &>(*_eventEmitter).onError();
+  static_cast<const ImageEventEmitter &>(*_eventEmitter).onLoadEnd();
 }
 
 @end

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -105,10 +105,10 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   [childComponentView removeFromSuperview];
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldInputAccessoryProps = static_cast<InputAccessoryProps const &>(*_props);
-  const auto &newInputAccessoryProps = static_cast<InputAccessoryProps const &>(*props);
+  const auto &oldInputAccessoryProps = static_cast<const InputAccessoryProps &>(*_props);
+  const auto &newInputAccessoryProps = static_cast<const InputAccessoryProps &>(*props);
 
   if (newInputAccessoryProps.backgroundColor != oldInputAccessoryProps.backgroundColor) {
     _contentView.backgroundColor = RCTUIColorFromSharedColor(newInputAccessoryProps.backgroundColor);
@@ -131,8 +131,8 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   }
 }
 
-- (void)updateLayoutMetrics:(LayoutMetrics const &)layoutMetrics
-           oldLayoutMetrics:(LayoutMetrics const &)oldLayoutMetrics
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
 {
   [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -171,7 +171,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   return concreteComponentDescriptorProvider<LegacyViewManagerInteropComponentDescriptor>();
 }
 
-- (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
   _state = std::static_pointer_cast<LegacyViewManagerInteropShadowNode::ConcreteState const>(state);
 }
@@ -217,7 +217,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   [_adapter.paperView didUpdateReactSubviews];
 
   if (updateMask & RNComponentViewUpdateMaskProps) {
-    const auto &newProps = static_cast<LegacyViewManagerInteropViewProps const &>(*_props);
+    const auto &newProps = static_cast<const LegacyViewManagerInteropViewProps &>(*_props);
     [_adapter setProps:newProps.otherProps];
   }
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, nullable) void (^eventInterceptor)(std::string eventName, folly::dynamic event);
 
-- (void)setProps:(folly::dynamic const &)props;
+- (void)setProps:(const folly::dynamic &)props;
 
 - (void)handleCommand:(NSString *)commandName args:(NSArray *)args;
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -56,7 +56,7 @@ static UIInterfaceOrientationMask supportedOrientationsMask(ModalHostViewSupport
   return supportedOrientations;
 }
 
-static std::tuple<BOOL, UIModalTransitionStyle> animationConfiguration(ModalHostViewAnimationType const animation)
+static std::tuple<BOOL, UIModalTransitionStyle> animationConfiguration(const ModalHostViewAnimationType animation)
 {
   switch (animation) {
     case ModalHostViewAnimationType::None:
@@ -68,7 +68,7 @@ static std::tuple<BOOL, UIModalTransitionStyle> animationConfiguration(ModalHost
   }
 }
 
-static UIModalPresentationStyle presentationConfiguration(ModalHostViewProps const &props)
+static UIModalPresentationStyle presentationConfiguration(const ModalHostViewProps &props)
 {
   if (props.transparent) {
     return UIModalPresentationOverFullScreen;
@@ -186,14 +186,14 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
     return nullptr;
   }
 
-  assert(std::dynamic_pointer_cast<ModalHostViewEventEmitter const>(_eventEmitter));
-  return std::static_pointer_cast<ModalHostViewEventEmitter const>(_eventEmitter);
+  assert(std::dynamic_pointer_cast<const ModalHostViewEventEmitter>(_eventEmitter));
+  return std::static_pointer_cast<const ModalHostViewEventEmitter>(_eventEmitter);
 }
 
 #pragma mark - RCTMountingTransactionObserving
 
-- (void)mountingTransactionWillMount:(MountingTransaction const &)transaction
-                withSurfaceTelemetry:(facebook::react::SurfaceTelemetry const &)surfaceTelemetry
+- (void)mountingTransactionWillMount:(const MountingTransaction &)transaction
+                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
 {
   _modalContentsSnapshot = [self.viewController.view snapshotViewAfterScreenUpdates:NO];
 }
@@ -243,15 +243,15 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   _shouldPresent = NO;
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &newProps = static_cast<ModalHostViewProps const &>(*props);
+  const auto &newProps = static_cast<const ModalHostViewProps &>(*props);
 
 #if !TARGET_OS_TV
   self.viewController.supportedInterfaceOrientations = supportedOrientationsMask(newProps.supportedOrientations);
 #endif
 
-  auto const [shouldAnimate, transitionStyle] = animationConfiguration(newProps.animationType);
+  const auto [shouldAnimate, transitionStyle] = animationConfiguration(newProps.animationType);
   _shouldAnimatePresentation = shouldAnimate;
   self.viewController.modalTransitionStyle = transitionStyle;
 
@@ -263,8 +263,8 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   [super updateProps:props oldProps:oldProps];
 }
 
-- (void)updateState:(facebook::react::State::Shared const &)state
-           oldState:(facebook::react::State::Shared const &)oldState
+- (void)updateState:(const facebook::react::State::Shared &)state
+           oldState:(const facebook::react::State::Shared &)oldState
 {
   _state = std::static_pointer_cast<const ModalHostViewShadowNode::ConcreteState>(state);
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
@@ -22,7 +22,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static auto const defaultProps = std::make_shared<SafeAreaViewProps const>();
+    static const auto defaultProps = std::make_shared<const SafeAreaViewProps>();
     _props = defaultProps;
   }
 
@@ -52,7 +52,7 @@ using namespace facebook::react;
   auto threshold = 1.0 / RCTScreenScale() + 0.01; // Size of a pixel plus some small threshold.
 
   _state->updateState(
-      [=](SafeAreaViewShadowNode::ConcreteState::Data const &oldData)
+      [=](const SafeAreaViewShadowNode::ConcreteState::Data &oldData)
           -> SafeAreaViewShadowNode::ConcreteState::SharedData {
         auto oldPadding = oldData.padding;
         auto deltaPadding = newPadding - oldPadding;
@@ -75,8 +75,8 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<SafeAreaViewComponentDescriptor>();
 }
 
-- (void)updateState:(facebook::react::State::Shared const &)state
-           oldState:(facebook::react::State::Shared const &)oldState
+- (void)updateState:(const facebook::react::State::Shared &)state
+           oldState:(const facebook::react::State::Shared &)oldState
 {
   _state = std::static_pointer_cast<SafeAreaViewShadowNode::ConcreteState const>(state);
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -36,7 +36,7 @@ using namespace facebook::react;
     // The pull-to-refresh view is not a subview of this view.
     self.hidden = YES;
 
-    static auto const defaultProps = std::make_shared<PullToRefreshViewProps const>();
+    static const auto defaultProps = std::make_shared<const PullToRefreshViewProps>();
     _props = defaultProps;
 
     _refreshControl = [UIRefreshControl new];
@@ -55,10 +55,10 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<PullToRefreshViewComponentDescriptor>();
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldConcreteProps = static_cast<PullToRefreshViewProps const &>(*_props);
-  const auto &newConcreteProps = static_cast<PullToRefreshViewProps const &>(*props);
+  const auto &oldConcreteProps = static_cast<const PullToRefreshViewProps &>(*_props);
+  const auto &newConcreteProps = static_cast<const PullToRefreshViewProps &>(*props);
 
   if (newConcreteProps.refreshing != oldConcreteProps.refreshing) {
     if (newConcreteProps.refreshing) {
@@ -89,12 +89,12 @@ using namespace facebook::react;
 
 - (void)handleUIControlEventValueChanged
 {
-  static_cast<PullToRefreshViewEventEmitter const &>(*_eventEmitter).onRefresh({});
+  static_cast<const PullToRefreshViewEventEmitter &>(*_eventEmitter).onRefresh({});
 }
 
 - (void)_updateTitle
 {
-  const auto &concreteProps = static_cast<PullToRefreshViewProps const &>(*_props);
+  const auto &concreteProps = static_cast<const PullToRefreshViewProps &>(*_props);
 
   if (concreteProps.title.empty()) {
     _refreshControl.attributedTitle = nil;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -26,9 +26,9 @@
 
 using namespace facebook::react;
 
-static CGFloat const kClippingLeeway = 44.0;
+static const CGFloat kClippingLeeway = 44.0;
 
-static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(ScrollViewProps const &props)
+static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(const ScrollViewProps &props)
 {
   switch (props.keyboardDismissMode) {
     case ScrollViewKeyboardDismissMode::None:
@@ -40,7 +40,7 @@ static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(ScrollV
   }
 }
 
-static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(ScrollViewProps const &props)
+static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(const ScrollViewProps &props)
 {
   switch (props.indicatorStyle) {
     case ScrollViewIndicatorStyle::Default:
@@ -160,8 +160,8 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   [self _prepareForMaintainVisibleScrollPosition];
 }
 
-- (void)mountingTransactionDidMount:(MountingTransaction const &)transaction
-               withSurfaceTelemetry:(facebook::react::SurfaceTelemetry const &)surfaceTelemetry
+- (void)mountingTransactionDidMount:(const MountingTransaction &)transaction
+               withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
 {
   [self _remountChildren];
   [self _adjustForMaintainVisibleContentPosition];
@@ -188,10 +188,10 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   }
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldScrollViewProps = static_cast<ScrollViewProps const &>(*_props);
-  const auto &newScrollViewProps = static_cast<ScrollViewProps const &>(*props);
+  const auto &oldScrollViewProps = static_cast<const ScrollViewProps &>(*_props);
+  const auto &newScrollViewProps = static_cast<const ScrollViewProps &>(*props);
 
 #define REMAP_PROP(reactName, localName, target)                      \
   if (oldScrollViewProps.reactName != newScrollViewProps.reactName) { \
@@ -266,7 +266,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
   if (oldScrollViewProps.snapToOffsets != newScrollViewProps.snapToOffsets) {
     NSMutableArray<NSNumber *> *snapToOffsets = [NSMutableArray array];
-    for (auto const &snapToOffset : newScrollViewProps.snapToOffsets) {
+    for (const auto &snapToOffset : newScrollViewProps.snapToOffsets) {
       [snapToOffsets addObject:[NSNumber numberWithFloat:snapToOffset]];
     }
     scrollView.snapToOffsets = snapToOffsets;
@@ -279,7 +279,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
   if ((oldScrollViewProps.contentInsetAdjustmentBehavior != newScrollViewProps.contentInsetAdjustmentBehavior) ||
       _shouldUpdateContentInsetAdjustmentBehavior) {
-    auto const contentInsetAdjustmentBehavior = newScrollViewProps.contentInsetAdjustmentBehavior;
+    const auto contentInsetAdjustmentBehavior = newScrollViewProps.contentInsetAdjustmentBehavior;
     if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::Never) {
       scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
     } else if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::Automatic) {
@@ -302,7 +302,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   [super updateProps:props oldProps:oldProps];
 }
 
-- (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
   assert(std::dynamic_pointer_cast<ScrollViewShadowNode::ConcreteState const>(state));
   _state = std::static_pointer_cast<ScrollViewShadowNode::ConcreteState const>(state);
@@ -404,7 +404,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     return;
   }
   auto contentOffset = RCTPointFromCGPoint(_scrollView.contentOffset);
-  _state->updateState([contentOffset](ScrollViewShadowNode::ConcreteState::Data const &data) {
+  _state->updateState([contentOffset](const ScrollViewShadowNode::ConcreteState::Data &data) {
     auto newData = data;
     newData.contentOffset = contentOffset;
     return std::make_shared<ScrollViewShadowNode::ConcreteState::Data const>(newData);
@@ -413,7 +413,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 - (void)prepareForRecycle
 {
-  const auto &props = static_cast<ScrollViewProps const &>(*_props);
+  const auto &props = static_cast<const ScrollViewProps &>(*_props);
   _scrollView.contentOffset = RCTCGPointFromPoint(props.contentOffset);
   // We set the default behavior to "never" so that iOS
   // doesn't do weird things to UIScrollView insets automatically
@@ -451,7 +451,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
       (now - _lastScrollEventDispatchTime > _scrollEventThrottle)) {
     _lastScrollEventDispatchTime = now;
     if (_eventEmitter) {
-      static_cast<ScrollViewEventEmitter const &>(*_eventEmitter).onScroll([self _scrollViewMetrics]);
+      static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScroll([self _scrollViewMetrics]);
     }
 
     RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag);
@@ -485,7 +485,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     return;
   }
 
-  static_cast<ScrollViewEventEmitter const &>(*_eventEmitter).onScrollBeginDrag([self _scrollViewMetrics]);
+  static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScrollBeginDrag([self _scrollViewMetrics]);
   _isUserTriggeredScrolling = YES;
 }
 
@@ -497,7 +497,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     return;
   }
 
-  static_cast<ScrollViewEventEmitter const &>(*_eventEmitter).onScrollEndDrag([self _scrollViewMetrics]);
+  static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScrollEndDrag([self _scrollViewMetrics]);
 
   [self _updateStateWithContentOffset];
 
@@ -516,7 +516,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     return;
   }
 
-  static_cast<ScrollViewEventEmitter const &>(*_eventEmitter).onMomentumScrollBegin([self _scrollViewMetrics]);
+  static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onMomentumScrollBegin([self _scrollViewMetrics]);
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
@@ -527,7 +527,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     return;
   }
 
-  static_cast<ScrollViewEventEmitter const &>(*_eventEmitter).onMomentumScrollEnd([self _scrollViewMetrics]);
+  static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onMomentumScrollEnd([self _scrollViewMetrics]);
   [self _updateStateWithContentOffset];
   _isUserTriggeredScrolling = NO;
 }
@@ -546,7 +546,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     return;
   }
 
-  static_cast<ScrollViewEventEmitter const &>(*_eventEmitter).onMomentumScrollEnd([self _scrollViewMetrics]);
+  static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onMomentumScrollEnd([self _scrollViewMetrics]);
   [self _updateStateWithContentOffset];
 }
 
@@ -558,7 +558,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     return;
   }
 
-  static_cast<ScrollViewEventEmitter const &>(*_eventEmitter).onScrollBeginDrag([self _scrollViewMetrics]);
+  static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScrollBeginDrag([self _scrollViewMetrics]);
 }
 
 - (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view atScale:(CGFloat)scale
@@ -569,7 +569,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     return;
   }
 
-  static_cast<ScrollViewEventEmitter const &>(*_eventEmitter).onScrollEndDrag([self _scrollViewMetrics]);
+  static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScrollEndDrag([self _scrollViewMetrics]);
   [self _updateStateWithContentOffset];
 }
 
@@ -612,7 +612,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
               fmax(_scrollView.contentInset.top, 0),
           0.01)); // Make width and height greater than 0
 
-  const auto &props = static_cast<ScrollViewProps const &>(*_props);
+  const auto &props = static_cast<const ScrollViewProps &>(*_props);
   if (!CGRectContainsPoint(maxRect, offset) && !props.scrollToOverflowEnabled) {
     CGFloat localX = fmax(offset.x, CGRectGetMinX(maxRect));
     localX = fmin(localX, CGRectGetMaxX(maxRect));
@@ -719,7 +719,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 - (void)_prepareForMaintainVisibleScrollPosition
 {
-  const auto &props = static_cast<ScrollViewProps const &>(*_props);
+  const auto &props = static_cast<const ScrollViewProps &>(*_props);
   if (!props.maintainVisibleContentPosition) {
     return;
   }
@@ -745,7 +745,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 - (void)_adjustForMaintainVisibleContentPosition
 {
-  const auto &props = static_cast<ScrollViewProps const &>(*_props);
+  const auto &props = static_cast<const ScrollViewProps &>(*_props);
   if (!props.maintainVisibleContentPosition) {
     return;
   }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -55,10 +55,10 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<SwitchComponentDescriptor>();
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldSwitchProps = static_cast<SwitchProps const &>(*_props);
-  const auto &newSwitchProps = static_cast<SwitchProps const &>(*props);
+  const auto &oldSwitchProps = static_cast<const SwitchProps &>(*_props);
+  const auto &newSwitchProps = static_cast<const SwitchProps &>(*props);
 
   // `value`
   if (oldSwitchProps.value != newSwitchProps.value) {
@@ -92,7 +92,7 @@ using namespace facebook::react;
 
 - (void)onChange:(UISwitch *)sender
 {
-  const auto &props = static_cast<SwitchProps const &>(*_props);
+  const auto &props = static_cast<const SwitchProps &>(*_props);
   if (props.value == sender.on) {
     return;
   }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -79,10 +79,10 @@ using namespace facebook::react;
       concreteComponentDescriptorProvider<TextComponentDescriptor>()};
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldParagraphProps = static_cast<ParagraphProps const &>(*_props);
-  const auto &newParagraphProps = static_cast<ParagraphProps const &>(*props);
+  const auto &oldParagraphProps = static_cast<const ParagraphProps &>(*_props);
+  const auto &newParagraphProps = static_cast<const ParagraphProps &>(*props);
 
   _paragraphAttributes = newParagraphProps.paragraphAttributes;
 
@@ -97,7 +97,7 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
-- (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
   _state = std::static_pointer_cast<ParagraphShadowNode::ConcreteState const>(state);
   [self setNeedsDisplay];
@@ -147,7 +147,7 @@ using namespace facebook::react;
 
 - (NSArray *)accessibilityElements
 {
-  const auto &paragraphProps = static_cast<ParagraphProps const &>(*_props);
+  const auto &paragraphProps = static_cast<const ParagraphProps &>(*_props);
 
   // If the component is not `accessible`, we return an empty array.
   // We do this because logically all nested <Text> components represent the content of the <Paragraph> component;
@@ -241,13 +241,13 @@ using namespace facebook::react;
 
 - (BOOL)canBecomeFirstResponder
 {
-  const auto &paragraphProps = static_cast<ParagraphProps const &>(*_props);
+  const auto &paragraphProps = static_cast<const ParagraphProps &>(*_props);
   return paragraphProps.isSelectable;
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
-  const auto &paragraphProps = static_cast<ParagraphProps const &>(*_props);
+  const auto &paragraphProps = static_cast<const ParagraphProps &>(*_props);
 
   if (paragraphProps.isSelectable && action == @selector(copy:)) {
     return YES;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -62,7 +62,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<TextInputProps const>();
+    static const auto defaultProps = std::make_shared<const TextInputProps>();
     _props = defaultProps;
     auto &props = *defaultProps;
 
@@ -82,7 +82,7 @@ using namespace facebook::react;
   [super didMoveToWindow];
 
   if (self.window && !_didMoveToWindow) {
-    const auto &props = static_cast<TextInputProps const &>(*_props);
+    const auto &props = static_cast<const TextInputProps &>(*_props);
     if (props.autoFocus) {
       [_backedTextInputView becomeFirstResponder];
     }
@@ -105,10 +105,10 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<TextInputComponentDescriptor>();
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldTextInputProps = static_cast<TextInputProps const &>(*_props);
-  const auto &newTextInputProps = static_cast<TextInputProps const &>(*props);
+  const auto &oldTextInputProps = static_cast<const TextInputProps &>(*_props);
+  const auto &newTextInputProps = static_cast<const TextInputProps &>(*props);
 
   // Traits:
   if (newTextInputProps.traits.multiline != oldTextInputProps.traits.multiline) {
@@ -215,7 +215,7 @@ using namespace facebook::react;
   [self setDefaultInputAccessoryView];
 }
 
-- (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
   _state = std::static_pointer_cast<TextInputShadowNode::ConcreteState const>(state);
 
@@ -238,8 +238,8 @@ using namespace facebook::react;
   }
 }
 
-- (void)updateLayoutMetrics:(LayoutMetrics const &)layoutMetrics
-           oldLayoutMetrics:(LayoutMetrics const &)oldLayoutMetrics
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
 {
   [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
 
@@ -249,7 +249,7 @@ using namespace facebook::react;
       RCTUIEdgeInsetsFromEdgeInsets(layoutMetrics.contentInsets - layoutMetrics.borderWidth);
 
   if (_eventEmitter) {
-    static_cast<TextInputEventEmitter const &>(*_eventEmitter).onContentSizeChange([self _textInputMetrics]);
+    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onContentSizeChange([self _textInputMetrics]);
   }
 }
 
@@ -275,7 +275,7 @@ using namespace facebook::react;
 
 - (void)textInputDidBeginEditing
 {
-  const auto &props = static_cast<TextInputProps const &>(*_props);
+  const auto &props = static_cast<const TextInputProps &>(*_props);
 
   if (props.traits.clearTextOnFocus) {
     _backedTextInputView.attributedText = nil;
@@ -288,7 +288,7 @@ using namespace facebook::react;
   }
 
   if (_eventEmitter) {
-    static_cast<TextInputEventEmitter const &>(*_eventEmitter).onFocus([self _textInputMetrics]);
+    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onFocus([self _textInputMetrics]);
   }
 }
 
@@ -300,8 +300,8 @@ using namespace facebook::react;
 - (void)textInputDidEndEditing
 {
   if (_eventEmitter) {
-    static_cast<TextInputEventEmitter const &>(*_eventEmitter).onEndEditing([self _textInputMetrics]);
-    static_cast<TextInputEventEmitter const &>(*_eventEmitter).onBlur([self _textInputMetrics]);
+    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onEndEditing([self _textInputMetrics]);
+    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onBlur([self _textInputMetrics]);
   }
 }
 
@@ -316,7 +316,7 @@ using namespace facebook::react;
   // (no connection to any specific "submitting" process).
 
   if (_eventEmitter && shouldSubmit) {
-    static_cast<TextInputEventEmitter const &>(*_eventEmitter).onSubmitEditing([self _textInputMetrics]);
+    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onSubmitEditing([self _textInputMetrics]);
   }
   return shouldSubmit;
 }
@@ -333,7 +333,7 @@ using namespace facebook::react;
 
 - (NSString *)textInputShouldChangeText:(NSString *)text inRange:(NSRange)range
 {
-  const auto &props = static_cast<TextInputProps const &>(*_props);
+  const auto &props = static_cast<const TextInputProps &>(*_props);
 
   if (!_backedTextInputView.textWasPasted) {
     if (_eventEmitter) {
@@ -341,7 +341,7 @@ using namespace facebook::react;
       keyPressMetrics.text = RCTStringFromNSString(text);
       keyPressMetrics.eventCount = _mostRecentEventCount;
 
-      auto const &textInputEventEmitter = static_cast<TextInputEventEmitter const &>(*_eventEmitter);
+      const auto &textInputEventEmitter = static_cast<const TextInputEventEmitter &>(*_eventEmitter);
       if (props.onKeyPressSync) {
         textInputEventEmitter.onKeyPressSync(keyPressMetrics);
       } else {
@@ -391,8 +391,8 @@ using namespace facebook::react;
   [self _updateState];
 
   if (_eventEmitter) {
-    auto const &textInputEventEmitter = static_cast<TextInputEventEmitter const &>(*_eventEmitter);
-    const auto &props = static_cast<TextInputProps const &>(*_props);
+    const auto &textInputEventEmitter = static_cast<const TextInputEventEmitter &>(*_eventEmitter);
+    const auto &props = static_cast<const TextInputProps &>(*_props);
     if (props.onChangeSync) {
       textInputEventEmitter.onChangeSync([self _textInputMetrics]);
     } else {
@@ -406,14 +406,14 @@ using namespace facebook::react;
   if (_comingFromJS) {
     return;
   }
-  const auto &props = static_cast<TextInputProps const &>(*_props);
+  const auto &props = static_cast<const TextInputProps &>(*_props);
   if (props.traits.multiline && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
     [self textInputDidChange];
     _ignoreNextTextInputCall = YES;
   }
 
   if (_eventEmitter) {
-    static_cast<TextInputEventEmitter const &>(*_eventEmitter).onSelectionChange([self _textInputMetrics]);
+    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onSelectionChange([self _textInputMetrics]);
   }
 }
 
@@ -422,7 +422,7 @@ using namespace facebook::react;
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
   if (_eventEmitter) {
-    static_cast<TextInputEventEmitter const &>(*_eventEmitter).onScroll([self _textInputMetrics]);
+    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onScroll([self _textInputMetrics]);
   }
 }
 
@@ -576,7 +576,7 @@ using namespace facebook::react;
 
 - (void)_restoreTextSelection
 {
-  const auto &selection = static_cast<TextInputProps const &>(*_props).selection;
+  const auto &selection = static_cast<const TextInputProps &>(*_props).selection;
   if (!selection.has_value()) {
     return;
   }
@@ -656,7 +656,7 @@ using namespace facebook::react;
 
 - (SubmitBehavior)getSubmitBehavior
 {
-  const auto &props = static_cast<TextInputProps const &>(*_props);
+  const auto &props = static_cast<const TextInputProps &>(*_props);
   const SubmitBehavior submitBehaviorDefaultable = props.traits.submitBehavior;
 
   // We should always have a non-default `submitBehavior`, but in case we don't, set it based on multiline.

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputNativeCommands.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputNativeCommands.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 RCT_EXTERN inline void
-RCTTextInputHandleCommand(id<RCTTextInputViewProtocol> componentView, NSString const *commandName, NSArray const *args)
+RCTTextInputHandleCommand(id<RCTTextInputViewProtocol> componentView, const NSString *commandName, const NSArray *args)
 {
   if ([commandName isEqualToString:@"focus"]) {
 #if RCT_DEBUG

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
@@ -35,9 +35,9 @@ UIKeyboardType RCTUIKeyboardTypeFromKeyboardType(facebook::react::KeyboardType k
 
 UIReturnKeyType RCTUIReturnKeyTypeFromReturnKeyType(facebook::react::ReturnKeyType returnKeyType);
 
-UITextContentType RCTUITextContentTypeFromString(std::string const &contentType);
+UITextContentType RCTUITextContentTypeFromString(const std::string &contentType);
 
-UITextInputPasswordRules *RCTUITextInputPasswordRulesFromString(std::string const &passwordRules);
+UITextInputPasswordRules *RCTUITextInputPasswordRulesFromString(const std::string &passwordRules);
 
 UITextSmartInsertDeleteType RCTUITextSmartInsertDeleteTypeFromOptionalBool(std::optional<bool> smartInsertDelete);
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -175,7 +175,7 @@ UIReturnKeyType RCTUIReturnKeyTypeFromReturnKeyType(ReturnKeyType returnKeyType)
   }
 }
 
-UITextContentType RCTUITextContentTypeFromString(std::string const &contentType)
+UITextContentType RCTUITextContentTypeFromString(const std::string &contentType)
 {
   static dispatch_once_t onceToken;
   static NSDictionary<NSString *, NSString *> *contentTypeMap;
@@ -240,7 +240,7 @@ UITextContentType RCTUITextContentTypeFromString(std::string const &contentType)
   return contentTypeMap[RCTNSStringFromString(contentType)] ?: @"";
 }
 
-UITextInputPasswordRules *RCTUITextInputPasswordRulesFromString(std::string const &passwordRules)
+UITextInputPasswordRules *RCTUITextInputPasswordRulesFromString(const std::string &passwordRules)
 {
   return [UITextInputPasswordRules passwordRulesWithDescriptor:RCTNSStringFromStringNilIfEmpty(passwordRules)];
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
@@ -45,10 +45,10 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<UnimplementedNativeViewComponentDescriptor>();
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldViewProps = static_cast<UnimplementedNativeViewProps const &>(*_props);
-  const auto &newViewProps = static_cast<UnimplementedNativeViewProps const &>(*props);
+  const auto &oldViewProps = static_cast<const UnimplementedNativeViewProps &>(*_props);
+  const auto &newViewProps = static_cast<const UnimplementedNativeViewProps &>(*props);
 
   if (oldViewProps.name != newViewProps.name) {
     _label.text = [NSString stringWithFormat:@"'%s' is not Fabric compatible yet.", newViewProps.name.c_str()];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
@@ -27,7 +27,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static auto const defaultProps = std::make_shared<UnimplementedViewProps const>();
+    static const auto defaultProps = std::make_shared<const UnimplementedViewProps>();
     _props = defaultProps;
 
     _label = [[UILabel alloc] initWithFrame:self.bounds];
@@ -52,10 +52,10 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<UnimplementedViewComponentDescriptor>();
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldUnimplementedViewProps = static_cast<UnimplementedViewProps const &>(*_props);
-  const auto &newUnimplementedViewProps = static_cast<UnimplementedViewProps const &>(*props);
+  const auto &oldUnimplementedViewProps = static_cast<const UnimplementedViewProps &>(*_props);
+  const auto &newUnimplementedViewProps = static_cast<const UnimplementedViewProps &>(*props);
 
   if (oldUnimplementedViewProps.getComponentName() != newUnimplementedViewProps.getComponentName()) {
     _label.text =

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -67,11 +67,11 @@ NS_ASSUME_NONNULL_BEGIN
  * Enforcing `call super` semantic for overridden methods from `RCTComponentViewProtocol`.
  * The methods update the instance variables.
  */
-- (void)updateProps:(facebook::react::Props::Shared const &)props
-           oldProps:(facebook::react::Props::Shared const &)oldProps NS_REQUIRES_SUPER;
-- (void)updateEventEmitter:(facebook::react::EventEmitter::Shared const &)eventEmitter NS_REQUIRES_SUPER;
-- (void)updateLayoutMetrics:(facebook::react::LayoutMetrics const &)layoutMetrics
-           oldLayoutMetrics:(facebook::react::LayoutMetrics const &)oldLayoutMetrics NS_REQUIRES_SUPER;
+- (void)updateProps:(const facebook::react::Props::Shared &)props
+           oldProps:(const facebook::react::Props::Shared &)oldProps NS_REQUIRES_SUPER;
+- (void)updateEventEmitter:(const facebook::react::EventEmitter::Shared &)eventEmitter NS_REQUIRES_SUPER;
+- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics NS_REQUIRES_SUPER;
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask NS_REQUIRES_SUPER;
 - (void)prepareForRecycle NS_REQUIRES_SUPER;
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -46,7 +46,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static auto const defaultProps = std::make_shared<ViewProps const>();
+    static const auto defaultProps = std::make_shared<const ViewProps>();
     _props = defaultProps;
     _reactSubviews = [NSMutableArray new];
     self.multipleTouchEnabled = YES;
@@ -178,7 +178,7 @@ using namespace facebook::react;
   }
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
   RCTAssert(props, @"`props` must not be `null`.");
 
@@ -193,8 +193,8 @@ using namespace facebook::react;
       NSStringFromClass([self class]));
 #endif
 
-  const auto &oldViewProps = static_cast<ViewProps const &>(*_props);
-  const auto &newViewProps = static_cast<ViewProps const &>(*props);
+  const auto &oldViewProps = static_cast<const ViewProps &>(*_props);
+  const auto &newViewProps = static_cast<const ViewProps &>(*props);
 
   BOOL needsInvalidateLayer = NO;
 
@@ -371,17 +371,17 @@ using namespace facebook::react;
 
   _needsInvalidateLayer = _needsInvalidateLayer || needsInvalidateLayer;
 
-  _props = std::static_pointer_cast<ViewProps const>(props);
+  _props = std::static_pointer_cast<const ViewProps>(props);
 }
 
-- (void)updateEventEmitter:(EventEmitter::Shared const &)eventEmitter
+- (void)updateEventEmitter:(const EventEmitter::Shared &)eventEmitter
 {
-  assert(std::dynamic_pointer_cast<ViewEventEmitter const>(eventEmitter));
-  _eventEmitter = std::static_pointer_cast<ViewEventEmitter const>(eventEmitter);
+  assert(std::dynamic_pointer_cast<const ViewEventEmitter>(eventEmitter));
+  _eventEmitter = std::static_pointer_cast<const ViewEventEmitter>(eventEmitter);
 }
 
-- (void)updateLayoutMetrics:(LayoutMetrics const &)layoutMetrics
-           oldLayoutMetrics:(LayoutMetrics const &)oldLayoutMetrics
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
 {
   // Using stored `_layoutMetrics` as `oldLayoutMetrics` here to avoid
   // re-applying individual sub-values which weren't changed.
@@ -425,7 +425,7 @@ using namespace facebook::react;
   [super prepareForRecycle];
 
   // If view was managed by animated, its props need to align with UIView's properties.
-  const auto &props = static_cast<ViewProps const &>(*_props);
+  const auto &props = static_cast<const ViewProps &>(*_props);
   if ([_propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN containsObject:@"transform"]) {
     self.layer.transform = RCTCATransform3DFromTransformMatrix(props.transform);
   }
@@ -555,14 +555,14 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     return;
   }
 
-  auto const borderMetrics = _props->resolveBorderMetrics(_layoutMetrics);
+  const auto borderMetrics = _props->resolveBorderMetrics(_layoutMetrics);
 
   // Stage 1. Shadow Path
   BOOL const layerHasShadow = layer.shadowOpacity > 0 && CGColorGetAlpha(layer.shadowColor) > 0;
   if (layerHasShadow) {
     if (CGColorGetAlpha(_backgroundColor.CGColor) > 0.999) {
       // If view has a solid background color, calculate shadow path from border.
-      RCTCornerInsets const cornerInsets =
+      const RCTCornerInsets cornerInsets =
           RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
       CGPathRef shadowPath = RCTPathCreateWithRoundedRect(self.bounds, cornerInsets, nil);
       layer.shadowPath = shadowPath;
@@ -576,7 +576,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
   }
 
   // Stage 2. Border Rendering
-  bool const useCoreAnimationBorderRendering =
+  const bool useCoreAnimationBorderRendering =
       borderMetrics.borderColors.isUniform() && borderMetrics.borderWidths.isUniform() &&
       borderMetrics.borderStyles.isUniform() && borderMetrics.borderRadii.isUniform() &&
       borderMetrics.borderStyles.left == BorderStyle::Solid &&
@@ -712,7 +712,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 
 - (NSString *)accessibilityValue
 {
-  const auto &props = static_cast<ViewProps const &>(*_props);
+  const auto &props = static_cast<const ViewProps &>(*_props);
 
   // Handle Switch.
   if ((self.accessibilityTraits & AccessibilityTraitSwitch) == AccessibilityTraitSwitch) {
@@ -789,14 +789,14 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 
 - (NSArray<UIAccessibilityCustomAction *> *)accessibilityCustomActions
 {
-  auto const &accessibilityActions = _props->accessibilityActions;
+  const auto &accessibilityActions = _props->accessibilityActions;
 
   if (accessibilityActions.empty()) {
     return nil;
   }
 
   NSMutableArray<UIAccessibilityCustomAction *> *customActions = [NSMutableArray array];
-  for (auto const &accessibilityAction : accessibilityActions) {
+  for (const auto &accessibilityAction : accessibilityActions) {
     [customActions
         addObject:[[UIAccessibilityCustomAction alloc] initWithName:RCTNSStringFromString(accessibilityAction.name)
                                                              target:self

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewDescriptor.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewDescriptor.h
@@ -31,19 +31,19 @@ class RCTComponentViewDescriptor final {
   bool observesMountingTransactionDidMount{false};
 };
 
-inline bool operator==(RCTComponentViewDescriptor const &lhs, RCTComponentViewDescriptor const &rhs)
+inline bool operator==(const RCTComponentViewDescriptor &lhs, const RCTComponentViewDescriptor &rhs)
 {
   return lhs.view == rhs.view;
 }
 
-inline bool operator!=(RCTComponentViewDescriptor const &lhs, RCTComponentViewDescriptor const &rhs)
+inline bool operator!=(const RCTComponentViewDescriptor &lhs, const RCTComponentViewDescriptor &rhs)
 {
   return lhs.view != rhs.view;
 }
 
 template <>
 struct std::hash<RCTComponentViewDescriptor> {
-  size_t operator()(RCTComponentViewDescriptor const &componentViewDescriptor) const
+  size_t operator()(const RCTComponentViewDescriptor &componentViewDescriptor) const
   {
     return std::hash<void *>()((__bridge void *)componentViewDescriptor.view);
   }

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.h
@@ -52,7 +52,7 @@ void RCTInstallNativeComponentRegistryBinding(facebook::jsi::Runtime &runtime);
  * Registers component if there is a matching class. Returns true if it matching class is found or the component has
  * already been registered, false otherwise.
  */
-- (BOOL)registerComponentIfPossible:(std::string const &)componentName;
+- (BOOL)registerComponentIfPossible:(const std::string &)componentName;
 
 /**
  * Creates a component view with given component handle.

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -46,7 +46,7 @@ using namespace facebook::react;
 // Allow JS runtime to register native components as needed. For static view configs.
 void RCTInstallNativeComponentRegistryBinding(facebook::jsi::Runtime &runtime)
 {
-  auto hasComponentProvider = [](std::string const &name) -> bool {
+  auto hasComponentProvider = [](const std::string &name) -> bool {
     return [[RCTComponentViewFactory currentComponentViewFactory]
         registerComponentIfPossible:componentNameByReactViewName(name)];
   };
@@ -99,7 +99,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
 #pragma clang diagnostic pop
 }
 
-- (BOOL)registerComponentIfPossible:(std::string const &)name
+- (BOOL)registerComponentIfPossible:(const std::string &)name
 {
   if (_registeredComponentsNames.find(name) != _registeredComponentsNames.end()) {
     // Component has already been registered.
@@ -186,7 +186,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   }
 }
 
-- (void)_addDescriptorToProviderRegistry:(ComponentDescriptorProvider const &)provider
+- (void)_addDescriptorToProviderRegistry:(const ComponentDescriptorProvider &)provider
 {
   _registeredComponentsNames.insert(provider.name);
   _providerRegistry.add(provider);

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -67,35 +67,35 @@ typedef NS_OPTIONS(NSInteger, RNComponentViewUpdateMask) {
  * Called for updating component's props.
  * Receiver must update native view props accordingly changed props.
  */
-- (void)updateProps:(facebook::react::Props::Shared const &)props
-           oldProps:(facebook::react::Props::Shared const &)oldProps;
+- (void)updateProps:(const facebook::react::Props::Shared &)props
+           oldProps:(const facebook::react::Props::Shared &)oldProps;
 
 /*
  * Called for updating component's state.
  * Receiver must update native view according to changed state.
  */
-- (void)updateState:(facebook::react::State::Shared const &)state
-           oldState:(facebook::react::State::Shared const &)oldState;
+- (void)updateState:(const facebook::react::State::Shared &)state
+           oldState:(const facebook::react::State::Shared &)oldState;
 
 /*
  * Called for updating component's event handlers set.
  * Receiver must cache `eventEmitter` object inside and use it for emitting
  * events when needed.
  */
-- (void)updateEventEmitter:(facebook::react::EventEmitter::Shared const &)eventEmitter;
+- (void)updateEventEmitter:(const facebook::react::EventEmitter::Shared &)eventEmitter;
 
 /*
  * Called for updating component's layout metrics.
  * Receiver must update `UIView` layout-related fields (such as `frame`,
  * `bounds`, `layer.zPosition`, and so on) accordingly.
  */
-- (void)updateLayoutMetrics:(facebook::react::LayoutMetrics const &)layoutMetrics
-           oldLayoutMetrics:(facebook::react::LayoutMetrics const &)oldLayoutMetrics;
+- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics;
 
 /*
  * Called when receiving a command
  */
-- (void)handleCommand:(NSString const *)commandName args:(NSArray const *)args;
+- (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args;
 
 /*
  * Called right after all update methods were called for a particular component view.

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewRegistry.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewRegistry.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  * for given `componentHandle` and with given `tag`.
  * #RefuseSingleUse
  */
-- (RCTComponentViewDescriptor const &)dequeueComponentViewWithComponentHandle:
+- (const RCTComponentViewDescriptor &)dequeueComponentViewWithComponentHandle:
                                           (facebook::react::ComponentHandle)componentHandle
                                                                           tag:(facebook::react::Tag)tag;
 
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns a component view descriptor by given `tag`.
  */
-- (RCTComponentViewDescriptor const &)componentViewDescriptorWithTag:(facebook::react::Tag)tag;
+- (const RCTComponentViewDescriptor &)componentViewDescriptorWithTag:(facebook::react::Tag)tag;
 
 /**
  * Finds a native component view by given `tag`.

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -41,7 +41,7 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
   return self;
 }
 
-- (RCTComponentViewDescriptor const &)dequeueComponentViewWithComponentHandle:(ComponentHandle)componentHandle
+- (const RCTComponentViewDescriptor &)dequeueComponentViewWithComponentHandle:(ComponentHandle)componentHandle
                                                                           tag:(Tag)tag
 {
   RCTAssertMainQueue();
@@ -70,7 +70,7 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
   [self _enqueueComponentViewWithComponentHandle:componentHandle componentViewDescriptor:componentViewDescriptor];
 }
 
-- (RCTComponentViewDescriptor const &)componentViewDescriptorWithTag:(Tag)tag
+- (const RCTComponentViewDescriptor &)componentViewDescriptorWithTag:(Tag)tag
 {
   RCTAssertMainQueue();
   auto iterator = _registry.find(tag);

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.h
@@ -64,11 +64,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setIsJSResponder:(BOOL)isJSResponder
     blockNativeResponder:(BOOL)blockNativeResponder
-           forShadowView:(facebook::react::ShadowView const &)shadowView;
+           forShadowView:(const facebook::react::ShadowView &)shadowView;
 
 - (void)synchronouslyUpdateViewOnUIThread:(ReactTag)reactTag
                              changedProps:(NSDictionary *)props
-                      componentDescriptor:(facebook::react::ComponentDescriptor const &)componentDescriptor;
+                      componentDescriptor:(const facebook::react::ComponentDescriptor &)componentDescriptor;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -43,14 +43,14 @@ static SurfaceId RCTSurfaceIdForView(UIView *view)
 }
 
 static void RCTPerformMountInstructions(
-    ShadowViewMutationList const &mutations,
+    const ShadowViewMutationList &mutations,
     RCTComponentViewRegistry *registry,
     RCTMountingTransactionObserverCoordinator &observerCoordinator,
     SurfaceId surfaceId)
 {
   SystraceSection s("RCTPerformMountInstructions");
 
-  for (auto const &mutation : mutations) {
+  for (const auto &mutation : mutations) {
     switch (mutation.type) {
       case ShadowViewMutation::Create: {
         auto &newChildShadowView = mutation.newChildShadowView;
@@ -241,7 +241,7 @@ static void RCTPerformMountInstructions(
   });
 }
 
-- (void)initiateTransaction:(MountingCoordinator const &)mountingCoordinator
+- (void)initiateTransaction:(const MountingCoordinator &)mountingCoordinator
 {
   SystraceSection s("-[RCTMountingManager initiateTransaction:]");
   RCTAssertMainQueue();
@@ -259,7 +259,7 @@ static void RCTPerformMountInstructions(
   } while (_followUpTransactionRequired);
 }
 
-- (void)performTransaction:(MountingCoordinator const &)mountingCoordinator
+- (void)performTransaction:(const MountingCoordinator &)mountingCoordinator
 {
   SystraceSection s("-[RCTMountingManager performTransaction:]");
   RCTAssertMainQueue();
@@ -267,15 +267,15 @@ static void RCTPerformMountInstructions(
   auto surfaceId = mountingCoordinator.getSurfaceId();
 
   mountingCoordinator.getTelemetryController().pullTransaction(
-      [&](MountingTransaction const &transaction, SurfaceTelemetry const &surfaceTelemetry) {
+      [&](const MountingTransaction &transaction, const SurfaceTelemetry &surfaceTelemetry) {
         [self.delegate mountingManager:self willMountComponentsWithRootTag:surfaceId];
         _observerCoordinator.notifyObserversMountingTransactionWillMount(transaction, surfaceTelemetry);
       },
-      [&](MountingTransaction const &transaction, SurfaceTelemetry const &surfaceTelemetry) {
+      [&](const MountingTransaction &transaction, const SurfaceTelemetry &surfaceTelemetry) {
         RCTPerformMountInstructions(
             transaction.getMutations(), _componentViewRegistry, _observerCoordinator, surfaceId);
       },
-      [&](MountingTransaction const &transaction, SurfaceTelemetry const &surfaceTelemetry) {
+      [&](const MountingTransaction &transaction, const SurfaceTelemetry &surfaceTelemetry) {
         _observerCoordinator.notifyObserversMountingTransactionDidMount(transaction, surfaceTelemetry);
         [self.delegate mountingManager:self didMountComponentsWithRootTag:surfaceId];
       });
@@ -283,7 +283,7 @@ static void RCTPerformMountInstructions(
 
 - (void)setIsJSResponder:(BOOL)isJSResponder
     blockNativeResponder:(BOOL)blockNativeResponder
-           forShadowView:(facebook::react::ShadowView const &)shadowView
+           forShadowView:(const facebook::react::ShadowView &)shadowView
 {
   ReactTag reactTag = shadowView.tag;
   RCTExecuteOnMainQueue(^{
@@ -309,7 +309,7 @@ static void RCTPerformMountInstructions(
   [componentView updateProps:newProps oldProps:oldProps];
   componentView.propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN = propKeys;
 
-  const auto &newViewProps = static_cast<ViewProps const &>(*newProps);
+  const auto &newViewProps = static_cast<const ViewProps &>(*newProps);
 
   if (props[@"transform"] &&
       !CATransform3DEqualToTransform(

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingTransactionObserverCoordinator.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingTransactionObserverCoordinator.h
@@ -21,21 +21,21 @@ class RCTMountingTransactionObserverCoordinator final {
    * `componentViewDescriptor` does not listen the events.
    */
   void registerViewComponentDescriptor(
-      RCTComponentViewDescriptor const &componentViewDescriptor,
+      const RCTComponentViewDescriptor &componentViewDescriptor,
       facebook::react::SurfaceId surfaceId);
   void unregisterViewComponentDescriptor(
-      RCTComponentViewDescriptor const &componentViewDescriptor,
+      const RCTComponentViewDescriptor &componentViewDescriptor,
       facebook::react::SurfaceId surfaceId);
 
   /*
    * To be called from `RCTMountingManager`.
    */
   void notifyObserversMountingTransactionWillMount(
-      facebook::react::MountingTransaction const &transaction,
-      facebook::react::SurfaceTelemetry const &surfaceTelemetry) const;
+      const facebook::react::MountingTransaction &transaction,
+      const facebook::react::SurfaceTelemetry &surfaceTelemetry) const;
   void notifyObserversMountingTransactionDidMount(
-      facebook::react::MountingTransaction const &transaction,
-      facebook::react::SurfaceTelemetry const &surfaceTelemetry) const;
+      const facebook::react::MountingTransaction &transaction,
+      const facebook::react::SurfaceTelemetry &surfaceTelemetry) const;
 
  private:
   facebook::butter::map<

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingTransactionObserverCoordinator.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingTransactionObserverCoordinator.mm
@@ -12,7 +12,7 @@
 using namespace facebook::react;
 
 void RCTMountingTransactionObserverCoordinator::registerViewComponentDescriptor(
-    RCTComponentViewDescriptor const &componentViewDescriptor,
+    const RCTComponentViewDescriptor &componentViewDescriptor,
     SurfaceId surfaceId)
 {
   if (!componentViewDescriptor.observesMountingTransactionWillMount &&
@@ -26,7 +26,7 @@ void RCTMountingTransactionObserverCoordinator::registerViewComponentDescriptor(
 }
 
 void RCTMountingTransactionObserverCoordinator::unregisterViewComponentDescriptor(
-    RCTComponentViewDescriptor const &componentViewDescriptor,
+    const RCTComponentViewDescriptor &componentViewDescriptor,
     SurfaceId surfaceId)
 {
   if (!componentViewDescriptor.observesMountingTransactionWillMount &&
@@ -40,8 +40,8 @@ void RCTMountingTransactionObserverCoordinator::unregisterViewComponentDescripto
 }
 
 void RCTMountingTransactionObserverCoordinator::notifyObserversMountingTransactionWillMount(
-    MountingTransaction const &transaction,
-    SurfaceTelemetry const &surfaceTelemetry) const
+    const MountingTransaction &transaction,
+    const SurfaceTelemetry &surfaceTelemetry) const
 {
   auto surfaceId = transaction.getSurfaceId();
   auto surfaceRegistryIterator = registry_.find(surfaceId);
@@ -49,7 +49,7 @@ void RCTMountingTransactionObserverCoordinator::notifyObserversMountingTransacti
     return;
   }
   auto &surfaceRegistry = surfaceRegistryIterator->second;
-  for (auto const &componentViewDescriptor : surfaceRegistry) {
+  for (const auto &componentViewDescriptor : surfaceRegistry) {
     if (componentViewDescriptor.observesMountingTransactionWillMount) {
       [(id<RCTMountingTransactionObserving>)componentViewDescriptor.view mountingTransactionWillMount:transaction
                                                                                  withSurfaceTelemetry:surfaceTelemetry];
@@ -58,8 +58,8 @@ void RCTMountingTransactionObserverCoordinator::notifyObserversMountingTransacti
 }
 
 void RCTMountingTransactionObserverCoordinator::notifyObserversMountingTransactionDidMount(
-    MountingTransaction const &transaction,
-    SurfaceTelemetry const &surfaceTelemetry) const
+    const MountingTransaction &transaction,
+    const SurfaceTelemetry &surfaceTelemetry) const
 {
   auto surfaceId = transaction.getSurfaceId();
   auto surfaceRegistryIterator = registry_.find(surfaceId);
@@ -67,7 +67,7 @@ void RCTMountingTransactionObserverCoordinator::notifyObserversMountingTransacti
     return;
   }
   auto &surfaceRegistry = surfaceRegistryIterator->second;
-  for (auto const &componentViewDescriptor : surfaceRegistry) {
+  for (const auto &componentViewDescriptor : surfaceRegistry) {
     if (componentViewDescriptor.observesMountingTransactionDidMount) {
       [(id<RCTMountingTransactionObserving>)componentViewDescriptor.view mountingTransactionDidMount:transaction
                                                                                 withSurfaceTelemetry:surfaceTelemetry];

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingTransactionObserving.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingTransactionObserving.h
@@ -50,16 +50,16 @@ NS_ASSUME_NONNULL_BEGIN
  * Is not being called for a component view which is being mounted as part of the transaction (because the view is not
  * registered as an observer yet).
  */
-- (void)mountingTransactionWillMount:(facebook::react::MountingTransaction const &)transaction
-                withSurfaceTelemetry:(facebook::react::SurfaceTelemetry const &)surfaceTelemetry;
+- (void)mountingTransactionWillMount:(const facebook::react::MountingTransaction &)transaction
+                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry;
 
 /*
  * Called right after the last mutation instruction is executed.
  * Is not being called for a component view which was being unmounted as part of the transaction (because the view is
  * not registered as an observer already).
  */
-- (void)mountingTransactionDidMount:(facebook::react::MountingTransaction const &)transaction
-               withSurfaceTelemetry:(facebook::react::SurfaceTelemetry const &)surfaceTelemetry;
+- (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
+               withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry;
 
 @end
 

--- a/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
+++ b/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
@@ -22,16 +22,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index;
 
-- (void)updateProps:(facebook::react::Props::Shared const &)props
-           oldProps:(facebook::react::Props::Shared const &)oldProps;
+- (void)updateProps:(const facebook::react::Props::Shared &)props
+           oldProps:(const facebook::react::Props::Shared &)oldProps;
 
-- (void)updateEventEmitter:(facebook::react::EventEmitter::Shared const &)eventEmitter;
+- (void)updateEventEmitter:(const facebook::react::EventEmitter::Shared &)eventEmitter;
 
-- (void)updateState:(facebook::react::State::Shared const &)state
-           oldState:(facebook::react::State::Shared const &)oldState;
+- (void)updateState:(const facebook::react::State::Shared &)state
+           oldState:(const facebook::react::State::Shared &)oldState;
 
-- (void)updateLayoutMetrics:(facebook::react::LayoutMetrics const &)layoutMetrics
-           oldLayoutMetrics:(facebook::react::LayoutMetrics const &)oldLayoutMetrics;
+- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics;
 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask;
 

--- a/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -60,18 +60,18 @@ using namespace facebook::react;
   [childComponentView removeFromSuperview];
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
   // Default implementation does nothing.
 }
 
-- (void)updateEventEmitter:(EventEmitter::Shared const &)eventEmitter
+- (void)updateEventEmitter:(const EventEmitter::Shared &)eventEmitter
 {
   // Default implementation does nothing.
 }
 
-- (void)updateState:(facebook::react::State::Shared const &)state
-           oldState:(facebook::react::State::Shared const &)oldState
+- (void)updateState:(const facebook::react::State::Shared &)state
+           oldState:(const facebook::react::State::Shared &)oldState
 {
   // Default implementation does nothing.
 }
@@ -81,8 +81,8 @@ using namespace facebook::react;
   // Default implementation does nothing.
 }
 
-- (void)updateLayoutMetrics:(LayoutMetrics const &)layoutMetrics
-           oldLayoutMetrics:(LayoutMetrics const &)oldLayoutMetrics
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
 {
   bool forceUpdate = oldLayoutMetrics == EmptyLayoutMetrics;
 

--- a/packages/react-native/React/Fabric/RCTConversions.h
+++ b/packages/react-native/React/Fabric/RCTConversions.h
@@ -34,7 +34,7 @@ inline std::string RCTStringFromNSString(NSString *string)
   return std::string{string.UTF8String ?: ""};
 }
 
-inline UIColor *_Nullable RCTUIColorFromSharedColor(facebook::react::SharedColor const &sharedColor)
+inline UIColor *_Nullable RCTUIColorFromSharedColor(const facebook::react::SharedColor &sharedColor)
 {
   if (!sharedColor) {
     return nil;
@@ -82,7 +82,7 @@ inline UIEdgeInsets RCTUIEdgeInsetsFromEdgeInsets(const facebook::react::EdgeIns
   return {edgeInsets.top, edgeInsets.left, edgeInsets.bottom, edgeInsets.right};
 }
 
-UIAccessibilityTraits const AccessibilityTraitSwitch = 0x20000000000001;
+const UIAccessibilityTraits AccessibilityTraitSwitch = 0x20000000000001;
 
 inline UIAccessibilityTraits RCTUIAccessibilityTraitsFromAccessibilityTraits(
     facebook::react::AccessibilityTraits accessibilityTraits)

--- a/packages/react-native/React/Fabric/RCTImageResponseDelegate.h
+++ b/packages/react-native/React/Fabric/RCTImageResponseDelegate.h
@@ -11,9 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol RCTImageResponseDelegate <NSObject>
 
-- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(void const *)observer;
-- (void)didReceiveProgress:(float)progress fromObserver:(void const *)observer;
-- (void)didReceiveFailureFromObserver:(void const *)observer;
+- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(const void *)observer;
+- (void)didReceiveProgress:(float)progress fromObserver:(const void *)observer;
+- (void)didReceiveFailureFromObserver:(const void *)observer;
 
 @end
 

--- a/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.h
+++ b/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.h
@@ -19,7 +19,7 @@ class RCTImageResponseObserverProxy final : public ImageResponseObserver {
  public:
   RCTImageResponseObserverProxy(id<RCTImageResponseDelegate> delegate = nil);
 
-  void didReceiveImage(ImageResponse const &imageResponse) const override;
+  void didReceiveImage(const ImageResponse &imageResponse) const override;
   void didReceiveProgress(float progress) const override;
   void didReceiveFailure() const override;
 

--- a/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.mm
+++ b/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.mm
@@ -19,7 +19,7 @@ RCTImageResponseObserverProxy::RCTImageResponseObserverProxy(id<RCTImageResponse
 {
 }
 
-void RCTImageResponseObserverProxy::didReceiveImage(ImageResponse const &imageResponse) const
+void RCTImageResponseObserverProxy::didReceiveImage(const ImageResponse &imageResponse) const
 {
   UIImage *image = (UIImage *)unwrapManagedObject(imageResponse.getImage());
   id metadata = unwrapManagedObject(imageResponse.getMetadata());

--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -30,16 +30,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)schedulerDidFinishTransaction:(facebook::react::MountingCoordinator::Shared)mountingCoordinator;
 
-- (void)schedulerDidDispatchCommand:(facebook::react::ShadowView const &)shadowView
-                        commandName:(std::string const &)commandName
-                               args:(folly::dynamic const &)args;
+- (void)schedulerDidDispatchCommand:(const facebook::react::ShadowView &)shadowView
+                        commandName:(const std::string &)commandName
+                               args:(const folly::dynamic &)args;
 
-- (void)schedulerDidSendAccessibilityEvent:(facebook::react::ShadowView const &)shadowView
-                                 eventType:(std::string const &)eventType;
+- (void)schedulerDidSendAccessibilityEvent:(const facebook::react::ShadowView &)shadowView
+                                 eventType:(const std::string &)eventType;
 
 - (void)schedulerDidSetIsJSResponder:(BOOL)isJSResponder
                 blockNativeResponder:(BOOL)blockNativeResponder
-                       forShadowView:(facebook::react::ShadowView const &)shadowView;
+                       forShadowView:(const facebook::react::ShadowView &)shadowView;
 
 @end
 
@@ -49,17 +49,17 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTScheduler : NSObject
 
 @property (atomic, weak, nullable) id<RCTSchedulerDelegate> delegate;
-@property (readonly) std::shared_ptr<facebook::react::UIManager> const uiManager;
+@property (readonly) const std::shared_ptr<facebook::react::UIManager> uiManager;
 
 - (instancetype)initWithToolbox:(facebook::react::SchedulerToolbox)toolbox;
 
-- (void)registerSurface:(facebook::react::SurfaceHandler const &)surfaceHandler;
-- (void)unregisterSurface:(facebook::react::SurfaceHandler const &)surfaceHandler;
+- (void)registerSurface:(const facebook::react::SurfaceHandler &)surfaceHandler;
+- (void)unregisterSurface:(const facebook::react::SurfaceHandler &)surfaceHandler;
 
-- (facebook::react::ComponentDescriptor const *)findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN:
+- (const facebook::react::ComponentDescriptor *)findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN:
     (facebook::react::ComponentHandle)handle;
 
-- (void)setupAnimationDriver:(facebook::react::SurfaceHandler const &)surfaceHandler;
+- (void)setupAnimationDriver:(const facebook::react::SurfaceHandler &)surfaceHandler;
 
 - (void)onAnimationStarted;
 
@@ -69,9 +69,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)reportMount:(facebook::react::SurfaceId)surfaceId;
 
-- (void)addEventListener:(std::shared_ptr<facebook::react::EventListener> const &)listener;
+- (void)addEventListener:(const std::shared_ptr<facebook::react::EventListener> &)listener;
 
-- (void)removeEventListener:(std::shared_ptr<facebook::react::EventListener> const &)listener;
+- (void)removeEventListener:(const std::shared_ptr<facebook::react::EventListener> &)listener;
 
 @end
 

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -45,7 +45,7 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     [scheduler.delegate schedulerDidDispatchCommand:shadowView commandName:commandName args:args];
   }
 
-  void schedulerDidSetIsJSResponder(ShadowView const &shadowView, bool isJSResponder, bool blockNativeResponder)
+  void schedulerDidSetIsJSResponder(const ShadowView &shadowView, bool isJSResponder, bool blockNativeResponder)
       override
   {
     RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
@@ -54,7 +54,7 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
                                        forShadowView:shadowView];
   }
 
-  void schedulerDidSendAccessibilityEvent(const ShadowView &shadowView, std::string const &eventType) override
+  void schedulerDidSendAccessibilityEvent(const ShadowView &shadowView, const std::string &eventType) override
   {
     RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
     [scheduler.delegate schedulerDidSendAccessibilityEvent:shadowView eventType:eventType];
@@ -84,7 +84,7 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
     [scheduler onAllAnimationsComplete];
   }
 
-  void activityDidChange(RunLoopObserver::Delegate const *delegate, RunLoopObserver::Activity activity)
+  void activityDidChange(const RunLoopObserver::Delegate *delegate, RunLoopObserver::Activity activity)
       const noexcept override
   {
     RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
@@ -146,22 +146,22 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
   _scheduler->setDelegate(nullptr);
 }
 
-- (void)registerSurface:(facebook::react::SurfaceHandler const &)surfaceHandler
+- (void)registerSurface:(const facebook::react::SurfaceHandler &)surfaceHandler
 {
   _scheduler->registerSurface(surfaceHandler);
 }
 
-- (void)unregisterSurface:(facebook::react::SurfaceHandler const &)surfaceHandler
+- (void)unregisterSurface:(const facebook::react::SurfaceHandler &)surfaceHandler
 {
   _scheduler->unregisterSurface(surfaceHandler);
 }
 
-- (ComponentDescriptor const *)findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN:(ComponentHandle)handle
+- (const ComponentDescriptor *)findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN:(ComponentHandle)handle
 {
   return _scheduler->findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(handle);
 }
 
-- (void)setupAnimationDriver:(facebook::react::SurfaceHandler const &)surfaceHandler
+- (void)setupAnimationDriver:(const facebook::react::SurfaceHandler &)surfaceHandler
 {
   surfaceHandler.getMountingCoordinator()->setMountingOverrideDelegate(_animationDriver);
 }
@@ -180,17 +180,17 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
   }
 }
 
-- (void)addEventListener:(std::shared_ptr<EventListener> const &)listener
+- (void)addEventListener:(const std::shared_ptr<EventListener> &)listener
 {
   return _scheduler->addEventListener(listener);
 }
 
-- (void)removeEventListener:(std::shared_ptr<EventListener> const &)listener
+- (void)removeEventListener:(const std::shared_ptr<EventListener> &)listener
 {
   return _scheduler->removeEventListener(listener);
 }
 
-- (std::shared_ptr<facebook::react::UIManager> const)uiManager
+- (const std::shared_ptr<facebook::react::UIManager>)uiManager
 {
   return _scheduler->getUIManager();
 }

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -714,7 +714,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
     std::vector<ActivePointer> activePointers;
     activePointers.reserve(_activePointers.size());
 
-    for (auto const &pair : _activePointers) {
+    for (const auto &pair : _activePointers) {
       activePointers.push_back(pair.second);
     }
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.h
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.h
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag props:(NSDictionary *)props;
 
-- (void)setupAnimationDriverWithSurfaceHandler:(facebook::react::SurfaceHandler const &)surfaceHandler;
+- (void)setupAnimationDriverWithSurfaceHandler:(const facebook::react::SurfaceHandler &)surfaceHandler;
 
 /*
  * Deprecated.

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -201,7 +201,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   return YES;
 }
 
-- (void)setupAnimationDriverWithSurfaceHandler:(facebook::react::SurfaceHandler const &)surfaceHandler
+- (void)setupAnimationDriverWithSurfaceHandler:(const facebook::react::SurfaceHandler &)surfaceHandler
 {
   [[self scheduler] setupAnimationDriver:surfaceHandler];
 }
@@ -254,7 +254,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (RCTScheduler *)_createScheduler
 {
-  auto reactNativeConfig = _contextContainer->at<std::shared_ptr<ReactNativeConfig const>>("ReactNativeConfig");
+  auto reactNativeConfig = _contextContainer->at<std::shared_ptr<const ReactNativeConfig>>("ReactNativeConfig");
 
   if (reactNativeConfig && reactNativeConfig->getBool("rn_convergence:dispatch_pointer_events")) {
     RCTSetDispatchW3CPointerEvents(YES);
@@ -290,7 +290,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
   auto componentRegistryFactory =
       [factory = wrapManagedObject(_mountingManager.componentViewRegistry.componentViewFactory)](
-          EventDispatcher::Weak const &eventDispatcher, ContextContainer::Shared const &contextContainer) {
+          const EventDispatcher::Weak &eventDispatcher, const ContextContainer::Shared &contextContainer) {
         return [(RCTComponentViewFactory *)unwrapManagedObject(factory)
             createComponentDescriptorRegistryWithParameters:{eventDispatcher, contextContainer}];
       };
@@ -313,7 +313,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   toolbox.bridgelessBindingsExecutor = _bridgelessBindingsExecutor;
 
   toolbox.mainRunLoopObserverFactory = [](RunLoopObserver::Activity activities,
-                                          RunLoopObserver::WeakOwner const &owner) {
+                                          const RunLoopObserver::WeakOwner &owner) {
     return std::make_unique<MainRunLoopObserver>(activities, owner);
   };
 
@@ -322,14 +322,14 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   }
 
   toolbox.synchronousEventBeatFactory =
-      [runtimeExecutor, runtimeScheduler = runtimeScheduler](EventBeat::SharedOwnerBox const &ownerBox) {
+      [runtimeExecutor, runtimeScheduler = runtimeScheduler](const EventBeat::SharedOwnerBox &ownerBox) {
         auto runLoopObserver =
             std::make_unique<MainRunLoopObserver const>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
         return std::make_unique<SynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor, runtimeScheduler);
       };
 
   toolbox.asynchronousEventBeatFactory =
-      [runtimeExecutor](EventBeat::SharedOwnerBox const &ownerBox) -> std::unique_ptr<EventBeat> {
+      [runtimeExecutor](const EventBeat::SharedOwnerBox &ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<MainRunLoopObserver const>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
     return std::make_unique<AsynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor);
@@ -373,9 +373,9 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   [_mountingManager scheduleTransaction:mountingCoordinator];
 }
 
-- (void)schedulerDidDispatchCommand:(ShadowView const &)shadowView
-                        commandName:(std::string const &)commandName
-                               args:(folly::dynamic const &)args
+- (void)schedulerDidDispatchCommand:(const ShadowView &)shadowView
+                        commandName:(const std::string &)commandName
+                               args:(const folly::dynamic &)args
 {
   ReactTag tag = shadowView.tag;
   NSString *commandStr = [[NSString alloc] initWithUTF8String:commandName.c_str()];
@@ -395,7 +395,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (void)schedulerDidSetIsJSResponder:(BOOL)isJSResponder
                 blockNativeResponder:(BOOL)blockNativeResponder
-                       forShadowView:(facebook::react::ShadowView const &)shadowView;
+                       forShadowView:(const facebook::react::ShadowView &)shadowView;
 {
   [_mountingManager setIsJSResponder:isJSResponder blockNativeResponder:blockNativeResponder forShadowView:shadowView];
 }

--- a/packages/react-native/React/Fabric/RCTSurfacePresenterBridgeAdapter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenterBridgeAdapter.mm
@@ -31,7 +31,7 @@ using namespace facebook::react;
 
 static ContextContainer::Shared RCTContextContainerFromBridge(RCTBridge *bridge)
 {
-  auto contextContainer = std::make_shared<ContextContainer const>();
+  auto contextContainer = std::make_shared<const ContextContainer>();
 
   RCTImageLoader *imageLoader = RCTTurboModuleEnabled()
       ? [bridge moduleForName:@"RCTImageLoader" lazilyLoadIfNecessary:YES]

--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -362,7 +362,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
     std::vector<ActiveTouch> activeTouches;
     activeTouches.reserve(_activeTouches.size());
 
-    for (auto const &pair : _activeTouches) {
+    for (const auto &pair : _activeTouches) {
       activeTouches.push_back(pair.second);
     }
 

--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.h
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.h
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCTFabricSurface (Internal)
 
-- (facebook::react::SurfaceHandler const &)surfaceHandler;
+- (const facebook::react::SurfaceHandler &)surfaceHandler;
 
 @end
 

--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -274,7 +274,7 @@ using namespace facebook::react;
 
 #pragma mark - Private
 
-- (SurfaceHandler const &)surfaceHandler;
+- (const SurfaceHandler &)surfaceHandler;
 {
   return *_surfaceHandler;
 }

--- a/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.h
+++ b/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.h
@@ -22,7 +22,7 @@ class PlatformRunLoopObserver : public RunLoopObserver {
  public:
   PlatformRunLoopObserver(
       RunLoopObserver::Activity activities,
-      RunLoopObserver::WeakOwner const &owner,
+      const RunLoopObserver::WeakOwner &owner,
       CFRunLoopRef runLoop);
 
   ~PlatformRunLoopObserver();
@@ -45,7 +45,7 @@ class MainRunLoopObserver final : public PlatformRunLoopObserver {
  public:
   MainRunLoopObserver(
       RunLoopObserver::Activity activities,
-      RunLoopObserver::WeakOwner const &owner)
+      const RunLoopObserver::WeakOwner &owner)
       : PlatformRunLoopObserver(activities, owner, CFRunLoopGetMain()) {}
 };
 

--- a/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.mm
+++ b/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.mm
@@ -45,7 +45,7 @@ static RunLoopObserver::Activity toRunLoopActivity(CFRunLoopActivity activity)
 
 PlatformRunLoopObserver::PlatformRunLoopObserver(
     RunLoopObserver::Activity activities,
-    RunLoopObserver::WeakOwner const &owner,
+    const RunLoopObserver::WeakOwner &owner,
     CFRunLoopRef runLoop)
     : RunLoopObserver(activities, owner), runLoop_(runLoop)
 {

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -22,7 +22,7 @@
 RCT_MOCK_DEF(RCTView, RCTContentInsets);
 #define RCTContentInsets RCT_MOCK_USE(RCTView, RCTContentInsets)
 
-UIAccessibilityTraits const SwitchAccessibilityTrait = 0x20000000000001;
+const UIAccessibilityTraits SwitchAccessibilityTrait = 0x20000000000001;
 
 @implementation UIView (RCTViewUnmounting)
 

--- a/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp
@@ -36,7 +36,7 @@
 namespace facebook::react {
 
 void registerComponents(
-    std::shared_ptr<ComponentDescriptorProviderRegistry const> registry) {
+    std::shared_ptr<const ComponentDescriptorProviderRegistry> registry) {
   // Custom Fabric Components go here. You can register custom
   // components coming from your App or from 3rd party libraries here.
   //

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
@@ -14,7 +14,7 @@
 namespace facebook::react {
 
 AsyncEventBeat::AsyncEventBeat(
-    EventBeat::SharedOwnerBox const &ownerBox,
+    const EventBeat::SharedOwnerBox &ownerBox,
     EventBeatManager *eventBeatManager,
     RuntimeExecutor runtimeExecutor,
     jni::global_ref<jobject> javaUIManager)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.h
@@ -16,7 +16,7 @@ namespace facebook::react {
 class AsyncEventBeat final : public EventBeat, public EventBeatManagerObserver {
  public:
   AsyncEventBeat(
-      EventBeat::SharedOwnerBox const &ownerBox,
+      const EventBeat::SharedOwnerBox &ownerBox,
       EventBeatManager *eventBeatManager,
       RuntimeExecutor runtimeExecutor,
       jni::global_ref<jobject> javaUIManager);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -272,7 +272,7 @@ void Binding::stopSurface(jint surfaceId) {
 }
 
 void Binding::registerSurface(SurfaceHandlerBinding *surfaceHandlerBinding) {
-  auto const &surfaceHandler = surfaceHandlerBinding->getSurfaceHandler();
+  const auto &surfaceHandler = surfaceHandlerBinding->getSurfaceHandler();
   auto scheduler = getScheduler();
   if (!scheduler) {
     LOG(ERROR) << "Binding::registerSurface: scheduler disappeared";
@@ -288,7 +288,7 @@ void Binding::registerSurface(SurfaceHandlerBinding *surfaceHandlerBinding) {
 }
 
 void Binding::unregisterSurface(SurfaceHandlerBinding *surfaceHandlerBinding) {
-  auto const &surfaceHandler = surfaceHandlerBinding->getSurfaceHandler();
+  const auto &surfaceHandler = surfaceHandlerBinding->getSurfaceHandler();
   auto scheduler = getScheduler();
   if (!scheduler) {
     LOG(ERROR) << "Binding::unregisterSurface: scheduler disappeared";
@@ -403,7 +403,7 @@ void Binding::installFabricUIManager(
   // TODO: T31905686 Create synchronous Event Beat
   EventBeat::Factory synchronousBeatFactory =
       [eventBeatManager, runtimeExecutor, globalJavaUiManager](
-          EventBeat::SharedOwnerBox const &ownerBox)
+          const EventBeat::SharedOwnerBox &ownerBox)
       -> std::unique_ptr<EventBeat> {
     return std::make_unique<AsyncEventBeat>(
         ownerBox, eventBeatManager, runtimeExecutor, globalJavaUiManager);
@@ -411,7 +411,7 @@ void Binding::installFabricUIManager(
 
   EventBeat::Factory asynchronousBeatFactory =
       [eventBeatManager, runtimeExecutor, globalJavaUiManager](
-          EventBeat::SharedOwnerBox const &ownerBox)
+          const EventBeat::SharedOwnerBox &ownerBox)
       -> std::unique_ptr<EventBeat> {
     return std::make_unique<AsyncEventBeat>(
         ownerBox, eventBeatManager, runtimeExecutor, globalJavaUiManager);
@@ -520,8 +520,8 @@ void Binding::schedulerDidRequestPreliminaryViewAllocation(
 
 void Binding::schedulerDidDispatchCommand(
     const ShadowView &shadowView,
-    std::string const &commandName,
-    folly::dynamic const &args) {
+    const std::string &commandName,
+    const folly::dynamic &args) {
   auto mountingManager = getMountingManager("schedulerDidDispatchCommand");
   if (!mountingManager) {
     return;
@@ -531,7 +531,7 @@ void Binding::schedulerDidDispatchCommand(
 
 void Binding::schedulerDidSendAccessibilityEvent(
     const ShadowView &shadowView,
-    std::string const &eventType) {
+    const std::string &eventType) {
   auto mountingManager =
       getMountingManager("schedulerDidSendAccessibilityEvent");
   if (!mountingManager) {
@@ -541,7 +541,7 @@ void Binding::schedulerDidSendAccessibilityEvent(
 }
 
 void Binding::schedulerDidSetIsJSResponder(
-    ShadowView const &shadowView,
+    const ShadowView &shadowView,
     bool isJSResponder,
     bool blockNativeResponder) {
   auto mountingManager = getMountingManager("schedulerDidSetIsJSResponder");

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -104,15 +104,15 @@ class Binding : public jni::HybridClass<Binding>,
 
   void schedulerDidDispatchCommand(
       const ShadowView &shadowView,
-      std::string const &commandName,
-      folly::dynamic const &args) override;
+      const std::string &commandName,
+      const folly::dynamic &args) override;
 
   void schedulerDidSendAccessibilityEvent(
       const ShadowView &shadowView,
-      std::string const &eventType) override;
+      const std::string &eventType) override;
 
   void schedulerDidSetIsJSResponder(
-      ShadowView const &shadowView,
+      const ShadowView &shadowView,
       bool isJSResponder,
       bool blockNativeResponder) override;
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
@@ -29,7 +29,7 @@ namespace facebook::react {
 CoreComponentsRegistry::CoreComponentsRegistry(ComponentFactory *delegate)
     : delegate_(delegate) {}
 
-std::shared_ptr<ComponentDescriptorProviderRegistry const>
+std::shared_ptr<const ComponentDescriptorProviderRegistry>
 CoreComponentsRegistry::sharedProviderRegistry() {
   static auto providerRegistry =
       []() -> std::shared_ptr<ComponentDescriptorProviderRegistry> {
@@ -82,8 +82,8 @@ CoreComponentsRegistry::initHybrid(
 
   // TODO T69453179: Codegen this file
   auto buildRegistryFunction =
-      [](EventDispatcher::Weak const &eventDispatcher,
-         ContextContainer::Shared const &contextContainer)
+      [](const EventDispatcher::Weak &eventDispatcher,
+         const ContextContainer::Shared &contextContainer)
       -> ComponentDescriptorRegistry::Shared {
     auto registry = CoreComponentsRegistry::sharedProviderRegistry()
                         ->createComponentDescriptorRegistry(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.h
@@ -24,7 +24,7 @@ class CoreComponentsRegistry
 
   explicit CoreComponentsRegistry(ComponentFactory *delegate);
 
-  static std::shared_ptr<ComponentDescriptorProviderRegistry const>
+  static std::shared_ptr<const ComponentDescriptorProviderRegistry>
   sharedProviderRegistry();
 
  private:

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventBeatManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventBeatManager.cpp
@@ -21,13 +21,13 @@ jni::local_ref<EventBeatManager::jhybriddata> EventBeatManager::initHybrid(
 }
 
 void EventBeatManager::addObserver(
-    EventBeatManagerObserver const &observer) const {
+    const EventBeatManagerObserver &observer) const {
   std::scoped_lock lock(mutex_);
   observers_.insert(&observer);
 }
 
 void EventBeatManager::removeObserver(
-    EventBeatManagerObserver const &observer) const {
+    const EventBeatManagerObserver &observer) const {
   std::scoped_lock lock(mutex_);
   observers_.erase(&observer);
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventBeatManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventBeatManager.h
@@ -42,8 +42,8 @@ class EventBeatManager : public jni::HybridClass<EventBeatManager> {
    * `EventBeatManager` does not own/retain observers; observers must overlive
    * the manager or be properly removed before deallocation.
    */
-  void addObserver(EventBeatManagerObserver const &observer) const;
-  void removeObserver(EventBeatManagerObserver const &observer) const;
+  void addObserver(const EventBeatManagerObserver &observer) const;
+  void removeObserver(const EventBeatManagerObserver &observer) const;
 
  private:
   /*
@@ -53,7 +53,7 @@ class EventBeatManager : public jni::HybridClass<EventBeatManager> {
 
   jni::alias_ref<EventBeatManager::jhybriddata> jhybridobject_;
 
-  mutable std::unordered_set<EventBeatManagerObserver const *>
+  mutable std::unordered_set<const EventBeatManagerObserver *>
       observers_{}; // Protected by `mutex_`
 
   mutable std::mutex mutex_;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -121,7 +121,7 @@ static inline void computeBufferSizes(
     std::vector<CppMountItem> &cppUpdateEventEmitterMountItems) {
   CppMountItem::Type lastType = CppMountItem::Type::Undefined;
   int numSameType = 0;
-  for (auto const &mountItem : cppCommonMountItems) {
+  for (const auto &mountItem : cppCommonMountItems) {
     const auto &mountItemType = mountItem.type;
 
     if (lastType == mountItemType) {
@@ -199,7 +199,7 @@ static inline void writeIntBufferTypePreamble(
 }
 
 // TODO: this method will be removed when binding for components are code-gen
-jni::local_ref<jstring> getPlatformComponentName(ShadowView const &shadowView) {
+jni::local_ref<jstring> getPlatformComponentName(const ShadowView &shadowView) {
   static std::string scrollViewComponentName = std::string("ScrollView");
   if (scrollViewComponentName == shadowView.componentName) {
     const auto &newViewProps =
@@ -228,8 +228,8 @@ static inline float scale(Float value, Float pointScaleFactor) {
 }
 
 jni::local_ref<jobject> FabricMountingManager::getProps(
-    ShadowView const &oldShadowView,
-    ShadowView const &newShadowView) {
+    const ShadowView &oldShadowView,
+    const ShadowView &newShadowView) {
   if (CoreFeatures::enableMapBuffer &&
       newShadowView.traits.check(
           ShadowNodeTraits::Trait::AndroidMapBufferPropsSupported)) {
@@ -465,7 +465,7 @@ void FabricMountingManager::executeMount(
 
     if (allocatedViewsIterator != allocatedViewRegistry_.end()) {
       auto &views = allocatedViewsIterator->second;
-      for (auto const &mutation : mutations) {
+      for (const auto &mutation : mutations) {
         switch (mutation.type) {
           case ShadowViewMutation::Create:
             views.insert(mutation.newChildShadowView.tag);
@@ -821,7 +821,7 @@ void FabricMountingManager::executeMount(
 
 void FabricMountingManager::preallocateShadowView(
     SurfaceId surfaceId,
-    ShadowView const &shadowView) {
+    const ShadowView &shadowView) {
   {
     std::lock_guard lock(allocatedViewsMutex_);
     auto allocatedViewsIterator = allocatedViewRegistry_.find(surfaceId);
@@ -872,9 +872,9 @@ void FabricMountingManager::preallocateShadowView(
 }
 
 void FabricMountingManager::dispatchCommand(
-    ShadowView const &shadowView,
-    std::string const &commandName,
-    folly::dynamic const &args) {
+    const ShadowView &shadowView,
+    const std::string &commandName,
+    const folly::dynamic &args) {
   static auto dispatchCommand =
       JFabricUIManager::javaClassStatic()
           ->getMethod<void(jint, jint, jstring, ReadableArray::javaobject)>(
@@ -891,8 +891,8 @@ void FabricMountingManager::dispatchCommand(
 }
 
 void FabricMountingManager::sendAccessibilityEvent(
-    ShadowView const &shadowView,
-    std::string const &eventType) {
+    const ShadowView &shadowView,
+    const std::string &eventType) {
   static auto sendAccessibilityEventFromJS =
       JFabricUIManager::javaClassStatic()->getMethod<void(jint, jint, jstring)>(
           "sendAccessibilityEventFromJS");
@@ -903,7 +903,7 @@ void FabricMountingManager::sendAccessibilityEvent(
 }
 
 void FabricMountingManager::setIsJSResponder(
-    ShadowView const &shadowView,
+    const ShadowView &shadowView,
     bool isJSResponder,
     bool blockNativeResponder) {
   static auto setJSResponder =

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -31,21 +31,21 @@ class FabricMountingManager final {
 
   void onSurfaceStop(SurfaceId surfaceId);
 
-  void preallocateShadowView(SurfaceId surfaceId, ShadowView const &shadowView);
+  void preallocateShadowView(SurfaceId surfaceId, const ShadowView &shadowView);
 
   void executeMount(const MountingTransaction &transaction);
 
   void dispatchCommand(
-      ShadowView const &shadowView,
-      std::string const &commandName,
-      folly::dynamic const &args);
+      const ShadowView &shadowView,
+      const std::string &commandName,
+      const folly::dynamic &args);
 
   void sendAccessibilityEvent(
       const ShadowView &shadowView,
-      std::string const &eventType);
+      const std::string &eventType);
 
   void setIsJSResponder(
-      ShadowView const &shadowView,
+      const ShadowView &shadowView,
       bool isJSResponder,
       bool blockNativeResponder);
 
@@ -61,11 +61,11 @@ class FabricMountingManager final {
   butter::map<SurfaceId, butter::set<Tag>> allocatedViewRegistry_{};
   std::recursive_mutex allocatedViewsMutex_;
 
-  bool const reduceDeleteCreateMutation_{false};
+  const bool reduceDeleteCreateMutation_{false};
 
   jni::local_ref<jobject> getProps(
-      ShadowView const &oldShadowView,
-      ShadowView const &newShadowView);
+      const ShadowView &oldShadowView,
+      const ShadowView &newShadowView);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.cpp
@@ -9,55 +9,55 @@
 
 namespace facebook::react {
 
-CppMountItem CppMountItem::CreateMountItem(ShadowView const &shadowView) {
+CppMountItem CppMountItem::CreateMountItem(const ShadowView &shadowView) {
   return {CppMountItem::Type::Create, {}, {}, shadowView, -1};
 }
-CppMountItem CppMountItem::DeleteMountItem(ShadowView const &shadowView) {
+CppMountItem CppMountItem::DeleteMountItem(const ShadowView &shadowView) {
   return {CppMountItem::Type::Delete, {}, shadowView, {}, -1};
 }
 CppMountItem CppMountItem::InsertMountItem(
-    ShadowView const &parentView,
-    ShadowView const &shadowView,
+    const ShadowView &parentView,
+    const ShadowView &shadowView,
     int index) {
   return {CppMountItem::Type::Insert, parentView, {}, shadowView, index};
 }
 CppMountItem CppMountItem::RemoveMountItem(
-    ShadowView const &parentView,
-    ShadowView const &shadowView,
+    const ShadowView &parentView,
+    const ShadowView &shadowView,
     int index) {
   return {CppMountItem::Type::Remove, parentView, shadowView, {}, index};
 }
 CppMountItem CppMountItem::RemoveDeleteTreeMountItem(
-    ShadowView const &parentView,
-    ShadowView const &shadowView,
+    const ShadowView &parentView,
+    const ShadowView &shadowView,
     int index) {
   return {
       CppMountItem::Type::RemoveDeleteTree, parentView, shadowView, {}, index};
 }
 CppMountItem CppMountItem::UpdatePropsMountItem(
-    ShadowView const &oldShadowView,
-    ShadowView const &newShadowView) {
+    const ShadowView &oldShadowView,
+    const ShadowView &newShadowView) {
   return {
       CppMountItem::Type::UpdateProps, {}, oldShadowView, newShadowView, -1};
 }
-CppMountItem CppMountItem::UpdateStateMountItem(ShadowView const &shadowView) {
+CppMountItem CppMountItem::UpdateStateMountItem(const ShadowView &shadowView) {
   return {CppMountItem::Type::UpdateState, {}, {}, shadowView, -1};
 }
 CppMountItem CppMountItem::UpdateLayoutMountItem(
-    ShadowView const &shadowView,
-    ShadowView const &parentView) {
+    const ShadowView &shadowView,
+    const ShadowView &parentView) {
   return {CppMountItem::Type::UpdateLayout, parentView, {}, shadowView, -1};
 }
 CppMountItem CppMountItem::UpdateEventEmitterMountItem(
-    ShadowView const &shadowView) {
+    const ShadowView &shadowView) {
   return {CppMountItem::Type::UpdateEventEmitter, {}, {}, shadowView, -1};
 }
 CppMountItem CppMountItem::UpdatePaddingMountItem(
-    ShadowView const &shadowView) {
+    const ShadowView &shadowView) {
   return {CppMountItem::Type::UpdatePadding, {}, {}, shadowView, -1};
 }
 CppMountItem CppMountItem::UpdateOverflowInsetMountItem(
-    ShadowView const &shadowView) {
+    const ShadowView &shadowView) {
   return {CppMountItem::Type::UpdateOverflowInset, {}, {}, shadowView, -1};
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.h
@@ -20,41 +20,41 @@ struct JMountItem : public jni::JavaClass<JMountItem> {
 struct CppMountItem final {
 #pragma mark - Designated Initializers
 
-  static CppMountItem CreateMountItem(ShadowView const &shadowView);
+  static CppMountItem CreateMountItem(const ShadowView &shadowView);
 
-  static CppMountItem DeleteMountItem(ShadowView const &shadowView);
+  static CppMountItem DeleteMountItem(const ShadowView &shadowView);
 
   static CppMountItem InsertMountItem(
-      ShadowView const &parentView,
-      ShadowView const &shadowView,
+      const ShadowView &parentView,
+      const ShadowView &shadowView,
       int index);
 
   static CppMountItem RemoveMountItem(
-      ShadowView const &parentView,
-      ShadowView const &shadowView,
+      const ShadowView &parentView,
+      const ShadowView &shadowView,
       int index);
 
   static CppMountItem RemoveDeleteTreeMountItem(
-      ShadowView const &parentView,
-      ShadowView const &shadowView,
+      const ShadowView &parentView,
+      const ShadowView &shadowView,
       int index);
 
   static CppMountItem UpdatePropsMountItem(
-      ShadowView const &oldShadowView,
-      ShadowView const &newShadowView);
+      const ShadowView &oldShadowView,
+      const ShadowView &newShadowView);
 
-  static CppMountItem UpdateStateMountItem(ShadowView const &shadowView);
+  static CppMountItem UpdateStateMountItem(const ShadowView &shadowView);
 
   static CppMountItem UpdateLayoutMountItem(
-      ShadowView const &shadowView,
-      ShadowView const &parentView);
+      const ShadowView &shadowView,
+      const ShadowView &parentView);
 
-  static CppMountItem UpdateEventEmitterMountItem(ShadowView const &shadowView);
+  static CppMountItem UpdateEventEmitterMountItem(const ShadowView &shadowView);
 
-  static CppMountItem UpdatePaddingMountItem(ShadowView const &shadowView);
+  static CppMountItem UpdatePaddingMountItem(const ShadowView &shadowView);
 
   static CppMountItem UpdateOverflowInsetMountItem(
-      ShadowView const &shadowView);
+      const ShadowView &shadowView);
 
 #pragma mark - Type
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
@@ -29,7 +29,7 @@ class StateWrapperImpl : public jni::HybridClass<StateWrapperImpl> {
   jni::local_ref<ReadableNativeMap::jhybridobject> getStateDataImpl();
   void updateStateImpl(NativeMap *map);
 
-  std::weak_ptr<State const> state_;
+  std::weak_ptr<const State> state_;
 
  private:
   jni::alias_ref<StateWrapperImpl::jhybriddata> jhybridobject_;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.cpp
@@ -12,7 +12,7 @@ namespace facebook::react {
 
 SurfaceHandlerBinding::SurfaceHandlerBinding(
     SurfaceId surfaceId,
-    std::string const &moduleName)
+    const std::string &moduleName)
     : surfaceHandler_(moduleName, surfaceId) {}
 
 void SurfaceHandlerBinding::setDisplayMode(jint mode) {
@@ -87,7 +87,7 @@ void SurfaceHandlerBinding::setProps(NativeMap *props) {
   surfaceHandler_.setProps(props->consume());
 }
 
-SurfaceHandler const &SurfaceHandlerBinding::getSurfaceHandler() {
+const SurfaceHandler &SurfaceHandlerBinding::getSurfaceHandler() {
   return surfaceHandler_;
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.h
@@ -22,7 +22,7 @@ class SurfaceHandlerBinding : public jni::HybridClass<SurfaceHandlerBinding> {
 
   static void registerNatives();
 
-  SurfaceHandlerBinding(SurfaceId surfaceId, std::string const &moduleName);
+  SurfaceHandlerBinding(SurfaceId surfaceId, const std::string &moduleName);
 
   void start();
   void stop();
@@ -48,7 +48,7 @@ class SurfaceHandlerBinding : public jni::HybridClass<SurfaceHandlerBinding> {
 
   void setProps(NativeMap *props);
 
-  SurfaceHandler const &getSurfaceHandler();
+  const SurfaceHandler &getSurfaceHandler();
 
  private:
   mutable std::shared_mutex lifecycleMutex_;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/viewPropConversions.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/viewPropConversions.h
@@ -20,10 +20,10 @@ namespace facebook::react {
 
 namespace {
 static MapBuffer convertAccessibilityActions(
-    std::vector<AccessibilityAction> const &actions) {
+    const std::vector<AccessibilityAction> &actions) {
   MapBufferBuilder builder(actions.size());
   for (auto i = 0; i < actions.size(); i++) {
-    auto const &action = actions[i];
+    const auto &action = actions[i];
     MapBufferBuilder actionsBuilder(2);
     actionsBuilder.putString(ACCESSIBILITY_ACTION_NAME, action.name);
     if (action.label.has_value()) {
@@ -36,7 +36,7 @@ static MapBuffer convertAccessibilityActions(
 }
 
 static MapBuffer convertAccessibilityLabelledBy(
-    AccessibilityLabelledBy const &labelledBy) {
+    const AccessibilityLabelledBy &labelledBy) {
   MapBufferBuilder builder(labelledBy.value.size());
   for (auto i = 0; i < labelledBy.value.size(); i++) {
     builder.putString(i, labelledBy.value[i]);
@@ -51,7 +51,7 @@ constexpr MapBuffer::Key ACCESSIBILITY_STATE_EXPANDED = 2;
 constexpr MapBuffer::Key ACCESSIBILITY_STATE_SELECTED = 3;
 constexpr MapBuffer::Key ACCESSIBILITY_STATE_CHECKED = 4;
 
-MapBuffer convertAccessibilityState(AccessibilityState const &state) {
+MapBuffer convertAccessibilityState(const AccessibilityState &state) {
   MapBufferBuilder builder(5);
   builder.putBool(ACCESSIBILITY_STATE_BUSY, state.busy);
   builder.putBool(ACCESSIBILITY_STATE_DISABLED, state.disabled);
@@ -79,7 +79,7 @@ MapBuffer convertAccessibilityState(AccessibilityState const &state) {
 inline void putOptionalColor(
     MapBufferBuilder &builder,
     MapBuffer::Key key,
-    std::optional<SharedColor> const &color) {
+    const std::optional<SharedColor> &color) {
   builder.putInt(key, color.has_value() ? toAndroidRepr(color.value()) : -1);
 }
 
@@ -91,7 +91,7 @@ constexpr MapBuffer::Key EDGE_START = 4;
 constexpr MapBuffer::Key EDGE_END = 5;
 constexpr MapBuffer::Key EDGE_ALL = 6;
 
-MapBuffer convertBorderColors(CascadedBorderColors const &colors) {
+MapBuffer convertBorderColors(const CascadedBorderColors &colors) {
   MapBufferBuilder builder(7);
   putOptionalColor(builder, EDGE_TOP, colors.top);
   putOptionalColor(builder, EDGE_RIGHT, colors.right);
@@ -120,11 +120,11 @@ constexpr MapBuffer::Key CORNER_START_START = 12;
 inline void putOptionalFloat(
     MapBufferBuilder &builder,
     MapBuffer::Key key,
-    std::optional<Float> const &value) {
+    const std::optional<Float> &value) {
   builder.putDouble(key, value.value_or(NAN));
 }
 
-MapBuffer convertBorderRadii(CascadedBorderRadii const &radii) {
+MapBuffer convertBorderRadii(const CascadedBorderRadii &radii) {
   MapBufferBuilder builder(13);
   putOptionalFloat(builder, CORNER_TOP_LEFT, radii.topLeft);
   putOptionalFloat(builder, CORNER_TOP_RIGHT, radii.topRight);
@@ -142,7 +142,7 @@ MapBuffer convertBorderRadii(CascadedBorderRadii const &radii) {
   return builder.build();
 }
 
-MapBuffer convertBorderWidths(YGStyle::Edges const &border) {
+MapBuffer convertBorderWidths(const YGStyle::Edges &border) {
   MapBufferBuilder builder(7);
   putOptionalFloat(
       builder, EDGE_TOP, optionalFloatFromYogaValue(border[YGEdgeTop]));
@@ -161,7 +161,7 @@ MapBuffer convertBorderWidths(YGStyle::Edges const &border) {
   return builder.build();
 }
 
-MapBuffer convertEdgeInsets(EdgeInsets const &insets) {
+MapBuffer convertEdgeInsets(const EdgeInsets &insets) {
   MapBufferBuilder builder(4);
   builder.putDouble(EDGE_TOP, insets.top);
   builder.putDouble(EDGE_RIGHT, insets.right);
@@ -178,12 +178,12 @@ constexpr MapBuffer::Key NATIVE_DRAWABLE_COLOR = 2;
 constexpr MapBuffer::Key NATIVE_DRAWABLE_BORDERLESS = 3;
 constexpr MapBuffer::Key NATIVE_DRAWABLE_RIPPLE_RADIUS = 4;
 
-MapBuffer convertNativeBackground(std::optional<NativeDrawable> const &value) {
+MapBuffer convertNativeBackground(const std::optional<NativeDrawable> &value) {
   if (!value.has_value()) {
     return MapBufferBuilder::EMPTY();
   }
 
-  auto const &drawable = value.value();
+  const auto &drawable = value.value();
   MapBufferBuilder builder(4);
   switch (drawable.kind) {
     case NativeDrawable::Kind::ThemeAttr:
@@ -209,7 +209,7 @@ MapBuffer convertNativeBackground(std::optional<NativeDrawable> const &value) {
 
 #endif
 
-MapBuffer convertTransform(Transform const &transform) {
+MapBuffer convertTransform(const Transform &transform) {
   MapBufferBuilder builder(16);
   for (int32_t i = 0; i < transform.matrix.size(); i++) {
     builder.putDouble(i, transform.matrix[i]);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
@@ -14,13 +14,13 @@
 
 namespace facebook::react {
 
-std::function<void(std::shared_ptr<ComponentDescriptorProviderRegistry const>)>
+std::function<void(std::shared_ptr<const ComponentDescriptorProviderRegistry>)>
     DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint{};
 
 DefaultComponentsRegistry::DefaultComponentsRegistry(ComponentFactory *delegate)
     : delegate_(delegate) {}
 
-std::shared_ptr<ComponentDescriptorProviderRegistry const>
+std::shared_ptr<const ComponentDescriptorProviderRegistry>
 DefaultComponentsRegistry::sharedProviderRegistry() {
   auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
 
@@ -37,8 +37,8 @@ DefaultComponentsRegistry::initHybrid(
   auto instance = makeCxxInstance(delegate);
 
   auto buildRegistryFunction =
-      [](EventDispatcher::Weak const &eventDispatcher,
-         ContextContainer::Shared const &contextContainer)
+      [](const EventDispatcher::Weak &eventDispatcher,
+         const ContextContainer::Shared &contextContainer)
       -> ComponentDescriptorRegistry::Shared {
     auto registry = DefaultComponentsRegistry::sharedProviderRegistry()
                         ->createComponentDescriptorRegistry(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.h
@@ -24,7 +24,7 @@ class DefaultComponentsRegistry
   static void registerNatives();
 
   static std::function<void(
-      std::shared_ptr<ComponentDescriptorProviderRegistry const>)>
+      std::shared_ptr<const ComponentDescriptorProviderRegistry>)>
       registerComponentDescriptorsFromEntryPoint;
 
   DefaultComponentsRegistry(ComponentFactory *delegate);
@@ -32,7 +32,7 @@ class DefaultComponentsRegistry
  private:
   friend HybridBase;
 
-  static std::shared_ptr<ComponentDescriptorProviderRegistry const>
+  static std::shared_ptr<const ComponentDescriptorProviderRegistry>
   sharedProviderRegistry();
 
   const ComponentFactory *delegate_;

--- a/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
+++ b/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
@@ -39,8 +39,8 @@ class LongLivedObjectCollection {
  public:
   static LongLivedObjectCollection &get();
 
-  LongLivedObjectCollection(LongLivedObjectCollection const &) = delete;
-  void operator=(LongLivedObjectCollection const &) = delete;
+  LongLivedObjectCollection(const LongLivedObjectCollection &) = delete;
+  void operator=(const LongLivedObjectCollection &) = delete;
 
   void add(std::shared_ptr<LongLivedObject> o);
   void remove(const LongLivedObject *o);

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationDriver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationDriver.cpp
@@ -32,13 +32,13 @@ void LayoutAnimationDriver::animationMutationsForFrame(
         continue;
       }
 
-      auto const &baselineShadowView = keyframe.viewStart;
-      auto const &finalShadowView = keyframe.viewEnd;
+      const auto &baselineShadowView = keyframe.viewStart;
+      const auto &finalShadowView = keyframe.viewEnd;
 
       // The contract with the "keyframes generation" phase is that any animated
       // node will have a valid configuration.
-      auto const layoutAnimationConfig = animation.layoutAnimationConfig;
-      auto const &mutationConfig =
+      const auto layoutAnimationConfig = animation.layoutAnimationConfig;
+      const auto &mutationConfig =
           (keyframe.type == AnimationConfigurationType::Delete
                ? layoutAnimationConfig.deleteConfig
                : (keyframe.type == AnimationConfigurationType::Create
@@ -81,7 +81,7 @@ void LayoutAnimationDriver::animationMutationsForFrame(
       callCallback(animation.successCallback);
 
       // Queue up "final" mutations for all keyframes in the completed animation
-      for (auto const &keyframe : animation.keyFrames) {
+      for (const auto &keyframe : animation.keyFrames) {
         if (keyframe.invalidated) {
           continue;
         }

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -35,7 +35,7 @@ namespace facebook::react {
 
 #ifdef LAYOUT_ANIMATION_VERBOSE_LOGGING
 static std::string GetMutationInstructionString(
-    ShadowViewMutation const &mutation) {
+    const ShadowViewMutation &mutation) {
   Tag tag = mutation.type == ShadowViewMutation::Type::Insert ||
           mutation.type == ShadowViewMutation::Type::Create
       ? mutation.newChildShadowView.tag
@@ -47,7 +47,7 @@ static std::string GetMutationInstructionString(
 
 void PrintMutationInstruction(
     std::string message,
-    ShadowViewMutation const &mutation) {
+    const ShadowViewMutation &mutation) {
   [&](std::ostream &stream) -> std::ostream & {
     stream << message
            << " Mutation: " << GetMutationInstructionString(mutation);
@@ -65,8 +65,8 @@ void PrintMutationInstruction(
 
 void PrintMutationInstructionRelative(
     std::string message,
-    ShadowViewMutation const &mutation,
-    ShadowViewMutation const &relativeMutation) {
+    const ShadowViewMutation &mutation,
+    const ShadowViewMutation &relativeMutation) {
   LOG(ERROR) << message
              << " Mutation: " << GetMutationInstructionString(mutation)
              << " RelativeMutation: "
@@ -102,7 +102,7 @@ LayoutAnimationKeyFrameManager::LayoutAnimationKeyFrameManager(
  */
 void LayoutAnimationKeyFrameManager::uiManagerDidConfigureNextLayoutAnimation(
     jsi::Runtime &runtime,
-    RawValue const &config,
+    const RawValue &config,
     const jsi::Value &successCallbackValue,
     const jsi::Value &failureCallbackValue) const {
   bool hasSuccessCallback = successCallbackValue.isObject() &&
@@ -170,7 +170,7 @@ std::optional<MountingTransaction>
 LayoutAnimationKeyFrameManager::pullTransaction(
     SurfaceId surfaceId,
     MountingTransaction::Number transactionNumber,
-    TransactionTelemetry const &telemetry,
+    const TransactionTelemetry &telemetry,
     ShadowViewMutationList mutations) const {
   // Current time in milliseconds
   uint64_t now = now_();
@@ -196,7 +196,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
     LOG(ERROR) << "BEGINNING DISPLAYING ONGOING inflightAnimations_!";
     int i = 0;
     int j = 0;
-    for (auto const &inflightAnimation : inflightAnimations_) {
+    for (const auto &inflightAnimation : inflightAnimations_) {
       i++;
       j = 0;
       if (inflightAnimation.completed) {
@@ -294,8 +294,8 @@ LayoutAnimationKeyFrameManager::pullTransaction(
       // "immediate mutations". The corresponding "insert" will also be executed
       // immediately and animated as an update.
       std::vector<AnimationKeyFrame> keyFramesToAnimate;
-      auto const layoutAnimationConfig = animation.layoutAnimationConfig;
-      for (auto const &mutation : mutations) {
+      const auto layoutAnimationConfig = animation.layoutAnimationConfig;
+      for (const auto &mutation : mutations) {
         if (mutation.type == ShadowViewMutation::Type::RemoveDeleteTree) {
           continue;
         }
@@ -351,7 +351,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
           wasInsertedTagRemoved = movedIt != movedTags.end();
         }
 
-        auto const &mutationConfig =
+        const auto &mutationConfig =
             (mutation.type == ShadowViewMutation::Type::Delete ||
                      (mutation.type == ShadowViewMutation::Type::Remove &&
                       !wasInsertedTagRemoved)
@@ -468,7 +468,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
 
               if (baselineShadowView.traits.check(
                       ShadowNodeTraits::Trait::ViewKind)) {
-                const auto &viewProps = static_cast<ViewProps const &>(*props);
+                const auto &viewProps = static_cast<const ViewProps &>(*props);
                 const_cast<ViewProps &>(viewProps).opacity = 0;
               }
 
@@ -489,7 +489,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                       .cloneProps(propsParserContext, viewStart.props, {});
               if (baselineShadowView.traits.check(
                       ShadowNodeTraits::Trait::ViewKind)) {
-                const auto &viewProps = static_cast<ViewProps const &>(*props);
+                const auto &viewProps = static_cast<const ViewProps &>(*props);
                 const_cast<ViewProps &>(viewProps).transform =
                     Transform::Scale(isScaleX ? 0 : 1, isScaleY ? 0 : 1, 1);
               }
@@ -590,7 +590,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                 if (baselineShadowView.traits.check(
                         ShadowNodeTraits::Trait::ViewKind)) {
                   const auto &viewProps =
-                      static_cast<ViewProps const &>(*props);
+                      static_cast<const ViewProps &>(*props);
                   const_cast<ViewProps &>(viewProps).opacity = 0;
                 }
 
@@ -615,7 +615,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                 if (baselineShadowView.traits.check(
                         ShadowNodeTraits::Trait::ViewKind)) {
                   const auto &viewProps =
-                      static_cast<ViewProps const &>(*props);
+                      static_cast<const ViewProps &>(*props);
                   const_cast<ViewProps &>(viewProps).transform =
                       Transform::Scale(isScaleX ? 0 : 1, isScaleY ? 0 : 1, 1);
                 }
@@ -650,7 +650,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
 
           // Handle conflicting animations
           for (auto &conflictingKeyFrame : conflictingAnimations) {
-            auto const &conflictingMutationBaselineShadowView =
+            const auto &conflictingMutationBaselineShadowView =
                 conflictingKeyFrame.viewStart;
 
             // We've found a conflict.
@@ -779,7 +779,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
             auto newKeyFrameForUpdate = std::find_if(
                 keyFramesToAnimate.begin(),
                 keyFramesToAnimate.end(),
-                [&](auto const &newKeyFrame) {
+                [&](const auto &newKeyFrame) {
                   return newKeyFrame.type ==
                       AnimationConfigurationType::Update &&
                       newKeyFrame.tag == keyFrame.tag;
@@ -963,7 +963,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
       LOG(ERROR) << "No Animation: Queue up final conflicting animations";
 #endif
       ShadowViewMutationList finalMutationsForConflictingAnimations{};
-      for (auto const &keyFrame : conflictingAnimations) {
+      for (const auto &keyFrame : conflictingAnimations) {
         queueFinalMutationsForCompletedKeyFrame(
             keyFrame,
             finalMutationsForConflictingAnimations,
@@ -982,7 +982,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
       LOG(ERROR)
           << "No Animation: Adjust delayed mutations based on all finalMutationsForConflictingAnimations";
 #endif
-      for (auto const &mutation : finalMutationsForConflictingAnimations) {
+      for (const auto &mutation : finalMutationsForConflictingAnimations) {
         if (mutation.type == ShadowViewMutation::Type::Remove ||
             mutation.type == ShadowViewMutation::Type::Insert) {
           adjustDelayedMutationIndicesForMutation(surfaceId, mutation);
@@ -1030,7 +1030,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
   LOG(ERROR)
       << "Adjust all delayed mutations based on final mutations generated by animation driver";
 #endif
-  for (auto const &mutation : mutationsForAnimation) {
+  for (const auto &mutation : mutationsForAnimation) {
     if (mutation.type == ShadowViewMutation::Type::Remove) {
       adjustDelayedMutationIndicesForMutation(surfaceId, mutation);
     }
@@ -1046,7 +1046,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
   LOG(ERROR) << "FINISHING DISPLAYING ONGOING inflightAnimations_!";
   int i = 0;
   int j = 0;
-  for (auto const &inflightAnimation : inflightAnimations_) {
+  for (const auto &inflightAnimation : inflightAnimations_) {
     i++;
     j = 0;
     if (inflightAnimation.completed) {
@@ -1057,7 +1057,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
       if (keyframe.invalidated) {
         continue;
       }
-      for (auto const &finalMutation : keyframe.finalMutationsForKeyFrame) {
+      for (const auto &finalMutation : keyframe.finalMutationsForKeyFrame) {
         if (!finalMutation.mutatedViewIsVirtual()) {
           std::string msg = "Animation " + std::to_string(i) + " keyframe " +
               std::to_string(j) + ": Final Animation";
@@ -1107,21 +1107,21 @@ void LayoutAnimationKeyFrameManager::setClockNow(
 #pragma mark - Protected
 
 bool LayoutAnimationKeyFrameManager::hasComponentDescriptorForShadowView(
-    ShadowView const &shadowView) const {
+    const ShadowView &shadowView) const {
   return componentDescriptorRegistry_->hasComponentDescriptorAt(
       shadowView.componentHandle);
 }
 
-ComponentDescriptor const &
+const ComponentDescriptor &
 LayoutAnimationKeyFrameManager::getComponentDescriptorForShadowView(
-    ShadowView const &shadowView) const {
+    const ShadowView &shadowView) const {
   return componentDescriptorRegistry_->at(shadowView.componentHandle);
 }
 
 ShadowView LayoutAnimationKeyFrameManager::createInterpolatedShadowView(
     Float progress,
-    ShadowView const &startingView,
-    ShadowView const &finalView) const {
+    const ShadowView &startingView,
+    const ShadowView &finalView) const {
   react_native_assert(startingView.tag > 0);
   react_native_assert(finalView.tag > 0);
   if (!hasComponentDescriptorForShadowView(startingView)) {
@@ -1131,7 +1131,7 @@ ShadowView LayoutAnimationKeyFrameManager::createInterpolatedShadowView(
     return finalView;
   }
 
-  ComponentDescriptor const &componentDescriptor =
+  const ComponentDescriptor &componentDescriptor =
       getComponentDescriptorForShadowView(startingView);
 
   // Base the mutated view on the finalView, so that the following stay
@@ -1166,8 +1166,8 @@ ShadowView LayoutAnimationKeyFrameManager::createInterpolatedShadowView(
   }
 
   // Interpolate LayoutMetrics
-  LayoutMetrics const &finalLayoutMetrics = finalView.layoutMetrics;
-  LayoutMetrics const &baselineLayoutMetrics = startingView.layoutMetrics;
+  const LayoutMetrics &finalLayoutMetrics = finalView.layoutMetrics;
+  const LayoutMetrics &baselineLayoutMetrics = startingView.layoutMetrics;
   LayoutMetrics interpolatedLayoutMetrics = finalLayoutMetrics;
   interpolatedLayoutMetrics.frame.origin.x = interpolateFloats(
       progress,
@@ -1191,13 +1191,13 @@ ShadowView LayoutAnimationKeyFrameManager::createInterpolatedShadowView(
 }
 
 void LayoutAnimationKeyFrameManager::callCallback(
-    LayoutAnimationCallbackWrapper const &callback) const {
+    const LayoutAnimationCallbackWrapper &callback) const {
   runtimeExecutor_(
       [callback](jsi::Runtime &runtime) { callback.call(runtime); });
 }
 
 void LayoutAnimationKeyFrameManager::queueFinalMutationsForCompletedKeyFrame(
-    AnimationKeyFrame const &keyframe,
+    const AnimationKeyFrame &keyframe,
     ShadowViewMutation::List &mutationsList,
     bool interrupted,
     const std::string & /*logPrefix*/) const {
@@ -1205,7 +1205,7 @@ void LayoutAnimationKeyFrameManager::queueFinalMutationsForCompletedKeyFrame(
     // TODO: modularize this segment, it is repeated 2x in KeyFrameManager
     // as well.
     ShadowView prev = keyframe.viewPrev;
-    for (auto const &finalMutation : keyframe.finalMutationsForKeyFrame) {
+    for (const auto &finalMutation : keyframe.finalMutationsForKeyFrame) {
       PrintMutationInstruction(
           logPrefix + ": Queuing up Final Mutation:", finalMutation);
       // Copy so that if something else mutates the inflight animations,
@@ -1327,7 +1327,7 @@ void LayoutAnimationKeyFrameManager::
 
   // First, collect all final mutations that could impact this immediate
   // mutation.
-  std::vector<ShadowViewMutation const *> candidateMutations{};
+  std::vector<const ShadowViewMutation *> candidateMutations{};
 
   for (auto inflightAnimationIt =
            inflightAnimations_.rbegin() + (skipLastAnimation ? 1 : 0);
@@ -1341,7 +1341,7 @@ void LayoutAnimationKeyFrameManager::
       continue;
     }
 
-    for (auto const &animatedKeyFrame : inflightAnimation.keyFrames) {
+    for (const auto &animatedKeyFrame : inflightAnimation.keyFrames) {
       if (animatedKeyFrame.invalidated) {
         continue;
       }
@@ -1352,7 +1352,7 @@ void LayoutAnimationKeyFrameManager::
         continue;
       }
 
-      for (auto const &delayedMutation :
+      for (const auto &delayedMutation :
            animatedKeyFrame.finalMutationsForKeyFrame) {
         if (delayedMutation.type != ShadowViewMutation::Type::Remove) {
           continue;
@@ -1391,7 +1391,7 @@ void LayoutAnimationKeyFrameManager::
             candidateMutations.begin(),
             candidateMutations.end(),
             [&changed, &mutation, &adjustedDelta, &isRemoveMutation](
-                ShadowViewMutation const *candidateMutation) {
+                const ShadowViewMutation *candidateMutation) {
               bool indexConflicts =
                   (candidateMutation->index < mutation.index ||
                    (isRemoveMutation &&
@@ -1414,7 +1414,7 @@ void LayoutAnimationKeyFrameManager::
 
 void LayoutAnimationKeyFrameManager::adjustDelayedMutationIndicesForMutation(
     SurfaceId surfaceId,
-    ShadowViewMutation const &mutation,
+    const ShadowViewMutation &mutation,
     bool skipLastAnimation) const {
   bool isRemoveMutation = mutation.type == ShadowViewMutation::Type::Remove;
   bool isInsertMutation = mutation.type == ShadowViewMutation::Type::Insert;
@@ -1527,10 +1527,10 @@ void LayoutAnimationKeyFrameManager::adjustDelayedMutationIndicesForMutation(
 
 void LayoutAnimationKeyFrameManager::getAndEraseConflictingAnimations(
     SurfaceId surfaceId,
-    ShadowViewMutationList const &mutations,
+    const ShadowViewMutationList &mutations,
     std::vector<AnimationKeyFrame> &conflictingAnimations) const {
   ShadowViewMutationList localConflictingMutations{};
-  for (auto const &mutation : mutations) {
+  for (const auto &mutation : mutations) {
     if (mutation.type == ShadowViewMutation::Type::RemoveDeleteTree) {
       continue;
     }
@@ -1538,7 +1538,7 @@ void LayoutAnimationKeyFrameManager::getAndEraseConflictingAnimations(
     bool mutationIsCreateOrDelete =
         mutation.type == ShadowViewMutation::Type::Create ||
         mutation.type == ShadowViewMutation::Type::Delete;
-    auto const &baselineShadowView =
+    const auto &baselineShadowView =
         (mutation.type == ShadowViewMutation::Type::Insert ||
          mutation.type == ShadowViewMutation::Type::Create)
         ? mutation.newChildShadowView

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
@@ -26,11 +26,11 @@ namespace facebook::react {
 #ifdef LAYOUT_ANIMATION_VERBOSE_LOGGING
 void PrintMutationInstruction(
     std::string message,
-    ShadowViewMutation const &mutation);
+    const ShadowViewMutation &mutation);
 void PrintMutationInstructionRelative(
     std::string message,
-    ShadowViewMutation const &mutation,
-    ShadowViewMutation const &relativeMutation);
+    const ShadowViewMutation &mutation,
+    const ShadowViewMutation &relativeMutation);
 #else
 #define PrintMutationInstruction(a, b)
 #define PrintMutationInstructionRelative(a, b, c)
@@ -48,11 +48,11 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
 
   void uiManagerDidConfigureNextLayoutAnimation(
       jsi::Runtime &runtime,
-      RawValue const &config,
+      const RawValue &config,
       const jsi::Value &successCallbackValue,
       const jsi::Value &failureCallbackValue) const override;
 
-  void setComponentDescriptorRegistry(SharedComponentDescriptorRegistry const &
+  void setComponentDescriptorRegistry(const SharedComponentDescriptorRegistry &
                                           componentDescriptorRegistry) override;
 
   void setReduceDeleteCreateMutation(bool reduceDeleteCreateMutation) override;
@@ -72,7 +72,7 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
   std::optional<MountingTransaction> pullTransaction(
       SurfaceId surfaceId,
       MountingTransaction::Number number,
-      TransactionTelemetry const &telemetry,
+      const TransactionTelemetry &telemetry,
       ShadowViewMutationList mutations) const override;
 
   // Exposed for testing.
@@ -102,9 +102,9 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
    */
   mutable std::vector<LayoutAnimation> inflightAnimations_{};
 
-  bool hasComponentDescriptorForShadowView(ShadowView const &shadowView) const;
-  ComponentDescriptor const &getComponentDescriptorForShadowView(
-      ShadowView const &shadowView) const;
+  bool hasComponentDescriptorForShadowView(const ShadowView &shadowView) const;
+  const ComponentDescriptor &getComponentDescriptorForShadowView(
+      const ShadowView &shadowView) const;
 
   /**
    * Given a `progress` between 0 and 1, a mutation and LayoutAnimation config,
@@ -117,8 +117,8 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
    */
   ShadowView createInterpolatedShadowView(
       Float progress,
-      ShadowView const &startingView,
-      ShadowView const &finalView) const;
+      const ShadowView &startingView,
+      const ShadowView &finalView) const;
 
   void callCallback(const LayoutAnimationCallbackWrapper &callback) const;
 
@@ -132,7 +132,7 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
    * Keyframe animation may have timed-out, or be canceled due to a conflict.
    */
   void queueFinalMutationsForCompletedKeyFrame(
-      AnimationKeyFrame const &keyframe,
+      const AnimationKeyFrame &keyframe,
       ShadowViewMutation::List &mutationsList,
       bool interrupted,
       const std::string &logPrefix) const;
@@ -158,12 +158,12 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
 
   void adjustDelayedMutationIndicesForMutation(
       SurfaceId surfaceId,
-      ShadowViewMutation const &mutation,
+      const ShadowViewMutation &mutation,
       bool skipLastAnimation = false) const;
 
   void getAndEraseConflictingAnimations(
       SurfaceId surfaceId,
-      ShadowViewMutationList const &mutations,
+      const ShadowViewMutationList &mutations,
       std::vector<AnimationKeyFrame> &conflictingAnimations) const;
 
   /*
@@ -172,7 +172,7 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
   void deleteAnimationsForStoppedSurfaces() const;
 
   void simulateImagePropsMemoryAccess(
-      ShadowViewMutationList const &mutations) const;
+      const ShadowViewMutationList &mutations) const;
 
   /**
    * Interpolates the props values.

--- a/packages/react-native/ReactCommon/react/renderer/animations/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/conversions.h
@@ -57,7 +57,7 @@ static inline std::optional<AnimationProperty> parseAnimationProperty(
 }
 
 static inline std::optional<AnimationConfig> parseAnimationConfig(
-    folly::dynamic const &config,
+    const folly::dynamic &config,
     double defaultDuration,
     bool parsePropertyType) {
   if (config.empty() || !config.isObject()) {
@@ -70,12 +70,12 @@ static inline std::optional<AnimationConfig> parseAnimationConfig(
         0};
   }
 
-  auto const typeIt = config.find("type");
+  const auto typeIt = config.find("type");
   if (typeIt == config.items().end()) {
     LOG(ERROR) << "Error parsing animation config: could not find field `type`";
     return {};
   }
-  auto const animationTypeParam = typeIt->second;
+  const auto animationTypeParam = typeIt->second;
   if (animationTypeParam.empty() || !animationTypeParam.isString()) {
     LOG(ERROR)
         << "Error parsing animation config: could not unwrap field `type`";
@@ -90,13 +90,13 @@ static inline std::optional<AnimationConfig> parseAnimationConfig(
 
   AnimationProperty animationProperty = AnimationProperty::NotApplicable;
   if (parsePropertyType) {
-    auto const propertyIt = config.find("property");
+    const auto propertyIt = config.find("property");
     if (propertyIt == config.items().end()) {
       LOG(ERROR)
           << "Error parsing animation config: could not find field `property`";
       return {};
     }
-    auto const animationPropertyParam = propertyIt->second;
+    const auto animationPropertyParam = propertyIt->second;
     if (animationPropertyParam.empty() || !animationPropertyParam.isString()) {
       LOG(ERROR)
           << "Error parsing animation config: could not unwrap field `property`";
@@ -117,7 +117,7 @@ static inline std::optional<AnimationConfig> parseAnimationConfig(
   Float springDamping = 0.5;
   Float initialVelocity = 0;
 
-  auto const durationIt = config.find("duration");
+  const auto durationIt = config.find("duration");
   if (durationIt != config.items().end()) {
     if (durationIt->second.isDouble()) {
       duration = durationIt->second.asDouble();
@@ -128,7 +128,7 @@ static inline std::optional<AnimationConfig> parseAnimationConfig(
     }
   }
 
-  auto const delayIt = config.find("delay");
+  const auto delayIt = config.find("delay");
   if (delayIt != config.items().end()) {
     if (delayIt->second.isDouble()) {
       delay = delayIt->second.asDouble();
@@ -139,7 +139,7 @@ static inline std::optional<AnimationConfig> parseAnimationConfig(
     }
   }
 
-  auto const springDampingIt = config.find("springDamping");
+  const auto springDampingIt = config.find("springDamping");
   if (springDampingIt != config.items().end() &&
       springDampingIt->second.isDouble()) {
     if (springDampingIt->second.isDouble()) {
@@ -151,7 +151,7 @@ static inline std::optional<AnimationConfig> parseAnimationConfig(
     }
   }
 
-  auto const initialVelocityIt = config.find("initialVelocity");
+  const auto initialVelocityIt = config.find("initialVelocity");
   if (initialVelocityIt != config.items().end()) {
     if (initialVelocityIt->second.isDouble()) {
       initialVelocity = (Float)initialVelocityIt->second.asDouble();
@@ -173,7 +173,7 @@ static inline std::optional<AnimationConfig> parseAnimationConfig(
 
 // Parse animation config from JS
 static inline std::optional<LayoutAnimationConfig> parseLayoutAnimationConfig(
-    folly::dynamic const &config) {
+    const folly::dynamic &config) {
   if (config.empty() || !config.isObject()) {
     return {};
   }

--- a/packages/react-native/ReactCommon/react/renderer/animations/tests/LayoutAnimationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/tests/LayoutAnimationTest.cpp
@@ -49,7 +49,7 @@ static void testShadowNodeTreeLifeCycleLayoutAnimations(
   auto entropy = seed == 0 ? Entropy() : Entropy(seed);
 
   auto eventDispatcher = EventDispatcher::Shared{};
-  auto contextContainer = std::make_shared<ContextContainer const>();
+  auto contextContainer = std::make_shared<const ContextContainer>();
   auto componentDescriptorParameters =
       ComponentDescriptorParameters{eventDispatcher, contextContainer, nullptr};
   auto viewComponentDescriptor =
@@ -61,7 +61,7 @@ static void testShadowNodeTreeLifeCycleLayoutAnimations(
 
   // Create a RuntimeExecutor
   RuntimeExecutor runtimeExecutor =
-      [](std::function<void(jsi::Runtime &)> const & /*unused*/) {};
+      [](const std::function<void(jsi::Runtime &)> & /*unused*/) {};
 
   // Create component descriptor registry for animation driver
   auto providerRegistry =
@@ -97,7 +97,7 @@ static void testShadowNodeTreeLifeCycleLayoutAnimations(
 
     // Creating an initial root shadow node.
     auto emptyRootNode = std::const_pointer_cast<RootShadowNode>(
-        std::static_pointer_cast<RootShadowNode const>(
+        std::static_pointer_cast<const RootShadowNode>(
             rootComponentDescriptor.createShadowNode(
                 ShadowNodeFragment{RootShadowNode::defaultSharedProps()},
                 family)));
@@ -114,7 +114,7 @@ static void testShadowNodeTreeLifeCycleLayoutAnimations(
         generateShadowNodeTree(entropy, viewComponentDescriptor, treeSize);
 
     // Injecting a tree into the root node.
-    auto currentRootNode = std::static_pointer_cast<RootShadowNode const>(
+    auto currentRootNode = std::static_pointer_cast<const RootShadowNode>(
         emptyRootNode->ShadowNode::clone(ShadowNodeFragment{
             ShadowNodeFragment::propsPlaceholder(),
             std::make_shared<ShadowNode::ListOfShared>(
@@ -138,7 +138,7 @@ static void testShadowNodeTreeLifeCycleLayoutAnimations(
               &messWithLayoutableOnlyFlag,
           });
 
-      std::vector<LayoutableShadowNode const *> affectedLayoutableNodes{};
+      std::vector<const LayoutableShadowNode *> affectedLayoutableNodes{};
       affectedLayoutableNodes.reserve(1024);
 
       // Laying out the tree.

--- a/packages/react-native/ReactCommon/react/renderer/animations/utils.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/utils.cpp
@@ -12,8 +12,8 @@ namespace facebook::react {
 
 std::pair<Float, Float> calculateAnimationProgress(
     uint64_t now,
-    LayoutAnimation const &animation,
-    AnimationConfig const &mutationConfig) {
+    const LayoutAnimation &animation,
+    const AnimationConfig &mutationConfig) {
   if (mutationConfig.animationType == AnimationType::None) {
     return {1, 1};
   }

--- a/packages/react-native/ReactCommon/react/renderer/animations/utils.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/utils.h
@@ -14,8 +14,8 @@
 namespace facebook::react {
 
 static inline bool shouldFirstComeBeforeSecondRemovesOnly(
-    ShadowViewMutation const &lhs,
-    ShadowViewMutation const &rhs) noexcept {
+    const ShadowViewMutation &lhs,
+    const ShadowViewMutation &rhs) noexcept {
   // Make sure that removes on the same level are sorted - highest indices must
   // come first.
   return (lhs.type == ShadowViewMutation::Type::Remove &&
@@ -25,8 +25,8 @@ static inline bool shouldFirstComeBeforeSecondRemovesOnly(
 }
 
 static inline bool shouldFirstComeBeforeSecondMutation(
-    ShadowViewMutation const &lhs,
-    ShadowViewMutation const &rhs) noexcept {
+    const ShadowViewMutation &lhs,
+    const ShadowViewMutation &rhs) noexcept {
   if (lhs.type != rhs.type) {
     // Deletes always come last
     if (lhs.type == ShadowViewMutation::Type::Delete) {
@@ -73,7 +73,7 @@ static inline bool shouldFirstComeBeforeSecondMutation(
 
 std::pair<Float, Float> calculateAnimationProgress(
     uint64_t now,
-    LayoutAnimation const &animation,
-    AnimationConfig const &mutationConfig);
+    const LayoutAnimation &animation,
+    const AnimationConfig &mutationConfig);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.cpp
@@ -91,7 +91,7 @@ void AttributedString::prependAttributedString(
       attributedString.fragments_.end());
 }
 
-Fragments const &AttributedString::getFragments() const {
+const Fragments &AttributedString::getFragments() const {
   return fragments_;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
@@ -79,7 +79,7 @@ class AttributedString : public Sealable, public DebugStringConvertible {
   /*
    * Returns a read-only reference to a list of fragments.
    */
-  Fragments const &getFragments() const;
+  const Fragments &getFragments() const;
 
   /*
    * Returns a reference to a list of fragments.

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedStringBox.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedStringBox.cpp
@@ -15,12 +15,12 @@ namespace facebook::react {
 
 AttributedStringBox::AttributedStringBox()
     : mode_(Mode::Value),
-      value_(std::make_shared<AttributedString const>(AttributedString{})),
+      value_(std::make_shared<const AttributedString>(AttributedString{})),
       opaquePointer_({}){};
 
-AttributedStringBox::AttributedStringBox(AttributedString const &value)
+AttributedStringBox::AttributedStringBox(const AttributedString &value)
     : mode_(Mode::Value),
-      value_(std::make_shared<AttributedString const>(value)),
+      value_(std::make_shared<const AttributedString>(value)),
       opaquePointer_({}){};
 
 AttributedStringBox::AttributedStringBox(std::shared_ptr<void> opaquePointer)
@@ -33,14 +33,14 @@ AttributedStringBox::AttributedStringBox(AttributedStringBox &&other) noexcept
       value_(std::move(other.value_)),
       opaquePointer_(std::move(other.opaquePointer_)) {
   other.mode_ = AttributedStringBox::Mode::Value;
-  other.value_ = std::make_shared<AttributedString const>(AttributedString{});
+  other.value_ = std::make_shared<const AttributedString>(AttributedString{});
 }
 
 AttributedStringBox::Mode AttributedStringBox::getMode() const {
   return mode_;
 }
 
-AttributedString const &AttributedStringBox::getValue() const {
+const AttributedString &AttributedStringBox::getValue() const {
   react_native_assert(mode_ == AttributedStringBox::Mode::Value);
   react_native_assert(value_);
   return *value_;
@@ -59,14 +59,14 @@ AttributedStringBox &AttributedStringBox::operator=(
     value_ = std::move(other.value_);
     opaquePointer_ = std::move(other.opaquePointer_);
     other.mode_ = AttributedStringBox::Mode::Value;
-    other.value_ = std::make_shared<AttributedString const>(AttributedString{});
+    other.value_ = std::make_shared<const AttributedString>(AttributedString{});
   }
   return *this;
 }
 
 bool operator==(
-    AttributedStringBox const &lhs,
-    AttributedStringBox const &rhs) {
+    const AttributedStringBox &lhs,
+    const AttributedStringBox &rhs) {
   if (lhs.getMode() != rhs.getMode()) {
     return false;
   }
@@ -80,8 +80,8 @@ bool operator==(
 }
 
 bool operator!=(
-    AttributedStringBox const &lhs,
-    AttributedStringBox const &rhs) {
+    const AttributedStringBox &lhs,
+    const AttributedStringBox &rhs) {
   return !(lhs == rhs);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedStringBox.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedStringBox.h
@@ -33,39 +33,39 @@ class AttributedStringBox final {
   /*
    * Custom explicit constructors.
    */
-  explicit AttributedStringBox(AttributedString const &value);
+  explicit AttributedStringBox(const AttributedString &value);
   explicit AttributedStringBox(std::shared_ptr<void> opaquePointer);
 
   /*
    * Movable, Copyable, Assignable.
    */
-  AttributedStringBox(AttributedStringBox const &other) = default;
+  AttributedStringBox(const AttributedStringBox &other) = default;
   AttributedStringBox(AttributedStringBox &&other) noexcept;
-  AttributedStringBox &operator=(AttributedStringBox const &other) = default;
+  AttributedStringBox &operator=(const AttributedStringBox &other) = default;
   AttributedStringBox &operator=(AttributedStringBox &&other) noexcept;
 
   /*
    * Getters.
    */
   Mode getMode() const;
-  AttributedString const &getValue() const;
+  const AttributedString &getValue() const;
   std::shared_ptr<void> getOpaquePointer() const;
 
  private:
   Mode mode_;
-  std::shared_ptr<AttributedString const> value_;
+  std::shared_ptr<const AttributedString> value_;
   std::shared_ptr<void> opaquePointer_;
 };
 
-bool operator==(AttributedStringBox const &lhs, AttributedStringBox const &rhs);
-bool operator!=(AttributedStringBox const &lhs, AttributedStringBox const &rhs);
+bool operator==(const AttributedStringBox &lhs, const AttributedStringBox &rhs);
+bool operator!=(const AttributedStringBox &lhs, const AttributedStringBox &rhs);
 
 } // namespace facebook::react
 
 template <>
 struct std::hash<facebook::react::AttributedStringBox> {
   size_t operator()(
-      facebook::react::AttributedStringBox const &attributedStringBox) const {
+      const facebook::react::AttributedStringBox &attributedStringBox) const {
     switch (attributedStringBox.getMode()) {
       case facebook::react::AttributedStringBox::Mode::Value:
         return std::hash<facebook::react::AttributedString>()(

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -686,9 +686,9 @@ inline void fromRawValue(
 
 inline ParagraphAttributes convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    ParagraphAttributes const &sourceParagraphAttributes,
-    ParagraphAttributes const &defaultParagraphAttributes) {
+    const RawProps &rawProps,
+    const ParagraphAttributes &sourceParagraphAttributes,
+    const ParagraphAttributes &defaultParagraphAttributes) {
   auto paragraphAttributes = ParagraphAttributes{};
 
   paragraphAttributes.maximumNumberOfLines = convertRawProp(
@@ -745,7 +745,7 @@ inline ParagraphAttributes convertRawProp(
 
 inline void fromRawValue(
     const PropsParserContext &context,
-    RawValue const &value,
+    const RawValue &value,
     AttributedString::Range &result) {
   auto map = (butter::map<std::string, int>)value;
 
@@ -759,7 +759,7 @@ inline void fromRawValue(
   }
 }
 
-inline std::string toString(AttributedString::Range const &range) {
+inline std::string toString(const AttributedString::Range &range) {
   return "{location: " + folly::to<std::string>(range.location) +
       ", length: " + folly::to<std::string>(range.length) + "}";
 }
@@ -921,7 +921,7 @@ inline folly::dynamic toDynamic(const AttributedString &attributedString) {
   return value;
 }
 
-inline folly::dynamic toDynamic(AttributedString::Range const &range) {
+inline folly::dynamic toDynamic(const AttributedString::Range &range) {
   folly::dynamic dynamicValue = folly::dynamic::object();
   dynamicValue["location"] = range.location;
   dynamicValue["length"] = range.length;

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorFactory.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorFactory.h
@@ -24,8 +24,8 @@ namespace facebook::react {
  */
 using ComponentRegistryFactory =
     std::function<SharedComponentDescriptorRegistry(
-        EventDispatcher::Weak const &eventDispatcher,
-        ContextContainer::Shared const &contextContainer)>;
+        const EventDispatcher::Weak &eventDispatcher,
+        const ContextContainer::Shared &contextContainer)>;
 
 ComponentRegistryFactory getDefaultComponentRegistryFactory();
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProvider.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProvider.h
@@ -19,7 +19,7 @@ namespace facebook::react {
  * abstract type and ownership of the newly created object.
  */
 using ComponentDescriptorConstructor = ComponentDescriptor::Unique(
-    ComponentDescriptorParameters const &parameters);
+    const ComponentDescriptorParameters &parameters);
 
 /*
  * Represents a unified way to construct an instance of a particular stored
@@ -44,12 +44,12 @@ class ComponentDescriptorProvider final {
  */
 template <typename ComponentDescriptorT>
 ComponentDescriptor::Unique concreteComponentDescriptorConstructor(
-    ComponentDescriptorParameters const &parameters) {
+    const ComponentDescriptorParameters &parameters) {
   static_assert(
       std::is_base_of<ComponentDescriptor, ComponentDescriptorT>::value,
       "ComponentDescriptorT must be a descendant of ComponentDescriptor");
 
-  return std::make_unique<ComponentDescriptorT const>(parameters);
+  return std::make_unique<const ComponentDescriptorT>(parameters);
 }
 
 /*

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.cpp
@@ -31,7 +31,7 @@ void ComponentDescriptorProviderRegistry::add(
 
   componentDescriptorProviders_.insert({provider.handle, provider});
 
-  for (auto const &weakRegistry : componentDescriptorRegistries_) {
+  for (const auto &weakRegistry : componentDescriptorRegistries_) {
     auto registry = weakRegistry.lock();
     if (!registry) {
       continue;
@@ -65,13 +65,13 @@ void ComponentDescriptorProviderRegistry::request(
 
 ComponentDescriptorRegistry::Shared
 ComponentDescriptorProviderRegistry::createComponentDescriptorRegistry(
-    ComponentDescriptorParameters const &parameters) const {
+    const ComponentDescriptorParameters &parameters) const {
   std::shared_lock lock(mutex_);
 
-  auto registry = std::make_shared<ComponentDescriptorRegistry const>(
+  auto registry = std::make_shared<const ComponentDescriptorRegistry>(
       parameters, *this, parameters.contextContainer);
 
-  for (auto const &pair : componentDescriptorProviders_) {
+  for (const auto &pair : componentDescriptorProviders_) {
     registry->add(pair.second);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
@@ -50,7 +50,7 @@ class ComponentDescriptorProviderRegistry final {
    * The methods can be called on any thread.
    */
   ComponentDescriptorRegistry::Shared createComponentDescriptorRegistry(
-      ComponentDescriptorParameters const &parameters) const;
+      const ComponentDescriptorParameters &parameters) const;
 
  private:
   friend class ComponentDescriptorRegistry;
@@ -58,7 +58,7 @@ class ComponentDescriptorProviderRegistry final {
   void request(ComponentName componentName) const;
 
   mutable std::shared_mutex mutex_;
-  mutable std::vector<std::weak_ptr<ComponentDescriptorRegistry const>>
+  mutable std::vector<std::weak_ptr<const ComponentDescriptorRegistry>>
       componentDescriptorRegistries_;
   mutable butter::map<ComponentHandle, ComponentDescriptorProvider const>
       componentDescriptorProviders_;

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
@@ -20,7 +20,7 @@ namespace facebook::react {
 
 ComponentDescriptorRegistry::ComponentDescriptorRegistry(
     ComponentDescriptorParameters parameters,
-    ComponentDescriptorProviderRegistry const &providerRegistry,
+    const ComponentDescriptorProviderRegistry &providerRegistry,
     ContextContainer::Shared contextContainer)
     : parameters_(std::move(parameters)),
       providerRegistry_(providerRegistry),
@@ -41,7 +41,7 @@ void ComponentDescriptorRegistry::add(
       componentDescriptor->getComponentName() ==
       componentDescriptorProvider.name);
 
-  auto sharedComponentDescriptor = std::shared_ptr<ComponentDescriptor const>(
+  auto sharedComponentDescriptor = std::shared_ptr<const ComponentDescriptor>(
       std::move(componentDescriptor));
   _registryByHandle[componentDescriptorProvider.handle] =
       sharedComponentDescriptor;
@@ -57,8 +57,8 @@ void ComponentDescriptorRegistry::registerComponentDescriptor(
   _registryByName[componentName] = componentDescriptor;
 }
 
-ComponentDescriptor const &ComponentDescriptorRegistry::at(
-    std::string const &componentName) const {
+const ComponentDescriptor &ComponentDescriptorRegistry::at(
+    const std::string &componentName) const {
   std::shared_lock lock(mutex_);
 
   auto unifiedComponentName = componentNameByReactViewName(componentName);
@@ -93,7 +93,7 @@ ComponentDescriptor const &ComponentDescriptorRegistry::at(
   return *it->second;
 }
 
-ComponentDescriptor const *ComponentDescriptorRegistry::
+const ComponentDescriptor *ComponentDescriptorRegistry::
     findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
         ComponentHandle componentHandle) const {
   std::shared_lock lock(mutex_);
@@ -106,7 +106,7 @@ ComponentDescriptor const *ComponentDescriptorRegistry::
   return iterator->second.get();
 }
 
-ComponentDescriptor const &ComponentDescriptorRegistry::at(
+const ComponentDescriptor &ComponentDescriptorRegistry::at(
     ComponentHandle componentHandle) const {
   std::shared_lock lock(mutex_);
 
@@ -123,21 +123,21 @@ bool ComponentDescriptorRegistry::hasComponentDescriptorAt(
 
 ShadowNode::Shared ComponentDescriptorRegistry::createNode(
     Tag tag,
-    std::string const &viewName,
+    const std::string &viewName,
     SurfaceId surfaceId,
-    folly::dynamic const &propsDynamic,
-    InstanceHandle::Shared const &instanceHandle) const {
+    const folly::dynamic &propsDynamic,
+    const InstanceHandle::Shared &instanceHandle) const {
   auto unifiedComponentName = componentNameByReactViewName(viewName);
-  auto const &componentDescriptor = this->at(unifiedComponentName);
+  const auto &componentDescriptor = this->at(unifiedComponentName);
 
-  auto const fragment =
+  const auto fragment =
       ShadowNodeFamilyFragment{tag, surfaceId, instanceHandle};
   auto family = componentDescriptor.createFamily(fragment);
-  auto const props = componentDescriptor.cloneProps(
+  const auto props = componentDescriptor.cloneProps(
       PropsParserContext{surfaceId, *contextContainer_.get()},
       nullptr,
       RawProps(propsDynamic));
-  auto const state = componentDescriptor.createInitialState(props, family);
+  const auto state = componentDescriptor.createInitialState(props, family);
 
   return componentDescriptor.createShadowNode(
       {

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.h
@@ -38,7 +38,7 @@ class ComponentDescriptorRegistry {
    */
   ComponentDescriptorRegistry(
       ComponentDescriptorParameters parameters,
-      ComponentDescriptorProviderRegistry const &providerRegistry,
+      const ComponentDescriptorProviderRegistry &providerRegistry,
       ContextContainer::Shared contextContainer);
 
   /*
@@ -46,21 +46,21 @@ class ComponentDescriptorRegistry {
    * If you requesting a ComponentDescriptor and unsure that it's there, you are
    * doing something wrong.
    */
-  ComponentDescriptor const *
+  const ComponentDescriptor *
   findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
       ComponentHandle componentHandle) const;
 
-  ComponentDescriptor const &at(std::string const &componentName) const;
-  ComponentDescriptor const &at(ComponentHandle componentHandle) const;
+  const ComponentDescriptor &at(const std::string &componentName) const;
+  const ComponentDescriptor &at(ComponentHandle componentHandle) const;
 
   bool hasComponentDescriptorAt(ComponentHandle componentHandle) const;
 
   ShadowNode::Shared createNode(
       Tag tag,
-      std::string const &viewName,
+      const std::string &viewName,
       SurfaceId surfaceId,
-      folly::dynamic const &props,
-      InstanceHandle::Shared const &instanceHandle) const;
+      const folly::dynamic &props,
+      const InstanceHandle::Shared &instanceHandle) const;
 
   void setFallbackComponentDescriptor(
       const SharedComponentDescriptor &descriptor);
@@ -87,7 +87,7 @@ class ComponentDescriptorRegistry {
   mutable butter::map<std::string, SharedComponentDescriptor> _registryByName;
   ComponentDescriptor::Shared _fallbackComponentDescriptor;
   ComponentDescriptorParameters parameters_{};
-  ComponentDescriptorProviderRegistry const &providerRegistry_;
+  const ComponentDescriptorProviderRegistry &providerRegistry_;
   ContextContainer::Shared contextContainer_;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
@@ -20,11 +20,11 @@ namespace facebook::react {
 class ImageComponentDescriptor final
     : public ConcreteComponentDescriptor<ImageShadowNode> {
  public:
-  ImageComponentDescriptor(ComponentDescriptorParameters const &parameters)
+  ImageComponentDescriptor(const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor(parameters),
         imageManager_(std::make_shared<ImageManager>(contextContainer_)){};
 
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
     auto &imageShadowNode = static_cast<ImageShadowNode &>(*shadowNode);

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -81,7 +81,7 @@ void ImageProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   // All Props structs setProp methods must always, unconditionally,
   // call all super::setProp methods, since multiple structs may
   // reuse the same values.

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -25,7 +25,7 @@ class ImageProps final : public ViewProps {
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #pragma mark - Props
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
@@ -25,7 +25,7 @@ void ImageShadowNode::updateStateIfNeeded() {
   ensureUnsealed();
 
   auto imageSource = getImageSource();
-  auto const &currentState = getStateData();
+  const auto &currentState = getStateData();
   bool hasSameRadius =
       getConcreteProps().blurRadius == currentState.getBlurRadius();
   bool hasSameImageSource = currentState.getImageSource() == imageSource;

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
@@ -42,9 +42,9 @@ class ImageShadowNode final : public ConcreteViewShadowNode<
   void setImageManager(const SharedImageManager &imageManager);
 
   static ImageState initialStateData(
-      Props::Shared const &props,
-      ShadowNodeFamily::Shared const & /*family*/,
-      ComponentDescriptor const &componentDescriptor) {
+      const Props::Shared &props,
+      const ShadowNodeFamily::Shared & /*family*/,
+      const ComponentDescriptor &componentDescriptor) {
     auto imageSource = ImageSource{ImageSource::Type::Invalid};
     return {imageSource, {imageSource, nullptr, {}}, 0};
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.cpp
@@ -13,7 +13,7 @@ ImageSource ImageState::getImageSource() const {
   return imageSource_;
 }
 
-ImageRequest const &ImageState::getImageRequest() const {
+const ImageRequest &ImageState::getImageRequest() const {
   return *imageRequest_;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
@@ -23,9 +23,9 @@ namespace facebook::react {
 class ImageState final {
  public:
   ImageState(
-      ImageSource const &imageSource,
+      const ImageSource &imageSource,
       ImageRequest imageRequest,
-      Float const blurRadius)
+      const Float blurRadius)
       : imageSource_(imageSource),
         imageRequest_(std::make_shared<ImageRequest>(std::move(imageRequest))),
         blurRadius_(blurRadius){};
@@ -39,12 +39,12 @@ class ImageState final {
    * Exposes for reading stored `ImageRequest` object.
    * `ImageRequest` object cannot be copied or moved from `ImageLocalData`.
    */
-  ImageRequest const &getImageRequest() const;
+  const ImageRequest &getImageRequest() const;
 
   Float getBlurRadius() const;
 
 #ifdef ANDROID
-  ImageState(ImageState const &previousState, folly::dynamic data)
+  ImageState(const ImageState &previousState, folly::dynamic data)
       : blurRadius_{0} {};
 
   /*
@@ -62,7 +62,7 @@ class ImageState final {
  private:
   ImageSource imageSource_;
   std::shared_ptr<ImageRequest> imageRequest_;
-  Float const blurRadius_;
+  const Float blurRadius_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
@@ -21,7 +21,7 @@ class InputAccessoryComponentDescriptor final
  public:
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     auto &layoutableShadowNode =
         static_cast<YogaLayoutableShadowNode &>(*shadowNode);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
@@ -18,7 +18,7 @@ class LegacyViewManagerInteropComponentDescriptor final
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
   LegacyViewManagerInteropComponentDescriptor(
-      ComponentDescriptorParameters const &parameters);
+      const ComponentDescriptorParameters &parameters);
   /*
    * Returns `name` and `handle` based on a `flavor`, not on static data from
    * `LegacyViewManagerInteropShadowNode`.
@@ -27,10 +27,10 @@ class LegacyViewManagerInteropComponentDescriptor final
   ComponentName getComponentName() const override;
 
  protected:
-  void adopt(ShadowNode::Unshared const &shadowNode) const override;
+  void adopt(const ShadowNode::Unshared &shadowNode) const override;
 
  private:
-  std::shared_ptr<void> const _coordinator;
+  const std::shared_ptr<void> _coordinator;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
@@ -73,9 +73,9 @@ static Class getViewManagerFromComponentName(const std::string &componentName)
   return nil;
 }
 
-static std::shared_ptr<void> const constructCoordinator(
-    ContextContainer::Shared const &contextContainer,
-    ComponentDescriptor::Flavor const &flavor)
+static const std::shared_ptr<void> constructCoordinator(
+    const ContextContainer::Shared &contextContainer,
+    const ComponentDescriptor::Flavor &flavor)
 {
   auto componentName = *std::static_pointer_cast<std::string const>(flavor);
   Class viewManagerClass = getViewManagerFromComponentName(componentName);
@@ -108,7 +108,7 @@ static std::shared_ptr<void> const constructCoordinator(
 }
 
 LegacyViewManagerInteropComponentDescriptor::LegacyViewManagerInteropComponentDescriptor(
-    ComponentDescriptorParameters const &parameters)
+    const ComponentDescriptorParameters &parameters)
     : ConcreteComponentDescriptor(parameters), _coordinator(constructCoordinator(contextContainer_, flavor_))
 {
 }
@@ -120,10 +120,10 @@ ComponentHandle LegacyViewManagerInteropComponentDescriptor::getComponentHandle(
 
 ComponentName LegacyViewManagerInteropComponentDescriptor::getComponentName() const
 {
-  return static_cast<std::string const *>(flavor_.get())->c_str();
+  return static_cast<const std::string *>(flavor_.get())->c_str();
 }
 
-void LegacyViewManagerInteropComponentDescriptor::adopt(ShadowNode::Unshared const &shadowNode) const
+void LegacyViewManagerInteropComponentDescriptor::adopt(const ShadowNode::Unshared &shadowNode) const
 {
   ConcreteComponentDescriptor::adopt(shadowNode);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.cpp
@@ -10,8 +10,8 @@
 
 namespace facebook::react {
 void LegacyViewManagerInteropViewEventEmitter::dispatchEvent(
-    std::string const &type,
-    folly::dynamic const &payload) const {
+    const std::string &type,
+    const folly::dynamic &payload) const {
   EventEmitter::dispatchEvent(type, payload);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.h
@@ -24,7 +24,7 @@ class LegacyViewManagerInteropViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
-  void dispatchEvent(std::string const &type, folly::dynamic const &payload)
+  void dispatchEvent(const std::string &type, const folly::dynamic &payload)
       const;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
@@ -29,7 +29,7 @@ typedef void (^InterceptorBlock)(std::string eventName, folly::dynamic event);
 
 - (void)removeObserveForTag:(NSInteger)tag;
 
-- (void)setProps:(folly::dynamic const &)props forView:(UIView *)view;
+- (void)setProps:(const folly::dynamic &)props forView:(UIView *)view;
 
 - (NSString *)componentViewName;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
@@ -87,7 +87,7 @@ using namespace facebook::react;
   return view;
 }
 
-- (void)setProps:(folly::dynamic const &)props forView:(UIView *)view
+- (void)setProps:(const folly::dynamic &)props forView:(UIView *)view
 {
   if (props.isObject()) {
     NSDictionary<NSString *, id> *convertedProps = convertFollyDynamicToId(props);

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
@@ -25,7 +25,7 @@ class UnstableLegacyViewManagerInteropComponentDescriptor
           ConcreteViewShadowNode<concreteComponentName, ViewProps>> {
  public:
   UnstableLegacyViewManagerInteropComponentDescriptor<concreteComponentName>(
-      ComponentDescriptorParameters const &parameters)
+      const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor<
             ConcreteViewShadowNode<concreteComponentName, ViewProps>>(
             parameters) {}

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
@@ -22,7 +22,7 @@ class ModalHostViewComponentDescriptor final
  public:
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     auto &layoutableShadowNode =
         static_cast<YogaLayoutableShadowNode &>(*shadowNode);
     auto &stateData =

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
@@ -30,7 +30,7 @@ class ModalHostViewState final {
 
 #ifdef ANDROID
   ModalHostViewState(
-      ModalHostViewState const &previousState,
+      const ModalHostViewState &previousState,
       folly::dynamic data)
       : screenSize(Size{
             (Float)data["screenWidth"].getDouble(),

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
@@ -20,13 +20,13 @@ class AndroidProgressBarComponentDescriptor final
     : public ConcreteComponentDescriptor<AndroidProgressBarShadowNode> {
  public:
   AndroidProgressBarComponentDescriptor(
-      ComponentDescriptorParameters const &parameters)
+      const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor(parameters),
         measurementsManager_(
             std::make_shared<AndroidProgressBarMeasurementsManager>(
                 contextContainer_)) {}
 
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
     auto &androidProgressBarShadowNode =

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
@@ -17,7 +17,7 @@ namespace facebook::react {
 
 Size AndroidProgressBarMeasurementsManager::measure(
     SurfaceId surfaceId,
-    AndroidProgressBarProps const &props,
+    const AndroidProgressBarProps &props,
     LayoutConstraints layoutConstraints) const {
   {
     std::scoped_lock lock(mutex_);

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
@@ -23,7 +23,7 @@ class AndroidProgressBarMeasurementsManager {
 
   Size measure(
       SurfaceId surfaceId,
-      AndroidProgressBarProps const &props,
+      const AndroidProgressBarProps &props,
       LayoutConstraints layoutConstraints) const;
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.cpp
@@ -24,8 +24,8 @@ void AndroidProgressBarShadowNode::setAndroidProgressBarMeasurementsManager(
 #pragma mark - LayoutableShadowNode
 
 Size AndroidProgressBarShadowNode::measureContent(
-    LayoutContext const & /*layoutContext*/,
-    LayoutConstraints const &layoutConstraints) const {
+    const LayoutContext & /*layoutContext*/,
+    const LayoutConstraints &layoutConstraints) const {
   return measurementsManager_->measure(
       getSurfaceId(), getConcreteProps(), layoutConstraints);
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
@@ -34,8 +34,8 @@ class AndroidProgressBarShadowNode final : public ConcreteViewShadowNode<
 #pragma mark - LayoutableShadowNode
 
   Size measureContent(
-      LayoutContext const &layoutContext,
-      LayoutConstraints const &layoutConstraints) const override;
+      const LayoutContext &layoutContext,
+      const LayoutConstraints &layoutConstraints) const override;
 
  private:
   std::shared_ptr<AndroidProgressBarMeasurementsManager> measurementsManager_;

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
@@ -12,7 +12,7 @@
 namespace facebook::react {
 
 #ifdef ANDROID
-inline folly::dynamic toDynamic(AndroidProgressBarProps const &props) {
+inline folly::dynamic toDynamic(const AndroidProgressBarProps &props) {
   folly::dynamic serializedProps = folly::dynamic::object();
   serializedProps["styleAttr"] = props.styleAttr;
   serializedProps["typeAttr"] = props.typeAttr;

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.cpp
@@ -17,8 +17,8 @@ namespace facebook::react {
 // RootShadowNode first.
 RootProps::RootProps(
     const PropsParserContext &context,
-    RootProps const &sourceProps,
-    RawProps const &rawProps)
+    const RootProps &sourceProps,
+    const RawProps &rawProps)
     : ViewProps(context, sourceProps, rawProps) {}
 
 // Note that a default/empty context may be passed here from RootShadowNode.
@@ -26,9 +26,9 @@ RootProps::RootProps(
 // RootShadowNode first.
 RootProps::RootProps(
     const PropsParserContext & /*context*/,
-    RootProps const & /*sourceProps*/,
-    LayoutConstraints const &layoutConstraints,
-    LayoutContext const &layoutContext)
+    const RootProps & /*sourceProps*/,
+    const LayoutConstraints &layoutConstraints,
+    const LayoutContext &layoutContext)
     : ViewProps(),
       layoutConstraints(layoutConstraints),
       layoutContext(layoutContext){};

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.h
@@ -21,13 +21,13 @@ class RootProps final : public ViewProps {
   RootProps() = default;
   RootProps(
       const PropsParserContext &context,
-      RootProps const &sourceProps,
-      RawProps const &rawProps);
+      const RootProps &sourceProps,
+      const RawProps &rawProps);
   RootProps(
       const PropsParserContext &context,
-      RootProps const &sourceProps,
-      LayoutConstraints const &layoutConstraints,
-      LayoutContext const &layoutContext);
+      const RootProps &sourceProps,
+      const LayoutConstraints &layoutConstraints,
+      const LayoutContext &layoutContext);
 
 #pragma mark - Props
 

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
@@ -15,7 +15,7 @@ namespace facebook::react {
 const char RootComponentName[] = "RootView";
 
 bool RootShadowNode::layoutIfNeeded(
-    std::vector<LayoutableShadowNode const *> *affectedNodes) {
+    std::vector<const LayoutableShadowNode *> *affectedNodes) {
   SystraceSection s("RootShadowNode::layout");
 
   if (getIsLayoutClean()) {
@@ -38,10 +38,10 @@ Transform RootShadowNode::getTransform() const {
 }
 
 RootShadowNode::Unshared RootShadowNode::clone(
-    PropsParserContext const &propsParserContext,
-    LayoutConstraints const &layoutConstraints,
-    LayoutContext const &layoutContext) const {
-  auto props = std::make_shared<RootProps const>(
+    const PropsParserContext &propsParserContext,
+    const LayoutConstraints &layoutConstraints,
+    const LayoutContext &layoutContext) const {
+  auto props = std::make_shared<const RootProps>(
       propsParserContext, getConcreteProps(), layoutConstraints, layoutContext);
   auto newRootShadowNode = std::make_shared<RootShadowNode>(
       *this,

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
@@ -31,7 +31,7 @@ class RootShadowNode final
  public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
-  using Shared = std::shared_ptr<RootShadowNode const>;
+  using Shared = std::shared_ptr<const RootShadowNode>;
   using Unshared = std::shared_ptr<RootShadowNode>;
 
   static ShadowNodeTraits BaseTraits() {
@@ -45,15 +45,15 @@ class RootShadowNode final
    * Returns `false` if the three is already laid out.
    */
   bool layoutIfNeeded(
-      std::vector<LayoutableShadowNode const *> *affectedNodes = {});
+      std::vector<const LayoutableShadowNode *> *affectedNodes = {});
 
   /*
    * Clones the node with given `layoutConstraints` and `layoutContext`.
    */
   RootShadowNode::Unshared clone(
-      PropsParserContext const &propsParserContext,
-      LayoutConstraints const &layoutConstraints,
-      LayoutContext const &layoutContext) const;
+      const PropsParserContext &propsParserContext,
+      const LayoutConstraints &layoutConstraints,
+      const LayoutContext &layoutContext) const;
 
   Transform getTransform() const override;
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
@@ -19,7 +19,7 @@ namespace facebook::react {
 class SafeAreaViewComponentDescriptor final
     : public ConcreteComponentDescriptor<SafeAreaViewShadowNode> {
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     react_native_assert(
         std::dynamic_pointer_cast<SafeAreaViewShadowNode>(shadowNode));
     auto &layoutableShadowNode =

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/RCTComponentViewHelpers.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/RCTComponentViewHelpers.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 RCT_EXTERN inline void
-RCTScrollViewHandleCommand(id<RCTScrollViewProtocol> componentView, NSString const *commandName, NSArray const *args)
+RCTScrollViewHandleCommand(id<RCTScrollViewProtocol> componentView, const NSString *commandName, const NSArray *args)
 {
   if ([commandName isEqualToString:@"flashScrollIndicators"]) {
 #if RCT_DEBUG

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -18,8 +18,8 @@ namespace facebook::react {
 
 ScrollViewProps::ScrollViewProps(
     const PropsParserContext &context,
-    ScrollViewProps const &sourceProps,
-    RawProps const &rawProps)
+    const ScrollViewProps &sourceProps,
+    const RawProps &rawProps)
     : ViewProps(context, sourceProps, rawProps),
       alwaysBounceHorizontal(
           CoreFeatures::enablePropIteratorSetter
@@ -334,7 +334,7 @@ void ScrollViewProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   // All Props structs setProp methods must always, unconditionally,
   // call all super::setProp methods, since multiple structs may
   // reuse the same values.

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -21,14 +21,14 @@ class ScrollViewProps final : public ViewProps {
   ScrollViewProps() = default;
   ScrollViewProps(
       const PropsParserContext &context,
-      ScrollViewProps const &sourceProps,
-      RawProps const &rawProps);
+      const ScrollViewProps &sourceProps,
+      const RawProps &rawProps);
 
   void setProp(
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #pragma mark - Props
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.cpp
@@ -49,10 +49,10 @@ void ScrollViewShadowNode::updateScrollContentOffsetIfNeeded() {
 }
 
 ScrollViewState ScrollViewShadowNode::initialStateData(
-    Props::Shared const &props,
+    const Props::Shared &props,
     const ShadowNodeFamily::Shared & /*family*/,
     const ComponentDescriptor & /*componentDescriptor*/) {
-  return {static_cast<ScrollViewProps const &>(*props).contentOffset, {}, 0};
+  return {static_cast<const ScrollViewProps &>(*props).contentOffset, {}, 0};
 }
 
 #pragma mark - LayoutableShadowNode

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
@@ -30,9 +30,9 @@ class ScrollViewShadowNode final : public ConcreteViewShadowNode<
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
   static ScrollViewState initialStateData(
-      Props::Shared const &props,
-      ShadowNodeFamily::Shared const &family,
-      ComponentDescriptor const &componentDescriptor);
+      const Props::Shared &props,
+      const ShadowNodeFamily::Shared &family,
+      const ComponentDescriptor &componentDescriptor);
 
 #pragma mark - LayoutableShadowNode
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
@@ -41,7 +41,7 @@ class ScrollViewState final {
   Size getContentSize() const;
 
 #ifdef ANDROID
-  ScrollViewState(ScrollViewState const &previousState, folly::dynamic data)
+  ScrollViewState(const ScrollViewState &previousState, folly::dynamic data)
       : contentOffset(
             {(Float)data["contentOffsetLeft"].getDouble(),
              (Float)data["contentOffsetTop"].getDouble()}),

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
@@ -21,12 +21,12 @@ class AndroidSwitchComponentDescriptor final
     : public ConcreteComponentDescriptor<AndroidSwitchShadowNode> {
  public:
   AndroidSwitchComponentDescriptor(
-      ComponentDescriptorParameters const &parameters)
+      const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor(parameters),
         measurementsManager_(std::make_shared<AndroidSwitchMeasurementsManager>(
             contextContainer_)) {}
 
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
     auto &androidSwitchShadowNode =

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.cpp
@@ -21,8 +21,8 @@ void AndroidSwitchShadowNode::setAndroidSwitchMeasurementsManager(
 #pragma mark - LayoutableShadowNode
 
 Size AndroidSwitchShadowNode::measureContent(
-    LayoutContext const & /*layoutContext*/,
-    LayoutConstraints const &layoutConstraints) const {
+    const LayoutContext & /*layoutContext*/,
+    const LayoutConstraints &layoutConstraints) const {
   return measurementsManager_->measure(getSurfaceId(), layoutConstraints);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
@@ -35,8 +35,8 @@ class AndroidSwitchShadowNode final : public ConcreteViewShadowNode<
 #pragma mark - LayoutableShadowNode
 
   Size measureContent(
-      LayoutContext const &layoutContext,
-      LayoutConstraints const &layoutConstraints) const override;
+      const LayoutContext &layoutContext,
+      const LayoutConstraints &layoutConstraints) const override;
 
  private:
   std::shared_ptr<AndroidSwitchMeasurementsManager> measurementsManager_;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -16,10 +16,10 @@
 namespace facebook::react {
 
 static TextAttributes convertRawProp(
-    PropsParserContext const &context,
-    RawProps const &rawProps,
-    TextAttributes const &sourceTextAttributes,
-    TextAttributes const &defaultTextAttributes) {
+    const PropsParserContext &context,
+    const RawProps &rawProps,
+    const TextAttributes &sourceTextAttributes,
+    const TextAttributes &defaultTextAttributes) {
   auto textAttributes = TextAttributes{};
 
   // Color (not accessed by ViewProps)
@@ -224,7 +224,7 @@ void BaseTextProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char * /*propName*/,
-    RawValue const &value) {
+    const RawValue &value) {
   static auto defaults = TextAttributes{};
 
   switch (hash) {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.h
@@ -30,7 +30,7 @@ class BaseTextProps {
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #pragma mark - Props
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
@@ -16,7 +16,7 @@
 
 namespace facebook::react {
 
-inline ShadowView shadowViewFromShadowNode(ShadowNode const &shadowNode) {
+inline ShadowView shadowViewFromShadowNode(const ShadowNode &shadowNode) {
   auto shadowView = ShadowView{shadowNode};
   // Clearing `props` and `state` (which we don't use) allows avoiding retain
   // cycles.
@@ -26,14 +26,14 @@ inline ShadowView shadowViewFromShadowNode(ShadowNode const &shadowNode) {
 }
 
 void BaseTextShadowNode::buildAttributedString(
-    TextAttributes const &baseTextAttributes,
-    ShadowNode const &parentNode,
+    const TextAttributes &baseTextAttributes,
+    const ShadowNode &parentNode,
     AttributedString &outAttributedString,
     Attachments &outAttachments) {
-  for (auto const &childNode : parentNode.getChildren()) {
+  for (const auto &childNode : parentNode.getChildren()) {
     // RawShadowNode
     auto rawTextShadowNode =
-        traitCast<RawTextShadowNode const *>(childNode.get());
+        traitCast<const RawTextShadowNode *>(childNode.get());
     if (rawTextShadowNode != nullptr) {
       auto fragment = AttributedString::Fragment{};
       fragment.string = rawTextShadowNode->getConcreteProps().text;
@@ -49,7 +49,7 @@ void BaseTextShadowNode::buildAttributedString(
     }
 
     // TextShadowNode
-    auto textShadowNode = traitCast<TextShadowNode const *>(childNode.get());
+    auto textShadowNode = traitCast<const TextShadowNode *>(childNode.get());
     if (textShadowNode != nullptr) {
       auto localTextAttributes = baseTextAttributes;
       localTextAttributes.apply(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.h
@@ -28,7 +28,7 @@ class BaseTextShadowNode {
      * Unowning pointer to a `ShadowNode` that represents the attachment.
      * Cannot be `null`.
      */
-    ShadowNode const *shadowNode;
+    const ShadowNode *shadowNode;
 
     /*
      * Index of the fragment in `AttributedString` that represents the
@@ -52,8 +52,8 @@ class BaseTextShadowNode {
    * function, or if TextInput should inherit from BaseTextShadowNode.
    */
   static void buildAttributedString(
-      TextAttributes const &baseTextAttributes,
-      ShadowNode const &parentNode,
+      const TextAttributes &baseTextAttributes,
+      const ShadowNode &parentNode,
       AttributedString &outAttributedString,
       Attachments &outAttachments);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphComponentDescriptor.h
@@ -20,7 +20,7 @@ namespace facebook::react {
 class ParagraphComponentDescriptor final
     : public ConcreteComponentDescriptor<ParagraphShadowNode> {
  public:
-  ParagraphComponentDescriptor(ComponentDescriptorParameters const &parameters)
+  ParagraphComponentDescriptor(const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor<ParagraphShadowNode>(parameters) {
     // Every single `ParagraphShadowNode` will have a reference to
     // a shared `TextLayoutManager`.
@@ -28,7 +28,7 @@ class ParagraphComponentDescriptor final
   }
 
  protected:
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
     auto &paragraphShadowNode = static_cast<ParagraphShadowNode &>(*shadowNode);
@@ -39,7 +39,7 @@ class ParagraphComponentDescriptor final
   }
 
  private:
-  std::shared_ptr<TextLayoutManager const> textLayoutManager_;
+  std::shared_ptr<const TextLayoutManager> textLayoutManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.cpp
@@ -11,12 +11,12 @@ namespace facebook::react {
 
 static jsi::Value linesMeasurementsPayload(
     jsi::Runtime &runtime,
-    LinesMeasurements const &linesMeasurements) {
+    const LinesMeasurements &linesMeasurements) {
   auto payload = jsi::Object(runtime);
   auto lines = jsi::Array(runtime, linesMeasurements.size());
 
   for (size_t i = 0; i < linesMeasurements.size(); ++i) {
-    auto const &lineMeasurement = linesMeasurements[i];
+    const auto &lineMeasurement = linesMeasurements[i];
     auto jsiLine = jsi::Object(runtime);
     jsiLine.setProperty(runtime, "text", lineMeasurement.text);
     jsiLine.setProperty(runtime, "x", lineMeasurement.frame.origin.x);
@@ -36,7 +36,7 @@ static jsi::Value linesMeasurementsPayload(
 }
 
 void ParagraphEventEmitter::onTextLayout(
-    LinesMeasurements const &linesMeasurements) const {
+    const LinesMeasurements &linesMeasurements) const {
   {
     std::scoped_lock guard(linesMeasurementsMutex_);
     if (linesMeasurementsMetrics_ == linesMeasurements) {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.h
@@ -16,7 +16,7 @@ class ParagraphEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
-  void onTextLayout(LinesMeasurements const &linesMeasurements) const;
+  void onTextLayout(const LinesMeasurements &linesMeasurements) const;
 
  private:
   mutable std::mutex linesMeasurementsMutex_;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -12,8 +12,8 @@
 namespace facebook::react {
 
 TextMeasurement ParagraphLayoutManager::measure(
-    AttributedString const &attributedString,
-    ParagraphAttributes const &paragraphAttributes,
+    const AttributedString &attributedString,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   if (CoreFeatures::cacheLastTextMeasurement) {
     bool shouldMeasure = shoudMeasureString(
@@ -39,8 +39,8 @@ TextMeasurement ParagraphLayoutManager::measure(
 }
 
 bool ParagraphLayoutManager::shoudMeasureString(
-    AttributedString const &attributedString,
-    ParagraphAttributes const &paragraphAttributes,
+    const AttributedString &attributedString,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   size_t newParagraphInputHash =
       folly::hash::hash_combine(0, attributedString, paragraphAttributes);
@@ -74,19 +74,19 @@ bool ParagraphLayoutManager::shoudMeasureString(
 }
 
 LinesMeasurements ParagraphLayoutManager::measureLines(
-    AttributedString const &attributedString,
-    ParagraphAttributes const &paragraphAttributes,
+    const AttributedString &attributedString,
+    const ParagraphAttributes &paragraphAttributes,
     Size size) const {
   return textLayoutManager_->measureLines(
       attributedString, paragraphAttributes, size);
 }
 
 void ParagraphLayoutManager::setTextLayoutManager(
-    std::shared_ptr<TextLayoutManager const> textLayoutManager) const {
+    std::shared_ptr<const TextLayoutManager> textLayoutManager) const {
   textLayoutManager_ = std::move(textLayoutManager);
 }
 
-std::shared_ptr<TextLayoutManager const>
+std::shared_ptr<const TextLayoutManager>
 ParagraphLayoutManager::getTextLayoutManager() const {
   return textLayoutManager_;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
@@ -24,23 +24,23 @@ namespace facebook::react {
 class ParagraphLayoutManager {
  public:
   TextMeasurement measure(
-      AttributedString const &attributedString,
-      ParagraphAttributes const &paragraphAttributes,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
   LinesMeasurements measureLines(
-      AttributedString const &attributedString,
-      ParagraphAttributes const &paragraphAttributes,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
       Size size) const;
 
   void setTextLayoutManager(
-      std::shared_ptr<TextLayoutManager const> textLayoutManager) const;
+      std::shared_ptr<const TextLayoutManager> textLayoutManager) const;
 
   /*
    * Returns an opaque pointer to platform-specific `TextLayoutManager`.
    * Is used on a native views layer to delegate text rendering to the manager.
    */
-  std::shared_ptr<TextLayoutManager const> getTextLayoutManager() const;
+  std::shared_ptr<const TextLayoutManager> getTextLayoutManager() const;
 
   /*
    * Returns opaque shared_ptr holding `NSTextStorage`.
@@ -51,7 +51,7 @@ class ParagraphLayoutManager {
   std::shared_ptr<void> getHostTextStorage() const;
 
  private:
-  std::shared_ptr<TextLayoutManager const> mutable textLayoutManager_{};
+  std::shared_ptr<const TextLayoutManager> mutable textLayoutManager_{};
 
   /*
    * Stores opaque pointer to `NSTextStorage` on iOS. nullptr on Android.
@@ -85,8 +85,8 @@ class ParagraphLayoutManager {
    * needed.
    */
   bool shoudMeasureString(
-      AttributedString const &attributedString,
-      ParagraphAttributes const &paragraphAttributes,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -19,8 +19,8 @@ namespace facebook::react {
 
 ParagraphProps::ParagraphProps(
     const PropsParserContext &context,
-    ParagraphProps const &sourceProps,
-    RawProps const &rawProps)
+    const ParagraphProps &sourceProps,
+    const RawProps &rawProps)
     : ViewProps(context, sourceProps, rawProps),
       BaseTextProps(context, sourceProps, rawProps),
       paragraphAttributes(
@@ -59,7 +59,7 @@ void ParagraphProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   // All Props structs setProp methods must always, unconditionally,
   // call all super::setProp methods, since multiple structs may
   // reuse the same values.

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -28,14 +28,14 @@ class ParagraphProps : public ViewProps, public BaseTextProps {
   ParagraphProps() = default;
   ParagraphProps(
       const PropsParserContext &context,
-      ParagraphProps const &sourceProps,
-      RawProps const &rawProps);
+      const ParagraphProps &sourceProps,
+      const RawProps &rawProps);
 
   void setProp(
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #pragma mark - Props
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -24,11 +24,11 @@ namespace facebook::react {
 
 using Content = ParagraphShadowNode::Content;
 
-char const ParagraphComponentName[] = "Paragraph";
+const char ParagraphComponentName[] = "Paragraph";
 
 ParagraphShadowNode::ParagraphShadowNode(
-    ShadowNode const &sourceShadowNode,
-    ShadowNodeFragment const &fragment)
+    const ShadowNode &sourceShadowNode,
+    const ShadowNodeFragment &fragment)
     : ConcreteViewShadowNode(sourceShadowNode, fragment) {
   if (CoreFeatures::enableCleanParagraphYogaNode) {
     if (!fragment.children && !fragment.props) {
@@ -40,8 +40,8 @@ ParagraphShadowNode::ParagraphShadowNode(
   }
 }
 
-Content const &ParagraphShadowNode::getContent(
-    LayoutContext const &layoutContext) const {
+const Content &ParagraphShadowNode::getContent(
+    const LayoutContext &layoutContext) const {
   if (content_.has_value()) {
     return content_.value();
   }
@@ -66,8 +66,8 @@ Content const &ParagraphShadowNode::getContent(
 }
 
 Content ParagraphShadowNode::getContentWithMeasuredAttachments(
-    LayoutContext const &layoutContext,
-    LayoutConstraints const &layoutConstraints) const {
+    const LayoutContext &layoutContext,
+    const LayoutConstraints &layoutConstraints) const {
   auto content = getContent(layoutContext);
 
   if (content.attachments.empty()) {
@@ -81,9 +81,9 @@ Content ParagraphShadowNode::getContentWithMeasuredAttachments(
 
   auto &fragments = content.attributedString.getFragments();
 
-  for (auto const &attachment : content.attachments) {
+  for (const auto &attachment : content.attachments) {
     auto laytableShadowNode =
-        traitCast<LayoutableShadowNode const *>(attachment.shadowNode);
+        traitCast<const LayoutableShadowNode *>(attachment.shadowNode);
 
     if (laytableShadowNode == nullptr) {
       continue;
@@ -108,13 +108,13 @@ Content ParagraphShadowNode::getContentWithMeasuredAttachments(
 }
 
 void ParagraphShadowNode::setTextLayoutManager(
-    std::shared_ptr<TextLayoutManager const> textLayoutManager) {
+    std::shared_ptr<const TextLayoutManager> textLayoutManager) {
   ensureUnsealed();
   getStateData().paragraphLayoutManager.setTextLayoutManager(
       std::move(textLayoutManager));
 }
 
-void ParagraphShadowNode::updateStateIfNeeded(Content const &content) {
+void ParagraphShadowNode::updateStateIfNeeded(const Content &content) {
   ensureUnsealed();
 
   auto &state = getStateData();
@@ -134,8 +134,8 @@ void ParagraphShadowNode::updateStateIfNeeded(Content const &content) {
 #pragma mark - LayoutableShadowNode
 
 Size ParagraphShadowNode::measureContent(
-    LayoutContext const &layoutContext,
-    LayoutConstraints const &layoutConstraints) const {
+    const LayoutContext &layoutContext,
+    const LayoutConstraints &layoutConstraints) const {
   auto content =
       getContentWithMeasuredAttachments(layoutContext, layoutConstraints);
 
@@ -201,7 +201,7 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
   for (size_t i = 0; i < content.attachments.size(); i++) {
     auto &attachment = content.attachments.at(i);
 
-    if (traitCast<LayoutableShadowNode const *>(attachment.shadowNode) ==
+    if (traitCast<const LayoutableShadowNode *>(attachment.shadowNode) ==
         nullptr) {
       // Not a layoutable `ShadowNode`, no need to lay it out.
       continue;
@@ -211,7 +211,7 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
 
     paragraphOwningShadowNode = paragraphShadowNode->cloneTree(
         attachment.shadowNode->getFamily(),
-        [&](ShadowNode const &oldShadowNode) {
+        [&](const ShadowNode &oldShadowNode) {
           clonedShadowNode = oldShadowNode.clone({});
           return clonedShadowNode;
         });
@@ -245,7 +245,7 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
   // reflect the changes that we made.
   if (paragraphShadowNode != this) {
     this->children_ =
-        static_cast<ParagraphShadowNode const *>(paragraphShadowNode)
+        static_cast<const ParagraphShadowNode *>(paragraphShadowNode)
             ->children_;
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -18,7 +18,7 @@
 
 namespace facebook::react {
 
-extern char const ParagraphComponentName[];
+extern const char ParagraphComponentName[];
 
 /*
  * `ShadowNode` for <Paragraph> component, represents <View>-like component
@@ -35,8 +35,8 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
   ParagraphShadowNode(
-      ShadowNode const &sourceShadowNode,
-      ShadowNodeFragment const &fragment);
+      const ShadowNode &sourceShadowNode,
+      const ShadowNodeFragment &fragment);
 
   static ShadowNodeTraits BaseTraits() {
     auto traits = ConcreteViewShadowNode::BaseTraits();
@@ -59,14 +59,14 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
    * and construct `ParagraphState` objects.
    */
   void setTextLayoutManager(
-      std::shared_ptr<TextLayoutManager const> textLayoutManager);
+      std::shared_ptr<const TextLayoutManager> textLayoutManager);
 
 #pragma mark - LayoutableShadowNode
 
   void layout(LayoutContext layoutContext) override;
   Size measureContent(
-      LayoutContext const &layoutContext,
-      LayoutConstraints const &layoutConstraints) const override;
+      const LayoutContext &layoutContext,
+      const LayoutConstraints &layoutConstraints) const override;
 
   /*
    * Internal representation of the nested content of the node in a format
@@ -83,20 +83,20 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
   /*
    * Builds (if needed) and returns a reference to a `Content` object.
    */
-  Content const &getContent(LayoutContext const &layoutContext) const;
+  const Content &getContent(const LayoutContext &layoutContext) const;
 
   /*
    * Builds and returns a `Content` object with given `layoutConstraints`.
    */
   Content getContentWithMeasuredAttachments(
-      LayoutContext const &layoutContext,
-      LayoutConstraints const &layoutConstraints) const;
+      const LayoutContext &layoutContext,
+      const LayoutConstraints &layoutConstraints) const;
 
   /*
    * Creates a `State` object (with `AttributedText` and
    * `TextLayoutManager`) if needed.
    */
-  void updateStateIfNeeded(Content const &content);
+  void updateStateIfNeeded(const Content &content);
 
   /*
    * Cached content of the subtree started from the node.

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphState.h
@@ -55,16 +55,16 @@ struct ParagraphState {
 
 #ifdef ANDROID
   ParagraphState(
-      AttributedString const &attributedString,
-      ParagraphAttributes const &paragraphAttributes,
-      ParagraphLayoutManager const &paragraphLayoutManager)
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
+      const ParagraphLayoutManager &paragraphLayoutManager)
       : attributedString(attributedString),
         paragraphAttributes(paragraphAttributes),
         paragraphLayoutManager(paragraphLayoutManager) {}
   ParagraphState() = default;
   ParagraphState(
-      ParagraphState const &previousState,
-      folly::dynamic const &data) {
+      const ParagraphState &previousState,
+      const folly::dynamic &data) {
     react_native_assert(false && "Not supported");
   };
   folly::dynamic getDynamic() const;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.cpp
@@ -20,7 +20,7 @@ void TextProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   BaseTextProps::setProp(context, hash, propName, value);
   Props::setProp(context, hash, propName, value);
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
@@ -27,7 +27,7 @@ class TextProps : public Props, public BaseTextProps {
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #pragma mark - DebugStringConvertible
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
@@ -52,8 +52,8 @@ class TextShadowNode : public ConcreteShadowNode<
       TextEventEmitter>;
 
   TextShadowNode(
-      ShadowNodeFragment const &fragment,
-      ShadowNodeFamily::Shared const &family,
+      const ShadowNodeFragment &fragment,
+      const ShadowNodeFamily::Shared &family,
       ShadowNodeTraits traits)
       : BaseShadowNode(fragment, family, traits), BaseTextShadowNode() {
     orderIndex_ = std::numeric_limits<decltype(orderIndex_)>::max();

--- a/packages/react-native/ReactCommon/react/renderer/components/text/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/conversions.h
@@ -16,7 +16,7 @@
 namespace facebook::react {
 
 #ifdef ANDROID
-inline folly::dynamic toDynamic(ParagraphState const &paragraphState) {
+inline folly::dynamic toDynamic(const ParagraphState &paragraphState) {
   folly::dynamic newState = folly::dynamic::object();
   newState["attributedString"] = toDynamic(paragraphState.attributedString);
   newState["paragraphAttributes"] =
@@ -25,7 +25,7 @@ inline folly::dynamic toDynamic(ParagraphState const &paragraphState) {
   return newState;
 }
 
-inline MapBuffer toMapBuffer(ParagraphState const &paragraphState) {
+inline MapBuffer toMapBuffer(const ParagraphState &paragraphState) {
   auto builder = MapBufferBuilder();
   auto attStringMapBuffer = toMapBuffer(paragraphState.attributedString);
   builder.putMapBuffer(TX_STATE_KEY_ATTRIBUTED_STRING, attStringMapBuffer);

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -26,7 +26,7 @@ class AndroidTextInputComponentDescriptor final
     : public ConcreteComponentDescriptor<AndroidTextInputShadowNode> {
  public:
   AndroidTextInputComponentDescriptor(
-      ComponentDescriptorParameters const &parameters)
+      const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor<AndroidTextInputShadowNode>(parameters) {
     // Every single `AndroidTextInputShadowNode` will have a reference to
     // a shared `TextLayoutManager`.
@@ -34,8 +34,8 @@ class AndroidTextInputComponentDescriptor final
   }
 
   virtual State::Shared createInitialState(
-      Props::Shared const &props,
-      ShadowNodeFamily::Shared const &family) const override {
+      const Props::Shared &props,
+      const ShadowNodeFamily::Shared &family) const override {
     int surfaceId = family->getSurfaceId();
 
     YGStyle::Edges theme;
@@ -70,7 +70,7 @@ class AndroidTextInputComponentDescriptor final
     }
 
     return std::make_shared<AndroidTextInputShadowNode::ConcreteState>(
-        std::make_shared<AndroidTextInputState const>(AndroidTextInputState(
+        std::make_shared<const AndroidTextInputState>(AndroidTextInputState(
             0,
             {},
             {},
@@ -83,7 +83,7 @@ class AndroidTextInputComponentDescriptor final
   }
 
  protected:
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     auto &textInputShadowNode =
         static_cast<AndroidTextInputShadowNode &>(*shadowNode);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -260,7 +260,7 @@ void AndroidTextInputProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   // All Props structs setProp methods must always, unconditionally,
   // call all super::setProp methods, since multiple structs may
   // reuse the same values.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -74,7 +74,7 @@ class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
   folly::dynamic getDynamic() const;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -97,7 +97,7 @@ void AndroidTextInputShadowNode::setTextLayoutManager(
 
 AttributedString AndroidTextInputShadowNode::getMostRecentAttributedString()
     const {
-  auto const &state = getStateData();
+  const auto &state = getStateData();
 
   auto reactTreeAttributedString = getAttributedString();
 
@@ -118,7 +118,7 @@ void AndroidTextInputShadowNode::updateStateIfNeeded() {
   ensureUnsealed();
 
   auto reactTreeAttributedString = getAttributedString();
-  auto const &state = getStateData();
+  const auto &state = getStateData();
 
   // Tree is often out of sync with the value of the TextInput.
   // This is by design - don't change the value of the TextInput in the State,
@@ -157,8 +157,8 @@ void AndroidTextInputShadowNode::updateStateIfNeeded() {
 #pragma mark - LayoutableShadowNode
 
 Size AndroidTextInputShadowNode::measureContent(
-    LayoutContext const & /*layoutContext*/,
-    LayoutConstraints const &layoutConstraints) const {
+    const LayoutContext & /*layoutContext*/,
+    const LayoutConstraints &layoutConstraints) const {
   if (getStateData().cachedAttributedStringId != 0) {
     return textLayoutManager_
         ->measureCachedSpannableById(

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
@@ -56,8 +56,8 @@ class AndroidTextInputShadowNode final : public ConcreteViewShadowNode<
 #pragma mark - LayoutableShadowNode
 
   Size measureContent(
-      LayoutContext const &layoutContext,
-      LayoutConstraints const &layoutConstraints) const override;
+      const LayoutContext &layoutContext,
+      const LayoutConstraints &layoutConstraints) const override;
   void layout(LayoutContext layoutContext) override;
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
@@ -38,8 +38,8 @@ AndroidTextInputState::AndroidTextInputState(
       defaultThemePaddingBottom(defaultThemePaddingBottom) {}
 
 AndroidTextInputState::AndroidTextInputState(
-    AndroidTextInputState const &previousState,
-    folly::dynamic const &data)
+    const AndroidTextInputState &previousState,
+    const folly::dynamic &data)
     : mostRecentEventCount(data.getDefault(
                                    "mostRecentEventCount",
                                    previousState.mostRecentEventCount)

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.h
@@ -74,8 +74,8 @@ class AndroidTextInputState final {
 
   AndroidTextInputState() = default;
   AndroidTextInputState(
-      AndroidTextInputState const &previousState,
-      folly::dynamic const &data);
+      const AndroidTextInputState &previousState,
+      const folly::dynamic &data);
   folly::dynamic getDynamic() const;
   MapBuffer getMapBuffer() const;
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
@@ -18,14 +18,14 @@ namespace facebook::react {
 class TextInputComponentDescriptor final
     : public ConcreteComponentDescriptor<TextInputShadowNode> {
  public:
-  TextInputComponentDescriptor(ComponentDescriptorParameters const &parameters)
+  TextInputComponentDescriptor(const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor<TextInputShadowNode>(parameters) {
     textLayoutManager_ =
-        std::make_shared<TextLayoutManager const>(contextContainer_);
+        std::make_shared<const TextLayoutManager>(contextContainer_);
   }
 
  protected:
-  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+  void adopt(const ShadowNode::Unshared &shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
     auto &concreteShadowNode = static_cast<TextInputShadowNode &>(*shadowNode);
@@ -33,7 +33,7 @@ class TextInputComponentDescriptor final
   }
 
  private:
-  std::shared_ptr<TextLayoutManager const> textLayoutManager_;
+  std::shared_ptr<const TextLayoutManager> textLayoutManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -11,7 +11,7 @@ namespace facebook::react {
 
 static jsi::Value textInputMetricsPayload(
     jsi::Runtime &runtime,
-    TextInputMetrics const &textInputMetrics) {
+    const TextInputMetrics &textInputMetrics) {
   auto payload = jsi::Object(runtime);
 
   payload.setProperty(
@@ -38,7 +38,7 @@ static jsi::Value textInputMetricsPayload(
 
 static jsi::Value textInputMetricsContentSizePayload(
     jsi::Runtime &runtime,
-    TextInputMetrics const &textInputMetrics) {
+    const TextInputMetrics &textInputMetrics) {
   auto payload = jsi::Object(runtime);
 
   {
@@ -55,7 +55,7 @@ static jsi::Value textInputMetricsContentSizePayload(
 
 static jsi::Value keyPressMetricsPayload(
     jsi::Runtime &runtime,
-    KeyPressMetrics const &keyPressMetrics) {
+    const KeyPressMetrics &keyPressMetrics) {
   auto payload = jsi::Object(runtime);
   payload.setProperty(runtime, "eventCount", keyPressMetrics.eventCount);
 
@@ -77,49 +77,49 @@ static jsi::Value keyPressMetricsPayload(
 };
 
 void TextInputEventEmitter::onFocus(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputEvent("focus", textInputMetrics);
 }
 
 void TextInputEventEmitter::onBlur(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputEvent("blur", textInputMetrics);
 }
 
 void TextInputEventEmitter::onChange(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputEvent("change", textInputMetrics);
 }
 
 void TextInputEventEmitter::onChangeSync(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputEvent(
       "changeSync", textInputMetrics, EventPriority::SynchronousBatched);
 }
 
 void TextInputEventEmitter::onContentSizeChange(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputContentSizeChangeEvent(
       "contentSizeChange", textInputMetrics);
 }
 
 void TextInputEventEmitter::onSelectionChange(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputEvent("selectionChange", textInputMetrics);
 }
 
 void TextInputEventEmitter::onEndEditing(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputEvent("endEditing", textInputMetrics);
 }
 
 void TextInputEventEmitter::onSubmitEditing(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputEvent("submitEditing", textInputMetrics);
 }
 
 void TextInputEventEmitter::onKeyPress(
-    KeyPressMetrics const &keyPressMetrics) const {
+    const KeyPressMetrics &keyPressMetrics) const {
   dispatchEvent(
       "keyPress",
       [keyPressMetrics](jsi::Runtime &runtime) {
@@ -129,7 +129,7 @@ void TextInputEventEmitter::onKeyPress(
 }
 
 void TextInputEventEmitter::onKeyPressSync(
-    KeyPressMetrics const &keyPressMetrics) const {
+    const KeyPressMetrics &keyPressMetrics) const {
   dispatchEvent(
       "keyPressSync",
       [keyPressMetrics](jsi::Runtime &runtime) {
@@ -139,13 +139,13 @@ void TextInputEventEmitter::onKeyPressSync(
 }
 
 void TextInputEventEmitter::onScroll(
-    TextInputMetrics const &textInputMetrics) const {
+    const TextInputMetrics &textInputMetrics) const {
   dispatchTextInputEvent("scroll", textInputMetrics);
 }
 
 void TextInputEventEmitter::dispatchTextInputEvent(
-    std::string const &name,
-    TextInputMetrics const &textInputMetrics,
+    const std::string &name,
+    const TextInputMetrics &textInputMetrics,
     EventPriority priority) const {
   dispatchEvent(
       name,
@@ -156,8 +156,8 @@ void TextInputEventEmitter::dispatchTextInputEvent(
 }
 
 void TextInputEventEmitter::dispatchTextInputContentSizeChangeEvent(
-    std::string const &name,
-    TextInputMetrics const &textInputMetrics,
+    const std::string &name,
+    const TextInputMetrics &textInputMetrics,
     EventPriority priority) const {
   dispatchEvent(
       name,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
@@ -36,27 +36,27 @@ class TextInputEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
-  void onFocus(TextInputMetrics const &textInputMetrics) const;
-  void onBlur(TextInputMetrics const &textInputMetrics) const;
-  void onChange(TextInputMetrics const &textInputMetrics) const;
-  void onChangeSync(TextInputMetrics const &textInputMetrics) const;
-  void onContentSizeChange(TextInputMetrics const &textInputMetrics) const;
-  void onSelectionChange(TextInputMetrics const &textInputMetrics) const;
-  void onEndEditing(TextInputMetrics const &textInputMetrics) const;
-  void onSubmitEditing(TextInputMetrics const &textInputMetrics) const;
-  void onKeyPress(KeyPressMetrics const &keyPressMetrics) const;
-  void onKeyPressSync(KeyPressMetrics const &keyPressMetrics) const;
-  void onScroll(TextInputMetrics const &textInputMetrics) const;
+  void onFocus(const TextInputMetrics &textInputMetrics) const;
+  void onBlur(const TextInputMetrics &textInputMetrics) const;
+  void onChange(const TextInputMetrics &textInputMetrics) const;
+  void onChangeSync(const TextInputMetrics &textInputMetrics) const;
+  void onContentSizeChange(const TextInputMetrics &textInputMetrics) const;
+  void onSelectionChange(const TextInputMetrics &textInputMetrics) const;
+  void onEndEditing(const TextInputMetrics &textInputMetrics) const;
+  void onSubmitEditing(const TextInputMetrics &textInputMetrics) const;
+  void onKeyPress(const KeyPressMetrics &keyPressMetrics) const;
+  void onKeyPressSync(const KeyPressMetrics &keyPressMetrics) const;
+  void onScroll(const TextInputMetrics &textInputMetrics) const;
 
  private:
   void dispatchTextInputEvent(
-      std::string const &name,
-      TextInputMetrics const &textInputMetrics,
+      const std::string &name,
+      const TextInputMetrics &textInputMetrics,
       EventPriority priority = EventPriority::AsynchronousBatched) const;
 
   void dispatchTextInputContentSizeChangeEvent(
-      std::string const &name,
-      TextInputMetrics const &textInputMetrics,
+      const std::string &name,
+      const TextInputMetrics &textInputMetrics,
       EventPriority priority = EventPriority::AsynchronousBatched) const;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputProps.cpp
@@ -16,8 +16,8 @@ namespace facebook::react {
 
 TextInputProps::TextInputProps(
     const PropsParserContext &context,
-    TextInputProps const &sourceProps,
-    RawProps const &rawProps)
+    const TextInputProps &sourceProps,
+    const RawProps &rawProps)
     : ViewProps(context, sourceProps, rawProps),
       BaseTextProps(context, sourceProps, rawProps),
       traits(convertRawProp(context, rawProps, sourceProps.traits, {})),
@@ -110,7 +110,7 @@ void TextInputProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   ViewProps::setProp(context, hash, propName, value);
   BaseTextProps::setProp(context, hash, propName, value);
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputProps.h
@@ -27,40 +27,40 @@ class TextInputProps final : public ViewProps, public BaseTextProps {
   TextInputProps() = default;
   TextInputProps(
       const PropsParserContext &context,
-      TextInputProps const &sourceProps,
-      RawProps const &rawProps);
+      const TextInputProps &sourceProps,
+      const RawProps &rawProps);
 
   void setProp(
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #pragma mark - Props
 
-  TextInputTraits const traits{};
-  ParagraphAttributes const paragraphAttributes{};
+  const TextInputTraits traits{};
+  const ParagraphAttributes paragraphAttributes{};
 
   std::string const defaultValue{};
 
   std::string const placeholder{};
-  SharedColor const placeholderTextColor{};
+  const SharedColor placeholderTextColor{};
 
   int maxLength{};
 
   /*
    * Tint colors
    */
-  SharedColor const cursorColor{};
-  SharedColor const selectionColor{};
+  const SharedColor cursorColor{};
+  const SharedColor selectionColor{};
   // TODO: Rename to `tintColor` and make universal.
-  SharedColor const underlineColorAndroid{};
+  const SharedColor underlineColorAndroid{};
 
   /*
    * "Private" (only used by TextInput.js) props
    */
   std::string const text{};
-  int const mostRecentEventCount{0};
+  const int mostRecentEventCount{0};
 
   bool autoFocus{false};
   std::optional<Selection> selection{};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputShadowNode.cpp
@@ -16,10 +16,10 @@
 
 namespace facebook::react {
 
-extern char const TextInputComponentName[] = "TextInput";
+extern const char TextInputComponentName[] = "TextInput";
 
 AttributedStringBox TextInputShadowNode::attributedStringBoxToMeasure(
-    LayoutContext const &layoutContext) const {
+    const LayoutContext &layoutContext) const {
   bool hasMeaningfulState =
       getState() && getState()->getRevision() != State::initialRevisionValue;
 
@@ -54,7 +54,7 @@ AttributedStringBox TextInputShadowNode::attributedStringBoxToMeasure(
 }
 
 AttributedString TextInputShadowNode::getAttributedString(
-    LayoutContext const &layoutContext) const {
+    const LayoutContext &layoutContext) const {
   auto textAttributes = getConcreteProps().getEffectiveTextAttributes(
       layoutContext.fontSizeMultiplier);
   auto attributedString = AttributedString{};
@@ -70,17 +70,17 @@ AttributedString TextInputShadowNode::getAttributedString(
 }
 
 void TextInputShadowNode::setTextLayoutManager(
-    std::shared_ptr<TextLayoutManager const> textLayoutManager) {
+    std::shared_ptr<const TextLayoutManager> textLayoutManager) {
   ensureUnsealed();
   textLayoutManager_ = std::move(textLayoutManager);
 }
 
 void TextInputShadowNode::updateStateIfNeeded(
-    LayoutContext const &layoutContext) {
+    const LayoutContext &layoutContext) {
   ensureUnsealed();
 
   auto reactTreeAttributedString = getAttributedString(layoutContext);
-  auto const &state = getStateData();
+  const auto &state = getStateData();
 
   react_native_assert(textLayoutManager_);
   react_native_assert(
@@ -104,8 +104,8 @@ void TextInputShadowNode::updateStateIfNeeded(
 #pragma mark - LayoutableShadowNode
 
 Size TextInputShadowNode::measureContent(
-    LayoutContext const &layoutContext,
-    LayoutConstraints const &layoutConstraints) const {
+    const LayoutContext &layoutContext,
+    const LayoutConstraints &layoutConstraints) const {
   return textLayoutManager_
       ->measure(
           attributedStringBoxToMeasure(layoutContext),

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputShadowNode.h
@@ -46,26 +46,26 @@ class TextInputShadowNode final : public ConcreteViewShadowNode<
    * and construct `TextInputState` objects.
    */
   void setTextLayoutManager(
-      std::shared_ptr<TextLayoutManager const> textLayoutManager);
+      std::shared_ptr<const TextLayoutManager> textLayoutManager);
 
 #pragma mark - LayoutableShadowNode
 
   Size measureContent(
-      LayoutContext const &layoutContext,
-      LayoutConstraints const &layoutConstraints) const override;
+      const LayoutContext &layoutContext,
+      const LayoutConstraints &layoutConstraints) const override;
   void layout(LayoutContext layoutContext) override;
 
  private:
   /*
    * Creates a `State` object if needed.
    */
-  void updateStateIfNeeded(LayoutContext const &layoutContext);
+  void updateStateIfNeeded(const LayoutContext &layoutContext);
 
   /*
    * Returns a `AttributedString` which represents text content of the node.
    */
   AttributedString getAttributedString(
-      LayoutContext const &layoutContext) const;
+      const LayoutContext &layoutContext) const;
 
   /*
    * Returns an `AttributedStringBox` which represents text content that should
@@ -73,9 +73,9 @@ class TextInputShadowNode final : public ConcreteViewShadowNode<
    * placeholder value or some character that represents the size of the font.
    */
   AttributedStringBox attributedStringBoxToMeasure(
-      LayoutContext const &layoutContext) const;
+      const LayoutContext &layoutContext) const;
 
-  std::shared_ptr<TextLayoutManager const> textLayoutManager_;
+  std::shared_ptr<const TextLayoutManager> textLayoutManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputState.cpp
@@ -11,8 +11,8 @@ namespace facebook::react {
 
 #ifdef ANDROID
 TextInputState::TextInputState(
-    TextInputState const & /*previousState*/,
-    folly::dynamic const & /*data*/){};
+    const TextInputState & /*previousState*/,
+    const folly::dynamic & /*data*/){};
 
 /*
  * Empty implementation for Android because it doesn't use this class.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputState.h
@@ -51,14 +51,14 @@ class TextInputState final {
    * text rendering infrastructure which is capable to render the
    * `AttributedString`.
    */
-  std::shared_ptr<TextLayoutManager const> layoutManager;
+  std::shared_ptr<const TextLayoutManager> layoutManager;
 
   size_t mostRecentEventCount{0};
 
 #ifdef ANDROID
   TextInputState(
-      TextInputState const &previousState,
-      folly::dynamic const &data);
+      const TextInputState &previousState,
+      const folly::dynamic &data);
 
   folly::dynamic getDynamic() const;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/propsConversions.h
@@ -16,9 +16,9 @@ namespace facebook::react {
 
 static TextInputTraits convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    TextInputTraits const &sourceTraits,
-    TextInputTraits const &defaultTraits) {
+    const RawProps &rawProps,
+    const TextInputTraits &sourceTraits,
+    const TextInputTraits &defaultTraits) {
   auto traits = TextInputTraits{};
 
   traits.multiline = convertRawProp(

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.cpp
@@ -15,13 +15,13 @@ ComponentHandle UnimplementedViewComponentDescriptor::getComponentHandle()
 }
 
 ComponentName UnimplementedViewComponentDescriptor::getComponentName() const {
-  return static_cast<std::string const *>(flavor_.get())->c_str();
+  return static_cast<const std::string *>(flavor_.get())->c_str();
 }
 
 Props::Shared UnimplementedViewComponentDescriptor::cloneProps(
-    PropsParserContext const &context,
-    Props::Shared const &props,
-    RawProps const &rawProps) const {
+    const PropsParserContext &context,
+    const Props::Shared &props,
+    const RawProps &rawProps) const {
   auto clonedProps =
       ConcreteComponentDescriptor<UnimplementedViewShadowNode>::cloneProps(
           context, props, rawProps);
@@ -32,7 +32,7 @@ Props::Shared UnimplementedViewComponentDescriptor::cloneProps(
   emptyRawProps.parse(rawPropsParser_, context);
   auto unimplementedViewProps = std::make_shared<UnimplementedViewProps>(
       context,
-      static_cast<UnimplementedViewProps const &>(*clonedProps),
+      static_cast<const UnimplementedViewProps &>(*clonedProps),
       emptyRawProps);
 
   unimplementedViewProps->setComponentName(getComponentName());

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
@@ -33,9 +33,9 @@ class UnimplementedViewComponentDescriptor final
    * `Props` object.
    */
   Props::Shared cloneProps(
-      PropsParserContext const &context,
-      Props::Shared const &props,
-      RawProps const &rawProps) const override;
+      const PropsParserContext &context,
+      const Props::Shared &props,
+      const RawProps &rawProps) const override;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -54,14 +54,14 @@ struct AccessibilityAction {
 };
 
 inline static bool operator==(
-    AccessibilityAction const &lhs,
-    AccessibilityAction const &rhs) {
+    const AccessibilityAction &lhs,
+    const AccessibilityAction &rhs) {
   return lhs.name == rhs.name && lhs.label == rhs.label;
 }
 
 inline static bool operator!=(
-    AccessibilityAction const &lhs,
-    AccessibilityAction const &rhs) {
+    const AccessibilityAction &lhs,
+    const AccessibilityAction &rhs) {
   return !(rhs == lhs);
 }
 
@@ -74,16 +74,16 @@ struct AccessibilityState {
 };
 
 constexpr bool operator==(
-    AccessibilityState const &lhs,
-    AccessibilityState const &rhs) {
+    const AccessibilityState &lhs,
+    const AccessibilityState &rhs) {
   return lhs.disabled == rhs.disabled && lhs.selected == rhs.selected &&
       lhs.checked == rhs.checked && lhs.busy == rhs.busy &&
       lhs.expanded == rhs.expanded;
 }
 
 constexpr bool operator!=(
-    AccessibilityState const &lhs,
-    AccessibilityState const &rhs) {
+    const AccessibilityState &lhs,
+    const AccessibilityState &rhs) {
   return !(rhs == lhs);
 }
 
@@ -92,14 +92,14 @@ struct AccessibilityLabelledBy {
 };
 
 inline static bool operator==(
-    AccessibilityLabelledBy const &lhs,
-    AccessibilityLabelledBy const &rhs) {
+    const AccessibilityLabelledBy &lhs,
+    const AccessibilityLabelledBy &rhs) {
   return lhs.value == rhs.value;
 }
 
 inline static bool operator!=(
-    AccessibilityLabelledBy const &lhs,
-    AccessibilityLabelledBy const &rhs) {
+    const AccessibilityLabelledBy &lhs,
+    const AccessibilityLabelledBy &rhs) {
   return !(lhs == rhs);
 }
 
@@ -111,15 +111,15 @@ struct AccessibilityValue {
 };
 
 constexpr bool operator==(
-    AccessibilityValue const &lhs,
-    AccessibilityValue const &rhs) {
+    const AccessibilityValue &lhs,
+    const AccessibilityValue &rhs) {
   return lhs.min == rhs.min && lhs.max == rhs.max && lhs.now == rhs.now &&
       lhs.text == rhs.text;
 }
 
 constexpr bool operator!=(
-    AccessibilityValue const &lhs,
-    AccessibilityValue const &rhs) {
+    const AccessibilityValue &lhs,
+    const AccessibilityValue &rhs) {
   return !(rhs == lhs);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -17,8 +17,8 @@ namespace facebook::react {
 
 AccessibilityProps::AccessibilityProps(
     const PropsParserContext &context,
-    AccessibilityProps const &sourceProps,
-    RawProps const &rawProps)
+    const AccessibilityProps &sourceProps,
+    const RawProps &rawProps)
     : accessible(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.accessible
                                                  : convertRawProp(
@@ -219,7 +219,7 @@ void AccessibilityProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char * /*propName*/,
-    RawValue const &value) {
+    const RawValue &value) {
   static auto defaults = AccessibilityProps{};
 
   switch (hash) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -20,17 +20,17 @@ class AccessibilityProps {
   AccessibilityProps() = default;
   AccessibilityProps(
       const PropsParserContext &context,
-      AccessibilityProps const &sourceProps,
-      RawProps const &rawProps);
+      const AccessibilityProps &sourceProps,
+      const RawProps &rawProps);
 
   void setProp(
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #ifdef ANDROID
-  void propsDiffMapBuffer(Props const *oldProps, MapBufferBuilder &builder)
+  void propsDiffMapBuffer(const Props *oldProps, MapBufferBuilder &builder)
       const;
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.cpp
@@ -12,7 +12,7 @@ namespace facebook::react {
 void setTouchPayloadOnObject(
     jsi::Object &object,
     jsi::Runtime &runtime,
-    BaseTouch const &touch) {
+    const BaseTouch &touch) {
   object.setProperty(runtime, "locationX", touch.offsetPoint.x);
   object.setProperty(runtime, "locationY", touch.offsetPoint.y);
   object.setProperty(runtime, "pageX", touch.pagePoint.x);
@@ -27,12 +27,12 @@ void setTouchPayloadOnObject(
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(BaseTouch const & /*touch*/) {
+std::string getDebugName(const BaseTouch & /*touch*/) {
   return "Touch";
 }
 
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    BaseTouch const &touch,
+    const BaseTouch &touch,
     DebugStringConvertibleOptions options) {
   return {
       {"pagePoint", getDebugDescription(touch.pagePoint, options)},

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
@@ -62,13 +62,13 @@ struct BaseTouch {
    * collections. Because of that they are expressed as separate classes.
    */
   struct Hasher {
-    size_t operator()(BaseTouch const &touch) const {
+    size_t operator()(const BaseTouch &touch) const {
       return std::hash<decltype(touch.identifier)>()(touch.identifier);
     }
   };
 
   struct Comparator {
-    bool operator()(BaseTouch const &lhs, BaseTouch const &rhs) const {
+    bool operator()(const BaseTouch &lhs, const BaseTouch &rhs) const {
       return lhs.identifier == rhs.identifier;
     }
   };
@@ -77,13 +77,13 @@ struct BaseTouch {
 void setTouchPayloadOnObject(
     jsi::Object &object,
     jsi::Runtime &runtime,
-    BaseTouch const &touch);
+    const BaseTouch &touch);
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(BaseTouch const &touch);
+std::string getDebugName(const BaseTouch &touch);
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    BaseTouch const &touch,
+    const BaseTouch &touch,
     DebugStringConvertibleOptions options);
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.cpp
@@ -13,7 +13,7 @@ namespace facebook::react {
 #pragma mark - Accessibility
 
 void BaseViewEventEmitter::onAccessibilityAction(
-    std::string const &name) const {
+    const std::string &name) const {
   dispatchEvent("accessibilityAction", [name](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     payload.setProperty(runtime, "actionName", name);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.h
@@ -23,7 +23,7 @@ class BaseViewEventEmitter : public TouchEventEmitter {
 
 #pragma mark - Accessibility
 
-  void onAccessibilityAction(std::string const &name) const;
+  void onAccessibilityAction(const std::string &name) const;
   void onAccessibilityTap() const;
   void onAccessibilityMagicTap() const;
   void onAccessibilityEscape() const;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -20,8 +20,8 @@ namespace facebook::react {
 
 BaseViewProps::BaseViewProps(
     const PropsParserContext &context,
-    BaseViewProps const &sourceProps,
-    RawProps const &rawProps,
+    const BaseViewProps &sourceProps,
+    const RawProps &rawProps,
     bool shouldSetRawProps)
     : YogaStylableProps(context, sourceProps, rawProps, shouldSetRawProps),
       AccessibilityProps(context, sourceProps, rawProps),
@@ -217,7 +217,7 @@ void BaseViewProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   // All Props structs setProp methods must always, unconditionally,
   // call all super::setProp methods, since multiple structs may
   // reuse the same values.
@@ -278,7 +278,7 @@ void BaseViewProps::setProp(
 
 #pragma mark - Convenience Methods
 
-static BorderRadii ensureNoOverlap(BorderRadii const &radii, Size const &size) {
+static BorderRadii ensureNoOverlap(const BorderRadii &radii, const Size &size) {
   // "Corner curves must not overlap: When the sum of any two adjacent border
   // radii exceeds the size of the border box, UAs must proportionally reduce
   // the used values of all border radii until none of them overlap."
@@ -315,7 +315,7 @@ static BorderRadii ensureNoOverlap(BorderRadii const &radii, Size const &size) {
 }
 
 BorderMetrics BaseViewProps::resolveBorderMetrics(
-    LayoutMetrics const &layoutMetrics) const {
+    const LayoutMetrics &layoutMetrics) const {
   auto isRTL =
       bool{layoutMetrics.layoutDirection == LayoutDirection::RightToLeft};
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -25,15 +25,15 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
   BaseViewProps() = default;
   BaseViewProps(
       const PropsParserContext &context,
-      BaseViewProps const &sourceProps,
-      RawProps const &rawProps,
+      const BaseViewProps &sourceProps,
+      const RawProps &rawProps,
       bool shouldSetRawProps = true);
 
   void setProp(
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #pragma mark - Props
 
@@ -74,7 +74,7 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
 #pragma mark - Convenience Methods
 
-  BorderMetrics resolveBorderMetrics(LayoutMetrics const &layoutMetrics) const;
+  BorderMetrics resolveBorderMetrics(const LayoutMetrics &layoutMetrics) const;
   bool getClipsContentToBounds() const;
 
 #pragma mark - DebugStringConvertible

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
@@ -53,16 +53,16 @@ class ConcreteViewShadowNode : public ConcreteShadowNode<
       Ts...>;
 
   ConcreteViewShadowNode(
-      ShadowNodeFragment const &fragment,
-      ShadowNodeFamily::Shared const &family,
+      const ShadowNodeFragment &fragment,
+      const ShadowNodeFamily::Shared &family,
       ShadowNodeTraits traits)
       : BaseShadowNode(fragment, family, traits) {
     initialize();
   }
 
   ConcreteViewShadowNode(
-      ShadowNode const &sourceShadowNode,
-      ShadowNodeFragment const &fragment)
+      const ShadowNode &sourceShadowNode,
+      const ShadowNodeFragment &fragment)
       : BaseShadowNode(sourceShadowNode, fragment) {
     initialize();
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.cpp
@@ -50,12 +50,12 @@ EventPayloadType PointerEvent::getType() const {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(PointerEvent const & /*pointerEvent*/) {
+std::string getDebugName(const PointerEvent & /*pointerEvent*/) {
   return "PointerEvent";
 }
 
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    PointerEvent const &pointerEvent,
+    const PointerEvent &pointerEvent,
     DebugStringConvertibleOptions options) {
   return {
       {"pointerId", getDebugDescription(pointerEvent.pointerId, options)},

--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
@@ -120,9 +120,9 @@ struct PointerEvent : public EventPayload {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(PointerEvent const &pointerEvent);
+std::string getDebugName(const PointerEvent &pointerEvent);
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    PointerEvent const &pointerEvent,
+    const PointerEvent &pointerEvent,
     DebugStringConvertibleOptions options);
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.cpp
@@ -11,12 +11,12 @@ namespace facebook::react {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(TouchEvent const & /*touchEvent*/) {
+std::string getDebugName(const TouchEvent & /*touchEvent*/) {
   return "TouchEvent";
 }
 
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    TouchEvent const &touchEvent,
+    const TouchEvent &touchEvent,
     DebugStringConvertibleOptions options) {
   return {
       {"touches", getDebugDescription(touchEvent.touches, options)},

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
@@ -41,9 +41,9 @@ struct TouchEvent {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(TouchEvent const &touchEvent);
+std::string getDebugName(const TouchEvent &touchEvent);
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    TouchEvent const &touchEvent,
+    const TouchEvent &touchEvent,
     DebugStringConvertibleOptions options);
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -13,10 +13,10 @@ namespace facebook::react {
 
 static jsi::Value touchesPayload(
     jsi::Runtime &runtime,
-    Touches const &touches) {
+    const Touches &touches) {
   auto array = jsi::Array(runtime, touches.size());
   int i = 0;
-  for (auto const &touch : touches) {
+  for (const auto &touch : touches) {
     auto object = jsi::Object(runtime);
     setTouchPayloadOnObject(object, runtime, touch);
     array.setValueAtIndex(runtime, i++, object);
@@ -26,7 +26,7 @@ static jsi::Value touchesPayload(
 
 static jsi::Value touchEventPayload(
     jsi::Runtime &runtime,
-    TouchEvent const &event) {
+    const TouchEvent &event) {
   auto object = jsi::Object(runtime);
   object.setProperty(
       runtime, "touches", touchesPayload(runtime, event.touches));
@@ -36,7 +36,7 @@ static jsi::Value touchEventPayload(
       runtime, "targetTouches", touchesPayload(runtime, event.targetTouches));
 
   if (!event.changedTouches.empty()) {
-    auto const &firstChangedTouch = *event.changedTouches.begin();
+    const auto &firstChangedTouch = *event.changedTouches.begin();
     setTouchPayloadOnObject(object, runtime, firstChangedTouch);
   }
   return object;
@@ -44,7 +44,7 @@ static jsi::Value touchEventPayload(
 
 void TouchEventEmitter::dispatchTouchEvent(
     std::string type,
-    TouchEvent const &event,
+    const TouchEvent &event,
     EventPriority priority,
     RawEvent::Category category) const {
   dispatchEvent(
@@ -58,7 +58,7 @@ void TouchEventEmitter::dispatchTouchEvent(
 
 void TouchEventEmitter::dispatchPointerEvent(
     std::string type,
-    PointerEvent const &event,
+    const PointerEvent &event,
     EventPriority priority,
     RawEvent::Category category) const {
   dispatchEvent(
@@ -68,7 +68,7 @@ void TouchEventEmitter::dispatchPointerEvent(
       category);
 }
 
-void TouchEventEmitter::onTouchStart(TouchEvent const &event) const {
+void TouchEventEmitter::onTouchStart(const TouchEvent &event) const {
   dispatchTouchEvent(
       "touchStart",
       event,
@@ -76,13 +76,13 @@ void TouchEventEmitter::onTouchStart(TouchEvent const &event) const {
       RawEvent::Category::ContinuousStart);
 }
 
-void TouchEventEmitter::onTouchMove(TouchEvent const &event) const {
+void TouchEventEmitter::onTouchMove(const TouchEvent &event) const {
   dispatchUniqueEvent("touchMove", [event](jsi::Runtime &runtime) {
     return touchEventPayload(runtime, event);
   });
 }
 
-void TouchEventEmitter::onTouchEnd(TouchEvent const &event) const {
+void TouchEventEmitter::onTouchEnd(const TouchEvent &event) const {
   dispatchTouchEvent(
       "touchEnd",
       event,
@@ -90,7 +90,7 @@ void TouchEventEmitter::onTouchEnd(TouchEvent const &event) const {
       RawEvent::Category::ContinuousEnd);
 }
 
-void TouchEventEmitter::onTouchCancel(TouchEvent const &event) const {
+void TouchEventEmitter::onTouchCancel(const TouchEvent &event) const {
   dispatchTouchEvent(
       "touchCancel",
       event,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -18,38 +18,38 @@ namespace facebook::react {
 
 class TouchEventEmitter;
 
-using SharedTouchEventEmitter = std::shared_ptr<TouchEventEmitter const>;
+using SharedTouchEventEmitter = std::shared_ptr<const TouchEventEmitter>;
 
 class TouchEventEmitter : public EventEmitter {
  public:
   using EventEmitter::EventEmitter;
 
-  void onTouchStart(TouchEvent const &event) const;
-  void onTouchMove(TouchEvent const &event) const;
-  void onTouchEnd(TouchEvent const &event) const;
-  void onTouchCancel(TouchEvent const &event) const;
+  void onTouchStart(const TouchEvent &event) const;
+  void onTouchMove(const TouchEvent &event) const;
+  void onTouchEnd(const TouchEvent &event) const;
+  void onTouchCancel(const TouchEvent &event) const;
 
-  void onClick(PointerEvent const &event) const;
-  void onPointerCancel(PointerEvent const &event) const;
-  void onPointerDown(PointerEvent const &event) const;
-  void onPointerMove(PointerEvent const &event) const;
-  void onPointerUp(PointerEvent const &event) const;
-  void onPointerEnter(PointerEvent const &event) const;
-  void onPointerLeave(PointerEvent const &event) const;
-  void onPointerOver(PointerEvent const &event) const;
-  void onPointerOut(PointerEvent const &event) const;
-  void onGotPointerCapture(PointerEvent const &event) const;
-  void onLostPointerCapture(PointerEvent const &event) const;
+  void onClick(const PointerEvent &event) const;
+  void onPointerCancel(const PointerEvent &event) const;
+  void onPointerDown(const PointerEvent &event) const;
+  void onPointerMove(const PointerEvent &event) const;
+  void onPointerUp(const PointerEvent &event) const;
+  void onPointerEnter(const PointerEvent &event) const;
+  void onPointerLeave(const PointerEvent &event) const;
+  void onPointerOver(const PointerEvent &event) const;
+  void onPointerOut(const PointerEvent &event) const;
+  void onGotPointerCapture(const PointerEvent &event) const;
+  void onLostPointerCapture(const PointerEvent &event) const;
 
  private:
   void dispatchTouchEvent(
       std::string type,
-      TouchEvent const &event,
+      const TouchEvent &event,
       EventPriority priority,
       RawEvent::Category category) const;
   void dispatchPointerEvent(
       std::string type,
-      PointerEvent const &event,
+      const PointerEvent &event,
       EventPriority priority,
       RawEvent::Category category) const;
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
@@ -15,7 +15,7 @@ namespace facebook::react {
 class ViewComponentDescriptor
     : public ConcreteComponentDescriptor<ViewShadowNode> {
  public:
-  ViewComponentDescriptor(ComponentDescriptorParameters const &parameters)
+  ViewComponentDescriptor(const ComponentDescriptorParameters &parameters)
       : ConcreteComponentDescriptor<ViewShadowNode>(parameters) {}
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
@@ -11,5 +11,5 @@
 
 namespace facebook::react {
 using ViewProps = HostPlatformViewProps;
-using SharedViewProps = std::shared_ptr<ViewProps const>;
+using SharedViewProps = std::shared_ptr<const ViewProps>;
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
@@ -22,12 +22,12 @@ static inline void interpolateViewProps(
     const Props::Shared &oldPropsShared,
     const Props::Shared &newPropsShared,
     Props::Shared &interpolatedPropsShared) {
-  ViewProps const *oldViewProps =
-      static_cast<ViewProps const *>(oldPropsShared.get());
-  ViewProps const *newViewProps =
-      static_cast<ViewProps const *>(newPropsShared.get());
+  const ViewProps *oldViewProps =
+      static_cast<const ViewProps *>(oldPropsShared.get());
+  const ViewProps *newViewProps =
+      static_cast<const ViewProps *>(newPropsShared.get());
   ViewProps *interpolatedProps = const_cast<ViewProps *>(
-      static_cast<ViewProps const *>(interpolatedPropsShared.get()));
+      static_cast<const ViewProps *>(interpolatedPropsShared.get()));
 
   interpolatedProps->opacity = oldViewProps->opacity +
       (newViewProps->opacity - oldViewProps->opacity) * animationProgress;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -13,12 +13,12 @@
 
 namespace facebook::react {
 
-char const ViewComponentName[] = "View";
+const char ViewComponentName[] = "View";
 
 ViewShadowNodeProps::ViewShadowNodeProps(
-    PropsParserContext const &context,
-    ViewShadowNodeProps const &sourceProps,
-    RawProps const &rawProps)
+    const PropsParserContext &context,
+    const ViewShadowNodeProps &sourceProps,
+    const RawProps &rawProps)
     : ViewProps(
           context,
           sourceProps,
@@ -26,22 +26,22 @@ ViewShadowNodeProps::ViewShadowNodeProps(
           !CoreFeatures::enableMapBuffer){};
 
 ViewShadowNode::ViewShadowNode(
-    ShadowNodeFragment const &fragment,
-    ShadowNodeFamily::Shared const &family,
+    const ShadowNodeFragment &fragment,
+    const ShadowNodeFamily::Shared &family,
     ShadowNodeTraits traits)
     : ConcreteViewShadowNode(fragment, family, traits) {
   initialize();
 }
 
 ViewShadowNode::ViewShadowNode(
-    ShadowNode const &sourceShadowNode,
-    ShadowNodeFragment const &fragment)
+    const ShadowNode &sourceShadowNode,
+    const ShadowNodeFragment &fragment)
     : ConcreteViewShadowNode(sourceShadowNode, fragment) {
   initialize();
 }
 
 void ViewShadowNode::initialize() noexcept {
-  auto &viewProps = static_cast<ViewProps const &>(*props_);
+  auto &viewProps = static_cast<const ViewProps &>(*props_);
 
   bool formsStackingContext = !viewProps.collapsable ||
       viewProps.pointerEvents == PointerEventsMode::None ||

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
@@ -22,8 +22,8 @@ class ViewShadowNodeProps final : public ViewProps {
   ViewShadowNodeProps() = default;
   ViewShadowNodeProps(
       const PropsParserContext &context,
-      ViewShadowNodeProps const &sourceProps,
-      RawProps const &rawProps);
+      const ViewShadowNodeProps &sourceProps,
+      const RawProps &rawProps);
 };
 
 /*
@@ -41,13 +41,13 @@ class ViewShadowNode final : public ConcreteViewShadowNode<
   }
 
   ViewShadowNode(
-      ShadowNodeFragment const &fragment,
-      ShadowNodeFamily::Shared const &family,
+      const ShadowNodeFragment &fragment,
+      const ShadowNodeFamily::Shared &family,
       ShadowNodeTraits traits);
 
   ViewShadowNode(
-      ShadowNode const &sourceShadowNode,
-      ShadowNodeFragment const &fragment);
+      const ShadowNode &sourceShadowNode,
+      const ShadowNodeFragment &fragment);
 
  private:
   void initialize() noexcept;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -73,8 +73,8 @@ ShadowNodeTraits::Trait YogaLayoutableShadowNode::IdentifierTrait() {
 }
 
 YogaLayoutableShadowNode::YogaLayoutableShadowNode(
-    ShadowNodeFragment const &fragment,
-    ShadowNodeFamily::Shared const &family,
+    const ShadowNodeFragment &fragment,
+    const ShadowNodeFamily::Shared &family,
     ShadowNodeTraits traits)
     : LayoutableShadowNode(fragment, family, traits),
       yogaConfig_(FabricDefaultYogaLog),
@@ -100,18 +100,18 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
 }
 
 YogaLayoutableShadowNode::YogaLayoutableShadowNode(
-    ShadowNode const &sourceShadowNode,
-    ShadowNodeFragment const &fragment)
+    const ShadowNode &sourceShadowNode,
+    const ShadowNodeFragment &fragment)
     : LayoutableShadowNode(sourceShadowNode, fragment),
       yogaConfig_(FabricDefaultYogaLog),
-      yogaNode_(static_cast<YogaLayoutableShadowNode const &>(sourceShadowNode)
+      yogaNode_(static_cast<const YogaLayoutableShadowNode &>(sourceShadowNode)
                     .yogaNode_) {
   // Note, cloned `YGNode` instance (copied using copy-constructor) inherits
   // dirty flag, measure function, and other properties being set originally in
   // the `YogaLayoutableShadowNode` constructor above.
 
   react_native_assert(
-      static_cast<YogaLayoutableShadowNode const &>(sourceShadowNode)
+      static_cast<const YogaLayoutableShadowNode &>(sourceShadowNode)
               .yogaNode_.isDirty() == yogaNode_.isDirty() &&
       "Yoga node must inherit dirty flag.");
 
@@ -124,7 +124,7 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
   }
 
   YGConfigRef previousConfig = YGNodeGetConfig(
-      &static_cast<YogaLayoutableShadowNode const &>(sourceShadowNode)
+      &static_cast<const YogaLayoutableShadowNode &>(sourceShadowNode)
            .yogaNode_);
 
   yogaNode_.setContext(this);
@@ -145,7 +145,7 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
   // configured.
   if (!fragment.props && !fragment.children) {
     yogaTreeHasBeenConfigured_ =
-        static_cast<YogaLayoutableShadowNode const &>(sourceShadowNode)
+        static_cast<const YogaLayoutableShadowNode &>(sourceShadowNode)
             .yogaTreeHasBeenConfigured_;
   }
 
@@ -182,7 +182,7 @@ void YogaLayoutableShadowNode::enableMeasurement() {
 }
 
 void YogaLayoutableShadowNode::appendYogaChild(
-    YogaLayoutableShadowNode::Shared const &childNode) {
+    const YogaLayoutableShadowNode::Shared &childNode) {
   // The caller must check this before calling this method.
   react_native_assert(
       !getTraits().check(ShadowNodeTraits::Trait::LeafYogaNode));
@@ -206,7 +206,7 @@ void YogaLayoutableShadowNode::adoptYogaChild(size_t index) {
       !getTraits().check(ShadowNodeTraits::Trait::LeafYogaNode));
 
   auto &childNode =
-      traitCast<YogaLayoutableShadowNode const &>(*getChildren().at(index));
+      traitCast<const YogaLayoutableShadowNode &>(*getChildren().at(index));
 
   if (childNode.yogaNode_.getOwner() == nullptr) {
     // The child node is not owned.
@@ -226,7 +226,7 @@ void YogaLayoutableShadowNode::adoptYogaChild(size_t index) {
 }
 
 void YogaLayoutableShadowNode::appendChild(
-    ShadowNode::Shared const &childNode) {
+    const ShadowNode::Shared &childNode) {
   ensureUnsealed();
   ensureConsistency();
 
@@ -260,8 +260,8 @@ void YogaLayoutableShadowNode::appendChild(
 }
 
 void YogaLayoutableShadowNode::replaceChild(
-    ShadowNode const &oldChild,
-    ShadowNode::Shared const &newChild,
+    const ShadowNode &oldChild,
+    const ShadowNode::Shared &newChild,
     int32_t suggestedIndex) {
   LayoutableShadowNode::replaceChild(oldChild, newChild, suggestedIndex);
 
@@ -269,7 +269,7 @@ void YogaLayoutableShadowNode::replaceChild(
   ensureYogaChildrenLookFine();
 
   auto layoutableOldChild =
-      traitCast<YogaLayoutableShadowNode const *>(&oldChild);
+      traitCast<const YogaLayoutableShadowNode *>(&oldChild);
   auto layoutableNewChild = traitCast<YogaLayoutableShadowNode>(newChild);
 
   if (layoutableOldChild == nullptr && layoutableNewChild == nullptr) {
@@ -286,7 +286,7 @@ void YogaLayoutableShadowNode::replaceChild(
       : std::find_if(
             yogaLayoutableChildren_.begin(),
             yogaLayoutableChildren_.end(),
-            [&](YogaLayoutableShadowNode::Shared const &layoutableChild) {
+            [&](const YogaLayoutableShadowNode::Shared &layoutableChild) {
               return layoutableChild.get() == layoutableOldChild;
             });
   auto oldChildIndex =
@@ -314,7 +314,7 @@ void YogaLayoutableShadowNode::replaceChild(
 }
 
 bool YogaLayoutableShadowNode::doesOwn(
-    YogaLayoutableShadowNode const &child) const {
+    const YogaLayoutableShadowNode &child) const {
   return child.yogaNode_.getOwner() == &yogaNode_;
 }
 
@@ -367,7 +367,7 @@ void YogaLayoutableShadowNode::updateYogaChildren() {
 void YogaLayoutableShadowNode::updateYogaProps() {
   ensureUnsealed();
 
-  auto props = static_cast<YogaStylableProps const &>(*props_);
+  auto props = static_cast<const YogaStylableProps &>(*props_);
   auto styleResult = applyAliasedProps(props.yogaStyle, props);
 
   // Resetting `dirty` flag only if `yogaStyle` portion of `Props` was changed.
@@ -494,7 +494,7 @@ void YogaLayoutableShadowNode::configureYogaTree(
 }
 
 YGErrata YogaLayoutableShadowNode::resolveErrata(YGErrata defaultErrata) const {
-  if (auto viewShadowNode = traitCast<ViewShadowNode const *>(this)) {
+  if (auto viewShadowNode = traitCast<const ViewShadowNode *>(this)) {
     const auto &props = viewShadowNode->getConcreteProps();
     switch (props.experimental_layoutConformance) {
       case LayoutConformance::Classic:
@@ -725,7 +725,7 @@ void YogaLayoutableShadowNode::layout(LayoutContext layoutContext) {
 
     auto layoutMetricsWithOverflowInset = childNode.getLayoutMetrics();
     if (layoutMetricsWithOverflowInset.displayType != DisplayType::None) {
-      auto viewChildNode = traitCast<ViewShadowNode const *>(&childNode);
+      auto viewChildNode = traitCast<const ViewShadowNode *>(&childNode);
       auto hitSlop = viewChildNode != nullptr
           ? viewChildNode->getConcreteProps().hitSlop
           : EdgeInsets{};
@@ -861,12 +861,12 @@ void YogaLayoutableShadowNode::swapStyleLeftAndRight() {
 }
 
 void YogaLayoutableShadowNode::swapLeftAndRightInYogaStyleProps(
-    YogaLayoutableShadowNode const &shadowNode) {
+    const YogaLayoutableShadowNode &shadowNode) {
   auto yogaStyle = shadowNode.yogaNode_.getStyle();
 
-  YGStyle::Edges const &position = yogaStyle.position();
-  YGStyle::Edges const &padding = yogaStyle.padding();
-  YGStyle::Edges const &margin = yogaStyle.margin();
+  const YGStyle::Edges &position = yogaStyle.position();
+  const YGStyle::Edges &padding = yogaStyle.padding();
+  const YGStyle::Edges &margin = yogaStyle.margin();
 
   // Swap Yoga node values, position, padding and margin.
 
@@ -904,8 +904,8 @@ void YogaLayoutableShadowNode::swapLeftAndRightInYogaStyleProps(
 }
 
 void YogaLayoutableShadowNode::swapLeftAndRightInViewProps(
-    YogaLayoutableShadowNode const &shadowNode) {
-  auto &typedCasting = static_cast<ViewProps const &>(*shadowNode.props_);
+    const YogaLayoutableShadowNode &shadowNode) {
+  auto &typedCasting = static_cast<const ViewProps &>(*shadowNode.props_);
   auto &props = const_cast<ViewProps &>(typedCasting);
 
   // Swap border node values, borderRadii, borderColors and borderStyles.
@@ -950,7 +950,7 @@ void YogaLayoutableShadowNode::swapLeftAndRightInViewProps(
     props.borderStyles.right.reset();
   }
 
-  YGStyle::Edges const &border = props.yogaStyle.border();
+  const YGStyle::Edges &border = props.yogaStyle.border();
 
   if (props.yogaStyle.border()[YGEdgeLeft] != YGValueUndefined) {
     props.yogaStyle.border()[YGEdgeStart] = border[YGEdgeLeft];
@@ -978,7 +978,7 @@ void YogaLayoutableShadowNode::ensureYogaChildrenLookFine() const {
   // signal that something went wrong.
   auto &yogaChildren = yogaNode_.getChildren();
 
-  for (auto const &yogaChild : yogaChildren) {
+  for (const auto &yogaChild : yogaChildren) {
     react_native_assert(yogaChild->getContext());
     react_native_assert(yogaChild->getChildren().size() < 16384);
     if (!yogaChild->getChildren().empty()) {
@@ -1010,7 +1010,7 @@ void YogaLayoutableShadowNode::ensureYogaChildrenAlignment() const {
     auto &child = children.at(i);
     react_native_assert(
         yogaChild->getContext() ==
-        traitCast<YogaLayoutableShadowNode const *>(child.get()));
+        traitCast<const YogaLayoutableShadowNode *>(child.get()));
   }
 #endif
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -25,7 +25,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   using CompactValue = facebook::yoga::detail::CompactValue;
 
  public:
-  using Shared = std::shared_ptr<YogaLayoutableShadowNode const>;
+  using Shared = std::shared_ptr<const YogaLayoutableShadowNode>;
   using ListOfShared =
       butter::small_vector<Shared, kShadowNodeChildrenSmallVectorSize>;
 
@@ -35,13 +35,13 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
 #pragma mark - Constructors
 
   YogaLayoutableShadowNode(
-      ShadowNodeFragment const &fragment,
-      ShadowNodeFamily::Shared const &family,
+      const ShadowNodeFragment &fragment,
+      const ShadowNodeFamily::Shared &family,
       ShadowNodeTraits traits);
 
   YogaLayoutableShadowNode(
-      ShadowNode const &sourceShadowNode,
-      ShadowNodeFragment const &fragment);
+      const ShadowNode &sourceShadowNode,
+      const ShadowNodeFragment &fragment);
 
 #pragma mark - Mutating Methods
 
@@ -51,10 +51,10 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    */
   void enableMeasurement();
 
-  void appendChild(ShadowNode::Shared const &child) override;
+  void appendChild(const ShadowNode::Shared &child) override;
   void replaceChild(
-      ShadowNode const &oldChild,
-      ShadowNode::Shared const &newChild,
+      const ShadowNode &oldChild,
+      const ShadowNode::Shared &newChild,
       int32_t suggestedIndex = -1) override;
 
   void updateYogaChildren();
@@ -117,14 +117,14 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    * Return true if child's yogaNode's owner is this->yogaNode_. Otherwise
    * returns false.
    */
-  bool doesOwn(YogaLayoutableShadowNode const &child) const;
+  bool doesOwn(const YogaLayoutableShadowNode &child) const;
 
   /*
    * Appends a Yoga node to the Yoga node associated with this node.
    * The method does *not* do anything besides that (no cloning or `owner` field
    * adjustment).
    */
-  void appendYogaChild(YogaLayoutableShadowNode::Shared const &childNode);
+  void appendYogaChild(const YogaLayoutableShadowNode::Shared &childNode);
 
   /*
    * Makes the child node with a given `index` (and Yoga node associated with) a
@@ -191,7 +191,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    * - border(Left|Right)Color → border(Start|End)Color
    */
   static void swapLeftAndRightInViewProps(
-      YogaLayoutableShadowNode const &shadowNode);
+      const YogaLayoutableShadowNode &shadowNode);
   /*
    * In yoga node passed as argument, reassigns following values
    * - (left|right) → (start|end)
@@ -199,7 +199,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    * - padding(Left|Right) → padding(Start|End)
    */
   static void swapLeftAndRightInYogaStyleProps(
-      YogaLayoutableShadowNode const &shadowNode);
+      const YogaLayoutableShadowNode &shadowNode);
 
   /*
    * Combine a base YGStyle with aliased properties which should be flattened

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -21,8 +21,8 @@ namespace facebook::react {
 
 YogaStylableProps::YogaStylableProps(
     const PropsParserContext &context,
-    YogaStylableProps const &sourceProps,
-    RawProps const &rawProps,
+    const YogaStylableProps &sourceProps,
+    const RawProps &rawProps,
     bool shouldSetRawProps)
     : Props(context, sourceProps, rawProps, shouldSetRawProps),
       yogaStyle(
@@ -37,7 +37,7 @@ YogaStylableProps::YogaStylableProps(
 template <typename T>
 static inline T const getFieldValue(
     const PropsParserContext &context,
-    RawValue const &value,
+    const RawValue &value,
     T const defaultValue) {
   if (value.hasValue()) {
     T res;
@@ -103,7 +103,7 @@ void YogaStylableProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   static const auto ygDefaults = YGStyle{};
   static const auto defaults = YogaStylableProps{};
 
@@ -161,7 +161,7 @@ void YogaStylableProps::setProp(
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 SharedDebugStringConvertibleList YogaStylableProps::getDebugProps() const {
-  auto const defaultYogaStyle = YGStyle{};
+  const auto defaultYogaStyle = YGStyle{};
   return {
       debugStringConvertibleItem(
           "direction", yogaStyle.direction(), defaultYogaStyle.direction()),
@@ -239,8 +239,8 @@ SharedDebugStringConvertibleList YogaStylableProps::getDebugProps() const {
 
 void YogaStylableProps::convertRawPropAliases(
     const PropsParserContext &context,
-    YogaStylableProps const &sourceProps,
-    RawProps const &rawProps) {
+    const YogaStylableProps &sourceProps,
+    const RawProps &rawProps) {
   inset = convertRawProp(
       context,
       rawProps,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
@@ -22,18 +22,18 @@ class YogaStylableProps : public Props {
   YogaStylableProps() = default;
   YogaStylableProps(
       const PropsParserContext &context,
-      YogaStylableProps const &sourceProps,
-      RawProps const &rawProps,
+      const YogaStylableProps &sourceProps,
+      const RawProps &rawProps,
       bool shouldSetRawProps = true);
 
   void setProp(
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
 #ifdef ANDROID
-  void propsDiffMapBuffer(Props const *oldProps, MapBufferBuilder &builder)
+  void propsDiffMapBuffer(const Props *oldProps, MapBufferBuilder &builder)
       const override;
 #endif
 
@@ -81,8 +81,8 @@ class YogaStylableProps : public Props {
  private:
   void convertRawPropAliases(
       const PropsParserContext &context,
-      YogaStylableProps const &sourceProps,
-      RawProps const &rawProps);
+      const YogaStylableProps &sourceProps,
+      const RawProps &rawProps);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/AccessibilityPropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/AccessibilityPropsMapBuffer.cpp
@@ -11,10 +11,10 @@
 namespace facebook::react {
 
 static MapBuffer convertAccessibilityActions(
-    std::vector<AccessibilityAction> const &actions) {
+    const std::vector<AccessibilityAction> &actions) {
   MapBufferBuilder builder(actions.size());
   for (auto i = 0; i < actions.size(); i++) {
-    auto const &action = actions[i];
+    const auto &action = actions[i];
     MapBufferBuilder actionsBuilder(2);
     actionsBuilder.putString(ACCESSIBILITY_ACTION_NAME, action.name);
     if (action.label.has_value()) {
@@ -27,7 +27,7 @@ static MapBuffer convertAccessibilityActions(
 }
 
 static MapBuffer convertAccessibilityLabelledBy(
-    AccessibilityLabelledBy const &labelledBy) {
+    const AccessibilityLabelledBy &labelledBy) {
   MapBufferBuilder builder(labelledBy.value.size());
   for (auto i = 0; i < labelledBy.value.size(); i++) {
     builder.putString(i, labelledBy.value[i]);
@@ -42,7 +42,7 @@ constexpr MapBuffer::Key ACCESSIBILITY_STATE_EXPANDED = 2;
 constexpr MapBuffer::Key ACCESSIBILITY_STATE_SELECTED = 3;
 constexpr MapBuffer::Key ACCESSIBILITY_STATE_CHECKED = 4;
 
-MapBuffer convertAccessibilityState(AccessibilityState const &state) {
+MapBuffer convertAccessibilityState(const AccessibilityState &state) {
   MapBufferBuilder builder(5);
   builder.putBool(ACCESSIBILITY_STATE_BUSY, state.busy);
   builder.putBool(ACCESSIBILITY_STATE_DISABLED, state.disabled);
@@ -69,7 +69,7 @@ MapBuffer convertAccessibilityState(AccessibilityState const &state) {
 
 // TODO: Currently unsupported: nextFocusForward/Left/Up/Right/Down
 void AccessibilityProps::propsDiffMapBuffer(
-    Props const *oldPropsPtr,
+    const Props *oldPropsPtr,
     MapBufferBuilder &builder) const {
   // Call with default props if necessary
   if (oldPropsPtr == nullptr) {
@@ -78,9 +78,9 @@ void AccessibilityProps::propsDiffMapBuffer(
     return;
   }
 
-  AccessibilityProps const &oldProps =
+  const AccessibilityProps &oldProps =
       *(reinterpret_cast<const AccessibilityProps *>(oldPropsPtr));
-  AccessibilityProps const &newProps = *this;
+  const AccessibilityProps &newProps = *this;
 
   if (oldProps.accessibilityActions != newProps.accessibilityActions) {
     builder.putMapBuffer(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -19,8 +19,8 @@ namespace facebook::react {
 
 HostPlatformViewProps::HostPlatformViewProps(
     const PropsParserContext &context,
-    HostPlatformViewProps const &sourceProps,
-    RawProps const &rawProps,
+    const HostPlatformViewProps &sourceProps,
+    const RawProps &rawProps,
     bool shouldSetRawProps)
     : BaseViewProps(context, sourceProps, rawProps, shouldSetRawProps),
       elevation(
@@ -101,7 +101,7 @@ void HostPlatformViewProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char *propName,
-    RawValue const &value) {
+    const RawValue &value) {
   // All Props structs setProp methods must always, unconditionally,
   // call all super::setProp methods, since multiple structs may
   // reuse the same values.

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -25,17 +25,17 @@ class HostPlatformViewProps : public BaseViewProps {
   HostPlatformViewProps() = default;
   HostPlatformViewProps(
       const PropsParserContext &context,
-      HostPlatformViewProps const &sourceProps,
-      RawProps const &rawProps,
+      const HostPlatformViewProps &sourceProps,
+      const RawProps &rawProps,
       bool shouldSetRawProps = true);
 
   void setProp(
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
-  void propsDiffMapBuffer(Props const *oldProps, MapBufferBuilder &builder)
+  void propsDiffMapBuffer(const Props *oldProps, MapBufferBuilder &builder)
       const override;
 
 #pragma mark - Props

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -12,11 +12,11 @@
 
 namespace facebook::react::HostPlatformViewTraitsInitializer {
 
-inline bool formsStackingContext(ViewProps const &viewProps) {
+inline bool formsStackingContext(const ViewProps &viewProps) {
   return viewProps.elevation != 0;
 }
 
-inline bool formsView(ViewProps const &viewProps) {
+inline bool formsView(const ViewProps &viewProps) {
   return viewProps.nativeBackground.has_value() ||
       viewProps.nativeForeground.has_value() || viewProps.focusable ||
       viewProps.hasTVPreferredFocus ||

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
@@ -56,7 +56,7 @@ struct NativeDrawable {
 
 static inline void fromRawValue(
     const PropsParserContext & /*context*/,
-    RawValue const &rawValue,
+    const RawValue &rawValue,
     NativeDrawable &result) {
   auto map = (butter::map<std::string, RawValue>)rawValue;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/ViewPropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/ViewPropsMapBuffer.cpp
@@ -16,7 +16,7 @@ namespace facebook::react {
 
 // TODO: Currently unsupported: nextFocusForward/Left/Up/Right/Down
 void ViewProps::propsDiffMapBuffer(
-    Props const *oldPropsPtr,
+    const Props *oldPropsPtr,
     MapBufferBuilder &builder) const {
   // Call with default props if necessary
   if (oldPropsPtr == nullptr) {
@@ -29,8 +29,8 @@ void ViewProps::propsDiffMapBuffer(
   YogaStylableProps::propsDiffMapBuffer(oldPropsPtr, builder);
   AccessibilityProps::propsDiffMapBuffer(oldPropsPtr, builder);
 
-  ViewProps const &oldProps = *(static_cast<const ViewProps *>(oldPropsPtr));
-  ViewProps const &newProps = *this;
+  const ViewProps &oldProps = *(static_cast<const ViewProps *>(oldPropsPtr));
+  const ViewProps &newProps = *this;
 
   if (oldProps.backfaceVisibility != newProps.backfaceVisibility) {
     int value;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/YogaStylablePropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/YogaStylablePropsMapBuffer.cpp
@@ -13,7 +13,7 @@
 
 namespace facebook::react {
 
-MapBuffer convertBorderWidths(YGStyle::Edges const &border) {
+MapBuffer convertBorderWidths(const YGStyle::Edges &border) {
   MapBufferBuilder builder(7);
   putOptionalFloat(
       builder, EDGE_TOP, optionalFloatFromYogaValue(border[YGEdgeTop]));
@@ -34,7 +34,7 @@ MapBuffer convertBorderWidths(YGStyle::Edges const &border) {
 
 // TODO: Currently unsupported: nextFocusForward/Left/Up/Right/Down
 void YogaStylableProps::propsDiffMapBuffer(
-    Props const *oldPropsPtr,
+    const Props *oldPropsPtr,
     MapBufferBuilder &builder) const {
   // Call with default props if necessary
   if (oldPropsPtr == nullptr) {
@@ -46,13 +46,13 @@ void YogaStylableProps::propsDiffMapBuffer(
   // Delegate to base classes
   Props::propsDiffMapBuffer(oldPropsPtr, builder);
 
-  YogaStylableProps const &oldProps =
+  const YogaStylableProps &oldProps =
       *(static_cast<const YogaStylableProps *>(oldPropsPtr));
-  YogaStylableProps const &newProps = *this;
+  const YogaStylableProps &newProps = *this;
 
   if (oldProps.yogaStyle != newProps.yogaStyle) {
-    auto const &oldStyle = oldProps.yogaStyle;
-    auto const &newStyle = newProps.yogaStyle;
+    const auto &oldStyle = oldProps.yogaStyle;
+    const auto &newStyle = newProps.yogaStyle;
 
     if (!(oldStyle.border() == newStyle.border())) {
       builder.putMapBuffer(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -12,11 +12,11 @@
 
 namespace facebook::react::HostPlatformViewTraitsInitializer {
 
-inline bool formsStackingContext(ViewProps const &props) {
+inline bool formsStackingContext(const ViewProps &props) {
   return false;
 }
 
-inline bool formsView(ViewProps const &props) {
+inline bool formsView(const ViewProps &props) {
   return false;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -77,11 +77,11 @@ struct ViewEvents {
   }
 };
 
-inline static bool operator==(ViewEvents const &lhs, ViewEvents const &rhs) {
+inline static bool operator==(const ViewEvents &lhs, const ViewEvents &rhs) {
   return lhs.bits == rhs.bits;
 }
 
-inline static bool operator!=(ViewEvents const &lhs, ViewEvents const &rhs) {
+inline static bool operator!=(const ViewEvents &lhs, const ViewEvents &rhs) {
   return lhs.bits != rhs.bits;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -19,11 +19,11 @@ namespace facebook::react {
 // ships fully for View
 static inline YGStyle::Dimensions convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    char const *widthName,
-    char const *heightName,
-    YGStyle::Dimensions const &sourceValue,
-    YGStyle::Dimensions const &defaultValue) {
+    const RawProps &rawProps,
+    const char *widthName,
+    const char *heightName,
+    const YGStyle::Dimensions &sourceValue,
+    const YGStyle::Dimensions &defaultValue) {
   auto dimensions = defaultValue;
   dimensions[YGDimensionWidth] = convertRawProp(
       context,
@@ -42,11 +42,11 @@ static inline YGStyle::Dimensions convertRawProp(
 
 static inline YGStyle::Edges convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    char const *prefix,
-    char const *suffix,
-    YGStyle::Edges const &sourceValue,
-    YGStyle::Edges const &defaultValue) {
+    const RawProps &rawProps,
+    const char *prefix,
+    const char *suffix,
+    const YGStyle::Edges &sourceValue,
+    const YGStyle::Edges &defaultValue) {
   auto result = defaultValue;
   result[YGEdgeLeft] = convertRawProp(
       context,
@@ -125,9 +125,9 @@ static inline YGStyle::Edges convertRawProp(
 
 static inline YGStyle::Edges convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    YGStyle::Edges const &sourceValue,
-    YGStyle::Edges const &defaultValue) {
+    const RawProps &rawProps,
+    const YGStyle::Edges &sourceValue,
+    const YGStyle::Edges &defaultValue) {
   auto result = defaultValue;
   result[YGEdgeLeft] = convertRawProp(
       context,
@@ -170,8 +170,8 @@ static inline YGStyle::Edges convertRawProp(
 
 static inline YGStyle convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    YGStyle const &sourceValue) {
+    const RawProps &rawProps,
+    const YGStyle &sourceValue) {
   auto yogaStyle = YGStyle{};
   yogaStyle.direction() = convertRawProp(
       context,
@@ -328,11 +328,11 @@ static inline YGStyle convertRawProp(
 template <typename T>
 static inline CascadedRectangleCorners<T> convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    char const *prefix,
-    char const *suffix,
-    CascadedRectangleCorners<T> const &sourceValue,
-    CascadedRectangleCorners<T> const &defaultValue) {
+    const RawProps &rawProps,
+    const char *prefix,
+    const char *suffix,
+    const CascadedRectangleCorners<T> &sourceValue,
+    const CascadedRectangleCorners<T> &defaultValue) {
   CascadedRectangleCorners<T> result;
 
   result.topLeft = convertRawProp(
@@ -442,11 +442,11 @@ static inline CascadedRectangleCorners<T> convertRawProp(
 template <typename T>
 static inline CascadedRectangleEdges<T> convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    char const *prefix,
-    char const *suffix,
-    CascadedRectangleEdges<T> const &sourceValue,
-    CascadedRectangleEdges<T> const &defaultValue) {
+    const RawProps &rawProps,
+    const char *prefix,
+    const char *suffix,
+    const CascadedRectangleEdges<T> &sourceValue,
+    const CascadedRectangleEdges<T> &defaultValue) {
   CascadedRectangleEdges<T> result;
 
   result.left = convertRawProp(
@@ -548,9 +548,9 @@ static inline CascadedRectangleEdges<T> convertRawProp(
 // This can be deleted when non-iterator ViewProp parsing is deleted
 static inline ViewEvents convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    ViewEvents const &sourceValue,
-    ViewEvents const &defaultValue) {
+    const RawProps &rawProps,
+    const ViewEvents &sourceValue,
+    const ViewEvents &defaultValue) {
   ViewEvents result{};
   using Offset = ViewEvents::Offset;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/ViewTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/ViewTest.cpp
@@ -93,7 +93,7 @@ TEST_F(YogaDirtyFlagTest, cloningPropsWithoutChangingThem) {
    * Cloning props without changing them must *not* dirty a Yoga node.
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
-      innerShadowNode_->getFamily(), [&](ShadowNode const &oldShadowNode) {
+      innerShadowNode_->getFamily(), [&](const ShadowNode &oldShadowNode) {
         auto &componentDescriptor = oldShadowNode.getComponentDescriptor();
         auto props = componentDescriptor.cloneProps(
             parserContext, oldShadowNode.getProps(), RawProps());
@@ -109,7 +109,7 @@ TEST_F(YogaDirtyFlagTest, changingNonLayoutSubPropsMustNotDirtyYogaNode) {
    * Changing *non-layout* sub-props must *not* dirty a Yoga node.
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
-      innerShadowNode_->getFamily(), [](ShadowNode const &oldShadowNode) {
+      innerShadowNode_->getFamily(), [](const ShadowNode &oldShadowNode) {
         auto viewProps = std::make_shared<ViewShadowNodeProps>();
         auto &props = *viewProps;
 
@@ -132,7 +132,7 @@ TEST_F(YogaDirtyFlagTest, changingLayoutSubPropsMustDirtyYogaNode) {
    * Changing *layout* sub-props *must* dirty a Yoga node.
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
-      innerShadowNode_->getFamily(), [](ShadowNode const &oldShadowNode) {
+      innerShadowNode_->getFamily(), [](const ShadowNode &oldShadowNode) {
         auto viewProps = std::make_shared<ViewShadowNodeProps>();
         auto &props = *viewProps;
 
@@ -151,7 +151,7 @@ TEST_F(YogaDirtyFlagTest, removingAllChildrenMustDirtyYogaNode) {
    * Removing all children *must* dirty a Yoga node.
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
-      innerShadowNode_->getFamily(), [](ShadowNode const &oldShadowNode) {
+      innerShadowNode_->getFamily(), [](const ShadowNode &oldShadowNode) {
         return oldShadowNode.clone(
             {ShadowNodeFragment::propsPlaceholder(),
              ShadowNode::emptySharedShadowNodeSharedList()});
@@ -166,7 +166,7 @@ TEST_F(YogaDirtyFlagTest, removingLastChildMustDirtyYogaNode) {
    * Removing the last child *must* dirty the Yoga node.
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
-      innerShadowNode_->getFamily(), [](ShadowNode const &oldShadowNode) {
+      innerShadowNode_->getFamily(), [](const ShadowNode &oldShadowNode) {
         auto children = oldShadowNode.getChildren();
         children.pop_back();
 
@@ -186,7 +186,7 @@ TEST_F(YogaDirtyFlagTest, reversingListOfChildrenMustDirtyYogaNode) {
    * Reversing a list of children *must* dirty a Yoga node.
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
-      innerShadowNode_->getFamily(), [](ShadowNode const &oldShadowNode) {
+      innerShadowNode_->getFamily(), [](const ShadowNode &oldShadowNode) {
         auto children = oldShadowNode.getChildren();
 
         std::reverse(children.begin(), children.end());
@@ -206,7 +206,7 @@ TEST_F(YogaDirtyFlagTest, updatingStateForScrollViewMistNotDirtyYogaNode) {
    * nodes.
    */
   auto newRootShadowNode = rootShadowNode_->cloneTree(
-      scrollViewShadowNode_->getFamily(), [](ShadowNode const &oldShadowNode) {
+      scrollViewShadowNode_->getFamily(), [](const ShadowNode &oldShadowNode) {
         auto state = ScrollViewState{};
         state.contentOffset = Point{42, 9000};
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/viewPropConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/viewPropConversions.h
@@ -48,12 +48,12 @@ constexpr MapBuffer::Key CORNER_START_START = 12;
 inline void putOptionalFloat(
     MapBufferBuilder &builder,
     MapBuffer::Key key,
-    std::optional<Float> const &value) {
+    const std::optional<Float> &value) {
   builder.putDouble(key, value.value_or(NAN));
 }
 
 inline std::optional<Float> optionalFromValue(
-    std::optional<BorderCurve> const &value) {
+    const std::optional<BorderCurve> &value) {
   if (!value) {
     return {};
   }
@@ -62,12 +62,12 @@ inline std::optional<Float> optionalFromValue(
 }
 
 inline std::optional<Float> optionalFromValue(
-    std::optional<Float> const &value) {
+    const std::optional<Float> &value) {
   return value;
 }
 
 inline std::optional<Float> optionalFromValue(
-    std::optional<BorderStyle> const &value) {
+    const std::optional<BorderStyle> &value) {
   if (!value) {
     return {};
   }
@@ -91,11 +91,11 @@ inline std::optional<Float> optionalFromValue(
 inline void putOptionalColor(
     MapBufferBuilder &builder,
     MapBuffer::Key key,
-    std::optional<SharedColor> const &color) {
+    const std::optional<SharedColor> &color) {
   builder.putInt(key, color.has_value() ? toAndroidRepr(color.value()) : -1);
 }
 
-inline MapBuffer convertBorderColors(CascadedBorderColors const &colors) {
+inline MapBuffer convertBorderColors(const CascadedBorderColors &colors) {
   MapBufferBuilder builder(7);
   putOptionalColor(builder, EDGE_TOP, colors.top);
   putOptionalColor(builder, EDGE_RIGHT, colors.right);
@@ -108,7 +108,7 @@ inline MapBuffer convertBorderColors(CascadedBorderColors const &colors) {
 }
 
 template <typename T>
-MapBuffer convertCascadedEdges(CascadedRectangleEdges<T> const &edges) {
+MapBuffer convertCascadedEdges(const CascadedRectangleEdges<T> &edges) {
   MapBufferBuilder builder(10);
   putOptionalFloat(builder, EDGE_TOP, optionalFromValue(edges.top));
   putOptionalFloat(builder, EDGE_RIGHT, optionalFromValue(edges.right));
@@ -125,7 +125,7 @@ MapBuffer convertCascadedEdges(CascadedRectangleEdges<T> const &edges) {
 }
 
 template <typename T>
-MapBuffer convertCascadedCorners(CascadedRectangleCorners<T> const &corners) {
+MapBuffer convertCascadedCorners(const CascadedRectangleCorners<T> &corners) {
   MapBufferBuilder builder(13);
   putOptionalFloat(
       builder, CORNER_TOP_LEFT, optionalFromValue(corners.topLeft));
@@ -153,7 +153,7 @@ MapBuffer convertCascadedCorners(CascadedRectangleCorners<T> const &corners) {
   return builder.build();
 }
 
-inline MapBuffer convertEdgeInsets(EdgeInsets const &insets) {
+inline MapBuffer convertEdgeInsets(const EdgeInsets &insets) {
   MapBufferBuilder builder(4);
   builder.putDouble(EDGE_TOP, insets.top);
   builder.putDouble(EDGE_RIGHT, insets.right);
@@ -171,12 +171,12 @@ constexpr MapBuffer::Key NATIVE_DRAWABLE_BORDERLESS = 3;
 constexpr MapBuffer::Key NATIVE_DRAWABLE_RIPPLE_RADIUS = 4;
 
 inline MapBuffer convertNativeBackground(
-    std::optional<NativeDrawable> const &value) {
+    const std::optional<NativeDrawable> &value) {
   if (!value.has_value()) {
     return MapBufferBuilder::EMPTY();
   }
 
-  auto const &drawable = value.value();
+  const auto &drawable = value.value();
   MapBufferBuilder builder(4);
   switch (drawable.kind) {
     case NativeDrawable::Kind::ThemeAttr:
@@ -202,7 +202,7 @@ inline MapBuffer convertNativeBackground(
 
 #endif
 
-inline MapBuffer convertTransform(Transform const &transform) {
+inline MapBuffer convertTransform(const Transform &transform) {
   MapBufferBuilder builder(16);
   for (int32_t i = 0; i < transform.matrix.size(); i++) {
     builder.putDouble(i, transform.matrix[i]);

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
@@ -10,12 +10,12 @@
 namespace facebook::react {
 
 ComponentDescriptor::ComponentDescriptor(
-    ComponentDescriptorParameters const &parameters)
+    const ComponentDescriptorParameters &parameters)
     : eventDispatcher_(parameters.eventDispatcher),
       contextContainer_(parameters.contextContainer),
       flavor_(parameters.flavor) {}
 
-ContextContainer::Shared const &ComponentDescriptor::getContextContainer()
+const ContextContainer::Shared &ComponentDescriptor::getContextContainer()
     const {
   return contextContainer_;
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -24,7 +24,7 @@ namespace facebook::react {
 class ComponentDescriptorParameters;
 class ComponentDescriptor;
 
-using SharedComponentDescriptor = std::shared_ptr<ComponentDescriptor const>;
+using SharedComponentDescriptor = std::shared_ptr<const ComponentDescriptor>;
 
 /*
  * Abstract class defining an interface of `ComponentDescriptor`.
@@ -34,8 +34,8 @@ using SharedComponentDescriptor = std::shared_ptr<ComponentDescriptor const>;
  */
 class ComponentDescriptor {
  public:
-  using Shared = std::shared_ptr<ComponentDescriptor const>;
-  using Unique = std::unique_ptr<ComponentDescriptor const>;
+  using Shared = std::shared_ptr<const ComponentDescriptor>;
+  using Unique = std::unique_ptr<const ComponentDescriptor>;
 
   /*
    * `Flavor` is a special concept designed to allow registering instances of
@@ -46,16 +46,16 @@ class ComponentDescriptor {
    * an interoperability layer with old renderer), we are thinking about
    * removing this feature completely after it's no longer needed.
    */
-  using Flavor = std::shared_ptr<void const>;
+  using Flavor = std::shared_ptr<const void>;
 
-  ComponentDescriptor(ComponentDescriptorParameters const &parameters);
+  ComponentDescriptor(const ComponentDescriptorParameters &parameters);
 
   virtual ~ComponentDescriptor() = default;
 
   /*
    * Returns stored instance of `ContextContainer`.
    */
-  ContextContainer::Shared const &getContextContainer() const;
+  const ContextContainer::Shared &getContextContainer() const;
 
   /*
    * Returns `componentHandle` associated with particular kind of components.
@@ -80,7 +80,7 @@ class ComponentDescriptor {
    */
   virtual ShadowNode::Shared createShadowNode(
       const ShadowNodeFragment &fragment,
-      ShadowNodeFamily::Shared const &family) const = 0;
+      const ShadowNodeFamily::Shared &family) const = 0;
 
   /*
    * Clones a `ShadowNode` with optionally new `props` and/or `children`.
@@ -113,28 +113,28 @@ class ComponentDescriptor {
    * State's data which can be constructed based on initial Props.
    */
   virtual State::Shared createInitialState(
-      Props::Shared const &props,
-      ShadowNodeFamily::Shared const &family) const = 0;
+      const Props::Shared &props,
+      const ShadowNodeFamily::Shared &family) const = 0;
 
   /*
    * Creates a new State object that represents (and contains) a new version of
    * State's data.
    */
   virtual State::Shared createState(
-      ShadowNodeFamily const &family,
+      const ShadowNodeFamily &family,
       const StateData::Shared &data) const = 0;
 
   /*
    * Creates a shadow node family for particular node.
    */
   virtual ShadowNodeFamily::Shared createFamily(
-      ShadowNodeFamilyFragment const &fragment) const = 0;
+      const ShadowNodeFamilyFragment &fragment) const = 0;
 
   /*
    * Creates an event emitter for particular node.
    */
   virtual SharedEventEmitter createEventEmitter(
-      InstanceHandle::Shared const &instanceHandle) const = 0;
+      const InstanceHandle::Shared &instanceHandle) const = 0;
 
  protected:
   EventDispatcher::Weak eventDispatcher_;

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -46,7 +46,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   using ConcreteState = typename ShadowNodeT::ConcreteState;
   using ConcreteStateData = typename ShadowNodeT::ConcreteState::Data;
 
-  ConcreteComponentDescriptor(ComponentDescriptorParameters const &parameters)
+  ConcreteComponentDescriptor(const ComponentDescriptorParameters &parameters)
       : ComponentDescriptor(parameters) {
     rawPropsParser_.prepare<ConcreteProps>();
   }
@@ -65,7 +65,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
 
   ShadowNode::Shared createShadowNode(
       const ShadowNodeFragment &fragment,
-      ShadowNodeFamily::Shared const &family) const override {
+      const ShadowNodeFamily::Shared &family) const override {
     auto shadowNode =
         std::make_shared<ShadowNodeT>(fragment, family, getTraits());
 
@@ -116,7 +116,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     if (CoreFeatures::enablePropIteratorSetter) {
       rawProps.iterateOverValues([&](RawPropsPropNameHash hash,
                                      const char *propName,
-                                     RawValue const &fn) {
+                                     const RawValue &fn) {
         shadowNodeProps.get()->setProp(context, hash, propName, fn);
       });
     }
@@ -125,22 +125,22 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   };
 
   virtual State::Shared createInitialState(
-      Props::Shared const &props,
-      ShadowNodeFamily::Shared const &family) const override {
+      const Props::Shared &props,
+      const ShadowNodeFamily::Shared &family) const override {
     if (std::is_same<ConcreteStateData, StateData>::value) {
       // Default case: Returning `null` for nodes that don't use `State`.
       return nullptr;
     }
 
     return std::make_shared<ConcreteState>(
-        std::make_shared<ConcreteStateData const>(
+        std::make_shared<const ConcreteStateData>(
             ConcreteShadowNode::initialStateData(props, family, *this)),
         family);
   }
 
   virtual State::Shared createState(
-      ShadowNodeFamily const &family,
-      StateData::Shared const &data) const override {
+      const ShadowNodeFamily &family,
+      const StateData::Shared &data) const override {
     if (std::is_same<ConcreteStateData, StateData>::value) {
       // Default case: Returning `null` for nodes that don't use `State`.
       return nullptr;
@@ -148,13 +148,13 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
 
     react_native_assert(data && "Provided `data` is nullptr.");
 
-    return std::make_shared<ConcreteState const>(
-        std::static_pointer_cast<ConcreteStateData const>(data),
+    return std::make_shared<const ConcreteState>(
+        std::static_pointer_cast<const ConcreteStateData>(data),
         *family.getMostRecentState());
   }
 
   ShadowNodeFamily::Shared createFamily(
-      ShadowNodeFamilyFragment const &fragment) const override {
+      const ShadowNodeFamilyFragment &fragment) const override {
     return std::make_shared<ShadowNodeFamily>(
         ShadowNodeFamilyFragment{
             fragment.tag, fragment.surfaceId, fragment.instanceHandle},
@@ -163,8 +163,8 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   }
 
   SharedEventEmitter createEventEmitter(
-      InstanceHandle::Shared const &instanceHandle) const override {
-    return std::make_shared<ConcreteEventEmitter const>(
+      const InstanceHandle::Shared &instanceHandle) const override {
+    return std::make_shared<const ConcreteEventEmitter>(
         std::make_shared<EventTarget>(instanceHandle), eventDispatcher_);
   }
 
@@ -181,7 +181,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
    *   - Set `ShadowNode`'s size from state in
    * `ModalHostViewComponentDescriptor`.
    */
-  virtual void adopt(ShadowNode::Unshared const &shadowNode) const {
+  virtual void adopt(const ShadowNode::Unshared &shadowNode) const {
     // Default implementation does nothing.
     react_native_assert(
         shadowNode->getComponentHandle() == getComponentHandle());

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -46,11 +46,11 @@ class ConcreteShadowNode : public BaseShadowNodeT {
   using BaseShadowNodeT::BaseShadowNodeT;
 
   using ConcreteProps = PropsT;
-  using SharedConcreteProps = std::shared_ptr<PropsT const>;
+  using SharedConcreteProps = std::shared_ptr<const PropsT>;
   using UnsharedConcreteProps = std::shared_ptr<PropsT>;
   using ConcreteEventEmitter = EventEmitterT;
-  using SharedConcreteEventEmitter = std::shared_ptr<EventEmitterT const>;
-  using SharedConcreteShadowNode = std::shared_ptr<ConcreteShadowNode const>;
+  using SharedConcreteEventEmitter = std::shared_ptr<const EventEmitterT>;
+  using SharedConcreteShadowNode = std::shared_ptr<const ConcreteShadowNode>;
   using ConcreteState = ConcreteState<StateDataT>;
   using ConcreteStateData = StateDataT;
 
@@ -72,11 +72,11 @@ class ConcreteShadowNode : public BaseShadowNodeT {
 
   static UnsharedConcreteProps Props(
       const PropsParserContext &context,
-      RawProps const &rawProps,
-      Props::Shared const &baseProps = nullptr) {
+      const RawProps &rawProps,
+      const Props::Shared &baseProps = nullptr) {
     return std::make_shared<PropsT>(
         context,
-        baseProps ? static_cast<PropsT const &>(*baseProps) : PropsT(),
+        baseProps ? static_cast<const PropsT &>(*baseProps) : PropsT(),
         rawProps);
   }
 
@@ -87,9 +87,9 @@ class ConcreteShadowNode : public BaseShadowNodeT {
   }
 
   static ConcreteStateData initialStateData(
-      Props::Shared const & /*props*/,
-      ShadowNodeFamily::Shared const & /*family*/,
-      ComponentDescriptor const & /*componentDescriptor*/) {
+      const Props::Shared & /*props*/,
+      const ShadowNodeFamily::Shared & /*family*/,
+      const ComponentDescriptor & /*componentDescriptor*/) {
     return {};
   }
 
@@ -97,18 +97,18 @@ class ConcreteShadowNode : public BaseShadowNodeT {
    * Returns a concrete props object associated with the node.
    * Thread-safe after the node is sealed.
    */
-  ConcreteProps const &getConcreteProps() const {
+  const ConcreteProps &getConcreteProps() const {
     react_native_assert(
         BaseShadowNodeT::props_ && "Props must not be `nullptr`.");
-    return static_cast<ConcreteProps const &>(*props_);
+    return static_cast<const ConcreteProps &>(*props_);
   }
 
   /*
    * Returns a concrete event emitter object associated with the node.
    * Thread-safe after the node is sealed.
    */
-  ConcreteEventEmitter const &getConcreteEventEmitter() const {
-    return static_cast<ConcreteEventEmitter const &>(
+  const ConcreteEventEmitter &getConcreteEventEmitter() const {
+    return static_cast<const ConcreteEventEmitter &>(
         *BaseShadowNodeT::getEventEmitter());
   }
 
@@ -116,9 +116,9 @@ class ConcreteShadowNode : public BaseShadowNodeT {
    * Returns a concrete state data associated with the node.
    * Thread-safe after the node is sealed.
    */
-  ConcreteStateData const &getStateData() const {
+  const ConcreteStateData &getStateData() const {
     react_native_assert(state_ && "State must not be `nullptr`.");
-    return static_cast<ConcreteState const *>(state_.get())->getData();
+    return static_cast<const ConcreteState *>(state_.get())->getData();
   }
 
   /*
@@ -127,8 +127,8 @@ class ConcreteShadowNode : public BaseShadowNodeT {
    */
   void setStateData(ConcreteStateData &&data) {
     Sealable::ensureUnsealed();
-    state_ = std::make_shared<ConcreteState const>(
-        std::make_shared<ConcreteStateData const>(std::move(data)), *state_);
+    state_ = std::make_shared<const ConcreteState>(
+        std::make_shared<const ConcreteStateData>(std::move(data)), *state_);
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
@@ -25,14 +25,14 @@ namespace facebook::react {
 template <typename DataT>
 class ConcreteState : public State {
  public:
-  using Shared = std::shared_ptr<ConcreteState const>;
+  using Shared = std::shared_ptr<const ConcreteState>;
   using Data = DataT;
-  using SharedData = std::shared_ptr<Data const>;
+  using SharedData = std::shared_ptr<const Data>;
 
   /*
    * Creates an updated `State` object with given previous one and `data`.
    */
-  explicit ConcreteState(SharedData const &data, State const &state)
+  explicit ConcreteState(const SharedData &data, const State &state)
       : State(data, state) {}
 
   /*
@@ -40,8 +40,8 @@ class ConcreteState : public State {
    * `data`.
    */
   explicit ConcreteState(
-      SharedData const &data,
-      ShadowNodeFamily::Shared const &family)
+      const SharedData &data,
+      const ShadowNodeFamily::Shared &family)
       : State(data, family) {}
 
   ~ConcreteState() override = default;
@@ -49,8 +49,8 @@ class ConcreteState : public State {
   /*
    * Returns stored data.
    */
-  Data const &getData() const {
-    return *static_cast<Data const *>(data_.get());
+  const Data &getData() const {
+    return *static_cast<const Data *>(data_.get());
   }
 
   /*
@@ -61,7 +61,7 @@ class ConcreteState : public State {
    */
   void updateState(Data &&newData, EventPriority priority) const {
     updateState(
-        [data{std::move(newData)}](Data const &oldData) -> SharedData {
+        [data{std::move(newData)}](const Data &oldData) -> SharedData {
           return std::make_shared<Data const>(data);
         },
         priority);
@@ -84,7 +84,7 @@ class ConcreteState : public State {
    * return `nullptr`.
    */
   void updateState(
-      std::function<StateData::Shared(Data const &oldData)> callback,
+      std::function<StateData::Shared(const Data &oldData)> callback,
       EventPriority priority = EventPriority::AsynchronousBatched) const {
     auto family = family_.lock();
 
@@ -95,7 +95,7 @@ class ConcreteState : public State {
     }
 
     auto stateUpdate = StateUpdate{
-        family, [=](StateData::Shared const &oldData) -> StateData::Shared {
+        family, [=](const StateData::Shared &oldData) -> StateData::Shared {
           react_native_assert(oldData);
           return callback(*static_cast<Data const *>(oldData.get()));
         }};

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicPropsUtilities.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicPropsUtilities.cpp
@@ -10,8 +10,8 @@
 namespace facebook::react {
 
 folly::dynamic mergeDynamicProps(
-    folly::dynamic const &source,
-    folly::dynamic const &patch) {
+    const folly::dynamic &source,
+    const folly::dynamic &patch) {
   auto result = source;
 
   if (!result.isObject()) {
@@ -24,7 +24,7 @@ folly::dynamic mergeDynamicProps(
 
   // Note, here we have to preserve sub-prop objects with `null` value as
   // an indication for the legacy mounting layer that it needs to clean them up.
-  for (auto const &pair : patch.items()) {
+  for (const auto &pair : patch.items()) {
     result[pair.first] = pair.second;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicPropsUtilities.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicPropsUtilities.h
@@ -18,7 +18,7 @@ namespace facebook::react {
  * `patch`, overriding existing keys.
  */
 folly::dynamic mergeDynamicProps(
-    folly::dynamic const &source,
-    folly::dynamic const &patch);
+    const folly::dynamic &source,
+    const folly::dynamic &patch);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -35,14 +35,14 @@ class EventBeat {
    * around this issue; it allows to store the pointer later, right after the
    * creation of some other object that owns an `EventBeat`.
    */
-  using Owner = std::weak_ptr<void const>;
+  using Owner = std::weak_ptr<const void>;
   struct OwnerBox {
     Owner owner;
   };
   using SharedOwnerBox = std::shared_ptr<OwnerBox>;
 
   using Factory =
-      std::function<std::unique_ptr<EventBeat>(SharedOwnerBox const &ownerBox)>;
+      std::function<std::unique_ptr<EventBeat>(const SharedOwnerBox &ownerBox)>;
 
   using BeatCallback = std::function<void(jsi::Runtime &runtime)>;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -17,10 +17,10 @@
 namespace facebook::react {
 
 EventDispatcher::EventDispatcher(
-    EventQueueProcessor const &eventProcessor,
-    EventBeat::Factory const &synchonousEventBeatFactory,
-    EventBeat::Factory const &asynchronousEventBeatFactory,
-    EventBeat::SharedOwnerBox const &ownerBox)
+    const EventQueueProcessor &eventProcessor,
+    const EventBeat::Factory &synchonousEventBeatFactory,
+    const EventBeat::Factory &asynchronousEventBeatFactory,
+    const EventBeat::SharedOwnerBox &ownerBox)
     : synchronousUnbatchedQueue_(std::make_unique<UnbatchedEventQueue>(
           eventProcessor,
           synchonousEventBeatFactory(ownerBox))),
@@ -76,7 +76,7 @@ const EventQueue &EventDispatcher::getEventQueue(EventPriority priority) const {
 }
 
 void EventDispatcher::addListener(
-    const std::shared_ptr<EventListener const> &listener) const {
+    const std::shared_ptr<const EventListener> &listener) const {
   eventListeners_.addListener(listener);
 }
 
@@ -84,7 +84,7 @@ void EventDispatcher::addListener(
  * Removes provided event listener to the event dispatcher.
  */
 void EventDispatcher::removeListener(
-    const std::shared_ptr<EventListener const> &listener) const {
+    const std::shared_ptr<const EventListener> &listener) const {
   eventListeners_.removeListener(listener);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -25,14 +25,14 @@ struct RawEvent;
  */
 class EventDispatcher {
  public:
-  using Shared = std::shared_ptr<EventDispatcher const>;
-  using Weak = std::weak_ptr<EventDispatcher const>;
+  using Shared = std::shared_ptr<const EventDispatcher>;
+  using Weak = std::weak_ptr<const EventDispatcher>;
 
   EventDispatcher(
-      EventQueueProcessor const &eventProcessor,
-      EventBeat::Factory const &synchonousEventBeatFactory,
-      EventBeat::Factory const &asynchronousEventBeatFactory,
-      EventBeat::SharedOwnerBox const &ownerBox);
+      const EventQueueProcessor &eventProcessor,
+      const EventBeat::Factory &synchonousEventBeatFactory,
+      const EventBeat::Factory &asynchronousEventBeatFactory,
+      const EventBeat::SharedOwnerBox &ownerBox);
 
   /*
    * Dispatches a raw event with given priority using event-delivery pipe.
@@ -56,16 +56,16 @@ class EventDispatcher {
   /*
    * Adds provided event listener to the event dispatcher.
    */
-  void addListener(const std::shared_ptr<EventListener const> &listener) const;
+  void addListener(const std::shared_ptr<const EventListener> &listener) const;
 
   /*
    * Removes provided event listener to the event dispatcher.
    */
   void removeListener(
-      const std::shared_ptr<EventListener const> &listener) const;
+      const std::shared_ptr<const EventListener> &listener) const;
 
  private:
-  EventQueue const &getEventQueue(EventPriority priority) const;
+  const EventQueue &getEventQueue(EventPriority priority) const;
 
   std::unique_ptr<UnbatchedEventQueue> synchronousUnbatchedQueue_;
   std::unique_ptr<BatchedEventQueue> synchronousBatchedQueue_;

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -32,7 +32,7 @@ using SharedEventEmitter = std::shared_ptr<const EventEmitter>;
  */
 class EventEmitter {
  public:
-  using Shared = std::shared_ptr<EventEmitter const>;
+  using Shared = std::shared_ptr<const EventEmitter>;
 
   static std::mutex &DispatchMutex();
 
@@ -56,7 +56,7 @@ class EventEmitter {
    */
   void setEnabled(bool enabled) const;
 
-  SharedEventTarget const &getEventTarget() const;
+  const SharedEventTarget &getEventTarget() const;
 
  protected:
 #ifdef ANDROID

--- a/packages/react-native/ReactCommon/react/renderer/core/EventListener.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventListener.cpp
@@ -15,21 +15,21 @@ bool EventListenerContainer::willDispatchEvent(const RawEvent &event) {
   std::shared_lock lock(mutex_);
 
   bool handled = false;
-  for (auto const &listener : eventListeners_) {
+  for (const auto &listener : eventListeners_) {
     handled = handled || listener->operator()(event);
   }
   return handled;
 }
 
 void EventListenerContainer::addListener(
-    const std::shared_ptr<EventListener const> &listener) {
+    const std::shared_ptr<const EventListener> &listener) {
   std::unique_lock lock(mutex_);
 
   eventListeners_.push_back(listener);
 }
 
 void EventListenerContainer::removeListener(
-    const std::shared_ptr<EventListener const> &listener) {
+    const std::shared_ptr<const EventListener> &listener) {
   std::unique_lock lock(mutex_);
 
   auto it = std::find(eventListeners_.begin(), eventListeners_.end(), listener);

--- a/packages/react-native/ReactCommon/react/renderer/core/EventListener.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventListener.h
@@ -30,12 +30,12 @@ class EventListenerContainer {
    */
   bool willDispatchEvent(const RawEvent &event);
 
-  void addListener(const std::shared_ptr<EventListener const> &listener);
-  void removeListener(const std::shared_ptr<EventListener const> &listener);
+  void addListener(const std::shared_ptr<const EventListener> &listener);
+  void removeListener(const std::shared_ptr<const EventListener> &listener);
 
  private:
   std::shared_mutex mutex_;
-  std::vector<std::shared_ptr<EventListener const>> eventListeners_;
+  std::vector<std::shared_ptr<const EventListener>> eventListeners_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueue.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueue.cpp
@@ -64,7 +64,7 @@ void EventQueue::enqueueStateUpdate(StateUpdate &&stateUpdate) const {
   {
     std::scoped_lock lock(queueMutex_);
     if (!stateUpdateQueue_.empty()) {
-      auto const position = stateUpdateQueue_.back();
+      const auto position = stateUpdateQueue_.back();
       if (stateUpdate.family == position.family) {
         stateUpdateQueue_.pop_back();
       }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -36,7 +36,7 @@ void EventQueueProcessor::flushEvents(
     }
   }
 
-  for (auto const &event : events) {
+  for (const auto &event : events) {
     if (event.category == RawEvent::Category::ContinuousEnd) {
       hasContinuousEventStarted_ = false;
     }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.h
@@ -28,9 +28,9 @@ class EventQueueProcessor {
   void flushStateUpdates(std::vector<StateUpdate> &&states) const;
 
  private:
-  EventPipe const eventPipe_;
-  EventPipeConclusion const eventPipeConclusion_;
-  StatePipe const statePipe_;
+  const EventPipe eventPipe_;
+  const EventPipeConclusion eventPipeConclusion_;
+  const StatePipe statePipe_;
 
   mutable bool hasContinuousEventStarted_{false};
 };

--- a/packages/react-native/ReactCommon/react/renderer/core/InstanceHandle.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/InstanceHandle.cpp
@@ -11,7 +11,7 @@ namespace facebook::react {
 
 InstanceHandle::InstanceHandle(
     jsi::Runtime &runtime,
-    jsi::Value const &instanceHandle,
+    const jsi::Value &instanceHandle,
     Tag tag)
     : weakInstanceHandle_(
           jsi::WeakObject(runtime, instanceHandle.asObject(runtime))),

--- a/packages/react-native/ReactCommon/react/renderer/core/InstanceHandle.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/InstanceHandle.h
@@ -19,7 +19,7 @@ class InstanceHandle {
 
   InstanceHandle(
       jsi::Runtime &runtime,
-      jsi::Value const &instanceHandle,
+      const jsi::Value &instanceHandle,
       Tag tag);
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutContext.h
@@ -33,7 +33,7 @@ struct LayoutContext {
    * list. The order is not specified. Nothing in this collection is owing (on
    * purpose), make sure the memory is managed responsibly.
    */
-  std::vector<LayoutableShadowNode const *> *affectedNodes{};
+  std::vector<const LayoutableShadowNode *> *affectedNodes{};
 
   /*
    * Flag indicating whether in reassignment of direction
@@ -61,7 +61,7 @@ struct LayoutContext {
   Point viewportOffset{};
 };
 
-inline bool operator==(LayoutContext const &lhs, LayoutContext const &rhs) {
+inline bool operator==(const LayoutContext &lhs, const LayoutContext &rhs) {
   return std::tie(
              lhs.pointScaleFactor,
              lhs.affectedNodes,
@@ -76,7 +76,7 @@ inline bool operator==(LayoutContext const &lhs, LayoutContext const &rhs) {
              rhs.viewportOffset);
 }
 
-inline bool operator!=(LayoutContext const &lhs, LayoutContext const &rhs) {
+inline bool operator!=(const LayoutContext &lhs, const LayoutContext &rhs) {
   return !(lhs == rhs);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.cpp
@@ -14,12 +14,12 @@ namespace facebook::react {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(LayoutMetrics const & /*object*/) {
+std::string getDebugName(const LayoutMetrics & /*object*/) {
   return "LayoutMetrics";
 }
 
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    LayoutMetrics const &object,
+    const LayoutMetrics &object,
     DebugStringConvertibleOptions options) {
   return {
       {"frame",

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -82,14 +82,14 @@ struct LayoutMetrics {
  * `LayoutMetrics` type.
  * The value is comparable by equality with any other `LayoutMetrics` value.
  */
-static LayoutMetrics const EmptyLayoutMetrics = {
+static const LayoutMetrics EmptyLayoutMetrics = {
     /* .frame = */ {{0, 0}, {-1.0, -1.0}}};
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(LayoutMetrics const &object);
+std::string getDebugName(const LayoutMetrics &object);
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    LayoutMetrics const &object,
+    const LayoutMetrics &object,
     DebugStringConvertibleOptions options);
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -21,7 +21,7 @@ template <class T>
 using LayoutableSmallVector = butter::small_vector<T, 16>;
 
 static LayoutableSmallVector<Rect> calculateTransformedFrames(
-    LayoutableSmallVector<ShadowNode const *> const &shadowNodeList,
+    const LayoutableSmallVector<ShadowNode const *> &shadowNodeList,
     LayoutableShadowNode::LayoutInspectingPolicy policy) {
   auto size = shadowNodeList.size();
   auto transformedFrames = LayoutableSmallVector<Rect>{size};
@@ -29,13 +29,13 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
 
   for (auto i = size; i > 0; --i) {
     auto currentShadowNode =
-        traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i - 1));
+        traitCast<const LayoutableShadowNode *>(shadowNodeList.at(i - 1));
     auto currentFrame = currentShadowNode->getLayoutMetrics().frame;
 
     if (policy.includeTransform) {
       if (Transform::isVerticalInversion(transformation)) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
+            traitCast<const LayoutableShadowNode *>(shadowNodeList.at(i));
         currentFrame.origin.y =
             parentShadowNode->getLayoutMetrics().frame.size.height -
             currentFrame.size.height - currentFrame.origin.y;
@@ -43,7 +43,7 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
 
       if (Transform::isHorizontalInversion(transformation)) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
+            traitCast<const LayoutableShadowNode *>(shadowNodeList.at(i));
         currentFrame.origin.x =
             parentShadowNode->getLayoutMetrics().frame.size.width -
             currentFrame.size.width - currentFrame.origin.x;
@@ -51,7 +51,7 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
 
       if (i != size) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
+            traitCast<const LayoutableShadowNode *>(shadowNodeList.at(i));
         auto contentOriginOffset = parentShadowNode->getContentOriginOffset();
         if (Transform::isVerticalInversion(transformation)) {
           contentOriginOffset.y = -contentOriginOffset.y;
@@ -72,21 +72,21 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
 }
 
 LayoutableShadowNode::LayoutableShadowNode(
-    ShadowNodeFragment const &fragment,
-    ShadowNodeFamily::Shared const &family,
+    const ShadowNodeFragment &fragment,
+    const ShadowNodeFamily::Shared &family,
     ShadowNodeTraits traits)
     : ShadowNode(fragment, family, traits), layoutMetrics_({}) {}
 
 LayoutableShadowNode::LayoutableShadowNode(
-    ShadowNode const &sourceShadowNode,
-    ShadowNodeFragment const &fragment)
+    const ShadowNode &sourceShadowNode,
+    const ShadowNodeFragment &fragment)
     : ShadowNode(sourceShadowNode, fragment),
-      layoutMetrics_(static_cast<LayoutableShadowNode const &>(sourceShadowNode)
+      layoutMetrics_(static_cast<const LayoutableShadowNode &>(sourceShadowNode)
                          .layoutMetrics_) {}
 
 LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
-    ShadowNodeFamily const &descendantNodeFamily,
-    LayoutableShadowNode const &ancestorNode,
+    const ShadowNodeFamily &descendantNodeFamily,
+    const LayoutableShadowNode &ancestorNode,
     LayoutInspectingPolicy policy) {
   // Prelude.
 
@@ -109,7 +109,7 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
 }
 
 LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
-    AncestorList const &ancestors,
+    const AncestorList &ancestors,
     LayoutInspectingPolicy policy) {
   if (ancestors.empty()) {
     // Specified nodes do not form an ancestor-descender relationship
@@ -122,7 +122,7 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
   // Step 1.
   // Creating a list of nodes that form a chain from the descender node to
   // ancestor node inclusively.
-  auto shadowNodeList = LayoutableSmallVector<ShadowNode const *>{};
+  auto shadowNodeList = LayoutableSmallVector<const ShadowNode *>{};
 
   // Finding the measured node.
   // The last element in the `AncestorList` is a pair of a parent of the node
@@ -152,7 +152,7 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
   // Step 2.
   // Computing the initial size of the measured node.
   auto descendantLayoutableNode =
-      traitCast<LayoutableShadowNode const *>(descendantNode);
+      traitCast<const LayoutableShadowNode *>(descendantNode);
 
   if (descendantLayoutableNode == nullptr) {
     return EmptyLayoutMetrics;
@@ -183,7 +183,7 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
   auto size = shadowNodeList.size();
   for (size_t i = 0; i < size; i++) {
     auto currentShadowNode =
-        traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
+        traitCast<const LayoutableShadowNode *>(shadowNodeList.at(i));
 
     if (currentShadowNode == nullptr) {
       return EmptyLayoutMetrics;
@@ -278,7 +278,7 @@ LayoutableShadowNode::getLayoutableChildNodes() const {
   LayoutableShadowNode::UnsharedList layoutableChildren;
   for (const auto &childShadowNode : getChildren()) {
     auto layoutableChildShadowNode =
-        traitCast<LayoutableShadowNode const *>(childShadowNode.get());
+        traitCast<const LayoutableShadowNode *>(childShadowNode.get());
     if (layoutableChildShadowNode != nullptr) {
       layoutableChildren.push_back(
           const_cast<LayoutableShadowNode *>(layoutableChildShadowNode));
@@ -288,14 +288,14 @@ LayoutableShadowNode::getLayoutableChildNodes() const {
 }
 
 Size LayoutableShadowNode::measureContent(
-    LayoutContext const & /*layoutContext*/,
-    LayoutConstraints const & /*layoutConstraints*/) const {
+    const LayoutContext & /*layoutContext*/,
+    const LayoutConstraints & /*layoutConstraints*/) const {
   return {};
 }
 
 Size LayoutableShadowNode::measure(
-    LayoutContext const &layoutContext,
-    LayoutConstraints const &layoutConstraints) const {
+    const LayoutContext &layoutContext,
+    const LayoutConstraints &layoutConstraints) const {
   auto clonedShadowNode = clone({});
   auto &layoutableShadowNode =
       static_cast<LayoutableShadowNode &>(*clonedShadowNode);
@@ -317,7 +317,7 @@ Float LayoutableShadowNode::lastBaseline(Size /*size*/) const {
 }
 
 ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
-    ShadowNode::Shared const &node,
+    const ShadowNode::Shared &node,
     Point point) {
   auto layoutableShadowNode =
       traitCast<const LayoutableShadowNode *>(node.get());
@@ -340,12 +340,12 @@ ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
   std::stable_sort(
       sortedChildren.begin(),
       sortedChildren.end(),
-      [](auto const &lhs, auto const &rhs) -> bool {
+      [](const auto &lhs, const auto &rhs) -> bool {
         return lhs->getOrderIndex() < rhs->getOrderIndex();
       });
 
   for (auto it = sortedChildren.rbegin(); it != sortedChildren.rend(); it++) {
-    auto const &childShadowNode = *it;
+    const auto &childShadowNode = *it;
     auto hitView = findNodeAtPoint(childShadowNode, newPoint);
     if (hitView) {
       return hitView;

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -32,13 +32,13 @@ struct LayoutContext;
 class LayoutableShadowNode : public ShadowNode {
  public:
   LayoutableShadowNode(
-      ShadowNodeFragment const &fragment,
-      ShadowNodeFamily::Shared const &family,
+      const ShadowNodeFragment &fragment,
+      const ShadowNodeFamily::Shared &family,
       ShadowNodeTraits traits);
 
   LayoutableShadowNode(
-      ShadowNode const &sourceShadowNode,
-      ShadowNodeFragment const &fragment);
+      const ShadowNode &sourceShadowNode,
+      const ShadowNodeFragment &fragment);
 
   static ShadowNodeTraits BaseTraits();
   static ShadowNodeTraits::Trait IdentifierTrait();
@@ -59,15 +59,15 @@ class LayoutableShadowNode : public ShadowNode {
    * tree.
    */
   static LayoutMetrics computeRelativeLayoutMetrics(
-      ShadowNodeFamily const &descendantNodeFamily,
-      LayoutableShadowNode const &ancestorNode,
+      const ShadowNodeFamily &descendantNodeFamily,
+      const LayoutableShadowNode &ancestorNode,
       LayoutInspectingPolicy policy);
 
   /*
    * Computes the layout metrics of a node relative to its specified ancestors.
    */
   static LayoutMetrics computeRelativeLayoutMetrics(
-      AncestorList const &ancestors,
+      const AncestorList &ancestors,
       LayoutInspectingPolicy policy);
 
   /*
@@ -85,8 +85,8 @@ class LayoutableShadowNode : public ShadowNode {
    * Default implementation returns zero size.
    */
   virtual Size measureContent(
-      LayoutContext const &layoutContext,
-      LayoutConstraints const &layoutConstraints) const;
+      const LayoutContext &layoutContext,
+      const LayoutConstraints &layoutConstraints) const;
 
   /*
    * Measures the node with given `layoutContext` and `layoutConstraints`.
@@ -94,8 +94,8 @@ class LayoutableShadowNode : public ShadowNode {
    * should *not* be included. Default implementation returns zero size.
    */
   virtual Size measure(
-      LayoutContext const &layoutContext,
-      LayoutConstraints const &layoutConstraints) const;
+      const LayoutContext &layoutContext,
+      const LayoutConstraints &layoutConstraints) const;
 
   /*
    * Computes layout recursively.
@@ -140,7 +140,7 @@ class LayoutableShadowNode : public ShadowNode {
    * parameter.
    */
   static ShadowNode::Shared findNodeAtPoint(
-      ShadowNode::Shared const &node,
+      const ShadowNode::Shared &node,
       Point point);
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
@@ -39,7 +39,7 @@ void Props::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
     const char * /*propName*/,
-    RawValue const &value) {
+    const RawValue &value) {
   switch (hash) {
     case CONSTEXPR_RAW_PROPS_KEY_HASH("nativeID"):
       fromRawValue(context, value, nativeId, {});
@@ -52,7 +52,7 @@ void Props::setProp(
 constexpr MapBuffer::Key PROPS_NATIVE_ID = 1;
 
 void Props::propsDiffMapBuffer(
-    Props const *oldPropsPtr,
+    const Props *oldPropsPtr,
     MapBufferBuilder &builder) const {
   // Call with default props if necessary
   if (oldPropsPtr == nullptr) {
@@ -61,8 +61,8 @@ void Props::propsDiffMapBuffer(
     return;
   }
 
-  Props const &oldProps = *oldPropsPtr;
-  Props const &newProps = *this;
+  const Props &oldProps = *oldPropsPtr;
+  const Props &newProps = *this;
 
   if (oldProps.nativeId != newProps.nativeId) {
     builder.putString(PROPS_NATIVE_ID, nativeId);

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -27,13 +27,13 @@ namespace facebook::react {
  */
 class Props : public virtual Sealable, public virtual DebugStringConvertible {
  public:
-  using Shared = std::shared_ptr<Props const>;
+  using Shared = std::shared_ptr<const Props>;
 
   Props() = default;
   Props(
       const PropsParserContext &context,
       const Props &sourceProps,
-      RawProps const &rawProps,
+      const RawProps &rawProps,
       bool shouldSetRawProps = true);
   virtual ~Props() = default;
 
@@ -51,7 +51,7 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
       const PropsParserContext &context,
       RawPropsPropNameHash hash,
       const char *propName,
-      RawValue const &value);
+      const RawValue &value);
 
   std::string nativeId;
 
@@ -59,7 +59,7 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
   folly::dynamic rawProps = folly::dynamic::object();
 
   virtual void propsDiffMapBuffer(
-      Props const *oldProps,
+      const Props *oldProps,
       MapBufferBuilder &builder) const;
 #endif
 };

--- a/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.h
@@ -19,16 +19,16 @@ namespace facebook::react {
 // be parsed without any context.
 struct PropsParserContext {
   PropsParserContext(
-      SurfaceId const surfaceId,
-      ContextContainer const &contextContainer)
+      const SurfaceId surfaceId,
+      const ContextContainer &contextContainer)
       : surfaceId(surfaceId), contextContainer(contextContainer) {}
 
   // Non-copyable
   PropsParserContext(const PropsParserContext &) = delete;
   PropsParserContext &operator=(const PropsParserContext &) = delete;
 
-  SurfaceId const surfaceId;
-  ContextContainer const &contextContainer;
+  const SurfaceId surfaceId;
+  const ContextContainer &contextContainer;
 
   // Temporary feature flags
   bool treatAutoAsYGValueUndefined() const;

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
@@ -20,7 +20,7 @@ RawProps::RawProps() {
 /*
  * Creates an object with given `runtime` and `value`.
  */
-RawProps::RawProps(jsi::Runtime &runtime, jsi::Value const &value) noexcept {
+RawProps::RawProps(jsi::Runtime &runtime, const jsi::Value &value) noexcept {
   if (value.isNull()) {
     mode_ = Mode::Empty;
     return;
@@ -37,7 +37,7 @@ RawProps::RawProps(jsi::Runtime &runtime, jsi::Value const &value) noexcept {
  * We need this temporary, only because we have a callsite that does not have
  * a `jsi::Runtime` behind the data.
  */
-RawProps::RawProps(folly::dynamic const &dynamic) noexcept {
+RawProps::RawProps(const folly::dynamic &dynamic) noexcept {
   if (dynamic.isNull()) {
     mode_ = Mode::Empty;
     return;
@@ -48,7 +48,7 @@ RawProps::RawProps(folly::dynamic const &dynamic) noexcept {
 }
 
 void RawProps::parse(
-    RawPropsParser const &parser,
+    const RawPropsParser &parser,
     const PropsParserContext & /*unused*/) const noexcept {
   react_native_assert(parser_ == nullptr && "A parser was already assigned.");
   parser_ = &parser;
@@ -84,9 +84,9 @@ bool RawProps::isEmpty() const noexcept {
  * Returns `nullptr` if a prop with the given name does not exist.
  */
 const RawValue *RawProps::at(
-    char const *name,
-    char const *prefix,
-    char const *suffix) const noexcept {
+    const char *name,
+    const char *prefix,
+    const char *suffix) const noexcept {
   react_native_assert(
       parser_ &&
       "The object is not parsed. `parse` must be called before `at`.");
@@ -94,9 +94,8 @@ const RawValue *RawProps::at(
 }
 
 void RawProps::iterateOverValues(
-    std::function<
-        void(RawPropsPropNameHash, const char *, RawValue const &)> const &fn)
-    const {
+    const std::function<
+        void(RawPropsPropNameHash, const char *, RawValue const &)> &fn) const {
   return parser_->iterateOverValues(*this, fn);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -51,7 +51,7 @@ class RawProps final {
   /*
    * Creates an object with given `runtime` and `value`.
    */
-  RawProps(jsi::Runtime &runtime, jsi::Value const &value) noexcept;
+  RawProps(jsi::Runtime &runtime, const jsi::Value &value) noexcept;
 
   /*
    * Creates an object with given `folly::dynamic` object.
@@ -59,7 +59,7 @@ class RawProps final {
    * We need this temporary, only because we have a callsite that does not have
    * a `jsi::Runtime` behind the data.
    */
-  RawProps(folly::dynamic const &dynamic) noexcept;
+  RawProps(const folly::dynamic &dynamic) noexcept;
 
   /*
    * Not moveable.
@@ -70,10 +70,10 @@ class RawProps final {
   /*
    * Not copyable.
    */
-  RawProps(RawProps const &other) noexcept = delete;
-  RawProps &operator=(RawProps const &other) noexcept = delete;
+  RawProps(const RawProps &other) noexcept = delete;
+  RawProps &operator=(const RawProps &other) noexcept = delete;
 
-  void parse(RawPropsParser const &parser, const PropsParserContext &)
+  void parse(const RawPropsParser &parser, const PropsParserContext &)
       const noexcept;
 
   /*
@@ -93,7 +93,7 @@ class RawProps final {
    * Returns a const unowning pointer to `RawValue` of a prop with a given name.
    * Returns `nullptr` if a prop with the given name does not exist.
    */
-  const RawValue *at(char const *name, char const *prefix, char const *suffix)
+  const RawValue *at(const char *name, const char *prefix, const char *suffix)
       const noexcept;
 
   /**
@@ -101,14 +101,14 @@ class RawProps final {
    * instead of using `at` to access values randomly.
    */
   void iterateOverValues(
-      std::function<
-          void(RawPropsPropNameHash, const char *, RawValue const &)> const &fn)
+      const std::function<
+          void(RawPropsPropNameHash, const char *, RawValue const &)> &fn)
       const;
 
  private:
   friend class RawPropsParser;
 
-  mutable RawPropsParser const *parser_{nullptr};
+  mutable const RawPropsParser *parser_{nullptr};
 
   /*
    * Source artefacts:

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKey.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKey.cpp
@@ -51,21 +51,21 @@ RawPropsKey::operator std::string() const noexcept {
   return std::string{buffer.data(), length};
 }
 
-static bool areFieldsEqual(char const *lhs, char const *rhs) {
+static bool areFieldsEqual(const char *lhs, const char *rhs) {
   if (lhs == nullptr || rhs == nullptr) {
     return lhs == rhs;
   }
   return lhs == rhs || strcmp(lhs, rhs) == 0;
 }
 
-bool operator==(RawPropsKey const &lhs, RawPropsKey const &rhs) noexcept {
+bool operator==(const RawPropsKey &lhs, const RawPropsKey &rhs) noexcept {
   // Note: We check the name first.
   return areFieldsEqual(lhs.name, rhs.name) &&
       areFieldsEqual(lhs.prefix, rhs.prefix) &&
       areFieldsEqual(lhs.suffix, rhs.suffix);
 }
 
-bool operator!=(RawPropsKey const &lhs, RawPropsKey const &rhs) noexcept {
+bool operator!=(const RawPropsKey &lhs, const RawPropsKey &rhs) noexcept {
   return !(lhs == rhs);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKey.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKey.h
@@ -18,9 +18,9 @@ namespace facebook::react {
  */
 class RawPropsKey final {
  public:
-  char const *prefix{};
-  char const *name{};
-  char const *suffix{};
+  const char *prefix{};
+  const char *name{};
+  const char *suffix{};
 
   /*
    * Converts to `std::string`.
@@ -34,7 +34,7 @@ class RawPropsKey final {
   void render(char *buffer, RawPropsPropNameLength *length) const noexcept;
 };
 
-bool operator==(RawPropsKey const &lhs, RawPropsKey const &rhs) noexcept;
-bool operator!=(RawPropsKey const &lhs, RawPropsKey const &rhs) noexcept;
+bool operator==(const RawPropsKey &lhs, const RawPropsKey &rhs) noexcept;
+bool operator!=(const RawPropsKey &lhs, const RawPropsKey &rhs) noexcept;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
@@ -17,14 +17,14 @@
 
 namespace facebook::react {
 
-bool RawPropsKeyMap::hasSameName(Item const &lhs, Item const &rhs) noexcept {
+bool RawPropsKeyMap::hasSameName(const Item &lhs, const Item &rhs) noexcept {
   return lhs.length == rhs.length &&
       (std::memcmp(lhs.name, rhs.name, lhs.length) == 0);
 }
 
 bool RawPropsKeyMap::shouldFirstOneBeBeforeSecondOne(
-    Item const &lhs,
-    Item const &rhs) noexcept {
+    const Item &lhs,
+    const Item &rhs) noexcept {
   if (lhs.length != rhs.length) {
     return lhs.length < rhs.length;
   }
@@ -33,7 +33,7 @@ bool RawPropsKeyMap::shouldFirstOneBeBeforeSecondOne(
 }
 
 void RawPropsKeyMap::insert(
-    RawPropsKey const &key,
+    const RawPropsKey &key,
     RawPropsValueIndex value) noexcept {
   auto item = Item{};
   item.value = value;
@@ -92,7 +92,7 @@ void RawPropsKeyMap::reindex() noexcept {
 }
 
 RawPropsValueIndex RawPropsKeyMap::at(
-    char const *name,
+    const char *name,
     RawPropsPropNameLength length) noexcept {
   react_native_assert(length > 0);
   react_native_assert(length < kPropNameLengthHardCap);

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.h
@@ -26,7 +26,7 @@ class RawPropsKeyMap final {
   /*
    * Stores `value` with by given `key`.
    */
-  void insert(RawPropsKey const &key, RawPropsValueIndex value) noexcept;
+  void insert(const RawPropsKey &key, RawPropsValueIndex value) noexcept;
 
   /*
    * Reindexes the stored data.
@@ -39,7 +39,7 @@ class RawPropsKeyMap final {
    * Returns `kRawPropsValueIndexEmpty` if the value wan't found.
    */
   RawPropsValueIndex at(
-      char const *name,
+      const char *name,
       RawPropsPropNameLength length) noexcept;
 
  private:
@@ -50,9 +50,9 @@ class RawPropsKeyMap final {
   };
 
   static bool shouldFirstOneBeBeforeSecondOne(
-      Item const &lhs,
-      Item const &rhs) noexcept;
-  static bool hasSameName(Item const &lhs, Item const &rhs) noexcept;
+      const Item &lhs,
+      const Item &rhs) noexcept;
+  static bool hasSameName(const Item &lhs, const Item &rhs) noexcept;
 
   butter::small_vector<Item, kNumberOfExplicitlySpecifiedPropsSoftCap> items_{};
   butter::small_vector<RawPropsPropNameLength, kPropNameLengthHardCap>

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -19,9 +19,9 @@ namespace facebook::react {
 // During parser initialization, Props structs are used to parse
 // "fake"/empty objects, and `at` is called repeatedly which tells us
 // which props are accessed during parsing, and in which order.
-RawValue const *RawPropsParser::at(
-    RawProps const &rawProps,
-    RawPropsKey const &key) const noexcept {
+const RawValue *RawPropsParser::at(
+    const RawProps &rawProps,
+    const RawPropsKey &key) const noexcept {
   if (UNLIKELY(!ready_)) {
     // Check against the same key being inserted more than once.
     // This happens commonly with nested Props structs, where the higher-level
@@ -94,7 +94,7 @@ void RawPropsParser::postPrepare() noexcept {
   nameToIndex_.reindex();
 }
 
-void RawPropsParser::preparse(RawProps const &rawProps) const noexcept {
+void RawPropsParser::preparse(const RawProps &rawProps) const noexcept {
   const size_t keyCount = keys_.size();
   rawProps.keyIndexToValueIndex_.resize(keyCount, kRawPropsValueIndexEmpty);
 
@@ -147,10 +147,10 @@ void RawPropsParser::preparse(RawProps const &rawProps) const noexcept {
     }
 
     case RawProps::Mode::Dynamic: {
-      auto const &dynamic = rawProps.dynamic_;
+      const auto &dynamic = rawProps.dynamic_;
       auto valueIndex = RawPropsValueIndex{0};
 
-      for (auto const &pair : dynamic.items()) {
+      for (const auto &pair : dynamic.items()) {
         auto name = pair.first.getString();
 
         auto keyIndex = nameToIndex_.at(
@@ -173,10 +173,10 @@ void RawPropsParser::preparse(RawProps const &rawProps) const noexcept {
  * To be used by RawProps only. Value iterator functions.
  */
 void RawPropsParser::iterateOverValues(
-    RawProps const &rawProps,
-    std::function<
-        void(RawPropsPropNameHash, const char *, RawValue const &)> const
-        &visit) const {
+    const RawProps &rawProps,
+    const std::function<
+        void(RawPropsPropNameHash, const char *, RawValue const &)> &visit)
+    const {
   switch (rawProps.mode_) {
     case RawProps::Mode::Empty:
       return;
@@ -208,9 +208,9 @@ void RawPropsParser::iterateOverValues(
     }
 
     case RawProps::Mode::Dynamic: {
-      auto const &dynamic = rawProps.dynamic_;
+      const auto &dynamic = rawProps.dynamic_;
 
-      for (auto const &pair : dynamic.items()) {
+      for (const auto &pair : dynamic.items()) {
         auto name = pair.first.getString();
 
         auto nameHash = RAW_PROPS_KEY_HASH(name.c_str());

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -62,7 +62,7 @@ class RawPropsParser final {
   /*
    * To be used by `RawProps` only.
    */
-  void preparse(RawProps const &rawProps) const noexcept;
+  void preparse(const RawProps &rawProps) const noexcept;
 
   /*
    * Non-generic part of `prepare`.
@@ -72,17 +72,17 @@ class RawPropsParser final {
   /*
    * To be used by `RawProps` only.
    */
-  RawValue const *at(RawProps const &rawProps, RawPropsKey const &key)
+  const RawValue *at(const RawProps &rawProps, const RawPropsKey &key)
       const noexcept;
 
   /**
    * To be used by RawProps only. Value iterator functions.
    */
   void iterateOverValues(
-      RawProps const &rawProps,
-      std::function<
-          void(RawPropsPropNameHash, const char *, RawValue const &)> const
-          &visit) const;
+      const RawProps &rawProps,
+      const std::function<
+          void(RawPropsPropNameHash, const char *, RawValue const &)> &visit)
+      const;
 
   mutable butter::small_vector<RawPropsKey, kNumberOfPropsPerComponentSoftCap>
       keys_{};

--- a/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
@@ -81,7 +81,7 @@ class RawValue {
    * internal use, but it's needed for user-code that does `auto val =
    * (butter::map<std::string, RawValue>)rawVal;`
    */
-  RawValue(RawValue const &other) noexcept : dynamic_(other.dynamic_) {}
+  RawValue(const RawValue &other) noexcept : dynamic_(other.dynamic_) {}
 
   RawValue &operator=(const RawValue &other) noexcept {
     if (this != &other) {

--- a/packages/react-native/ReactCommon/react/renderer/core/ReactPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ReactPrimitives.h
@@ -35,7 +35,7 @@ using ComponentHandle = int64_t;
  * String identifier for components used for addressing them from
  * JavaScript side.
  */
-using ComponentName = char const *;
+using ComponentName = const char *;
 
 /*
  * Defines how visual side effects (views, images, text, and so on) are

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -36,8 +36,8 @@ ShadowNode::SharedListOfShared ShadowNode::emptySharedShadowNodeSharedList() {
  * is finished.
  */
 Props::Shared ShadowNode::propsForClonedShadowNode(
-    ShadowNode const &sourceShadowNode,
-    Props::Shared const &props) {
+    const ShadowNode &sourceShadowNode,
+    const Props::Shared &props) {
 #ifdef ANDROID
   bool hasBeenMounted = sourceShadowNode.hasBeenMounted_;
   bool sourceNodeHasRawProps = !sourceShadowNode.getProps()->rawProps.empty();
@@ -58,7 +58,7 @@ bool ShadowNode::sameFamily(const ShadowNode &first, const ShadowNode &second) {
 #pragma mark - Constructors
 
 ShadowNode::ShadowNode(
-    ShadowNodeFragment const &fragment,
+    const ShadowNodeFragment &fragment,
     ShadowNodeFamily::Shared family,
     ShadowNodeTraits traits)
     :
@@ -78,7 +78,7 @@ ShadowNode::ShadowNode(
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
 
-  for (auto const &child : *children_) {
+  for (const auto &child : *children_) {
     child->family_->setParent(family_);
   }
 
@@ -87,8 +87,8 @@ ShadowNode::ShadowNode(
 }
 
 ShadowNode::ShadowNode(
-    ShadowNode const &sourceShadowNode,
-    ShadowNodeFragment const &fragment)
+    const ShadowNode &sourceShadowNode,
+    const ShadowNodeFragment &fragment)
     :
 #if RN_DEBUG_STRING_CONVERTIBLE
       revision_(sourceShadowNode.revision_ + 1),
@@ -117,8 +117,8 @@ ShadowNode::ShadowNode(
 
 ShadowNode::Unshared ShadowNode::clone(
     const ShadowNodeFragment &fragment) const {
-  auto const &family = *family_;
-  auto const &componentDescriptor = family.componentDescriptor_;
+  const auto &family = *family_;
+  const auto &componentDescriptor = family.componentDescriptor_;
   if (family.nativeProps_DEPRECATED != nullptr) {
     auto propsParserContext = PropsParserContext{family_->getSurfaceId(), {}};
     if (fragment.props == ShadowNodeFragment::propsPlaceholder()) {
@@ -216,7 +216,7 @@ void ShadowNode::sealRecursive() const {
 
   props_->seal();
 
-  for (auto const &child : *children_) {
+  for (const auto &child : *children_) {
     child->sealRecursive();
   }
 }
@@ -234,8 +234,8 @@ void ShadowNode::appendChild(const ShadowNode::Shared &child) {
 }
 
 void ShadowNode::replaceChild(
-    ShadowNode const &oldChild,
-    ShadowNode::Shared const &newChild,
+    const ShadowNode &oldChild,
+    const ShadowNode::Shared &newChild,
     int32_t suggestedIndex) {
   ensureUnsealed();
 
@@ -282,13 +282,13 @@ void ShadowNode::setMounted(bool mounted) const {
   family_->eventEmitter_->setEnabled(mounted);
 }
 
-ShadowNodeFamily const &ShadowNode::getFamily() const {
+const ShadowNodeFamily &ShadowNode::getFamily() const {
   return *family_;
 }
 
 ShadowNode::Unshared ShadowNode::cloneTree(
-    ShadowNodeFamily const &shadowNodeFamily,
-    std::function<ShadowNode::Unshared(ShadowNode const &oldShadowNode)> const
+    const ShadowNodeFamily &shadowNodeFamily,
+    const std::function<ShadowNode::Unshared(ShadowNode const &oldShadowNode)>
         &callback) const {
   auto ancestors = shadowNodeFamily.getAncestors(*this);
 
@@ -341,7 +341,7 @@ std::string ShadowNode::getDebugValue() const {
 SharedDebugStringConvertibleList ShadowNode::getDebugChildren() const {
   auto debugChildren = SharedDebugStringConvertibleList{};
 
-  for (auto const &child : *children_) {
+  for (const auto &child : *children_) {
     auto debugChild =
         std::dynamic_pointer_cast<const DebugStringConvertible>(child);
     if (debugChild) {

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -33,20 +33,20 @@ class ShadowNode : public Sealable,
                    public DebugStringConvertible,
                    public jsi::NativeState {
  public:
-  using Shared = std::shared_ptr<ShadowNode const>;
-  using Weak = std::weak_ptr<ShadowNode const>;
+  using Shared = std::shared_ptr<const ShadowNode>;
+  using Weak = std::weak_ptr<const ShadowNode>;
   using Unshared = std::shared_ptr<ShadowNode>;
   using ListOfShared =
       butter::small_vector<Shared, kShadowNodeChildrenSmallVectorSize>;
   using ListOfWeak =
       butter::small_vector<Weak, kShadowNodeChildrenSmallVectorSize>;
-  using SharedListOfShared = std::shared_ptr<ListOfShared const>;
+  using SharedListOfShared = std::shared_ptr<const ListOfShared>;
   using UnsharedListOfShared = std::shared_ptr<ListOfShared>;
   using UnsharedListOfWeak = std::shared_ptr<ListOfWeak>;
 
   using AncestorList = butter::small_vector<
       std::pair<
-          std::reference_wrapper<ShadowNode const> /* parentNode */,
+          std::reference_wrapper<const ShadowNode> /* parentNode */,
           int /* childIndex */>,
       64>;
 
@@ -72,7 +72,7 @@ class ShadowNode : public Sealable,
    * Creates a Shadow Node based on fields specified in a `fragment`.
    */
   ShadowNode(
-      ShadowNodeFragment const &fragment,
+      const ShadowNodeFragment &fragment,
       ShadowNodeFamily::Shared family,
       ShadowNodeTraits traits);
 
@@ -88,8 +88,8 @@ class ShadowNode : public Sealable,
   /*
    * Not copyable.
    */
-  ShadowNode(ShadowNode const &shadowNode) noexcept = delete;
-  ShadowNode &operator=(ShadowNode const &other) noexcept = delete;
+  ShadowNode(const ShadowNode &shadowNode) noexcept = delete;
+  ShadowNode &operator=(const ShadowNode &other) noexcept = delete;
 
   virtual ~ShadowNode() override = default;
 
@@ -106,8 +106,8 @@ class ShadowNode : public Sealable,
    * Returns `nullptr` if the operation cannot be performed successfully.
    */
   Unshared cloneTree(
-      ShadowNodeFamily const &shadowNodeFamily,
-      std::function<Unshared(ShadowNode const &oldShadowNode)> const &callback)
+      const ShadowNodeFamily &shadowNodeFamily,
+      const std::function<Unshared(ShadowNode const &oldShadowNode)> &callback)
       const;
 
 #pragma mark - Getters
@@ -120,9 +120,9 @@ class ShadowNode : public Sealable,
    */
   ShadowNodeTraits getTraits() const;
 
-  Props::Shared const &getProps() const;
-  ListOfShared const &getChildren() const;
-  SharedEventEmitter const &getEventEmitter() const;
+  const Props::Shared &getProps() const;
+  const ListOfShared &getChildren() const;
+  const SharedEventEmitter &getEventEmitter() const;
   jsi::Value getInstanceHandle(jsi::Runtime &runtime) const;
   Tag getTag() const;
   SurfaceId getSurfaceId() const;
@@ -160,14 +160,14 @@ class ShadowNode : public Sealable,
 
   void sealRecursive() const;
 
-  ShadowNodeFamily const &getFamily() const;
+  const ShadowNodeFamily &getFamily() const;
 
 #pragma mark - Mutating Methods
 
-  virtual void appendChild(Shared const &child);
+  virtual void appendChild(const Shared &child);
   virtual void replaceChild(
-      ShadowNode const &oldChild,
-      Shared const &newChild,
+      const ShadowNode &oldChild,
+      const Shared &newChild,
       int32_t suggestedIndex = -1);
 
   /*
@@ -190,7 +190,7 @@ class ShadowNode : public Sealable,
    * is used and useful for debug-printing purposes *only*.
    * Do not access this value in any circumstances.
    */
-  int const revision_;
+  const int revision_;
 #endif
 
  protected:
@@ -216,8 +216,8 @@ class ShadowNode : public Sealable,
   mutable std::atomic<bool> hasBeenMounted_{false};
 
   static Props::Shared propsForClonedShadowNode(
-      ShadowNode const &sourceShadowNode,
-      Props::Shared const &props);
+      const ShadowNode &sourceShadowNode,
+      const Props::Shared &props);
 
  protected:
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
@@ -19,9 +19,9 @@ namespace facebook::react {
 using AncestorList = ShadowNode::AncestorList;
 
 ShadowNodeFamily::ShadowNodeFamily(
-    ShadowNodeFamilyFragment const &fragment,
+    const ShadowNodeFamilyFragment &fragment,
     EventDispatcher::Weak eventDispatcher,
-    ComponentDescriptor const &componentDescriptor)
+    const ComponentDescriptor &componentDescriptor)
     : eventDispatcher_(std::move(eventDispatcher)),
       tag_(fragment.tag),
       surfaceId_(fragment.surfaceId),
@@ -32,7 +32,7 @@ ShadowNodeFamily::ShadowNodeFamily(
       componentHandle_(componentDescriptor.getComponentHandle()),
       componentName_(componentDescriptor.getComponentName()) {}
 
-void ShadowNodeFamily::setParent(ShadowNodeFamily::Shared const &parent) const {
+void ShadowNodeFamily::setParent(const ShadowNodeFamily::Shared &parent) const {
   react_native_assert(parent_.lock() == nullptr || parent_.lock() == parent);
   if (hasParent_) {
     return;
@@ -63,8 +63,8 @@ const ComponentDescriptor &ShadowNodeFamily::getComponentDescriptor() const {
 }
 
 AncestorList ShadowNodeFamily::getAncestors(
-    ShadowNode const &ancestorShadowNode) const {
-  auto families = butter::small_vector<ShadowNodeFamily const *, 64>{};
+    const ShadowNode &ancestorShadowNode) const {
+  auto families = butter::small_vector<const ShadowNodeFamily *, 64>{};
   auto ancestorFamily = ancestorShadowNode.family_.get();
 
   auto family = this;
@@ -107,7 +107,7 @@ State::Shared ShadowNodeFamily::getMostRecentState() const {
   return mostRecentState_;
 }
 
-void ShadowNodeFamily::setMostRecentState(State::Shared const &state) const {
+void ShadowNodeFamily::setMostRecentState(const State::Shared &state) const {
   std::unique_lock lock(mutex_);
 
   /*
@@ -127,8 +127,8 @@ void ShadowNodeFamily::setMostRecentState(State::Shared const &state) const {
   mostRecentState_ = state;
 }
 
-std::shared_ptr<State const> ShadowNodeFamily::getMostRecentStateIfObsolete(
-    State const &state) const {
+std::shared_ptr<const State> ShadowNodeFamily::getMostRecentStateIfObsolete(
+    const State &state) const {
   std::unique_lock lock(mutex_);
   if (!state.isObsolete_) {
     return {};

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -35,9 +35,9 @@ class State;
  * retain ownership of them.
  */
 struct ShadowNodeFamilyFragment {
-  Tag const tag;
-  SurfaceId const surfaceId;
-  InstanceHandle::Shared const &instanceHandle;
+  const Tag tag;
+  const SurfaceId surfaceId;
+  const InstanceHandle::Shared &instanceHandle;
 };
 
 /*
@@ -46,26 +46,26 @@ struct ShadowNodeFamilyFragment {
  */
 class ShadowNodeFamily final {
  public:
-  using Shared = std::shared_ptr<ShadowNodeFamily const>;
-  using Weak = std::weak_ptr<ShadowNodeFamily const>;
+  using Shared = std::shared_ptr<const ShadowNodeFamily>;
+  using Weak = std::weak_ptr<const ShadowNodeFamily>;
 
   using AncestorList = butter::small_vector<
       std::pair<
-          std::reference_wrapper<ShadowNode const> /* parentNode */,
+          std::reference_wrapper<const ShadowNode> /* parentNode */,
           int /* childIndex */>,
       64>;
 
   ShadowNodeFamily(
-      ShadowNodeFamilyFragment const &fragment,
+      const ShadowNodeFamilyFragment &fragment,
       EventDispatcher::Weak eventDispatcher,
-      ComponentDescriptor const &componentDescriptor);
+      const ComponentDescriptor &componentDescriptor);
 
   /*
    * Sets the parent.
    * This is not technically thread-safe, but practically it mutates the object
    * only once (and the model enforces that this first call is not concurrent).
    */
-  void setParent(ShadowNodeFamily::Shared const &parent) const;
+  void setParent(const ShadowNodeFamily::Shared &parent) const;
 
   /*
    * Returns a handle (or name) associated with the component.
@@ -87,7 +87,7 @@ class ShadowNodeFamily final {
    * Can be called from any thread.
    * The theoretical complexity of the algorithm is `O(ln(n))`. Use it wisely.
    */
-  AncestorList getAncestors(ShadowNode const &ancestorShadowNode) const;
+  AncestorList getAncestors(const ShadowNode &ancestorShadowNode) const;
 
   SurfaceId getSurfaceId() const;
 
@@ -96,8 +96,8 @@ class ShadowNodeFamily final {
   /*
    * Sets and gets the most recent state.
    */
-  std::shared_ptr<State const> getMostRecentState() const;
-  void setMostRecentState(std::shared_ptr<State const> const &state) const;
+  std::shared_ptr<const State> getMostRecentState() const;
+  void setMostRecentState(const std::shared_ptr<State const> &state) const;
 
   /*
    * Dispatches a state update with given priority.
@@ -121,22 +121,22 @@ class ShadowNodeFamily final {
    * otherwise returns `nullptr`.
    * To be used by `State` only.
    */
-  std::shared_ptr<State const> getMostRecentStateIfObsolete(
-      State const &state) const;
+  std::shared_ptr<const State> getMostRecentStateIfObsolete(
+      const State &state) const;
 
   EventDispatcher::Weak eventDispatcher_;
-  mutable std::shared_ptr<State const> mostRecentState_;
+  mutable std::shared_ptr<const State> mostRecentState_;
   mutable std::shared_mutex mutex_;
 
   /*
    * Deprecated.
    */
-  Tag const tag_;
+  const Tag tag_;
 
   /*
    * Identifier of a running Surface instance.
    */
-  SurfaceId const surfaceId_;
+  const SurfaceId surfaceId_;
 
   /*
    * Weak reference to the React instance handle
@@ -146,13 +146,13 @@ class ShadowNodeFamily final {
   /*
    * `EventEmitter` associated with all nodes of the family.
    */
-  SharedEventEmitter const eventEmitter_;
+  const SharedEventEmitter eventEmitter_;
 
   /*
    * Reference to a concrete `ComponentDescriptor` that manages nodes of this
    * type.
    */
-  ComponentDescriptor const &componentDescriptor_;
+  const ComponentDescriptor &componentDescriptor_;
 
   /*
    * ComponentHandle and ComponentName must be stored (cached) inside the object

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.cpp
@@ -9,25 +9,25 @@
 
 namespace facebook::react {
 
-Props::Shared const &ShadowNodeFragment::propsPlaceholder() {
+const Props::Shared &ShadowNodeFragment::propsPlaceholder() {
   static auto &instance = *new Props::Shared();
   return instance;
 }
 
-ShadowNode::SharedListOfShared const &
+const ShadowNode::SharedListOfShared &
 ShadowNodeFragment::childrenPlaceholder() {
   static auto &instance = *new ShadowNode::SharedListOfShared();
   return instance;
 }
 
-State::Shared const &ShadowNodeFragment::statePlaceholder() {
+const State::Shared &ShadowNodeFragment::statePlaceholder() {
   static auto &instance = *new State::Shared();
   return instance;
 }
 
 using Value = ShadowNodeFragment::Value;
 
-Value::Value(ShadowNodeFragment const &fragment)
+Value::Value(const ShadowNodeFragment &fragment)
     : props(fragment.props),
       children(fragment.children),
       state(fragment.state) {}

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
@@ -25,18 +25,18 @@ namespace facebook::react {
  * fragment content to store or pass the data asynchronously.
  */
 struct ShadowNodeFragment {
-  Props::Shared const &props = propsPlaceholder();
-  ShadowNode::SharedListOfShared const &children = childrenPlaceholder();
-  State::Shared const &state = statePlaceholder();
+  const Props::Shared &props = propsPlaceholder();
+  const ShadowNode::SharedListOfShared &children = childrenPlaceholder();
+  const State::Shared &state = statePlaceholder();
 
   /*
    * Placeholders.
    * Use as default arguments as an indication that the field does not need to
    * be changed.
    */
-  static Props::Shared const &propsPlaceholder();
-  static ShadowNode::SharedListOfShared const &childrenPlaceholder();
-  static State::Shared const &statePlaceholder();
+  static const Props::Shared &propsPlaceholder();
+  static const ShadowNode::SharedListOfShared &childrenPlaceholder();
+  static const State::Shared &statePlaceholder();
 
   /*
    * `ShadowNodeFragment` is not owning data-structure, it only stores raw
@@ -48,7 +48,7 @@ struct ShadowNodeFragment {
     /*
      * Creates an object with given `ShadowNodeFragment`.
      */
-    Value(ShadowNodeFragment const &fragment);
+    Value(const ShadowNodeFragment &fragment);
 
     /*
      * Creates a `ShadowNodeFragment` from the object.

--- a/packages/react-native/ReactCommon/react/renderer/core/State.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.cpp
@@ -16,12 +16,12 @@
 
 namespace facebook::react {
 
-State::State(StateData::Shared data, State const &state)
+State::State(StateData::Shared data, const State &state)
     : family_(state.family_),
       data_(std::move(data)),
       revision_(state.revision_ + 1){};
 
-State::State(StateData::Shared data, ShadowNodeFamily::Shared const &family)
+State::State(StateData::Shared data, const ShadowNodeFamily::Shared &family)
     : family_(family),
       data_(std::move(data)),
       revision_{State::initialRevisionValue} {};

--- a/packages/react-native/ReactCommon/react/renderer/core/State.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.h
@@ -33,10 +33,10 @@ class State {
    * Constructors are protected to make calling them directly with
    * type-erasured arguments impossible.
    */
-  explicit State(StateData::Shared data, State const &state);
+  explicit State(StateData::Shared data, const State &state);
   explicit State(
       StateData::Shared data,
-      ShadowNodeFamily::Shared const &family);
+      const ShadowNodeFamily::Shared &family);
 
  public:
   virtual ~State() = default;
@@ -78,7 +78,7 @@ class State {
    * Returns a shared pointer to data.
    * To be used by `UIManager` only.
    */
-  StateData::Shared const &getDataPointer() const {
+  const StateData::Shared &getDataPointer() const {
     return data_;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/StateData.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StateData.h
@@ -22,11 +22,11 @@ namespace facebook::react {
  * don't have a state.
  */
 struct StateData final {
-  using Shared = std::shared_ptr<void const>;
+  using Shared = std::shared_ptr<const void>;
 
 #ifdef ANDROID
   StateData() = default;
-  StateData(StateData const &previousState, folly::dynamic data) {}
+  StateData(const StateData &previousState, folly::dynamic data) {}
   folly::dynamic getDynamic() const;
   MapBuffer getMapBuffer() const;
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/core/StatePipe.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StatePipe.h
@@ -13,6 +13,6 @@
 
 namespace facebook::react {
 
-using StatePipe = std::function<void(StateUpdate const &stateUpdate)>;
+using StatePipe = std::function<void(const StateUpdate &stateUpdate)>;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/StateUpdate.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StateUpdate.h
@@ -14,12 +14,12 @@
 namespace facebook::react {
 
 class ShadowNodeFamily;
-using SharedShadowNodeFamily = std::shared_ptr<ShadowNodeFamily const>;
+using SharedShadowNodeFamily = std::shared_ptr<const ShadowNodeFamily>;
 
 class StateUpdate {
  public:
   using Callback =
-      std::function<StateData::Shared(StateData::Shared const &data)>;
+      std::function<StateData::Shared(const StateData::Shared &data)>;
   using FailureCallback = std::function<void()>;
 
   SharedShadowNodeFamily family;

--- a/packages/react-native/ReactCommon/react/renderer/core/TraitCast.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/TraitCast.h
@@ -55,7 +55,7 @@ namespace facebook::react {
 // Cast from one ShadowNode reference to another, terminating if the cast is
 // invalid.
 template <typename ShadowNodeReferenceT>
-ShadowNodeReferenceT traitCast(ShadowNode const &shadowNode) {
+ShadowNodeReferenceT traitCast(const ShadowNode &shadowNode) {
   return details::traitCastRef<ShadowNodeReferenceT>(shadowNode);
 }
 template <typename ShadowNodeReferenceT>
@@ -66,7 +66,7 @@ ShadowNodeReferenceT traitCast(ShadowNode &shadowNode) {
 // Cast from one ShadowNode pointer to another, returning nullptr if the cast is
 // invalid.
 template <typename ShadowNodePointerT>
-ShadowNodePointerT traitCast(ShadowNode const *shadowNode) {
+ShadowNodePointerT traitCast(const ShadowNode *shadowNode) {
   return details::traitCastPointer<ShadowNodePointerT>(shadowNode);
 }
 template <typename ShadowNodePointerT>
@@ -82,9 +82,9 @@ std::shared_ptr<ShadowNodeT> traitCast(
   return details::traitCastShared<ShadowNodeT>(shadowNode);
 }
 template <typename ShadowNodeT, typename ParamT>
-std::shared_ptr<ShadowNodeT const> traitCast(
-    const std::shared_ptr<ParamT const> &shadowNode) {
-  return details::traitCastShared<ShadowNodeT const>(shadowNode);
+std::shared_ptr<const ShadowNodeT> traitCast(
+    const std::shared_ptr<const ParamT> &shadowNode) {
+  return details::traitCastShared<const ShadowNodeT>(shadowNode);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -26,7 +26,7 @@ namespace facebook::react {
 template <typename T>
 void fromRawValue(
     const PropsParserContext &context,
-    RawValue const &rawValue,
+    const RawValue &rawValue,
     T &result,
     T defaultValue) {
   if (!rawValue.hasValue()) {
@@ -40,7 +40,7 @@ void fromRawValue(
 template <typename T>
 void fromRawValue(
     const PropsParserContext &context,
-    RawValue const &rawValue,
+    const RawValue &rawValue,
     T &result) {
   result = (T)rawValue;
 }
@@ -48,7 +48,7 @@ void fromRawValue(
 template <typename T>
 void fromRawValue(
     const PropsParserContext &context,
-    RawValue const &rawValue,
+    const RawValue &rawValue,
     std::optional<T> &result) {
   T resultValue;
   fromRawValue(context, rawValue, resultValue);
@@ -58,7 +58,7 @@ void fromRawValue(
 template <typename T>
 void fromRawValue(
     const PropsParserContext &context,
-    RawValue const &rawValue,
+    const RawValue &rawValue,
     std::vector<T> &result) {
   if (rawValue.hasType<std::vector<RawValue>>()) {
     auto items = (std::vector<RawValue>)rawValue;
@@ -84,7 +84,7 @@ void fromRawValue(
 template <typename T>
 void fromRawValue(
     const PropsParserContext &context,
-    RawValue const &rawValue,
+    const RawValue &rawValue,
     std::vector<std::vector<T>> &result) {
   if (rawValue.hasType<std::vector<std::vector<RawValue>>>()) {
     auto items = (std::vector<std::vector<RawValue>>)rawValue;
@@ -110,12 +110,12 @@ void fromRawValue(
 template <typename T, typename U = T>
 T convertRawProp(
     const PropsParserContext &context,
-    RawProps const &rawProps,
-    char const *name,
+    const RawProps &rawProps,
+    const char *name,
     T const &sourceValue,
     U const &defaultValue,
-    char const *namePrefix = nullptr,
-    char const *nameSuffix = nullptr) {
+    const char *namePrefix = nullptr,
+    const char *nameSuffix = nullptr) {
   const auto *rawValue = rawProps.at(name, namePrefix, nameSuffix);
   if (LIKELY(rawValue == nullptr)) {
     return sourceValue;

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
@@ -14,7 +14,7 @@
 using namespace facebook::react;
 
 TEST(ComponentDescriptorTest, createShadowNode) {
-  auto eventDispatcher = std::shared_ptr<EventDispatcher const>();
+  auto eventDispatcher = std::shared_ptr<const EventDispatcher>();
   SharedComponentDescriptor descriptor =
       std::make_shared<TestComponentDescriptor>(
           ComponentDescriptorParameters{eventDispatcher, nullptr, nullptr});
@@ -50,7 +50,7 @@ TEST(ComponentDescriptorTest, createShadowNode) {
 }
 
 TEST(ComponentDescriptorTest, cloneShadowNode) {
-  auto eventDispatcher = std::shared_ptr<EventDispatcher const>();
+  auto eventDispatcher = std::shared_ptr<const EventDispatcher>();
   SharedComponentDescriptor descriptor =
       std::make_shared<TestComponentDescriptor>(
           ComponentDescriptorParameters{eventDispatcher, nullptr, nullptr});
@@ -83,7 +83,7 @@ TEST(ComponentDescriptorTest, cloneShadowNode) {
 }
 
 TEST(ComponentDescriptorTest, appendChild) {
-  auto eventDispatcher = std::shared_ptr<EventDispatcher const>();
+  auto eventDispatcher = std::shared_ptr<const EventDispatcher>();
   SharedComponentDescriptor descriptor =
       std::make_shared<TestComponentDescriptor>(
           ComponentDescriptorParameters{eventDispatcher, nullptr, nullptr});

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
@@ -33,7 +33,7 @@ class EventQueueProcessorTest : public testing::Test {
     };
 
     auto dummyEventPipeConclusion = [](jsi::Runtime &runtime) {};
-    auto dummyStatePipe = [](StateUpdate const &stateUpdate) {};
+    auto dummyStatePipe = [](const StateUpdate &stateUpdate) {};
 
     eventProcessor_ = std::make_unique<EventQueueProcessor>(
         eventPipe, dummyEventPipeConclusion, dummyStatePipe);

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -18,7 +18,7 @@ using namespace facebook::react;
 class ShadowNodeTest : public ::testing::Test {
  protected:
   ShadowNodeTest()
-      : eventDispatcher_(std::shared_ptr<EventDispatcher const>()),
+      : eventDispatcher_(std::shared_ptr<const EventDispatcher>()),
         componentDescriptor_(TestComponentDescriptor({eventDispatcher_})) {
     /*
      * The structure:
@@ -156,7 +156,7 @@ class ShadowNodeTest : public ::testing::Test {
         traits);
   }
 
-  std::shared_ptr<EventDispatcher const> eventDispatcher_;
+  std::shared_ptr<const EventDispatcher> eventDispatcher_;
   std::shared_ptr<TestShadowNode> nodeA_;
   std::shared_ptr<TestShadowNode> nodeAA_;
   std::shared_ptr<TestShadowNode> nodeABA_;
@@ -247,7 +247,7 @@ TEST_F(ShadowNodeTest, handleState) {
 
   auto props = std::make_shared<const TestProps>();
 
-  auto const initialState =
+  const auto initialState =
       componentDescriptor_.createInitialState(props, family);
 
   auto firstNode = std::make_shared<TestShadowNode>(

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/TestComponent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/TestComponent.h
@@ -35,7 +35,7 @@ struct TestState {
   TestState() = default;
 
 #ifdef ANDROID
-  TestState(TestState const &previousState, folly::dynamic &&data){};
+  TestState(const TestState &previousState, folly::dynamic &&data){};
 
   folly::dynamic getDynamic() const {
     return {};

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/benchmarks/RawPropsBenchmark.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/benchmarks/RawPropsBenchmark.cpp
@@ -17,7 +17,7 @@
 
 namespace facebook::react {
 
-auto contextContainer = std::make_shared<ContextContainer const>();
+auto contextContainer = std::make_shared<const ContextContainer>();
 auto eventDispatcher = std::shared_ptr<EventDispatcher>{nullptr};
 auto viewComponentDescriptor = ViewComponentDescriptor{
     ComponentDescriptorParameters{eventDispatcher, contextContainer}};

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/traitCastTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/traitCastTest.cpp
@@ -53,21 +53,21 @@ TEST(traitCastTest, testOne) {
 
   // Casting `nullptr` returns `nullptrs`.
   ShadowNode *nullShadowNode = nullptr;
-  EXPECT_FALSE(traitCast<LayoutableShadowNode const *>(nullShadowNode));
-  EXPECT_FALSE(traitCast<YogaLayoutableShadowNode const *>(nullShadowNode));
-  EXPECT_FALSE(traitCast<LayoutableShadowNode const *>(nullShadowNode));
+  EXPECT_FALSE(traitCast<const LayoutableShadowNode *>(nullShadowNode));
+  EXPECT_FALSE(traitCast<const YogaLayoutableShadowNode *>(nullShadowNode));
+  EXPECT_FALSE(traitCast<const LayoutableShadowNode *>(nullShadowNode));
   EXPECT_FALSE(traitCast<LayoutableShadowNode *>(nullShadowNode));
   EXPECT_FALSE(traitCast<LayoutableShadowNode>(
       std::shared_ptr<ShadowNode>(nullShadowNode)));
 
   // `ViewShadowNode` is `LayoutableShadowNode` and `YogaLayoutableShadowNode`.
-  EXPECT_TRUE(traitCast<LayoutableShadowNode const *>(viewShadowNode.get()));
+  EXPECT_TRUE(traitCast<const LayoutableShadowNode *>(viewShadowNode.get()));
   EXPECT_TRUE(
-      traitCast<YogaLayoutableShadowNode const *>(viewShadowNode.get()));
+      traitCast<const YogaLayoutableShadowNode *>(viewShadowNode.get()));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<LayoutableShadowNode const &>(*viewShadowNode));
+      traitCast<const LayoutableShadowNode &>(*viewShadowNode));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<YogaLayoutableShadowNode const &>(*viewShadowNode));
+      traitCast<const YogaLayoutableShadowNode &>(*viewShadowNode));
   EXPECT_NO_FATAL_FAILURE(
       traitCast<YogaLayoutableShadowNode &>(*viewShadowNode));
   EXPECT_TRUE(traitCast<LayoutableShadowNode *>(viewShadowNode.get()));
@@ -76,71 +76,71 @@ TEST(traitCastTest, testOne) {
   // `ScrollViewShadowNode` is `LayoutableShadowNode` and
   // `YogaLayoutableShadowNode`.
   EXPECT_TRUE(
-      traitCast<LayoutableShadowNode const *>(scrollViewShadowNode.get()));
+      traitCast<const LayoutableShadowNode *>(scrollViewShadowNode.get()));
   EXPECT_TRUE(
-      traitCast<YogaLayoutableShadowNode const *>(scrollViewShadowNode.get()));
+      traitCast<const YogaLayoutableShadowNode *>(scrollViewShadowNode.get()));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<LayoutableShadowNode const &>(*scrollViewShadowNode));
+      traitCast<const LayoutableShadowNode &>(*scrollViewShadowNode));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<YogaLayoutableShadowNode const &>(*scrollViewShadowNode));
+      traitCast<const YogaLayoutableShadowNode &>(*scrollViewShadowNode));
 
   // `ParagraphShadowNode` is `LayoutableShadowNode` and
   // `YogaLayoutableShadowNode`.
   EXPECT_TRUE(
-      traitCast<LayoutableShadowNode const *>(paragraphShadowNode.get()));
+      traitCast<const LayoutableShadowNode *>(paragraphShadowNode.get()));
   EXPECT_TRUE(
-      traitCast<YogaLayoutableShadowNode const *>(paragraphShadowNode.get()));
+      traitCast<const YogaLayoutableShadowNode *>(paragraphShadowNode.get()));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<LayoutableShadowNode const &>(*paragraphShadowNode));
+      traitCast<const LayoutableShadowNode &>(*paragraphShadowNode));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<YogaLayoutableShadowNode const &>(*paragraphShadowNode));
+      traitCast<const YogaLayoutableShadowNode &>(*paragraphShadowNode));
 
   // `TextShadowNode` is *not* `LayoutableShadowNode` nor
   // `YogaLayoutableShadowNode`.
-  EXPECT_FALSE(traitCast<LayoutableShadowNode const *>(textShadowNode.get()));
+  EXPECT_FALSE(traitCast<const LayoutableShadowNode *>(textShadowNode.get()));
   EXPECT_FALSE(
-      traitCast<YogaLayoutableShadowNode const *>(textShadowNode.get()));
+      traitCast<const YogaLayoutableShadowNode *>(textShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<LayoutableShadowNode const &>(*textShadowNode), "");
+      traitCast<const LayoutableShadowNode &>(*textShadowNode), "");
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<YogaLayoutableShadowNode const &>(*textShadowNode), "");
+      traitCast<const YogaLayoutableShadowNode &>(*textShadowNode), "");
 
   // `RawTextShadowNode` is *not* `LayoutableShadowNode` nor
   // `YogaLayoutableShadowNode`.
   EXPECT_FALSE(
-      traitCast<LayoutableShadowNode const *>(rawTextShadowNode.get()));
+      traitCast<const LayoutableShadowNode *>(rawTextShadowNode.get()));
   EXPECT_FALSE(
-      traitCast<YogaLayoutableShadowNode const *>(rawTextShadowNode.get()));
+      traitCast<const YogaLayoutableShadowNode *>(rawTextShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<LayoutableShadowNode const &>(*rawTextShadowNode), "");
+      traitCast<const LayoutableShadowNode &>(*rawTextShadowNode), "");
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<YogaLayoutableShadowNode const &>(*rawTextShadowNode), "");
+      traitCast<const YogaLayoutableShadowNode &>(*rawTextShadowNode), "");
 
   // trait cast to `RawTextShadowNode` works on `RawTextShadowNode`
   // and not on TextShadowNode or ViewShadowNode
-  EXPECT_TRUE(traitCast<RawTextShadowNode const *>(
+  EXPECT_TRUE(traitCast<const RawTextShadowNode *>(
       shadowNodeForRawTextShadowNode.get()));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<RawTextShadowNode const &>(*shadowNodeForRawTextShadowNode));
+      traitCast<const RawTextShadowNode &>(*shadowNodeForRawTextShadowNode));
   EXPECT_FALSE(
-      traitCast<RawTextShadowNode const *>(shadowNodeForTextShadowNode.get()));
+      traitCast<const RawTextShadowNode *>(shadowNodeForTextShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<RawTextShadowNode const &>(*shadowNodeForTextShadowNode), "");
-  EXPECT_FALSE(traitCast<RawTextShadowNode const *>(viewShadowNode.get()));
+      traitCast<const RawTextShadowNode &>(*shadowNodeForTextShadowNode), "");
+  EXPECT_FALSE(traitCast<const RawTextShadowNode *>(viewShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<RawTextShadowNode const &>(*viewShadowNode), "");
+      traitCast<const RawTextShadowNode &>(*viewShadowNode), "");
 
   // trait cast to `TextShadowNode` works on `TextShadowNode`
   // and not on RawTextShadowNode or ViewShadowNode
   EXPECT_TRUE(
-      traitCast<TextShadowNode const *>(shadowNodeForTextShadowNode.get()));
+      traitCast<const TextShadowNode *>(shadowNodeForTextShadowNode.get()));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<TextShadowNode const &>(*shadowNodeForTextShadowNode));
+      traitCast<const TextShadowNode &>(*shadowNodeForTextShadowNode));
   EXPECT_FALSE(
-      traitCast<TextShadowNode const *>(shadowNodeForRawTextShadowNode.get()));
+      traitCast<const TextShadowNode *>(shadowNodeForRawTextShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<TextShadowNode const &>(*shadowNodeForRawTextShadowNode), "");
-  EXPECT_FALSE(traitCast<TextShadowNode const *>(viewShadowNode.get()));
+      traitCast<const TextShadowNode &>(*shadowNodeForRawTextShadowNode), "");
+  EXPECT_FALSE(traitCast<const TextShadowNode *>(viewShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<TextShadowNode const &>(*viewShadowNode), "");
+      traitCast<const TextShadowNode &>(*viewShadowNode), "");
 }

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.cpp
@@ -25,7 +25,7 @@ std::string DebugStringConvertible::getDebugChildrenDescription(
   auto trailing = options.format ? std::string{"\n"} : std::string{""};
   std::string childrenString;
 
-  for (auto const &child : getDebugChildren()) {
+  for (const auto &child : getDebugChildren()) {
     if (!child) {
       continue;
     }
@@ -51,7 +51,7 @@ std::string DebugStringConvertible::getDebugPropsDescription(
 
   std::string propsString;
 
-  for (auto const &prop : getDebugProps()) {
+  for (const auto &prop : getDebugProps()) {
     if (!prop) {
       continue;
     }
@@ -125,22 +125,22 @@ SharedDebugStringConvertibleList DebugStringConvertible::getDebugProps() const {
 /*
  * `toString`-family implementation.
  */
-std::string toString(std::string const &value) {
+std::string toString(const std::string &value) {
   return value;
 }
-std::string toString(int const &value) {
+std::string toString(const int &value) {
   return folly::to<std::string>(value);
 }
-std::string toString(bool const &value) {
+std::string toString(const bool &value) {
   return folly::to<std::string>(value);
 }
-std::string toString(float const &value) {
+std::string toString(const float &value) {
   return folly::to<std::string>(value);
 }
-std::string toString(double const &value) {
+std::string toString(const double &value) {
   return folly::to<std::string>(value);
 }
-std::string toString(void const *value) {
+std::string toString(const void *value) {
   if (value == nullptr) {
     return "null";
   }

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -92,12 +92,12 @@ class DebugStringConvertible {};
  * Set of particular-format-opinionated functions that convert base types to
  * `std::string`; practically incapsulate `folly:to<>` and `folly::format`.
  */
-std::string toString(std::string const &value);
-std::string toString(int const &value);
-std::string toString(bool const &value);
-std::string toString(float const &value);
-std::string toString(double const &value);
-std::string toString(void const *value);
+std::string toString(const std::string &value);
+std::string toString(const int &value);
+std::string toString(const bool &value);
+std::string toString(const float &value);
+std::string toString(const double &value);
+std::string toString(const void *value);
 
 template <typename T>
 std::string toString(const std::optional<T> &value) {
@@ -291,36 +291,36 @@ inline std::string getDebugDescription(
 
 // `std::string`
 inline std::string getDebugDescription(
-    std::string const &string,
+    const std::string &string,
     DebugStringConvertibleOptions options) {
   return string;
 }
 
 // `std::vector<T>`
 template <typename T, typename... Ts>
-std::string getDebugName(std::vector<T, Ts...> const &vector) {
+std::string getDebugName(const std::vector<T, Ts...> &vector) {
   return "List";
 }
 
 template <typename T, typename... Ts>
 std::vector<T, Ts...> getDebugChildren(
-    std::vector<T, Ts...> const &vector,
+    const std::vector<T, Ts...> &vector,
     DebugStringConvertibleOptions options) {
   return vector;
 }
 
 // `std::array<T, Size>`
 template <typename T, size_t Size>
-std::string getDebugName(std::array<T, Size> const &array) {
+std::string getDebugName(const std::array<T, Size> &array) {
   return "List";
 }
 
 template <typename T, size_t Size>
 std::vector<T> getDebugChildren(
-    std::array<T, Size> const &array,
+    const std::array<T, Size> &array,
     DebugStringConvertibleOptions options) {
   auto vector = std::vector<T>{};
-  for (auto const &value : array) {
+  for (const auto &value : array) {
     vector.push_back(value);
   }
   return vector;
@@ -328,13 +328,13 @@ std::vector<T> getDebugChildren(
 
 // `std::unordered_set<T>`
 template <typename T, typename... Ts>
-std::string getDebugName(std::unordered_set<T, Ts...> const &set) {
+std::string getDebugName(const std::unordered_set<T, Ts...> &set) {
   return "Set";
 }
 
 template <typename T, typename... Ts>
 std::vector<T> getDebugChildren(
-    std::unordered_set<T, Ts...> const &set,
+    const std::unordered_set<T, Ts...> &set,
     DebugStringConvertibleOptions options) {
   auto vector = std::vector<T>{};
   vector.insert(vector.end(), set.begin(), set.end());
@@ -344,7 +344,7 @@ std::vector<T> getDebugChildren(
 // `std::shared_ptr<T>`
 template <typename T>
 inline std::string getDebugDescription(
-    std::shared_ptr<T> const &pointer,
+    const std::shared_ptr<T> &pointer,
     DebugStringConvertibleOptions options) {
   return getDebugDescription((void *)pointer.get(), options) + "(shared)";
 }
@@ -352,7 +352,7 @@ inline std::string getDebugDescription(
 // `std::weak_ptr<T>`
 template <typename T>
 inline std::string getDebugDescription(
-    std::weak_ptr<T> const &pointer,
+    const std::weak_ptr<T> &pointer,
     DebugStringConvertibleOptions options) {
   return getDebugDescription((void *)pointer.lock().get(), options) + "(weak)";
 }
@@ -360,7 +360,7 @@ inline std::string getDebugDescription(
 // `std::unique_ptr<T>`
 template <typename T>
 inline std::string getDebugDescription(
-    std::unique_ptr<T const> const &pointer,
+    const std::unique_ptr<T const> &pointer,
     DebugStringConvertibleOptions options) {
   return getDebugDescription((void *)pointer.get(), options) + "(unique)";
 }
@@ -374,11 +374,11 @@ struct DebugStringConvertibleObject {
   std::string value;
 };
 
-inline std::string getDebugName(DebugStringConvertibleObject const &object) {
+inline std::string getDebugName(const DebugStringConvertibleObject &object) {
   return object.name;
 }
 
-inline std::string getDebugValue(DebugStringConvertibleObject const &object) {
+inline std::string getDebugValue(const DebugStringConvertibleObject &object) {
   return object.value;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.cpp
@@ -16,13 +16,13 @@ ComponentBuilder::ComponentBuilder(
     : componentDescriptorRegistry_(std::move(componentDescriptorRegistry)){};
 
 ShadowNode::Unshared ComponentBuilder::build(
-    ElementFragment const &elementFragment) const {
+    const ElementFragment &elementFragment) const {
   auto &componentDescriptor =
       componentDescriptorRegistry_->at(elementFragment.componentHandle);
 
   auto children = ShadowNode::ListOfShared{};
   children.reserve(elementFragment.children.size());
-  for (auto const &childFragment : elementFragment.children) {
+  for (const auto &childFragment : elementFragment.children) {
     children.push_back(build(childFragment));
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.h
@@ -30,9 +30,9 @@ class ComponentBuilder final {
   /*
    * Copyable and movable.
    */
-  ComponentBuilder(ComponentBuilder const &componentBuilder) = default;
+  ComponentBuilder(const ComponentBuilder &componentBuilder) = default;
   ComponentBuilder(ComponentBuilder &&componentBuilder) noexcept = default;
-  ComponentBuilder &operator=(ComponentBuilder const &other) = default;
+  ComponentBuilder &operator=(const ComponentBuilder &other) = default;
   ComponentBuilder &operator=(ComponentBuilder &&other) = default;
 
   /*
@@ -48,7 +48,7 @@ class ComponentBuilder final {
   /*
    * Internal, type-erased version of `build`.
    */
-  ShadowNode::Unshared build(ElementFragment const &elementFragment) const;
+  ShadowNode::Unshared build(const ElementFragment &elementFragment) const;
 
   ComponentDescriptorRegistry::Shared componentDescriptorRegistry_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/element/Element.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/Element.h
@@ -30,15 +30,15 @@ template <typename ShadowNodeT>
 class Element final {
  public:
   using ConcreteProps = typename ShadowNodeT::ConcreteProps;
-  using SharedConcreteProps = std::shared_ptr<ConcreteProps const>;
+  using SharedConcreteProps = std::shared_ptr<const ConcreteProps>;
   using ConcreteState = typename ShadowNodeT::ConcreteState;
   using ConcreteStateData = typename ShadowNodeT::ConcreteStateData;
-  using SharedConcreteState = std::shared_ptr<ConcreteState const>;
+  using SharedConcreteState = std::shared_ptr<const ConcreteState>;
   using ConcreteShadowNode = ShadowNodeT;
   using ConcreteUnsharedShadowNode = std::shared_ptr<ConcreteShadowNode>;
 
   using ConcreteReferenceCallback =
-      std::function<void(std::shared_ptr<ShadowNodeT const> const &shadowNode)>;
+      std::function<void(const std::shared_ptr<ShadowNodeT const> &shadowNode)>;
 
   /*
    * Constructs an `Element`.
@@ -94,7 +94,7 @@ class Element final {
   Element &stateData(std::function<void(ConcreteStateData &)> callback) {
     fragment_.stateCallback =
         [callback = std::move(callback)](
-            State::Shared const &state) -> StateData::Shared {
+            const State::Shared &state) -> StateData::Shared {
       auto stateData =
           static_cast<ConcreteState const *>(state.get())->getData();
       callback(stateData);
@@ -109,7 +109,7 @@ class Element final {
   Element &children(std::vector<ElementFragment> children) {
     auto fragments = ElementFragment::List{};
     fragments.reserve(children.size());
-    for (auto const &child : children) {
+    for (const auto &child : children) {
       fragments.push_back(child);
     }
     fragment_.children = fragments;
@@ -121,10 +121,10 @@ class Element final {
    * component which is being constructed.
    */
   Element &reference(
-      std::function<void(ConcreteUnsharedShadowNode const &shadowNode)>
+      std::function<void(const ConcreteUnsharedShadowNode &shadowNode)>
           callback) {
     fragment_.referenceCallback =
-        [callback = std::move(callback)](ShadowNode::Shared const &shadowNode) {
+        [callback = std::move(callback)](const ShadowNode::Shared &shadowNode) {
           callback(std::const_pointer_cast<ConcreteShadowNode>(
               std::static_pointer_cast<ConcreteShadowNode const>(shadowNode)));
         };
@@ -136,7 +136,7 @@ class Element final {
    * that is being constructed.
    */
   Element &reference(ConcreteUnsharedShadowNode &outShadowNode) {
-    fragment_.referenceCallback = [&](ShadowNode::Shared const &shadowNode) {
+    fragment_.referenceCallback = [&](const ShadowNode::Shared &shadowNode) {
       outShadowNode = std::const_pointer_cast<ConcreteShadowNode>(
           std::static_pointer_cast<ConcreteShadowNode const>(shadowNode));
     };

--- a/packages/react-native/ReactCommon/react/renderer/element/ElementFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/ElementFragment.h
@@ -27,10 +27,10 @@ class ElementFragment final {
   using List = std::vector<ElementFragment>;
   using ListOfShared = std::vector<Shared>;
   using ReferenceCallback =
-      std::function<void(ShadowNode::Unshared const &shadowNode)>;
+      std::function<void(const ShadowNode::Unshared &shadowNode)>;
   using FinalizeCallback = std::function<void(ShadowNode &shadowNode)>;
   using StateCallback =
-      std::function<StateData::Shared(State::Shared const &state)>;
+      std::function<StateData::Shared(const State::Shared &state)>;
 
   /*
    * ComponentDescriptor part (describes the type)

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
@@ -9,7 +9,7 @@
 
 namespace facebook::react {
 
-bool isColorMeaningful(SharedColor const &color) noexcept {
+bool isColorMeaningful(const SharedColor &color) noexcept {
   if (!color) {
     return false;
   }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -51,7 +51,7 @@ class SharedColor {
   Color color_;
 };
 
-bool isColorMeaningful(SharedColor const &color) noexcept;
+bool isColorMeaningful(const SharedColor &color) noexcept;
 SharedColor colorFromComponents(ColorComponents components);
 ColorComponents colorComponentsFromColor(SharedColor color);
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
@@ -21,38 +21,38 @@ struct Point {
   Float x{0};
   Float y{0};
 
-  Point &operator+=(Point const &point) noexcept {
+  Point &operator+=(const Point &point) noexcept {
     x += point.x;
     y += point.y;
     return *this;
   }
 
-  Point &operator-=(Point const &point) noexcept {
+  Point &operator-=(const Point &point) noexcept {
     x -= point.x;
     y -= point.y;
     return *this;
   }
 
-  Point &operator*=(Point const &point) noexcept {
+  Point &operator*=(const Point &point) noexcept {
     x *= point.x;
     y *= point.y;
     return *this;
   }
 
-  friend Point operator+(Point lhs, Point const &rhs) noexcept {
+  friend Point operator+(Point lhs, const Point &rhs) noexcept {
     return lhs += rhs;
   }
 
-  friend Point operator-(Point lhs, Point const &rhs) noexcept {
+  friend Point operator-(Point lhs, const Point &rhs) noexcept {
     return lhs -= rhs;
   }
 };
 
-inline bool operator==(Point const &rhs, Point const &lhs) noexcept {
+inline bool operator==(const Point &rhs, const Point &lhs) noexcept {
   return std::tie(lhs.x, lhs.y) == std::tie(rhs.x, rhs.y);
 }
 
-inline bool operator!=(Point const &rhs, Point const &lhs) noexcept {
+inline bool operator!=(const Point &rhs, const Point &lhs) noexcept {
   return !(lhs == rhs);
 }
 
@@ -62,7 +62,7 @@ namespace std {
 
 template <>
 struct hash<facebook::react::Point> {
-  size_t operator()(facebook::react::Point const &point) const noexcept {
+  size_t operator()(const facebook::react::Point &point) const noexcept {
     return folly::hash::hash_combine(0, point.x, point.y);
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
@@ -24,11 +24,11 @@ struct Rect {
   Point origin{0, 0};
   Size size{0, 0};
 
-  bool operator==(Rect const &rhs) const noexcept {
+  bool operator==(const Rect &rhs) const noexcept {
     return std::tie(this->origin, this->size) == std::tie(rhs.origin, rhs.size);
   }
 
-  bool operator!=(Rect const &rhs) const noexcept {
+  bool operator!=(const Rect &rhs) const noexcept {
     return !(*this == rhs);
   }
 
@@ -54,7 +54,7 @@ struct Rect {
     return {getMidX(), getMidY()};
   }
 
-  void unionInPlace(Rect const &rect) noexcept {
+  void unionInPlace(const Rect &rect) noexcept {
     auto x1 = std::min(getMinX(), rect.getMinX());
     auto y1 = std::min(getMinY(), rect.getMinY());
     auto x2 = std::max(getMaxX(), rect.getMaxX());
@@ -69,7 +69,7 @@ struct Rect {
         point.y <= (origin.y + size.height);
   }
 
-  static Rect intersect(Rect const &rect1, Rect const &rect2) {
+  static Rect intersect(const Rect &rect1, const Rect &rect2) {
     Float x1 = std::max(rect1.origin.x, rect2.origin.x);
     Float y1 = std::max(rect1.origin.y, rect2.origin.y);
     Float x2 = std::min(
@@ -88,10 +88,10 @@ struct Rect {
   }
 
   static Rect boundingRect(
-      Point const &a,
-      Point const &b,
-      Point const &c,
-      Point const &d) noexcept {
+      const Point &a,
+      const Point &b,
+      const Point &c,
+      const Point &d) noexcept {
     auto leftTopPoint = a;
     auto rightBottomPoint = a;
 
@@ -124,7 +124,7 @@ namespace std {
 
 template <>
 struct hash<facebook::react::Rect> {
-  size_t operator()(facebook::react::Rect const &rect) const noexcept {
+  size_t operator()(const facebook::react::Rect &rect) const noexcept {
     return folly::hash::hash_combine(0, rect.origin, rect.size);
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
@@ -25,7 +25,7 @@ struct RectangleCorners {
   T bottomLeft{};
   T bottomRight{};
 
-  bool operator==(RectangleCorners<T> const &rhs) const noexcept {
+  bool operator==(const RectangleCorners<T> &rhs) const noexcept {
     return std::tie(
                this->topLeft,
                this->topRight,
@@ -34,7 +34,7 @@ struct RectangleCorners {
         std::tie(rhs.topLeft, rhs.topRight, rhs.bottomLeft, rhs.bottomRight);
   }
 
-  bool operator!=(RectangleCorners<T> const &rhs) const noexcept {
+  bool operator!=(const RectangleCorners<T> &rhs) const noexcept {
     return !(*this == rhs);
   }
 
@@ -56,7 +56,7 @@ namespace std {
 template <typename T>
 struct hash<facebook::react::RectangleCorners<T>> {
   size_t operator()(
-      facebook::react::RectangleCorners<T> const &corners) const noexcept {
+      const facebook::react::RectangleCorners<T> &corners) const noexcept {
     return folly::hash::hash_combine(
         0,
         corners.topLeft,

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
@@ -26,12 +26,12 @@ struct RectangleEdges {
   T right{};
   T bottom{};
 
-  bool operator==(RectangleEdges<T> const &rhs) const noexcept {
+  bool operator==(const RectangleEdges<T> &rhs) const noexcept {
     return std::tie(this->left, this->top, this->right, this->bottom) ==
         std::tie(rhs.left, rhs.top, rhs.right, rhs.bottom);
   }
 
-  bool operator!=(RectangleEdges<T> const &rhs) const noexcept {
+  bool operator!=(const RectangleEdges<T> &rhs) const noexcept {
     return !(*this == rhs);
   }
 
@@ -39,16 +39,16 @@ struct RectangleEdges {
     return left == top && left == right && left == bottom;
   }
 
-  static RectangleEdges<T> const ZERO;
+  static const RectangleEdges<T> ZERO;
 };
 
 template <typename T>
-RectangleEdges<T> const RectangleEdges<T>::ZERO = {};
+const RectangleEdges<T> RectangleEdges<T>::ZERO = {};
 
 template <typename T>
 RectangleEdges<T> operator+(
-    RectangleEdges<T> const &lhs,
-    RectangleEdges<T> const &rhs) noexcept {
+    const RectangleEdges<T> &lhs,
+    const RectangleEdges<T> &rhs) noexcept {
   return RectangleEdges<T>{
       lhs.left + rhs.left,
       lhs.top + rhs.top,
@@ -58,8 +58,8 @@ RectangleEdges<T> operator+(
 
 template <typename T>
 RectangleEdges<T> operator-(
-    RectangleEdges<T> const &lhs,
-    RectangleEdges<T> const &rhs) noexcept {
+    const RectangleEdges<T> &lhs,
+    const RectangleEdges<T> &rhs) noexcept {
   return RectangleEdges<T>{
       lhs.left - rhs.left,
       lhs.top - rhs.top,
@@ -75,7 +75,7 @@ using EdgeInsets = RectangleEdges<Float>;
 /*
  * Adjusts a rectangle by the given edge insets.
  */
-inline Rect insetBy(Rect const &rect, EdgeInsets const &insets) noexcept {
+inline Rect insetBy(const Rect &rect, const EdgeInsets &insets) noexcept {
   return Rect{
       {rect.origin.x + insets.left, rect.origin.y + insets.top},
       {rect.size.width - insets.left - insets.right,
@@ -85,7 +85,7 @@ inline Rect insetBy(Rect const &rect, EdgeInsets const &insets) noexcept {
 /*
  * Adjusts a rectangle by the given edge outsets.
  */
-inline Rect outsetBy(Rect const &rect, EdgeInsets const &outsets) noexcept {
+inline Rect outsetBy(const Rect &rect, const EdgeInsets &outsets) noexcept {
   return Rect{
       {rect.origin.x - outsets.left, rect.origin.y - outsets.top},
       {rect.size.width + outsets.left + outsets.right,
@@ -99,7 +99,7 @@ namespace std {
 template <typename T>
 struct hash<facebook::react::RectangleEdges<T>> {
   size_t operator()(
-      facebook::react::RectangleEdges<T> const &edges) const noexcept {
+      const facebook::react::RectangleEdges<T> &edges) const noexcept {
     return folly::hash::hash_combine(
         0, edges.left, edges.right, edges.top, edges.bottom);
   }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Size.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Size.h
@@ -22,24 +22,24 @@ struct Size {
   Float width{0};
   Float height{0};
 
-  Size &operator+=(Point const &point) noexcept {
+  Size &operator+=(const Point &point) noexcept {
     width += point.x;
     height += point.y;
     return *this;
   }
 
-  Size &operator*=(Point const &point) noexcept {
+  Size &operator*=(const Point &point) noexcept {
     width *= point.x;
     height *= point.y;
     return *this;
   }
 };
 
-inline bool operator==(Size const &rhs, Size const &lhs) noexcept {
+inline bool operator==(const Size &rhs, const Size &lhs) noexcept {
   return std::tie(lhs.width, lhs.height) == std::tie(rhs.width, rhs.height);
 }
 
-inline bool operator!=(Size const &rhs, Size const &lhs) noexcept {
+inline bool operator!=(const Size &rhs, const Size &lhs) noexcept {
   return !(lhs == rhs);
 }
 
@@ -49,7 +49,7 @@ namespace std {
 
 template <>
 struct hash<facebook::react::Size> {
-  size_t operator()(facebook::react::Size const &size) const {
+  size_t operator()(const facebook::react::Size &size) const {
     return folly::hash::hash_combine(0, size.width, size.height);
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
@@ -15,7 +15,7 @@
 namespace facebook::react {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
-void Transform::print(Transform const &t, std::string prefix) {
+void Transform::print(const Transform &t, std::string prefix) {
   LOG(ERROR) << prefix << "[ " << t.matrix[0] << " " << t.matrix[1] << " "
              << t.matrix[2] << " " << t.matrix[3] << " ]";
   LOG(ERROR) << prefix << "[ " << t.matrix[4] << " " << t.matrix[5] << " "
@@ -191,8 +191,8 @@ TransformOperation Transform::DefaultTransformOperation(
 
 Transform Transform::Interpolate(
     Float animationProgress,
-    Transform const &lhs,
-    Transform const &rhs) {
+    const Transform &lhs,
+    const Transform &rhs) {
   // Iterate through operations and reconstruct an interpolated resulting
   // transform If at any point we hit an "Arbitrary" Transform, return at that
   // point
@@ -248,15 +248,15 @@ Transform Transform::Interpolate(
   return result;
 }
 
-bool Transform::isVerticalInversion(Transform const &transform) {
+bool Transform::isVerticalInversion(const Transform &transform) {
   return transform.at(1, 1) == -1;
 }
 
-bool Transform::isHorizontalInversion(Transform const &transform) {
+bool Transform::isHorizontalInversion(const Transform &transform) {
   return transform.at(0, 0) == -1;
 }
 
-bool Transform::operator==(Transform const &rhs) const {
+bool Transform::operator==(const Transform &rhs) const {
   for (auto i = 0; i < 16; i++) {
     if (matrix[i] != rhs.matrix[i]) {
       return false;
@@ -265,11 +265,11 @@ bool Transform::operator==(Transform const &rhs) const {
   return true;
 }
 
-bool Transform::operator!=(Transform const &rhs) const {
+bool Transform::operator!=(const Transform &rhs) const {
   return !(*this == rhs);
 }
 
-Transform Transform::operator*(Transform const &rhs) const {
+Transform Transform::operator*(const Transform &rhs) const {
   if (*this == Transform::Identity()) {
     return rhs;
   }
@@ -351,11 +351,11 @@ Float &Transform::at(int i, int j) {
   return matrix[(i * 4) + j];
 }
 
-Float const &Transform::at(int i, int j) const {
+const Float &Transform::at(int i, int j) const {
   return matrix[(i * 4) + j];
 }
 
-Point operator*(Point const &point, Transform const &transform) {
+Point operator*(const Point &point, const Transform &transform) {
   if (transform == Transform::Identity()) {
     return point;
   }
@@ -365,12 +365,12 @@ Point operator*(Point const &point, Transform const &transform) {
   return {result.x, result.y};
 }
 
-Rect operator*(Rect const &rect, Transform const &transform) {
+Rect operator*(const Rect &rect, const Transform &transform) {
   auto center = rect.getCenter();
   return transform.applyWithCenter(rect, center);
 }
 
-Rect Transform::applyWithCenter(Rect const &rect, Point const &center) const {
+Rect Transform::applyWithCenter(const Rect &rect, const Point &center) const {
   auto a = Point{rect.origin.x, rect.origin.y} - center;
   auto b = Point{rect.getMaxX(), rect.origin.y} - center;
   auto c = Point{rect.getMaxX(), rect.getMaxY()} - center;
@@ -390,7 +390,7 @@ Rect Transform::applyWithCenter(Rect const &rect, Point const &center) const {
       transformedA, transformedB, transformedC, transformedD);
 }
 
-EdgeInsets operator*(EdgeInsets const &edgeInsets, Transform const &transform) {
+EdgeInsets operator*(const EdgeInsets &edgeInsets, const Transform &transform) {
   return EdgeInsets{
       edgeInsets.left * transform.matrix[0],
       edgeInsets.top * transform.matrix[5],
@@ -398,7 +398,7 @@ EdgeInsets operator*(EdgeInsets const &edgeInsets, Transform const &transform) {
       edgeInsets.bottom * transform.matrix[5]};
 }
 
-Vector operator*(Transform const &transform, Vector const &vector) {
+Vector operator*(const Transform &transform, const Vector &vector) {
   return {
       vector.x * transform.at(0, 0) + vector.y * transform.at(1, 0) +
           vector.z * transform.at(2, 0) + vector.w * transform.at(3, 0),
@@ -411,7 +411,7 @@ Vector operator*(Transform const &transform, Vector const &vector) {
   };
 }
 
-Size operator*(Size const &size, Transform const &transform) {
+Size operator*(const Size &size, const Transform &transform) {
   if (transform == Transform::Identity()) {
     return size;
   }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -63,7 +63,7 @@ struct Transform {
    * For debugging only. Prints out the matrix.
    */
 #if RN_DEBUG_STRING_CONVERTIBLE
-  static void print(Transform const &t, std::string prefix);
+  static void print(const Transform &t, std::string prefix);
 #endif
 
   /*
@@ -132,30 +132,30 @@ struct Transform {
    */
   static Transform Interpolate(
       Float animationProgress,
-      Transform const &lhs,
-      Transform const &rhs);
+      const Transform &lhs,
+      const Transform &rhs);
 
-  static bool isVerticalInversion(Transform const &transform);
-  static bool isHorizontalInversion(Transform const &transform);
+  static bool isVerticalInversion(const Transform &transform);
+  static bool isHorizontalInversion(const Transform &transform);
 
   /*
    * Equality operators.
    */
-  bool operator==(Transform const &rhs) const;
-  bool operator!=(Transform const &rhs) const;
+  bool operator==(const Transform &rhs) const;
+  bool operator!=(const Transform &rhs) const;
 
   /*
    * Matrix subscript.
    */
   Float &at(int i, int j);
-  Float const &at(int i, int j) const;
+  const Float &at(int i, int j) const;
 
   /*
    * Concatenates (multiplies) transform matrices.
    */
-  Transform operator*(Transform const &rhs) const;
+  Transform operator*(const Transform &rhs) const;
 
-  Rect applyWithCenter(Rect const &rect, Point const &center) const;
+  Rect applyWithCenter(const Rect &rect, const Point &center) const;
 
   /**
    * Convert to folly::dynamic.
@@ -186,26 +186,26 @@ struct Transform {
 /*
  * Applies transformation to the given point.
  */
-Point operator*(Point const &point, Transform const &transform);
+Point operator*(const Point &point, const Transform &transform);
 
 /*
  * Applies transformation to the given size.
  */
-Size operator*(Size const &size, Transform const &transform);
+Size operator*(const Size &size, const Transform &transform);
 
 /*
  * Applies transformation to the given rect.
  * ONLY SUPPORTS scale and translation transformation.
  */
-Rect operator*(Rect const &rect, Transform const &transform);
+Rect operator*(const Rect &rect, const Transform &transform);
 
 /*
  * Applies transformation to the given EdgeInsets.
  * ONLY SUPPORTS scale transformation.
  */
-EdgeInsets operator*(EdgeInsets const &edgeInsets, Transform const &transform);
+EdgeInsets operator*(const EdgeInsets &edgeInsets, const Transform &transform);
 
-Vector operator*(Transform const &transform, Vector const &vector);
+Vector operator*(const Transform &transform, const Vector &vector);
 
 } // namespace facebook::react
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
@@ -25,7 +25,7 @@ using SharedImageManager = std::shared_ptr<ImageManager>;
  */
 class ImageManager {
  public:
-  ImageManager(ContextContainer::Shared const &contextContainer);
+  ImageManager(const ContextContainer::Shared &contextContainer);
   ~ImageManager();
 
   ImageRequest requestImage(const ImageSource &imageSource, SurfaceId surfaceId)

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
@@ -20,7 +20,7 @@ class ImageResponseObserver {
   virtual ~ImageResponseObserver() noexcept = default;
 
   virtual void didReceiveProgress(float progress) const = 0;
-  virtual void didReceiveImage(ImageResponse const &imageResponse) const = 0;
+  virtual void didReceiveImage(const ImageResponse &imageResponse) const = 0;
   virtual void didReceiveFailure() const = 0;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.cpp
@@ -14,7 +14,7 @@
 namespace facebook::react {
 
 void ImageResponseObserverCoordinator::addObserver(
-    ImageResponseObserver const &observer) const {
+    const ImageResponseObserver &observer) const {
   mutex_.lock();
   switch (status_) {
     case ImageResponse::Status::Loading: {
@@ -38,7 +38,7 @@ void ImageResponseObserverCoordinator::addObserver(
 }
 
 void ImageResponseObserverCoordinator::removeObserver(
-    ImageResponseObserver const &observer) const {
+    const ImageResponseObserver &observer) const {
   std::scoped_lock lock(mutex_);
 
   // We remove only one element to maintain a balance between add/remove calls.
@@ -61,7 +61,7 @@ void ImageResponseObserverCoordinator::nativeImageResponseProgress(
 }
 
 void ImageResponseObserverCoordinator::nativeImageResponseComplete(
-    ImageResponse const &imageResponse) const {
+    const ImageResponse &imageResponse) const {
   mutex_.lock();
   imageData_ = imageResponse.getImage();
   imageMetadata_ = imageResponse.getMetadata();

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
@@ -29,12 +29,12 @@ class ImageResponseObserverCoordinator {
    * If the current image request status is not equal to `Loading`, the observer
    * will be called immediately.
    */
-  void addObserver(ImageResponseObserver const &observer) const;
+  void addObserver(const ImageResponseObserver &observer) const;
 
   /*
    * Interested parties may stop observing the image response.
    */
-  void removeObserver(ImageResponseObserver const &observer) const;
+  void removeObserver(const ImageResponseObserver &observer) const;
 
   /*
    * Platform-specific image loader will call this method with progress updates.
@@ -45,7 +45,7 @@ class ImageResponseObserverCoordinator {
    * Platform-specific image loader will call this method with a completed image
    * response.
    */
-  void nativeImageResponseComplete(ImageResponse const &imageResponse) const;
+  void nativeImageResponseComplete(const ImageResponse &imageResponse) const;
 
   /*
    * Platform-specific image loader will call this method in case of any
@@ -58,7 +58,7 @@ class ImageResponseObserverCoordinator {
    * List of observers.
    * Mutable: protected by mutex_.
    */
-  mutable butter::small_vector<ImageResponseObserver const *, 1> observers_;
+  mutable butter::small_vector<const ImageResponseObserver *, 1> observers_;
 
   /*
    * Current status of image loading.

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageTelemetry.h
@@ -18,7 +18,7 @@ namespace facebook::react {
  */
 class ImageTelemetry final {
  public:
-  ImageTelemetry(SurfaceId const surfaceId) : surfaceId_(surfaceId) {
+  ImageTelemetry(const SurfaceId surfaceId) : surfaceId_(surfaceId) {
     willRequestUrlTime_ = telemetryTimePointNow();
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageManager.cpp
@@ -10,7 +10,7 @@
 namespace facebook::react {
 
 ImageManager::ImageManager(
-    ContextContainer::Shared const & /*contextContainer*/) {
+    const ContextContainer::Shared & /*contextContainer*/) {
   // Silence unused-private-field warning.
   (void)self_;
   // Not implemented.

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageManager.mm
@@ -16,7 +16,7 @@
 
 namespace facebook::react {
 
-ImageManager::ImageManager(ContextContainer::Shared const &contextContainer)
+ImageManager::ImageManager(const ContextContainer::Shared &contextContainer)
 {
   id<RCTImageLoaderWithAttributionProtocol> imageLoader =
       (id<RCTImageLoaderWithAttributionProtocol>)unwrapManagedObject(

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/LeakChecker.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/LeakChecker.cpp
@@ -18,7 +18,7 @@ LeakChecker::LeakChecker(RuntimeExecutor runtimeExecutor)
     : runtimeExecutor_(std::move(runtimeExecutor)) {}
 
 void LeakChecker::uiManagerDidCreateShadowNodeFamily(
-    ShadowNodeFamily::Shared const &shadowNodeFamily) const {
+    const ShadowNodeFamily::Shared &shadowNodeFamily) const {
   registry_.add(shadowNodeFamily);
 }
 
@@ -43,7 +43,7 @@ void LeakChecker::stopSurface(SurfaceId surfaceId) {
 void LeakChecker::checkSurfaceForLeaks(SurfaceId surfaceId) const {
   auto weakFamilies = registry_.weakFamiliesForSurfaceId(surfaceId);
   unsigned int numberOfLeaks = 0;
-  for (auto const &weakFamily : weakFamilies) {
+  for (const auto &weakFamily : weakFamilies) {
     auto strong = weakFamily.lock();
     if (strong) {
       ++numberOfLeaks;

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/LeakChecker.h
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/LeakChecker.h
@@ -22,13 +22,13 @@ class LeakChecker final {
   LeakChecker(RuntimeExecutor runtimeExecutor);
 
   void uiManagerDidCreateShadowNodeFamily(
-      ShadowNodeFamily::Shared const &shadowNodeFamily) const;
+      const ShadowNodeFamily::Shared &shadowNodeFamily) const;
   void stopSurface(SurfaceId surfaceId);
 
  private:
   void checkSurfaceForLeaks(SurfaceId surfaceId) const;
 
-  RuntimeExecutor const runtimeExecutor_{};
+  const RuntimeExecutor runtimeExecutor_{};
 
   WeakFamilyRegistry registry_{};
   SurfaceId previouslyStoppedSurface_{};

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/WeakFamilyRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/WeakFamilyRegistry.cpp
@@ -10,7 +10,7 @@
 namespace facebook::react {
 
 void WeakFamilyRegistry::add(
-    ShadowNodeFamily::Shared const &shadowNodeFamily) const {
+    const ShadowNodeFamily::Shared &shadowNodeFamily) const {
   std::scoped_lock lock(familiesMutex_);
   ShadowNodeFamily::Weak weakFamily = shadowNodeFamily;
   families_[shadowNodeFamily->getSurfaceId()].push_back(weakFamily);

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/WeakFamilyRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/WeakFamilyRegistry.h
@@ -18,7 +18,7 @@ class WeakFamilyRegistry final {
  public:
   using WeakFamilies = std::vector<ShadowNodeFamily::Weak>;
 
-  void add(ShadowNodeFamily::Shared const &shadowNodeFamily) const;
+  void add(const ShadowNodeFamily::Shared &shadowNodeFamily) const;
   void removeFamiliesWithSurfaceId(SurfaceId surfaceId) const;
   WeakFamilies weakFamiliesForSurfaceId(SurfaceId surfaceId) const;
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
@@ -22,7 +22,7 @@ static inline int32_t valueOffset(int32_t bucketIndex) {
 // TODO T83483191: Extend MapBuffer C++ implementation to support basic random
 // access
 MapBuffer::MapBuffer(std::vector<uint8_t> data) : bytes_(std::move(data)) {
-  auto header = reinterpret_cast<Header const *>(bytes_.data());
+  auto header = reinterpret_cast<const Header *>(bytes_.data());
   count_ = header->count;
 
   if (header->bufferSize != bytes_.size()) {
@@ -39,7 +39,7 @@ int32_t MapBuffer::getKeyBucket(Key key) const {
     int32_t mid = (lo + hi) >> 1;
 
     Key midVal =
-        *reinterpret_cast<Key const *>(bytes_.data() + bucketOffset(mid));
+        *reinterpret_cast<const Key *>(bytes_.data() + bucketOffset(mid));
 
     if (midVal < key) {
       lo = mid + 1;
@@ -57,7 +57,7 @@ int32_t MapBuffer::getInt(Key key) const {
   auto bucketIndex = getKeyBucket(key);
   react_native_assert(bucketIndex != -1 && "Key not found in MapBuffer");
 
-  return *reinterpret_cast<int32_t const *>(
+  return *reinterpret_cast<const int32_t *>(
       bytes_.data() + valueOffset(bucketIndex));
 }
 
@@ -69,7 +69,7 @@ double MapBuffer::getDouble(Key key) const {
   auto bucketIndex = getKeyBucket(key);
   react_native_assert(bucketIndex != -1 && "Key not found in MapBuffer");
 
-  return *reinterpret_cast<double const *>(
+  return *reinterpret_cast<const double *>(
       bytes_.data() + valueOffset(bucketIndex));
 }
 
@@ -84,9 +84,9 @@ std::string MapBuffer::getString(Key key) const {
   // of the map buffer
   int32_t dynamicDataOffset = getDynamicDataOffset();
   int32_t offset = getInt(key);
-  int32_t stringLength = *reinterpret_cast<int32_t const *>(
+  int32_t stringLength = *reinterpret_cast<const int32_t *>(
       bytes_.data() + dynamicDataOffset + offset);
-  uint8_t const *stringPtr =
+  const uint8_t *stringPtr =
       bytes_.data() + dynamicDataOffset + offset + sizeof(int);
 
   return {stringPtr, stringPtr + stringLength};
@@ -98,7 +98,7 @@ MapBuffer MapBuffer::getMapBuffer(Key key) const {
   int32_t dynamicDataOffset = getDynamicDataOffset();
 
   int32_t offset = getInt(key);
-  int32_t mapBufferLength = *reinterpret_cast<int32_t const *>(
+  int32_t mapBufferLength = *reinterpret_cast<const int32_t *>(
       bytes_.data() + dynamicDataOffset + offset);
 
   std::vector<uint8_t> value(mapBufferLength);
@@ -116,13 +116,13 @@ std::vector<MapBuffer> MapBuffer::getMapBufferList(MapBuffer::Key key) const {
 
   int32_t dynamicDataOffset = getDynamicDataOffset();
   int32_t offset = getInt(key);
-  int32_t mapBufferListLength = *reinterpret_cast<int32_t const *>(
+  int32_t mapBufferListLength = *reinterpret_cast<const int32_t *>(
       bytes_.data() + dynamicDataOffset + offset);
   offset = offset + sizeof(uint32_t);
 
   int32_t curLen = 0;
   while (curLen < mapBufferListLength) {
-    int32_t mapBufferLength = *reinterpret_cast<int32_t const *>(
+    int32_t mapBufferLength = *reinterpret_cast<const int32_t *>(
         bytes_.data() + dynamicDataOffset + offset + curLen);
     curLen = curLen + sizeof(uint32_t);
     std::vector<uint8_t> value(mapBufferLength);
@@ -140,7 +140,7 @@ size_t MapBuffer::size() const {
   return bytes_.size();
 }
 
-uint8_t const *MapBuffer::data() const {
+const uint8_t *MapBuffer::data() const {
   return bytes_.data();
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -108,7 +108,7 @@ class MapBuffer {
 
   explicit MapBuffer(std::vector<uint8_t> data);
 
-  MapBuffer(MapBuffer const &buffer) = delete;
+  MapBuffer(const MapBuffer &buffer) = delete;
 
   MapBuffer &operator=(const MapBuffer &other) = delete;
 
@@ -131,7 +131,7 @@ class MapBuffer {
 
   size_t size() const;
 
-  uint8_t const *data() const;
+  const uint8_t *data() const;
 
   uint16_t count() const;
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -29,7 +29,7 @@ MapBufferBuilder::MapBufferBuilder(uint32_t initialSize) {
 void MapBufferBuilder::storeKeyValue(
     MapBuffer::Key key,
     MapBuffer::DataType type,
-    uint8_t const *value,
+    const uint8_t *value,
     uint32_t valueSize) {
   if (valueSize > MAX_BUCKET_VALUE_SIZE) {
     LOG(ERROR) << "Error: size of value must be <= MAX_VALUE_SIZE. ValueSize: "
@@ -56,7 +56,7 @@ void MapBufferBuilder::putBool(MapBuffer::Key key, bool value) {
   storeKeyValue(
       key,
       MapBuffer::DataType::Boolean,
-      reinterpret_cast<uint8_t const *>(&intValue),
+      reinterpret_cast<const uint8_t *>(&intValue),
       INT_SIZE);
 }
 
@@ -64,7 +64,7 @@ void MapBufferBuilder::putDouble(MapBuffer::Key key, double value) {
   storeKeyValue(
       key,
       MapBuffer::DataType::Double,
-      reinterpret_cast<uint8_t const *>(&value),
+      reinterpret_cast<const uint8_t *>(&value),
       DOUBLE_SIZE);
 }
 
@@ -72,11 +72,11 @@ void MapBufferBuilder::putInt(MapBuffer::Key key, int32_t value) {
   storeKeyValue(
       key,
       MapBuffer::DataType::Int,
-      reinterpret_cast<uint8_t const *>(&value),
+      reinterpret_cast<const uint8_t *>(&value),
       INT_SIZE);
 }
 
-void MapBufferBuilder::putString(MapBuffer::Key key, std::string const &value) {
+void MapBufferBuilder::putString(MapBuffer::Key key, const std::string &value) {
   auto strSize = value.size();
   const char *strData = value.data();
 
@@ -90,11 +90,11 @@ void MapBufferBuilder::putString(MapBuffer::Key key, std::string const &value) {
   storeKeyValue(
       key,
       MapBuffer::DataType::String,
-      reinterpret_cast<uint8_t const *>(&offset),
+      reinterpret_cast<const uint8_t *>(&offset),
       INT_SIZE);
 }
 
-void MapBufferBuilder::putMapBuffer(MapBuffer::Key key, MapBuffer const &map) {
+void MapBufferBuilder::putMapBuffer(MapBuffer::Key key, const MapBuffer &map) {
   auto mapBufferSize = map.size();
 
   auto offset = dynamicData_.size();
@@ -109,7 +109,7 @@ void MapBufferBuilder::putMapBuffer(MapBuffer::Key key, MapBuffer const &map) {
   storeKeyValue(
       key,
       MapBuffer::DataType::Map,
-      reinterpret_cast<uint8_t const *>(&offset),
+      reinterpret_cast<const uint8_t *>(&offset),
       INT_SIZE);
 }
 
@@ -142,13 +142,13 @@ void MapBufferBuilder::putMapBufferList(
   storeKeyValue(
       key,
       MapBuffer::DataType::Map,
-      reinterpret_cast<uint8_t const *>(&offset),
+      reinterpret_cast<const uint8_t *>(&offset),
       INT_SIZE);
 }
 
 static inline bool compareBuckets(
-    MapBuffer::Bucket const &a,
-    MapBuffer::Bucket const &b) {
+    const MapBuffer::Bucket &a,
+    const MapBuffer::Bucket &b) {
   return a.key < b.key;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
@@ -31,9 +31,9 @@ class MapBufferBuilder {
 
   void putDouble(MapBuffer::Key key, double value);
 
-  void putString(MapBuffer::Key key, std::string const &value);
+  void putString(MapBuffer::Key key, const std::string &value);
 
-  void putMapBuffer(MapBuffer::Key key, MapBuffer const &map);
+  void putMapBuffer(MapBuffer::Key key, const MapBuffer &map);
 
   void putMapBufferList(
       MapBuffer::Key key,
@@ -55,7 +55,7 @@ class MapBufferBuilder {
   void storeKeyValue(
       MapBuffer::Key key,
       MapBuffer::DataType type,
-      uint8_t const *value,
+      const uint8_t *value,
       uint32_t valueSize);
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -31,7 +31,7 @@
 
 enum class NoBreadcrumb {};
 
-#define BREADCRUMB_TYPE NoBreadcrumb const &
+#define BREADCRUMB_TYPE const NoBreadcrumb &
 #define DIFF_BREADCRUMB(X) \
   {}
 #define CREATE_DIFF_BREADCRUMB(X) \
@@ -160,7 +160,7 @@ class TinyMap final {
           std::remove_if(
               vector_.begin(),
               vector_.end(),
-              [](auto const &item) { return item.first == 0; }),
+              [](const auto &item) { return item.first == 0; }),
           vector_.end());
     }
     numErased_ = 0;
@@ -176,8 +176,8 @@ class TinyMap final {
  * Sorting comparator for `reorderInPlaceIfNeeded`.
  */
 static bool shouldFirstPairComesBeforeSecondOne(
-    ShadowViewNodePair const *lhs,
-    ShadowViewNodePair const *rhs) noexcept {
+    const ShadowViewNodePair *lhs,
+    const ShadowViewNodePair *rhs) noexcept {
   return lhs->shadowNode->getOrderIndex() < rhs->shadowNode->getOrderIndex();
 }
 
@@ -191,7 +191,7 @@ static void reorderInPlaceIfNeeded(
   }
 
   auto isReorderNeeded = false;
-  for (auto const &pair : pairs) {
+  for (const auto &pair : pairs) {
     if (pair->shadowNode->getOrderIndex() != 0) {
       isReorderNeeded = true;
       break;
@@ -206,7 +206,7 @@ static void reorderInPlaceIfNeeded(
       pairs.begin(), pairs.end(), &shouldFirstPairComesBeforeSecondOne);
 }
 
-static inline bool shadowNodeIsConcrete(ShadowNode const &shadowNode) {
+static inline bool shadowNodeIsConcrete(const ShadowNode &shadowNode) {
   return shadowNode.getTraits().check(ShadowNodeTraits::Trait::FormsView);
 }
 
@@ -214,8 +214,8 @@ static void sliceChildShadowNodeViewPairsRecursivelyV2(
     ShadowViewNodePair::NonOwningList &pairList,
     ViewNodePairScope &scope,
     Point layoutOffset,
-    ShadowNode const &shadowNode) {
-  for (auto const &sharedChildShadowNode : shadowNode.getChildren()) {
+    const ShadowNode &shadowNode) {
+  for (const auto &sharedChildShadowNode : shadowNode.getChildren()) {
     auto &childShadowNode = *sharedChildShadowNode;
 
 #ifndef ANDROID
@@ -259,7 +259,7 @@ static void sliceChildShadowNodeViewPairsRecursivelyV2(
 }
 
 ShadowViewNodePair::NonOwningList sliceChildShadowNodeViewPairsV2(
-    ShadowNode const &shadowNode,
+    const ShadowNode &shadowNode,
     ViewNodePairScope &scope,
     bool allowFlattened,
     Point layoutOffset) {
@@ -294,7 +294,7 @@ ShadowViewNodePair::NonOwningList sliceChildShadowNodeViewPairsV2(
  */
 static ShadowViewNodePair::NonOwningList
 sliceChildShadowNodeViewPairsFromViewNodePair(
-    ShadowViewNodePair const &shadowViewNodePair,
+    const ShadowViewNodePair &shadowViewNodePair,
     ViewNodePairScope &scope,
     bool allowFlattened = false) {
   return sliceChildShadowNodeViewPairsV2(
@@ -337,7 +337,7 @@ static_assert(
 static void calculateShadowViewMutationsV2(
     ViewNodePairScope &scope,
     ShadowViewMutation::List &mutations,
-    ShadowView const &parentShadowView,
+    const ShadowView &parentShadowView,
     ShadowViewNodePair::NonOwningList &&oldChildPairs,
     ShadowViewNodePair::NonOwningList &&newChildPairs,
     bool isRecursionRedundant = false);
@@ -357,25 +357,25 @@ static void updateMatchedPairSubtrees(
     OrderedMutationInstructionContainer &mutationContainer,
     TinyMap<Tag, ShadowViewNodePair *> &newRemainingPairs,
     ShadowViewNodePair::NonOwningList &oldChildPairs,
-    ShadowView const &parentShadowView,
-    ShadowViewNodePair const &oldPair,
-    ShadowViewNodePair const &newPair);
+    const ShadowView &parentShadowView,
+    const ShadowViewNodePair &oldPair,
+    const ShadowViewNodePair &newPair);
 
 static void updateMatchedPair(
     OrderedMutationInstructionContainer &mutationContainer,
     bool oldNodeFoundInOrder,
     bool newNodeFoundInOrder,
-    ShadowView const &parentShadowView,
-    ShadowViewNodePair const &oldPair,
-    ShadowViewNodePair const &newPair);
+    const ShadowView &parentShadowView,
+    const ShadowViewNodePair &oldPair,
+    const ShadowViewNodePair &newPair);
 
 static void calculateShadowViewMutationsFlattener(
     ViewNodePairScope &scope,
     ReparentMode reparentMode,
     OrderedMutationInstructionContainer &mutationContainer,
-    ShadowView const &parentShadowView,
+    const ShadowView &parentShadowView,
     TinyMap<Tag, ShadowViewNodePair *> &unvisitedOtherNodes,
-    ShadowViewNodePair const &node,
+    const ShadowViewNodePair &node,
     TinyMap<Tag, ShadowViewNodePair *> *parentSubVisitedOtherNewNodes = nullptr,
     TinyMap<Tag, ShadowViewNodePair *> *parentSubVisitedOtherOldNodes =
         nullptr);
@@ -393,9 +393,9 @@ static void updateMatchedPairSubtrees(
     OrderedMutationInstructionContainer &mutationContainer,
     TinyMap<Tag, ShadowViewNodePair *> &newRemainingPairs,
     ShadowViewNodePair::NonOwningList &oldChildPairs,
-    ShadowView const &parentShadowView,
-    ShadowViewNodePair const &oldPair,
-    ShadowViewNodePair const &newPair) {
+    const ShadowView &parentShadowView,
+    const ShadowViewNodePair &oldPair,
+    const ShadowViewNodePair &newPair) {
   // Are we flattening or unflattening either one? If node was
   // flattened in both trees, there's no change, just continue.
   if (oldPair.flattened && newPair.flattened) {
@@ -511,9 +511,9 @@ static void updateMatchedPair(
     OrderedMutationInstructionContainer &mutationContainer,
     bool oldNodeFoundInOrder,
     bool newNodeFoundInOrder,
-    ShadowView const &parentShadowView,
-    ShadowViewNodePair const &oldPair,
-    ShadowViewNodePair const &newPair) {
+    const ShadowView &parentShadowView,
+    const ShadowViewNodePair &oldPair,
+    const ShadowViewNodePair &newPair) {
   oldPair.otherTreePair = &newPair;
   newPair.otherTreePair = &oldPair;
 
@@ -605,9 +605,9 @@ static void calculateShadowViewMutationsFlattener(
     ViewNodePairScope &scope,
     ReparentMode reparentMode,
     OrderedMutationInstructionContainer &mutationContainer,
-    ShadowView const &parentShadowView,
+    const ShadowView &parentShadowView,
     TinyMap<Tag, ShadowViewNodePair *> &unvisitedOtherNodes,
-    ShadowViewNodePair const &node,
+    const ShadowViewNodePair &node,
     TinyMap<Tag, ShadowViewNodePair *> *parentSubVisitedOtherNewNodes,
     TinyMap<Tag, ShadowViewNodePair *> *parentSubVisitedOtherOldNodes) {
   DEBUG_LOGS({
@@ -661,7 +661,7 @@ static void calculateShadowViewMutationsFlattener(
 
   // Candidates for full tree creation or deletion at the end of this function
   auto deletionCreationCandidatePairs =
-      TinyMap<Tag, ShadowViewNodePair const *>{};
+      TinyMap<Tag, const ShadowViewNodePair *>{};
 
   for (size_t index = 0;
        index < treeChildren.size() && index < treeChildren.size();
@@ -1033,7 +1033,7 @@ static void calculateShadowViewMutationsFlattener(
 static void calculateShadowViewMutationsV2(
     ViewNodePairScope &scope,
     ShadowViewMutation::List &mutations,
-    ShadowView const &parentShadowView,
+    const ShadowView &parentShadowView,
     ShadowViewNodePair::NonOwningList &&oldChildPairs,
     ShadowViewNodePair::NonOwningList &&newChildPairs,
     bool isRecursionRedundant) {
@@ -1142,7 +1142,7 @@ static void calculateShadowViewMutationsV2(
     // We've reached the end of the new children. We can delete+remove the
     // rest.
     for (; index < oldChildPairs.size(); index++) {
-      auto const &oldChildPair = *oldChildPairs[index];
+      const auto &oldChildPair = *oldChildPairs[index];
 
       DEBUG_LOGS({
         LOG(ERROR) << "Differ Branch 2: Deleting Tag/Tree: ["
@@ -1204,7 +1204,7 @@ static void calculateShadowViewMutationsV2(
     // If we don't have any more existing children we can choose a fast path
     // since the rest will all be create+insert.
     for (; index < newChildPairs.size(); index++) {
-      auto const &newChildPair = *newChildPairs[index];
+      const auto &newChildPair = *newChildPairs[index];
 
       DEBUG_LOGS({
         LOG(ERROR) << "Differ Branch 3: Creating Tag/Tree: ["
@@ -1237,7 +1237,7 @@ static void calculateShadowViewMutationsV2(
     // Collect map of tags in the new list
     auto newRemainingPairs = TinyMap<Tag, ShadowViewNodePair *>{};
     auto newInsertedPairs = TinyMap<Tag, ShadowViewNodePair *>{};
-    auto deletionCandidatePairs = TinyMap<Tag, ShadowViewNodePair const *>{};
+    auto deletionCandidatePairs = TinyMap<Tag, const ShadowViewNodePair *>{};
     for (; index < newChildPairs.size(); index++) {
       auto &newChildPair = *newChildPairs[index];
       newRemainingPairs.insert({newChildPair.shadowView.tag, &newChildPair});
@@ -1256,8 +1256,8 @@ static void calculateShadowViewMutationsV2(
 
       // Advance both pointers if pointing to the same element
       if (haveNewPair && haveOldPair) {
-        auto const &oldChildPair = *oldChildPairs[oldIndex];
-        auto const &newChildPair = *newChildPairs[newIndex];
+        const auto &oldChildPair = *oldChildPairs[oldIndex];
+        const auto &newChildPair = *newChildPairs[newIndex];
 
         Tag newTag = newChildPair.shadowView.tag;
         Tag oldTag = oldChildPair.shadowView.tag;
@@ -1301,7 +1301,7 @@ static void calculateShadowViewMutationsV2(
       // We have an old pair, but we either don't have any remaining new pairs
       // or we have one but it's not matched up with the old pair
       if (haveOldPair) {
-        auto const &oldChildPair = *oldChildPairs[oldIndex];
+        const auto &oldChildPair = *oldChildPairs[oldIndex];
 
         Tag oldTag = oldChildPair.shadowView.tag;
 
@@ -1309,9 +1309,9 @@ static void calculateShadowViewMutationsV2(
         // a move. The new node has already been inserted, we just need to
         // remove the node from its old position now, and update the node's
         // subtree.
-        auto const insertedIt = newInsertedPairs.find(oldTag);
+        const auto insertedIt = newInsertedPairs.find(oldTag);
         if (insertedIt != newInsertedPairs.end()) {
-          auto const &newChildPair = *insertedIt->second;
+          const auto &newChildPair = *insertedIt->second;
 
           updateMatchedPair(
               mutationContainer,
@@ -1338,7 +1338,7 @@ static void calculateShadowViewMutationsV2(
         // Should we generate a delete+remove instruction for the old node?
         // If there's an old node and it's not found in the "new" list, we
         // generate remove+delete for this node and its subtree.
-        auto const newIt = newRemainingPairs.find(oldTag);
+        const auto newIt = newRemainingPairs.find(oldTag);
         if (newIt == newRemainingPairs.end()) {
           oldIndex++;
 
@@ -1366,7 +1366,7 @@ static void calculateShadowViewMutationsV2(
           // concrete.
           if (oldChildPair.inOtherTree() &&
               oldChildPair.otherTreePair->isConcreteView) {
-            ShadowView const &otherTreeView =
+            const ShadowView &otherTreeView =
                 oldChildPair.otherTreePair->shadowView;
 
             // Remove, but remove using the *new* node, since we know
@@ -1441,7 +1441,7 @@ static void calculateShadowViewMutationsV2(
         continue;
       }
 
-      auto const &oldChildPair = *deletionCandidatePair.second;
+      const auto &oldChildPair = *deletionCandidatePair.second;
 
       DEBUG_LOGS({
         LOG(ERROR)
@@ -1483,7 +1483,7 @@ static void calculateShadowViewMutationsV2(
         continue;
       }
 
-      auto const &newChildPair = *newInsertedPair.second;
+      const auto &newChildPair = *newInsertedPair.second;
 
       DEBUG_LOGS({
         LOG(ERROR)
@@ -1553,8 +1553,8 @@ static void calculateShadowViewMutationsV2(
 static void sliceChildShadowNodeViewPairsRecursivelyLegacy(
     ShadowViewNodePair::OwningList &pairList,
     Point layoutOffset,
-    ShadowNode const &shadowNode) {
-  for (auto const &sharedChildShadowNode : shadowNode.getChildren()) {
+    const ShadowNode &shadowNode) {
+  for (const auto &sharedChildShadowNode : shadowNode.getChildren()) {
     auto &childShadowNode = *sharedChildShadowNode;
 
 #ifndef ANDROID
@@ -1591,7 +1591,7 @@ static void sliceChildShadowNodeViewPairsRecursivelyLegacy(
  * Only used by unit tests currently.
  */
 ShadowViewNodePair::OwningList sliceChildShadowNodeViewPairsLegacy(
-    ShadowNode const &shadowNode) {
+    const ShadowNode &shadowNode) {
   auto pairList = ShadowViewNodePair::OwningList{};
 
   if (!shadowNode.getTraits().check(
@@ -1606,8 +1606,8 @@ ShadowViewNodePair::OwningList sliceChildShadowNodeViewPairsLegacy(
 }
 
 ShadowViewMutation::List calculateShadowViewMutations(
-    ShadowNode const &oldRootShadowNode,
-    ShadowNode const &newRootShadowNode) {
+    const ShadowNode &oldRootShadowNode,
+    const ShadowNode &newRootShadowNode) {
   SystraceSection s("calculateShadowViewMutations");
 
   // Root shadow nodes must be belong the same family.

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
@@ -45,8 +45,8 @@ using ViewNodePairScope = std::deque<ShadowViewNodePair>;
  * The list of mutations might be and might not be optimal.
  */
 ShadowViewMutation::List calculateShadowViewMutations(
-    ShadowNode const &oldRootShadowNode,
-    ShadowNode const &newRootShadowNode);
+    const ShadowNode &oldRootShadowNode,
+    const ShadowNode &newRootShadowNode);
 
 /**
  * Generates a list of `ShadowViewNodePair`s that represents a layer of a
@@ -54,7 +54,7 @@ ShadowViewMutation::List calculateShadowViewMutations(
  * not form views and their children are flattened.
  */
 ShadowViewNodePair::NonOwningList sliceChildShadowNodeViewPairsV2(
-    ShadowNode const &shadowNode,
+    const ShadowNode &shadowNode,
     ViewNodePairScope &viewNodePairScope,
     bool allowFlattened = false,
     Point layoutOffset = {0, 0});
@@ -64,6 +64,6 @@ ShadowViewNodePair::NonOwningList sliceChildShadowNodeViewPairsV2(
  * flattened view hierarchy. This is *only* used by unit tests currently.
  */
 ShadowViewNodePair::OwningList sliceChildShadowNodeViewPairsLegacy(
-    ShadowNode const &shadowNode);
+    const ShadowNode &shadowNode);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
@@ -67,7 +67,7 @@ bool MountingCoordinator::waitForTransaction(
 }
 
 void MountingCoordinator::updateBaseRevision(
-    ShadowTreeRevision const &baseRevision) const {
+    const ShadowTreeRevision &baseRevision) const {
   baseRevision_ = baseRevision;
 }
 
@@ -182,16 +182,16 @@ bool MountingCoordinator::hasPendingTransactions() const {
   return lastRevision_.has_value();
 }
 
-TelemetryController const &MountingCoordinator::getTelemetryController() const {
+const TelemetryController &MountingCoordinator::getTelemetryController() const {
   return telemetryController_;
 }
 
-ShadowTreeRevision const &MountingCoordinator::getBaseRevision() const {
+const ShadowTreeRevision &MountingCoordinator::getBaseRevision() const {
   return baseRevision_;
 }
 
 void MountingCoordinator::setMountingOverrideDelegate(
-    std::weak_ptr<MountingOverrideDelegate const> delegate) const {
+    std::weak_ptr<const MountingOverrideDelegate> delegate) const {
   std::scoped_lock lock(mutex_);
   mountingOverrideDelegate_ = std::move(delegate);
 }

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -34,7 +34,7 @@ namespace facebook::react {
  */
 class MountingCoordinator final {
  public:
-  using Shared = std::shared_ptr<MountingCoordinator const>;
+  using Shared = std::shared_ptr<const MountingCoordinator>;
 
   /*
    * The constructor is meant to be used only inside `ShadowTree`, and it's
@@ -77,20 +77,20 @@ class MountingCoordinator final {
    */
   bool waitForTransaction(std::chrono::duration<double> timeout) const;
 
-  TelemetryController const &getTelemetryController() const;
+  const TelemetryController &getTelemetryController() const;
 
-  ShadowTreeRevision const &getBaseRevision() const;
+  const ShadowTreeRevision &getBaseRevision() const;
 
   /*
    * Methods from this section are meant to be used by
    * `MountingOverrideDelegate` only.
    */
  public:
-  void updateBaseRevision(ShadowTreeRevision const &baseRevision) const;
+  void updateBaseRevision(const ShadowTreeRevision &baseRevision) const;
   void resetLatestRevision() const;
 
   void setMountingOverrideDelegate(
-      std::weak_ptr<MountingOverrideDelegate const> delegate) const;
+      std::weak_ptr<const MountingOverrideDelegate> delegate) const;
 
   /*
    * Methods from this section are meant to be used by `ShadowTree` only.
@@ -110,14 +110,14 @@ class MountingCoordinator final {
   void revoke() const;
 
  private:
-  SurfaceId const surfaceId_;
+  const SurfaceId surfaceId_;
 
   mutable std::mutex mutex_;
   mutable ShadowTreeRevision baseRevision_;
   mutable std::optional<ShadowTreeRevision> lastRevision_{};
   mutable MountingTransaction::Number number_{0};
   mutable std::condition_variable signal_;
-  mutable std::weak_ptr<MountingOverrideDelegate const>
+  mutable std::weak_ptr<const MountingOverrideDelegate>
       mountingOverrideDelegate_;
 
   TelemetryController telemetryController_;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingOverrideDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingOverrideDelegate.h
@@ -38,7 +38,7 @@ class MountingOverrideDelegate {
   virtual std::optional<MountingTransaction> pullTransaction(
       SurfaceId surfaceId,
       MountingTransaction::Number number,
-      TransactionTelemetry const &telemetry,
+      const TransactionTelemetry &telemetry,
       ShadowViewMutationList mutations) const = 0;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.cpp
@@ -21,7 +21,7 @@ MountingTransaction::MountingTransaction(
       mutations_(std::move(mutations)),
       telemetry_(std::move(telemetry)) {}
 
-ShadowViewMutationList const &MountingTransaction::getMutations() const & {
+const ShadowViewMutationList &MountingTransaction::getMutations() const & {
   return mutations_;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.h
@@ -58,7 +58,7 @@ class MountingTransaction final {
    * Returns a list of mutations that represent the transaction. The list can be
    * empty (theoretically).
    */
-  ShadowViewMutationList const &getMutations() const &;
+  const ShadowViewMutationList &getMutations() const &;
   ShadowViewMutationList getMutations() &&;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -23,7 +23,7 @@
 namespace facebook::react {
 
 using ShadowTreeCommitTransaction = std::function<RootShadowNode::Unshared(
-    RootShadowNode const &oldRootShadowNode)>;
+    const RootShadowNode &oldRootShadowNode)>;
 
 /*
  * Represents the shadow tree and its lifecycle.
@@ -77,10 +77,10 @@ class ShadowTree final {
    */
   ShadowTree(
       SurfaceId surfaceId,
-      LayoutConstraints const &layoutConstraints,
-      LayoutContext const &layoutContext,
-      ShadowTreeDelegate const &delegate,
-      ContextContainer const &contextContainer);
+      const LayoutConstraints &layoutConstraints,
+      const LayoutContext &layoutContext,
+      const ShadowTreeDelegate &delegate,
+      const ContextContainer &contextContainer);
 
   ~ShadowTree();
 
@@ -139,10 +139,10 @@ class ShadowTree final {
   void mount(ShadowTreeRevision revision, bool mountSynchronously) const;
 
   void emitLayoutEvents(
-      std::vector<LayoutableShadowNode const *> &affectedLayoutableNodes) const;
+      std::vector<const LayoutableShadowNode *> &affectedLayoutableNodes) const;
 
-  SurfaceId const surfaceId_;
-  ShadowTreeDelegate const &delegate_;
+  const SurfaceId surfaceId_;
+  const ShadowTreeDelegate &delegate_;
   mutable std::shared_mutex commitMutex_;
   mutable CommitMode commitMode_{
       CommitMode::Normal}; // Protected by `commitMutex_`.

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
@@ -25,9 +25,9 @@ class ShadowTreeDelegate {
    * Returning a `nullptr` cancels the commit.
    */
   virtual RootShadowNode::Unshared shadowTreeWillCommit(
-      ShadowTree const &shadowTree,
-      RootShadowNode::Shared const &oldRootShadowNode,
-      RootShadowNode::Unshared const &newRootShadowNode) const = 0;
+      const ShadowTree &shadowTree,
+      const RootShadowNode::Shared &oldRootShadowNode,
+      const RootShadowNode::Unshared &newRootShadowNode) const = 0;
 
   /*
    * Called right after Shadow Tree commit a new state of the tree.

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<ShadowTree> ShadowTreeRegistry::remove(
 
 bool ShadowTreeRegistry::visit(
     SurfaceId surfaceId,
-    std::function<void(const ShadowTree &shadowTree)> const &callback) const {
+    const std::function<void(const ShadowTree &shadowTree)> &callback) const {
   std::shared_lock lock(mutex_);
 
   auto iterator = registry_.find(surfaceId);
@@ -52,11 +52,11 @@ bool ShadowTreeRegistry::visit(
 }
 
 void ShadowTreeRegistry::enumerate(
-    std::function<void(const ShadowTree &shadowTree, bool &stop)> const
+    const std::function<void(const ShadowTree &shadowTree, bool &stop)>
         &callback) const {
   std::shared_lock lock(mutex_);
   auto stop = false;
-  for (auto const &pair : registry_) {
+  for (const auto &pair : registry_) {
     callback(*pair.second, stop);
     if (stop) {
       return;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
@@ -50,7 +50,7 @@ class ShadowTreeRegistry final {
    */
   bool visit(
       SurfaceId surfaceId,
-      std::function<void(const ShadowTree &shadowTree)> const &callback) const;
+      const std::function<void(const ShadowTree &shadowTree)> &callback) const;
 
   /*
    * Enumerates all stored shadow trees.
@@ -58,7 +58,7 @@ class ShadowTreeRegistry final {
    * Can be called from any thread.
    */
   void enumerate(
-      std::function<void(const ShadowTree &shadowTree, bool &stop)> const
+      const std::function<void(const ShadowTree &shadowTree, bool &stop)>
           &callback) const;
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.cpp
@@ -13,9 +13,9 @@
 
 namespace facebook::react {
 
-static LayoutMetrics layoutMetricsFromShadowNode(ShadowNode const &shadowNode) {
+static LayoutMetrics layoutMetricsFromShadowNode(const ShadowNode &shadowNode) {
   auto layoutableShadowNode =
-      traitCast<LayoutableShadowNode const *>(&shadowNode);
+      traitCast<const LayoutableShadowNode *>(&shadowNode);
   return layoutableShadowNode != nullptr
       ? layoutableShadowNode->getLayoutMetrics()
       : EmptyLayoutMetrics;
@@ -57,12 +57,12 @@ bool ShadowView::operator!=(const ShadowView &rhs) const {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(ShadowView const &object) {
+std::string getDebugName(const ShadowView &object) {
   return object.componentHandle == 0 ? "Invalid" : object.componentName;
 }
 
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    ShadowView const &object,
+    const ShadowView &object,
     DebugStringConvertibleOptions options) {
   return {
       {"surfaceId", getDebugDescription(object.surfaceId, options)},

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
@@ -24,19 +24,19 @@ namespace facebook::react {
  */
 struct ShadowView final {
   ShadowView() = default;
-  ShadowView(ShadowView const &shadowView) = default;
+  ShadowView(const ShadowView &shadowView) = default;
   ShadowView(ShadowView &&shadowView) noexcept = default;
 
   /*
    * Constructs a `ShadowView` from given `ShadowNode`.
    */
-  explicit ShadowView(ShadowNode const &shadowNode);
+  explicit ShadowView(const ShadowNode &shadowNode);
 
-  ShadowView &operator=(ShadowView const &other) = default;
+  ShadowView &operator=(const ShadowView &other) = default;
   ShadowView &operator=(ShadowView &&other) = default;
 
-  bool operator==(ShadowView const &rhs) const;
-  bool operator!=(ShadowView const &rhs) const;
+  bool operator==(const ShadowView &rhs) const;
+  bool operator!=(const ShadowView &rhs) const;
 
   ComponentName componentName{};
   ComponentHandle componentHandle{};
@@ -51,9 +51,9 @@ struct ShadowView final {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(ShadowView const &object);
+std::string getDebugName(const ShadowView &object);
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    ShadowView const &object,
+    const ShadowView &object,
     DebugStringConvertibleOptions options);
 
 #endif
@@ -70,7 +70,7 @@ struct ShadowViewNodePair final {
       small_vector<ShadowViewNodePair, kShadowNodeChildrenSmallVectorSize>;
 
   ShadowView shadowView;
-  ShadowNode const *shadowNode;
+  const ShadowNode *shadowNode;
   bool flattened{false};
   bool isConcreteView{true};
   Point contextOrigin{0, 0};
@@ -83,7 +83,7 @@ struct ShadowViewNodePair final {
    * rely on this more heavily to simplify the diffing algorithm
    * overall?
    */
-  mutable ShadowViewNodePair const *otherTreePair{nullptr};
+  mutable const ShadowViewNodePair *otherTreePair{nullptr};
 
   /*
    * The stored pointer to `ShadowNode` represents an identity of the pair.
@@ -107,7 +107,7 @@ struct ShadowViewNodePairLegacy final {
       kShadowNodeChildrenSmallVectorSize>;
 
   ShadowView shadowView;
-  ShadowNode const *shadowNode;
+  const ShadowNode *shadowNode;
   bool flattened{false};
   bool isConcreteView{true};
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.cpp
@@ -126,7 +126,7 @@ ShadowViewMutation::ShadowViewMutation(
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(ShadowViewMutation const &mutation) {
+std::string getDebugName(const ShadowViewMutation &mutation) {
   switch (mutation.type) {
     case ShadowViewMutation::Create:
       return "Create";
@@ -144,7 +144,7 @@ std::string getDebugName(ShadowViewMutation const &mutation) {
 }
 
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    ShadowViewMutation const &mutation,
+    const ShadowViewMutation &mutation,
     DebugStringConvertibleOptions options) {
   return {
       mutation.oldChildShadowView.componentHandle != 0

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
@@ -124,9 +124,9 @@ using ShadowViewMutationList = std::vector<ShadowViewMutation>;
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(ShadowViewMutation const &mutation);
+std::string getDebugName(const ShadowViewMutation &mutation);
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    ShadowViewMutation const &mutation,
+    const ShadowViewMutation &mutation,
     DebugStringConvertibleOptions options);
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/mounting/StubView.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/StubView.cpp
@@ -26,7 +26,7 @@ StubView::operator ShadowView() const {
   return shadowView;
 }
 
-void StubView::update(ShadowView const &shadowView) {
+void StubView::update(const ShadowView &shadowView) {
   componentName = shadowView.componentName;
   componentHandle = shadowView.componentHandle;
   surfaceId = shadowView.surfaceId;
@@ -37,7 +37,7 @@ void StubView::update(ShadowView const &shadowView) {
   state = shadowView.state;
 }
 
-bool operator==(StubView const &lhs, StubView const &rhs) {
+bool operator==(const StubView &lhs, const StubView &rhs) {
   if (lhs.props != rhs.props) {
 #ifdef STUB_VIEW_TREE_VERBOSE
     LOG(ERROR) << "StubView: props do not match. lhs hash: "
@@ -57,20 +57,20 @@ bool operator==(StubView const &lhs, StubView const &rhs) {
   return true;
 }
 
-bool operator!=(StubView const &lhs, StubView const &rhs) {
+bool operator!=(const StubView &lhs, const StubView &rhs) {
   return !(lhs == rhs);
 }
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(StubView const &stubView) {
+std::string getDebugName(const StubView &stubView) {
   return std::string{"Stub"} +
       std::string{
           stubView.componentHandle != 0 ? stubView.componentName : "[invalid]"};
 }
 
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    StubView const &stubView,
+    const StubView &stubView,
     DebugStringConvertibleOptions options) {
   return {
       {"surfaceId", getDebugDescription(stubView.surfaceId, options)},
@@ -83,10 +83,10 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
 }
 
 std::vector<StubView> getDebugChildren(
-    StubView const &stubView,
+    const StubView &stubView,
     DebugStringConvertibleOptions /*options*/) {
   std::vector<StubView> result;
-  for (auto const &child : stubView.children) {
+  for (const auto &child : stubView.children) {
     result.push_back(*child);
   }
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/StubView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/StubView.h
@@ -24,11 +24,11 @@ class StubView final {
   using Shared = std::shared_ptr<StubView>;
 
   StubView() = default;
-  StubView(StubView const &stubView) = default;
+  StubView(const StubView &stubView) = default;
 
   operator ShadowView() const;
 
-  void update(ShadowView const &shadowView);
+  void update(const ShadowView &shadowView);
 
   ComponentName componentName;
   ComponentHandle componentHandle;
@@ -42,18 +42,18 @@ class StubView final {
   Tag parentTag{NO_VIEW_TAG};
 };
 
-bool operator==(StubView const &lhs, StubView const &rhs);
-bool operator!=(StubView const &lhs, StubView const &rhs);
+bool operator==(const StubView &lhs, const StubView &rhs);
+bool operator!=(const StubView &lhs, const StubView &rhs);
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
-std::string getDebugName(StubView const &stubView);
+std::string getDebugName(const StubView &stubView);
 
 std::vector<DebugStringConvertibleObject> getDebugProps(
-    StubView const &stubView,
+    const StubView &stubView,
     DebugStringConvertibleOptions options);
 std::vector<StubView> getDebugChildren(
-    StubView const &stubView,
+    const StubView &stubView,
     DebugStringConvertibleOptions options);
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.cpp
@@ -18,18 +18,18 @@
 
 namespace facebook::react {
 
-StubViewTree::StubViewTree(ShadowView const &shadowView) {
+StubViewTree::StubViewTree(const ShadowView &shadowView) {
   auto view = std::make_shared<StubView>();
   view->update(shadowView);
   rootTag_ = shadowView.tag;
   registry_[shadowView.tag] = view;
 }
 
-StubView const &StubViewTree::getRootStubView() const {
+const StubView &StubViewTree::getRootStubView() const {
   return *registry_.at(rootTag_);
 }
 
-StubView const &StubViewTree::getStubView(Tag tag) const {
+const StubView &StubViewTree::getStubView(Tag tag) const {
   return *registry_.at(tag);
 }
 
@@ -37,9 +37,9 @@ size_t StubViewTree::size() const {
   return registry_.size();
 }
 
-void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
+void StubViewTree::mutate(const ShadowViewMutationList &mutations) {
   STUB_VIEW_LOG({ LOG(ERROR) << "StubView: Mutating Begin"; });
-  for (auto const &mutation : mutations) {
+  for (const auto &mutation : mutations) {
     switch (mutation.type) {
       case ShadowViewMutation::Create: {
         react_native_assert(mutation.parentShadowView == ShadowView{});
@@ -263,7 +263,7 @@ void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
 }
 
 std::ostream &StubViewTree::dumpTags(std::ostream &stream) {
-  for (auto const &pair : registry_) {
+  for (const auto &pair : registry_) {
     auto &stubView = *registry_.at(pair.first);
     stream << "[" << stubView.tag << "]##"
            << std::hash<ShadowView>{}((ShadowView)stubView) << " ";
@@ -271,7 +271,7 @@ std::ostream &StubViewTree::dumpTags(std::ostream &stream) {
   return stream;
 }
 
-bool operator==(StubViewTree const &lhs, StubViewTree const &rhs) {
+bool operator==(const StubViewTree &lhs, const StubViewTree &rhs) {
   if (lhs.registry_.size() != rhs.registry_.size()) {
     STUB_VIEW_LOG({
       LOG(ERROR) << "Registry sizes are different. Sizes: LHS: "
@@ -287,7 +287,7 @@ bool operator==(StubViewTree const &lhs, StubViewTree const &rhs) {
     return false;
   }
 
-  for (auto const &pair : lhs.registry_) {
+  for (const auto &pair : lhs.registry_) {
     auto &lhsStubView = *lhs.registry_.at(pair.first);
     auto &rhsStubView = *rhs.registry_.at(pair.first);
 
@@ -306,7 +306,7 @@ bool operator==(StubViewTree const &lhs, StubViewTree const &rhs) {
   return true;
 }
 
-bool operator!=(StubViewTree const &lhs, StubViewTree const &rhs) {
+bool operator!=(const StubViewTree &lhs, const StubViewTree &rhs) {
   return !(lhs == rhs);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.h
@@ -18,16 +18,16 @@ namespace facebook::react {
 class StubViewTree {
  public:
   StubViewTree() = default;
-  StubViewTree(ShadowView const &shadowView);
+  StubViewTree(const ShadowView &shadowView);
 
-  void mutate(ShadowViewMutationList const &mutations);
+  void mutate(const ShadowViewMutationList &mutations);
 
-  StubView const &getRootStubView() const;
+  const StubView &getRootStubView() const;
 
   /*
    * Returns a view with given tag.
    */
-  StubView const &getStubView(Tag tag) const;
+  const StubView &getStubView(Tag tag) const;
 
   /*
    * Returns the total amount of views in the tree.
@@ -38,8 +38,8 @@ class StubViewTree {
   Tag rootTag_{};
   std::unordered_map<Tag, StubView::Shared> registry_{};
 
-  friend bool operator==(StubViewTree const &lhs, StubViewTree const &rhs);
-  friend bool operator!=(StubViewTree const &lhs, StubViewTree const &rhs);
+  friend bool operator==(const StubViewTree &lhs, const StubViewTree &rhs);
+  friend bool operator!=(const StubViewTree &lhs, const StubViewTree &rhs);
 
   std::ostream &dumpTags(std::ostream &stream);
 
@@ -48,7 +48,7 @@ class StubViewTree {
   }
 };
 
-bool operator==(StubViewTree const &lhs, StubViewTree const &rhs);
-bool operator!=(StubViewTree const &lhs, StubViewTree const &rhs);
+bool operator==(const StubViewTree &lhs, const StubViewTree &rhs);
+bool operator!=(const StubViewTree &lhs, const StubViewTree &rhs);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/TelemetryController.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/TelemetryController.cpp
@@ -12,13 +12,13 @@
 namespace facebook::react {
 
 TelemetryController::TelemetryController(
-    MountingCoordinator const &mountingCoordinator) noexcept
+    const MountingCoordinator &mountingCoordinator) noexcept
     : mountingCoordinator_(mountingCoordinator) {}
 
 bool TelemetryController::pullTransaction(
-    MountingTransactionCallback const &willMount,
-    MountingTransactionCallback const &doMount,
-    MountingTransactionCallback const &didMount) const {
+    const MountingTransactionCallback &willMount,
+    const MountingTransactionCallback &doMount,
+    const MountingTransactionCallback &didMount) const {
   auto optional = mountingCoordinator_.pullTransaction();
   if (!optional.has_value()) {
     return false;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/TelemetryController.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/TelemetryController.h
@@ -18,8 +18,8 @@ namespace facebook::react {
 class MountingCoordinator;
 
 using MountingTransactionCallback = std::function<void(
-    MountingTransaction const &transaction,
-    SurfaceTelemetry const &surfaceTelemetry)>;
+    const MountingTransaction &transaction,
+    const SurfaceTelemetry &surfaceTelemetry)>;
 
 /*
  * Provides convenient tools for aggregating and accessing telemetry data
@@ -31,13 +31,13 @@ class TelemetryController final {
   /*
    * To be used by `MountingCoordinator`.
    */
-  TelemetryController(MountingCoordinator const &mountingCoordinator) noexcept;
+  TelemetryController(const MountingCoordinator &mountingCoordinator) noexcept;
 
   /*
    * Not copyable.
    */
-  TelemetryController(TelemetryController const &other) noexcept = delete;
-  TelemetryController &operator=(TelemetryController const &other) noexcept =
+  TelemetryController(const TelemetryController &other) noexcept = delete;
+  TelemetryController &operator=(const TelemetryController &other) noexcept =
       delete;
 
  public:
@@ -45,12 +45,12 @@ class TelemetryController final {
    * Calls `MountingCoordinator::pullTransaction()` and aggregates telemetry.
    */
   bool pullTransaction(
-      MountingTransactionCallback const &willMount,
-      MountingTransactionCallback const &doMount,
-      MountingTransactionCallback const &didMount) const;
+      const MountingTransactionCallback &willMount,
+      const MountingTransactionCallback &doMount,
+      const MountingTransactionCallback &didMount) const;
 
  private:
-  MountingCoordinator const &mountingCoordinator_;
+  const MountingCoordinator &mountingCoordinator_;
   mutable SurfaceTelemetry compoundTelemetry_{};
   mutable std::mutex mutex_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs.cpp
@@ -17,8 +17,8 @@ namespace facebook::react {
  * Sorting comparator for `reorderInPlaceIfNeeded`.
  */
 static bool shouldFirstPairComesBeforeSecondOne(
-    ShadowViewNodePair const &lhs,
-    ShadowViewNodePair const &rhs) noexcept {
+    const ShadowViewNodePair &lhs,
+    const ShadowViewNodePair &rhs) noexcept {
   return lhs.shadowNode->getOrderIndex() < rhs.shadowNode->getOrderIndex();
 }
 
@@ -41,13 +41,13 @@ static void reorderInPlaceIfNeeded(
  */
 static void calculateShadowViewMutationsForNewTree(
     ShadowViewMutation::List &mutations,
-    ShadowView const &parentShadowView,
+    const ShadowView &parentShadowView,
     ShadowViewNodePair::OwningList newChildPairs) {
   // Sorting pairs based on `orderIndex` if needed.
   reorderInPlaceIfNeeded(newChildPairs);
 
   for (size_t index = 0; index < newChildPairs.size(); index++) {
-    auto const &newChildPair = newChildPairs[index];
+    const auto &newChildPair = newChildPairs[index];
 
     mutations.push_back(
         ShadowViewMutation::CreateMutation(newChildPair.shadowView));
@@ -63,7 +63,7 @@ static void calculateShadowViewMutationsForNewTree(
 }
 
 StubViewTree buildStubViewTreeWithoutUsingDifferentiator(
-    ShadowNode const &rootShadowNode) {
+    const ShadowNode &rootShadowNode) {
   auto mutations = ShadowViewMutation::List{};
   mutations.reserve(256);
 
@@ -82,7 +82,7 @@ StubViewTree buildStubViewTreeWithoutUsingDifferentiator(
 }
 
 StubViewTree buildStubViewTreeUsingDifferentiator(
-    ShadowNode const &rootShadowNode) {
+    const ShadowNode &rootShadowNode) {
   auto emptyRootShadowNode = rootShadowNode.clone(ShadowNodeFragment{
       ShadowNodeFragment::propsPlaceholder(),
       ShadowNode::emptySharedShadowNodeSharedList()});

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs.h
@@ -18,13 +18,13 @@ namespace facebook::react {
  * implementation (*without* using Differentiator).
  */
 StubViewTree buildStubViewTreeWithoutUsingDifferentiator(
-    ShadowNode const &rootShadowNode);
+    const ShadowNode &rootShadowNode);
 
 /*
  * Builds a ShadowView tree from given root ShadowNode using Differentiator by
  * generating mutation instructions between empty and final trees.
  */
 StubViewTree buildStubViewTreeUsingDifferentiator(
-    ShadowNode const &rootShadowNode);
+    const ShadowNode &rootShadowNode);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/MountingTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/MountingTest.cpp
@@ -21,7 +21,7 @@
 namespace facebook::react {
 
 static SharedViewProps nonFlattenedDefaultProps(
-    ComponentDescriptor const &componentDescriptor) {
+    const ComponentDescriptor &componentDescriptor) {
   folly::dynamic dynamic = folly::dynamic::object();
   dynamic["position"] = "absolute";
   dynamic["top"] = 0;
@@ -37,13 +37,13 @@ static SharedViewProps nonFlattenedDefaultProps(
 
   PropsParserContext parserContext{-1, contextContainer};
 
-  return std::static_pointer_cast<ViewProps const>(
+  return std::static_pointer_cast<const ViewProps>(
       componentDescriptor.cloneProps(
           parserContext, nullptr, RawProps{dynamic}));
 }
 
 static ShadowNode::Shared makeNode(
-    ComponentDescriptor const &componentDescriptor,
+    const ComponentDescriptor &componentDescriptor,
     int tag,
     const ShadowNode::ListOfShared &children,
     bool flattened = false) {
@@ -84,7 +84,7 @@ TEST(MountingTest, testReorderingInstructionGeneration) {
 
   // Creating an initial root shadow node.
   auto emptyRootNode = std::const_pointer_cast<RootShadowNode>(
-      std::static_pointer_cast<RootShadowNode const>(
+      std::static_pointer_cast<const RootShadowNode>(
           rootComponentDescriptor.createShadowNode(
               ShadowNodeFragment{RootShadowNode::defaultSharedProps()},
               rootFamily)));
@@ -154,74 +154,74 @@ TEST(MountingTest, testReorderingInstructionGeneration) {
           childK})});
 
   // Injecting a tree into the root node.
-  auto rootNodeV1 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV1 = std::static_pointer_cast<const RootShadowNode>(
       emptyRootNode->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV1})}));
-  auto rootNodeV2 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV2 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV1->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV2})}));
-  auto rootNodeV3 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV3 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV2->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV3})}));
-  auto rootNodeV4 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV4 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV3->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV4})}));
-  auto rootNodeV5 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV5 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV4->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV5})}));
-  auto rootNodeV6 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV6 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV5->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV6})}));
-  auto rootNodeV7 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV7 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV6->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV7})}));
 
   // Layout
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV1{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV1{};
   affectedLayoutableNodesV1.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV1)
       ->layoutIfNeeded(&affectedLayoutableNodesV1);
   rootNodeV1->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV2{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV2{};
   affectedLayoutableNodesV2.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV2)
       ->layoutIfNeeded(&affectedLayoutableNodesV2);
   rootNodeV2->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV3{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV3{};
   affectedLayoutableNodesV3.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV3)
       ->layoutIfNeeded(&affectedLayoutableNodesV3);
   rootNodeV3->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV4{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV4{};
   affectedLayoutableNodesV4.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV4)
       ->layoutIfNeeded(&affectedLayoutableNodesV4);
   rootNodeV4->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV5{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV5{};
   affectedLayoutableNodesV5.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV5)
       ->layoutIfNeeded(&affectedLayoutableNodesV5);
   rootNodeV5->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV6{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV6{};
   affectedLayoutableNodesV6.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV6)
       ->layoutIfNeeded(&affectedLayoutableNodesV6);
@@ -395,7 +395,7 @@ TEST(MountingTest, testViewReparentingInstructionGeneration) {
 
   // Creating an initial root shadow node.
   auto emptyRootNode = std::const_pointer_cast<RootShadowNode>(
-      std::static_pointer_cast<RootShadowNode const>(
+      std::static_pointer_cast<const RootShadowNode>(
           rootComponentDescriptor.createShadowNode(
               ShadowNodeFragment{RootShadowNode::defaultSharedProps()},
               rootFamily)));
@@ -566,58 +566,58 @@ TEST(MountingTest, testViewReparentingInstructionGeneration) {
                                                       {})})})})})})})})})})});
 
   // Injecting a tree into the root node.
-  auto rootNodeV1 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV1 = std::static_pointer_cast<const RootShadowNode>(
       emptyRootNode->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV1})}));
-  auto rootNodeV2 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV2 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV1->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV2})}));
-  auto rootNodeV3 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV3 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV2->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV3})}));
-  auto rootNodeV4 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV4 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV3->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV4})}));
-  auto rootNodeV5 = std::static_pointer_cast<RootShadowNode const>(
+  auto rootNodeV5 = std::static_pointer_cast<const RootShadowNode>(
       rootNodeV4->ShadowNode::clone(ShadowNodeFragment{
           ShadowNodeFragment::propsPlaceholder(),
           std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared{shadowNodeV5})}));
 
   // Layout
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV1{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV1{};
   affectedLayoutableNodesV1.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV1)
       ->layoutIfNeeded(&affectedLayoutableNodesV1);
   rootNodeV1->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV2{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV2{};
   affectedLayoutableNodesV2.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV2)
       ->layoutIfNeeded(&affectedLayoutableNodesV2);
   rootNodeV2->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV3{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV3{};
   affectedLayoutableNodesV3.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV3)
       ->layoutIfNeeded(&affectedLayoutableNodesV3);
   rootNodeV3->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV4{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV4{};
   affectedLayoutableNodesV4.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV4)
       ->layoutIfNeeded(&affectedLayoutableNodesV4);
   rootNodeV4->sealRecursive();
 
-  std::vector<LayoutableShadowNode const *> affectedLayoutableNodesV5{};
+  std::vector<const LayoutableShadowNode *> affectedLayoutableNodesV5{};
   affectedLayoutableNodesV5.reserve(1024);
   std::const_pointer_cast<RootShadowNode>(rootNodeV5)
       ->layoutIfNeeded(&affectedLayoutableNodesV5);

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
@@ -55,7 +55,7 @@ static void testShadowNodeTreeLifeCycle(
 
     // Creating an initial root shadow node.
     auto emptyRootNode = std::const_pointer_cast<RootShadowNode>(
-        std::static_pointer_cast<RootShadowNode const>(
+        std::static_pointer_cast<const RootShadowNode>(
             rootComponentDescriptor.createShadowNode(
                 ShadowNodeFragment{RootShadowNode::defaultSharedProps()},
                 family)));
@@ -72,7 +72,7 @@ static void testShadowNodeTreeLifeCycle(
         generateShadowNodeTree(entropy, viewComponentDescriptor, treeSize);
 
     // Injecting a tree into the root node.
-    auto currentRootNode = std::static_pointer_cast<RootShadowNode const>(
+    auto currentRootNode = std::static_pointer_cast<const RootShadowNode>(
         emptyRootNode->ShadowNode::clone(ShadowNodeFragment{
             ShadowNodeFragment::propsPlaceholder(),
             std::make_shared<ShadowNode::ListOfShared>(
@@ -96,7 +96,7 @@ static void testShadowNodeTreeLifeCycle(
               &messWithLayoutableOnlyFlag,
           });
 
-      std::vector<LayoutableShadowNode const *> affectedLayoutableNodes{};
+      std::vector<const LayoutableShadowNode *> affectedLayoutableNodes{};
       affectedLayoutableNodes.reserve(1024);
 
       // Laying out the tree.
@@ -114,12 +114,12 @@ static void testShadowNodeTreeLifeCycle(
       // view is not followed by a CREATE for the same view.
       {
         std::vector<int> deletedTags{};
-        for (auto const &mutation : mutations) {
+        for (const auto &mutation : mutations) {
           if (mutation.type == ShadowViewMutation::Type::Delete) {
             deletedTags.push_back(mutation.oldChildShadowView.tag);
           }
         }
-        for (auto const &mutation : mutations) {
+        for (const auto &mutation : mutations) {
           if (mutation.type == ShadowViewMutation::Type::Create) {
             if (std::find(
                     deletedTags.begin(),
@@ -206,7 +206,7 @@ static void testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
 
     // Creating an initial root shadow node.
     auto emptyRootNode = std::const_pointer_cast<RootShadowNode>(
-        std::static_pointer_cast<RootShadowNode const>(
+        std::static_pointer_cast<const RootShadowNode>(
             rootComponentDescriptor.createShadowNode(
                 ShadowNodeFragment{RootShadowNode::defaultSharedProps()},
                 family)));
@@ -223,7 +223,7 @@ static void testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
         generateShadowNodeTree(entropy, viewComponentDescriptor, treeSize);
 
     // Injecting a tree into the root node.
-    auto currentRootNode = std::static_pointer_cast<RootShadowNode const>(
+    auto currentRootNode = std::static_pointer_cast<const RootShadowNode>(
         emptyRootNode->ShadowNode::clone(ShadowNodeFragment{
             ShadowNodeFragment::propsPlaceholder(),
             std::make_shared<ShadowNode::ListOfShared>(
@@ -248,7 +248,7 @@ static void testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
       alterShadowTree(entropy, nextRootNode, &messWithNodeFlattenednessFlags);
       alterShadowTree(entropy, nextRootNode, &messWithChildren);
 
-      std::vector<LayoutableShadowNode const *> affectedLayoutableNodes{};
+      std::vector<const LayoutableShadowNode *> affectedLayoutableNodes{};
       affectedLayoutableNodes.reserve(1024);
 
       // Laying out the tree.
@@ -266,12 +266,12 @@ static void testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
       // view is not followed by a CREATE for the same view.
       {
         std::vector<int> deletedTags{};
-        for (auto const &mutation : mutations) {
+        for (const auto &mutation : mutations) {
           if (mutation.type == ShadowViewMutation::Type::Delete) {
             deletedTags.push_back(mutation.oldChildShadowView.tag);
           }
         }
-        for (auto const &mutation : mutations) {
+        for (const auto &mutation : mutations) {
           if (mutation.type == ShadowViewMutation::Type::Create) {
             if (std::find(
                     deletedTags.begin(),

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -152,11 +152,11 @@ class StackingContextTest : public ::testing::Test {
   }
 
   void mutateViewShadowNodeProps_(
-      std::shared_ptr<ViewShadowNode> const &node,
+      const std::shared_ptr<ViewShadowNode> &node,
       std::function<void(ViewProps &props)> callback) {
     rootShadowNode_ =
         std::static_pointer_cast<RootShadowNode>(rootShadowNode_->cloneTree(
-            node->getFamily(), [&](ShadowNode const &oldShadowNode) {
+            node->getFamily(), [&](const ShadowNode &oldShadowNode) {
               auto viewProps = std::make_shared<ViewShadowNodeProps>();
               callback(*viewProps);
               return oldShadowNode.clone(ShadowNodeFragment{viewProps});
@@ -164,7 +164,7 @@ class StackingContextTest : public ::testing::Test {
   }
 
   void testViewTree_(
-      std::function<void(StubViewTree const &viewTree)> const &callback) {
+      const std::function<void(StubViewTree const &viewTree)> &callback) {
     rootShadowNode_->layoutIfNeeded();
 
     callback(buildStubViewTreeUsingDifferentiator(*rootShadowNode_));
@@ -179,7 +179,7 @@ class StackingContextTest : public ::testing::Test {
 };
 
 TEST_F(StackingContextTest, defaultPropsMakeEverythingFlattened) {
-  testViewTree_([](StubViewTree const &viewTree) {
+  testViewTree_([](const StubViewTree &viewTree) {
     // 1 view in total.
     EXPECT_EQ(viewTree.size(), 1);
 
@@ -280,7 +280,7 @@ TEST_F(StackingContextTest, mostPropsDoNotForceViewsToMaterialize) {
     props.hitSlop = EdgeInsets{42, 42, 42, 42};
   });
 
-  testViewTree_([](StubViewTree const &viewTree) {
+  testViewTree_([](const StubViewTree &viewTree) {
     // 1 view in total.
     EXPECT_EQ(viewTree.size(), 1);
 
@@ -359,7 +359,7 @@ TEST_F(StackingContextTest, somePropsForceViewsToMaterialize1) {
   mutateViewShadowNodeProps_(
       nodeBBA_, [](ViewProps &props) { props.shadowColor = blackColor(); });
 
-  testViewTree_([](StubViewTree const &viewTree) {
+  testViewTree_([](const StubViewTree &viewTree) {
     // 4 views in total.
     EXPECT_EQ(viewTree.size(), 4);
 
@@ -466,7 +466,7 @@ TEST_F(StackingContextTest, somePropsForceViewsToMaterialize2) {
   mutateViewShadowNodeProps_(
       nodeBD_, [](ViewProps &props) { props.opacity = 0.42; });
 
-  testViewTree_([](StubViewTree const &viewTree) {
+  testViewTree_([](const StubViewTree &viewTree) {
     // 10 views in total.
     EXPECT_EQ(viewTree.size(), 10);
 
@@ -572,7 +572,7 @@ TEST_F(StackingContextTest, zIndexAndFlattenedNodes) {
     props.zIndex = 8996;
   });
 
-  testViewTree_([](StubViewTree const &viewTree) {
+  testViewTree_([](const StubViewTree &viewTree) {
     // 7 views in total.
     EXPECT_EQ(viewTree.size(), 7);
 
@@ -656,7 +656,7 @@ TEST_F(StackingContextTest, zIndexAndFlattenedNodes) {
     props.zIndex = 42;
   });
 
-  testViewTree_([](StubViewTree const &viewTree) {
+  testViewTree_([](const StubViewTree &viewTree) {
     // 8 views in total.
     EXPECT_EQ(viewTree.size(), 8);
 
@@ -684,7 +684,7 @@ TEST_F(StackingContextTest, zIndexAndFlattenedNodes) {
     props.zIndex = {};
   });
 
-  testViewTree_([](StubViewTree const &viewTree) {
+  testViewTree_([](const StubViewTree &viewTree) {
     // 7 views in total.
     EXPECT_EQ(viewTree.size(), 7);
 
@@ -767,7 +767,7 @@ TEST_F(StackingContextTest, zIndexAndFlattenedNodes) {
     yogaStyle.display() = YGDisplayNone;
   });
 
-  testViewTree_([](StubViewTree const &viewTree) {
+  testViewTree_([](const StubViewTree &viewTree) {
 #ifdef ANDROID
     // T153547836: Android still mounts views with
     // ShadowNodeTraits::Trait::Hidden

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
@@ -25,9 +25,9 @@ using namespace facebook::react;
 class DummyShadowTreeDelegate : public ShadowTreeDelegate {
  public:
   RootShadowNode::Unshared shadowTreeWillCommit(
-      ShadowTree const & /*shadowTree*/,
-      RootShadowNode::Shared const & /*oldRootShadowNode*/,
-      RootShadowNode::Unshared const &newRootShadowNode) const override {
+      const ShadowTree & /*shadowTree*/,
+      const RootShadowNode::Shared & /*oldRootShadowNode*/,
+      const RootShadowNode::Unshared &newRootShadowNode) const override {
     return newRootShadowNode;
   };
 
@@ -36,20 +36,20 @@ class DummyShadowTreeDelegate : public ShadowTreeDelegate {
       bool mountSynchronously) const override{};
 };
 
-inline ShadowNode const *findDescendantNode(
-    ShadowNode const &shadowNode,
-    ShadowNodeFamily const &family) {
-  ShadowNode const *result = nullptr;
-  shadowNode.cloneTree(family, [&](ShadowNode const &oldShadowNode) {
+inline const ShadowNode *findDescendantNode(
+    const ShadowNode &shadowNode,
+    const ShadowNodeFamily &family) {
+  const ShadowNode *result = nullptr;
+  shadowNode.cloneTree(family, [&](const ShadowNode &oldShadowNode) {
     result = &oldShadowNode;
     return oldShadowNode.clone({});
   });
   return result;
 }
 
-inline ShadowNode const *findDescendantNode(
-    ShadowTree const &shadowTree,
-    ShadowNodeFamily const &family) {
+inline const ShadowNode *findDescendantNode(
+    const ShadowTree &shadowTree,
+    const ShadowNodeFamily &family) {
   return findDescendantNode(
       *shadowTree.getCurrentRevision().rootShadowNode, family);
 }
@@ -108,7 +108,7 @@ TEST(StateReconciliationTest, testStateReconciliation) {
       contextContainer};
 
   shadowTree.commit(
-      [&](RootShadowNode const & /*oldRootShadowNode*/) {
+      [&](const RootShadowNode & /*oldRootShadowNode*/) {
         return std::static_pointer_cast<RootShadowNode>(rootShadowNodeState1);
       },
       {true});
@@ -119,10 +119,10 @@ TEST(StateReconciliationTest, testStateReconciliation) {
       findDescendantNode(*rootShadowNodeState1, family)->getState(), state1);
 
   auto state2 = scrollViewComponentDescriptor.createState(
-      family, std::make_shared<ScrollViewState const>());
+      family, std::make_shared<const ScrollViewState>());
 
   auto rootShadowNodeState2 =
-      shadowNode->cloneTree(family, [&](ShadowNode const &oldShadowNode) {
+      shadowNode->cloneTree(family, [&](const ShadowNode &oldShadowNode) {
         return oldShadowNode.clone(
             {ShadowNodeFragment::propsPlaceholder(),
              ShadowNodeFragment::childrenPlaceholder(),
@@ -133,7 +133,7 @@ TEST(StateReconciliationTest, testStateReconciliation) {
       findDescendantNode(*rootShadowNodeState2, family)->getState(), state2);
 
   shadowTree.commit(
-      [&](RootShadowNode const & /*oldRootShadowNode*/) {
+      [&](const RootShadowNode & /*oldRootShadowNode*/) {
         return std::static_pointer_cast<RootShadowNode>(rootShadowNodeState2);
       },
       {true});
@@ -142,10 +142,10 @@ TEST(StateReconciliationTest, testStateReconciliation) {
   EXPECT_EQ(state2->getMostRecentState(), state2);
 
   auto state3 = scrollViewComponentDescriptor.createState(
-      family, std::make_shared<ScrollViewState const>());
+      family, std::make_shared<const ScrollViewState>());
 
   auto rootShadowNodeState3 = rootShadowNodeState2->cloneTree(
-      family, [&](ShadowNode const &oldShadowNode) {
+      family, [&](const ShadowNode &oldShadowNode) {
         return oldShadowNode.clone(
             {ShadowNodeFragment::propsPlaceholder(),
              ShadowNodeFragment::childrenPlaceholder(),
@@ -156,7 +156,7 @@ TEST(StateReconciliationTest, testStateReconciliation) {
       findDescendantNode(*rootShadowNodeState3, family)->getState(), state3);
 
   shadowTree.commit(
-      [&](RootShadowNode const & /*oldRootShadowNode*/) {
+      [&](const RootShadowNode & /*oldRootShadowNode*/) {
         return std::static_pointer_cast<RootShadowNode>(rootShadowNodeState3);
       },
       {true});
@@ -171,7 +171,7 @@ TEST(StateReconciliationTest, testStateReconciliation) {
   // Here we commit the old tree but we expect that the state associated with
   // the node will stay the same (newer that the old tree has).
   shadowTree.commit(
-      [&](RootShadowNode const & /*oldRootShadowNode*/) {
+      [&](const RootShadowNode & /*oldRootShadowNode*/) {
         return std::static_pointer_cast<RootShadowNode>(rootShadowNodeState2);
       },
       {true});

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.cpp
@@ -24,7 +24,7 @@ IntersectionObserver::IntersectionObserver(
       thresholds_(std::move(thresholds)) {}
 
 static Rect getRootBoundingRect(
-    LayoutableShadowNode const &layoutableRootShadowNode) {
+    const LayoutableShadowNode &layoutableRootShadowNode) {
   auto layoutMetrics = layoutableRootShadowNode.getLayoutMetrics();
 
   if (layoutMetrics == EmptyLayoutMetrics ||
@@ -38,7 +38,7 @@ static Rect getRootBoundingRect(
 }
 
 static Rect getTargetBoundingRect(
-    ShadowNodeFamily::AncestorList const &targetAncestors) {
+    const ShadowNodeFamily::AncestorList &targetAncestors) {
   auto layoutMetrics = LayoutableShadowNode::computeRelativeLayoutMetrics(
       targetAncestors,
       {/* .includeTransform = */ true,
@@ -47,7 +47,7 @@ static Rect getTargetBoundingRect(
 }
 
 static Rect getClippedTargetBoundingRect(
-    ShadowNodeFamily::AncestorList const &targetAncestors) {
+    const ShadowNodeFamily::AncestorList &targetAncestors) {
   auto layoutMetrics = LayoutableShadowNode::computeRelativeLayoutMetrics(
       targetAncestors,
       {/* .includeTransform = */ true,
@@ -60,9 +60,9 @@ static Rect getClippedTargetBoundingRect(
 // Partially equivalent to
 // https://w3c.github.io/IntersectionObserver/#compute-the-intersection
 static Rect computeIntersection(
-    Rect const &rootBoundingRect,
-    Rect const &targetBoundingRect,
-    ShadowNodeFamily::AncestorList const &targetAncestors) {
+    const Rect &rootBoundingRect,
+    const Rect &targetBoundingRect,
+    const ShadowNodeFamily::AncestorList &targetAncestors) {
   auto absoluteIntersectionRect =
       Rect::intersect(rootBoundingRect, targetBoundingRect);
 
@@ -90,10 +90,10 @@ static Rect computeIntersection(
 // https://w3c.github.io/IntersectionObserver/#update-intersection-observations-algo
 std::optional<IntersectionObserverEntry>
 IntersectionObserver::updateIntersectionObservation(
-    RootShadowNode const &rootShadowNode,
+    const RootShadowNode &rootShadowNode,
     double mountTime) {
-  auto const layoutableRootShadowNode =
-      traitCast<LayoutableShadowNode const *>(&rootShadowNode);
+  const auto layoutableRootShadowNode =
+      traitCast<const LayoutableShadowNode *>(&rootShadowNode);
 
   react_native_assert(
       layoutableRootShadowNode != nullptr &&
@@ -153,9 +153,9 @@ Float IntersectionObserver::getHighestThresholdCrossed(
 
 std::optional<IntersectionObserverEntry>
 IntersectionObserver::setIntersectingState(
-    Rect const &rootBoundingRect,
-    Rect const &targetBoundingRect,
-    Rect const &intersectionRect,
+    const Rect &rootBoundingRect,
+    const Rect &targetBoundingRect,
+    const Rect &intersectionRect,
     Float threshold,
     double mountTime) {
   auto newState = IntersectionObserverState::Intersecting(threshold);
@@ -179,8 +179,8 @@ IntersectionObserver::setIntersectingState(
 
 std::optional<IntersectionObserverEntry>
 IntersectionObserver::setNotIntersectingState(
-    Rect const &rootBoundingRect,
-    Rect const &targetBoundingRect,
+    const Rect &rootBoundingRect,
+    const Rect &targetBoundingRect,
     double mountTime) {
   if (state_ != IntersectionObserverState::NotIntersecting()) {
     state_ = IntersectionObserverState::NotIntersecting();

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
@@ -40,14 +40,14 @@ class IntersectionObserver {
   // Partially equivalent to
   // https://w3c.github.io/IntersectionObserver/#update-intersection-observations-algo
   std::optional<IntersectionObserverEntry> updateIntersectionObservation(
-      RootShadowNode const &rootShadowNode,
+      const RootShadowNode &rootShadowNode,
       double mountTime);
 
   IntersectionObserverObserverId getIntersectionObserverId() const {
     return intersectionObserverId_;
   }
 
-  ShadowNode const &getTargetShadowNode() const {
+  const ShadowNode &getTargetShadowNode() const {
     return *targetShadowNode_;
   }
 
@@ -59,15 +59,15 @@ class IntersectionObserver {
   Float getHighestThresholdCrossed(Float intersectionRatio);
 
   std::optional<IntersectionObserverEntry> setIntersectingState(
-      Rect const &rootBoundingRect,
-      Rect const &targetBoundingRect,
-      Rect const &intersectionRect,
+      const Rect &rootBoundingRect,
+      const Rect &targetBoundingRect,
+      const Rect &intersectionRect,
       Float threshold,
       double mountTime);
 
   std::optional<IntersectionObserverEntry> setNotIntersectingState(
-      Rect const &rootBoundingRect,
-      Rect const &targetBoundingRect,
+      const Rect &rootBoundingRect,
+      const Rect &targetBoundingRect,
       double mountTime);
 
   IntersectionObserverObserverId intersectionObserverId_;

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
@@ -19,7 +19,7 @@ void IntersectionObserverManager::observe(
     IntersectionObserverObserverId intersectionObserverId,
     const ShadowNode::Shared &shadowNode,
     std::vector<Float> thresholds,
-    UIManager const &uiManager) {
+    const UIManager &uiManager) {
   SystraceSection s("IntersectionObserverManager::observe");
 
   auto surfaceId = shadowNode->getSurfaceId();
@@ -45,7 +45,7 @@ void IntersectionObserverManager::observe(
   auto &shadowTreeRegistry = uiManager.getShadowTreeRegistry();
   MountingCoordinator::Shared mountingCoordinator = nullptr;
   RootShadowNode::Shared rootShadowNode = nullptr;
-  shadowTreeRegistry.visit(surfaceId, [&](ShadowTree const &shadowTree) {
+  shadowTreeRegistry.visit(surfaceId, [&](const ShadowTree &shadowTree) {
     mountingCoordinator = shadowTree.getMountingCoordinator();
     rootShadowNode = shadowTree.getCurrentRevision().rootShadowNode;
   });
@@ -67,7 +67,7 @@ void IntersectionObserverManager::observe(
 
 void IntersectionObserverManager::unobserve(
     IntersectionObserverObserverId intersectionObserverId,
-    ShadowNode const &shadowNode) {
+    const ShadowNode &shadowNode) {
   SystraceSection s("IntersectionObserverManager::unobserve");
 
   std::unique_lock lock(observersMutex_);
@@ -85,7 +85,7 @@ void IntersectionObserverManager::unobserve(
       std::remove_if(
           observers.begin(),
           observers.end(),
-          [intersectionObserverId, &shadowNode](auto const &observer) {
+          [intersectionObserverId, &shadowNode](const auto &observer) {
             return observer.getIntersectionObserverId() ==
                 intersectionObserverId &&
                 ShadowNode::sameFamily(
@@ -139,13 +139,13 @@ IntersectionObserverManager::takeRecords() {
 }
 
 void IntersectionObserverManager::shadowTreeDidMount(
-    RootShadowNode::Shared const &rootShadowNode,
+    const RootShadowNode::Shared &rootShadowNode,
     double mountTime) noexcept {
   updateIntersectionObservations(*rootShadowNode, mountTime);
 }
 
 void IntersectionObserverManager::updateIntersectionObservations(
-    RootShadowNode const &rootShadowNode,
+    const RootShadowNode &rootShadowNode,
     double mountTime) {
   SystraceSection s(
       "IntersectionObserverManager::updateIntersectionObservations");

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
@@ -24,11 +24,11 @@ class IntersectionObserverManager final : public UIManagerMountHook {
       IntersectionObserverObserverId intersectionObserverId,
       const ShadowNode::Shared &shadowNode,
       std::vector<Float> thresholds,
-      UIManager const &uiManager);
+      const UIManager &uiManager);
 
   void unobserve(
       IntersectionObserverObserverId intersectionObserverId,
-      ShadowNode const &shadowNode);
+      const ShadowNode &shadowNode);
 
   void connect(
       UIManager &uiManager,
@@ -41,7 +41,7 @@ class IntersectionObserverManager final : public UIManagerMountHook {
 #pragma mark - UIManagerMountHook
 
   void shadowTreeDidMount(
-      RootShadowNode::Shared const &rootShadowNode,
+      const RootShadowNode::Shared &rootShadowNode,
       double mountTime) noexcept override;
 
  private:
@@ -63,10 +63,10 @@ class IntersectionObserverManager final : public UIManagerMountHook {
   // Equivalent to
   // https://w3c.github.io/IntersectionObserver/#update-intersection-observations-algo
   void updateIntersectionObservations(
-      RootShadowNode const &rootShadowNode,
+      const RootShadowNode &rootShadowNode,
       double mountTime);
 
-  IntersectionObserver const &getRegisteredIntersectionObserver(
+  const IntersectionObserver &getRegisteredIntersectionObserver(
       SurfaceId surfaceId,
       IntersectionObserverObserverId observerId) const;
 };

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
@@ -24,7 +24,7 @@ void MutationObserver::observe(
   }
 }
 
-void MutationObserver::unobserve(ShadowNode const &targetShadowNode) {
+void MutationObserver::unobserve(const ShadowNode &targetShadowNode) {
   // We don't know if it's being observed deeply or not, so we need to check
   // both possibilities.
   deeplyObservedShadowNodes_.erase(
@@ -40,7 +40,7 @@ void MutationObserver::unobserve(ShadowNode const &targetShadowNode) {
       std::remove_if(
           shallowlyObservedShadowNodes_.begin(),
           shallowlyObservedShadowNodes_.end(),
-          [&targetShadowNode](auto const shadowNode) {
+          [&targetShadowNode](const auto shadowNode) {
             return ShadowNode::sameFamily(*shadowNode, targetShadowNode);
           }),
       shallowlyObservedShadowNodes_.end());
@@ -52,8 +52,8 @@ bool MutationObserver::isObserving() const {
 }
 
 static ShadowNode::Shared getShadowNodeInTree(
-    ShadowNode const &shadowNode,
-    ShadowNode const &newTree) {
+    const ShadowNode &shadowNode,
+    const ShadowNode &newTree) {
   auto ancestors = shadowNode.getFamily().getAncestors(newTree);
   if (ancestors.empty()) {
     return nullptr;
@@ -64,8 +64,8 @@ static ShadowNode::Shared getShadowNodeInTree(
 }
 
 static ShadowNode::Shared findNodeOfSameFamily(
-    ShadowNode::ListOfShared const &list,
-    ShadowNode const &node) {
+    const ShadowNode::ListOfShared &list,
+    const ShadowNode &node) {
   for (auto &current : list) {
     if (ShadowNode::sameFamily(node, *current)) {
       return current;
@@ -75,8 +75,8 @@ static ShadowNode::Shared findNodeOfSameFamily(
 }
 
 void MutationObserver::recordMutations(
-    RootShadowNode const &oldRootShadowNode,
-    RootShadowNode const &newRootShadowNode,
+    const RootShadowNode &oldRootShadowNode,
+    const RootShadowNode &newRootShadowNode,
     std::vector<const MutationRecord> &recordedMutations) const {
   // This tracks the nodes that have already been processed by this observer,
   // so we avoid unnecessary work and duplicated entries.
@@ -107,8 +107,8 @@ void MutationObserver::recordMutations(
 
 void MutationObserver::recordMutationsInTarget(
     ShadowNode::Shared targetShadowNode,
-    RootShadowNode const &oldRootShadowNode,
-    RootShadowNode const &newRootShadowNode,
+    const RootShadowNode &oldRootShadowNode,
+    const RootShadowNode &newRootShadowNode,
     bool observeSubtree,
     std::vector<const MutationRecord> &recordedMutations,
     SetOfShadowNodePointers &processedNodes) const {
@@ -143,8 +143,8 @@ void MutationObserver::recordMutationsInTarget(
 
 void MutationObserver::recordMutationsInSubtrees(
     ShadowNode::Shared targetShadowNode,
-    ShadowNode const &oldNode,
-    ShadowNode const &newNode,
+    const ShadowNode &oldNode,
+    const ShadowNode &newNode,
     bool observeSubtree,
     std::vector<const MutationRecord> &recordedMutations,
     SetOfShadowNodePointers processedNodes) const {

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
@@ -28,13 +28,13 @@ class MutationObserver {
   MutationObserver(MutationObserverId intersectionObserverId);
 
   void observe(ShadowNode::Shared targetShadowNode, bool observeSubtree);
-  void unobserve(ShadowNode const &targetShadowNode);
+  void unobserve(const ShadowNode &targetShadowNode);
 
   bool isObserving() const;
 
   void recordMutations(
-      RootShadowNode const &oldRootShadowNode,
-      RootShadowNode const &newRootShadowNode,
+      const RootShadowNode &oldRootShadowNode,
+      const RootShadowNode &newRootShadowNode,
       std::vector<const MutationRecord> &recordedMutations) const;
 
  private:
@@ -42,20 +42,20 @@ class MutationObserver {
   std::vector<ShadowNode::Shared> deeplyObservedShadowNodes_;
   std::vector<ShadowNode::Shared> shallowlyObservedShadowNodes_;
 
-  using SetOfShadowNodePointers = std::unordered_set<ShadowNode const *>;
+  using SetOfShadowNodePointers = std::unordered_set<const ShadowNode *>;
 
   void recordMutationsInTarget(
       ShadowNode::Shared targetShadowNode,
-      RootShadowNode const &oldRootShadowNode,
-      RootShadowNode const &newRootShadowNode,
+      const RootShadowNode &oldRootShadowNode,
+      const RootShadowNode &newRootShadowNode,
       bool observeSubtree,
       std::vector<const MutationRecord> &recordedMutations,
       SetOfShadowNodePointers &processedNodes) const;
 
   void recordMutationsInSubtrees(
       ShadowNode::Shared targetShadowNode,
-      ShadowNode const &oldNode,
-      ShadowNode const &newNode,
+      const ShadowNode &oldNode,
+      const ShadowNode &newNode,
       bool observeSubtree,
       std::vector<const MutationRecord> &recordedMutations,
       SetOfShadowNodePointers processedNodes) const;

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
@@ -18,7 +18,7 @@ void MutationObserverManager::observe(
     MutationObserverId mutationObserverId,
     ShadowNode::Shared shadowNode,
     bool observeSubtree,
-    UIManager const &uiManager) {
+    const UIManager &uiManager) {
   SystraceSection s("MutationObserverManager::observe");
 
   auto surfaceId = shadowNode->getSurfaceId();
@@ -38,7 +38,7 @@ void MutationObserverManager::observe(
 
 void MutationObserverManager::unobserve(
     MutationObserverId mutationObserverId,
-    ShadowNode const &shadowNode) {
+    const ShadowNode &shadowNode) {
   SystraceSection s("MutationObserverManager::unobserve");
 
   auto surfaceId = shadowNode.getSurfaceId();
@@ -99,22 +99,22 @@ void MutationObserverManager::disconnect(UIManager &uiManager) {
 }
 
 void MutationObserverManager::commitHookWasRegistered(
-    UIManager const &uiManager) noexcept {}
+    const UIManager &uiManager) noexcept {}
 void MutationObserverManager::commitHookWasUnregistered(
-    UIManager const &uiManager) noexcept {}
+    const UIManager &uiManager) noexcept {}
 
 RootShadowNode::Unshared MutationObserverManager::shadowTreeWillCommit(
-    ShadowTree const &shadowTree,
-    RootShadowNode::Shared const &oldRootShadowNode,
-    RootShadowNode::Unshared const &newRootShadowNode) noexcept {
+    const ShadowTree &shadowTree,
+    const RootShadowNode::Shared &oldRootShadowNode,
+    const RootShadowNode::Unshared &newRootShadowNode) noexcept {
   runMutationObservations(shadowTree, *oldRootShadowNode, *newRootShadowNode);
   return newRootShadowNode;
 }
 
 void MutationObserverManager::runMutationObservations(
-    ShadowTree const &shadowTree,
-    RootShadowNode const &oldRootShadowNode,
-    RootShadowNode const &newRootShadowNode) {
+    const ShadowTree &shadowTree,
+    const RootShadowNode &oldRootShadowNode,
+    const RootShadowNode &newRootShadowNode) {
   SystraceSection s("MutationObserverManager::runMutationObservations");
 
   auto surfaceId = shadowTree.getSurfaceId();

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
@@ -23,11 +23,11 @@ class MutationObserverManager final : public UIManagerCommitHook {
       MutationObserverId mutationObserverId,
       ShadowNode::Shared shadowNode,
       bool observeSubtree,
-      UIManager const &uiManager);
+      const UIManager &uiManager);
 
   void unobserve(
       MutationObserverId mutationObserverId,
-      ShadowNode const &shadowNode);
+      const ShadowNode &shadowNode);
 
   void connect(
       UIManager &uiManager,
@@ -37,13 +37,13 @@ class MutationObserverManager final : public UIManagerCommitHook {
 
 #pragma mark - UIManagerCommitHook
 
-  void commitHookWasRegistered(UIManager const &uiManager) noexcept override;
-  void commitHookWasUnregistered(UIManager const &uiManager) noexcept override;
+  void commitHookWasRegistered(const UIManager &uiManager) noexcept override;
+  void commitHookWasUnregistered(const UIManager &uiManager) noexcept override;
 
   RootShadowNode::Unshared shadowTreeWillCommit(
-      ShadowTree const &shadowTree,
-      RootShadowNode::Shared const &oldRootShadowNode,
-      RootShadowNode::Unshared const &newRootShadowNode) noexcept override;
+      const ShadowTree &shadowTree,
+      const RootShadowNode::Shared &oldRootShadowNode,
+      const RootShadowNode::Unshared &newRootShadowNode) noexcept override;
 
  private:
   std::unordered_map<
@@ -55,9 +55,9 @@ class MutationObserverManager final : public UIManagerCommitHook {
   bool commitHookRegistered_{};
 
   void runMutationObservations(
-      ShadowTree const &shadowTree,
-      RootShadowNode const &oldRootShadowNode,
-      RootShadowNode const &newRootShadowNode);
+      const ShadowTree &shadowTree,
+      const RootShadowNode &oldRootShadowNode,
+      const RootShadowNode &newRootShadowNode);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -25,8 +25,8 @@ class RuntimeScheduler final {
   /*
    * Not copyable.
    */
-  RuntimeScheduler(RuntimeScheduler const &) = delete;
-  RuntimeScheduler &operator=(RuntimeScheduler const &) = delete;
+  RuntimeScheduler(const RuntimeScheduler &) = delete;
+  RuntimeScheduler &operator=(const RuntimeScheduler &) = delete;
 
   /*
    * Not movable.
@@ -115,7 +115,7 @@ class RuntimeScheduler final {
       TaskPriorityComparer>
       taskQueue_;
 
-  RuntimeExecutor const runtimeExecutor_;
+  const RuntimeExecutor runtimeExecutor_;
   mutable SchedulerPriority currentPriority_{SchedulerPriority::NormalPriority};
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
@@ -20,7 +20,7 @@ namespace facebook::react {
 std::shared_ptr<RuntimeSchedulerBinding>
 RuntimeSchedulerBinding::createAndInstallIfNeeded(
     jsi::Runtime &runtime,
-    std::shared_ptr<RuntimeScheduler> const &runtimeScheduler) {
+    const std::shared_ptr<RuntimeScheduler> &runtimeScheduler) {
   auto runtimeSchedulerModuleName = "nativeRuntimeScheduler";
 
   auto runtimeSchedulerValue =
@@ -67,7 +67,7 @@ bool RuntimeSchedulerBinding::getIsSynchronous() const {
 
 jsi::Value RuntimeSchedulerBinding::get(
     jsi::Runtime &runtime,
-    jsi::PropNameID const &name) {
+    const jsi::PropNameID &name) {
   auto propertyName = name.utf8(runtime);
 
   if (propertyName == "unstable_scheduleCallback") {
@@ -77,8 +77,8 @@ jsi::Value RuntimeSchedulerBinding::get(
         3,
         [this](
             jsi::Runtime &runtime,
-            jsi::Value const &,
-            jsi::Value const *arguments,
+            const jsi::Value &,
+            const jsi::Value *arguments,
             size_t) noexcept -> jsi::Value {
           SchedulerPriority priority = fromRawValue(arguments[0].getNumber());
           auto callback = arguments[1].getObject(runtime).getFunction(runtime);
@@ -97,8 +97,8 @@ jsi::Value RuntimeSchedulerBinding::get(
         1,
         [this](
             jsi::Runtime &runtime,
-            jsi::Value const &,
-            jsi::Value const *arguments,
+            const jsi::Value &,
+            const jsi::Value *arguments,
             size_t) noexcept -> jsi::Value {
           runtimeScheduler_->cancelTask(*taskFromValue(runtime, arguments[0]));
           return jsi::Value::undefined();
@@ -112,8 +112,8 @@ jsi::Value RuntimeSchedulerBinding::get(
         0,
         [this](
             jsi::Runtime &,
-            jsi::Value const &,
-            jsi::Value const *,
+            const jsi::Value &,
+            const jsi::Value *,
             size_t) noexcept -> jsi::Value {
           auto shouldYield = runtimeScheduler_->getShouldYield();
           return {shouldYield};
@@ -126,8 +126,8 @@ jsi::Value RuntimeSchedulerBinding::get(
         name,
         0,
         [](jsi::Runtime &,
-           jsi::Value const &,
-           jsi::Value const *,
+           const jsi::Value &,
+           const jsi::Value *,
            size_t) noexcept -> jsi::Value {
           // RequestPaint is left empty by design.
           return jsi::Value::undefined();
@@ -141,8 +141,8 @@ jsi::Value RuntimeSchedulerBinding::get(
         0,
         [this](
             jsi::Runtime &,
-            jsi::Value const &,
-            jsi::Value const *,
+            const jsi::Value &,
+            const jsi::Value *,
             size_t) noexcept -> jsi::Value {
           auto now = runtimeScheduler_->now();
           auto asDouble =
@@ -160,8 +160,8 @@ jsi::Value RuntimeSchedulerBinding::get(
         0,
         [this](
             jsi::Runtime &runtime,
-            jsi::Value const &,
-            jsi::Value const *,
+            const jsi::Value &,
+            const jsi::Value *,
             size_t) noexcept -> jsi::Value {
           auto currentPriorityLevel =
               runtimeScheduler_->getCurrentPriorityLevel();

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
@@ -28,7 +28,7 @@ class RuntimeSchedulerBinding : public jsi::HostObject {
    */
   static std::shared_ptr<RuntimeSchedulerBinding> createAndInstallIfNeeded(
       jsi::Runtime &runtime,
-      std::shared_ptr<RuntimeScheduler> const &runtimeScheduler);
+      const std::shared_ptr<RuntimeScheduler> &runtimeScheduler);
 
   /*
    * Returns a shared pointer to RuntimeSchedulerBinding previously installed
@@ -40,7 +40,7 @@ class RuntimeSchedulerBinding : public jsi::HostObject {
   /*
    * `jsi::HostObject` specific overloads.
    */
-  jsi::Value get(jsi::Runtime &runtime, jsi::PropNameID const &name) override;
+  jsi::Value get(jsi::Runtime &runtime, const jsi::PropNameID &name) override;
 
   bool getIsSynchronous() const;
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -46,8 +46,8 @@ struct Task final : public jsi::NativeState {
 class TaskPriorityComparer {
  public:
   inline bool operator()(
-      std::shared_ptr<Task> const &lhs,
-      std::shared_ptr<Task> const &rhs) {
+      const std::shared_ptr<Task> &lhs,
+      const std::shared_ptr<Task> &rhs) {
     return lhs->expirationTime > rhs->expirationTime;
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -14,7 +14,7 @@
 namespace facebook::react {
 
 struct TaskWrapper : public jsi::HostObject {
-  TaskWrapper(std::shared_ptr<Task> const &task) : task(task) {}
+  TaskWrapper(const std::shared_ptr<Task> &task) : task(task) {}
 
   std::shared_ptr<Task> task;
 };
@@ -34,7 +34,7 @@ inline static jsi::Value valueFromTask(
 
 inline static std::shared_ptr<Task> taskFromValue(
     jsi::Runtime &runtime,
-    jsi::Value const &value) {
+    const jsi::Value &value) {
   if (value.isNull()) {
     return nullptr;
   }

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -53,8 +53,8 @@ class RuntimeSchedulerTest : public testing::Test {
         3,
         [this, callback = std::move(callback)](
             jsi::Runtime & /*unused*/,
-            jsi::Value const & /*unused*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*unused*/,
+            const jsi::Value *arguments,
             size_t /*unused*/) -> jsi::Value {
           ++hostFunctionCallCount_;
           auto didUserCallbackTimeout = arguments[0].getBool();
@@ -318,7 +318,7 @@ TEST_F(RuntimeSchedulerTest, getCurrentPriorityLevel) {
 TEST_F(RuntimeSchedulerTest, scheduleWorkWithYielding) {
   bool wasCalled = false;
   runtimeScheduler_->scheduleWork(
-      [&](jsi::Runtime const & /*unused*/) { wasCalled = true; });
+      [&](const jsi::Runtime & /*unused*/) { wasCalled = true; });
 
   EXPECT_FALSE(wasCalled);
 
@@ -346,7 +346,7 @@ TEST_F(RuntimeSchedulerTest, normalTaskYieldsToPlatformEvent) {
   runtimeScheduler_->scheduleTask(
       SchedulerPriority::NormalPriority, std::move(callback));
 
-  runtimeScheduler_->scheduleWork([&](jsi::Runtime const & /*unused*/) {
+  runtimeScheduler_->scheduleWork([&](const jsi::Runtime & /*unused*/) {
     didRunPlatformWork = true;
     EXPECT_FALSE(didRunJavaScriptTask);
     EXPECT_FALSE(runtimeScheduler_->getShouldYield());
@@ -373,7 +373,7 @@ TEST_F(RuntimeSchedulerTest, expiredTaskDoesntYieldToPlatformEvent) {
   runtimeScheduler_->scheduleTask(
       SchedulerPriority::NormalPriority, std::move(callback));
 
-  runtimeScheduler_->scheduleWork([&](jsi::Runtime const & /*unused*/) {
+  runtimeScheduler_->scheduleWork([&](const jsi::Runtime & /*unused*/) {
     didRunPlatformWork = true;
     EXPECT_TRUE(didRunJavaScriptTask);
   });
@@ -401,7 +401,7 @@ TEST_F(RuntimeSchedulerTest, immediateTaskDoesntYieldToPlatformEvent) {
   runtimeScheduler_->scheduleTask(
       SchedulerPriority::ImmediatePriority, std::move(callback));
 
-  runtimeScheduler_->scheduleWork([&](jsi::Runtime const & /*unused*/) {
+  runtimeScheduler_->scheduleWork([&](const jsi::Runtime & /*unused*/) {
     didRunPlatformWork = true;
     EXPECT_TRUE(didRunJavaScriptTask);
   });

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
@@ -38,7 +38,7 @@ class StubErrorUtils : public jsi::HostObject {
   /*
    * `jsi::HostObject` specific overloads.
    */
-  jsi::Value get(jsi::Runtime &runtime, jsi::PropNameID const &name) override {
+  jsi::Value get(jsi::Runtime &runtime, const jsi::PropNameID &name) override {
     auto propertyName = name.utf8(runtime);
 
     if (propertyName == "reportFatalError") {
@@ -48,8 +48,8 @@ class StubErrorUtils : public jsi::HostObject {
           1,
           [this](
               jsi::Runtime &runtime,
-              jsi::Value const &,
-              jsi::Value const *arguments,
+              const jsi::Value &,
+              const jsi::Value *arguments,
               size_t) noexcept -> jsi::Value {
             reportFatalCallCount_++;
             return jsi::Value::undefined();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/AsynchronousEventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/AsynchronousEventBeat.cpp
@@ -22,7 +22,7 @@ AsynchronousEventBeat::AsynchronousEventBeat(
 }
 
 void AsynchronousEventBeat::activityDidChange(
-    RunLoopObserver::Delegate const *delegate,
+    const RunLoopObserver::Delegate *delegate,
     RunLoopObserver::Activity /*activity*/) const noexcept {
   react_native_assert(delegate == this);
   induce();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/AsynchronousEventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/AsynchronousEventBeat.h
@@ -28,7 +28,7 @@ class AsynchronousEventBeat : public EventBeat,
 #pragma mark - RunLoopObserver::Delegate
 
   void activityDidChange(
-      RunLoopObserver::Delegate const *delegate,
+      const RunLoopObserver::Delegate *delegate,
       RunLoopObserver::Activity activity) const noexcept override;
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -36,7 +36,7 @@ namespace facebook::react {
 class Scheduler final : public UIManagerDelegate {
  public:
   Scheduler(
-      SchedulerToolbox const &schedulerToolbox,
+      const SchedulerToolbox &schedulerToolbox,
       UIManagerAnimationDelegate *animationDelegate,
       SchedulerDelegate *delegate);
   ~Scheduler() override;
@@ -48,11 +48,11 @@ class Scheduler final : public UIManagerDelegate {
    * All registered `SurfaceHandler` objects must be unregistered
    * (with the same `Scheduler`) before their deallocation.
    */
-  void registerSurface(SurfaceHandler const &surfaceHandler) const noexcept;
-  void unregisterSurface(SurfaceHandler const &surfaceHandler) const noexcept;
+  void registerSurface(const SurfaceHandler &surfaceHandler) const noexcept;
+  void unregisterSurface(const SurfaceHandler &surfaceHandler) const noexcept;
 
   InspectorData getInspectorDataForInstance(
-      EventEmitter const &eventEmitter) const noexcept;
+      const EventEmitter &eventEmitter) const noexcept;
 
   void renderTemplateToSurface(
       SurfaceId surfaceId,
@@ -63,7 +63,7 @@ class Scheduler final : public UIManagerDelegate {
    * `ComponentDescriptor`s are not designed to be used outside of `UIManager`,
    * there is no any guarantees about their lifetime.
    */
-  ComponentDescriptor const *
+  const ComponentDescriptor *
   findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
       ComponentHandle handle) const;
 
@@ -92,13 +92,13 @@ class Scheduler final : public UIManagerDelegate {
   void uiManagerDidCreateShadowNode(const ShadowNode &shadowNode) override;
   void uiManagerDidDispatchCommand(
       const ShadowNode::Shared &shadowNode,
-      std::string const &commandName,
-      folly::dynamic const &args) override;
+      const std::string &commandName,
+      const folly::dynamic &args) override;
   void uiManagerDidSendAccessibilityEvent(
       const ShadowNode::Shared &shadowNode,
-      std::string const &eventType) override;
+      const std::string &eventType) override;
   void uiManagerDidSetIsJSResponder(
-      ShadowNode::Shared const &shadowNode,
+      const ShadowNode::Shared &shadowNode,
       bool isJSResponder,
       bool blockNativeResponder) override;
 
@@ -111,9 +111,9 @@ class Scheduler final : public UIManagerDelegate {
   void reportMount(SurfaceId surfaceId) const;
 
 #pragma mark - Event listeners
-  void addEventListener(const std::shared_ptr<EventListener const> &listener);
+  void addEventListener(const std::shared_ptr<const EventListener> &listener);
   void removeEventListener(
-      const std::shared_ptr<EventListener const> &listener);
+      const std::shared_ptr<const EventListener> &listener);
 
  private:
   friend class SurfaceHandler;
@@ -133,7 +133,7 @@ class Scheduler final : public UIManagerDelegate {
    * parts that need to have ownership (and only ownership) of that, and then
    * fill the optional.
    */
-  std::shared_ptr<std::optional<EventDispatcher const>> eventDispatcher_;
+  std::shared_ptr<std::optional<const EventDispatcher>> eventDispatcher_;
 
   /**
    * Hold onto ContextContainer. See SchedulerToolbox.

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -37,18 +37,18 @@ class SchedulerDelegate {
 
   virtual void schedulerDidDispatchCommand(
       const ShadowView &shadowView,
-      std::string const &commandName,
-      folly::dynamic const &args) = 0;
+      const std::string &commandName,
+      const folly::dynamic &args) = 0;
 
   virtual void schedulerDidSendAccessibilityEvent(
       const ShadowView &shadowView,
-      std::string const &eventType) = 0;
+      const std::string &eventType) = 0;
 
   /*
    * Set JS responder for a view
    */
   virtual void schedulerDidSetIsJSResponder(
-      ShadowView const &shadowView,
+      const ShadowView &shadowView,
       bool isJSResponder,
       bool blockNativeResponder) = 0;
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -16,7 +16,7 @@ namespace facebook::react {
 using Status = SurfaceHandler::Status;
 
 SurfaceHandler::SurfaceHandler(
-    std::string const &moduleName,
+    const std::string &moduleName,
     SurfaceId surfaceId) noexcept {
   parameters_.moduleName = moduleName;
   parameters_.surfaceId = surfaceId;
@@ -164,7 +164,7 @@ std::string SurfaceHandler::getModuleName() const noexcept {
   return parameters_.moduleName;
 }
 
-void SurfaceHandler::setProps(folly::dynamic const &props) const noexcept {
+void SurfaceHandler::setProps(const folly::dynamic &props) const noexcept {
   SystraceSection s("SurfaceHandler::setProps");
   auto parameters = Parameters{};
   {
@@ -192,7 +192,7 @@ folly::dynamic SurfaceHandler::getProps() const noexcept {
   return parameters_.props;
 }
 
-std::shared_ptr<MountingCoordinator const>
+std::shared_ptr<const MountingCoordinator>
 SurfaceHandler::getMountingCoordinator() const noexcept {
   std::shared_lock lock(linkMutex_);
   react_native_assert(
@@ -205,8 +205,8 @@ SurfaceHandler::getMountingCoordinator() const noexcept {
 #pragma mark - Layout
 
 Size SurfaceHandler::measure(
-    LayoutConstraints const &layoutConstraints,
-    LayoutContext const &layoutContext) const noexcept {
+    const LayoutConstraints &layoutConstraints,
+    const LayoutContext &layoutContext) const noexcept {
   std::shared_lock lock(linkMutex_);
 
   if (link_.status != Status::Running) {
@@ -229,8 +229,8 @@ Size SurfaceHandler::measure(
 }
 
 void SurfaceHandler::constraintLayout(
-    LayoutConstraints const &layoutConstraints,
-    LayoutContext const &layoutContext) const noexcept {
+    const LayoutConstraints &layoutConstraints,
+    const LayoutContext &layoutContext) const noexcept {
   SystraceSection s("SurfaceHandler::constraintLayout");
   {
     std::unique_lock lock(parametersMutex_);
@@ -257,7 +257,7 @@ void SurfaceHandler::constraintLayout(
     react_native_assert(
         link_.shadowTree && "`link_.shadowTree` must not be null.");
     link_.shadowTree->commit(
-        [&](RootShadowNode const &oldRootShadowNode) {
+        [&](const RootShadowNode &oldRootShadowNode) {
           return oldRootShadowNode.clone(
               propsParserContext, layoutConstraints, layoutContext);
         },
@@ -302,7 +302,7 @@ void SurfaceHandler::applyDisplayMode(DisplayMode displayMode) const noexcept {
       // Committing the current revision back. It will be mounted only when
       // `DisplayMode` is changed back to `Normal`.
       link_.shadowTree->commit(
-          [&](RootShadowNode const & /*oldRootShadowNode*/) {
+          [&](const RootShadowNode & /*oldRootShadowNode*/) {
             return std::static_pointer_cast<RootShadowNode>(
                 revision.rootShadowNode->ShadowNode::clone({}));
           },
@@ -311,7 +311,7 @@ void SurfaceHandler::applyDisplayMode(DisplayMode displayMode) const noexcept {
   }
 }
 
-void SurfaceHandler::setUIManager(UIManager const *uiManager) const noexcept {
+void SurfaceHandler::setUIManager(const UIManager *uiManager) const noexcept {
   std::unique_lock lock(linkMutex_);
 
   react_native_assert(

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
@@ -61,16 +61,16 @@ class SurfaceHandler {
   /*
    * Can be constructed anytime with a `moduleName` and a `surfaceId`.
    */
-  SurfaceHandler(std::string const &moduleName, SurfaceId surfaceId) noexcept;
+  SurfaceHandler(const std::string &moduleName, SurfaceId surfaceId) noexcept;
   virtual ~SurfaceHandler() noexcept;
 
   /*
    * Movable-only.
    */
   SurfaceHandler(SurfaceHandler &&other) noexcept;
-  SurfaceHandler(SurfaceHandler const &SurfaceHandler) noexcept = delete;
+  SurfaceHandler(const SurfaceHandler &SurfaceHandler) noexcept = delete;
   SurfaceHandler &operator=(SurfaceHandler &&other) noexcept;
-  SurfaceHandler &operator=(SurfaceHandler const &other) noexcept = delete;
+  SurfaceHandler &operator=(const SurfaceHandler &other) noexcept = delete;
 
 #pragma mark - Surface Life-Cycle Management
 
@@ -111,7 +111,7 @@ class SurfaceHandler {
    * Provides access for surface props.
    * Props can be changed anytime (even for `Unregistered` surface).
    */
-  void setProps(folly::dynamic const &props) const noexcept;
+  void setProps(const folly::dynamic &props) const noexcept;
   folly::dynamic getProps() const noexcept;
 
   /*
@@ -119,7 +119,7 @@ class SurfaceHandler {
    * Can be not be called when the status is `Unregistered`.
    * The returning value cannot be `nullptr`.
    */
-  std::shared_ptr<MountingCoordinator const> getMountingCoordinator()
+  std::shared_ptr<const MountingCoordinator> getMountingCoordinator()
       const noexcept;
 
 #pragma mark - Layout
@@ -129,15 +129,15 @@ class SurfaceHandler {
    * Returns zero size if called on the stopped or unregistered surface.
    */
   Size measure(
-      LayoutConstraints const &layoutConstraints,
-      LayoutContext const &layoutContext) const noexcept;
+      const LayoutConstraints &layoutConstraints,
+      const LayoutContext &layoutContext) const noexcept;
 
   /*
    * Sets layout constraints and layout context for the surface.
    */
   void constraintLayout(
-      LayoutConstraints const &layoutConstraints,
-      LayoutContext const &layoutContext) const noexcept;
+      const LayoutConstraints &layoutConstraints,
+      const LayoutContext &layoutContext) const noexcept;
 
   /*
    * Returns layout constraints and layout context associated with the surface.
@@ -151,7 +151,7 @@ class SurfaceHandler {
   /*
    * Must be called by `Scheduler` during registration process.
    */
-  void setUIManager(UIManager const *uiManager) const noexcept;
+  void setUIManager(const UIManager *uiManager) const noexcept;
 
   void applyDisplayMode(DisplayMode displayMode) const noexcept;
 
@@ -188,8 +188,8 @@ class SurfaceHandler {
    */
   struct Link {
     Status status{Status::Unregistered};
-    UIManager const *uiManager{};
-    ShadowTree const *shadowTree{};
+    const UIManager *uiManager{};
+    const ShadowTree *shadowTree{};
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -11,15 +11,15 @@
 
 namespace facebook::react {
 
-SurfaceManager::SurfaceManager(Scheduler const &scheduler) noexcept
+SurfaceManager::SurfaceManager(const Scheduler &scheduler) noexcept
     : scheduler_(scheduler) {}
 
 void SurfaceManager::startSurface(
     SurfaceId surfaceId,
-    std::string const &moduleName,
-    folly::dynamic const &props,
-    LayoutConstraints const &layoutConstraints,
-    LayoutContext const &layoutContext) const noexcept {
+    const std::string &moduleName,
+    const folly::dynamic &props,
+    const LayoutConstraints &layoutConstraints,
+    const LayoutContext &layoutContext) const noexcept {
   {
     std::unique_lock lock(mutex_);
     auto surfaceHandler = SurfaceHandler{moduleName, surfaceId};
@@ -27,7 +27,7 @@ void SurfaceManager::startSurface(
     registry_.emplace(surfaceId, std::move(surfaceHandler));
   }
 
-  visit(surfaceId, [&](SurfaceHandler const &surfaceHandler) {
+  visit(surfaceId, [&](const SurfaceHandler &surfaceHandler) {
     surfaceHandler.setProps(props);
     surfaceHandler.constraintLayout(layoutConstraints, layoutContext);
 
@@ -38,7 +38,7 @@ void SurfaceManager::startSurface(
 }
 
 void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
-  visit(surfaceId, [&](SurfaceHandler const &surfaceHandler) {
+  visit(surfaceId, [&](const SurfaceHandler &surfaceHandler) {
     surfaceHandler.stop();
     scheduler_.unregisterSurface(surfaceHandler);
   });
@@ -53,11 +53,11 @@ void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
 
 Size SurfaceManager::measureSurface(
     SurfaceId surfaceId,
-    LayoutConstraints const &layoutConstraints,
-    LayoutContext const &layoutContext) const noexcept {
+    const LayoutConstraints &layoutConstraints,
+    const LayoutContext &layoutContext) const noexcept {
   auto size = Size{};
 
-  visit(surfaceId, [&](SurfaceHandler const &surfaceHandler) {
+  visit(surfaceId, [&](const SurfaceHandler &surfaceHandler) {
     size = surfaceHandler.measure(layoutConstraints, layoutContext);
   });
 
@@ -68,7 +68,7 @@ MountingCoordinator::Shared SurfaceManager::findMountingCoordinator(
     SurfaceId surfaceId) const noexcept {
   auto mountingCoordinator = MountingCoordinator::Shared{};
 
-  visit(surfaceId, [&](SurfaceHandler const &surfaceHandler) {
+  visit(surfaceId, [&](const SurfaceHandler &surfaceHandler) {
     mountingCoordinator = surfaceHandler.getMountingCoordinator();
   });
 
@@ -77,16 +77,16 @@ MountingCoordinator::Shared SurfaceManager::findMountingCoordinator(
 
 void SurfaceManager::constraintSurfaceLayout(
     SurfaceId surfaceId,
-    LayoutConstraints const &layoutConstraints,
-    LayoutContext const &layoutContext) const noexcept {
-  visit(surfaceId, [=](SurfaceHandler const &surfaceHandler) {
+    const LayoutConstraints &layoutConstraints,
+    const LayoutContext &layoutContext) const noexcept {
+  visit(surfaceId, [=](const SurfaceHandler &surfaceHandler) {
     surfaceHandler.constraintLayout(layoutConstraints, layoutContext);
   });
 }
 
 void SurfaceManager::visit(
     SurfaceId surfaceId,
-    std::function<void(SurfaceHandler const &surfaceHandler)> const &callback)
+    const std::function<void(SurfaceHandler const &surfaceHandler)> &callback)
     const noexcept {
   std::shared_lock lock(mutex_);
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -26,28 +26,28 @@ namespace facebook::react {
  */
 class SurfaceManager final {
  public:
-  explicit SurfaceManager(Scheduler const &scheduler) noexcept;
+  explicit SurfaceManager(const Scheduler &scheduler) noexcept;
 
 #pragma mark - Surface Management
 
   void startSurface(
       SurfaceId surfaceId,
-      std::string const &moduleName,
-      folly::dynamic const &props,
-      LayoutConstraints const &layoutConstraints = {},
-      LayoutContext const &layoutContext = {}) const noexcept;
+      const std::string &moduleName,
+      const folly::dynamic &props,
+      const LayoutConstraints &layoutConstraints = {},
+      const LayoutContext &layoutContext = {}) const noexcept;
 
   void stopSurface(SurfaceId surfaceId) const noexcept;
 
   Size measureSurface(
       SurfaceId surfaceId,
-      LayoutConstraints const &layoutConstraints,
-      LayoutContext const &layoutContext) const noexcept;
+      const LayoutConstraints &layoutConstraints,
+      const LayoutContext &layoutContext) const noexcept;
 
   void constraintSurfaceLayout(
       SurfaceId surfaceId,
-      LayoutConstraints const &layoutConstraints,
-      LayoutContext const &layoutContext) const noexcept;
+      const LayoutConstraints &layoutConstraints,
+      const LayoutContext &layoutContext) const noexcept;
 
   MountingCoordinator::Shared findMountingCoordinator(
       SurfaceId surfaceId) const noexcept;
@@ -55,10 +55,10 @@ class SurfaceManager final {
  private:
   void visit(
       SurfaceId surfaceId,
-      std::function<void(SurfaceHandler const &surfaceHandler)> const &callback)
+      const std::function<void(SurfaceHandler const &surfaceHandler)> &callback)
       const noexcept;
 
-  Scheduler const &scheduler_;
+  const Scheduler &scheduler_;
   mutable std::shared_mutex mutex_; // Protects `registry_`.
   mutable butter::map<SurfaceId, SurfaceHandler> registry_{};
 };

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SynchronousEventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SynchronousEventBeat.cpp
@@ -26,7 +26,7 @@ SynchronousEventBeat::SynchronousEventBeat(
 }
 
 void SynchronousEventBeat::activityDidChange(
-    RunLoopObserver::Delegate const *delegate,
+    const RunLoopObserver::Delegate *delegate,
     RunLoopObserver::Activity /*activity*/) const noexcept {
   react_native_assert(delegate == this);
   lockExecutorAndBeat();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SynchronousEventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SynchronousEventBeat.h
@@ -31,7 +31,7 @@ class SynchronousEventBeat final : public EventBeat,
 #pragma mark - RunLoopObserver::Delegate
 
   void activityDidChange(
-      RunLoopObserver::Delegate const *delegate,
+      const RunLoopObserver::Delegate *delegate,
       RunLoopObserver::Activity activity) const noexcept override;
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/SurfaceTelemetry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/SurfaceTelemetry.cpp
@@ -12,7 +12,7 @@
 namespace facebook::react {
 
 void SurfaceTelemetry::incorporate(
-    TransactionTelemetry const &telemetry,
+    const TransactionTelemetry &telemetry,
     int numberOfMutations) {
   layoutTime_ += telemetry.getLayoutEndTime() - telemetry.getLayoutStartTime();
   textMeasureTime_ += telemetry.getTextMeasureTime();

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/SurfaceTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/SurfaceTelemetry.h
@@ -44,7 +44,7 @@ class SurfaceTelemetry final {
    * for the Surface.
    */
   void incorporate(
-      TransactionTelemetry const &telemetry,
+      const TransactionTelemetry &telemetry,
       int numberOfMutations);
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/templateprocessor/UITemplateProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/templateprocessor/UITemplateProcessor.cpp
@@ -38,7 +38,7 @@ ShadowNode::Shared UITemplateProcessor::runCommand(
     std::vector<folly::dynamic> &registers,
     const ComponentDescriptorRegistry &componentDescriptorRegistry,
     const NativeModuleRegistry &nativeModuleRegistry,
-    std::shared_ptr<const ReactNativeConfig> const &reactNativeConfig) {
+    const std::shared_ptr<const ReactNativeConfig> &reactNativeConfig) {
   const std::string &opcode = command[0].asString();
   const int tagOffset = 420000;
   // TODO: change to integer codes and a switch statement
@@ -51,7 +51,7 @@ ShadowNode::Shared UITemplateProcessor::runCommand(
         tag + tagOffset, type, surfaceId, props, nullptr);
     if (parentTag > -1) { // parentTag == -1 indicates root node
       auto parentShadowNode = nodes[static_cast<size_t>(parentTag)];
-      auto const &componentDescriptor = componentDescriptorRegistry.at(
+      const auto &componentDescriptor = componentDescriptorRegistry.at(
           parentShadowNode->getComponentHandle());
       componentDescriptor.appendChild(parentShadowNode, nodes[tag]);
     }
@@ -105,7 +105,7 @@ ShadowNode::Shared UITemplateProcessor::buildShadowTree(
     const folly::dynamic &params,
     const ComponentDescriptorRegistry &componentDescriptorRegistry,
     const NativeModuleRegistry &nativeModuleRegistry,
-    std::shared_ptr<const ReactNativeConfig> const &reactNativeConfig) {
+    const std::shared_ptr<const ReactNativeConfig> &reactNativeConfig) {
   if (DEBUG_FLY) {
     LOG(INFO)
         << "(strt) UITemplateProcessor inject hardcoded 'server rendered' view tree";

--- a/packages/react-native/ReactCommon/react/renderer/templateprocessor/UITemplateProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/templateprocessor/UITemplateProcessor.h
@@ -49,7 +49,7 @@ class UITemplateProcessor {
       const folly::dynamic &params,
       const ComponentDescriptorRegistry &componentDescriptorRegistry,
       const NativeModuleRegistry &nativeModuleRegistry,
-      std::shared_ptr<const ReactNativeConfig> const &reactNativeConfig);
+      const std::shared_ptr<const ReactNativeConfig> &reactNativeConfig);
 
  private:
   static ShadowNode::Shared runCommand(
@@ -59,6 +59,6 @@ class UITemplateProcessor {
       std::vector<folly::dynamic> &registers,
       const ComponentDescriptorRegistry &componentDescriptorRegistry,
       const NativeModuleRegistry &nativeModuleRegistry,
-      std::shared_ptr<const ReactNativeConfig> const &reactNativeConfig);
+      const std::shared_ptr<const ReactNativeConfig> &reactNativeConfig);
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/templateprocessor/tests/UITemplateProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/templateprocessor/tests/UITemplateProcessorTest.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<const ReactNativeConfig> mockReactNativeConfig_ =
 
 TEST(UITemplateProcessorTest, testSimpleBytecode) {
   auto surfaceId = 11;
-  auto eventDispatcher = std::shared_ptr<EventDispatcher const>();
+  auto eventDispatcher = std::shared_ptr<const EventDispatcher>();
   auto componentDescriptorRegistry =
       getComponentRegistryFactory()(eventDispatcher, nullptr);
   auto nativeModuleRegistry = buildNativeModuleRegistry();
@@ -116,7 +116,7 @@ TEST(UITemplateProcessorTest, testSimpleBytecode) {
 
 TEST(UITemplateProcessorTest, testConditionalBytecode) {
   auto surfaceId = 11;
-  auto eventDispatcher = std::shared_ptr<EventDispatcher const>();
+  auto eventDispatcher = std::shared_ptr<const EventDispatcher>();
   auto componentDescriptorRegistry =
       getComponentRegistryFactory()(eventDispatcher, nullptr);
   auto nativeModuleRegistry = buildNativeModuleRegistry();

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.cpp
@@ -11,7 +11,7 @@
 
 namespace facebook::react {
 
-static Rect rectFromDynamic(folly::dynamic const &data) {
+static Rect rectFromDynamic(const folly::dynamic &data) {
   Point origin;
   origin.x = static_cast<Float>(data.getDefault("x", 0).getDouble());
   origin.y = static_cast<Float>(data.getDefault("y", 0).getDouble());
@@ -38,7 +38,7 @@ LineMeasurement::LineMeasurement(
       ascender(ascender),
       xHeight(xHeight) {}
 
-LineMeasurement::LineMeasurement(folly::dynamic const &data)
+LineMeasurement::LineMeasurement(const folly::dynamic &data)
     : text(data.getDefault("text", "").getString()),
       frame(rectFromDynamic(data)),
       descender(
@@ -48,7 +48,7 @@ LineMeasurement::LineMeasurement(folly::dynamic const &data)
       ascender(static_cast<Float>(data.getDefault("ascender", 0).getDouble())),
       xHeight(static_cast<Float>(data.getDefault("xHeight", 0).getDouble())) {}
 
-bool LineMeasurement::operator==(LineMeasurement const &rhs) const {
+bool LineMeasurement::operator==(const LineMeasurement &rhs) const {
   return std::tie(
              this->text,
              this->frame,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -32,9 +32,9 @@ struct LineMeasurement {
       Float ascender,
       Float xHeight);
 
-  LineMeasurement(folly::dynamic const &data);
+  LineMeasurement(const folly::dynamic &data);
 
-  bool operator==(LineMeasurement const &rhs) const;
+  bool operator==(const LineMeasurement &rhs) const;
 };
 
 using LinesMeasurements = std::vector<LineMeasurement>;
@@ -83,8 +83,8 @@ using TextMeasureCache = SimpleThreadSafeCache<
     kSimpleThreadSafeCacheSizeCap>;
 
 inline bool areTextAttributesEquivalentLayoutWise(
-    TextAttributes const &lhs,
-    TextAttributes const &rhs) {
+    const TextAttributes &lhs,
+    const TextAttributes &rhs) {
   // Here we check all attributes that affect layout metrics and don't check any
   // attributes that affect only a decorative aspect of displayed text (like
   // colors).
@@ -111,7 +111,7 @@ inline bool areTextAttributesEquivalentLayoutWise(
 }
 
 inline size_t textAttributesHashLayoutWise(
-    TextAttributes const &textAttributes) {
+    const TextAttributes &textAttributes) {
   // Taking into account the same props as
   // `areTextAttributesEquivalentLayoutWise` mentions.
   return folly::hash::hash_combine(
@@ -130,8 +130,8 @@ inline size_t textAttributesHashLayoutWise(
 }
 
 inline bool areAttributedStringFragmentsEquivalentLayoutWise(
-    AttributedString::Fragment const &lhs,
-    AttributedString::Fragment const &rhs) {
+    const AttributedString::Fragment &lhs,
+    const AttributedString::Fragment &rhs) {
   return lhs.string == rhs.string &&
       areTextAttributesEquivalentLayoutWise(
              lhs.textAttributes, rhs.textAttributes) &&
@@ -143,7 +143,7 @@ inline bool areAttributedStringFragmentsEquivalentLayoutWise(
 }
 
 inline size_t textAttributesHashLayoutWise(
-    AttributedString::Fragment const &fragment) {
+    const AttributedString::Fragment &fragment) {
   // Here we are not taking `isAttachment` and `layoutMetrics` into account
   // because they are logically interdependent and this can break an invariant
   // between hash and equivalence functions (and cause cache misses).
@@ -154,8 +154,8 @@ inline size_t textAttributesHashLayoutWise(
 }
 
 inline bool areAttributedStringsEquivalentLayoutWise(
-    AttributedString const &lhs,
-    AttributedString const &rhs) {
+    const AttributedString &lhs,
+    const AttributedString &rhs) {
   auto &lhsFragment = lhs.getFragments();
   auto &rhsFragment = rhs.getFragments();
 
@@ -175,10 +175,10 @@ inline bool areAttributedStringsEquivalentLayoutWise(
 }
 
 inline size_t textAttributedStringHashLayoutWise(
-    AttributedString const &attributedString) {
+    const AttributedString &attributedString) {
   auto seed = size_t{0};
 
-  for (auto const &fragment : attributedString.getFragments()) {
+  for (const auto &fragment : attributedString.getFragments()) {
     seed =
         folly::hash::hash_combine(seed, textAttributesHashLayoutWise(fragment));
   }
@@ -187,8 +187,8 @@ inline size_t textAttributedStringHashLayoutWise(
 }
 
 inline bool operator==(
-    TextMeasureCacheKey const &lhs,
-    TextMeasureCacheKey const &rhs) {
+    const TextMeasureCacheKey &lhs,
+    const TextMeasureCacheKey &rhs) {
   return areAttributedStringsEquivalentLayoutWise(
              lhs.attributedString, rhs.attributedString) &&
       lhs.paragraphAttributes == rhs.paragraphAttributes &&
@@ -197,8 +197,8 @@ inline bool operator==(
 }
 
 inline bool operator!=(
-    TextMeasureCacheKey const &lhs,
-    TextMeasureCacheKey const &rhs) {
+    const TextMeasureCacheKey &lhs,
+    const TextMeasureCacheKey &rhs) {
   return !(lhs == rhs);
 }
 
@@ -208,7 +208,7 @@ namespace std {
 
 template <>
 struct hash<facebook::react::TextMeasureCacheKey> {
-  size_t operator()(facebook::react::TextMeasureCacheKey const &key) const {
+  size_t operator()(const facebook::react::TextMeasureCacheKey &key) const {
     return folly::hash::hash_combine(
         0,
         textAttributedStringHashLayoutWise(key.attributedString),

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -23,9 +23,9 @@ using namespace facebook::jni;
 namespace facebook::react {
 
 Size measureAndroidComponent(
-    ContextContainer::Shared const &contextContainer,
+    const ContextContainer::Shared &contextContainer,
     Tag rootTag,
-    std::string const &componentName,
+    const std::string &componentName,
     folly::dynamic localData,
     folly::dynamic props,
     folly::dynamic state,
@@ -94,7 +94,7 @@ Size measureAndroidComponent(
 Size measureAndroidComponentMapBuffer(
     const ContextContainer::Shared &contextContainer,
     Tag rootTag,
-    std::string const &componentName,
+    const std::string &componentName,
     MapBuffer localData,
     MapBuffer props,
     float minWidth,
@@ -157,15 +157,15 @@ void *TextLayoutManager::getNativeTextLayoutManager() const {
 }
 
 TextMeasurement TextLayoutManager::measure(
-    AttributedStringBox const &attributedStringBox,
-    ParagraphAttributes const &paragraphAttributes,
+    const AttributedStringBox &attributedStringBox,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints,
     std::shared_ptr<void> /* hostTextStorage */) const {
   auto &attributedString = attributedStringBox.getValue();
 
   auto measurement = measureCache_.get(
       {attributedString, paragraphAttributes, layoutConstraints},
-      [&](TextMeasureCacheKey const & /*key*/) {
+      [&](const TextMeasureCacheKey & /*key*/) {
         auto telemetry = TransactionTelemetry::threadLocalTelemetry();
         if (telemetry != nullptr) {
           telemetry->willMeasureText();
@@ -185,15 +185,15 @@ TextMeasurement TextLayoutManager::measure(
   return measurement;
 }
 std::shared_ptr<void> TextLayoutManager::getHostTextStorage(
-    AttributedString const & /* attributedStringBox */,
-    ParagraphAttributes const & /* paragraphAttributes */,
+    const AttributedString & /* attributedStringBox */,
+    const ParagraphAttributes & /* paragraphAttributes */,
     LayoutConstraints /* layoutConstraints */) const {
   return nullptr;
 }
 
 TextMeasurement TextLayoutManager::measureCachedSpannableById(
     int64_t cacheId,
-    ParagraphAttributes const &paragraphAttributes,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   auto env = Environment::current();
   auto attachmentPositions = env->NewFloatArray(0);
@@ -227,8 +227,8 @@ TextMeasurement TextLayoutManager::measureCachedSpannableById(
 }
 
 LinesMeasurements TextLayoutManager::measureLines(
-    AttributedString const &attributedString,
-    ParagraphAttributes const &paragraphAttributes,
+    const AttributedString &attributedString,
+    const ParagraphAttributes &paragraphAttributes,
     Size size) const {
   const jni::global_ref<jobject> &fabricUIManager =
       contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
@@ -256,7 +256,7 @@ LinesMeasurements TextLayoutManager::measureLines(
   LinesMeasurements lineMeasurements;
   lineMeasurements.reserve(dynamicArray.size());
 
-  for (auto const &data : dynamicArray) {
+  for (const auto &data : dynamicArray) {
     lineMeasurements.push_back(LineMeasurement(data));
   }
 
@@ -269,12 +269,12 @@ LinesMeasurements TextLayoutManager::measureLines(
 
 TextMeasurement TextLayoutManager::doMeasure(
     AttributedString attributedString,
-    ParagraphAttributes const &paragraphAttributes,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   layoutConstraints.maximumSize.height = std::numeric_limits<Float>::infinity();
 
   int attachmentsCount = 0;
-  for (auto const &fragment : attributedString.getFragments()) {
+  for (const auto &fragment : attributedString.getFragments()) {
     if (fragment.isAttachment()) {
       attachmentsCount++;
     }
@@ -304,9 +304,9 @@ TextMeasurement TextLayoutManager::doMeasure(
 
   auto attachments = TextMeasurement::Attachments{};
   if (attachmentsCount > 0) {
-    folly::dynamic const &fragments = serializedAttributedString["fragments"];
+    const folly::dynamic &fragments = serializedAttributedString["fragments"];
     int attachmentIndex = 0;
-    for (auto const &fragment : fragments) {
+    for (const auto &fragment : fragments) {
       auto isAttachment = fragment.find("isAttachment");
       if (isAttachment != fragment.items().end() &&
           isAttachment->second.getBool()) {
@@ -333,12 +333,12 @@ TextMeasurement TextLayoutManager::doMeasure(
 
 TextMeasurement TextLayoutManager::doMeasureMapBuffer(
     AttributedString attributedString,
-    ParagraphAttributes const &paragraphAttributes,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   layoutConstraints.maximumSize.height = std::numeric_limits<Float>::infinity();
 
   int attachmentsCount = 0;
-  for (auto const &fragment : attributedString.getFragments()) {
+  for (const auto &fragment : attributedString.getFragments()) {
     if (fragment.isAttachment()) {
       attachmentsCount++;
     }

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -30,8 +30,8 @@ class TextLayoutManager {
   /*
    * Not copyable.
    */
-  TextLayoutManager(TextLayoutManager const &) = delete;
-  TextLayoutManager &operator=(TextLayoutManager const &) = delete;
+  TextLayoutManager(const TextLayoutManager &) = delete;
+  TextLayoutManager &operator=(const TextLayoutManager &) = delete;
 
   /*
    * Not movable.
@@ -43,14 +43,14 @@ class TextLayoutManager {
    * Measures `attributedString` using native text rendering infrastructure.
    */
   TextMeasurement measure(
-      AttributedStringBox const &attributedStringBox,
-      ParagraphAttributes const &paragraphAttributes,
+      const AttributedStringBox &attributedStringBox,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints,
       std::shared_ptr<void> /* hostTextStorage */) const;
 
   std::shared_ptr<void> getHostTextStorage(
-      AttributedString const &attributedString,
-      ParagraphAttributes const &paragraphAttributes,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
   /**
@@ -59,7 +59,7 @@ class TextLayoutManager {
    */
   TextMeasurement measureCachedSpannableById(
       int64_t cacheId,
-      ParagraphAttributes const &paragraphAttributes,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
   /*
@@ -67,8 +67,8 @@ class TextLayoutManager {
    * infrastructure.
    */
   LinesMeasurements measureLines(
-      AttributedString const &attributedString,
-      ParagraphAttributes const &paragraphAttributes,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
       Size size) const;
 
   /*
@@ -80,17 +80,17 @@ class TextLayoutManager {
  private:
   TextMeasurement doMeasure(
       AttributedString attributedString,
-      ParagraphAttributes const &paragraphAttributes,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
   TextMeasurement doMeasureMapBuffer(
       AttributedString attributedString,
-      ParagraphAttributes const &paragraphAttributes,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
   LinesMeasurements measureLinesMapBuffer(
-      AttributedString const &attributedString,
-      ParagraphAttributes const &paragraphAttributes,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
       Size size) const;
 
   void *self_{};

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
@@ -19,7 +19,7 @@ TextMeasurement TextLayoutManager::measure(
     LayoutConstraints layoutConstraints,
     std::shared_ptr<void>) const {
   TextMeasurement::Attachments attachments;
-  for (auto const &fragment : attributedStringBox.getValue().getFragments()) {
+  for (const auto &fragment : attributedStringBox.getValue().getFragments()) {
     if (fragment.isAttachment()) {
       attachments.push_back(
           TextMeasurement::Attachment{{{0, 0}, {0, 0}}, false});

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
@@ -23,16 +23,16 @@ NSString *const RCTTextAttributesAccessibilityRoleAttributeName = @"Accessibilit
  * Creates `NSTextAttributes` from given `facebook::react::TextAttributes`
  */
 NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(
-    facebook::react::TextAttributes const &textAttributes);
+    const facebook::react::TextAttributes &textAttributes);
 
 /*
  * Conversions amond `NSAttributedString`, `AttributedString` and `AttributedStringBox`.
  */
 NSAttributedString *RCTNSAttributedStringFromAttributedString(
-    facebook::react::AttributedString const &attributedString);
+    const facebook::react::AttributedString &attributedString);
 
 NSAttributedString *RCTNSAttributedStringFromAttributedStringBox(
-    facebook::react::AttributedStringBox const &attributedStringBox);
+    const facebook::react::AttributedStringBox &attributedStringBox);
 
 facebook::react::AttributedStringBox RCTAttributedStringBoxFromNSAttributedString(
     NSAttributedString *nsAttributedString);

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -178,7 +178,7 @@ inline static UIColor *RCTEffectiveBackgroundColorFromTextAttributes(const TextA
   return effectiveBackgroundColor ?: [UIColor clearColor];
 }
 
-NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(TextAttributes const &textAttributes)
+NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(const TextAttributes &textAttributes)
 {
   NSMutableDictionary<NSAttributedStringKey, id> *attributes = [NSMutableDictionary dictionaryWithCapacity:10];
 
@@ -402,7 +402,7 @@ NSAttributedString *RCTNSAttributedStringFromAttributedString(const AttributedSt
   return nsAttributedString;
 }
 
-NSAttributedString *RCTNSAttributedStringFromAttributedStringBox(AttributedStringBox const &attributedStringBox)
+NSAttributedString *RCTNSAttributedStringFromAttributedStringBox(const AttributedStringBox &attributedStringBox)
 {
   switch (attributedStringBox.getMode()) {
     case AttributedStringBox::Mode::Value:

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -24,7 +24,7 @@ class TextLayoutManager;
  */
 class TextLayoutManager {
  public:
-  TextLayoutManager(ContextContainer::Shared const &contextContainer);
+  TextLayoutManager(const ContextContainer::Shared &contextContainer);
 
   /*
    * Measures `attributedString` using native text rendering infrastructure.

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -13,7 +13,7 @@
 
 namespace facebook::react {
 
-TextLayoutManager::TextLayoutManager(ContextContainer::Shared const &contextContainer)
+TextLayoutManager::TextLayoutManager(const ContextContainer::Shared &contextContainer)
 {
   self_ = wrapManagedObject([RCTTextLayoutManager new]);
 }
@@ -57,7 +57,7 @@ TextMeasurement TextLayoutManager::measure(
       auto &attributedString = attributedStringBox.getValue();
 
       measurement = measureCache_.get(
-          {attributedString, paragraphAttributes, layoutConstraints}, [&](TextMeasureCacheKey const &key) {
+          {attributedString, paragraphAttributes, layoutConstraints}, [&](const TextMeasureCacheKey &key) {
             auto telemetry = TransactionTelemetry::threadLocalTelemetry();
             if (telemetry) {
               telemetry->willMeasureText();

--- a/packages/react-native/ReactCommon/react/renderer/timeline/Timeline.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/Timeline.cpp
@@ -11,7 +11,7 @@
 
 namespace facebook::react {
 
-Timeline::Timeline(ShadowTree const &shadowTree) : shadowTree_(&shadowTree) {
+Timeline::Timeline(const ShadowTree &shadowTree) : shadowTree_(&shadowTree) {
   record(shadowTree.getCurrentRevision().rootShadowNode);
 };
 
@@ -48,7 +48,7 @@ TimelineFrame::List Timeline::getFrames() const noexcept {
 
   auto frames = TimelineFrame::List{};
   frames.reserve(snapshots_.size());
-  for (auto const &snapshot : snapshots_) {
+  for (const auto &snapshot : snapshots_) {
     frames.push_back(snapshot.getFrame());
   }
   return frames;
@@ -59,15 +59,15 @@ TimelineFrame Timeline::getCurrentFrame() const noexcept {
   return snapshots_.at(currentSnapshotIndex_).getFrame();
 }
 
-void Timeline::rewind(TimelineFrame const &frame) const noexcept {
+void Timeline::rewind(const TimelineFrame &frame) const noexcept {
   std::scoped_lock lock(mutex_);
   rewind(snapshots_.at(frame.getIndex()));
 }
 
 RootShadowNode::Unshared Timeline::shadowTreeWillCommit(
-    ShadowTree const & /*shadowTree*/,
-    RootShadowNode::Shared const & /*oldRootShadowNode*/,
-    RootShadowNode::Unshared const &newRootShadowNode) const noexcept {
+    const ShadowTree & /*shadowTree*/,
+    const RootShadowNode::Shared & /*oldRootShadowNode*/,
+    const RootShadowNode::Unshared &newRootShadowNode) const noexcept {
   std::scoped_lock lock(mutex_);
 
   if (rewinding_) {
@@ -86,7 +86,7 @@ RootShadowNode::Unshared Timeline::shadowTreeWillCommit(
 #pragma mark - Private & Internal
 
 void Timeline::record(
-    RootShadowNode::Shared const &rootShadowNode) const noexcept {
+    const RootShadowNode::Shared &rootShadowNode) const noexcept {
   auto index = (int)snapshots_.size();
   snapshots_.push_back(TimelineSnapshot{rootShadowNode, index});
 
@@ -95,7 +95,7 @@ void Timeline::record(
   }
 }
 
-void Timeline::rewind(TimelineSnapshot const &snapshot) const noexcept {
+void Timeline::rewind(const TimelineSnapshot &snapshot) const noexcept {
   std::scoped_lock lock(mutex_);
 
   currentSnapshotIndex_ = snapshot.getFrame().getIndex();
@@ -106,7 +106,7 @@ void Timeline::rewind(TimelineSnapshot const &snapshot) const noexcept {
   auto rootShadowNode = snapshot.getRootShadowNode();
 
   shadowTree_->commit(
-      [&](RootShadowNode const & /*oldRootShadowNode*/)
+      [&](const RootShadowNode & /*oldRootShadowNode*/)
           -> RootShadowNode::Unshared {
         return std::static_pointer_cast<RootShadowNode>(
             rootShadowNode->ShadowNode::clone({}));

--- a/packages/react-native/ReactCommon/react/renderer/timeline/Timeline.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/Timeline.h
@@ -24,7 +24,7 @@ class Timeline final {
   friend class TimelineController;
 
  public:
-  Timeline(ShadowTree const &shadowTree);
+  Timeline(const ShadowTree &shadowTree);
 
  private:
 #pragma mark - Private methods to be used by `TimelineHandler`.
@@ -34,23 +34,23 @@ class Timeline final {
   bool isPaused() const noexcept;
   TimelineFrame::List getFrames() const noexcept;
   TimelineFrame getCurrentFrame() const noexcept;
-  void rewind(TimelineFrame const &frame) const noexcept;
+  void rewind(const TimelineFrame &frame) const noexcept;
   SurfaceId getSurfaceId() const noexcept;
 
 #pragma mark - Private methods to be used by `TimelineController`.
 
   RootShadowNode::Unshared shadowTreeWillCommit(
-      ShadowTree const &shadowTree,
-      RootShadowNode::Shared const &oldRootShadowNode,
-      RootShadowNode::Unshared const &newRootShadowNode) const noexcept;
+      const ShadowTree &shadowTree,
+      const RootShadowNode::Shared &oldRootShadowNode,
+      const RootShadowNode::Unshared &newRootShadowNode) const noexcept;
 
 #pragma mark - Private & Internal
 
-  void record(RootShadowNode::Shared const &rootShadowNode) const noexcept;
-  void rewind(TimelineSnapshot const &snapshot) const noexcept;
+  void record(const RootShadowNode::Shared &rootShadowNode) const noexcept;
+  void rewind(const TimelineSnapshot &snapshot) const noexcept;
 
   mutable std::recursive_mutex mutex_;
-  mutable ShadowTree const *shadowTree_{nullptr};
+  mutable const ShadowTree *shadowTree_{nullptr};
   mutable int currentSnapshotIndex_{0};
   mutable TimelineSnapshot::List snapshots_{};
   mutable bool paused_{false};

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineController.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineController.cpp
@@ -15,10 +15,10 @@ namespace facebook::react {
 TimelineHandler TimelineController::enable(SurfaceId surfaceId) const {
   assert(uiManager_);
 
-  ShadowTree const *shadowTreePtr = nullptr;
+  const ShadowTree *shadowTreePtr = nullptr;
   uiManager_->getShadowTreeRegistry().visit(
       surfaceId,
-      [&](ShadowTree const &shadowTree) { shadowTreePtr = &shadowTree; });
+      [&](const ShadowTree &shadowTree) { shadowTreePtr = &shadowTree; });
 
   assert(shadowTreePtr);
 
@@ -42,19 +42,19 @@ void TimelineController::disable(TimelineHandler &&handler) const {
 }
 
 void TimelineController::commitHookWasRegistered(
-    UIManager const &uiManager) noexcept {
+    const UIManager &uiManager) noexcept {
   uiManager_ = &uiManager;
 }
 
 void TimelineController::commitHookWasUnregistered(
-    UIManager const & /*uiManager*/) noexcept {
+    const UIManager & /*uiManager*/) noexcept {
   uiManager_ = nullptr;
 }
 
 RootShadowNode::Unshared TimelineController::shadowTreeWillCommit(
-    ShadowTree const &shadowTree,
-    RootShadowNode::Shared const &oldRootShadowNode,
-    RootShadowNode::Unshared const &newRootShadowNode) noexcept {
+    const ShadowTree &shadowTree,
+    const RootShadowNode::Shared &oldRootShadowNode,
+    const RootShadowNode::Unshared &newRootShadowNode) noexcept {
   std::shared_lock<std::shared_mutex> lock(timelinesMutex_);
 
   assert(uiManager_ && "`uiManager_` must not be `nullptr`.");

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineController.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineController.h
@@ -25,7 +25,7 @@ namespace facebook::react {
  */
 class TimelineController final : public UIManagerCommitHook {
  public:
-  using Shared = std::shared_ptr<TimelineController const>;
+  using Shared = std::shared_ptr<const TimelineController>;
 
   /*
    * Creates a `TimelineHandler` associated with given `SurfaceId` and starts
@@ -50,13 +50,13 @@ class TimelineController final : public UIManagerCommitHook {
 #pragma mark - UIManagerCommitHook
 
   RootShadowNode::Unshared shadowTreeWillCommit(
-      ShadowTree const &shadowTree,
-      RootShadowNode::Shared const &oldRootShadowNode,
-      RootShadowNode::Unshared const &newRootShadowNode) noexcept override;
+      const ShadowTree &shadowTree,
+      const RootShadowNode::Shared &oldRootShadowNode,
+      const RootShadowNode::Unshared &newRootShadowNode) noexcept override;
 
-  void commitHookWasRegistered(UIManager const &uiManager) noexcept override;
+  void commitHookWasRegistered(const UIManager &uiManager) noexcept override;
 
-  void commitHookWasUnregistered(UIManager const &uiManager) noexcept override;
+  void commitHookWasUnregistered(const UIManager &uiManager) noexcept override;
 
  private:
   /*
@@ -69,7 +69,7 @@ class TimelineController final : public UIManagerCommitHook {
    */
   mutable butter::map<SurfaceId, std::unique_ptr<Timeline>> timelines_;
 
-  mutable UIManager const *uiManager_;
+  mutable const UIManager *uiManager_;
   mutable SurfaceId lastUpdatedSurface_;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineFrame.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineFrame.h
@@ -30,8 +30,8 @@ class TimelineFrame final {
   using List = std::vector<TimelineFrame>;
 
   TimelineFrame() = delete;
-  TimelineFrame(TimelineFrame const &timelineFrame) noexcept = default;
-  TimelineFrame &operator=(TimelineFrame const &other) noexcept = default;
+  TimelineFrame(const TimelineFrame &timelineFrame) noexcept = default;
+  TimelineFrame &operator=(const TimelineFrame &other) noexcept = default;
 
   int getIndex() const noexcept;
   TelemetryTimePoint getTimePoint() const noexcept;

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineHandler.cpp
@@ -13,7 +13,7 @@
 
 namespace facebook::react {
 
-TimelineHandler::TimelineHandler(Timeline const &timeline) noexcept
+TimelineHandler::TimelineHandler(const Timeline &timeline) noexcept
     : timeline_(&timeline) {}
 
 TimelineHandler::TimelineHandler(TimelineHandler &&other) noexcept {
@@ -61,7 +61,7 @@ TimelineFrame::List TimelineHandler::getFrames() const noexcept {
   return timeline_->getFrames();
 }
 
-void TimelineHandler::rewind(TimelineFrame const &frame) const noexcept {
+void TimelineHandler::rewind(const TimelineFrame &frame) const noexcept {
   ensureNotEmpty();
   return timeline_->rewind(frame);
 }

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineHandler.h
@@ -23,9 +23,9 @@ class TimelineHandler final {
    * Movable, not copyable.
    */
   TimelineHandler(TimelineHandler &&other) noexcept;
-  TimelineHandler(TimelineHandler const &timelineHandler) = delete;
+  TimelineHandler(const TimelineHandler &timelineHandler) = delete;
   TimelineHandler &operator=(TimelineHandler &&other) noexcept;
-  TimelineHandler &operator=(TimelineHandler const &other) = delete;
+  TimelineHandler &operator=(const TimelineHandler &other) = delete;
 
   /*
    * Stops (or resumes) mounting of new commits.
@@ -44,7 +44,7 @@ class TimelineHandler final {
   /*
    * Rewinds the UI to a given frame.
    */
-  void rewind(TimelineFrame const &frame) const noexcept;
+  void rewind(const TimelineFrame &frame) const noexcept;
 
   /*
    * Rewinds the UI for a given number of frames back or forward.
@@ -57,7 +57,7 @@ class TimelineHandler final {
   /*
    * Can only be constructed by `TimelineController`.
    */
-  TimelineHandler(Timeline const &timeline) noexcept;
+  TimelineHandler(const Timeline &timeline) noexcept;
 
   /*
    * Must be called before deallocation to make it not crash.
@@ -72,7 +72,7 @@ class TimelineHandler final {
 
   void ensureNotEmpty() const noexcept;
 
-  Timeline const *timeline_{};
+  const Timeline *timeline_{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -45,35 +45,35 @@ class PointerEventsProcessor final {
  public:
   void interceptPointerEvent(
       jsi::Runtime &runtime,
-      EventTarget const *eventTarget,
-      std::string const &type,
+      const EventTarget *eventTarget,
+      const std::string &type,
       ReactEventPriority priority,
-      PointerEvent const &event,
-      DispatchEvent const &eventDispatcher,
-      UIManager const &uiManager);
+      const PointerEvent &event,
+      const DispatchEvent &eventDispatcher,
+      const UIManager &uiManager);
 
   void setPointerCapture(
       PointerIdentifier pointerId,
-      ShadowNode::Shared const &shadowNode);
+      const ShadowNode::Shared &shadowNode);
   void releasePointerCapture(
       PointerIdentifier pointerId,
-      ShadowNode const *shadowNode);
+      const ShadowNode *shadowNode);
   bool hasPointerCapture(
       PointerIdentifier pointerId,
-      ShadowNode const *shadowNode);
+      const ShadowNode *shadowNode);
 
  private:
   ActivePointer *getActivePointer(PointerIdentifier pointerId);
 
-  void registerActivePointer(PointerEvent const &event);
-  void updateActivePointer(PointerEvent const &event);
-  void unregisterActivePointer(PointerEvent const &event);
+  void registerActivePointer(const PointerEvent &event);
+  void updateActivePointer(const PointerEvent &event);
+  void unregisterActivePointer(const PointerEvent &event);
 
   void processPendingPointerCapture(
-      PointerEvent const &event,
+      const PointerEvent &event,
       jsi::Runtime &runtime,
-      DispatchEvent const &eventDispatcher,
-      UIManager const &uiManager);
+      const DispatchEvent &eventDispatcher,
+      const UIManager &uiManager);
 
   ActivePointerRegistry activePointers_;
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/SurfaceRegistryBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/SurfaceRegistryBinding.cpp
@@ -32,8 +32,8 @@ void throwIfBridgeless(
 void SurfaceRegistryBinding::startSurface(
     jsi::Runtime &runtime,
     SurfaceId surfaceId,
-    std::string const &moduleName,
-    folly::dynamic const &initialProps,
+    const std::string &moduleName,
+    const folly::dynamic &initialProps,
     DisplayMode displayMode) {
   SystraceSection s("SurfaceRegistryBinding::startSurface");
   jsi::Object parameters(runtime);
@@ -67,8 +67,8 @@ void SurfaceRegistryBinding::startSurface(
 void SurfaceRegistryBinding::setSurfaceProps(
     jsi::Runtime &runtime,
     SurfaceId surfaceId,
-    std::string const &moduleName,
-    folly::dynamic const &initialProps,
+    const std::string &moduleName,
+    const folly::dynamic &initialProps,
     DisplayMode displayMode) {
   SystraceSection s("UIManagerBinding::setSurfaceProps");
   jsi::Object parameters(runtime);

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/SurfaceRegistryBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/SurfaceRegistryBinding.h
@@ -23,8 +23,8 @@ class SurfaceRegistryBinding final {
   static void startSurface(
       jsi::Runtime &runtime,
       SurfaceId surfaceId,
-      std::string const &moduleName,
-      folly::dynamic const &initialProps,
+      const std::string &moduleName,
+      const folly::dynamic &initialProps,
       DisplayMode displayMode);
 
   /*
@@ -35,8 +35,8 @@ class SurfaceRegistryBinding final {
   static void setSurfaceProps(
       jsi::Runtime &runtime,
       SurfaceId surfaceId,
-      std::string const &moduleName,
-      folly::dynamic const &initialProps,
+      const std::string &moduleName,
+      const folly::dynamic &initialProps,
       DisplayMode displayMode);
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -41,7 +41,7 @@ ShadowNodeWrapper::~ShadowNodeWrapper() = default;
 ShadowNodeListWrapper::~ShadowNodeListWrapper() = default;
 
 static std::unique_ptr<LeakChecker> constructLeakCheckerIfNeeded(
-    RuntimeExecutor const &runtimeExecutor) {
+    const RuntimeExecutor &runtimeExecutor) {
 #ifdef REACT_NATIVE_DEBUG
   return std::make_unique<LeakChecker>(runtimeExecutor);
 #else
@@ -50,7 +50,7 @@ static std::unique_ptr<LeakChecker> constructLeakCheckerIfNeeded(
 }
 
 UIManager::UIManager(
-    RuntimeExecutor const &runtimeExecutor,
+    const RuntimeExecutor &runtimeExecutor,
     BackgroundExecutor backgroundExecutor,
     ContextContainer::Shared contextContainer)
     : runtimeExecutor_(runtimeExecutor),
@@ -65,7 +65,7 @@ UIManager::~UIManager() {
 
 ShadowNode::Shared UIManager::createNode(
     Tag tag,
-    std::string const &name,
+    const std::string &name,
     SurfaceId surfaceId,
     const RawProps &rawProps,
     const InstanceHandle::Shared &instanceHandle) const {
@@ -77,12 +77,12 @@ ShadowNode::Shared UIManager::createNode(
 
   PropsParserContext propsParserContext{surfaceId, *contextContainer_.get()};
 
-  auto const fragment =
+  const auto fragment =
       ShadowNodeFamilyFragment{tag, surfaceId, instanceHandle};
   auto family = componentDescriptor.createFamily(fragment);
-  auto const props =
+  const auto props =
       componentDescriptor.cloneProps(propsParserContext, nullptr, rawProps);
-  auto const state = componentDescriptor.createInitialState(props, family);
+  const auto state = componentDescriptor.createInitialState(props, family);
 
   auto shadowNode = componentDescriptor.createShadowNode(
       ShadowNodeFragment{
@@ -111,9 +111,9 @@ ShadowNode::Shared UIManager::createNode(
 }
 
 ShadowNode::Shared UIManager::cloneNode(
-    ShadowNode const &shadowNode,
-    ShadowNode::SharedListOfShared const &children,
-    RawProps const *rawProps) const {
+    const ShadowNode &shadowNode,
+    const ShadowNode::SharedListOfShared &children,
+    const RawProps *rawProps) const {
   SystraceSection s(
       "UIManager::cloneNode", "componentName", shadowNode.getComponentName());
 
@@ -165,11 +165,11 @@ void UIManager::appendChild(
 
 void UIManager::completeSurface(
     SurfaceId surfaceId,
-    ShadowNode::UnsharedListOfShared const &rootChildren,
+    const ShadowNode::UnsharedListOfShared &rootChildren,
     ShadowTree::CommitOptions commitOptions) const {
   SystraceSection s("UIManager::completeSurface", "surfaceId", surfaceId);
 
-  shadowTreeRegistry_.visit(surfaceId, [&](ShadowTree const &shadowTree) {
+  shadowTreeRegistry_.visit(surfaceId, [&](const ShadowTree &shadowTree) {
     shadowTree.commit(
         [&](RootShadowNode const &oldRootShadowNode) {
           return std::make_shared<RootShadowNode>(
@@ -184,7 +184,7 @@ void UIManager::completeSurface(
 }
 
 void UIManager::setIsJSResponder(
-    ShadowNode::Shared const &shadowNode,
+    const ShadowNode::Shared &shadowNode,
     bool isJSResponder,
     bool blockNativeResponder) const {
   if (delegate_ != nullptr) {
@@ -195,8 +195,8 @@ void UIManager::setIsJSResponder(
 
 void UIManager::startSurface(
     ShadowTree::Unique &&shadowTree,
-    std::string const &moduleName,
-    folly::dynamic const &props,
+    const std::string &moduleName,
+    const folly::dynamic &props,
     DisplayMode displayMode) const {
   SystraceSection s("UIManager::startSurface");
 
@@ -212,8 +212,8 @@ void UIManager::startSurface(
 
 void UIManager::setSurfaceProps(
     SurfaceId surfaceId,
-    std::string const &moduleName,
-    folly::dynamic const &props,
+    const std::string &moduleName,
+    const folly::dynamic &props,
     DisplayMode displayMode) const {
   SystraceSection s("UIManager::setSurfaceProps");
 
@@ -249,10 +249,10 @@ ShadowTree::Unique UIManager::stopSurface(SurfaceId surfaceId) const {
 }
 
 ShadowNode::Shared UIManager::getNewestCloneOfShadowNode(
-    ShadowNode const &shadowNode) const {
+    const ShadowNode &shadowNode) const {
   auto ancestorShadowNode = ShadowNode::Shared{};
   shadowTreeRegistry_.visit(
-      shadowNode.getSurfaceId(), [&](ShadowTree const &shadowTree) {
+      shadowNode.getSurfaceId(), [&](const ShadowTree &shadowTree) {
         ancestorShadowNode = shadowTree.getCurrentRevision().rootShadowNode;
       });
 
@@ -271,10 +271,10 @@ ShadowNode::Shared UIManager::getNewestCloneOfShadowNode(
 }
 
 ShadowNode::Shared UIManager::getNewestParentOfShadowNode(
-    ShadowNode const &shadowNode) const {
+    const ShadowNode &shadowNode) const {
   auto ancestorShadowNode = ShadowNode::Shared{};
   shadowTreeRegistry_.visit(
-      shadowNode.getSurfaceId(), [&](ShadowTree const &shadowTree) {
+      shadowNode.getSurfaceId(), [&](const ShadowTree &shadowTree) {
         ancestorShadowNode = shadowTree.getCurrentRevision().rootShadowNode;
       });
 
@@ -299,7 +299,7 @@ ShadowNode::Shared UIManager::getNewestParentOfShadowNode(
 }
 
 std::string UIManager::getTextContentInNewestCloneOfShadowNode(
-    ShadowNode const &shadowNode) const {
+    const ShadowNode &shadowNode) const {
   auto newestCloneOfShadowNode = getNewestCloneOfShadowNode(shadowNode);
   std::string result;
   getTextContentInShadowNode(*newestCloneOfShadowNode, result);
@@ -307,8 +307,8 @@ std::string UIManager::getTextContentInNewestCloneOfShadowNode(
 }
 
 int UIManager::compareDocumentPosition(
-    ShadowNode const &shadowNode,
-    ShadowNode const &otherShadowNode) const {
+    const ShadowNode &shadowNode,
+    const ShadowNode &otherShadowNode) const {
   // Quick check for node vs. itself
   if (&shadowNode == &otherShadowNode) {
     return 0;
@@ -320,7 +320,7 @@ int UIManager::compareDocumentPosition(
 
   auto ancestorShadowNode = ShadowNode::Shared{};
   shadowTreeRegistry_.visit(
-      shadowNode.getSurfaceId(), [&](ShadowTree const &shadowTree) {
+      shadowNode.getSurfaceId(), [&](const ShadowTree &shadowTree) {
         ancestorShadowNode = shadowTree.getCurrentRevision().rootShadowNode;
       });
   if (!ancestorShadowNode) {
@@ -361,15 +361,15 @@ int UIManager::compareDocumentPosition(
 }
 
 ShadowNode::Shared UIManager::findNodeAtPoint(
-    ShadowNode::Shared const &node,
+    const ShadowNode::Shared &node,
     Point point) const {
   return LayoutableShadowNode::findNodeAtPoint(
       getNewestCloneOfShadowNode(*node), point);
 }
 
 LayoutMetrics UIManager::getRelativeLayoutMetrics(
-    ShadowNode const &shadowNode,
-    ShadowNode const *ancestorShadowNode,
+    const ShadowNode &shadowNode,
+    const ShadowNode *ancestorShadowNode,
     LayoutableShadowNode::LayoutInspectingPolicy policy) const {
   SystraceSection s("UIManager::getRelativeLayoutMetrics");
 
@@ -379,7 +379,7 @@ LayoutMetrics UIManager::getRelativeLayoutMetrics(
 
   if (ancestorShadowNode == nullptr) {
     shadowTreeRegistry_.visit(
-        shadowNode.getSurfaceId(), [&](ShadowTree const &shadowTree) {
+        shadowNode.getSurfaceId(), [&](const ShadowTree &shadowTree) {
           owningAncestorShadowNode =
               shadowTree.getCurrentRevision().rootShadowNode;
           ancestorShadowNode = owningAncestorShadowNode.get();
@@ -393,7 +393,7 @@ LayoutMetrics UIManager::getRelativeLayoutMetrics(
   }
 
   auto layoutableAncestorShadowNode =
-      traitCast<LayoutableShadowNode const *>(ancestorShadowNode);
+      traitCast<const LayoutableShadowNode *>(ancestorShadowNode);
 
   if (layoutableAncestorShadowNode == nullptr) {
     return EmptyLayoutMetrics;
@@ -403,7 +403,7 @@ LayoutMetrics UIManager::getRelativeLayoutMetrics(
       shadowNode.getFamily(), *layoutableAncestorShadowNode, policy);
 }
 
-void UIManager::updateState(StateUpdate const &stateUpdate) const {
+void UIManager::updateState(const StateUpdate &stateUpdate) const {
   SystraceSection s(
       "UIManager::updateState",
       "componentName",
@@ -413,7 +413,7 @@ void UIManager::updateState(StateUpdate const &stateUpdate) const {
   auto &componentDescriptor = family->getComponentDescriptor();
 
   shadowTreeRegistry_.visit(
-      family->getSurfaceId(), [&](ShadowTree const &shadowTree) {
+      family->getSurfaceId(), [&](const ShadowTree &shadowTree) {
         shadowTree.commit(
             [&](RootShadowNode const &oldRootShadowNode) {
               auto isValid = true;
@@ -450,16 +450,16 @@ void UIManager::updateState(StateUpdate const &stateUpdate) const {
 
 void UIManager::dispatchCommand(
     const ShadowNode::Shared &shadowNode,
-    std::string const &commandName,
-    folly::dynamic const &args) const {
+    const std::string &commandName,
+    const folly::dynamic &args) const {
   if (delegate_ != nullptr) {
     delegate_->uiManagerDidDispatchCommand(shadowNode, commandName, args);
   }
 }
 
 void UIManager::setNativeProps_DEPRECATED(
-    ShadowNode::Shared const &shadowNode,
-    RawProps const &rawProps) const {
+    const ShadowNode::Shared &shadowNode,
+    const RawProps &rawProps) const {
   auto &family = shadowNode->getFamily();
   if (family.nativeProps_DEPRECATED) {
     // Values in `rawProps` patch (take precedence over)
@@ -475,7 +475,7 @@ void UIManager::setNativeProps_DEPRECATED(
   }
 
   shadowTreeRegistry_.visit(
-      family.getSurfaceId(), [&](ShadowTree const &shadowTree) {
+      family.getSurfaceId(), [&](const ShadowTree &shadowTree) {
         shadowTree.commit(
             [&](RootShadowNode const &oldRootShadowNode) {
               auto rootNode = oldRootShadowNode.cloneTree(
@@ -501,7 +501,7 @@ void UIManager::setNativeProps_DEPRECATED(
 
 void UIManager::sendAccessibilityEvent(
     const ShadowNode::Shared &shadowNode,
-    std::string const &eventType) {
+    const std::string &eventType) {
   if (delegate_ != nullptr) {
     delegate_->uiManagerDidSendAccessibilityEvent(shadowNode, eventType);
   }
@@ -509,9 +509,9 @@ void UIManager::sendAccessibilityEvent(
 
 void UIManager::configureNextLayoutAnimation(
     jsi::Runtime &runtime,
-    RawValue const &config,
-    jsi::Value const &successCallback,
-    jsi::Value const &failureCallback) const {
+    const RawValue &config,
+    const jsi::Value &successCallback,
+    const jsi::Value &failureCallback) const {
   if (animationDelegate_ != nullptr) {
     animationDelegate_->uiManagerDidConfigureNextLayoutAnimation(
         runtime,
@@ -528,7 +528,7 @@ static ShadowNode::Shared findShadowNodeByTagRecursively(
     return parentShadowNode;
   }
 
-  for (ShadowNode::Shared const &shadowNode : parentShadowNode->getChildren()) {
+  for (const ShadowNode::Shared &shadowNode : parentShadowNode->getChildren()) {
     auto result = findShadowNodeByTagRecursively(shadowNode, tag);
     if (result) {
       return result;
@@ -541,7 +541,7 @@ static ShadowNode::Shared findShadowNodeByTagRecursively(
 ShadowNode::Shared UIManager::findShadowNodeByTag_DEPRECATED(Tag tag) const {
   auto shadowNode = ShadowNode::Shared{};
 
-  shadowTreeRegistry_.enumerate([&](ShadowTree const &shadowTree, bool &stop) {
+  shadowTreeRegistry_.enumerate([&](const ShadowTree &shadowTree, bool &stop) {
     RootShadowNode const *rootShadowNode;
     // The public interface of `ShadowTree` discourages accessing a stored
     // pointer to a root node because of the possible data race.
@@ -586,7 +586,7 @@ UIManagerDelegate *UIManager::getDelegate() {
 }
 
 void UIManager::visitBinding(
-    std::function<void(UIManagerBinding const &uiManagerBinding)> const
+    const std::function<void(UIManagerBinding const &uiManagerBinding)>
         &callback,
     jsi::Runtime &runtime) const {
   auto uiManagerBinding = UIManagerBinding::getBinding(runtime);
@@ -595,7 +595,7 @@ void UIManager::visitBinding(
   }
 }
 
-ShadowTreeRegistry const &UIManager::getShadowTreeRegistry() const {
+const ShadowTreeRegistry &UIManager::getShadowTreeRegistry() const {
   return shadowTreeRegistry_;
 }
 
@@ -635,9 +635,9 @@ void UIManager::unregisterMountHook(UIManagerMountHook &mountHook) {
 #pragma mark - ShadowTreeDelegate
 
 RootShadowNode::Unshared UIManager::shadowTreeWillCommit(
-    ShadowTree const &shadowTree,
-    RootShadowNode::Shared const &oldRootShadowNode,
-    RootShadowNode::Unshared const &newRootShadowNode) const {
+    const ShadowTree &shadowTree,
+    const RootShadowNode::Shared &oldRootShadowNode,
+    const RootShadowNode::Unshared &newRootShadowNode) const {
   SystraceSection s("UIManager::shadowTreeWillCommit");
 
   std::shared_lock lock(commitHookMutex_);
@@ -668,7 +668,7 @@ void UIManager::reportMount(SurfaceId surfaceId) const {
   auto time = JSExecutor::performanceNow();
 
   auto rootShadowNode = RootShadowNode::Shared{};
-  shadowTreeRegistry_.visit(surfaceId, [&](ShadowTree const &shadowTree) {
+  shadowTreeRegistry_.visit(surfaceId, [&](const ShadowTree &shadowTree) {
     rootShadowNode =
         shadowTree.getMountingCoordinator()->getBaseRevision().rootShadowNode;
   });
@@ -701,7 +701,7 @@ void UIManager::stopSurfaceForAnimationDelegate(SurfaceId surfaceId) const {
 void UIManager::animationTick() const {
   if (animationDelegate_ != nullptr &&
       animationDelegate_->shouldAnimateFrame()) {
-    shadowTreeRegistry_.enumerate([](ShadowTree const &shadowTree, bool &) {
+    shadowTreeRegistry_.enumerate([](const ShadowTree &shadowTree, bool &) {
       shadowTree.notifyDelegatesOfUpdates();
     });
   }

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -36,7 +36,7 @@ class UIManagerMountHook;
 class UIManager final : public ShadowTreeDelegate {
  public:
   UIManager(
-      RuntimeExecutor const &runtimeExecutor,
+      const RuntimeExecutor &runtimeExecutor,
       BackgroundExecutor backgroundExecutor,
       ContextContainer::Shared contextContainer);
 
@@ -74,7 +74,7 @@ class UIManager final : public ShadowTreeDelegate {
    * The callback is called synchronously on the same thread.
    */
   void visitBinding(
-      std::function<void(UIManagerBinding const &uiManagerBinding)> const
+      const std::function<void(UIManagerBinding const &uiManagerBinding)>
           &callback,
       jsi::Runtime &runtime) const;
 
@@ -91,30 +91,30 @@ class UIManager final : public ShadowTreeDelegate {
   void unregisterMountHook(UIManagerMountHook &mountHook);
 
   ShadowNode::Shared getNewestCloneOfShadowNode(
-      ShadowNode const &shadowNode) const;
+      const ShadowNode &shadowNode) const;
 
   ShadowNode::Shared getNewestParentOfShadowNode(
-      ShadowNode const &shadowNode) const;
+      const ShadowNode &shadowNode) const;
 
   std::string getTextContentInNewestCloneOfShadowNode(
-      ShadowNode const &shadowNode) const;
+      const ShadowNode &shadowNode) const;
 
   int compareDocumentPosition(
-      ShadowNode const &shadowNode,
-      ShadowNode const &otherShadowNode) const;
+      const ShadowNode &shadowNode,
+      const ShadowNode &otherShadowNode) const;
 
 #pragma mark - Surface Start & Stop
 
   void startSurface(
       ShadowTree::Unique &&shadowTree,
-      std::string const &moduleName,
-      folly::dynamic const &props,
+      const std::string &moduleName,
+      const folly::dynamic &props,
       DisplayMode displayMode) const;
 
   void setSurfaceProps(
       SurfaceId surfaceId,
-      std::string const &moduleName,
-      folly::dynamic const &props,
+      const std::string &moduleName,
+      const folly::dynamic &props,
       DisplayMode displayMode) const;
 
   ShadowTree::Unique stopSurface(SurfaceId surfaceId) const;
@@ -126,21 +126,21 @@ class UIManager final : public ShadowTreeDelegate {
       bool mountSynchronously) const override;
 
   RootShadowNode::Unshared shadowTreeWillCommit(
-      ShadowTree const &shadowTree,
-      RootShadowNode::Shared const &oldRootShadowNode,
-      RootShadowNode::Unshared const &newRootShadowNode) const override;
+      const ShadowTree &shadowTree,
+      const RootShadowNode::Shared &oldRootShadowNode,
+      const RootShadowNode::Unshared &newRootShadowNode) const override;
 
   ShadowNode::Shared createNode(
       Tag tag,
-      std::string const &componentName,
+      const std::string &componentName,
       SurfaceId surfaceId,
       const RawProps &props,
       const InstanceHandle::Shared &instanceHandle) const;
 
   ShadowNode::Shared cloneNode(
-      ShadowNode const &shadowNode,
-      ShadowNode::SharedListOfShared const &children = nullptr,
-      RawProps const *rawProps = nullptr) const;
+      const ShadowNode &shadowNode,
+      const ShadowNode::SharedListOfShared &children = nullptr,
+      const RawProps *rawProps = nullptr) const;
 
   void appendChild(
       const ShadowNode::Shared &parentShadowNode,
@@ -148,16 +148,16 @@ class UIManager final : public ShadowTreeDelegate {
 
   void completeSurface(
       SurfaceId surfaceId,
-      ShadowNode::UnsharedListOfShared const &rootChildren,
+      const ShadowNode::UnsharedListOfShared &rootChildren,
       ShadowTree::CommitOptions commitOptions) const;
 
   void setIsJSResponder(
-      ShadowNode::Shared const &shadowNode,
+      const ShadowNode::Shared &shadowNode,
       bool isJSResponder,
       bool blockNativeResponder) const;
 
   ShadowNode::Shared findNodeAtPoint(
-      ShadowNode::Shared const &shadowNode,
+      const ShadowNode::Shared &shadowNode,
       Point point) const;
 
   /*
@@ -166,28 +166,28 @@ class UIManager final : public ShadowTreeDelegate {
    * `ancestorShadowNode` is nullptr).
    */
   LayoutMetrics getRelativeLayoutMetrics(
-      ShadowNode const &shadowNode,
-      ShadowNode const *ancestorShadowNode,
+      const ShadowNode &shadowNode,
+      const ShadowNode *ancestorShadowNode,
       LayoutableShadowNode::LayoutInspectingPolicy policy) const;
 
   /*
    * Creates a new shadow node with given state data, clones what's necessary
    * and performs a commit.
    */
-  void updateState(StateUpdate const &stateUpdate) const;
+  void updateState(const StateUpdate &stateUpdate) const;
 
   void dispatchCommand(
       const ShadowNode::Shared &shadowNode,
-      std::string const &commandName,
-      folly::dynamic const &args) const;
+      const std::string &commandName,
+      const folly::dynamic &args) const;
 
   void setNativeProps_DEPRECATED(
-      ShadowNode::Shared const &shadowNode,
-      RawProps const &rawProps) const;
+      const ShadowNode::Shared &shadowNode,
+      const RawProps &rawProps) const;
 
   void sendAccessibilityEvent(
       const ShadowNode::Shared &shadowNode,
-      std::string const &eventType);
+      const std::string &eventType);
 
   /*
    * Iterates over all shadow nodes which are parts of all registered surfaces
@@ -197,7 +197,7 @@ class UIManager final : public ShadowTreeDelegate {
    */
   ShadowNode::Shared findShadowNodeByTag_DEPRECATED(Tag tag) const;
 
-  ShadowTreeRegistry const &getShadowTreeRegistry() const;
+  const ShadowTreeRegistry &getShadowTreeRegistry() const;
 
   void reportMount(SurfaceId surfaceId) const;
 
@@ -216,16 +216,16 @@ class UIManager final : public ShadowTreeDelegate {
    */
   void configureNextLayoutAnimation(
       jsi::Runtime &runtime,
-      RawValue const &config,
-      jsi::Value const &successCallback,
-      jsi::Value const &failureCallback) const;
+      const RawValue &config,
+      const jsi::Value &successCallback,
+      const jsi::Value &failureCallback) const;
 
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   UIManagerDelegate *delegate_{};
   UIManagerAnimationDelegate *animationDelegate_{nullptr};
-  RuntimeExecutor const runtimeExecutor_{};
+  const RuntimeExecutor runtimeExecutor_{};
   ShadowTreeRegistry shadowTreeRegistry_{};
-  BackgroundExecutor const backgroundExecutor_{};
+  const BackgroundExecutor backgroundExecutor_{};
   ContextContainer::Shared contextContainer_;
 
   mutable std::shared_mutex commitHookMutex_;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
@@ -24,9 +24,9 @@ class UIManagerAnimationDelegate {
    */
   virtual void uiManagerDidConfigureNextLayoutAnimation(
       jsi::Runtime &runtime,
-      RawValue const &config,
-      jsi::Value const &successCallback,
-      jsi::Value const &failureCallback) const = 0;
+      const RawValue &config,
+      const jsi::Value &successCallback,
+      const jsi::Value &failureCallback) const = 0;
 
   /**
    * Set ComponentDescriptor registry.

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -25,7 +25,7 @@ namespace facebook::react {
 
 void UIManagerBinding::createAndInstallIfNeeded(
     jsi::Runtime &runtime,
-    std::shared_ptr<UIManager> const &uiManager) {
+    const std::shared_ptr<UIManager> &uiManager) {
   auto uiManagerModuleName = "nativeFabricUIManager";
 
   auto uiManagerValue =
@@ -64,7 +64,7 @@ UIManagerBinding::~UIManagerBinding() {
 
 jsi::Value UIManagerBinding::getInspectorDataForInstance(
     jsi::Runtime &runtime,
-    EventEmitter const &eventEmitter) const {
+    const EventEmitter &eventEmitter) const {
   auto eventTarget = eventEmitter.eventTarget_;
   EventEmitter::DispatchMutex().lock();
 
@@ -91,8 +91,8 @@ jsi::Value UIManagerBinding::getInspectorDataForInstance(
 
 void UIManagerBinding::dispatchEvent(
     jsi::Runtime &runtime,
-    EventTarget const *eventTarget,
-    std::string const &type,
+    const EventTarget *eventTarget,
+    const std::string &type,
     ReactEventPriority priority,
     const EventPayload &eventPayload) const {
   SystraceSection s("UIManagerBinding::dispatchEvent", "type", type);
@@ -101,8 +101,8 @@ void UIManagerBinding::dispatchEvent(
     auto pointerEvent = static_cast<const PointerEvent &>(eventPayload);
     auto dispatchCallback = [this](
                                 jsi::Runtime &runtime,
-                                EventTarget const *eventTarget,
-                                std::string const &type,
+                                const EventTarget *eventTarget,
+                                const std::string &type,
                                 ReactEventPriority priority,
                                 const EventPayload &eventPayload) {
       this->dispatchEventToJS(
@@ -123,8 +123,8 @@ void UIManagerBinding::dispatchEvent(
 
 void UIManagerBinding::dispatchEventToJS(
     jsi::Runtime &runtime,
-    EventTarget const *eventTarget,
-    std::string const &type,
+    const EventTarget *eventTarget,
+    const std::string &type,
     ReactEventPriority priority,
     const EventPayload &eventPayload) const {
   auto payload = eventPayload.asJSIValue(runtime);
@@ -156,7 +156,7 @@ void UIManagerBinding::dispatchEventToJS(
   }
 
   auto &eventHandlerWrapper =
-      static_cast<EventHandlerWrapper const &>(*eventHandler_);
+      static_cast<const EventHandlerWrapper &>(*eventHandler_);
 
   currentEventPriority_ = priority;
   eventHandlerWrapper.callback.call(
@@ -173,7 +173,7 @@ void UIManagerBinding::invalidate() const {
 
 static void validateArgumentCount(
     jsi::Runtime &runtime,
-    std::string const &methodName,
+    const std::string &methodName,
     size_t expected,
     size_t actual) {
   if (actual < expected) {
@@ -186,7 +186,7 @@ static void validateArgumentCount(
 
 jsi::Value UIManagerBinding::get(
     jsi::Runtime &runtime,
-    jsi::PropNameID const &name) {
+    const jsi::PropNameID &name) {
   auto methodName = name.utf8(runtime);
   SystraceSection s("UIManagerBinding::get", "name", methodName);
 
@@ -228,8 +228,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -260,8 +260,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -280,8 +280,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -302,8 +302,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -336,8 +336,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -358,8 +358,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -382,8 +382,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -405,8 +405,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -423,8 +423,8 @@ jsi::Value UIManagerBinding::get(
         name,
         0,
         [](jsi::Runtime &runtime,
-           jsi::Value const & /*thisValue*/,
-           jsi::Value const * /*arguments*/,
+           const jsi::Value & /*thisValue*/,
+           const jsi::Value * /*arguments*/,
            size_t /*count*/) -> jsi::Value {
           auto shadowNodeList = std::make_shared<ShadowNode::ListOfShared>(
               ShadowNode::ListOfShared({}));
@@ -440,8 +440,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -463,8 +463,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [weakUIManager, uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -531,8 +531,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [this, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -552,8 +552,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -579,8 +579,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -625,8 +625,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -664,8 +664,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -709,8 +709,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -747,8 +747,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -768,8 +768,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -790,8 +790,8 @@ jsi::Value UIManagerBinding::get(
         0,
         [this](
             jsi::Runtime & /*runtime*/,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const * /*arguments*/,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value * /*arguments*/,
             size_t /*count*/) -> jsi::Value {
           return {serialize(currentEventPriority_)};
         });
@@ -813,8 +813,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const &,
-            jsi::Value const *arguments,
+            const jsi::Value &,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -855,8 +855,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -896,8 +896,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -930,8 +930,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -966,8 +966,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -998,8 +998,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -1035,8 +1035,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -1080,8 +1080,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -1164,8 +1164,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [uiManager, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
@@ -1218,8 +1218,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [this, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
           bool isCapturing = pointerEventsProcessor_.hasPointerCapture(
@@ -1237,8 +1237,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [this, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
           pointerEventsProcessor_.setPointerCapture(
@@ -1256,8 +1256,8 @@ jsi::Value UIManagerBinding::get(
         paramCount,
         [this, methodName, paramCount](
             jsi::Runtime &runtime,
-            jsi::Value const & /*thisValue*/,
-            jsi::Value const *arguments,
+            const jsi::Value & /*thisValue*/,
+            const jsi::Value *arguments,
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
           pointerEventsProcessor_.releasePointerCapture(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -28,7 +28,7 @@ class UIManagerBinding : public jsi::HostObject {
    */
   static void createAndInstallIfNeeded(
       jsi::Runtime &runtime,
-      std::shared_ptr<UIManager> const &uiManager);
+      const std::shared_ptr<UIManager> &uiManager);
 
   /*
    * Returns a pointer to UIManagerBinding previously installed into a runtime.
@@ -42,7 +42,7 @@ class UIManagerBinding : public jsi::HostObject {
 
   jsi::Value getInspectorDataForInstance(
       jsi::Runtime &runtime,
-      EventEmitter const &eventEmitter) const;
+      const EventEmitter &eventEmitter) const;
 
   /*
    * Delivers raw event data to JavaScript.
@@ -50,8 +50,8 @@ class UIManagerBinding : public jsi::HostObject {
    */
   void dispatchEvent(
       jsi::Runtime &runtime,
-      EventTarget const *eventTarget,
-      std::string const &type,
+      const EventTarget *eventTarget,
+      const std::string &type,
       ReactEventPriority priority,
       const EventPayload &payload) const;
 
@@ -67,7 +67,7 @@ class UIManagerBinding : public jsi::HostObject {
   /*
    * `jsi::HostObject` specific overloads.
    */
-  jsi::Value get(jsi::Runtime &runtime, jsi::PropNameID const &name) override;
+  jsi::Value get(jsi::Runtime &runtime, const jsi::PropNameID &name) override;
 
   UIManager &getUIManager();
 
@@ -78,13 +78,13 @@ class UIManagerBinding : public jsi::HostObject {
    */
   void dispatchEventToJS(
       jsi::Runtime &runtime,
-      EventTarget const *eventTarget,
-      std::string const &type,
+      const EventTarget *eventTarget,
+      const std::string &type,
       ReactEventPriority priority,
       const EventPayload &payload) const;
 
   std::shared_ptr<UIManager> uiManager_;
-  std::unique_ptr<EventHandler const> eventHandler_;
+  std::unique_ptr<const EventHandler> eventHandler_;
   mutable PointerEventsProcessor pointerEventsProcessor_;
   mutable ReactEventPriority currentEventPriority_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
@@ -22,9 +22,9 @@ class UIManagerCommitHook {
   /*
    * Called right after the commit hook is registered or unregistered.
    */
-  virtual void commitHookWasRegistered(UIManager const &uiManager) noexcept = 0;
+  virtual void commitHookWasRegistered(const UIManager &uiManager) noexcept = 0;
   virtual void commitHookWasUnregistered(
-      UIManager const &uiManager) noexcept = 0;
+      const UIManager &uiManager) noexcept = 0;
 
   /*
    * Called right before a `ShadowTree` commits a new tree.
@@ -32,9 +32,9 @@ class UIManagerCommitHook {
    * from `ShadowTreeDelegate`.
    */
   virtual RootShadowNode::Unshared shadowTreeWillCommit(
-      ShadowTree const &shadowTree,
-      RootShadowNode::Shared const &oldRootShadowNode,
-      RootShadowNode::Unshared const &newRootShadowNode) noexcept = 0;
+      const ShadowTree &shadowTree,
+      const RootShadowNode::Shared &oldRootShadowNode,
+      const RootShadowNode::Unshared &newRootShadowNode) noexcept = 0;
 
   virtual ~UIManagerCommitHook() noexcept = default;
 };

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -38,8 +38,8 @@ class UIManagerDelegate {
    */
   virtual void uiManagerDidDispatchCommand(
       const ShadowNode::Shared &shadowNode,
-      std::string const &commandName,
-      folly::dynamic const &args) = 0;
+      const std::string &commandName,
+      const folly::dynamic &args) = 0;
 
   /*
    * Called when UIManager wants to dispatch some accessibility event
@@ -48,13 +48,13 @@ class UIManagerDelegate {
    */
   virtual void uiManagerDidSendAccessibilityEvent(
       const ShadowNode::Shared &shadowNode,
-      std::string const &eventType) = 0;
+      const std::string &eventType) = 0;
 
   /*
    * Set JS responder for a view.
    */
   virtual void uiManagerDidSetIsJSResponder(
-      ShadowNode::Shared const &shadowNode,
+      const ShadowNode::Shared &shadowNode,
       bool isJSResponder,
       bool blockNativeResponder) = 0;
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerMountHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerMountHook.h
@@ -25,7 +25,7 @@ class UIManagerMountHook {
    * Called right after a `ShadowTree` is mounted in the host platform.
    */
   virtual void shadowTreeDidMount(
-      RootShadowNode::Shared const &rootShadowNode,
+      const RootShadowNode::Shared &rootShadowNode,
       double mountTime) noexcept = 0;
 
   virtual ~UIManagerMountHook() noexcept = default;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/bindingUtils.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/bindingUtils.cpp
@@ -14,7 +14,7 @@ namespace facebook::react {
 
 static jsi::Value getModule(
     jsi::Runtime &runtime,
-    std::string const &moduleName) {
+    const std::string &moduleName) {
   auto batchedBridge =
       runtime.global().getPropertyAsObject(runtime, "__fbBatchedBridge");
   auto getCallableModule =
@@ -55,8 +55,8 @@ static bool checkGetCallableModuleIsActive(jsi::Runtime &runtime) {
 
 jsi::Value callMethodOfModule(
     jsi::Runtime &runtime,
-    std::string const &moduleName,
-    std::string const &methodName,
+    const std::string &moduleName,
+    const std::string &methodName,
     std::initializer_list<jsi::Value> args) {
   if (checkGetCallableModuleIsActive(runtime)) {
     auto module = getModule(runtime, moduleName);

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/bindingUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/bindingUtils.h
@@ -13,8 +13,8 @@ namespace facebook::react {
 
 jsi::Value callMethodOfModule(
     jsi::Runtime &runtime,
-    std::string const &moduleName,
-    std::string const &methodName,
+    const std::string &moduleName,
+    const std::string &methodName,
     std::initializer_list<jsi::Value> args);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
@@ -115,9 +115,9 @@ inline static jsi::Value valueFromShadowNodeList(
 }
 
 inline static ShadowNode::UnsharedListOfShared shadowNodeListFromWeakList(
-    ShadowNode::UnsharedListOfWeak const &weakShadowNodeList) {
+    const ShadowNode::UnsharedListOfWeak &weakShadowNodeList) {
   auto result = std::make_shared<ShadowNode::ListOfShared>();
-  for (auto const &weakShadowNode : *weakShadowNodeList) {
+  for (const auto &weakShadowNode : *weakShadowNodeList) {
     auto sharedShadowNode = weakShadowNode.lock();
     if (!sharedShadowNode) {
       return nullptr;
@@ -129,23 +129,23 @@ inline static ShadowNode::UnsharedListOfShared shadowNodeListFromWeakList(
 
 inline static ShadowNode::UnsharedListOfWeak weakShadowNodeListFromValue(
     jsi::Runtime &runtime,
-    jsi::Value const &value) {
+    const jsi::Value &value) {
   auto shadowNodeList = shadowNodeListFromValue(runtime, value);
   auto weakShadowNodeList = std::make_shared<ShadowNode::ListOfWeak>();
-  for (auto const &shadowNode : *shadowNodeList) {
+  for (const auto &shadowNode : *shadowNodeList) {
     weakShadowNodeList->push_back(shadowNode);
   }
   return weakShadowNodeList;
 }
 
-inline static Tag tagFromValue(jsi::Value const &value) {
+inline static Tag tagFromValue(const jsi::Value &value) {
   return (Tag)value.getNumber();
 }
 
 inline static InstanceHandle::Shared instanceHandleFromValue(
     jsi::Runtime &runtime,
-    jsi::Value const &instanceHandleValue,
-    jsi::Value const &tagValue) {
+    const jsi::Value &instanceHandleValue,
+    const jsi::Value &tagValue) {
   react_native_assert(!instanceHandleValue.isNull());
   if (instanceHandleValue.isNull()) {
     return nullptr;
@@ -156,11 +156,11 @@ inline static InstanceHandle::Shared instanceHandleFromValue(
 
 inline static SurfaceId surfaceIdFromValue(
     jsi::Runtime &runtime,
-    jsi::Value const &value) {
+    const jsi::Value &value) {
   return (SurfaceId)value.getNumber();
 }
 
-inline static int displayModeToInt(DisplayMode const value) {
+inline static int displayModeToInt(const DisplayMode value) {
   // the result of this method should be in sync with
   // Libraries/ReactNative/DisplayMode.js
   switch (value) {
@@ -175,25 +175,25 @@ inline static int displayModeToInt(DisplayMode const value) {
 
 inline static std::string stringFromValue(
     jsi::Runtime &runtime,
-    jsi::Value const &value) {
+    const jsi::Value &value) {
   return value.getString(runtime).utf8(runtime);
 }
 
 inline static folly::dynamic commandArgsFromValue(
     jsi::Runtime &runtime,
-    jsi::Value const &value) {
+    const jsi::Value &value) {
   return jsi::dynamicFromValue(runtime, value);
 }
 
 inline static jsi::Value getArrayOfInstanceHandlesFromShadowNodes(
-    ShadowNode::ListOfShared const &nodes,
+    const ShadowNode::ListOfShared &nodes,
     jsi::Runtime &runtime) {
   // JSI doesn't support adding elements to an array after creation,
   // so we need to accumulate the values in a vector and then create
   // the array when we know the size.
   std::vector<jsi::Value> nonNullInstanceHandles;
   nonNullInstanceHandles.reserve(nodes.size());
-  for (auto const &shadowNode : nodes) {
+  for (const auto &shadowNode : nodes) {
     auto instanceHandle = (*shadowNode).getInstanceHandle(runtime);
     if (!instanceHandle.isNull()) {
       nonNullInstanceHandles.push_back(std::move(instanceHandle));
@@ -208,14 +208,14 @@ inline static jsi::Value getArrayOfInstanceHandlesFromShadowNodes(
 }
 
 inline static void getTextContentInShadowNode(
-    ShadowNode const &shadowNode,
+    const ShadowNode &shadowNode,
     std::string &result) {
-  auto rawTextShadowNode = traitCast<RawTextShadowNode const *>(&shadowNode);
+  auto rawTextShadowNode = traitCast<const RawTextShadowNode *>(&shadowNode);
   if (rawTextShadowNode != nullptr) {
     result.append(rawTextShadowNode->getConcreteProps().text);
   }
 
-  for (auto const &childNode : shadowNode.getChildren()) {
+  for (const auto &childNode : shadowNode.getChildren()) {
     getTextContentInShadowNode(*childNode.get(), result);
   }
 }

--- a/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.cpp
@@ -50,7 +50,7 @@ void BufferedRuntimeExecutor::flush() {
 
 void BufferedRuntimeExecutor::unsafeFlush() {
   while (queue_.size() > 0) {
-    BufferedWork const &bufferedWork = queue_.top();
+    const BufferedWork &bufferedWork = queue_.top();
     Work work = std::move(bufferedWork.work_);
     runtimeExecutor_(std::move(work));
     queue_.pop();

--- a/packages/react-native/ReactCommon/react/runtime/nativeviewconfig/LegacyUIManagerConstantsProviderBinding.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/nativeviewconfig/LegacyUIManagerConstantsProviderBinding.cpp
@@ -13,8 +13,8 @@ void install(jsi::Runtime &runtime, ProviderType &&provider) {
   auto name = "RN$LegacyInterop_UIManager_getConstants";
   auto hostFunction = [provider = std::move(provider)](
                           jsi::Runtime &runtime,
-                          jsi::Value const & /*thisValue*/,
-                          jsi::Value const * /*arguments*/,
+                          const jsi::Value & /*thisValue*/,
+                          const jsi::Value * /*arguments*/,
                           size_t count) -> jsi::Value {
     if (count != 0) {
       throw new jsi::JSError(runtime, "0 arguments expected.");

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -436,7 +436,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                                          encoding:[NSString defaultCStringEncoding]];
   std::vector<facebook::react::MapBuffer> frames = errorMap.getMapBufferList(JSErrorHandlerKey::kAllStackFrames);
   NSMutableArray<NSDictionary<NSString *, id> *> *stack = [NSMutableArray new];
-  for (facebook::react::MapBuffer const &mapBuffer : frames) {
+  for (const facebook::react::MapBuffer &mapBuffer : frames) {
     NSDictionary *frame = @{
       @"file" : [NSString stringWithCString:mapBuffer.getString(JSErrorHandlerKey::kFrameFileName).c_str()
                                    encoding:[NSString defaultCStringEncoding]],

--- a/packages/react-native/ReactCommon/react/test_utils/Entropy.h
+++ b/packages/react-native/ReactCommon/react/test_utils/Entropy.h
@@ -105,7 +105,7 @@ class Entropy final {
     auto spreadResult = std::vector<std::vector<T>>(deviationLimit * 2);
     std::fill(spreadResult.begin(), spreadResult.end(), std::vector<T>{});
 
-    for (auto const &item : items) {
+    for (const auto &item : items) {
       auto position = int(distribution(generator_) + deviationLimit);
       position = std::max(0, std::min(position, deviationLimit * 2));
 
@@ -115,7 +115,7 @@ class Entropy final {
     }
 
     auto result = std::vector<std::vector<T>>{};
-    for (auto const &chunk : spreadResult) {
+    for (const auto &chunk : spreadResult) {
       if (chunk.size() == 0) {
         continue;
       }

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -39,11 +39,11 @@ class ShadowTreeEdge final {
 };
 
 static bool traverseShadowTree(
-    ShadowNode::Shared const &parentShadowNode,
-    std::function<void(ShadowTreeEdge const &edge, bool &stop)> const
+    const ShadowNode::Shared &parentShadowNode,
+    const std::function<void(ShadowTreeEdge const &edge, bool &stop)>
         &callback) {
   auto index = int{0};
-  for (auto const &childNode : parentShadowNode->getChildren()) {
+  for (const auto &childNode : parentShadowNode->getChildren()) {
     auto stop = bool{false};
 
     callback(ShadowTreeEdge{childNode, parentShadowNode, index}, stop);
@@ -61,23 +61,23 @@ static bool traverseShadowTree(
   return false;
 }
 
-static int countShadowNodes(ShadowNode::Shared const &rootShadowNode) {
+static int countShadowNodes(const ShadowNode::Shared &rootShadowNode) {
   auto counter = int{0};
 
   traverseShadowTree(
       rootShadowNode,
-      [&](ShadowTreeEdge const &edge, bool &stop) { counter++; });
+      [&](const ShadowTreeEdge &edge, bool &stop) { counter++; });
 
   return counter;
 }
 
 static ShadowTreeEdge findShadowNodeWithIndex(
-    ShadowNode::Shared const &rootNode,
+    const ShadowNode::Shared &rootNode,
     int index) {
   auto counter = int{0};
   auto result = ShadowTreeEdge{};
 
-  traverseShadowTree(rootNode, [&](ShadowTreeEdge const &edge, bool &stop) {
+  traverseShadowTree(rootNode, [&](const ShadowTreeEdge &edge, bool &stop) {
     if (index == counter) {
       result = edge;
     }
@@ -89,8 +89,8 @@ static ShadowTreeEdge findShadowNodeWithIndex(
 }
 
 static ShadowTreeEdge findRandomShadowNode(
-    Entropy const &entropy,
-    ShadowNode::Shared const &rootShadowNode) {
+    const Entropy &entropy,
+    const ShadowNode::Shared &rootShadowNode) {
   auto count = countShadowNodes(rootShadowNode);
   return findShadowNodeWithIndex(
       rootShadowNode,
@@ -98,18 +98,18 @@ static ShadowTreeEdge findRandomShadowNode(
 }
 
 static ShadowNode::ListOfShared cloneSharedShadowNodeList(
-    ShadowNode::ListOfShared const &list) {
+    const ShadowNode::ListOfShared &list) {
   auto result = ShadowNode::ListOfShared{};
   result.reserve(list.size());
-  for (auto const &shadowNode : list) {
+  for (const auto &shadowNode : list) {
     result.push_back(shadowNode->clone({}));
   }
   return result;
 }
 
 static inline ShadowNode::Unshared messWithChildren(
-    Entropy const &entropy,
-    ShadowNode const &shadowNode) {
+    const Entropy &entropy,
+    const ShadowNode &shadowNode) {
   auto children = shadowNode.getChildren();
   children = cloneSharedShadowNodeList(children);
   entropy.shuffle(children);
@@ -119,8 +119,8 @@ static inline ShadowNode::Unshared messWithChildren(
 }
 
 static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(
-    Entropy const &entropy,
-    ShadowNode const &shadowNode) {
+    const Entropy &entropy,
+    const ShadowNode &shadowNode) {
   auto oldProps = shadowNode.getProps();
 
   ContextContainer contextContainer{};
@@ -130,7 +130,7 @@ static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(
       parserContext, oldProps, RawProps(folly::dynamic::object()));
 
   auto &viewProps =
-      const_cast<ViewProps &>(static_cast<ViewProps const &>(*newProps));
+      const_cast<ViewProps &>(static_cast<const ViewProps &>(*newProps));
 
   if (entropy.random<bool>(0.1)) {
     viewProps.nativeId = entropy.random<bool>() ? "42" : "";
@@ -176,8 +176,8 @@ static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(
 // Similar to `messWithLayoutableOnlyFlag` but has a 50/50 chance of flattening
 // (or unflattening) a node's children.
 static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
-    Entropy const &entropy,
-    ShadowNode const &shadowNode) {
+    const Entropy &entropy,
+    const ShadowNode &shadowNode) {
   ContextContainer contextContainer{};
   PropsParserContext parserContext{-1, contextContainer};
 
@@ -186,7 +186,7 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
       parserContext, oldProps, RawProps(folly::dynamic::object()));
 
   auto &viewProps =
-      const_cast<ViewProps &>(static_cast<ViewProps const &>(*newProps));
+      const_cast<ViewProps &>(static_cast<const ViewProps &>(*newProps));
 
   if (entropy.random<bool>(0.5)) {
     viewProps.nativeId = "";
@@ -217,8 +217,8 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
 }
 
 static inline ShadowNode::Unshared messWithYogaStyles(
-    Entropy const &entropy,
-    ShadowNode const &shadowNode) {
+    const Entropy &entropy,
+    const ShadowNode &shadowNode) {
   folly::dynamic dynamic = folly::dynamic::object();
 
   if (entropy.random<bool>()) {
@@ -238,7 +238,7 @@ static inline ShadowNode::Unshared messWithYogaStyles(
   // failures if the size of properties also changes.
   EXPECT_EQ(properties.size(), 20);
 
-  for (auto const &property : properties) {
+  for (const auto &property : properties) {
     if (entropy.random<bool>(0.1)) {
       dynamic[property] = entropy.random<int>(0, 1024);
     }
@@ -257,23 +257,23 @@ static inline ShadowNode::Unshared messWithYogaStyles(
 }
 
 using ShadowNodeAlteration = std::function<
-    ShadowNode::Unshared(Entropy const &entropy, ShadowNode const &shadowNode)>;
+    ShadowNode::Unshared(const Entropy &entropy, const ShadowNode &shadowNode)>;
 
 static inline void alterShadowTree(
-    Entropy const &entropy,
+    const Entropy &entropy,
     RootShadowNode::Shared &rootShadowNode,
     ShadowNodeAlteration alteration) {
   auto edge = findRandomShadowNode(entropy, rootShadowNode);
 
   rootShadowNode =
       std::static_pointer_cast<RootShadowNode>(rootShadowNode->cloneTree(
-          edge.shadowNode->getFamily(), [&](ShadowNode const &oldShadowNode) {
+          edge.shadowNode->getFamily(), [&](const ShadowNode &oldShadowNode) {
             return alteration(entropy, oldShadowNode);
           }));
 }
 
 static inline void alterShadowTree(
-    Entropy const &entropy,
+    const Entropy &entropy,
     RootShadowNode::Shared &rootShadowNode,
     std::vector<ShadowNodeAlteration> alterations) {
   auto i = entropy.random<int>(0, alterations.size() - 1);
@@ -281,17 +281,17 @@ static inline void alterShadowTree(
 }
 
 static SharedViewProps generateDefaultProps(
-    ComponentDescriptor const &componentDescriptor) {
+    const ComponentDescriptor &componentDescriptor) {
   ContextContainer contextContainer{};
   PropsParserContext parserContext{-1, contextContainer};
 
-  return std::static_pointer_cast<ViewProps const>(
+  return std::static_pointer_cast<const ViewProps>(
       componentDescriptor.cloneProps(parserContext, nullptr, RawProps{}));
 }
 
 static inline ShadowNode::Shared generateShadowNodeTree(
-    Entropy const &entropy,
-    ComponentDescriptor const &componentDescriptor,
+    const Entropy &entropy,
+    const ComponentDescriptor &componentDescriptor,
     int size,
     int deviation = 3) {
   if (size <= 1) {
@@ -306,7 +306,7 @@ static inline ShadowNode::Shared generateShadowNodeTree(
   auto chunks = entropy.distribute(items, deviation);
   auto children = ShadowNode::ListOfShared{};
 
-  for (auto const &chunk : chunks) {
+  for (const auto &chunk : chunks) {
     children.push_back(
         generateShadowNodeTree(entropy, componentDescriptor, chunk.size()));
   }

--- a/packages/react-native/ReactCommon/react/utils/CalledOnceMovableOnlyFunction.h
+++ b/packages/react-native/ReactCommon/react/utils/CalledOnceMovableOnlyFunction.h
@@ -40,10 +40,10 @@ class CalledOnceMovableOnlyFunction {
   /*
    * Not copyable.
    */
-  CalledOnceMovableOnlyFunction(CalledOnceMovableOnlyFunction const &other) =
+  CalledOnceMovableOnlyFunction(const CalledOnceMovableOnlyFunction &other) =
       delete;
   CalledOnceMovableOnlyFunction &operator=(
-      CalledOnceMovableOnlyFunction const &other) = delete;
+      const CalledOnceMovableOnlyFunction &other) = delete;
 
   /*
    * Movable.

--- a/packages/react-native/ReactCommon/react/utils/ContextContainer.h
+++ b/packages/react-native/ReactCommon/react/utils/ContextContainer.h
@@ -26,7 +26,7 @@ namespace facebook::react {
  */
 class ContextContainer final {
  public:
-  using Shared = std::shared_ptr<ContextContainer const>;
+  using Shared = std::shared_ptr<const ContextContainer>;
 
   /*
    * Registers an instance of the particular type `T` in the container
@@ -40,7 +40,7 @@ class ContextContainer final {
    *`ReactNativeConfig`.
    */
   template <typename T>
-  void insert(std::string const &key, T const &instance) const {
+  void insert(const std::string &key, T const &instance) const {
     std::unique_lock lock(mutex_);
 
     instances_.insert({key, std::make_shared<T>(instance)});
@@ -50,7 +50,7 @@ class ContextContainer final {
    * Removes an instance stored for a given `key`.
    * Does nothing if the instance was not found.
    */
-  void erase(std::string const &key) const {
+  void erase(const std::string &key) const {
     std::unique_lock lock(mutex_);
 
     instances_.erase(key);
@@ -61,10 +61,10 @@ class ContextContainer final {
    * Values with keys that already exist in the container will be replaced with
    * values from the given container.
    */
-  void update(ContextContainer const &contextContainer) const {
+  void update(const ContextContainer &contextContainer) const {
     std::unique_lock lock(mutex_);
 
-    for (auto const &pair : contextContainer.instances_) {
+    for (const auto &pair : contextContainer.instances_) {
       instances_.erase(pair.first);
       instances_.insert(pair);
     }
@@ -76,7 +76,7 @@ class ContextContainer final {
    * Throws an exception if the instance could not be found.
    */
   template <typename T>
-  T at(std::string const &key) const {
+  T at(const std::string &key) const {
     std::shared_lock lock(mutex_);
 
     react_native_assert(
@@ -91,7 +91,7 @@ class ContextContainer final {
    * Returns an empty optional if the instance could not be found.
    */
   template <typename T>
-  std::optional<T> find(std::string const &key) const {
+  std::optional<T> find(const std::string &key) const {
     std::shared_lock lock(mutex_);
 
     auto iterator = instances_.find(key);

--- a/packages/react-native/ReactCommon/react/utils/ManagedObjectWrapper.h
+++ b/packages/react-native/ReactCommon/react/utils/ManagedObjectWrapper.h
@@ -55,7 +55,7 @@ inline std::shared_ptr<void> wrapManagedObject(id object) noexcept
   return std::shared_ptr<void>((__bridge_retained void *)object, detail::wrappedManagedObjectDeleter);
 }
 
-inline id unwrapManagedObject(std::shared_ptr<void> const &object) noexcept
+inline id unwrapManagedObject(const std::shared_ptr<void> &object) noexcept
 {
   return (__bridge id)object.get();
 }
@@ -67,7 +67,7 @@ inline std::shared_ptr<void> wrapManagedObjectWeakly(id object) noexcept
   return wrapManagedObject(weakWrapper);
 }
 
-inline id unwrapManagedObjectWeakly(std::shared_ptr<void> const &object) noexcept
+inline id unwrapManagedObjectWeakly(const std::shared_ptr<void> &object) noexcept
 {
   RCTInternalGenericWeakWrapper *weakWrapper = (RCTInternalGenericWeakWrapper *)unwrapManagedObject(object);
   react_native_assert(weakWrapper && "`RCTInternalGenericWeakWrapper` instance must not be `nil`.");

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.cpp
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.cpp
@@ -13,10 +13,10 @@ namespace facebook::react {
 
 RunLoopObserver::RunLoopObserver(
     Activity activities,
-    WeakOwner const &owner) noexcept
+    const WeakOwner &owner) noexcept
     : activities_(activities), owner_(owner) {}
 
-void RunLoopObserver::setDelegate(Delegate const *delegate) const noexcept {
+void RunLoopObserver::setDelegate(const Delegate *delegate) const noexcept {
   // We need these constraints to ensure basic thread-safety.
   react_native_assert(delegate && "A delegate must not be `nullptr`.");
   react_native_assert(

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
@@ -18,7 +18,7 @@ namespace facebook::react {
  */
 class RunLoopObserver {
  public:
-  using Unique = std::unique_ptr<RunLoopObserver const>;
+  using Unique = std::unique_ptr<const RunLoopObserver>;
 
   /*
    * The concept of an owner.
@@ -38,8 +38,8 @@ class RunLoopObserver {
    * `shared_ptr<X>(shared_ptr<Y> const &, X *)`) with the actual one (sharing
    * the control block).
    */
-  using Owner = std::shared_ptr<void const>;
-  using WeakOwner = std::weak_ptr<void const>;
+  using Owner = std::shared_ptr<const void>;
+  using WeakOwner = std::weak_ptr<const void>;
 
   /*
    * Run loop activity stages which run loop observers can be observe.
@@ -63,7 +63,7 @@ class RunLoopObserver {
      * is retained during this call.
      * Will be called on the thread associated with the run loop.
      */
-    virtual void activityDidChange(Delegate const *delegate, Activity activity)
+    virtual void activityDidChange(const Delegate *delegate, Activity activity)
         const noexcept = 0;
 
     virtual ~Delegate() noexcept = default;
@@ -71,19 +71,19 @@ class RunLoopObserver {
 
   using Factory = std::function<std::unique_ptr<RunLoopObserver>(
       Activity activities,
-      WeakOwner const &owner)>;
+      const WeakOwner &owner)>;
 
   /*
    * Constructs a run loop observer.
    */
-  RunLoopObserver(Activity activities, WeakOwner const &owner) noexcept;
+  RunLoopObserver(Activity activities, const WeakOwner &owner) noexcept;
   virtual ~RunLoopObserver() noexcept = default;
 
   /*
    * Sets the delegate.
    * Must be called just once.
    */
-  void setDelegate(Delegate const *delegate) const noexcept;
+  void setDelegate(const Delegate *delegate) const noexcept;
 
   /*
    * Enables or disables run loop observing.
@@ -118,9 +118,9 @@ class RunLoopObserver {
    */
   void activityDidChange(Activity activity) const noexcept;
 
-  Activity const activities_{};
-  WeakOwner const owner_;
-  mutable Delegate const *delegate_{nullptr};
+  const Activity activities_{};
+  const WeakOwner owner_;
+  mutable const Delegate *delegate_{nullptr};
   mutable std::atomic<bool> enabled_{false};
 };
 

--- a/packages/react-native/ReactCommon/react/utils/Telemetry.h
+++ b/packages/react-native/ReactCommon/react/utils/Telemetry.h
@@ -30,7 +30,7 @@ using TelemetryDuration = std::chrono::nanoseconds;
 /*
  * Represents a time point which never happens.
  */
-static TelemetryTimePoint const kTelemetryUndefinedTimePoint =
+static const TelemetryTimePoint kTelemetryUndefinedTimePoint =
     TelemetryTimePoint::max();
 
 /*

--- a/packages/react-native/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
@@ -36,7 +36,7 @@ using RuntimeExecutor =
  * is no synchronization.
  */
 inline static void executeAsynchronously(
-    RuntimeExecutor const &runtimeExecutor,
+    const RuntimeExecutor &runtimeExecutor,
     std::function<void(jsi::Runtime &runtime)> &&callback) noexcept {
   std::thread([callback = std::move(callback), runtimeExecutor]() mutable {
     runtimeExecutor(std::move(callback));
@@ -51,7 +51,7 @@ inline static void executeAsynchronously(
  * `callback` will be executed.
  */
 inline static void executeSynchronously_CAN_DEADLOCK(
-    RuntimeExecutor const &runtimeExecutor,
+    const RuntimeExecutor &runtimeExecutor,
     std::function<void(jsi::Runtime &runtime)> &&callback) noexcept {
   std::mutex mutex;
   mutex.lock();
@@ -73,7 +73,7 @@ inline static void executeSynchronously_CAN_DEADLOCK(
  * thread.
  */
 inline static void executeSynchronouslyOnSameThread_CAN_DEADLOCK(
-    RuntimeExecutor const &runtimeExecutor,
+    const RuntimeExecutor &runtimeExecutor,
     std::function<void(jsi::Runtime &runtime)> &&callback) noexcept {
   // Note: We need the third mutex to get back to the main thread before
   // the lambda is finished (because all mutexes are allocated on the stack).
@@ -114,7 +114,7 @@ inline static void executeSynchronouslyOnSameThread_CAN_DEADLOCK(
 
 template <typename DataT>
 inline static DataT executeSynchronouslyOnSameThread_CAN_DEADLOCK(
-    RuntimeExecutor const &runtimeExecutor,
+    const RuntimeExecutor &runtimeExecutor,
     std::function<DataT(jsi::Runtime &runtime)> &&callback) noexcept {
   DataT data;
 

--- a/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
+++ b/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
@@ -64,10 +64,10 @@ using namespace facebook::react;
                          alpha:1.0];
 }
 
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+- (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &oldViewProps = *std::static_pointer_cast<RNTMyNativeViewProps const>(_props);
-  const auto &newViewProps = *std::static_pointer_cast<RNTMyNativeViewProps const>(props);
+  const auto &oldViewProps = *std::static_pointer_cast<const RNTMyNativeViewProps>(_props);
+  const auto &newViewProps = *std::static_pointer_cast<const RNTMyNativeViewProps>(props);
 
   if (oldViewProps.values != newViewProps.values) {
     if (_eventEmitter) {
@@ -100,7 +100,7 @@ using namespace facebook::react;
           newStringVector,
           newLatLonVector,
           newIntVectorVector};
-      std::static_pointer_cast<RNTMyNativeViewEventEmitter const>(_eventEmitter)->onIntArrayChanged(value);
+      std::static_pointer_cast<const RNTMyNativeViewEventEmitter>(_eventEmitter)->onIntArrayChanged(value);
     }
   }
 

--- a/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
+++ b/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
@@ -22,7 +22,7 @@ namespace react {
 extern const char RNTMyNativeViewName[] = "RNTMyLegacyNativeView";
 
 void registerComponents(
-    std::shared_ptr<ComponentDescriptorProviderRegistry const> registry) {
+    std::shared_ptr<const ComponentDescriptorProviderRegistry> registry) {
   registry->add(concreteComponentDescriptorProvider<
                 RNTMyNativeViewComponentDescriptor>());
   registry->add(concreteComponentDescriptorProvider<


### PR DESCRIPTION
Summary:
React Native uses an inconsistent mix of "west const" and "east const". E.g. `const auto &` in 74 files, but `auto const &` in 60. Sometimes they are mixed from one line to the next:  {F1079102436}

Clang format 14 adds a QualifierAlignment option, but fbsource is still on 12, so we cannot use it in our config until the [world is updated]()https://fb.workplace.com/groups/toolchain.fndn/posts/24006558685624673/?comment_id=24009214565359085&reply_comment_id=24009455088668366. This diff just runs a local version of Clang format locally first to fix QualifierAlignment, then reformats with the fbsource version, to fix any other output differences unrelated to that. This will not continually enforce a style, but will make the world more consistent, and hopefully encourage a consistent style until we can set it.

West const seems more popular in `//xplat` so I just picked left alignment somewhat arbitrarily, but we could also maybe take a poll on this.

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D48761722

