### PR TITLE
ComponentDescriptor::adopt now accepts reference to ShadowNode

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
@@ -24,10 +24,10 @@ class ImageComponentDescriptor final
       : ConcreteComponentDescriptor(parameters),
         imageManager_(std::make_shared<ImageManager>(contextContainer_)){};
 
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
-    auto& imageShadowNode = static_cast<ImageShadowNode&>(*shadowNode);
+    auto& imageShadowNode = static_cast<ImageShadowNode&>(shadowNode);
 
     // `ImageShadowNode` uses `ImageManager` to initiate image loading and
     // communicate the loading state and results to mounting layer.

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
@@ -21,13 +21,13 @@ class InputAccessoryComponentDescriptor final
  public:
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     auto& layoutableShadowNode =
-        static_cast<YogaLayoutableShadowNode&>(*shadowNode);
+        static_cast<YogaLayoutableShadowNode&>(shadowNode);
 
     auto& stateData =
         static_cast<const InputAccessoryShadowNode::ConcreteState&>(
-            *shadowNode->getState())
+            *shadowNode.getState())
             .getData();
 
     layoutableShadowNode.setSize(

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
@@ -27,7 +27,7 @@ class LegacyViewManagerInteropComponentDescriptor final
   ComponentName getComponentName() const override;
 
  protected:
-  void adopt(const ShadowNode::Unshared& shadowNode) const override;
+  void adopt(ShadowNode& shadowNode) const override;
 
  private:
   const std::shared_ptr<void> _coordinator;

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
@@ -123,12 +123,11 @@ ComponentName LegacyViewManagerInteropComponentDescriptor::getComponentName() co
   return static_cast<const std::string *>(flavor_.get())->c_str();
 }
 
-void LegacyViewManagerInteropComponentDescriptor::adopt(const ShadowNode::Unshared &shadowNode) const
+void LegacyViewManagerInteropComponentDescriptor::adopt(ShadowNode &shadowNode) const
 {
   ConcreteComponentDescriptor::adopt(shadowNode);
 
-  assert(std::dynamic_pointer_cast<LegacyViewManagerInteropShadowNode>(shadowNode));
-  auto &legacyViewManagerInteropShadowNode = static_cast<LegacyViewManagerInteropShadowNode &>(*shadowNode);
+  auto &legacyViewManagerInteropShadowNode = static_cast<LegacyViewManagerInteropShadowNode &>(shadowNode);
 
   auto state = LegacyViewManagerInteropState{};
   state.coordinator = _coordinator;

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
@@ -22,12 +22,12 @@ class ModalHostViewComponentDescriptor final
  public:
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     auto& layoutableShadowNode =
-        static_cast<YogaLayoutableShadowNode&>(*shadowNode);
+        static_cast<YogaLayoutableShadowNode&>(shadowNode);
     auto& stateData =
         static_cast<const ModalHostViewShadowNode::ConcreteState&>(
-            *shadowNode->getState())
+            *shadowNode.getState())
             .getData();
 
     layoutableShadowNode.setSize(

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
@@ -26,11 +26,11 @@ class AndroidProgressBarComponentDescriptor final
             std::make_shared<AndroidProgressBarMeasurementsManager>(
                 contextContainer_)) {}
 
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
     auto& androidProgressBarShadowNode =
-        static_cast<AndroidProgressBarShadowNode&>(*shadowNode);
+        static_cast<AndroidProgressBarShadowNode&>(shadowNode);
 
     // `AndroidProgressBarShadowNode` uses
     // `AndroidProgressBarMeasurementsManager` to provide measurements to Yoga.

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
@@ -19,13 +19,11 @@ namespace facebook::react {
 class SafeAreaViewComponentDescriptor final
     : public ConcreteComponentDescriptor<SafeAreaViewShadowNode> {
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
-    react_native_assert(
-        std::dynamic_pointer_cast<SafeAreaViewShadowNode>(shadowNode));
+  void adopt(ShadowNode& shadowNode) const override {
     auto& layoutableShadowNode =
-        static_cast<YogaLayoutableShadowNode&>(*shadowNode);
+        static_cast<YogaLayoutableShadowNode&>(shadowNode);
     auto& stateData = static_cast<const SafeAreaViewShadowNode::ConcreteState&>(
-                          *shadowNode->getState())
+                          *shadowNode.getState())
                           .getData();
     layoutableShadowNode.setPadding(stateData.padding);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
@@ -26,11 +26,11 @@ class AndroidSwitchComponentDescriptor final
         measurementsManager_(std::make_shared<AndroidSwitchMeasurementsManager>(
             contextContainer_)) {}
 
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
     auto& androidSwitchShadowNode =
-        static_cast<AndroidSwitchShadowNode&>(*shadowNode);
+        static_cast<AndroidSwitchShadowNode&>(shadowNode);
 
     // `AndroidSwitchShadowNode` uses `AndroidSwitchMeasurementsManager` to
     // provide measurements to Yoga.

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphComponentDescriptor.h
@@ -28,10 +28,10 @@ class ParagraphComponentDescriptor final
   }
 
  protected:
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
-    auto& paragraphShadowNode = static_cast<ParagraphShadowNode&>(*shadowNode);
+    auto& paragraphShadowNode = static_cast<ParagraphShadowNode&>(shadowNode);
 
     // `ParagraphShadowNode` uses `TextLayoutManager` to measure text content
     // and communicate text rendering metrics to mounting layer.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -83,9 +83,9 @@ class AndroidTextInputComponentDescriptor final
   }
 
  protected:
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     auto& textInputShadowNode =
-        static_cast<AndroidTextInputShadowNode&>(*shadowNode);
+        static_cast<AndroidTextInputShadowNode&>(shadowNode);
 
     // `ParagraphShadowNode` uses `TextLayoutManager` to measure text content
     // and communicate text rendering metrics to mounting layer.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
@@ -25,10 +25,10 @@ class TextInputComponentDescriptor final
   }
 
  protected:
-  void adopt(const ShadowNode::Unshared& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
-    auto& concreteShadowNode = static_cast<TextInputShadowNode&>(*shadowNode);
+    auto& concreteShadowNode = static_cast<TextInputShadowNode&>(shadowNode);
     concreteShadowNode.setTextLayoutManager(textLayoutManager_);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -137,10 +137,27 @@ class ComponentDescriptor {
       const InstanceHandle::Shared& instanceHandle) const = 0;
 
  protected:
+  friend ShadowNode;
+
   EventDispatcher::Weak eventDispatcher_;
   ContextContainer::Shared contextContainer_;
   RawPropsParser rawPropsParser_{};
   Flavor flavor_;
+
+  /*
+   * Called immediately after `ShadowNode` is created, cloned or state is
+   * progressed using clonesless state progression (not fully shipped yet).
+   *
+   * Override this method to pass information from custom `ComponentDescriptor`
+   * to new instance of `ShadowNode`.
+   *
+   * Example usages:
+   *   - Inject image manager to `ImageShadowNode` in
+   * `ImageComponentDescriptor`.
+   *   - Set `ShadowNode`'s size from state in
+   * `ModalHostViewComponentDescriptor`.
+   */
+  virtual void adopt(ShadowNode& shadowNode) const = 0;
 };
 
 /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -69,7 +69,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     auto shadowNode =
         std::make_shared<ShadowNodeT>(fragment, family, getTraits());
 
-    adopt(shadowNode);
+    adopt(*shadowNode);
 
     return shadowNode;
   }
@@ -79,7 +79,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
       const ShadowNodeFragment& fragment) const override {
     auto shadowNode = std::make_shared<ShadowNodeT>(sourceShadowNode, fragment);
 
-    adopt(shadowNode);
+    adopt(*shadowNode);
     return shadowNode;
   }
 
@@ -169,22 +169,10 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   }
 
  protected:
-  /*
-   * Called immediately after `ShadowNode` is created or cloned.
-   *
-   * Override this method to pass information from custom `ComponentDescriptor`
-   * to new instance of `ShadowNode`.
-   *
-   * Example usages:
-   *   - Inject image manager to `ImageShadowNode` in
-   * `ImageComponentDescriptor`.
-   *   - Set `ShadowNode`'s size from state in
-   * `ModalHostViewComponentDescriptor`.
-   */
-  virtual void adopt(const ShadowNode::Unshared& shadowNode) const {
+  virtual void adopt(ShadowNode& shadowNode) const override {
     // Default implementation does nothing.
     react_native_assert(
-        shadowNode->getComponentHandle() == getComponentHandle());
+        shadowNode.getComponentHandle() == getComponentHandle());
   }
 };
 


### PR DESCRIPTION
Summary:
changelog: [internal]

Changes `ComponentDescriptor::adopt` to not be protected and it now accepts ShadowNode reference rather than shared_ptr.

Differential Revision: D49054000


