### PR TITLE
Revert to built-in devToolsFrontendUrl in target list

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -20,7 +20,6 @@ import type {IncomingMessage, ServerResponse} from 'http';
 
 import url from 'url';
 import WS from 'ws';
-import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';
 import Device from './Device';
 
 const debug = require('debug')('Metro:InspectorProxy');
@@ -116,12 +115,19 @@ export default class InspectorProxy {
     const debuggerUrl = `${this._serverBaseUrl}${WS_DEBUGGER_URL}?device=${deviceId}&page=${page.id}`;
     const webSocketDebuggerUrl = 'ws://' + debuggerUrl;
 
+    // For now, `/json/list` returns the legacy built-in `devtools://` URL, to
+    // preserve existing handling by Flipper. This may return a placeholder in
+    // future -- please use the `/open-debugger` endpoint.
+    const devtoolsFrontendUrl =
+      'devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=' +
+      encodeURIComponent(webSocketDebuggerUrl);
+
     return {
       id: `${deviceId}-${page.id}`,
       description: page.app,
       title: page.title,
       faviconUrl: 'https://reactjs.org/favicon.ico',
-      devtoolsFrontendUrl: getDevToolsFrontendUrl(webSocketDebuggerUrl),
+      devtoolsFrontendUrl,
       type: 'node',
       webSocketDebuggerUrl,
       vm: page.vm,

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -17,6 +17,7 @@ import type {Logger} from '../types/Logger';
 
 import url from 'url';
 import getDevServerUrl from '../utils/getDevServerUrl';
+import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';
 import queryInspectorTargets from '../utils/queryInspectorTargets';
 
 const debuggerInstances = new Map<string, ?LaunchedBrowser>();
@@ -83,7 +84,7 @@ export default function openDebuggerMiddleware({
         debuggerInstances.set(
           appId,
           await browserLauncher.launchDebuggerAppWindow(
-            target.devtoolsFrontendUrl,
+            getDevToolsFrontendUrl(target.webSocketDebuggerUrl),
           ),
         );
         res.end();


### PR DESCRIPTION
Summary:
Reverts external behaviour of https://github.com/facebook/react-native/pull/39122.

- `/json/list` once again returns the built-in `devtools://devtools/bundled/js_app.html` URL — effectively freezing the current experience in Flipper.
- `/open-debugger` continues to use the *new* frontend via `getDevToolsFrontendUrl`.
    - *Eventually*, we'll want to align this as the returned `devtoolsFrontendUrl` value once Flipper is out of the picture.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D48868767

