### PR TITLE
Fix announcement issue with Switch

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -630,7 +630,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
         info.setCheckable(true);
         info.setChecked(boolValue);
         if (info.getClassName().equals(AccessibilityRole.getValue(AccessibilityRole.SWITCH))) {
-          info.setText(
+          info.setStateDescription(
               context.getString(
                   boolValue ? R.string.state_on_description : R.string.state_off_description));
         }


### PR DESCRIPTION
Summary: Previously, switches were being announced using Talkback in this order: [state][role][label] but they should be announced as [state][label][role].

Reviewed By: NickGerleman

Differential Revision: D48807314


