### PR TITLE
Persist Hermes MacOS Artifacts to Workspace Depending on Build Flavor

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -1124,12 +1124,27 @@ jobs:
                 paths: /tmp/hermes/dSYM/Release
       - store_hermes_apple_artifacts:
           flavor: << parameters.flavor >>
+      - when:
+          condition:
+            equal: [ << parameters.flavor >>, "Release" ]
+          steps:
+            - persist_to_workspace:
+                root: /tmp/hermes/
+                paths:
+                  - hermes-runtime-darwin/hermes-ios-release.tar.gz
+      - when:
+          condition:
+            equal: [ << parameters.flavor >>, "Debug" ]
+          steps:
+            - persist_to_workspace:
+                root: /tmp/hermes/
+                paths:
+                  - hermes-runtime-darwin/hermes-ios-debug.tar.gz
       - persist_to_workspace:
           root: /tmp/hermes/
           paths:
-            - hermes-runtime-darwin
-            - osx-bin
-            - dSYM
+            - osx-bin/<< parameters.flavor >>
+            - dSYM/<< parameters.flavor >>
 
   build_hermesc_windows:
     executor:


### PR DESCRIPTION
## Summary:

In some occasion, we have a race condition when:
- prepare hermes workspace has some artifacts but not all of them, and it store them to the workspace
- the pipeline rebuilds the missing artifacts
- the build_hermes_macos jobs tries to upload the pre-existing artifacts, uploading the whole folder.

So, for example, imagine that at the prepare_hermes_workspace time, we are able to restore both the `hermes-ios-release.tar.gz` and the `hermes-ios-debug.tar.gz`. When the two 
concurrent `build_hermes_MacOS-Debug` and `build_hermes_MacOS-Release`, they will both try to upload both tars at the same time, and that results in the concurrent errors we 
are seeing.

This change should fix this, by having the Debug job upload the Debug artifacts only and the Release jobs upload the Release artifacts only, so there will be no concurrent 
upload of the same files. 

## Changelog:

[Internal] - Upload Hermes macos artifacts depending on the Build flavor.

## Test Plan:

CircleCI stays green.
