### PR TITLE
Add missing type for TextInput.readOnly in Typescript

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -814,6 +814,11 @@ export interface TextInputProps
    */
   placeholderTextColor?: ColorValue | undefined;
 
+  /** 
+   * If `true`, text is not editable. The default value is `false`.
+   */
+  readOnly?: boolean | undefined;
+
   /**
    * enum('default', 'go', 'google', 'join', 'next', 'route', 'search', 'send', 'yahoo', 'done', 'emergency-call')
    * Determines how the return key should look.

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -814,7 +814,7 @@ export interface TextInputProps
    */
   placeholderTextColor?: ColorValue | undefined;
 
-  /** 
+  /**
    * If `true`, text is not editable. The default value is `false`.
    */
   readOnly?: boolean | undefined;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The `readOnly` prop is available in the `TextInput` implementation (see [usage #1](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Components/TextInput/TextInput.js#L1646), [usage #2](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Components/TextInput/TextInput.js#L1671)), but the corresponding Typescript type is currently missing. Those who use Typescript get an invalid prop error when using the `readOnly` prop on `TextInput`.

Having this prop type included in TypeScript would fix the bug above and also would be beneficial for consistency and comprehensive type support.

Notably, this prop is also included in the Flow types [here](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js#L814).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Add missing type for TextInput.readOnly in Typescript

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

N/A
