### PR TITLE
Enable custom debugger frontend experiment for /open-debugger

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -117,6 +117,10 @@ async function runServer(
     port,
     projectRoot,
     logger,
+    unstable_experiments: {
+      // NOTE: Only affects the /open-debugger endpoint
+      enableCustomDebuggerFrontend: true,
+    },
   });
 
   let reportEvent: (event: TerminalReportableEvent) => void;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Sets `unstable_experiments.enableCustomDebuggerFrontend: true` in `dev-middleware` (see D48602725) when mounted by the RN CLI.

Differential Revision: D49019399


