### PR TITLE
Remove superfluous JSI import?

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -27,7 +27,6 @@
 
 #ifdef WITH_FBSYSTRACE
 #include <fbsystrace.h>
-#include <jsi/jsi/jsi.h>
 
 using fbsystrace::FbSystraceAsyncFlow;
 #endif


### PR DESCRIPTION
Summary:
Seems to be invalid given the other jsi import

## Changelog:
[Internal] - Remove invalid import

Reviewed By: NickGerleman

Differential Revision: D47380384
