### PR TITLE
Simplify shadow node fragment placeholders

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.cpp
@@ -9,19 +9,25 @@
 
 namespace facebook::react {
 
+#if defined(__clang__)
+#define NO_DESTROY [[clang::no_destroy]]
+#else
+#define NO_DESTROY
+#endif
+
 const Props::Shared &ShadowNodeFragment::propsPlaceholder() {
-  static auto &instance = *new Props::Shared();
+  NO_DESTROY static Props::Shared instance;
   return instance;
 }
 
 const ShadowNode::SharedListOfShared &
 ShadowNodeFragment::childrenPlaceholder() {
-  static auto &instance = *new ShadowNode::SharedListOfShared();
+  NO_DESTROY static ShadowNode::SharedListOfShared instance;
   return instance;
 }
 
 const State::Shared &ShadowNodeFragment::statePlaceholder() {
-  static auto &instance = *new State::Shared();
+  NO_DESTROY static State::Shared instance;
   return instance;
 }
 


### PR DESCRIPTION
Summary:
We can avoid static guards and heap allocation memory by forcing a default initialized shared_ptr (which is constexpr), and telling the compiler to not bother with registering a destructor, as these shared_ptr will never hold a value.

Changelog: [Internal]

Differential Revision: D48867013

