### PR TITLE
Allow to control flipper with an Env var

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -32,7 +32,9 @@ if USE_FRAMEWORKS
   use_frameworks! :linkage => linkage.to_sym
 end
 
-def pods(target_name, options = {}, use_flipper: !IN_CI && !USE_FRAMEWORKS)
+$shouldUseFlipper =  ENV['USE_FLIPPER'] ? ENV['USE_FLIPPER'] == '1' : !IN_CI && !USE_FRAMEWORKS
+
+def pods(target_name, options = {}, use_flipper: $shouldUseFlipper)
   project 'RNTesterPods.xcodeproj'
 
   fabric_enabled = true


### PR DESCRIPTION
Summary:
This change allow us to control whether we want to install flipper or not in RNTester using an env var.
This is just a simple quality of life change to speed up local testing.

## Changelog:
[Internal] - Allow to control whether to install Flipper or not from an env variable

Differential Revision: D48907743


