### PR TITLE
Fix downloading hermes for nightlies

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -115,7 +115,7 @@ def podspec_source(source_type, version, react_native_path)
     when HermesEngineSourceType::DOWNLOAD_PREBUILD_RELEASE_TARBALL
         return podspec_source_download_prebuild_release_tarball(react_native_path, version)
     when HermesEngineSourceType::DOWNLOAD_PREBUILT_NIGHTLY_TARBALL
-        return podspec_source_download_prebuilt_nightly_tarball()
+        return podspec_source_download_prebuilt_nightly_tarball(react_native_path, version)
     else
         abort "[Hermes] Unsupported or invalid source type provided: #{source_type}"
     end
@@ -184,7 +184,7 @@ def podspec_source_download_prebuild_release_tarball(react_native_path, version)
     return {:http => url}
 end
 
-def podspec_source_download_prebuilt_nightly_tarball()
+def podspec_source_download_prebuilt_nightly_tarball(react_native_path, version)
     destination_path = download_nightly_hermes(react_native_path, version)
     url = nightly_tarball_url(version)
     hermes_log("Using nightly tarball from URL: #{url}")
@@ -206,6 +206,11 @@ end
 def download_stable_hermes(react_native_path, version, configuration)
     tarball_url = release_tarball_url(version, configuration)
     download_hermes_tarball(react_native_path, tarball_url, version, configuration)
+end
+
+def download_nightly_hermes(react_native_path, version)
+    tarball_url = nightly_tarball_url(version)
+    download_hermes_tarball(react_native_path, tarball_url, version, :debug)
 end
 
 def download_hermes_tarball(react_native_path, tarball_url, version, configuration)

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -115,7 +115,7 @@ def podspec_source(source_type, version, react_native_path)
     when HermesEngineSourceType::DOWNLOAD_PREBUILD_RELEASE_TARBALL
         return podspec_source_download_prebuild_release_tarball(react_native_path, version)
     when HermesEngineSourceType::DOWNLOAD_PREBUILT_NIGHTLY_TARBALL
-        return podspec_source_download_prebuilt_nightly_tarball(react_native_path, version)
+        return podspec_source_download_prebuilt_nightly_tarball(version)
     else
         abort "[Hermes] Unsupported or invalid source type provided: #{source_type}"
     end
@@ -184,8 +184,7 @@ def podspec_source_download_prebuild_release_tarball(react_native_path, version)
     return {:http => url}
 end
 
-def podspec_source_download_prebuilt_nightly_tarball(react_native_path, version)
-    destination_path = download_nightly_hermes(react_native_path, version)
+def podspec_source_download_prebuilt_nightly_tarball(version)
     url = nightly_tarball_url(version)
     hermes_log("Using nightly tarball from URL: #{url}")
     return {:http => url}
@@ -206,11 +205,6 @@ end
 def download_stable_hermes(react_native_path, version, configuration)
     tarball_url = release_tarball_url(version, configuration)
     download_hermes_tarball(react_native_path, tarball_url, version, configuration)
-end
-
-def download_nightly_hermes(react_native_path, version)
-    tarball_url = nightly_tarball_url(version)
-    download_hermes_tarball(react_native_path, tarball_url, version, :debug)
 end
 
 def download_hermes_tarball(react_native_path, tarball_url, version, configuration)


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/pull/38963 introduced a regression that breaks downloading hermes tarball for nightlies. It fails with the following error when running `pod install`:

```
Fetching podspec for `hermes-engine` from `../../../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`
[!] Failed to load 'hermes-engine' podspec: 
[!] Invalid `hermes-engine.podspec` file: undefined local variable or method `react_native_path' for Pod:Module
Did you mean?  react_native_post_install.
```

The root cause is that the `download_nightly_hermes` method was just not implemented.

## Changelog:

[IOS] [FIXED] - Fixed downloading hermes tarball for nightlies

## Test Plan:

After applying these changes, `pod install` in my project no longer fails and downloads the tarball correctly.