### PR TITLE
- xplat RN

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -135,7 +135,7 @@ inline static CGFloat RCTEffectiveFontSizeMultiplierFromTextAttributes(const Tex
 
 inline static UIFont *RCTEffectiveFontFromTextAttributes(const TextAttributes &textAttributes)
 {
-  NSString *fontFamily = [NSString stringWithCString:textAttributes.fontFamily.c_str() encoding:NSUTF8StringEncoding];
+  NSString *fontFamily = [NSString stringWithUTF8String:textAttributes.fontFamily.c_str()];
 
   RCTFontProperties fontProperties;
   fontProperties.family = fontFamily;
@@ -291,10 +291,10 @@ NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(c
 
   if (textAttributes.role.has_value()) {
     std::string roleStr = toString(textAttributes.role.value());
-    attributes[RCTTextAttributesAccessibilityRoleAttributeName] = [NSString stringWithCString:roleStr.c_str()];
+    attributes[RCTTextAttributesAccessibilityRoleAttributeName] = [NSString stringWithUTF8String:roleStr.c_str()];
   } else if (textAttributes.accessibilityRole.has_value()) {
     std::string roleStr = toString(textAttributes.accessibilityRole.value());
-    attributes[RCTTextAttributesAccessibilityRoleAttributeName] = [NSString stringWithCString:roleStr.c_str()];
+    attributes[RCTTextAttributesAccessibilityRoleAttributeName] = [NSString stringWithUTF8String:roleStr.c_str()];
   }
 
   return [attributes copy];
@@ -371,7 +371,7 @@ NSAttributedString *RCTNSAttributedStringFromAttributedString(const AttributedSt
 
       nsAttributedStringFragment = [[NSMutableAttributedString attributedStringWithAttachment:attachment] mutableCopy];
     } else {
-      NSString *string = [NSString stringWithCString:fragment.string.c_str() encoding:NSUTF8StringEncoding];
+      NSString *string = [NSString stringWithUTF8String:fragment.string.c_str()];
 
       if (fragment.textAttributes.textTransform.has_value()) {
         auto textTransform = fragment.textAttributes.textTransform.value();


### PR DESCRIPTION
Summary:
https://developer.apple.com/documentation/foundation/nsstring/1497289-stringwithcstring

[Changelog]:[ios][Fixed] Remove usage of deprecated stringWithCString function

Reviewed By: christophpurrer

Differential Revision: D48692609

