### PR TITLE
Copy new Hermes CDP headers for iOS build

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -73,6 +73,18 @@ Pod::Spec.new do |spec|
       ss.header_dir = 'hermes'
     end
 
+    spec.subspec 'inspector' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'API/hermes/inspector/*.h'
+      ss.header_dir = 'hermes/inspector'
+    end
+
+    spec.subspec 'inspector_chrome' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'API/hermes/inspector/chrome/*.h'
+      ss.header_dir = 'hermes/inspector/chrome'
+    end
+
     spec.subspec 'Public' do |ss|
       ss.source_files = ''
       ss.public_header_files = 'public/hermes/Public/*.h'

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -121,9 +121,19 @@ function build_apple_framework {
     fi
 
     # Copy over Hermes and JSI API headers.
-    mkdir -p destroot/include/hermes/Public destroot/include/jsi
+    mkdir -p destroot/include/hermes/Public
     cp public/hermes/Public/*.h destroot/include/hermes/Public
+
+    mkdir -p destroot/include/hermes
     cp API/hermes/*.h destroot/include/hermes
+
+    mkdir -p destroot/include/hermes/inspector
+    cp API/hermes/inspector/*.h destroot/include/hermes/inspector
+
+    mkdir -p destroot/include/hermes/inspector/chrome
+    cp API/hermes/inspector/chrome/*.h destroot/include/hermes/inspector/chrome
+
+    mkdir -p destroot/include/jsi
     cp "$JSI_PATH"/jsi/*.h destroot/include/jsi
   popd > /dev/null || exit 1
 }
@@ -137,10 +147,20 @@ function prepare_dest_root_for_ci {
   cp -R "./build_catalyst/API/hermes/hermes.framework"* "destroot/Library/Frameworks/catalyst"
   cp "./build_macosx/bin/"* "destroot/bin"
 
-  mkdir -p destroot/include/hermes/Public destroot/include/jsi
-
+  # Copy over Hermes and JSI API headers.
+  mkdir -p destroot/include/hermes/Public
   cp public/hermes/Public/*.h destroot/include/hermes/Public
+
+  mkdir -p destroot/include/hermes
   cp API/hermes/*.h destroot/include/hermes
+
+  mkdir -p destroot/include/hermes/inspector
+  cp API/hermes/inspector/*.h destroot/include/hermes/inspector
+
+  mkdir -p destroot/include/hermes/inspector/chrome
+  cp API/hermes/inspector/chrome/*.h destroot/include/hermes/inspector/chrome
+
+  mkdir -p destroot/include/jsi
   cp "$JSI_PATH"/jsi/*.h destroot/include/jsi
 }
 


### PR DESCRIPTION
Summary:
The new Hermes CDP introduces new directories & headers. These need to be copied just like the other headers that Hermes API provides.

Changelog: [General][Changed] Include new Hermes CDP headers for iOS/Mac builds

Differential Revision: D49067283

