### PR TITLE
Clarify meaning of State constructor args

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
@@ -32,8 +32,8 @@ class ConcreteState : public State {
   /*
    * Creates an updated `State` object with given previous one and `data`.
    */
-  explicit ConcreteState(const SharedData& data, const State& state)
-      : State(data, state) {}
+  explicit ConcreteState(const SharedData& data, const State& previousState)
+      : State(data, previousState) {}
 
   /*
    * Creates a first-of-its-family `State` object with given `family` and

--- a/packages/react-native/ReactCommon/react/renderer/core/State.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.cpp
@@ -16,10 +16,10 @@
 
 namespace facebook::react {
 
-State::State(StateData::Shared data, const State& state)
-    : family_(state.family_),
+State::State(StateData::Shared data, const State& previousState)
+    : family_(previousState.family_),
       data_(std::move(data)),
-      revision_(state.revision_ + 1){};
+      revision_(previousState.revision_ + 1){};
 
 State::State(StateData::Shared data, const ShadowNodeFamily::Shared& family)
     : family_(family),

--- a/packages/react-native/ReactCommon/react/renderer/core/State.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.h
@@ -33,7 +33,7 @@ class State {
    * Constructors are protected to make calling them directly with
    * type-erasured arguments impossible.
    */
-  explicit State(StateData::Shared data, const State& state);
+  explicit State(StateData::Shared data, const State& previousState);
   explicit State(
       StateData::Shared data,
       const ShadowNodeFamily::Shared& family);


### PR DESCRIPTION
Summary:
Make it explicit that the second arg for the State update constructor is the old State object, which we use to increment the revision.

Changelog: [Internal]

Differential Revision: D49008431


