### PR TITLE
Fix use_hermes condition in React-Core

### DIFF
--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -21,7 +21,7 @@ folly_version = '2021.07.22.00'
 socket_rocket_version = '0.6.0'
 boost_compiler_flags = '-Wno-documentation'
 
-use_hermes = ENV['USE_HERMES'] == '1'
+use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 use_frameworks = ENV['USE_FRAMEWORKS'] != nil
 
 header_subspecs = {
@@ -95,7 +95,7 @@ Pod::Spec.new do |s|
     ]
     # If we are using Hermes (the default is use hermes, so USE_HERMES can be nil), we don't have jsc installed
     # So we have to exclude the JSCExecutorFactory
-    if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
+    if use_hermes
       exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
     end
     ss.exclude_files = exclude_files
@@ -136,10 +136,10 @@ Pod::Spec.new do |s|
   s.dependency "Yoga"
   s.dependency "glog"
 
-  if ENV['USE_HERMES'] == "0"
-    s.dependency 'React-jsc'
-  else
+  if use_hermes
     s.dependency 'React-hermes'
     s.dependency 'hermes-engine'
+  else
+    s.dependency 'React-jsc'
   end
 end

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -32,7 +32,9 @@ if USE_FRAMEWORKS
   use_frameworks! :linkage => linkage.to_sym
 end
 
-def pods(target_name, options = {}, use_flipper: !IN_CI && !USE_FRAMEWORKS)
+$shouldUseFlipper =  ENV['USE_FLIPPER'] ? ENV['USE_FLIPPER'] == '1' : !IN_CI && !USE_FRAMEWORKS
+
+def pods(target_name, options = {}, use_flipper: $shouldUseFlipper)
   project 'RNTesterPods.xcodeproj'
 
   fabric_enabled = true


### PR DESCRIPTION
Summary:
The use_hermes condition in React core was imprecise as using hermes is the default now. So, if USE_HERMES is not defined, then we are using hermes.

## Changelog:
[iOS][Fixed] - Use the right condition in React-Core for USE_HERMES.

Differential Revision: D48907854

