### PR TITLE
Migrate from legacy to new Hermes CDP handler

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.cpp
@@ -6,7 +6,11 @@
  */
 
 #include "ConnectionDemux.h"
-#include "Connection.h"
+
+#ifdef HERMES_ENABLE_DEBUGGER
+
+#include <hermes/inspector/RuntimeAdapter.h>
+#include <hermes/inspector/chrome/CDPHandler.h>
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 
@@ -24,7 +28,7 @@ namespace {
 class LocalConnection : public ILocalConnection {
  public:
   LocalConnection(
-      std::shared_ptr<Connection> conn,
+      std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn,
       std::shared_ptr<std::unordered_set<std::string>> inspectedContexts);
   ~LocalConnection();
 
@@ -32,12 +36,12 @@ class LocalConnection : public ILocalConnection {
   void disconnect() override;
 
  private:
-  std::shared_ptr<Connection> conn_;
+  std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn_;
   std::shared_ptr<std::unordered_set<std::string>> inspectedContexts_;
 };
 
 LocalConnection::LocalConnection(
-    std::shared_ptr<Connection> conn,
+    std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn,
     std::shared_ptr<std::unordered_set<std::string>> inspectedContexts)
     : conn_(conn), inspectedContexts_(inspectedContexts) {
   inspectedContexts_->insert(conn->getTitle());
@@ -46,12 +50,12 @@ LocalConnection::LocalConnection(
 LocalConnection::~LocalConnection() = default;
 
 void LocalConnection::sendMessage(std::string str) {
-  conn_->sendMessage(std::move(str));
+  conn_->handle(std::move(str));
 }
 
 void LocalConnection::disconnect() {
   inspectedContexts_->erase(conn_->getTitle());
-  conn_->disconnect();
+  conn_->unregisterCallbacks();
 }
 
 } // namespace
@@ -87,8 +91,8 @@ DebugSessionToken ConnectionDemux::enableDebugging(
 
   auto waitForDebugger =
       (inspectedContexts_->find(title) != inspectedContexts_->end());
-  return addPage(
-      std::make_shared<Connection>(std::move(adapter), title, waitForDebugger));
+  return addPage(hermes::inspector_modern::chrome::CDPHandler::create(
+      std::move(adapter), title, waitForDebugger));
 }
 
 void ConnectionDemux::disableDebugging(DebugSessionToken session) {
@@ -99,10 +103,19 @@ void ConnectionDemux::disableDebugging(DebugSessionToken session) {
   removePage(session);
 }
 
-int ConnectionDemux::addPage(std::shared_ptr<Connection> conn) {
+int ConnectionDemux::addPage(
+    std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn) {
   auto connectFunc = [conn, this](std::unique_ptr<IRemoteConnection> remoteConn)
       -> std::unique_ptr<ILocalConnection> {
-    if (!conn->connect(std::move(remoteConn))) {
+    // This cannot be unique_ptr as std::function is copyable but unique_ptr
+    // isn't. TODO: Change the CDPHandler API to accommodate this and not
+    // require a copyable callback?
+    std::shared_ptr<IRemoteConnection> sharedConn = std::move(remoteConn);
+    if (!conn->registerCallbacks(
+            [sharedConn](const std::string &message) {
+              sharedConn->onMessage(message);
+            },
+            [sharedConn]() { sharedConn->onDisconnect(); })) {
       return nullptr;
     }
 
@@ -122,7 +135,7 @@ void ConnectionDemux::removePage(int pageId) {
   auto conn = conns_.at(pageId);
   std::string title = conn->getTitle();
   inspectedContexts_->erase(title);
-  conn->disconnect();
+  conn->unregisterCallbacks();
   conns_.erase(pageId);
 }
 
@@ -130,3 +143,5 @@ void ConnectionDemux::removePage(int pageId) {
 } // namespace inspector_modern
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifdef HERMES_ENABLE_DEBUGGER
+
 #include <memory>
 #include <mutex>
 #include <string>
@@ -14,9 +16,9 @@
 #include <unordered_set>
 
 #include <hermes/hermes.h>
-#include <hermes/inspector-modern/RuntimeAdapter.h>
-#include <hermes/inspector-modern/chrome/Connection.h>
 #include <hermes/inspector-modern/chrome/Registration.h>
+#include <hermes/inspector/RuntimeAdapter.h>
+#include <hermes/inspector/chrome/CDPHandler.h>
 #include <jsinspector-modern/InspectorInterfaces.h>
 
 namespace facebook {
@@ -44,13 +46,17 @@ class ConnectionDemux {
   void disableDebugging(DebugSessionToken session);
 
  private:
-  int addPage(std::shared_ptr<Connection> conn);
+  int addPage(
+      std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler> conn);
   void removePage(int pageId);
 
   facebook::react::jsinspector_modern::IInspector &globalInspector_;
 
   std::mutex mutex_;
-  std::unordered_map<int, std::shared_ptr<Connection>> conns_;
+  std::unordered_map<
+      int,
+      std::shared_ptr<hermes::inspector_modern::chrome::CDPHandler>>
+      conns_;
   std::shared_ptr<std::unordered_set<std::string>> inspectedContexts_;
 };
 
@@ -58,3 +64,5 @@ class ConnectionDemux {
 } // namespace inspector_modern
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.cpp
@@ -8,6 +8,8 @@
 #include "Registration.h"
 #include "ConnectionDemux.h"
 
+#ifdef HERMES_ENABLE_DEBUGGER
+
 namespace facebook {
 namespace hermes {
 namespace inspector_modern {
@@ -37,3 +39,5 @@ void disableDebugging(DebugSessionToken session) {
 } // namespace inspector_modern
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#ifdef HERMES_ENABLE_DEBUGGER
+
 #include <memory>
 #include <string>
 
 #include <hermes/hermes.h>
-#include <hermes/inspector-modern/RuntimeAdapter.h>
+#include <hermes/inspector/RuntimeAdapter.h>
 
 namespace facebook {
 namespace hermes {
@@ -41,3 +43,5 @@ extern void disableDebugging(DebugSessionToken session);
 } // namespace inspector_modern
 } // namespace hermes
 } // namespace facebook
+
+#endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -23,3 +23,11 @@ target_link_libraries(bridgelesshermes
         jsi
         hermes_executor_common
 )
+
+if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+        target_compile_options(
+                bridgelesshermes
+                PRIVATE
+                -DHERMES_ENABLE_DEBUGGER=1
+        )
+endif()

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -11,8 +11,8 @@
 #include <jsi/jsilib.h>
 
 #ifdef HERMES_ENABLE_DEBUGGER
-#include <hermes/inspector-modern/RuntimeAdapter.h>
 #include <hermes/inspector-modern/chrome/Registration.h>
+#include <hermes/inspector/RuntimeAdapter.h>
 #include <jsi/decorator.h>
 #endif
 


### PR DESCRIPTION
Summary:
Updates React Native to use the new CDP handler provided by the Hermes engine instead of the legacy one (`Connection.cpp`) built into React Native. The new Hermes CDP handler has a simpler & safer design, new features (e.g. `console.log` buffering) and is under active development by the Hermes team.

NOTE: Both the legacy and modern handlers are Hermes-specific. In future work, React Native will *wrap* the modern Hermes handler in an engine-agnostic CDP layer implementing additional functionality and managing the lifecycle of debugging sessions more correctly. This diff is the first step of this larger migration.

Changelog: [General][Changed] Use new Hermes CDP handler implementation for debugging

Differential Revision: D48783980

