### PR TITLE
Implement "tickleJS" for Hermes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
@@ -22,9 +22,10 @@ void JHermesInstance::registerNatives() {
   });
 }
 
-std::unique_ptr<jsi::Runtime> JHermesInstance::createJSRuntime() noexcept {
+std::unique_ptr<jsi::Runtime> JHermesInstance::createJSRuntime(
+    std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
   // TODO T105438175 Pass ReactNativeConfig to init Hermes with MobileConfig
-  return HermesInstance::createJSRuntime();
+  return HermesInstance::createJSRuntime(nullptr, nullptr, msgQueueThread);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include <cxxreact/MessageQueueThread.h>
 #include <fbjni/fbjni.h>
 #include <jni.h>
 #include <jsi/jsi.h>
@@ -29,7 +30,8 @@ class JHermesInstance
 
   static void registerNatives();
 
-  std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept;
+  std::unique_ptr<jsi::Runtime> createJSRuntime(
+      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;
 
   ~JHermesInstance() {}
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -61,7 +61,7 @@ JReactInstance::JReactInstance(
   jBindingsInstaller_ = jni::make_global(jBindingsInstaller);
 
   instance_ = std::make_unique<ReactInstance>(
-      jsEngineInstance->cthis()->createJSRuntime(),
+      jsEngineInstance->cthis()->createJSRuntime(sharedJSMessageQueueThread),
       sharedJSMessageQueueThread,
       timerManager,
       std::move(jsErrorHandlingFunc));

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jsc/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jsc/jni/OnLoad.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cxxreact/MessageQueueThread.h>
 #include <fbjni/fbjni.h>
 #include <jsc/JSCRuntime.h>
 #include <jsi/jsi.h>
@@ -29,7 +30,8 @@ class JSCInstance : public jni::HybridClass<JSCInstance, JJSEngineInstance> {
     });
   }
 
-  std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept {
+  std::unique_ptr<jsi::Runtime> createJSRuntime(
+      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
     return jsc::makeJSCRuntime();
   }
 

--- a/packages/react-native/ReactCommon/react/runtime/JSEngineInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSEngineInstance.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ReactCommon/RuntimeExecutor.h>
+#include <cxxreact/MessageQueueThread.h>
 #include <jsi/jsi.h>
 
 namespace facebook::react {
@@ -17,7 +18,8 @@ namespace facebook::react {
  */
 class JSEngineInstance {
  public:
-  virtual std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept = 0;
+  virtual std::unique_ptr<jsi::Runtime> createJSRuntime(
+      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept = 0;
 
   virtual ~JSEngineInstance() = default;
 };

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cxxreact/MessageQueueThread.h>
 #include <hermes/hermes.h>
 #include <jsi/jsi.h>
 #include <react/config/ReactNativeConfig.h>
@@ -15,12 +16,10 @@ namespace facebook::react {
 
 class HermesInstance {
  public:
-  // This is only needed for Android. Consider removing.
-  static std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept;
-
   static std::unique_ptr<jsi::Runtime> createJSRuntime(
       std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
-      std::shared_ptr<::hermes::vm::CrashManager> cm) noexcept;
+      std::shared_ptr<::hermes::vm::CrashManager> cm,
+      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
@@ -7,6 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import <cxxreact/MessageQueueThread.h>
 #import <hermes/Public/CrashManager.h>
 #import <jsi/jsi.h>
 #import <react/runtime/JSEngineInstance.h>
@@ -25,7 +26,8 @@ class RCTHermesInstance : public JSEngineInstance {
       std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
       CrashManagerProvider crashManagerProvider);
 
-  std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept override;
+  std::unique_ptr<jsi::Runtime> createJSRuntime(
+      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept override;
 
   ~RCTHermesInstance(){};
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.mm
@@ -20,10 +20,12 @@ RCTHermesInstance::RCTHermesInstance(
 {
 }
 
-std::unique_ptr<jsi::Runtime> RCTHermesInstance::createJSRuntime() noexcept
+std::unique_ptr<jsi::Runtime> RCTHermesInstance::createJSRuntime(
+    std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
 {
   return _hermesInstance->createJSRuntime(
-      _reactNativeConfig, _crashManagerProvider ? _crashManagerProvider() : nullptr);
+      _reactNativeConfig, _crashManagerProvider ? _crashManagerProvider() : nullptr, msgQueueThread);
 }
+
 } // namespace react
 } // namespace facebook

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -218,7 +218,10 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
   // Create the React Instance
   _reactInstance = std::make_unique<ReactInstance>(
-      _jsEngineInstance->createJSRuntime(), _jsThreadManager.jsMessageThread, timerManager, jsErrorHandlingFunc);
+      _jsEngineInstance->createJSRuntime(_jsThreadManager.jsMessageThread),
+      _jsThreadManager.jsMessageThread,
+      timerManager,
+      jsErrorHandlingFunc);
   _valid = true;
 
   RuntimeExecutor bufferedRuntimeExecutor = _reactInstance->getBufferedRuntimeExecutor();

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <cxxreact/MessageQueueThread.h>
 #import <jsi/jsi.h>
 #import <react/runtime/JSEngineInstance.h>
 
@@ -15,7 +16,8 @@ class RCTJscInstance : public JSEngineInstance {
  public:
   RCTJscInstance();
 
-  std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept override;
+  std::unique_ptr<jsi::Runtime> createJSRuntime(
+      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept override;
 
   ~RCTJscInstance(){};
 };

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.mm
@@ -13,7 +13,8 @@ namespace react {
 
 RCTJscInstance::RCTJscInstance() {}
 
-std::unique_ptr<jsi::Runtime> RCTJscInstance::createJSRuntime() noexcept
+std::unique_ptr<jsi::Runtime> RCTJscInstance::createJSRuntime(
+    std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
 {
   return jsc::makeJSCRuntime();
 }


### PR DESCRIPTION
Summary:
"tickleJS" is a function in RN Hermes Debugger, we need to implement it for Bridgeless for feature correctness and keep parity with Bridge.

Changelog:
[General][Changed] -  Implement "tickleJS" for Hermes

Differential Revision: D48952581

