### PR TITLE
Fix invariant violation when using viewability callbacks with horizontal RTL FlatList on Paper

### DIFF
--- a/packages/virtualized-lists/Lists/ListMetricsAggregator.js
+++ b/packages/virtualized-lists/Lists/ListMetricsAggregator.js
@@ -14,6 +14,8 @@ import {keyExtractor as defaultKeyExtractor} from './VirtualizeUtils';
 
 import invariant from 'invariant';
 
+type LayoutEventDirection = 'top-down' | 'bottom-up';
+
 export type CellMetrics = {
   /**
    * Index of the item in the list
@@ -83,7 +85,7 @@ export default class ListMetricsAggregator {
 
   // Fabric and Paper may call onLayout in different orders. We can tell which
   // direction layout events happen on the first layout.
-  _onLayoutDirection: 'top-down' | 'bottom-up' = 'top-down';
+  _onLayoutDirection: LayoutEventDirection = 'top-down';
 
   /**
    * Notify the ListMetricsAggregator that a cell has been laid out.
@@ -282,6 +284,26 @@ export default class ListMetricsAggregator {
    */
   hasContentLength(): boolean {
     return this._contentLength != null;
+  }
+
+  /**
+   * Whether the ListMetricsAggregator is notified of cell metrics before
+   * ScrollView metrics (bottom-up) or ScrollView metrics before cell metrics
+   * (top-down).
+   *
+   * Must be queried after cell layout
+   */
+  getLayoutEventDirection(): LayoutEventDirection {
+    return this._onLayoutDirection;
+  }
+
+  /**
+   * Whether the ListMetricsAggregator must be aware of the current length of
+   * ScrollView content to be able to correctly resolve the (flow-relative)
+   * metrics of a cell.
+   */
+  needsContentLengthForCellMetrics(): boolean {
+    return this._orientation.horizontal && this._orientation.rtl;
   }
 
   /**


### PR DESCRIPTION
Summary:
In RTL we must have scrollview content length in order to resolve cell metrics. This means that on Paper, where layout events are bottom up, we cannot immediately calculate viewability in response to cell metric changes, as we may not yet have an accurate length of laid out list content.

This change makes us defer calculation of viewability changes in this case via `setTimeout()`, to run in a single batch after the next layout events are fired.

Changelog:
[General][Fixed] - Fix invariant violation when using viewability callbacks with horizontal RTL FlatList on Paper

Differential Revision: D49072963


