### PR TITLE
Use Hermes-engine version in caches for RNTester jobs

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -180,6 +180,24 @@ commands:
           name: Report size of RNTester.app (analysis-bot)
           command: GITHUB_TOKEN="$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A""$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B" scripts/circleci/report-bundle-size.sh << parameters.platform >> || true
 
+  setup_hermes_version:
+    steps:
+      - run:
+          name: Set up Hermes workspace and caching
+          command: |
+            mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
+
+            if [ -f "$HERMES_VERSION_FILE" ]; then
+              echo "Hermes Version file found! Using this version for the build:"
+              cat $HERMES_VERSION_FILE > /tmp/hermes/hermesversion
+            else
+              echo "Hermes Version file not found!!!"
+              echo "Using the last commit from main for the build:"
+              HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
+              echo $HERMES_TAG_SHA > /tmp/hermes/hermesversion
+            fi
+            cat /tmp/hermes/hermesversion
+
   get_react_native_version:
     steps:
       - run:

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -122,8 +122,7 @@ jobs:
     steps:
       - checkout_code_with_cache
       - run_yarn
-      - attach_workspace:
-          at: .
+      - setup_hermes_version
       - run:
           name: Install appium
           command: npm install appium@2.0.0 -g
@@ -219,8 +218,6 @@ jobs:
             cd packages/rn-tester
             yarn start
           background: true
-      - attach_workspace:
-          at: .
       - with_gradle_cache:
           steps:
             - run:
@@ -688,21 +685,7 @@ jobs:
             apt install -y nodejs
             npm install --global yarn
       - checkout
-      - run:
-          name: Set up Hermes workspace and caching
-          command: |
-            mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
-
-            if [ -f "$HERMES_VERSION_FILE" ]; then
-              echo "Hermes Version file found! Using this version for the build:"
-              cat $HERMES_VERSION_FILE > /tmp/hermes/hermesversion
-            else
-              echo "Hermes Version file not found!!!"
-              echo "Using the last commit from main for the build:"
-              HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
-              echo $HERMES_TAG_SHA > /tmp/hermes/hermesversion
-            fi
-            cat /tmp/hermes/hermesversion
+      - setup_hermes_version
       - get_react_native_version
       - restore_cache:
           key: *hermes_workspace_cache_key

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -91,11 +91,11 @@ references:
     hermes_dsym_release_cache_key: &hermes_dsym_release_cache_key v1-hermes-release-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     # Cocoapods - RNTester
     pods_cache_key: &pods_cache_key v10-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
-    cocoapods_cache_key: &cocoapods_cache_key v7-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}
+    cocoapods_cache_key: &cocoapods_cache_key v7-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
     rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v5-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}
 
     # Cocoapods - Template
-    template_cocoapods_cache_key: &template_cocoapods_cache_key v1-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}
+    template_cocoapods_cache_key: &template_cocoapods_cache_key v1-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
     template_podfile_lock_cache_key: &template_podfile_lock_cache_key v1-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}
 
     # Windows


### PR DESCRIPTION
Summary:
With the recent CI optimization, we were caching the hermes-engine stored in the Pods folder in order to reuse it.
However, by doing so, we would not avtually use the hermes-engine we were building in CI nor we were using the most recent version in the E2E tests as the Podfile.lock would not have actually changed and Cocoapods would have found a proper version for the Hermes-engine.

## Changelog:
[Internal] - use the hermes engine version to invalidate cocoapods caches

Differential Revision: D49125000

