### PR TITLE
Fix view recycling incorrectly resetting transform

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -79,9 +79,9 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     // setScaleX
     // setScaleY
     // setCameraDistance
-    setTransform(view, null);
+    setTransformProperty(view, null, null);
 
-    // RenderNode params not covered by setTransform above
+    // RenderNode params not covered by setTransformProperty above
     view.resetPivot();
     view.setTop(0);
     view.setBottom(0);
@@ -94,6 +94,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setTag(R.id.transform_origin, null);
     view.setTag(R.id.invalidate_transform, null);
     view.removeOnLayoutChangeListener(this);
+
     // setShadowColor
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       view.setOutlineAmbientShadowColor(Color.BLACK);


### PR DESCRIPTION
Summary: This broke on Android platforms where `ReactFeatureFlags.enableViewRecycling` is enabled, as `setTransform` no longer directly mutates the transform properties, but instead goes through `setTransformProperty`

Reviewed By: rshest

Differential Revision: D49008194

Changelog: [Internal]


