### PR TITLE
Migrate from legacy to new Hermes CDP handler (#39268)

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -180,6 +180,24 @@ commands:
           name: Report size of RNTester.app (analysis-bot)
           command: GITHUB_TOKEN="$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A""$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B" scripts/circleci/report-bundle-size.sh << parameters.platform >> || true
 
+  setup_hermes_version:
+    steps:
+      - run:
+          name: Set up Hermes workspace and caching
+          command: |
+            mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
+
+            if [ -f "$HERMES_VERSION_FILE" ]; then
+              echo "Hermes Version file found! Using this version for the build:"
+              cat $HERMES_VERSION_FILE > /tmp/hermes/hermesversion
+            else
+              echo "Hermes Version file not found!!!"
+              echo "Using the last commit from main for the build:"
+              HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
+              echo $HERMES_TAG_SHA > /tmp/hermes/hermesversion
+            fi
+            cat /tmp/hermes/hermesversion
+
   get_react_native_version:
     steps:
       - run:

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -122,8 +122,7 @@ jobs:
     steps:
       - checkout_code_with_cache
       - run_yarn
-      - attach_workspace:
-          at: .
+      - setup_hermes_version
       - run:
           name: Install appium
           command: npm install appium@2.0.0 -g
@@ -219,8 +218,6 @@ jobs:
             cd packages/rn-tester
             yarn start
           background: true
-      - attach_workspace:
-          at: .
       - with_gradle_cache:
           steps:
             - run:
@@ -688,21 +685,7 @@ jobs:
             apt install -y nodejs
             npm install --global yarn
       - checkout
-      - run:
-          name: Set up Hermes workspace and caching
-          command: |
-            mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
-
-            if [ -f "$HERMES_VERSION_FILE" ]; then
-              echo "Hermes Version file found! Using this version for the build:"
-              cat $HERMES_VERSION_FILE > /tmp/hermes/hermesversion
-            else
-              echo "Hermes Version file not found!!!"
-              echo "Using the last commit from main for the build:"
-              HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
-              echo $HERMES_TAG_SHA > /tmp/hermes/hermesversion
-            fi
-            cat /tmp/hermes/hermesversion
+      - setup_hermes_version
       - get_react_native_version
       - restore_cache:
           key: *hermes_workspace_cache_key

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -91,11 +91,11 @@ references:
     hermes_dsym_release_cache_key: &hermes_dsym_release_cache_key v1-hermes-release-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     # Cocoapods - RNTester
     pods_cache_key: &pods_cache_key v10-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
-    cocoapods_cache_key: &cocoapods_cache_key v7-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}
+    cocoapods_cache_key: &cocoapods_cache_key v7-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
     rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v5-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}
 
     # Cocoapods - Template
-    template_cocoapods_cache_key: &template_cocoapods_cache_key v1-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}
+    template_cocoapods_cache_key: &template_cocoapods_cache_key v1-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
     template_podfile_lock_cache_key: &template_podfile_lock_cache_key v1-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}
 
     # Windows

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -31,9 +31,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "executor/*.{cpp,h}",
-                             "inspector-modern/*.{cpp,h}",
                              "inspector-modern/chrome/*.{cpp,h}",
-                             "inspector-modern/detail/*.{cpp,h}"
   s.public_header_files    = "executor/HermesExecutorFactory.h"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = {

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-file(GLOB hermesinspectormodern_SRC CONFIGURE_DEPENDS *.cpp detail/*.cpp chrome/*.cpp)
+file(GLOB hermesinspectormodern_SRC CONFIGURE_DEPENDS chrome/*.cpp)
 
 add_library(hermes_inspector_modern
         STATIC
@@ -15,7 +15,6 @@ add_library(hermes_inspector_modern
 target_compile_options(
         hermes_inspector_modern
         PRIVATE
-        -DHERMES_INSPECTOR_FOLLY_KLUDGE=1
         -std=c++17
         -fexceptions
 )
@@ -32,9 +31,6 @@ target_include_directories(hermes_inspector_modern PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(hermes_inspector_modern
         jsinspector
         fb
-        fbjni
-        folly_futures
-        folly_runtime
         glog
         hermes-engine::libhermes
         jsi)

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.cpp
@@ -6,7 +6,11 @@
  */
 
 #include "ConnectionDemux.h"
-#include "Connection.h"
+
+#ifdef HERMES_ENABLE_DEBUGGER
+
+#include <hermes/inspector/RuntimeAdapter.h>
+#include <hermes/inspector/chrome/CDPHandler.h>
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 
@@ -24,7 +28,7 @@ namespace {
 class LocalConnection : public ILocalConnection {
  public:
   LocalConnection(
-      std::shared_ptr<Connection> conn,
+      std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn,
       std::shared_ptr<std::unordered_set<std::string>> inspectedContexts);
   ~LocalConnection();
 
@@ -32,12 +36,12 @@ class LocalConnection : public ILocalConnection {
   void disconnect() override;
 
  private:
-  std::shared_ptr<Connection> conn_;
+  std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn_;
   std::shared_ptr<std::unordered_set<std::string>> inspectedContexts_;
 };
 
 LocalConnection::LocalConnection(
-    std::shared_ptr<Connection> conn,
+    std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn,
     std::shared_ptr<std::unordered_set<std::string>> inspectedContexts)
     : conn_(conn), inspectedContexts_(inspectedContexts) {
   inspectedContexts_->insert(conn->getTitle());
@@ -46,12 +50,12 @@ LocalConnection::LocalConnection(
 LocalConnection::~LocalConnection() = default;
 
 void LocalConnection::sendMessage(std::string str) {
-  conn_->sendMessage(std::move(str));
+  conn_->handle(std::move(str));
 }
 
 void LocalConnection::disconnect() {
   inspectedContexts_->erase(conn_->getTitle());
-  conn_->disconnect();
+  conn_->unregisterCallbacks();
 }
 
 } // namespace
@@ -87,8 +91,8 @@ DebugSessionToken ConnectionDemux::enableDebugging(
 
   auto waitForDebugger =
       (inspectedContexts_->find(title) != inspectedContexts_->end());
-  return addPage(
-      std::make_shared<Connection>(std::move(adapter), title, waitForDebugger));
+  return addPage(hermes::inspector_modern::chrome::CDPHandler::create(
+      std::move(adapter), title, waitForDebugger));
 }
 
 void ConnectionDemux::disableDebugging(DebugSessionToken session) {
@@ -99,10 +103,19 @@ void ConnectionDemux::disableDebugging(DebugSessionToken session) {
   removePage(session);
 }
 
-int ConnectionDemux::addPage(std::shared_ptr<Connection> conn) {
+int ConnectionDemux::addPage(
+    std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn) {
   auto connectFunc = [conn, this](std::unique_ptr<IRemoteConnection> remoteConn)
       -> std::unique_ptr<ILocalConnection> {
-    if (!conn->connect(std::move(remoteConn))) {
+    // This cannot be unique_ptr as std::function is copyable but unique_ptr
+    // isn't. TODO: Change the CDPHandler API to accommodate this and not
+    // require a copyable callback?
+    std::shared_ptr<IRemoteConnection> sharedConn = std::move(remoteConn);
+    if (!conn->registerCallbacks(
+            [sharedConn](const std::string &message) {
+              sharedConn->onMessage(message);
+            },
+            [sharedConn]() { sharedConn->onDisconnect(); })) {
       return nullptr;
     }
 
@@ -122,7 +135,7 @@ void ConnectionDemux::removePage(int pageId) {
   auto conn = conns_.at(pageId);
   std::string title = conn->getTitle();
   inspectedContexts_->erase(title);
-  conn->disconnect();
+  conn->unregisterCallbacks();
   conns_.erase(pageId);
 }
 
@@ -130,3 +143,5 @@ void ConnectionDemux::removePage(int pageId) {
 } // namespace inspector_modern
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifdef HERMES_ENABLE_DEBUGGER
+
 #include <memory>
 #include <mutex>
 #include <string>
@@ -14,9 +16,9 @@
 #include <unordered_set>
 
 #include <hermes/hermes.h>
-#include <hermes/inspector-modern/RuntimeAdapter.h>
-#include <hermes/inspector-modern/chrome/Connection.h>
 #include <hermes/inspector-modern/chrome/Registration.h>
+#include <hermes/inspector/RuntimeAdapter.h>
+#include <hermes/inspector/chrome/CDPHandler.h>
 #include <jsinspector-modern/InspectorInterfaces.h>
 
 namespace facebook {
@@ -44,13 +46,17 @@ class ConnectionDemux {
   void disableDebugging(DebugSessionToken session);
 
  private:
-  int addPage(std::shared_ptr<Connection> conn);
+  int addPage(
+      std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn);
   void removePage(int pageId);
 
   facebook::react::jsinspector_modern::IInspector &globalInspector_;
 
   std::mutex mutex_;
-  std::unordered_map<int, std::shared_ptr<Connection>> conns_;
+  std::unordered_map<
+      int,
+      std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler>>
+      conns_;
   std::shared_ptr<std::unordered_set<std::string>> inspectedContexts_;
 };
 
@@ -58,3 +64,5 @@ class ConnectionDemux {
 } // namespace inspector_modern
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.cpp
@@ -8,6 +8,8 @@
 #include "Registration.h"
 #include "ConnectionDemux.h"
 
+#ifdef HERMES_ENABLE_DEBUGGER
+
 namespace facebook {
 namespace hermes {
 namespace inspector_modern {
@@ -37,3 +39,5 @@ void disableDebugging(DebugSessionToken session) {
 } // namespace inspector_modern
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#ifdef HERMES_ENABLE_DEBUGGER
+
 #include <memory>
 #include <string>
 
 #include <hermes/hermes.h>
-#include <hermes/inspector-modern/RuntimeAdapter.h>
+#include <hermes/inspector/RuntimeAdapter.h>
 
 namespace facebook {
 namespace hermes {
@@ -41,3 +43,5 @@ extern void disableDebugging(DebugSessionToken session);
 } // namespace inspector_modern
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -23,3 +23,11 @@ target_link_libraries(bridgelesshermes
         jsi
         hermes_executor_common
 )
+
+if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+        target_compile_options(
+                bridgelesshermes
+                PRIVATE
+                -DHERMES_ENABLE_DEBUGGER=1
+        )
+endif()

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -11,8 +11,8 @@
 #include <jsi/jsilib.h>
 
 #ifdef HERMES_ENABLE_DEBUGGER
-#include <hermes/inspector-modern/RuntimeAdapter.h>
 #include <hermes/inspector-modern/chrome/Registration.h>
+#include <hermes/inspector/RuntimeAdapter.h>
 #include <jsi/decorator.h>
 #endif
 

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -73,6 +73,18 @@ Pod::Spec.new do |spec|
       ss.header_dir = 'hermes'
     end
 
+    spec.subspec 'inspector' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'API/hermes/inspector/*.h'
+      ss.header_dir = 'hermes/inspector'
+    end
+
+    spec.subspec 'inspector_chrome' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'API/hermes/inspector/chrome/*.h'
+      ss.header_dir = 'hermes/inspector/chrome'
+    end
+
     spec.subspec 'Public' do |ss|
       ss.source_files = ''
       ss.public_header_files = 'public/hermes/Public/*.h'

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -121,9 +121,19 @@ function build_apple_framework {
     fi
 
     # Copy over Hermes and JSI API headers.
-    mkdir -p destroot/include/hermes/Public destroot/include/jsi
+    mkdir -p destroot/include/hermes/Public
     cp public/hermes/Public/*.h destroot/include/hermes/Public
+
+    mkdir -p destroot/include/hermes
     cp API/hermes/*.h destroot/include/hermes
+
+    mkdir -p destroot/include/hermes/inspector
+    cp API/hermes/inspector/*.h destroot/include/hermes/inspector
+
+    mkdir -p destroot/include/hermes/inspector/chrome
+    cp API/hermes/inspector/chrome/*.h destroot/include/hermes/inspector/chrome
+
+    mkdir -p destroot/include/jsi
     cp "$JSI_PATH"/jsi/*.h destroot/include/jsi
   popd > /dev/null || exit 1
 }
@@ -137,10 +147,20 @@ function prepare_dest_root_for_ci {
   cp -R "./build_catalyst/API/hermes/hermes.framework"* "destroot/Library/Frameworks/catalyst"
   cp "./build_macosx/bin/"* "destroot/bin"
 
-  mkdir -p destroot/include/hermes/Public destroot/include/jsi
-
+  # Copy over Hermes and JSI API headers.
+  mkdir -p destroot/include/hermes/Public
   cp public/hermes/Public/*.h destroot/include/hermes/Public
+
+  mkdir -p destroot/include/hermes
   cp API/hermes/*.h destroot/include/hermes
+
+  mkdir -p destroot/include/hermes/inspector
+  cp API/hermes/inspector/*.h destroot/include/hermes/inspector
+
+  mkdir -p destroot/include/hermes/inspector/chrome
+  cp API/hermes/inspector/chrome/*.h destroot/include/hermes/inspector/chrome
+
+  mkdir -p destroot/include/jsi
   cp "$JSI_PATH"/jsi/*.h destroot/include/jsi
 }
 


### PR DESCRIPTION
Summary:


Updates React Native to use the new CDP handler provided by the Hermes engine instead of the legacy one (`Connection.cpp`) built into React Native. The new Hermes CDP handler has a simpler & safer design, new features (e.g. `console.log` buffering) and is under active development by the Hermes team.

NOTE: Both the legacy and modern handlers are Hermes-specific. In future work, React Native will *wrap* the modern Hermes handler in an engine-agnostic CDP layer implementing additional functionality and managing the lifecycle of debugging sessions more correctly. This diff is the first step of this larger migration.

Changelog: [General][Changed] Use new Hermes CDP handler implementation for debugging

Differential Revision: D48783980

