### PR TITLE
Ensure ReactNativeEnv Jest environment will be treated like "node"

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "prettier-plugin-hermes-parser": "0.14.0",
     "react": "18.2.0",
     "react-test-renderer": "18.2.0",
+    "react-native-env-test-module": "file:./packages/react-native/jest/__tests__/react-native-env-test-module",
     "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",
     "typescript": "5.0.4",

--- a/packages/react-native/jest/__tests__/react-native-env-test-module/package.json
+++ b/packages/react-native/jest/__tests__/react-native-env-test-module/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "react-native-env-test-module",
+  "description": "This module is used by react-native-env-test.js to ensure the custom Jest environment is a Node environment",
+  "version": "0.0.1",
+  "exports": {
+    ".": {
+      "node": "./src/node.js",
+      "browser": "./src/browser.js",
+      "default": "./src/browser.js"
+    }
+  }
+}

--- a/packages/react-native/jest/__tests__/react-native-env-test-module/src/browser.js
+++ b/packages/react-native/jest/__tests__/react-native-env-test-module/src/browser.js
@@ -1,0 +1,1 @@
+module.exports = 'browser';

--- a/packages/react-native/jest/__tests__/react-native-env-test-module/src/node.js
+++ b/packages/react-native/jest/__tests__/react-native-env-test-module/src/node.js
@@ -1,0 +1,1 @@
+module.exports = 'node';

--- a/packages/react-native/jest/__tests__/react-native-env-test.js
+++ b/packages/react-native/jest/__tests__/react-native-env-test.js
@@ -1,0 +1,8 @@
+/**
+ * @jest-environment <rootDir>/packages/react-native/jest/react-native-env.js
+ */
+import testModuleExportString from 'react-native-env-test-module';
+
+test('ReactNativeEnv is a node environment', () => {
+  expect(testModuleExportString).toBe('node');
+});

--- a/packages/react-native/jest/react-native-env.js
+++ b/packages/react-native/jest/react-native-env.js
@@ -12,5 +12,5 @@
 const NodeEnv = require('jest-environment-node').TestEnvironment;
 
 module.exports = class ReactNativeEnv extends NodeEnv {
-  customExportConditions = ['require', 'react-native'];
+  customExportConditions = ['require', 'react-native', 'node'];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9717,6 +9717,9 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+"react-native-env-test-module@file:./packages/react-native/jest/__tests__/react-native-env-test-module":
+  version "0.0.1"
+
 react-refresh@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.0.tgz#d421f9bd65e0e4b9822a399f14ac56bda9c92292"


### PR DESCRIPTION
## Summary:

The new custom Jest environment could cause issues with some modules, like uuid@9.0.0 as it had a custom name - "react-native" - and no fallback to "node" as an alternative. This meant it could, incorrectly, be pointed towards browser exports instead if they were a "default" export (like here: https://github.com/uuidjs/uuid/blob/v9.0.0/package.json#L32)

## Changelog:

Pick one each for the category and type tags:

[GENERAL] [FIXED] - The custom RN Jest environment was not considered a "node"-like environment when processing module "exports"

## Test Plan:

Added unit test for this. I needed to add a new module to the repo to support this. I didn't add it under `packages` as per a normal module since it felt very specific to the test but let me know if the setup should be altered.