### PR TITLE
Make RuntimeScheduler tests less flaky

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -481,7 +481,7 @@ TEST_F(RuntimeSchedulerTest, basicSameThreadExecution) {
     EXPECT_FALSE(runtimeScheduler_->getIsSynchronous());
   });
 
-  auto hasTask = stubQueue_->waitForTask(1ms);
+  auto hasTask = stubQueue_->waitForTask();
 
   EXPECT_TRUE(hasTask);
   EXPECT_FALSE(didRunSynchronousTask);
@@ -517,7 +517,7 @@ TEST_F(RuntimeSchedulerTest, sameThreadTaskCreatesImmediatePriorityTask) {
         });
   });
 
-  auto hasTask = stubQueue_->waitForTask(1ms);
+  auto hasTask = stubQueue_->waitForTask();
 
   EXPECT_TRUE(hasTask);
   EXPECT_FALSE(didRunSynchronousTask);
@@ -556,7 +556,7 @@ TEST_F(RuntimeSchedulerTest, sameThreadTaskCreatesLowPriorityTask) {
         });
   });
 
-  auto hasTask = stubQueue_->waitForTask(1ms);
+  auto hasTask = stubQueue_->waitForTask();
 
   EXPECT_TRUE(hasTask);
   EXPECT_FALSE(didRunSynchronousTask);
@@ -593,7 +593,7 @@ TEST_F(RuntimeSchedulerTest, twoThreadsRequestAccessToTheRuntime) {
         });
   });
 
-  auto hasTask = stubQueue_->waitForTasks(2, 1ms);
+  auto hasTask = stubQueue_->waitForTasks(2);
 
   EXPECT_TRUE(hasTask);
   EXPECT_FALSE(didRunWork);

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubQueue.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubQueue.h
@@ -47,17 +47,15 @@ class StubQueue {
     return callbackQueue_.size();
   }
 
-  bool waitForTask(std::chrono::duration<double> timeout) const {
+  bool waitForTask() const {
     std::unique_lock<std::mutex> lock(mutex_);
     return signal_.wait_for(
-        lock, timeout, [this]() { return !callbackQueue_.empty(); });
+        lock, StubQueue::timeout, [this]() { return !callbackQueue_.empty(); });
   }
 
-  bool waitForTasks(
-      std::size_t numberOfTasks,
-      std::chrono::duration<double> timeout) const {
+  bool waitForTasks(std::size_t numberOfTasks) const {
     std::unique_lock<std::mutex> lock(mutex_);
-    return signal_.wait_for(lock, timeout, [this, numberOfTasks]() {
+    return signal_.wait_for(lock, StubQueue::timeout, [this, numberOfTasks]() {
       return numberOfTasks == callbackQueue_.size();
     });
   }
@@ -66,4 +64,7 @@ class StubQueue {
   mutable std::condition_variable signal_;
   mutable std::mutex mutex_;
   std::queue<std::function<void()>> callbackQueue_;
+
+  static constexpr std::chrono::duration<double> timeout =
+      std::chrono::milliseconds(100);
 };


### PR DESCRIPTION
Summary:
changelog: [internal]

Increase the wait threshold when waiting for a task in a stub queue to reduce test flakyness.

Differential Revision: D49093046


