### PR TITLE
Update typings for StyleSheet.create to catch typos in style keys

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
@@ -37,14 +37,14 @@ export namespace StyleSheet {
   export function create<T extends NamedStyles<T> | NamedStyles<any>>(
     // The extra & NamedStyles<any> here helps Typescript catch typos: e.g.,
     // the following code would not error with `styles: T | NamedStyles<T>`,
-    // but would error with `styles: (T | NamedStyles<T>) & NamedStyles<any>`
+    // but would error with `styles: T & NamedStyles<any>`
     //
     // ```ts
     // StyleSheet.create({
     //   someComponent: { marginLeft: 1, magrinRight: 1 },
     // });
     // ```
-    styles: (T | NamedStyles<T>) & NamedStyles<any>,
+    styles: T & NamedStyles<any>,
   ): T;
 
   /**

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
@@ -35,7 +35,16 @@ export namespace StyleSheet {
    * Creates a StyleSheet style reference from the given object.
    */
   export function create<T extends NamedStyles<T> | NamedStyles<any>>(
-    styles: T | NamedStyles<T>,
+    // The extra & NamedStyles<any> here helps Typescript catch typos: e.g.,
+    // the following code would not error with `styles: T | NamedStyles<T>`,
+    // but would error with `styles: (T | NamedStyles<T>) & NamedStyles<any>`
+    //
+    // ```ts
+    // StyleSheet.create({
+    //   someComponent: { marginLeft: 1, magrinRight: 1 },
+    // });
+    // ```
+    styles: (T | NamedStyles<T>) & NamedStyles<any>,
   ): T;
 
   /**

--- a/packages/react-native/types/__typetests__/stylesheet-create.tsx
+++ b/packages/react-native/types/__typetests__/stylesheet-create.tsx
@@ -31,3 +31,12 @@ const styles = StyleSheet.create({
     ],
   },
 });
+
+const styles2 = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    // Should error due to misspelled parameter name
+    // @ts-expect-error
+    magrinRight: 1,
+  },
+});

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -51,7 +51,7 @@
 //                 Mateusz Wit <https://github.com/MateWW>
 //                 Saad Najmi <https://github.com/saadnajmi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.1
+// Minimum TypeScript Version: 4.8
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Previously, when you tried to create some styles using `StyleSheet.create`, you can create styles with invalid styles:

```ts
const styles = StyleSheet.create({
  container: {
    marginLeft: 1,
    magrinRight: 1, // This is a typo, but would not cause typecheck errors
  },
});
```

The root cause is that Typescript uses a looser [Excess Property Checks](https://www.typescriptlang.org/docs/handbook/2/objects.html#excess-property-checks) if we're using template types rather than using the actual specific types in the function signature.

- https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/62481

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[INTERNAL] [FIXED] - Make StyleSheet.create better check property keys for typos

## Test Plan:

Added a test in __typeTests__, which should get run by CI.
