### PR TITLE
Fix refs in Pressable leading to tree clone

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -24,6 +24,7 @@ import type {
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
 import {type RectOrSize} from '../../StyleSheet/Rect';
+import useMergeRefs from '../../Utilities/useMergeRefs';
 import View from '../View/View';
 import useAndroidRippleForView, {
   type RippleConfig,
@@ -235,7 +236,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
   } = props;
 
   const viewRef = useRef<React.ElementRef<typeof View> | null>(null);
-  useImperativeHandle(forwardedRef, () => viewRef.current);
+  useMergeRefs(forwardedRef, viewRef);
 
   const android_rippleConfig = useAndroidRippleForView(android_ripple, viewRef);
 


### PR DESCRIPTION
Summary:
`useImperativeHandle` without a dependencies array causes React to re-clone the tree, leading to undesirable layout effects.

Changelog: [Internal]

Differential Revision: D49056493

