### PR TITLE
Reuse test_ios_rntester to run iOS tests

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -506,3 +506,53 @@ commands:
                 when: << parameters.when >>
                 path: << parameters.path >>
                 destination: << parameters.destination >>
+
+  prepare_ios_tests:
+    description: This command runs a set of commands to prepare iOS for running unit tests
+    steps:
+      - brew_install:
+          package: xcbeautify
+      - run:
+          name: Run Ruby Tests
+          command: |
+            cd packages/react-native/scripts
+            sh run_ruby_tests.sh
+      - run:
+          name: Boot iPhone Simulator
+          command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
+
+      - run:
+          name: Configure Environment Variables
+          command: |
+            echo 'export PATH=/usr/local/opt/node@18/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+
+      - run:
+          name: "Brew: Tap wix/brew"
+          command: brew tap wix/brew
+      - brew_install:
+          package: applesimutils watchman
+      - run:
+          name: Configure Watchman
+          command: echo "{}" > .watchmanconfig
+
+  run_ios_tests:
+    description: This command run iOS tests and collects results
+    steps:
+      - run:
+          name: "Run Tests: iOS Unit and Integration Tests"
+          command: node ./scripts/circleci/run_with_retry.js 3 yarn test-ios
+      - run:
+          name: Zip Derived data folder
+          when: always
+          command: |
+            echo "zipping tests results"
+            cd /Users/distiller/Library/Developer/Xcode
+            XCRESULT_PATH=$(find . -name '*.xcresult')
+            tar -zcvf xcresults.tar.gz $XCRESULT_PATH
+      - store_artifacts_if_needed:
+          path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
+      - report_bundle_size:
+          platform: ios
+      - store_test_results:
+          path: ./reports/junit

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -110,109 +110,6 @@ jobs:
           path: ./reports/junit
 
   # -------------------------
-  #     JOBS: iOS Unit Tests
-  # -------------------------
-  test_ios:
-    executor: reactnativeios
-    parameters:
-      run_unit_tests:
-        description: Specifies whether unit tests should run.
-        type: boolean
-        default: false
-      jsengine:
-        default: "Hermes"
-        description: Which JavaScript engine to use. Must be one of "Hermes", "JSC".
-        type: enum
-        enum: ["Hermes", "JSC"]
-      ruby_version:
-        default: "2.6.10"
-        description: The version of ruby that must be used
-        type: string
-    environment:
-      - REPORTS_DIR: "./reports/junit"
-    steps:
-      - checkout_code_with_cache
-      - setup_ruby:
-          ruby_version: << parameters.ruby_version >>
-      - brew_install:
-          package: xcbeautify
-      - run:
-          name: Run Ruby Tests
-          command: |
-            cd packages/react-native/scripts
-            sh run_ruby_tests.sh
-      - run_yarn
-      - *attach_hermes_workspace
-      - run: |
-          cd packages/rn-tester
-          bundle check || bundle install
-      - run:
-          name: Boot iPhone Simulator
-          command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
-
-      - run:
-          name: Configure Environment Variables
-          command: |
-            echo 'export PATH=/usr/local/opt/node@18/bin:$PATH' >> $BASH_ENV
-            source $BASH_ENV
-
-      - run:
-          name: "Brew: Tap wix/brew"
-          command: brew tap wix/brew
-      - brew_install:
-          package: applesimutils watchman
-
-      - run:
-          name: Configure Watchman
-          command: echo "{}" > .watchmanconfig
-
-      - run:
-          name: Setup the CocoaPods environment
-          command: |
-            bundle exec pod setup
-
-      - with_hermes_tarball_cache_span:
-          set_tarball_path: True
-          steps:
-            - with_rntester_pods_cache_span:
-                steps:
-                  - run:
-                      name: Generate RNTesterPods Workspace
-                      command: |
-                        if [[ << parameters.jsengine >> == "JSC" ]]; then
-                          export USE_HERMES=0
-                        fi
-
-                        cd packages/rn-tester
-                        bundle install
-                        bundle exec pod install --verbose
-
-      # -------------------------
-      # Runs iOS unit tests
-      - when:
-          condition: << parameters.run_unit_tests >>
-          steps:
-            - run:
-                name: "Run Tests: iOS Unit and Integration Tests"
-                command: node ./scripts/circleci/run_with_retry.js 3 yarn test-ios
-            - run:
-                name: Zip Derived data folder
-                when: always
-                command: |
-                  echo "zipping tests results"
-                  cd /Users/distiller/Library/Developer/Xcode
-                  XCRESULT_PATH=$(find . -name '*.xcresult')
-                  tar -zcvf xcresults.tar.gz $XCRESULT_PATH
-            - store_artifacts_if_needed:
-                path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
-      # -------------------------
-      # Collect Results
-      - report_bundle_size:
-          platform: ios
-      - store_test_results:
-          path: ./reports/junit
-
-  # -------------------------
   #     JOBS: iOS E2E Tests
   # -------------------------
   test_e2e_ios:
@@ -627,6 +524,10 @@ jobs:
         default: "2.6.10"
         description: The version of ruby that must be used
         type: string
+      run_unit_tests:
+        description: whether unit tests should run or not.
+        default: false
+        type: boolean
     steps:
       - checkout_code_with_cache
       - run_yarn
@@ -641,6 +542,10 @@ jobs:
           command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
       - setup_ruby:
           ruby_version: << parameters.ruby_version >>
+      - when:
+          condition: << parameters.run_unit_tests >>
+          steps:
+            - prepare_ios_tests
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
           steps:
@@ -666,13 +571,24 @@ jobs:
 
                         bundle install
                         bundle exec pod install
-                  - run:
-                      name: Build RNTester
-                      command: |
-                        xcodebuild build \
-                          -workspace packages/rn-tester/RNTesterPods.xcworkspace \
-                          -scheme RNTester \
-                          -sdk iphonesimulator
+                  - when:
+                      condition:
+                        # The run_ios_test will also build RNTester so we don't nee to build it
+                        # here if we run tests
+                        equal: [ false, << parameters.run_unit_tests >> ]
+
+                      steps:
+                          - run:
+                              name: Build RNTester
+                              command: |
+                                xcodebuild build \
+                                  -workspace packages/rn-tester/RNTesterPods.xcworkspace \
+                                  -scheme RNTester \
+                                  -sdk iphonesimulator
+                  - when:
+                      condition: << parameters.run_unit_tests >>
+                      steps:
+                          - run_ios_tests
 
   # -------------------------
   #    JOBS: Windows

--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -169,14 +169,11 @@
               - architecture: "OldArch"
                 jsengine: "JSC"
                 use_frameworks: "StaticLibraries"
-      - test_ios:
-          name: "Test iOS with Ruby 3.2.0"
+      - test_ios_rntester:
           run_unit_tests: true
-          requires:
-            - build_hermes_macos
-          ruby_version: "3.2.0"
-      - test_ios:
-          run_unit_tests: true
+          architecture: "OldArch"
+          use_frameworks: "StaticLibraries"
+          ruby_version: "2.6.10"
           requires:
             - build_hermes_macos
           matrix:

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -160,14 +160,11 @@
               - architecture: "OldArch"
                 jsengine: "JSC"
                 use_frameworks: "StaticLibraries"
-      - test_ios:
-          name: "Test iOS with Ruby 3.2.0"
+      - test_ios_rntester:
           run_unit_tests: true
-          requires:
-            - build_hermes_macos
-          ruby_version: "3.2.0"
-      - test_ios:
-          run_unit_tests: true
+          architecture: "OldArch"
+          use_frameworks: "StaticLibraries"
+          ruby_version: "2.6.10"
           requires:
             - build_hermes_macos
           matrix:

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -83,8 +83,8 @@ references:
     # Hermes iOS
     hermesc_apple_cache_key: &hermesc_apple_cache_key v2-hermesc-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_apple_slices_cache_key: &hermes_apple_slices_cache_key v2-hermes-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
-    hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v4-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v3-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
+    hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v4-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
+    hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v3-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_macosx_bin_release_cache_key: &hermes_macosx_bin_release_cache_key v1-hermes-release-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_macosx_bin_debug_cache_key: &hermes_macosx_bin_debug_cache_key v1-hermes-debug-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_dsym_debug_cache_key: &hermes_dsym_debug_cache_key v1-hermes-debug-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}


### PR DESCRIPTION
Summary:
When we were reworking the Build logic in CI, we thought that the `test_ios` job and the `test_ios_rntester` jobs were the same. But, actually, they aren't.
So, now, we are seeing failures in the `test_ios` because its caches are not updated.

This changes remove the duplication of the two jobs, making sure that they use the same job, adding the possibility to run tests directly in rntester.

## Changelog:
[Internal] - Reuse test_ios_rntester to run iOS tests

Differential Revision: D48950096

