### PR TITLE
Only disable throttling when scrollEventThrottle isn't set

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -134,7 +134,11 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
     [self.scrollViewDelegateSplitter addDelegate:self];
 
-    _scrollEventThrottle = INFINITY;
+    if (CoreFeatures::disableScrollEventThrottleRequirement) {
+      _scrollEventThrottle = 0;
+    } else {
+      _scrollEventThrottle = INFINITY;
+    }
   }
 
   return self;
@@ -447,8 +451,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   }
 
   NSTimeInterval now = CACurrentMediaTime();
-  if (CoreFeatures::disableScrollEventThrottleRequirement || (_lastScrollEventDispatchTime == 0) ||
-      (now - _lastScrollEventDispatchTime > _scrollEventThrottle)) {
+  if ((_lastScrollEventDispatchTime == 0) || (now - _lastScrollEventDispatchTime > _scrollEventThrottle)) {
     _lastScrollEventDispatchTime = now;
     if (_eventEmitter) {
       static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScroll([self _scrollViewMetrics]);


### PR DESCRIPTION
Summary:
This QE is meant to change behavior to not throttle if `scrollEventThrottle` isn't set, but it's actually disabling throttling entirely.

This changes the gating to instead change the initialization path to set `_scrollEventThrottle = 0` when the QE is set.

`_scrollEventThrottle` is already set to zero when the `scrollEventThrottle` prop is removed/set to null, as the default value in ScrollViewProps.

Changelog: [internal]

Differential Revision: D48968754


