### PR TITLE
fix: `role="searchbox"` should assign "SearchField" trait on iOS

### DIFF
--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -92,7 +92,7 @@ RCT_MULTI_ENUM_CONVERTER(
       @"scrollbar" : @(UIAccessibilityTraitNone),
       @"scrollview" : @(UIAccessibilityTraitNone),
       @"search" : @(UIAccessibilityTraitSearchField),
-      @"searchbox" : @(UIAccessibilityTraitNone),
+      @"searchbox" : @(UIAccessibilityTraitSearchField),
       @"selected" : @(UIAccessibilityTraitSelected),
       @"separator" : @(UIAccessibilityTraitNone),
       @"slider" : @(UIAccessibilityTraitNone),


### PR DESCRIPTION
## Summary:

Experimenting with Accessibility Inspector on iOS I've discovered that while when assigning `accessibilityRole="searchbox"` to a text input results in "Traits" reporting "Search Field" trait. However, when using ARIA-compatible `role="search"` such trait is not assigned, and text input will have an empty trait.

Afaiu this is incorrect as using `role="search"` and `accessibilityRole="searchbox"` should equivalent effect.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Setting `role="searchbox"` assigns "Search Field" accessibility trait to a view


## Test Plan:

No UI changes, it affects only accessibility.
