### PR TITLE
Enable `-Wconversion`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNI.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNI.h
@@ -22,12 +22,12 @@ namespace {
 const int HAS_NEW_LAYOUT = 16;
 
 union YGNodeContext {
-  uintptr_t edgesSet = 0;
+  int32_t edgesSet = 0;
   void* asVoidPtr;
 };
 
 class YGNodeEdges {
-  uintptr_t edges_;
+  int32_t edges_;
 
 public:
   enum Edge {

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJTypesVanilla.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJTypesVanilla.h
@@ -14,7 +14,7 @@
 #include "jni.h"
 
 class PtrJNodeMapVanilla {
-  std::map<YGNodeConstRef, size_t> ptrsToIdxs_{};
+  std::map<YGNodeConstRef, jsize> ptrsToIdxs_{};
   jobjectArray javaNodes_{};
 
 public:
@@ -25,13 +25,13 @@ public:
     using namespace facebook::yoga::vanillajni;
 
     JNIEnv* env = getCurrentEnv();
-    size_t nativePointersSize = env->GetArrayLength(javaNativePointers);
-    std::vector<jlong> nativePointers(nativePointersSize);
+    jsize nativePointersSize = env->GetArrayLength(javaNativePointers);
+    std::vector<jlong> nativePointers(static_cast<size_t>(nativePointersSize));
     env->GetLongArrayRegion(
         javaNativePointers, 0, nativePointersSize, nativePointers.data());
 
-    for (size_t i = 0; i < nativePointersSize; ++i) {
-      ptrsToIdxs_[(YGNodeConstRef) nativePointers[i]] = i;
+    for (jsize i = 0; i < nativePointersSize; ++i) {
+      ptrsToIdxs_[(YGNodeConstRef) nativePointers[static_cast<size_t>(i)]] = i;
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/common.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/common.cpp
@@ -18,7 +18,8 @@ void registerNatives(
 
   assertNoPendingJniExceptionIf(env, !clazz);
 
-  auto result = env->RegisterNatives(clazz, methods, numMethods);
+  auto result =
+      env->RegisterNatives(clazz, methods, static_cast<int32_t>(numMethods));
 
   assertNoPendingJniExceptionIf(env, result != JNI_OK);
 }

--- a/packages/react-native/ReactCommon/yoga/cmake/project-defaults.cmake
+++ b/packages/react-native/ReactCommon/yoga/cmake/project-defaults.cmake
@@ -35,6 +35,7 @@ add_compile_options(
     -Wall
     -Wextra
     -Werror
+    -Wconversion
     # Disable RTTI
     $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
     # Use -O2 (prioritize speed)

--- a/packages/react-native/ReactCommon/yoga/yoga/bits/NumericBitfield.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/bits/NumericBitfield.h
@@ -15,12 +15,12 @@
 
 namespace facebook::yoga::details {
 
-constexpr size_t log2ceilFn(size_t n) {
+constexpr uint8_t log2ceilFn(uint8_t n) {
   return n < 1 ? 0 : (1 + log2ceilFn(n / 2));
 }
 
-constexpr int mask(size_t bitWidth, size_t index) {
-  return ((1 << bitWidth) - 1) << index;
+constexpr uint32_t mask(uint8_t bitWidth, uint8_t index) {
+  return ((1u << bitWidth) - 1u) << index;
 }
 
 } // namespace facebook::yoga::details
@@ -29,38 +29,31 @@ namespace facebook::yoga {
 
 // The number of bits necessary to represent enums defined with YG_ENUM_SEQ_DECL
 template <typename Enum>
-constexpr size_t minimumBitCount() {
+constexpr uint8_t minimumBitCount() {
   static_assert(
       enums::count<Enum>() > 0, "Enums must have at least one entries");
   return details::log2ceilFn(enums::count<Enum>() - 1);
 }
 
 template <typename Enum>
-constexpr Enum getEnumData(int flags, size_t index) {
+constexpr Enum getEnumData(uint32_t flags, uint8_t index) {
   return static_cast<Enum>(
       (flags & details::mask(minimumBitCount<Enum>(), index)) >> index);
 }
 
 template <typename Enum>
-void setEnumData(uint32_t& flags, size_t index, int newValue) {
-  flags = (flags & ~details::mask(minimumBitCount<Enum>(), index)) |
+void setEnumData(uint32_t& flags, uint8_t index, uint32_t newValue) {
+  flags =
+      (flags &
+       ~static_cast<uint32_t>(details::mask(minimumBitCount<Enum>(), index))) |
       ((newValue << index) & (details::mask(minimumBitCount<Enum>(), index)));
 }
 
-template <typename Enum>
-void setEnumData(uint8_t& flags, size_t index, int newValue) {
-  flags =
-      (flags &
-       ~static_cast<uint8_t>(details::mask(minimumBitCount<Enum>(), index))) |
-      ((newValue << index) &
-       (static_cast<uint8_t>(details::mask(minimumBitCount<Enum>(), index))));
-}
-
-constexpr bool getBooleanData(int flags, size_t index) {
+constexpr bool getBooleanData(uint32_t flags, uint8_t index) {
   return (flags >> index) & 1;
 }
 
-inline void setBooleanData(uint8_t& flags, size_t index, bool value) {
+inline void setBooleanData(uint32_t& flags, uint8_t index, bool value) {
   if (value) {
     flags |= 1 << index;
   } else {

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -33,7 +33,7 @@ static void appendFormattedString(std::string& str, const char* fmt, ...) {
   va_start(args, fmt);
   va_list argsCopy;
   va_copy(argsCopy, args);
-  std::vector<char> buf(1 + vsnprintf(NULL, 0, fmt, args));
+  std::vector<char> buf(1 + static_cast<size_t>(vsnprintf(NULL, 0, fmt, args)));
   va_end(args);
   vsnprintf(buf.data(), buf.size(), fmt, argsCopy);
   va_end(argsCopy);
@@ -96,7 +96,7 @@ static void appendEdges(
   } else {
     for (int edge = YGEdgeLeft; edge != YGEdgeAll; ++edge) {
       std::string str = key + "-" + YGEdgeToString(static_cast<YGEdge>(edge));
-      appendNumberIfNotZero(base, str, edges[edge]);
+      appendNumberIfNotZero(base, str, edges[static_cast<size_t>(edge)]);
     }
   }
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/event/event.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/event/event.h
@@ -38,7 +38,7 @@ enum struct LayoutPassReason : int {
 struct LayoutData {
   int layouts;
   int measures;
-  int maxMeasureCache;
+  uint32_t maxMeasureCache;
   int cachedLayouts;
   int cachedMeasures;
   int measureCallbacks;

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
@@ -15,6 +15,14 @@
 
 namespace facebook::yoga {
 
+#pragma pack(push)
+#pragma pack(1)
+struct LayoutResultFlags {
+  uint32_t direction : 2;
+  bool hadOverflow : 1;
+};
+#pragma pack(pop)
+
 struct LayoutResults {
   // This value was chosen based on empirical data:
   // 98% of analyzed layouts require less than 8 entries.
@@ -27,10 +35,7 @@ struct LayoutResults {
   std::array<float, 4> padding = {};
 
 private:
-  static constexpr size_t directionOffset = 0;
-  static constexpr size_t hadOverflowOffset =
-      directionOffset + minimumBitCount<YGDirection>();
-  uint8_t flags = 0;
+  LayoutResultFlags flags_{};
 
 public:
   uint32_t computedFlexBasisGeneration = 0;
@@ -48,17 +53,15 @@ public:
   CachedMeasurement cachedLayout{};
 
   YGDirection direction() const {
-    return getEnumData<YGDirection>(flags, directionOffset);
+    return static_cast<YGDirection>(flags_.direction);
   }
 
   void setDirection(YGDirection direction) {
-    setEnumData<YGDirection>(flags, directionOffset, direction);
+    flags_.direction = static_cast<uint32_t>(direction) & 0x03;
   }
 
-  bool hadOverflow() const { return getBooleanData(flags, hadOverflowOffset); }
-  void setHadOverflow(bool hadOverflow) {
-    setBooleanData(flags, hadOverflowOffset, hadOverflow);
-  }
+  bool hadOverflow() const { return flags_.hadOverflow; }
+  void setHadOverflow(bool hadOverflow) { flags_.hadOverflow = hadOverflow; }
 
   bool operator==(LayoutResults layout) const;
   bool operator!=(LayoutResults layout) const { return !(*this == layout); }

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
 
 #include <yoga/algorithm/FlexDirection.h>
@@ -264,7 +265,7 @@ YOGA_EXPORT void Node::setMeasureFunc(MeasureWithContextFn measureFunc) {
   setMeasureFunc(m);
 }
 
-void Node::replaceChild(Node* child, uint32_t index) {
+void Node::replaceChild(Node* child, size_t index) {
   children_[index] = child;
 }
 
@@ -272,8 +273,8 @@ void Node::replaceChild(Node* oldChild, Node* newChild) {
   std::replace(children_.begin(), children_.end(), oldChild, newChild);
 }
 
-void Node::insertChild(Node* child, uint32_t index) {
-  children_.insert(children_.begin() + index, child);
+void Node::insertChild(Node* child, size_t index) {
+  children_.insert(children_.begin() + static_cast<ptrdiff_t>(index), child);
 }
 
 void Node::setConfig(yoga::Config* config) {
@@ -311,24 +312,30 @@ bool Node::removeChild(Node* child) {
   return false;
 }
 
-void Node::removeChild(uint32_t index) {
-  children_.erase(children_.begin() + index);
+void Node::removeChild(size_t index) {
+  children_.erase(children_.begin() + static_cast<ptrdiff_t>(index));
 }
 
 void Node::setLayoutDirection(YGDirection direction) {
   layout_.setDirection(direction);
 }
 
-void Node::setLayoutMargin(float margin, int index) {
-  layout_.margin[index] = margin;
+void Node::setLayoutMargin(float margin, YGEdge edge) {
+  assertFatal(
+      edge < layout_.margin.size(), "Edge must be top/left/bottom/right");
+  layout_.margin[edge] = margin;
 }
 
-void Node::setLayoutBorder(float border, int index) {
-  layout_.border[index] = border;
+void Node::setLayoutBorder(float border, YGEdge edge) {
+  assertFatal(
+      edge < layout_.border.size(), "Edge must be top/left/bottom/right");
+  layout_.border[edge] = border;
 }
 
-void Node::setLayoutPadding(float padding, int index) {
-  layout_.padding[index] = padding;
+void Node::setLayoutPadding(float padding, YGEdge edge) {
+  assertFatal(
+      edge < layout_.padding.size(), "Edge must be top/left/bottom/right");
+  layout_.padding[edge] = padding;
 }
 
 void Node::setLayoutLastOwnerDirection(YGDirection direction) {
@@ -339,8 +346,10 @@ void Node::setLayoutComputedFlexBasis(const FloatOptional computedFlexBasis) {
   layout_.computedFlexBasis = computedFlexBasis;
 }
 
-void Node::setLayoutPosition(float position, int index) {
-  layout_.position[index] = position;
+void Node::setLayoutPosition(float position, YGEdge edge) {
+  assertFatal(
+      edge < layout_.position.size(), "Edge must be top/left/bottom/right");
+  layout_.position[edge] = position;
 }
 
 void Node::setLayoutComputedFlexBasisGeneration(
@@ -348,16 +357,19 @@ void Node::setLayoutComputedFlexBasisGeneration(
   layout_.computedFlexBasisGeneration = computedFlexBasisGeneration;
 }
 
-void Node::setLayoutMeasuredDimension(float measuredDimension, int index) {
-  layout_.measuredDimensions[index] = measuredDimension;
+void Node::setLayoutMeasuredDimension(
+    float measuredDimension,
+    YGDimension dimension) {
+  layout_.measuredDimensions[static_cast<size_t>(dimension)] =
+      measuredDimension;
 }
 
 void Node::setLayoutHadOverflow(bool hadOverflow) {
   layout_.setHadOverflow(hadOverflow);
 }
 
-void Node::setLayoutDimension(float dimension, int index) {
-  layout_.dimensions[index] = dimension;
+void Node::setLayoutDimension(float dimensionValue, YGDimension dimension) {
+  layout_.dimensions[static_cast<size_t>(dimension)] = dimensionValue;
 }
 
 // If both left and right are defined, then use left. Otherwise return +left or

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -27,7 +27,7 @@ struct NodeFlags {
   bool hasNewLayout : 1;
   bool isReferenceBaseline : 1;
   bool isDirty : 1;
-  uint8_t nodeType : 1;
+  uint32_t nodeType : 1;
   bool measureUsesContext : 1;
   bool baselineUsesContext : 1;
   bool printUsesContext : 1;
@@ -181,8 +181,8 @@ public:
     return resolvedDimensions_;
   }
 
-  YGValue getResolvedDimension(int index) const {
-    return resolvedDimensions_[index];
+  YGValue getResolvedDimension(YGDimension dimension) const {
+    return resolvedDimensions_[static_cast<size_t>(dimension)];
   }
 
   static CompactValue computeEdgeValueForColumn(
@@ -257,7 +257,7 @@ public:
   }
 
   void setNodeType(YGNodeType nodeType) {
-    flags_.nodeType = static_cast<uint8_t>(nodeType);
+    flags_.nodeType = static_cast<uint32_t>(nodeType) & 0x01;
   }
 
   void setMeasureFunc(YGMeasureFunc measureFunc);
@@ -303,14 +303,16 @@ public:
   void setLayoutComputedFlexBasis(const FloatOptional computedFlexBasis);
   void setLayoutComputedFlexBasisGeneration(
       uint32_t computedFlexBasisGeneration);
-  void setLayoutMeasuredDimension(float measuredDimension, int index);
+  void setLayoutMeasuredDimension(
+      float measuredDimension,
+      YGDimension dimension);
   void setLayoutHadOverflow(bool hadOverflow);
-  void setLayoutDimension(float dimension, int index);
+  void setLayoutDimension(float dimensionValue, YGDimension dimension);
   void setLayoutDirection(YGDirection direction);
-  void setLayoutMargin(float margin, int index);
-  void setLayoutBorder(float border, int index);
-  void setLayoutPadding(float padding, int index);
-  void setLayoutPosition(float position, int index);
+  void setLayoutMargin(float margin, YGEdge edge);
+  void setLayoutBorder(float border, YGEdge edge);
+  void setLayoutPadding(float padding, YGEdge edge);
+  void setLayoutPosition(float position, YGEdge edge);
   void setPosition(
       const YGDirection direction,
       const float mainSize,
@@ -327,11 +329,11 @@ public:
   void clearChildren();
   /// Replaces the occurrences of oldChild with newChild
   void replaceChild(Node* oldChild, Node* newChild);
-  void replaceChild(Node* child, uint32_t index);
-  void insertChild(Node* child, uint32_t index);
+  void replaceChild(Node* child, size_t index);
+  void insertChild(Node* child, size_t index);
   /// Removes the first occurrence of child
   bool removeChild(Node* child);
-  void removeChild(uint32_t index);
+  void removeChild(size_t index);
 
   void cloneChildrenIfNeeded(void*);
   void markDirtyAndPropagate();

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -36,7 +36,7 @@ public:
   template <typename T>
   struct BitfieldRef {
     Style& style;
-    size_t offset;
+    uint8_t offset;
     operator T() const { return getEnumData<T>(style.flags, offset); }
     BitfieldRef<T>& operator=(T x) {
       setEnumData<T>(style.flags, offset, x);
@@ -84,24 +84,24 @@ public:
   ~Style() = default;
 
 private:
-  static constexpr size_t directionOffset = 0;
-  static constexpr size_t flexdirectionOffset =
+  static constexpr uint8_t directionOffset = 0;
+  static constexpr uint8_t flexdirectionOffset =
       directionOffset + minimumBitCount<YGDirection>();
-  static constexpr size_t justifyContentOffset =
+  static constexpr uint8_t justifyContentOffset =
       flexdirectionOffset + minimumBitCount<YGFlexDirection>();
-  static constexpr size_t alignContentOffset =
+  static constexpr uint8_t alignContentOffset =
       justifyContentOffset + minimumBitCount<YGJustify>();
-  static constexpr size_t alignItemsOffset =
+  static constexpr uint8_t alignItemsOffset =
       alignContentOffset + minimumBitCount<YGAlign>();
-  static constexpr size_t alignSelfOffset =
+  static constexpr uint8_t alignSelfOffset =
       alignItemsOffset + minimumBitCount<YGAlign>();
-  static constexpr size_t positionTypeOffset =
+  static constexpr uint8_t positionTypeOffset =
       alignSelfOffset + minimumBitCount<YGAlign>();
-  static constexpr size_t flexWrapOffset =
+  static constexpr uint8_t flexWrapOffset =
       positionTypeOffset + minimumBitCount<YGPositionType>();
-  static constexpr size_t overflowOffset =
+  static constexpr uint8_t overflowOffset =
       flexWrapOffset + minimumBitCount<YGWrap>();
-  static constexpr size_t displayOffset =
+  static constexpr uint8_t displayOffset =
       overflowOffset + minimumBitCount<YGOverflow>();
 
   uint32_t flags = 0;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1359

This enables clang warnings around potentially unsafe conversions, such as those with mismatched signedness, or ones which may lead to truncation.

This should catch issues in local development which create errors for MSVC (e.g. Dash), who's default `/W3` includes warnings akin to `-Wshorten-64-to-32`.

This full set of warnings here is a tad spammy, but probably more useful than not.

Changelog: [Internal]

Reviewed By: yungsters

Differential Revision: D48954777

