### PR TITLE
Consider transforms correctly in some of the new DOM layout methods

### DIFF
--- a/packages/react-native/Libraries/DOM/Nodes/ReactNativeElement.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReactNativeElement.js
@@ -25,7 +25,7 @@ import TextInputState from '../../Components/TextInput/TextInputState';
 import {getFabricUIManager} from '../../ReactNative/FabricUIManager';
 import {create as createAttributePayload} from '../../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
 import warnForStyleProps from '../../ReactNative/ReactFabricPublicInstance/warnForStyleProps';
-import ReadOnlyElement from './ReadOnlyElement';
+import ReadOnlyElement, {getBoundingClientRect} from './ReadOnlyElement';
 import ReadOnlyNode from './ReadOnlyNode';
 import {
   getPublicInstanceFromInternalInstanceHandle,
@@ -58,7 +58,9 @@ export default class ReactNativeElement
   }
 
   get offsetHeight(): number {
-    return Math.round(this.getBoundingClientRect().height);
+    return Math.round(
+      getBoundingClientRect(this, {includeTransform: false}).height,
+    );
   }
 
   get offsetLeft(): number {
@@ -110,7 +112,9 @@ export default class ReactNativeElement
   }
 
   get offsetWidth(): number {
-    return Math.round(this.getBoundingClientRect().width);
+    return Math.round(
+      getBoundingClientRect(this, {includeTransform: false}).width,
+    );
   }
 
   /**

--- a/packages/react-native/Libraries/DOM/Nodes/ReadOnlyElement.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReadOnlyElement.js
@@ -211,20 +211,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   getBoundingClientRect(): DOMRect {
-    const shadowNode = getShadowNode(this);
-
-    if (shadowNode != null) {
-      const rect = nullthrows(getFabricUIManager()).getBoundingClientRect(
-        shadowNode,
-      );
-
-      if (rect) {
-        return new DOMRect(rect[0], rect[1], rect[2], rect[3]);
-      }
-    }
-
-    // Empty rect if any of the above failed
-    return new DOMRect(0, 0, 0, 0);
+    return getBoundingClientRect(this, {includeTransform: true});
   }
 
   /**
@@ -261,4 +248,30 @@ function getChildElements(node: ReadOnlyNode): $ReadOnlyArray<ReadOnlyElement> {
   return getChildNodes(node).filter(
     childNode => childNode instanceof ReadOnlyElement,
   );
+}
+
+/**
+ * The public API for `getBoundingClientRect` always includes transform,
+ * so we use this internal version to get the data without transform to
+ * implement methods like `offsetWidth` and `offsetHeight`.
+ */
+export function getBoundingClientRect(
+  node: ReadOnlyElement,
+  {includeTransform}: {includeTransform: boolean},
+): DOMRect {
+  const shadowNode = getShadowNode(node);
+
+  if (shadowNode != null) {
+    const rect = nullthrows(getFabricUIManager()).getBoundingClientRect(
+      shadowNode,
+      includeTransform,
+    );
+
+    if (rect) {
+      return new DOMRect(rect[0], rect[1], rect[2], rect[3]);
+    }
+  }
+
+  // Empty rect if any of the above failed
+  return new DOMRect(0, 0, 0, 0);
 }

--- a/packages/react-native/Libraries/DOM/Nodes/ReadOnlyElement.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReadOnlyElement.js
@@ -227,10 +227,6 @@ export default class ReadOnlyElement extends ReadOnlyNode {
     return new DOMRect(0, 0, 0, 0);
   }
 
-  getClientRects(): DOMRectList {
-    throw new TypeError('Unimplemented');
-  }
-
   /**
    * Pointer Capture APIs
    */

--- a/packages/react-native/Libraries/DOM/Nodes/ReadOnlyElement.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReadOnlyElement.js
@@ -135,7 +135,16 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get scrollHeight(): number {
-    throw new Error('Unimplemented');
+    const node = getShadowNode(this);
+
+    if (node != null) {
+      const scrollSize = nullthrows(getFabricUIManager()).getScrollSize(node);
+      if (scrollSize != null) {
+        return scrollSize[1];
+      }
+    }
+
+    return 0;
   }
 
   get scrollLeft(): number {
@@ -169,7 +178,16 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get scrollWidth(): number {
-    throw new Error('Unimplemented');
+    const node = getShadowNode(this);
+
+    if (node != null) {
+      const scrollSize = nullthrows(getFabricUIManager()).getScrollSize(node);
+      if (scrollSize != null) {
+        return scrollSize[0];
+      }
+    }
+
+    return 0;
   }
 
   get tagName(): string {

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -91,6 +91,9 @@ export interface Spec {
   +getScrollPosition: (
     node: Node,
   ) => ?[/* scrollLeft: */ number, /* scrollTop: */ number];
+  +getScrollSize: (
+    node: Node,
+  ) => ?[/* scrollWidth: */ number, /* scrollHeight: */ number];
   +getInnerSize: (node: Node) => ?[/* width: */ number, /* height: */ number];
   +getBorderSize: (
     node: Node,
@@ -141,6 +144,7 @@ const CACHED_PROPERTIES = [
   'getBoundingClientRect',
   'getOffset',
   'getScrollPosition',
+  'getScrollSize',
   'getInnerSize',
   'getBorderSize',
   'getTagName',

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -75,6 +75,7 @@ export interface Spec {
   +getTextContent: (node: Node) => string;
   +getBoundingClientRect: (
     node: Node,
+    includeTransform: boolean,
   ) => ?[
     /* x: */ number,
     /* y: */ number,

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
@@ -124,7 +124,7 @@ export default class ReactFabricHostComponent implements INativeMethods {
       this.__internalInstanceHandle,
     );
     if (node != null) {
-      const rect = fabricGetBoundingClientRect(node);
+      const rect = fabricGetBoundingClientRect(node, true);
 
       if (rect) {
         return new DOMRect(rect[0], rect[1], rect[2], rect[3]);

--- a/packages/react-native/Libraries/ReactNative/__mocks__/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/__mocks__/FabricUIManager.js
@@ -524,6 +524,34 @@ const FabricUIManagerMock: IFabricUIManagerMock = {
     },
   ),
 
+  getScrollSize: jest.fn(
+    (node: Node): ?[/* scrollLeft: */ number, /* scrollTop: */ number] => {
+      ensureHostNode(node);
+
+      const nodeInCurrentTree = getNodeInCurrentTree(node);
+      const currentProps =
+        nodeInCurrentTree != null ? fromNode(nodeInCurrentTree).props : null;
+      if (currentProps == null) {
+        return null;
+      }
+
+      const scrollForTests: ?{
+        scrollWidth: number,
+        scrollHeight: number,
+        ...
+      } =
+        // $FlowExpectedError[prop-missing]
+        currentProps.__scrollForTests;
+
+      if (scrollForTests == null) {
+        return null;
+      }
+
+      const {scrollWidth, scrollHeight} = scrollForTests;
+      return [scrollWidth, scrollHeight];
+    },
+  ),
+
   getInnerSize: jest.fn(
     (node: Node): ?[/* width: */ number, /* height: */ number] => {
       ensureHostNode(node);

--- a/packages/react-native/Libraries/ReactNative/__mocks__/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/__mocks__/FabricUIManager.js
@@ -295,6 +295,7 @@ const FabricUIManagerMock: IFabricUIManagerMock = {
   getBoundingClientRect: jest.fn(
     (
       node: Node,
+      includeTransform: boolean,
     ): ?[
       /* x:*/ number,
       /* y:*/ number,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -89,6 +89,8 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
 
   void layout(LayoutContext layoutContext) override;
 
+  Rect getContentBounds() const;
+
  protected:
   /*
    * Yoga config associated (only) with this particular node.

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -841,14 +841,20 @@ jsi::Value UIManagerBinding::get(
     // This is similar to `measureInWindow`, except it's explicitly synchronous
     // (returns the result instead of passing it to a callback).
 
-    // getBoundingClientRect(shadowNode: ShadowNode):
+    // It allows indicating whether to include transforms so it can also be used
+    // to implement methods like
+    // [`offsetWidth`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth)
+    // and
+    // [`offsetHeight`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight).
+
+    // getBoundingClientRect(shadowNode: ShadowNode, includeTransform: boolean):
     //   [
     //     /* x: */ number,
     //     /* y: */ number,
     //     /* width: */ number,
     //     /* height: */ number
     //   ]
-    auto paramCount = 1;
+    auto paramCount = 2;
     return jsi::Function::createFromHostFunction(
         runtime,
         name,
@@ -860,10 +866,12 @@ jsi::Value UIManagerBinding::get(
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
+          bool includeTransform = arguments[1].getBool();
+
           auto layoutMetrics = uiManager->getRelativeLayoutMetrics(
               *shadowNodeFromValue(runtime, arguments[0]),
               nullptr,
-              {/* .includeTransform = */ true,
+              {/* .includeTransform = */ includeTransform,
                /* .includeViewportOffset = */ true});
 
           if (layoutMetrics == EmptyLayoutMetrics) {
@@ -1101,7 +1109,7 @@ jsi::Value UIManagerBinding::get(
           // If the node is not displayed (itself or any of its ancestors has
           // "display: none"), this returns an empty layout metrics object.
           auto layoutMetrics = uiManager->getRelativeLayoutMetrics(
-              *shadowNode, nullptr, {/* .includeTransform = */ true});
+              *shadowNode, nullptr, {/* .includeTransform = */ false});
 
           if (layoutMetrics == EmptyLayoutMetrics) {
             return jsi::Value::undefined();
@@ -1313,7 +1321,7 @@ jsi::Value UIManagerBinding::get(
           // If the node is not displayed (itself or any of its ancestors has
           // "display: none"), this returns an empty layout metrics object.
           auto layoutMetrics = uiManager->getRelativeLayoutMetrics(
-              *shadowNode, nullptr, {/* .includeTransform = */ true});
+              *shadowNode, nullptr, {/* .includeTransform = */ false});
 
           if (layoutMetrics == EmptyLayoutMetrics ||
               layoutMetrics.displayType == DisplayType::Inline) {
@@ -1367,7 +1375,7 @@ jsi::Value UIManagerBinding::get(
           // If the node is not displayed (itself or any of its ancestors has
           // "display: none"), this returns an empty layout metrics object.
           auto layoutMetrics = uiManager->getRelativeLayoutMetrics(
-              *shadowNode, nullptr, {/* .includeTransform = */ true});
+              *shadowNode, nullptr, {/* .includeTransform = */ false});
 
           if (layoutMetrics == EmptyLayoutMetrics ||
               layoutMetrics.displayType == DisplayType::Inline) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
@@ -221,4 +221,39 @@ inline static void getTextContentInShadowNode(
     getTextContentInShadowNode(*childNode.get(), result);
   }
 }
+
+inline static Rect getScrollableContentBounds(
+    Rect contentBounds,
+    LayoutMetrics layoutMetrics) {
+  auto paddingFrame = layoutMetrics.getPaddingFrame();
+
+  auto paddingBottom =
+      layoutMetrics.contentInsets.bottom - layoutMetrics.borderWidth.bottom;
+  auto paddingLeft =
+      layoutMetrics.contentInsets.left - layoutMetrics.borderWidth.left;
+  auto paddingRight =
+      layoutMetrics.contentInsets.right - layoutMetrics.borderWidth.right;
+
+  auto minY = paddingFrame.getMinY();
+  auto maxY =
+      std::max(paddingFrame.getMaxY(), contentBounds.getMaxY() + paddingBottom);
+
+  auto minX = layoutMetrics.layoutDirection == LayoutDirection::RightToLeft
+      ? std::min(paddingFrame.getMinX(), contentBounds.getMinX() - paddingLeft)
+      : paddingFrame.getMinX();
+  auto maxX = layoutMetrics.layoutDirection == LayoutDirection::RightToLeft
+      ? paddingFrame.getMaxX()
+      : std::max(
+            paddingFrame.getMaxX(), contentBounds.getMaxX() + paddingRight);
+
+  return Rect{Point{minX, minY}, Size{maxX - minX, maxY - minY}};
+}
+
+inline static Size getScrollSize(
+    LayoutMetrics layoutMetrics,
+    Rect contentBounds) {
+  auto scrollableContentBounds =
+      getScrollableContentBounds(contentBounds, layoutMetrics);
+  return scrollableContentBounds.size;
+}
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
This fixes these methods to ignore transforms, as per the spec:
* `offsetLeft`
* `offsetTop`
* `offsetWidth`
* `offsetHeight`
* `clientLeft`
* `clientTop`
* `clientWidth`
* `clientHeight`

`scrollWidth` and `scrollHeight` are the last methods we need to fix, as their fix is more complex than in these cases. I'll do it in a follow-up diff.

Changelog: [internal]

Reviewed By: NickGerleman

Differential Revision: D49069517

