### PR TITLE
Seal RootShadowNode just before it is promoted

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -371,9 +371,6 @@ CommitStatus ShadowTree::tryCommit(
   telemetry.unsetAsThreadLocal();
   telemetry.didLayout(affectedLayoutableNodes.size());
 
-  // Seal the shadow node so it can no longer be mutated
-  newRootShadowNode->sealRecursive();
-
   {
     // Updating `currentRevision_` in unique manner if it hasn't changed.
     std::unique_lock lock(commitMutex_);
@@ -408,6 +405,9 @@ CommitStatus ShadowTree::tryCommit(
 
     telemetry.didCommit();
     telemetry.setRevisionNumber(static_cast<int>(newRevisionNumber));
+
+    // Seal the shadow node so it can no longer be mutated
+    newRootShadowNode->sealRecursive();
 
     newRevision = ShadowTreeRevision{
         std::move(newRootShadowNode), newRevisionNumber, telemetry};


### PR DESCRIPTION
Summary:
changelog: [internal]

We want to seal node just before it is promoted.

Reviewed By: javache, NickGerleman

Differential Revision: D49054011

