### PR TITLE
decode urls before reencoding with NSURL

### DIFF
--- a/packages/react-native/React/Base/RCTConvert.m
+++ b/packages/react-native/React/Base/RCTConvert.m
@@ -84,8 +84,16 @@ RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncod
   }
 
   @try { // NSURL has a history of crashing with bad input, so let's be safe
+    NSURL *URL = nil;
 
-    NSURL *URL = [NSURL URLWithString:path];
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000
+    if (@available(iOS 17.0, *)) {
+      NSString *decodedPercentPath = [path stringByRemovingPercentEncoding];
+      URL = [NSURL URLWithString:decodedPercentPath encodingInvalidCharacters:YES];
+    }
+#endif
+
+    URL = URL ?: [NSURL URLWithString:path];
     if (URL.scheme) { // Was a well-formed absolute URL
       return URL;
     }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in ios 17, NSURLs are encoded respecting RFC 3986 (https://www.ietf.org/rfc/rfc3986.txt) as opposed to RFC 1738/1808 before.

following this, `NSURL`'s parsing algorithm has changed such that if they encounter a reserved character, such as `[`, the parser will percent encode all possible characters in the url, including `%`.

this causes trouble for urls that already have some encoding. for the string `%22[]`, the new parsing algorithm will return the following:

RFC 1738/1808 -> `%22%5B%5D`
RFC 3986 -> `%2522%5B%5D` (invalid encoding)

the solution here is to decode all the percentified encodings in the input string, completely stripping it of the percent encodings, and then re-encoding it. thus, the string will transform as follows:

`%22[]` -> `"[]` -> `%22%5B%5D`

we probably don't need the OS check, but including it just to be safe.

Differential Revision: D49082077


