### PR TITLE
forward-compatible use of u8"..." strings

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -50,7 +50,8 @@ TEST_P(JSITest, PropNameIDTest) {
       rt, movedQuux, PropNameID::forAscii(rt, std::string("foo"))));
   uint8_t utf8[] = {0xF0, 0x9F, 0x86, 0x97};
   PropNameID utf8PropNameID = PropNameID::forUtf8(rt, utf8, sizeof(utf8));
-  EXPECT_EQ(utf8PropNameID.utf8(rt), u8"\U0001F197");
+  EXPECT_EQ(
+      utf8PropNameID.utf8(rt), reinterpret_cast<const char*>(u8"\U0001F197"));
   EXPECT_TRUE(PropNameID::compare(
       rt, utf8PropNameID, PropNameID::forUtf8(rt, utf8, sizeof(utf8))));
   PropNameID nonUtf8PropNameID = PropNameID::forUtf8(rt, "meow");
@@ -532,7 +533,7 @@ TEST_P(JSITest, FunctionTest) {
                    "s1",
                    String::createFromAscii(rt, "s2"),
                    std::string{"s3"},
-                   std::string{u8"s\u2600"},
+                   std::string{reinterpret_cast<const char*>(u8"s\u2600")},
                    // invalid UTF8 sequence due to unexpected continuation byte
                    std::string{"s\x80"},
                    Object(rt),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/hermes/pull/1113

Since C++20, the type of a `u8"..."` string literal is `const char8_t[N]` whereas prior to C++20 the type is `const char[N]`. `char8_t` has the same size, alignment, and signedness as `unsigned char` but is a different type from `unsigned char`, as well as being a different type from `signed char` and from `char`.

In context, the uses of the `u8"..."` expect `const char*` (to which `const char[N]` decays) and not `const char8_t*` (to which `const char8_t[N]` decays). To fit the string to the context since C++20, we must `reinterpret_cast` to `const char*`; this is a type-level no-op prior to C++20.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D48908076


