### PR TITLE
yoga::bit_cast

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -16,6 +16,7 @@
 #include "YogaJniException.h"
 
 #include <yoga/Yoga-internal.h>
+#include <yoga/bits/BitCast.h>
 
 // TODO: Reconcile missing layoutContext functionality from callbacks in the C
 // API and use that
@@ -677,11 +678,10 @@ static YGSize YGJNIMeasureFunc(
     uint32_t wBits = 0xFFFFFFFF & (measureResult >> 32);
     uint32_t hBits = 0xFFFFFFFF & measureResult;
 
-    // TODO: this is unsafe under strict aliasing and should use bit_cast
-    const float* measuredWidth = reinterpret_cast<float*>(&wBits);
-    const float* measuredHeight = reinterpret_cast<float*>(&hBits);
+    const float measuredWidth = yoga::bit_cast<float>(wBits);
+    const float measuredHeight = yoga::bit_cast<float>(hBits);
 
-    return YGSize{*measuredWidth, *measuredHeight};
+    return YGSize{measuredWidth, measuredHeight};
   } else {
     return YGSize{
         widthMode == YGMeasureModeUndefined ? 0 : width,

--- a/packages/react-native/ReactCommon/yoga/yoga/bits/BitCast.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/bits/BitCast.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstring>
+#include <type_traits>
+
+namespace facebook::yoga {
+
+// Polyfill for std::bit_cast() from C++20, to allow safe type punning
+// https://en.cppreference.com/w/cpp/numeric/bit_cast
+template <class To, class From>
+std::enable_if_t<
+    sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<From> &&
+        std::is_trivially_copyable_v<To> &&
+        std::is_trivially_constructible_v<To>,
+    To>
+bit_cast(const From& src) noexcept {
+  To dst;
+  std::memcpy(&dst, &src, sizeof(To));
+  return dst;
+}
+
+} // namespace facebook::yoga


### PR DESCRIPTION
Summary:
This adds a function polyfilling C++ 20's `std::bit_cast`, using `memcpy()` to be safe with strict aliasing rules.

This replaces the conditional code in CompactValue for type punning, an unsafe place in YGJNI where we do it unsafely, and is used in ValuePool. The polyfill can be switched to `std::bit_cast` whenever we adopt C++ 20.

Note that this doesn't actually call into `memcpy()`, as verified by Godbolt. Compilers are aware of the memcpy type punning pattern and optimize it, but it's ugly and confusing to folks who haven't seen it before.

Reviewed By: javache

Differential Revision: D49082997


