### PR TITLE
Introduce WillBeDeprecatedInNewArchitecture annotation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java
@@ -8,6 +8,7 @@
 package com.facebook.react;
 
 import androidx.annotation.NonNull;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -30,6 +31,7 @@ import java.util.List;
  *
  * <p>TODO(6788500, 6788507): Implement support for adding custom views, events and resources
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public interface ReactPackage {
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Main interface for providing additional capabilities to the catalyst framework by couple of
@@ -44,4 +45,16 @@ public interface ReactPackage {
   /** @return a list of view managers that should be registered with {@link UIManagerModule} */
   @NonNull
   List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext);
+
+  /**
+   * Given a module name, it returns an instance of {@link NativeModule} for the name
+   *
+   * @param name name of the Native Module
+   * @param reactContext {@link ReactApplicationContext} context for this
+   */
+  @Nullable
+  default NativeModule getModule(
+      @NonNull String name, @NonNull ReactApplicationContext reactContext) {
+    return null;
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ModuleHolder;
 import com.facebook.react.bridge.ModuleSpec;
@@ -41,8 +42,9 @@ public abstract class TurboReactPackage implements ReactPackage {
    * @param name name of the Native Module
    * @param reactContext {@link ReactApplicationContext} context for this
    */
+  @Override
   public abstract @Nullable NativeModule getModule(
-      String name, final ReactApplicationContext reactContext);
+      @NonNull String name, @NonNull ReactApplicationContext reactContext);
 
   /**
    * This is a temporary method till we implement TurboModules. Once we implement TurboModules, we

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/DeprecatedInNewArchitecture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/DeprecatedInNewArchitecture.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations
+
+/**
+ * Annotates a method or class that will be deprecated once the NewArchitecture is fully released in
+ * OSS.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class DeprecatedInNewArchitecture()


### PR DESCRIPTION
Summary:
In this diff I'm introducing the new WillBeDeprecatedInNewArchitecture annotation, the goal of this annotation is to describe that a class or method will be deprecated when the new architecture of react native is fully rolled out in
OSS.

changelog: [Android] Introduce WillBeDeprecatedInNewArchitecture annotation

Reviewed By: cortinico

Differential Revision: D49068234

