### PR TITLE
Avoid computing contentFrame when not using overflow: visible

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -89,6 +89,8 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
 
   void layout(LayoutContext layoutContext) override;
 
+  Rect getContentBounds() const;
+
  protected:
   /*
    * Yoga config associated (only) with this particular node.


### PR DESCRIPTION
Summary:
This diff extracts the logic to compute the content bounds of a shadow node (to compute its overflow insets) to a separate method. The new method is renamed as `getContentBounds` because layout metrics already have a method called `getContentFrame` that has a different meaning (the content box of the node, which excludes border and padding).

As a nice side-effect, we can now avoid executing this logic altogether if the node doesn't have overflow: visible (because we weren't assigning the result anywhere anyway).

NOTE: This method is made public because we need it to compute `scrollWidth` and `scrollHeight` in a following diff.

Changelog: [internal]

Reviewed By: NickGerleman

Differential Revision: D49020219

