### PR TITLE
Register Babel in Jest setup to load transformer

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -32,6 +32,8 @@ const nodeFiles = /[\\/]metro(?:-[^/]*)[\\/]/;
 // hook. This is used below to configure babelTransformSync under Jest.
 const {only: _, ...nodeBabelOptions} = metroBabelRegister.config([]);
 
+// Register Babel to allow the transformer itself to be loaded from source.
+require('../scripts/build/babel-register').registerForMonorepo();
 const transformer = require('@react-native/metro-babel-transformer');
 
 module.exports = {


### PR DESCRIPTION
Summary:
As `react-native/babel-preset` is extended to include parts of codegen (written in Flow) via `react-native/babel-plugin-codegen`, we need to register Babel (with a Node JS config) in order to load the `react-native/babel-transformer` that Jest needs to transform RN code when running from source.

(This is *only* relevant to running from source, ie internally at Meta or when developing on a clone of the OSS repo)

Changelog: [Internal]

Differential Revision: D48871440

