### PR TITLE
Breaking: Remove "UseLegacyStretchBehaviour" functions

### DIFF
--- a/packages/react-native/Libraries/Text/BaseText/RCTBaseTextShadowView.mm
+++ b/packages/react-native/Libraries/Text/BaseText/RCTBaseTextShadowView.mm
@@ -15,7 +15,7 @@
 NSString *const RCTBaseTextShadowViewEmbeddedShadowViewAttributeName =
     @"RCTBaseTextShadowViewEmbeddedShadowViewAttributeName";
 
-static void RCTInlineViewYogaNodeDirtied(YGNodeRef node)
+static void RCTInlineViewYogaNodeDirtied(YGNodeConstRef node)
 {
   // An inline view (a view nested inside of a text node) does not have a parent
   // in the Yoga tree. Consequently, we have to manually propagate the inline

--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
@@ -368,8 +368,12 @@
   return size.height + maximumDescender;
 }
 
-static YGSize
-RCTTextShadowViewMeasure(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
+static YGSize RCTTextShadowViewMeasure(
+    YGNodeConstRef node,
+    float width,
+    YGMeasureMode widthMode,
+    float height,
+    YGMeasureMode heightMode)
 {
   CGSize maximumSize = (CGSize){
       widthMode == YGMeasureModeUndefined ? CGFLOAT_MAX : RCTCoreGraphicsFloatFromYogaFloat(width),
@@ -402,7 +406,7 @@ RCTTextShadowViewMeasure(YGNodeRef node, float width, YGMeasureMode widthMode, f
       RCTYogaFloatFromCoreGraphicsFloat(size.height + epsilon)};
 }
 
-static float RCTTextShadowViewBaseline(YGNodeRef node, const float width, const float height)
+static float RCTTextShadowViewBaseline(YGNodeConstRef node, const float width, const float height)
 {
   RCTTextShadowView *shadowTextView = (__bridge RCTTextShadowView *)YGNodeGetContext(node);
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.mm
@@ -259,7 +259,7 @@
 }
 
 static YGSize RCTBaseTextInputShadowViewMeasure(
-    YGNodeRef node,
+    YGNodeConstRef node,
     float width,
     YGMeasureMode widthMode,
     float height,
@@ -302,7 +302,7 @@ static YGSize RCTBaseTextInputShadowViewMeasure(
       RCTYogaFloatFromCoreGraphicsFloat(measuredSize.width), RCTYogaFloatFromCoreGraphicsFloat(measuredSize.height)};
 }
 
-static float RCTTextInputShadowViewBaseline(YGNodeRef node, const float width, const float height)
+static float RCTTextInputShadowViewBaseline(YGNodeConstRef node, const float width, const float height)
 {
   RCTBaseTextInputShadowView *shadowTextView = (__bridge RCTBaseTextInputShadowView *)YGNodeGetContext(node);
 

--- a/packages/react-native/Libraries/Wrapper/RCTWrapperShadowView.m
+++ b/packages/react-native/Libraries/Wrapper/RCTWrapperShadowView.m
@@ -30,7 +30,7 @@
 }
 
 static YGSize RCTWrapperShadowViewMeasure(
-    YGNodeRef node,
+    YGNodeConstRef node,
     float width,
     YGMeasureMode widthMode,
     float height,

--- a/packages/react-native/React/Views/RCTShadowView.m
+++ b/packages/react-native/React/Views/RCTShadowView.m
@@ -60,7 +60,7 @@ typedef NS_ENUM(unsigned int, meta_prop_t) {
 
 // YogaNode API
 
-static void RCTPrint(YGNodeRef node)
+static void RCTPrint(YGNodeConstRef node)
 {
   RCTShadowView *shadowView = (__bridge RCTShadowView *)YGNodeGetContext(node);
   printf("%s(%lld), ", shadowView.viewName.UTF8String, (long long)shadowView.reactTag.integerValue);
@@ -568,7 +568,7 @@ RCT_POSITION_PROPERTY(End, end, YGEdgeEnd)
 // IntrinsicContentSize
 
 static inline YGSize
-RCTShadowViewMeasure(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
+RCTShadowViewMeasure(YGNodeConstRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
 {
   RCTShadowView *shadowView = (__bridge RCTShadowView *)YGNodeGetContext(node);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfig.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfig.java
@@ -18,18 +18,6 @@ public abstract class YogaConfig {
   public abstract void setPrintTreeFlag(boolean enable);
 
   public abstract void setPointScaleFactor(float pixelsInPoint);
-  /**
-   * Yoga previously had an error where containers would take the maximum space possible instead of the minimum
-   * like they are supposed to. In practice this resulted in implicit behaviour similar to align-self: stretch;
-   * Because this was such a long-standing bug we must allow legacy users to switch back to this behaviour.
-   *
-   * @deprecated "setUseLegacyStretchBehaviour" will be removed in the next release. Usage should be replaced with
-   * "setErrata(YogaErrata.ALL)" to opt out of all future breaking conformance fixes, or
-   * "setErrata(YogaErrata.STRETCH_FLEX_BASIS)" to opt out of the specific conformance fix previously disabled by
-   * "UseLegacyStretchBehaviour".
-   */
-  @Deprecated
-  public abstract void setUseLegacyStretchBehaviour(boolean useLegacyStretchBehaviour);
 
   public abstract void setErrata(YogaErrata errata);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfigJNIBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfigJNIBase.java
@@ -43,15 +43,6 @@ public abstract class YogaConfigJNIBase extends YogaConfig {
     YogaNative.jni_YGConfigSetPointScaleFactorJNI(mNativePointer, pixelsInPoint);
   }
 
-  /**
-   * Yoga previously had an error where containers would take the maximum space possible instead of the minimum
-   * like they are supposed to. In practice this resulted in implicit behaviour similar to align-self: stretch;
-   * Because this was such a long-standing bug we must allow legacy users to switch back to this behaviour.
-   */
-  public void setUseLegacyStretchBehaviour(boolean useLegacyStretchBehaviour) {
-    YogaNative.jni_YGConfigSetUseLegacyStretchBehaviourJNI(mNativePointer, useLegacyStretchBehaviour);
-  }
-
   public void setErrata(YogaErrata errata) {
     YogaNative.jni_YGConfigSetErrataJNI(mNativePointer, errata.intValue());
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
@@ -24,7 +24,6 @@ public class YogaNative {
   static native void jni_YGConfigSetUseWebDefaultsJNI(long nativePointer, boolean useWebDefaults);
   static native void jni_YGConfigSetPrintTreeFlagJNI(long nativePointer, boolean enable);
   static native void jni_YGConfigSetPointScaleFactorJNI(long nativePointer, float pixelsInPoint);
-  static native void jni_YGConfigSetUseLegacyStretchBehaviourJNI(long nativePointer, boolean useLegacyStretchBehaviour);
   static native void jni_YGConfigSetErrataJNI(long nativePointer, int errata);
   static native int jni_YGConfigGetErrataJNI(long nativePointer);
   static native void jni_YGConfigSetLoggerJNI(long nativePointer, YogaLogger logger);

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -93,18 +93,6 @@ static void jni_YGConfigSetPointScaleFactorJNI(
   YGConfigSetPointScaleFactor(config, pixelsInPoint);
 }
 
-static void jni_YGConfigSetUseLegacyStretchBehaviourJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer,
-    jboolean useLegacyStretchBehaviour) {
-  const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-  YGConfigSetUseLegacyStretchBehaviour(config, useLegacyStretchBehaviour);
-#pragma clang diagnostic pop
-}
-
 static void jni_YGConfigSetErrataJNI(
     JNIEnv* /*env*/,
     jobject /*obj*/,
@@ -790,9 +778,6 @@ static JNINativeMethod methods[] = {
     {"jni_YGConfigSetPointScaleFactorJNI",
      "(JF)V",
      (void*) jni_YGConfigSetPointScaleFactorJNI},
-    {"jni_YGConfigSetUseLegacyStretchBehaviourJNI",
-     "(JZ)V",
-     (void*) jni_YGConfigSetUseLegacyStretchBehaviourJNI},
     {"jni_YGConfigSetErrataJNI", "(JI)V", (void*) jni_YGConfigSetErrataJNI},
     {"jni_YGConfigGetErrataJNI", "(J)I", (void*) jni_YGConfigGetErrataJNI},
     {"jni_YGConfigSetLoggerJNI",

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -27,7 +27,7 @@ using namespace facebook::yoga;
 using namespace facebook::yoga::vanillajni;
 
 static inline ScopedLocalRef<jobject> YGNodeJobject(
-    YGNodeRef node,
+    YGNodeConstRef node,
     void* layoutContext) {
   return reinterpret_cast<PtrJNodeMapVanilla*>(layoutContext)->ref(node);
 }
@@ -138,8 +138,8 @@ static jlong jni_YGNodeNewWithConfigJNI(
 }
 
 static int YGJNILogFunc(
-    const YGConfigRef config,
-    const YGNodeRef /*node*/,
+    const YGConfigConstRef config,
+    const YGNodeConstRef /*node*/,
     YGLogLevel level,
     void* /*layoutContext*/,
     const char* format,
@@ -639,7 +639,7 @@ static void jni_YGNodeStyleSetBorderJNI(
       yogaNodeRef, static_cast<YGEdge>(edge), static_cast<float>(border));
 }
 
-static void YGTransferLayoutDirection(YGNodeRef node, jobject javaNode) {
+static void YGTransferLayoutDirection(YGNodeConstRef node, jobject javaNode) {
   // Don't change this field name without changing the name of the field in
   // Database.java
   JNIEnv* env = getCurrentEnv();
@@ -655,7 +655,7 @@ static void YGTransferLayoutDirection(YGNodeRef node, jobject javaNode) {
 }
 
 static YGSize YGJNIMeasureFunc(
-    YGNodeRef node,
+    YGNodeConstRef node,
     float width,
     YGMeasureMode widthMode,
     float height,
@@ -700,7 +700,7 @@ static void jni_YGNodeSetHasMeasureFuncJNI(
 }
 
 static float YGJNIBaselineFunc(
-    YGNodeRef node,
+    YGNodeConstRef node,
     float width,
     float height,
     void* layoutContext) {

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -362,7 +362,7 @@ static void YGTransferLayoutOutputsRecursive(
 
   YGNodeSetHasNewLayout(root, false);
 
-  for (uint32_t i = 0; i < YGNodeGetChildCount(root); i++) {
+  for (size_t i = 0; i < YGNodeGetChildCount(root); i++) {
     YGTransferLayoutOutputsRecursive(
         env, thiz, YGNodeGetChild(root, i), layoutContext);
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -190,9 +190,7 @@ void YogaLayoutableShadowNode::appendYogaChild(
   ensureYogaChildrenLookFine();
 
   yogaLayoutableChildren_.push_back(childNode);
-  yogaNode_.insertChild(
-      &childNode->yogaNode_,
-      static_cast<uint32_t>(yogaNode_.getChildren().size()));
+  yogaNode_.insertChild(&childNode->yogaNode_, yogaNode_.getChildren().size());
 
   ensureYogaChildrenLookFine();
 }
@@ -219,7 +217,7 @@ void YogaLayoutableShadowNode::adoptYogaChild(size_t index) {
     auto clonedChildNode = childNode.clone({});
 
     // Replace the child node with a newly cloned one in the children list.
-    replaceChild(childNode, clonedChildNode, static_cast<int>(index));
+    replaceChild(childNode, clonedChildNode, static_cast<int32_t>(index));
   }
 
   ensureYogaChildrenLookFine();
@@ -513,7 +511,7 @@ YGErrata YogaLayoutableShadowNode::resolveErrata(YGErrata defaultErrata) const {
 }
 
 YogaLayoutableShadowNode& YogaLayoutableShadowNode::cloneChildInPlace(
-    int32_t layoutableChildIndex) {
+    size_t layoutableChildIndex) {
   ensureUnsealed();
 
   const auto& childNode = *yogaLayoutableChildren_[layoutableChildIndex];
@@ -525,7 +523,8 @@ YogaLayoutableShadowNode& YogaLayoutableShadowNode::cloneChildInPlace(
        ShadowNodeFragment::childrenPlaceholder(),
        childNode.getState()});
 
-  replaceChild(childNode, clonedChildNode, layoutableChildIndex);
+  replaceChild(
+      childNode, clonedChildNode, static_cast<int32_t>(layoutableChildIndex));
   return static_cast<YogaLayoutableShadowNode&>(*clonedChildNode);
 }
 
@@ -790,7 +789,7 @@ Rect YogaLayoutableShadowNode::getContentBounds() const {
 YGNodeRef YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector(
     YGNodeConstRef /*oldYogaNode*/,
     YGNodeConstRef parentYogaNode,
-    int childIndex) {
+    size_t childIndex) {
   SystraceSection s("YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector");
 
   auto& parentNode = shadowNodeFromContext(parentYogaNode);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -26,8 +26,8 @@
 namespace facebook::react {
 
 static int FabricDefaultYogaLog(
-    const YGConfigRef /*unused*/,
-    const YGNodeRef /*unused*/,
+    const YGConfigConstRef /*unused*/,
+    const YGNodeConstRef /*unused*/,
     YGLogLevel level,
     const char* format,
     va_list args) {
@@ -787,9 +787,9 @@ Rect YogaLayoutableShadowNode::getContentBounds() const {
 
 #pragma mark - Yoga Connectors
 
-YGNode* YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector(
-    YGNode* /*oldYogaNode*/,
-    YGNode* parentYogaNode,
+YGNodeRef YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector(
+    YGNodeConstRef /*oldYogaNode*/,
+    YGNodeConstRef parentYogaNode,
     int childIndex) {
   SystraceSection s("YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector");
 
@@ -798,7 +798,7 @@ YGNode* YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector(
 }
 
 YGSize YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector(
-    YGNode* yogaNode,
+    YGNodeConstRef yogaNode,
     float width,
     YGMeasureMode widthMode,
     float height,
@@ -845,7 +845,7 @@ YGSize YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector(
 }
 
 YogaLayoutableShadowNode& YogaLayoutableShadowNode::shadowNodeFromContext(
-    YGNodeRef yogaNode) {
+    YGNodeConstRef yogaNode) {
   return traitCast<YogaLayoutableShadowNode&>(
       *static_cast<ShadowNode*>(YGNodeGetContext(yogaNode)));
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -159,16 +159,17 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
       yoga::Config& config,
       YGConfigRef previousConfig = nullptr);
   static YGNodeRef yogaNodeCloneCallbackConnector(
-      YGNodeRef oldYogaNode,
-      YGNodeRef parentYogaNode,
+      YGNodeConstRef oldYogaNode,
+      YGNodeConstRef parentYogaNode,
       int childIndex);
   static YGSize yogaNodeMeasureCallbackConnector(
-      YGNodeRef yogaNode,
+      YGNodeConstRef yogaNode,
       float width,
       YGMeasureMode widthMode,
       float height,
       YGMeasureMode heightMode);
-  static YogaLayoutableShadowNode& shadowNodeFromContext(YGNodeRef yogaNode);
+  static YogaLayoutableShadowNode& shadowNodeFromContext(
+      YGNodeConstRef yogaNode);
 
 #pragma mark - RTL Legacy Autoflip
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -153,7 +153,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   /**
    * Replcaes a child with a mutable clone of itself, returning the clone.
    */
-  YogaLayoutableShadowNode& cloneChildInPlace(int32_t layoutableChildIndex);
+  YogaLayoutableShadowNode& cloneChildInPlace(size_t layoutableChildIndex);
 
   static yoga::Config& initializeYogaConfig(
       yoga::Config& config,
@@ -161,7 +161,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   static YGNodeRef yogaNodeCloneCallbackConnector(
       YGNodeConstRef oldYogaNode,
       YGNodeConstRef parentYogaNode,
-      int childIndex);
+      size_t childIndex);
   static YGSize yogaNodeMeasureCallbackConnector(
       YGNodeConstRef yogaNode,
       float width,

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -1017,21 +1017,6 @@ YOGA_EXPORT void YGConfigSetUseWebDefaults(
   resolveRef(config)->setUseWebDefaults(enabled);
 }
 
-YOGA_EXPORT bool YGConfigGetUseLegacyStretchBehaviour(
-    const YGConfigConstRef config) {
-  return resolveRef(config)->hasErrata(YGErrataStretchFlexBasis);
-}
-
-YOGA_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
-    const YGConfigRef config,
-    const bool useLegacyStretchBehaviour) {
-  if (useLegacyStretchBehaviour) {
-    resolveRef(config)->addErrata(YGErrataStretchFlexBasis);
-  } else {
-    resolveRef(config)->removeErrata(YGErrataStretchFlexBasis);
-  }
-}
-
 bool YGConfigGetUseWebDefaults(const YGConfigConstRef config) {
   return resolveRef(config)->useWebDefaults();
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -99,93 +99,95 @@ YOGA_EXPORT bool YGFloatIsUndefined(const float value) {
   return yoga::isUndefined(value);
 }
 
-YOGA_EXPORT void* YGNodeGetContext(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->getContext();
+YOGA_EXPORT void* YGNodeGetContext(YGNodeConstRef node) {
+  return resolveRef(node)->getContext();
 }
 
 YOGA_EXPORT void YGNodeSetContext(YGNodeRef node, void* context) {
-  return static_cast<yoga::Node*>(node)->setContext(context);
+  return resolveRef(node)->setContext(context);
 }
 
 YOGA_EXPORT YGConfigRef YGNodeGetConfig(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->getConfig();
+  return resolveRef(node)->getConfig();
 }
 
 YOGA_EXPORT void YGNodeSetConfig(YGNodeRef node, YGConfigRef config) {
-  static_cast<yoga::Node*>(node)->setConfig(static_cast<yoga::Config*>(config));
+  resolveRef(node)->setConfig(resolveRef(config));
 }
 
-YOGA_EXPORT bool YGNodeHasMeasureFunc(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->hasMeasureFunc();
+YOGA_EXPORT bool YGNodeHasMeasureFunc(YGNodeConstRef node) {
+  return resolveRef(node)->hasMeasureFunc();
 }
 
 YOGA_EXPORT void YGNodeSetMeasureFunc(
     YGNodeRef node,
     YGMeasureFunc measureFunc) {
-  static_cast<yoga::Node*>(node)->setMeasureFunc(measureFunc);
+  resolveRef(node)->setMeasureFunc(measureFunc);
 }
 
-YOGA_EXPORT bool YGNodeHasBaselineFunc(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->hasBaselineFunc();
+YOGA_EXPORT bool YGNodeHasBaselineFunc(YGNodeConstRef node) {
+  return resolveRef(node)->hasBaselineFunc();
 }
 
 YOGA_EXPORT void YGNodeSetBaselineFunc(
     YGNodeRef node,
     YGBaselineFunc baselineFunc) {
-  static_cast<yoga::Node*>(node)->setBaselineFunc(baselineFunc);
+  resolveRef(node)->setBaselineFunc(baselineFunc);
 }
 
-YOGA_EXPORT YGDirtiedFunc YGNodeGetDirtiedFunc(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->getDirtied();
+YOGA_EXPORT YGDirtiedFunc YGNodeGetDirtiedFunc(YGNodeConstRef node) {
+  return resolveRef(node)->getDirtied();
 }
 
 YOGA_EXPORT void YGNodeSetDirtiedFunc(
     YGNodeRef node,
     YGDirtiedFunc dirtiedFunc) {
-  static_cast<yoga::Node*>(node)->setDirtiedFunc(dirtiedFunc);
+  resolveRef(node)->setDirtiedFunc(dirtiedFunc);
 }
 
 YOGA_EXPORT void YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc) {
-  static_cast<yoga::Node*>(node)->setPrintFunc(printFunc);
+  resolveRef(node)->setPrintFunc(printFunc);
 }
 
-YOGA_EXPORT bool YGNodeGetHasNewLayout(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->getHasNewLayout();
+YOGA_EXPORT bool YGNodeGetHasNewLayout(YGNodeConstRef node) {
+  return resolveRef(node)->getHasNewLayout();
 }
 
 YOGA_EXPORT void YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled) {
-  static_cast<yoga::Config*>(config)->setShouldPrintTree(enabled);
+  resolveRef(config)->setShouldPrintTree(enabled);
 }
 
 YOGA_EXPORT void YGNodeSetHasNewLayout(YGNodeRef node, bool hasNewLayout) {
-  static_cast<yoga::Node*>(node)->setHasNewLayout(hasNewLayout);
+  resolveRef(node)->setHasNewLayout(hasNewLayout);
 }
 
-YOGA_EXPORT YGNodeType YGNodeGetNodeType(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->getNodeType();
+YOGA_EXPORT YGNodeType YGNodeGetNodeType(YGNodeConstRef node) {
+  return resolveRef(node)->getNodeType();
 }
 
 YOGA_EXPORT void YGNodeSetNodeType(YGNodeRef node, YGNodeType nodeType) {
-  return static_cast<yoga::Node*>(node)->setNodeType(nodeType);
+  return resolveRef(node)->setNodeType(nodeType);
 }
 
-YOGA_EXPORT bool YGNodeIsDirty(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->isDirty();
+YOGA_EXPORT bool YGNodeIsDirty(YGNodeConstRef node) {
+  return resolveRef(node)->isDirty();
 }
 
 YOGA_EXPORT void YGNodeMarkDirtyAndPropagateToDescendants(
     const YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->markDirtyAndPropagateDownwards();
+  return resolveRef(node)->markDirtyAndPropagateDownwards();
 }
 
 int32_t gConfigInstanceCount = 0;
 
 YOGA_EXPORT WIN_EXPORT YGNodeRef YGNodeNewWithConfig(const YGConfigRef config) {
-  auto* node = new yoga::Node{static_cast<yoga::Config*>(config)};
+  auto* node = new yoga::Node{resolveRef(config)};
   yoga::assertFatal(
       config != nullptr, "Tried to construct YGNode with null config");
   yoga::assertFatalWithConfig(
-      config, node != nullptr, "Could not allocate memory for node");
+      resolveRef(config),
+      node != nullptr,
+      "Could not allocate memory for node");
   Event::publish<Event::NodeAllocation>(node, {config});
 
   return node;
@@ -201,8 +203,8 @@ YOGA_EXPORT YGNodeRef YGNodeNew(void) {
 }
 
 YOGA_EXPORT YGNodeRef YGNodeClone(YGNodeRef oldNodeRef) {
-  auto oldNode = static_cast<yoga::Node*>(oldNodeRef);
-  auto node = new yoga::Node(*oldNode);
+  auto oldNode = resolveRef(oldNodeRef);
+  const auto node = new yoga::Node(*oldNode);
   yoga::assertFatalWithConfig(
       oldNode->getConfig(),
       node != nullptr,
@@ -213,7 +215,7 @@ YOGA_EXPORT YGNodeRef YGNodeClone(YGNodeRef oldNodeRef) {
 }
 
 YOGA_EXPORT void YGNodeFree(const YGNodeRef nodeRef) {
-  auto node = static_cast<yoga::Node*>(nodeRef);
+  const auto node = resolveRef(nodeRef);
 
   if (auto owner = node->getOwner()) {
     owner->removeChild(node);
@@ -232,13 +234,13 @@ YOGA_EXPORT void YGNodeFree(const YGNodeRef nodeRef) {
 
 YOGA_EXPORT void YGNodeDeallocate(const YGNodeRef node) {
   Event::publish<Event::NodeDeallocation>(node, {YGNodeGetConfig(node)});
-  delete static_cast<yoga::Node*>(node);
+  delete resolveRef(node);
 }
 
 YOGA_EXPORT void YGNodeFreeRecursiveWithCleanupFunc(
     const YGNodeRef rootRef,
     YGNodeCleanupFunc cleanup) {
-  const auto root = static_cast<yoga::Node*>(rootRef);
+  const auto root = resolveRef(rootRef);
 
   uint32_t skipped = 0;
   while (YGNodeGetChildCount(root) > skipped) {
@@ -262,7 +264,7 @@ YOGA_EXPORT void YGNodeFreeRecursive(const YGNodeRef root) {
 }
 
 YOGA_EXPORT void YGNodeReset(YGNodeRef node) {
-  static_cast<yoga::Node*>(node)->reset();
+  resolveRef(node)->reset();
 }
 
 YOGA_EXPORT int32_t YGConfigGetInstanceCount(void) {
@@ -280,30 +282,30 @@ YOGA_EXPORT YGConfigRef YGConfigNew(void) {
 }
 
 YOGA_EXPORT void YGConfigFree(const YGConfigRef config) {
-  delete static_cast<yoga::Config*>(config);
+  delete resolveRef(config);
   gConfigInstanceCount--;
 }
 
 YOGA_EXPORT void YGNodeSetIsReferenceBaseline(
     YGNodeRef nodeRef,
     bool isReferenceBaseline) {
-  auto node = static_cast<yoga::Node*>(nodeRef);
+  const auto node = resolveRef(nodeRef);
   if (node->isReferenceBaseline() != isReferenceBaseline) {
     node->setIsReferenceBaseline(isReferenceBaseline);
     node->markDirtyAndPropagate();
   }
 }
 
-YOGA_EXPORT bool YGNodeIsReferenceBaseline(YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->isReferenceBaseline();
+YOGA_EXPORT bool YGNodeIsReferenceBaseline(YGNodeConstRef node) {
+  return resolveRef(node)->isReferenceBaseline();
 }
 
 YOGA_EXPORT void YGNodeInsertChild(
     const YGNodeRef ownerRef,
     const YGNodeRef childRef,
     const uint32_t index) {
-  auto owner = static_cast<yoga::Node*>(ownerRef);
-  auto child = static_cast<yoga::Node*>(childRef);
+  auto owner = resolveRef(ownerRef);
+  auto child = resolveRef(childRef);
 
   yoga::assertFatalWithNode(
       owner,
@@ -324,8 +326,8 @@ YOGA_EXPORT void YGNodeSwapChild(
     const YGNodeRef ownerRef,
     const YGNodeRef childRef,
     const uint32_t index) {
-  auto owner = static_cast<yoga::Node*>(ownerRef);
-  auto child = static_cast<yoga::Node*>(childRef);
+  auto owner = resolveRef(ownerRef);
+  auto child = resolveRef(childRef);
 
   owner->replaceChild(child, index);
   child->setOwner(owner);
@@ -334,8 +336,8 @@ YOGA_EXPORT void YGNodeSwapChild(
 YOGA_EXPORT void YGNodeRemoveChild(
     const YGNodeRef ownerRef,
     const YGNodeRef excludedChildRef) {
-  auto owner = static_cast<yoga::Node*>(ownerRef);
-  auto excludedChild = static_cast<yoga::Node*>(excludedChildRef);
+  auto owner = resolveRef(ownerRef);
+  auto excludedChild = resolveRef(excludedChildRef);
 
   if (YGNodeGetChildCount(owner) == 0) {
     // This is an empty set. Nothing to remove.
@@ -356,7 +358,7 @@ YOGA_EXPORT void YGNodeRemoveChild(
 }
 
 YOGA_EXPORT void YGNodeRemoveAllChildren(const YGNodeRef ownerRef) {
-  auto owner = static_cast<yoga::Node*>(ownerRef);
+  auto owner = resolveRef(ownerRef);
 
   const uint32_t childCount = YGNodeGetChildCount(owner);
   if (childCount == 0) {
@@ -386,7 +388,7 @@ YOGA_EXPORT void YGNodeSetChildren(
     const YGNodeRef ownerRef,
     const YGNodeRef* childrenRefs,
     const uint32_t count) {
-  auto owner = static_cast<yoga::Node*>(ownerRef);
+  auto owner = resolveRef(ownerRef);
   auto children = reinterpret_cast<yoga::Node* const*>(childrenRefs);
 
   if (!owner) {
@@ -425,7 +427,7 @@ YOGA_EXPORT void YGNodeSetChildren(
 
 YOGA_EXPORT YGNodeRef
 YGNodeGetChild(const YGNodeRef nodeRef, const uint32_t index) {
-  auto node = static_cast<yoga::Node*>(nodeRef);
+  const auto node = resolveRef(nodeRef);
 
   if (index < node->getChildren().size()) {
     return node->getChild(index);
@@ -434,20 +436,19 @@ YGNodeGetChild(const YGNodeRef nodeRef, const uint32_t index) {
 }
 
 YOGA_EXPORT uint32_t YGNodeGetChildCount(const YGNodeConstRef node) {
-  return static_cast<uint32_t>(
-      static_cast<const yoga::Node*>(node)->getChildren().size());
+  return static_cast<uint32_t>(resolveRef(node)->getChildren().size());
 }
 
 YOGA_EXPORT YGNodeRef YGNodeGetOwner(const YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->getOwner();
+  return resolveRef(node)->getOwner();
 }
 
 YOGA_EXPORT YGNodeRef YGNodeGetParent(const YGNodeRef node) {
-  return static_cast<yoga::Node*>(node)->getOwner();
+  return resolveRef(node)->getOwner();
 }
 
 YOGA_EXPORT void YGNodeMarkDirty(const YGNodeRef nodeRef) {
-  auto node = static_cast<yoga::Node*>(nodeRef);
+  const auto node = resolveRef(nodeRef);
 
   yoga::assertFatalWithNode(
       node,
@@ -460,9 +461,9 @@ YOGA_EXPORT void YGNodeMarkDirty(const YGNodeRef nodeRef) {
 
 YOGA_EXPORT void YGNodeCopyStyle(
     const YGNodeRef dstNodeRef,
-    const YGNodeRef srcNodeRef) {
-  auto dstNode = static_cast<yoga::Node*>(dstNodeRef);
-  auto srcNode = static_cast<yoga::Node*>(srcNodeRef);
+    const YGNodeConstRef srcNodeRef) {
+  auto dstNode = resolveRef(dstNodeRef);
+  auto srcNode = resolveRef(srcNodeRef);
 
   if (!(dstNode->getStyle() == srcNode->getStyle())) {
     dstNode->setStyle(srcNode->getStyle());
@@ -471,14 +472,14 @@ YOGA_EXPORT void YGNodeCopyStyle(
 }
 
 YOGA_EXPORT float YGNodeStyleGetFlexGrow(const YGNodeConstRef nodeRef) {
-  auto node = static_cast<const yoga::Node*>(nodeRef);
+  const auto node = resolveRef(nodeRef);
   return node->getStyle().flexGrow().isUndefined()
       ? Style::DefaultFlexGrow
       : node->getStyle().flexGrow().unwrap();
 }
 
 YOGA_EXPORT float YGNodeStyleGetFlexShrink(const YGNodeConstRef nodeRef) {
-  auto node = static_cast<const yoga::Node*>(nodeRef);
+  const auto node = resolveRef(nodeRef);
   return node->getStyle().flexShrink().isUndefined()
       ? (node->getConfig()->useWebDefaults() ? Style::WebDefaultFlexShrink
                                              : Style::DefaultFlexShrink)
@@ -502,7 +503,7 @@ void updateStyle(
 template <typename Ref, typename T>
 void updateStyle(YGNodeRef node, Ref (Style::*prop)(), T value) {
   updateStyle(
-      static_cast<yoga::Node*>(node),
+      resolveRef(node),
       value,
       [prop](Style& s, T x) { return (s.*prop)() != x; },
       [prop](Style& s, T x) { (s.*prop)() = x; });
@@ -515,7 +516,7 @@ void updateIndexedStyleProp(
     Idx idx,
     CompactValue value) {
   updateStyle(
-      static_cast<yoga::Node*>(node),
+      resolveRef(node),
       value,
       [idx, prop](Style& s, CompactValue x) { return (s.*prop)()[idx] != x; },
       [idx, prop](Style& s, CompactValue x) { (s.*prop)()[idx] = x; });
@@ -536,7 +537,7 @@ YOGA_EXPORT void YGNodeStyleSetDirection(
   updateStyle<MSVC_HINT(direction)>(node, &Style::direction, value);
 }
 YOGA_EXPORT YGDirection YGNodeStyleGetDirection(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().direction();
+  return resolveRef(node)->getStyle().direction();
 }
 
 YOGA_EXPORT void YGNodeStyleSetFlexDirection(
@@ -547,7 +548,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexDirection(
 }
 YOGA_EXPORT YGFlexDirection
 YGNodeStyleGetFlexDirection(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().flexDirection();
+  return resolveRef(node)->getStyle().flexDirection();
 }
 
 YOGA_EXPORT void YGNodeStyleSetJustifyContent(
@@ -557,7 +558,7 @@ YOGA_EXPORT void YGNodeStyleSetJustifyContent(
       node, &Style::justifyContent, justifyContent);
 }
 YOGA_EXPORT YGJustify YGNodeStyleGetJustifyContent(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().justifyContent();
+  return resolveRef(node)->getStyle().justifyContent();
 }
 
 YOGA_EXPORT void YGNodeStyleSetAlignContent(
@@ -567,7 +568,7 @@ YOGA_EXPORT void YGNodeStyleSetAlignContent(
       node, &Style::alignContent, alignContent);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignContent(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().alignContent();
+  return resolveRef(node)->getStyle().alignContent();
 }
 
 YOGA_EXPORT void YGNodeStyleSetAlignItems(
@@ -576,7 +577,7 @@ YOGA_EXPORT void YGNodeStyleSetAlignItems(
   updateStyle<MSVC_HINT(alignItems)>(node, &Style::alignItems, alignItems);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignItems(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().alignItems();
+  return resolveRef(node)->getStyle().alignItems();
 }
 
 YOGA_EXPORT void YGNodeStyleSetAlignSelf(
@@ -585,7 +586,7 @@ YOGA_EXPORT void YGNodeStyleSetAlignSelf(
   updateStyle<MSVC_HINT(alignSelf)>(node, &Style::alignSelf, alignSelf);
 }
 YOGA_EXPORT YGAlign YGNodeStyleGetAlignSelf(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().alignSelf();
+  return resolveRef(node)->getStyle().alignSelf();
 }
 
 YOGA_EXPORT void YGNodeStyleSetPositionType(
@@ -596,7 +597,7 @@ YOGA_EXPORT void YGNodeStyleSetPositionType(
 }
 YOGA_EXPORT YGPositionType
 YGNodeStyleGetPositionType(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().positionType();
+  return resolveRef(node)->getStyle().positionType();
 }
 
 YOGA_EXPORT void YGNodeStyleSetFlexWrap(
@@ -605,7 +606,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexWrap(
   updateStyle<MSVC_HINT(flexWrap)>(node, &Style::flexWrap, flexWrap);
 }
 YOGA_EXPORT YGWrap YGNodeStyleGetFlexWrap(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().flexWrap();
+  return resolveRef(node)->getStyle().flexWrap();
 }
 
 YOGA_EXPORT void YGNodeStyleSetOverflow(
@@ -614,7 +615,7 @@ YOGA_EXPORT void YGNodeStyleSetOverflow(
   updateStyle<MSVC_HINT(overflow)>(node, &Style::overflow, overflow);
 }
 YOGA_EXPORT YGOverflow YGNodeStyleGetOverflow(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().overflow();
+  return resolveRef(node)->getStyle().overflow();
 }
 
 YOGA_EXPORT void YGNodeStyleSetDisplay(
@@ -623,7 +624,7 @@ YOGA_EXPORT void YGNodeStyleSetDisplay(
   updateStyle<MSVC_HINT(display)>(node, &Style::display, display);
 }
 YOGA_EXPORT YGDisplay YGNodeStyleGetDisplay(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)->getStyle().display();
+  return resolveRef(node)->getStyle().display();
 }
 
 // TODO(T26792433): Change the API to accept FloatOptional.
@@ -633,7 +634,7 @@ YOGA_EXPORT void YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
 
 // TODO(T26792433): Change the API to accept FloatOptional.
 YOGA_EXPORT float YGNodeStyleGetFlex(const YGNodeConstRef nodeRef) {
-  auto node = static_cast<const yoga::Node*>(nodeRef);
+  const auto node = resolveRef(nodeRef);
   return node->getStyle().flex().isUndefined()
       ? YGUndefined
       : node->getStyle().flex().unwrap();
@@ -656,8 +657,7 @@ YOGA_EXPORT void YGNodeStyleSetFlexShrink(
 }
 
 YOGA_EXPORT YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
-  YGValue flexBasis =
-      static_cast<const yoga::Node*>(node)->getStyle().flexBasis();
+  YGValue flexBasis = resolveRef(node)->getStyle().flexBasis();
   if (flexBasis.unit == YGUnitUndefined || flexBasis.unit == YGUnitAuto) {
     // TODO(T26792433): Get rid off the use of YGUndefined at client side
     flexBasis.value = YGUndefined;
@@ -701,7 +701,7 @@ YOGA_EXPORT void YGNodeStyleSetPositionPercent(
       node, &Style::position, edge, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
-  return static_cast<const yoga::Node*>(node)->getStyle().position()[edge];
+  return resolveRef(node)->getStyle().position()[edge];
 }
 
 YOGA_EXPORT void YGNodeStyleSetMargin(
@@ -723,7 +723,7 @@ YOGA_EXPORT void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
       node, &Style::margin, edge, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
-  return static_cast<const yoga::Node*>(node)->getStyle().margin()[edge];
+  return resolveRef(node)->getStyle().margin()[edge];
 }
 
 YOGA_EXPORT void YGNodeStyleSetPadding(
@@ -743,7 +743,7 @@ YOGA_EXPORT void YGNodeStyleSetPaddingPercent(
       node, &Style::padding, edge, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
-  return static_cast<const yoga::Node*>(node)->getStyle().padding()[edge];
+  return resolveRef(node)->getStyle().padding()[edge];
 }
 
 // TODO(T26792433): Change the API to accept FloatOptional.
@@ -758,7 +758,7 @@ YOGA_EXPORT void YGNodeStyleSetBorder(
 YOGA_EXPORT float YGNodeStyleGetBorder(
     const YGNodeConstRef node,
     const YGEdge edge) {
-  auto border = static_cast<const yoga::Node*>(node)->getStyle().border()[edge];
+  auto border = resolveRef(node)->getStyle().border()[edge];
   if (border.isUndefined() || border.isAuto()) {
     // TODO(T26792433): Rather than returning YGUndefined, change the api to
     // return FloatOptional.
@@ -779,8 +779,7 @@ YOGA_EXPORT void YGNodeStyleSetGap(
 YOGA_EXPORT float YGNodeStyleGetGap(
     const YGNodeConstRef node,
     const YGGutter gutter) {
-  auto gapLength =
-      static_cast<const yoga::Node*>(node)->getStyle().gap()[gutter];
+  auto gapLength = resolveRef(node)->getStyle().gap()[gutter];
   if (gapLength.isUndefined() || gapLength.isAuto()) {
     // TODO(T26792433): Rather than returning YGUndefined, change the api to
     // return FloatOptional.
@@ -794,8 +793,7 @@ YOGA_EXPORT float YGNodeStyleGetGap(
 
 // TODO(T26792433): Change the API to accept FloatOptional.
 YOGA_EXPORT float YGNodeStyleGetAspectRatio(const YGNodeConstRef node) {
-  const FloatOptional op =
-      static_cast<const yoga::Node*>(node)->getStyle().aspectRatio();
+  const FloatOptional op = resolveRef(node)->getStyle().aspectRatio();
   return op.isUndefined() ? YGUndefined : op.unwrap();
 }
 
@@ -822,9 +820,7 @@ YOGA_EXPORT void YGNodeStyleSetWidthAuto(YGNodeRef node) {
       node, &Style::dimensions, YGDimensionWidth, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)
-      ->getStyle()
-      .dimensions()[YGDimensionWidth];
+  return resolveRef(node)->getStyle().dimensions()[YGDimensionWidth];
 }
 
 YOGA_EXPORT void YGNodeStyleSetHeight(YGNodeRef node, float points) {
@@ -842,9 +838,7 @@ YOGA_EXPORT void YGNodeStyleSetHeightAuto(YGNodeRef node) {
       node, &Style::dimensions, YGDimensionHeight, CompactValue::ofAuto());
 }
 YOGA_EXPORT YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)
-      ->getStyle()
-      .dimensions()[YGDimensionHeight];
+  return resolveRef(node)->getStyle().dimensions()[YGDimensionHeight];
 }
 
 YOGA_EXPORT void YGNodeStyleSetMinWidth(
@@ -862,9 +856,7 @@ YOGA_EXPORT void YGNodeStyleSetMinWidthPercent(
       node, &Style::minDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)
-      ->getStyle()
-      .minDimensions()[YGDimensionWidth];
+  return resolveRef(node)->getStyle().minDimensions()[YGDimensionWidth];
 }
 
 YOGA_EXPORT void YGNodeStyleSetMinHeight(
@@ -882,9 +874,7 @@ YOGA_EXPORT void YGNodeStyleSetMinHeightPercent(
       node, &Style::minDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)
-      ->getStyle()
-      .minDimensions()[YGDimensionHeight];
+  return resolveRef(node)->getStyle().minDimensions()[YGDimensionHeight];
 }
 
 YOGA_EXPORT void YGNodeStyleSetMaxWidth(
@@ -902,9 +892,7 @@ YOGA_EXPORT void YGNodeStyleSetMaxWidthPercent(
       node, &Style::maxDimensions, YGDimensionWidth, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)
-      ->getStyle()
-      .maxDimensions()[YGDimensionWidth];
+  return resolveRef(node)->getStyle().maxDimensions()[YGDimensionWidth];
 }
 
 YOGA_EXPORT void YGNodeStyleSetMaxHeight(
@@ -922,20 +910,18 @@ YOGA_EXPORT void YGNodeStyleSetMaxHeightPercent(
       node, &Style::maxDimensions, YGDimensionHeight, value);
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
-  return static_cast<const yoga::Node*>(node)
-      ->getStyle()
-      .maxDimensions()[YGDimensionHeight];
+  return resolveRef(node)->getStyle().maxDimensions()[YGDimensionHeight];
 }
 
-#define YG_NODE_LAYOUT_PROPERTY_IMPL(type, name, instanceName)       \
-  YOGA_EXPORT type YGNodeLayoutGet##name(const YGNodeRef node) {     \
-    return static_cast<yoga::Node*>(node)->getLayout().instanceName; \
+#define YG_NODE_LAYOUT_PROPERTY_IMPL(type, name, instanceName)        \
+  YOGA_EXPORT type YGNodeLayoutGet##name(const YGNodeConstRef node) { \
+    return resolveRef(node)->getLayout().instanceName;                \
   }
 
 #define YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(type, name, instanceName) \
   YOGA_EXPORT type YGNodeLayoutGet##name(                               \
-      const YGNodeRef nodeRef, const YGEdge edge) {                     \
-    auto node = static_cast<yoga::Node*>(nodeRef);                      \
+      const YGNodeConstRef nodeRef, const YGEdge edge) {                \
+    const auto node = resolveRef(nodeRef);                              \
     yoga::assertFatalWithNode(                                          \
         node,                                                           \
         edge <= YGEdgeEnd,                                              \
@@ -975,9 +961,9 @@ YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Padding, padding)
 
 #ifdef DEBUG
 YOGA_EXPORT void YGNodePrint(
-    const YGNodeRef nodeRef,
+    const YGNodeConstRef nodeRef,
     const YGPrintOptions options) {
-  const auto node = static_cast<yoga::Node*>(nodeRef);
+  const auto node = resolveRef(nodeRef);
   std::string str;
   yoga::nodeToString(str, node, options, 0);
   yoga::log(node, YGLogLevelDebug, nullptr, str.c_str());
@@ -986,12 +972,12 @@ YOGA_EXPORT void YGNodePrint(
 
 YOGA_EXPORT void YGConfigSetLogger(const YGConfigRef config, YGLogger logger) {
   if (logger != nullptr) {
-    static_cast<yoga::Config*>(config)->setLogger(logger);
+    resolveRef(config)->setLogger(logger);
   } else {
 #ifdef ANDROID
-    static_cast<yoga::Config*>(config)->setLogger(&YGAndroidLog);
+    resolveRef(config)->setLogger(&YGAndroidLog);
 #else
-    static_cast<yoga::Config*>(config)->setLogger(&YGDefaultLog);
+    resolveRef(config)->setLogger(&YGDefaultLog);
 #endif
   }
 }
@@ -1000,21 +986,21 @@ YOGA_EXPORT void YGConfigSetPointScaleFactor(
     const YGConfigRef config,
     const float pixelsInPoint) {
   yoga::assertFatalWithConfig(
-      config,
+      resolveRef(config),
       pixelsInPoint >= 0.0f,
       "Scale factor should not be less than zero");
 
   // We store points for Pixel as we will use it for rounding
   if (pixelsInPoint == 0.0f) {
     // Zero is used to skip rounding
-    static_cast<yoga::Config*>(config)->setPointScaleFactor(0.0f);
+    resolveRef(config)->setPointScaleFactor(0.0f);
   } else {
-    static_cast<yoga::Config*>(config)->setPointScaleFactor(pixelsInPoint);
+    resolveRef(config)->setPointScaleFactor(pixelsInPoint);
   }
 }
 
-YOGA_EXPORT float YGConfigGetPointScaleFactor(const YGConfigRef config) {
-  return static_cast<yoga::Config*>(config)->getPointScaleFactor();
+YOGA_EXPORT float YGConfigGetPointScaleFactor(const YGConfigConstRef config) {
+  return resolveRef(config)->getPointScaleFactor();
 }
 
 YOGA_EXPORT float YGRoundValueToPixelGrid(
@@ -1030,63 +1016,60 @@ YOGA_EXPORT void YGConfigSetExperimentalFeatureEnabled(
     const YGConfigRef config,
     const YGExperimentalFeature feature,
     const bool enabled) {
-  static_cast<yoga::Config*>(config)->setExperimentalFeatureEnabled(
-      feature, enabled);
+  resolveRef(config)->setExperimentalFeatureEnabled(feature, enabled);
 }
 
 YOGA_EXPORT bool YGConfigIsExperimentalFeatureEnabled(
-    const YGConfigRef config,
+    const YGConfigConstRef config,
     const YGExperimentalFeature feature) {
-  return static_cast<yoga::Config*>(config)->isExperimentalFeatureEnabled(
-      feature);
+  return resolveRef(config)->isExperimentalFeatureEnabled(feature);
 }
 
 YOGA_EXPORT void YGConfigSetUseWebDefaults(
     const YGConfigRef config,
     const bool enabled) {
-  static_cast<yoga::Config*>(config)->setUseWebDefaults(enabled);
+  resolveRef(config)->setUseWebDefaults(enabled);
 }
 
 YOGA_EXPORT bool YGConfigGetUseLegacyStretchBehaviour(
-    const YGConfigRef config) {
-  return static_cast<yoga::Config*>(config)->hasErrata(
-      YGErrataStretchFlexBasis);
+    const YGConfigConstRef config) {
+  return resolveRef(config)->hasErrata(YGErrataStretchFlexBasis);
 }
 
 YOGA_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
     const YGConfigRef config,
     const bool useLegacyStretchBehaviour) {
   if (useLegacyStretchBehaviour) {
-    static_cast<yoga::Config*>(config)->addErrata(YGErrataStretchFlexBasis);
+    resolveRef(config)->addErrata(YGErrataStretchFlexBasis);
   } else {
-    static_cast<yoga::Config*>(config)->removeErrata(YGErrataStretchFlexBasis);
+    resolveRef(config)->removeErrata(YGErrataStretchFlexBasis);
   }
 }
 
-bool YGConfigGetUseWebDefaults(const YGConfigRef config) {
-  return static_cast<yoga::Config*>(config)->useWebDefaults();
+bool YGConfigGetUseWebDefaults(const YGConfigConstRef config) {
+  return resolveRef(config)->useWebDefaults();
 }
 
 YOGA_EXPORT void YGConfigSetContext(const YGConfigRef config, void* context) {
-  static_cast<yoga::Config*>(config)->setContext(context);
+  resolveRef(config)->setContext(context);
 }
 
-YOGA_EXPORT void* YGConfigGetContext(const YGConfigRef config) {
-  return static_cast<yoga::Config*>(config)->getContext();
+YOGA_EXPORT void* YGConfigGetContext(const YGConfigConstRef config) {
+  return resolveRef(config)->getContext();
 }
 
 YOGA_EXPORT void YGConfigSetErrata(YGConfigRef config, YGErrata errata) {
-  static_cast<yoga::Config*>(config)->setErrata(errata);
+  resolveRef(config)->setErrata(errata);
 }
 
-YOGA_EXPORT YGErrata YGConfigGetErrata(YGConfigRef config) {
-  return static_cast<yoga::Config*>(config)->getErrata();
+YOGA_EXPORT YGErrata YGConfigGetErrata(YGConfigConstRef config) {
+  return resolveRef(config)->getErrata();
 }
 
 YOGA_EXPORT void YGConfigSetCloneNodeFunc(
     const YGConfigRef config,
     const YGCloneNodeFunc callback) {
-  static_cast<yoga::Config*>(config)->setCloneNodeCallback(callback);
+  resolveRef(config)->setCloneNodeCallback(callback);
 }
 
 // TODO: This should not be part of the public API. Remove after removing
@@ -1118,7 +1101,7 @@ YOGA_EXPORT bool YGNodeCanUseCachedMeasurement(
       lastComputedHeight,
       marginRow,
       marginColumn,
-      static_cast<yoga::Config*>(config));
+      resolveRef(config));
 }
 
 YOGA_EXPORT void YGNodeCalculateLayout(
@@ -1131,15 +1114,11 @@ YOGA_EXPORT void YGNodeCalculateLayout(
 }
 
 YOGA_EXPORT void YGNodeCalculateLayoutWithContext(
-    const YGNodeRef nodeRef,
+    const YGNodeRef node,
     const float ownerWidth,
     const float ownerHeight,
     const YGDirection ownerDirection,
     void* layoutContext) {
   yoga::calculateLayout(
-      static_cast<Node*>(nodeRef),
-      ownerWidth,
-      ownerHeight,
-      ownerDirection,
-      layoutContext);
+      resolveRef(node), ownerWidth, ownerHeight, ownerDirection, layoutContext);
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -172,8 +172,6 @@ YOGA_EXPORT void YGNodeMarkDirtyAndPropagateToDescendants(
   return resolveRef(node)->markDirtyAndPropagateDownwards();
 }
 
-int32_t gConfigInstanceCount = 0;
-
 YOGA_EXPORT WIN_EXPORT YGNodeRef YGNodeNewWithConfig(const YGConfigRef config) {
   auto* node = new yoga::Node{resolveRef(config)};
   yoga::assertFatal(
@@ -261,23 +259,17 @@ YOGA_EXPORT void YGNodeReset(YGNodeRef node) {
   resolveRef(node)->reset();
 }
 
-YOGA_EXPORT int32_t YGConfigGetInstanceCount(void) {
-  return gConfigInstanceCount;
-}
-
 YOGA_EXPORT YGConfigRef YGConfigNew(void) {
 #ifdef ANDROID
   const YGConfigRef config = new yoga::Config(YGAndroidLog);
 #else
   const YGConfigRef config = new yoga::Config(YGDefaultLog);
 #endif
-  gConfigInstanceCount++;
   return config;
 }
 
 YOGA_EXPORT void YGConfigFree(const YGConfigRef config) {
   delete resolveRef(config);
-  gConfigInstanceCount--;
 }
 
 YOGA_EXPORT void YGNodeSetIsReferenceBaseline(

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -22,15 +22,15 @@ using namespace facebook::yoga;
 
 #ifdef ANDROID
 static int YGAndroidLog(
-    const YGConfigRef config,
-    const YGNodeRef node,
+    const YGConfigConstRef config,
+    const YGNodeConstRef node,
     YGLogLevel level,
     const char* format,
     va_list args);
 #else
 static int YGDefaultLog(
-    const YGConfigRef config,
-    const YGNodeRef node,
+    const YGConfigConstRef config,
+    const YGNodeConstRef node,
     YGLogLevel level,
     const char* format,
     va_list args);
@@ -39,8 +39,8 @@ static int YGDefaultLog(
 #ifdef ANDROID
 #include <android/log.h>
 static int YGAndroidLog(
-    const YGConfigRef /*config*/,
-    const YGNodeRef /*node*/,
+    const YGConfigConstRef /*config*/,
+    const YGNodeConstRef /*node*/,
     YGLogLevel level,
     const char* format,
     va_list args) {
@@ -69,16 +69,12 @@ static int YGAndroidLog(
   return result;
 }
 #else
-#define YG_UNUSED(x) (void) (x);
-
 static int YGDefaultLog(
-    const YGConfigRef config,
-    const YGNodeRef node,
+    const YGConfigConstRef /*config*/,
+    const YGNodeConstRef /*node*/,
     YGLogLevel level,
     const char* format,
     va_list args) {
-  YG_UNUSED(config);
-  YG_UNUSED(node);
   switch (level) {
     case YGLogLevelError:
     case YGLogLevelFatal:
@@ -91,8 +87,6 @@ static int YGDefaultLog(
       return vprintf(format, args);
   }
 }
-
-#undef YG_UNUSED
 #endif
 
 YOGA_EXPORT bool YGFloatIsUndefined(const float value) {
@@ -202,7 +196,7 @@ YOGA_EXPORT YGNodeRef YGNodeNew(void) {
   return YGNodeNewWithConfig(YGConfigGetDefault());
 }
 
-YOGA_EXPORT YGNodeRef YGNodeClone(YGNodeRef oldNodeRef) {
+YOGA_EXPORT YGNodeRef YGNodeClone(YGNodeConstRef oldNodeRef) {
   auto oldNode = resolveRef(oldNodeRef);
   const auto node = new yoga::Node(*oldNode);
   yoga::assertFatalWithConfig(

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -216,8 +216,8 @@ YOGA_EXPORT void YGNodeFree(const YGNodeRef nodeRef) {
     node->setOwner(nullptr);
   }
 
-  const uint32_t childCount = YGNodeGetChildCount(node);
-  for (uint32_t i = 0; i < childCount; i++) {
+  const size_t childCount = node->getChildCount();
+  for (size_t i = 0; i < childCount; i++) {
     auto child = node->getChild(i);
     child->setOwner(nullptr);
   }
@@ -236,8 +236,8 @@ YOGA_EXPORT void YGNodeFreeRecursiveWithCleanupFunc(
     YGNodeCleanupFunc cleanup) {
   const auto root = resolveRef(rootRef);
 
-  uint32_t skipped = 0;
-  while (YGNodeGetChildCount(root) > skipped) {
+  size_t skipped = 0;
+  while (root->getChildCount() > skipped) {
     const auto child = root->getChild(skipped);
     if (child->getOwner() != root) {
       // Don't free shared nodes that we don't own.
@@ -297,7 +297,7 @@ YOGA_EXPORT bool YGNodeIsReferenceBaseline(YGNodeConstRef node) {
 YOGA_EXPORT void YGNodeInsertChild(
     const YGNodeRef ownerRef,
     const YGNodeRef childRef,
-    const uint32_t index) {
+    const size_t index) {
   auto owner = resolveRef(ownerRef);
   auto child = resolveRef(childRef);
 
@@ -319,7 +319,7 @@ YOGA_EXPORT void YGNodeInsertChild(
 YOGA_EXPORT void YGNodeSwapChild(
     const YGNodeRef ownerRef,
     const YGNodeRef childRef,
-    const uint32_t index) {
+    const size_t index) {
   auto owner = resolveRef(ownerRef);
   auto child = resolveRef(childRef);
 
@@ -333,7 +333,7 @@ YOGA_EXPORT void YGNodeRemoveChild(
   auto owner = resolveRef(ownerRef);
   auto excludedChild = resolveRef(excludedChildRef);
 
-  if (YGNodeGetChildCount(owner) == 0) {
+  if (owner->getChildCount() == 0) {
     // This is an empty set. Nothing to remove.
     return;
   }
@@ -354,7 +354,7 @@ YOGA_EXPORT void YGNodeRemoveChild(
 YOGA_EXPORT void YGNodeRemoveAllChildren(const YGNodeRef ownerRef) {
   auto owner = resolveRef(ownerRef);
 
-  const uint32_t childCount = YGNodeGetChildCount(owner);
+  const size_t childCount = owner->getChildCount();
   if (childCount == 0) {
     // This is an empty set already. Nothing to do.
     return;
@@ -363,7 +363,7 @@ YOGA_EXPORT void YGNodeRemoveAllChildren(const YGNodeRef ownerRef) {
   if (firstChild->getOwner() == owner) {
     // If the first child has this node as its owner, we assume that this child
     // set is unique.
-    for (uint32_t i = 0; i < childCount; i++) {
+    for (size_t i = 0; i < childCount; i++) {
       yoga::Node* oldChild = owner->getChild(i);
       oldChild->setLayout({}); // layout is no longer valid
       oldChild->setOwner(nullptr);
@@ -381,7 +381,7 @@ YOGA_EXPORT void YGNodeRemoveAllChildren(const YGNodeRef ownerRef) {
 YOGA_EXPORT void YGNodeSetChildren(
     const YGNodeRef ownerRef,
     const YGNodeRef* childrenRefs,
-    const uint32_t count) {
+    const size_t count) {
   auto owner = resolveRef(ownerRef);
   auto children = reinterpret_cast<yoga::Node* const*>(childrenRefs);
 
@@ -391,7 +391,7 @@ YOGA_EXPORT void YGNodeSetChildren(
 
   const std::vector<yoga::Node*> childrenVector = {children, children + count};
   if (childrenVector.size() == 0) {
-    if (YGNodeGetChildCount(owner) > 0) {
+    if (owner->getChildCount() > 0) {
       for (auto* child : owner->getChildren()) {
         child->setLayout({});
         child->setOwner(nullptr);
@@ -400,7 +400,7 @@ YOGA_EXPORT void YGNodeSetChildren(
       owner->markDirtyAndPropagate();
     }
   } else {
-    if (YGNodeGetChildCount(owner) > 0) {
+    if (owner->getChildCount() > 0) {
       for (auto* oldChild : owner->getChildren()) {
         // Our new children may have nodes in common with the old children. We
         // don't reset these common nodes.
@@ -420,7 +420,7 @@ YOGA_EXPORT void YGNodeSetChildren(
 }
 
 YOGA_EXPORT YGNodeRef
-YGNodeGetChild(const YGNodeRef nodeRef, const uint32_t index) {
+YGNodeGetChild(const YGNodeRef nodeRef, const size_t index) {
   const auto node = resolveRef(nodeRef);
 
   if (index < node->getChildren().size()) {
@@ -429,8 +429,8 @@ YGNodeGetChild(const YGNodeRef nodeRef, const uint32_t index) {
   return nullptr;
 }
 
-YOGA_EXPORT uint32_t YGNodeGetChildCount(const YGNodeConstRef node) {
-  return static_cast<uint32_t>(resolveRef(node)->getChildren().size());
+YOGA_EXPORT size_t YGNodeGetChildCount(const YGNodeConstRef node) {
+  return resolveRef(node)->getChildren().size();
 }
 
 YOGA_EXPORT YGNodeRef YGNodeGetOwner(const YGNodeRef node) {

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -29,28 +29,30 @@ typedef struct YGNode* YGNodeRef;
 typedef const struct YGNode* YGNodeConstRef;
 
 typedef YGSize (*YGMeasureFunc)(
-    YGNodeRef node,
+    YGNodeConstRef node,
     float width,
     YGMeasureMode widthMode,
     float height,
     YGMeasureMode heightMode);
-typedef float (*YGBaselineFunc)(YGNodeRef node, float width, float height);
-typedef void (*YGDirtiedFunc)(YGNodeRef node);
-typedef void (*YGPrintFunc)(YGNodeRef node);
-typedef void (*YGNodeCleanupFunc)(YGNodeRef node);
+typedef float (*YGBaselineFunc)(YGNodeConstRef node, float width, float height);
+typedef void (*YGDirtiedFunc)(YGNodeConstRef node);
+typedef void (*YGPrintFunc)(YGNodeConstRef node);
+typedef void (*YGNodeCleanupFunc)(YGNodeConstRef node);
 typedef int (*YGLogger)(
-    YGConfigRef config,
-    YGNodeRef node,
+    YGConfigConstRef config,
+    YGNodeConstRef node,
     YGLogLevel level,
     const char* format,
     va_list args);
-typedef YGNodeRef (
-    *YGCloneNodeFunc)(YGNodeRef oldNode, YGNodeRef owner, int childIndex);
+typedef YGNodeRef (*YGCloneNodeFunc)(
+    YGNodeConstRef oldNode,
+    YGNodeConstRef owner,
+    int childIndex);
 
 // YGNode
 WIN_EXPORT YGNodeRef YGNodeNew(void);
 WIN_EXPORT YGNodeRef YGNodeNewWithConfig(YGConfigRef config);
-WIN_EXPORT YGNodeRef YGNodeClone(YGNodeRef node);
+WIN_EXPORT YGNodeRef YGNodeClone(YGNodeConstRef node);
 WIN_EXPORT void YGNodeFree(YGNodeRef node);
 WIN_EXPORT void YGNodeFreeRecursiveWithCleanupFunc(
     YGNodeRef node,

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -9,6 +9,7 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include <yoga/YGEnums.h>
@@ -47,7 +48,7 @@ typedef int (*YGLogger)(
 typedef YGNodeRef (*YGCloneNodeFunc)(
     YGNodeConstRef oldNode,
     YGNodeConstRef owner,
-    int childIndex);
+    size_t childIndex);
 
 // YGNode
 WIN_EXPORT YGNodeRef YGNodeNew(void);
@@ -63,23 +64,20 @@ WIN_EXPORT void YGNodeReset(YGNodeRef node);
 WIN_EXPORT void YGNodeInsertChild(
     YGNodeRef node,
     YGNodeRef child,
-    uint32_t index);
+    size_t index);
 
-WIN_EXPORT void YGNodeSwapChild(
-    YGNodeRef node,
-    YGNodeRef child,
-    uint32_t index);
+WIN_EXPORT void YGNodeSwapChild(YGNodeRef node, YGNodeRef child, size_t index);
 
 WIN_EXPORT void YGNodeRemoveChild(YGNodeRef node, YGNodeRef child);
 WIN_EXPORT void YGNodeRemoveAllChildren(YGNodeRef node);
-WIN_EXPORT YGNodeRef YGNodeGetChild(YGNodeRef node, uint32_t index);
+WIN_EXPORT YGNodeRef YGNodeGetChild(YGNodeRef node, size_t index);
 WIN_EXPORT YGNodeRef YGNodeGetOwner(YGNodeRef node);
 WIN_EXPORT YGNodeRef YGNodeGetParent(YGNodeRef node);
-WIN_EXPORT uint32_t YGNodeGetChildCount(YGNodeConstRef node);
+WIN_EXPORT size_t YGNodeGetChildCount(YGNodeConstRef node);
 WIN_EXPORT void YGNodeSetChildren(
     YGNodeRef owner,
     const YGNodeRef* children,
-    uint32_t count);
+    size_t count);
 
 WIN_EXPORT void YGNodeSetIsReferenceBaseline(
     YGNodeRef node,

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -330,7 +330,6 @@ void YGConfigSetUseLegacyStretchBehaviour(
 // YGConfig
 WIN_EXPORT YGConfigRef YGConfigNew(void);
 WIN_EXPORT void YGConfigFree(YGConfigRef config);
-WIN_EXPORT int32_t YGConfigGetInstanceCount(void);
 
 WIN_EXPORT void YGConfigSetExperimentalFeatureEnabled(
     YGConfigRef config,

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -306,27 +306,6 @@ WIN_EXPORT void YGConfigSetPointScaleFactor(
     float pixelsInPoint);
 WIN_EXPORT float YGConfigGetPointScaleFactor(YGConfigConstRef config);
 
-// Yoga previously had an error where containers would take the maximum space
-// possible instead of the minimum like they are supposed to. In practice this
-// resulted in implicit behaviour similar to align-self: stretch; Because this
-// was such a long-standing bug we must allow legacy users to switch back to
-// this behaviour.
-WIN_EXPORT YG_DEPRECATED(
-    "Please use "
-    "\"YGConfigGetErrata()\"") bool YGConfigGetUseLegacyStretchBehaviour(YGConfigConstRef
-                                                                             config);
-WIN_EXPORT
-YG_DEPRECATED(
-    "\"YGConfigSetUseLegacyStretchBehaviour\" will be removed in the next "
-    "release. Usage should be replaced with \"YGConfigSetErrata(YGErrataAll)\" "
-    "to opt out of all future breaking conformance fixes, or "
-    "\"YGConfigSetErrata(YGErrataStretchFlexBasis)\" to opt out of the "
-    "specific conformance fix previously disabled by "
-    "\"UseLegacyStretchBehaviour\".")
-void YGConfigSetUseLegacyStretchBehaviour(
-    YGConfigRef config,
-    bool useLegacyStretchBehaviour);
-
 // YGConfig
 WIN_EXPORT YGConfigRef YGConfigNew(void);
 WIN_EXPORT void YGConfigFree(YGConfigRef config);

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -23,6 +23,7 @@ typedef struct YGSize {
 } YGSize;
 
 typedef struct YGConfig* YGConfigRef;
+typedef const struct YGConfig* YGConfigConstRef;
 
 typedef struct YGNode* YGNodeRef;
 typedef const struct YGNode* YGNodeConstRef;
@@ -82,7 +83,7 @@ WIN_EXPORT void YGNodeSetIsReferenceBaseline(
     YGNodeRef node,
     bool isReferenceBaseline);
 
-WIN_EXPORT bool YGNodeIsReferenceBaseline(YGNodeRef node);
+WIN_EXPORT bool YGNodeIsReferenceBaseline(YGNodeConstRef node);
 
 WIN_EXPORT void YGNodeCalculateLayout(
     YGNodeRef node,
@@ -104,7 +105,7 @@ WIN_EXPORT void YGNodeMarkDirty(YGNodeRef node);
 // `YGCalculateLayout` will cause the recalculation of each and every node.
 WIN_EXPORT void YGNodeMarkDirtyAndPropagateToDescendants(YGNodeRef node);
 
-WIN_EXPORT void YGNodePrint(YGNodeRef node, YGPrintOptions options);
+WIN_EXPORT void YGNodePrint(YGNodeConstRef node, YGPrintOptions options);
 
 WIN_EXPORT bool YGFloatIsUndefined(float value);
 
@@ -125,27 +126,27 @@ WIN_EXPORT bool YGNodeCanUseCachedMeasurement(
     float marginColumn,
     YGConfigRef config);
 
-WIN_EXPORT void YGNodeCopyStyle(YGNodeRef dstNode, YGNodeRef srcNode);
+WIN_EXPORT void YGNodeCopyStyle(YGNodeRef dstNode, YGNodeConstRef srcNode);
 
-WIN_EXPORT void* YGNodeGetContext(YGNodeRef node);
+WIN_EXPORT void* YGNodeGetContext(YGNodeConstRef node);
 WIN_EXPORT void YGNodeSetContext(YGNodeRef node, void* context);
 
 WIN_EXPORT YGConfigRef YGNodeGetConfig(YGNodeRef node);
 WIN_EXPORT void YGNodeSetConfig(YGNodeRef node, YGConfigRef config);
 
 void YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled);
-bool YGNodeHasMeasureFunc(YGNodeRef node);
+bool YGNodeHasMeasureFunc(YGNodeConstRef node);
 WIN_EXPORT void YGNodeSetMeasureFunc(YGNodeRef node, YGMeasureFunc measureFunc);
-bool YGNodeHasBaselineFunc(YGNodeRef node);
+bool YGNodeHasBaselineFunc(YGNodeConstRef node);
 void YGNodeSetBaselineFunc(YGNodeRef node, YGBaselineFunc baselineFunc);
-YGDirtiedFunc YGNodeGetDirtiedFunc(YGNodeRef node);
+YGDirtiedFunc YGNodeGetDirtiedFunc(YGNodeConstRef node);
 void YGNodeSetDirtiedFunc(YGNodeRef node, YGDirtiedFunc dirtiedFunc);
 void YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc);
-WIN_EXPORT bool YGNodeGetHasNewLayout(YGNodeRef node);
+WIN_EXPORT bool YGNodeGetHasNewLayout(YGNodeConstRef node);
 WIN_EXPORT void YGNodeSetHasNewLayout(YGNodeRef node, bool hasNewLayout);
-YGNodeType YGNodeGetNodeType(YGNodeRef node);
+YGNodeType YGNodeGetNodeType(YGNodeConstRef node);
 void YGNodeSetNodeType(YGNodeRef node, YGNodeType nodeType);
-WIN_EXPORT bool YGNodeIsDirty(YGNodeRef node);
+WIN_EXPORT bool YGNodeIsDirty(YGNodeConstRef node);
 
 WIN_EXPORT void YGNodeStyleSetDirection(YGNodeRef node, YGDirection direction);
 WIN_EXPORT YGDirection YGNodeStyleGetDirection(YGNodeConstRef node);
@@ -280,22 +281,22 @@ WIN_EXPORT YGValue YGNodeStyleGetMaxHeight(YGNodeConstRef node);
 WIN_EXPORT void YGNodeStyleSetAspectRatio(YGNodeRef node, float aspectRatio);
 WIN_EXPORT float YGNodeStyleGetAspectRatio(YGNodeConstRef node);
 
-WIN_EXPORT float YGNodeLayoutGetLeft(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetTop(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetRight(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetBottom(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetWidth(YGNodeRef node);
-WIN_EXPORT float YGNodeLayoutGetHeight(YGNodeRef node);
-WIN_EXPORT YGDirection YGNodeLayoutGetDirection(YGNodeRef node);
-WIN_EXPORT bool YGNodeLayoutGetHadOverflow(YGNodeRef node);
+WIN_EXPORT float YGNodeLayoutGetLeft(YGNodeConstRef node);
+WIN_EXPORT float YGNodeLayoutGetTop(YGNodeConstRef node);
+WIN_EXPORT float YGNodeLayoutGetRight(YGNodeConstRef node);
+WIN_EXPORT float YGNodeLayoutGetBottom(YGNodeConstRef node);
+WIN_EXPORT float YGNodeLayoutGetWidth(YGNodeConstRef node);
+WIN_EXPORT float YGNodeLayoutGetHeight(YGNodeConstRef node);
+WIN_EXPORT YGDirection YGNodeLayoutGetDirection(YGNodeConstRef node);
+WIN_EXPORT bool YGNodeLayoutGetHadOverflow(YGNodeConstRef node);
 
 // Get the computed values for these nodes after performing layout. If they were
 // set using point values then the returned value will be the same as
 // YGNodeStyleGetXXX. However if they were set using a percentage value then the
 // returned value is the computed value used during layout.
-WIN_EXPORT float YGNodeLayoutGetMargin(YGNodeRef node, YGEdge edge);
-WIN_EXPORT float YGNodeLayoutGetBorder(YGNodeRef node, YGEdge edge);
-WIN_EXPORT float YGNodeLayoutGetPadding(YGNodeRef node, YGEdge edge);
+WIN_EXPORT float YGNodeLayoutGetMargin(YGNodeConstRef node, YGEdge edge);
+WIN_EXPORT float YGNodeLayoutGetBorder(YGNodeConstRef node, YGEdge edge);
+WIN_EXPORT float YGNodeLayoutGetPadding(YGNodeConstRef node, YGEdge edge);
 
 WIN_EXPORT void YGConfigSetLogger(YGConfigRef config, YGLogger logger);
 // Set this to number of pixels in 1 point to round calculation results If you
@@ -303,7 +304,7 @@ WIN_EXPORT void YGConfigSetLogger(YGConfigRef config, YGLogger logger);
 WIN_EXPORT void YGConfigSetPointScaleFactor(
     YGConfigRef config,
     float pixelsInPoint);
-WIN_EXPORT float YGConfigGetPointScaleFactor(YGConfigRef config);
+WIN_EXPORT float YGConfigGetPointScaleFactor(YGConfigConstRef config);
 
 // Yoga previously had an error where containers would take the maximum space
 // possible instead of the minimum like they are supposed to. In practice this
@@ -312,7 +313,7 @@ WIN_EXPORT float YGConfigGetPointScaleFactor(YGConfigRef config);
 // this behaviour.
 WIN_EXPORT YG_DEPRECATED(
     "Please use "
-    "\"YGConfigGetErrata()\"") bool YGConfigGetUseLegacyStretchBehaviour(YGConfigRef
+    "\"YGConfigGetErrata()\"") bool YGConfigGetUseLegacyStretchBehaviour(YGConfigConstRef
                                                                              config);
 WIN_EXPORT
 YG_DEPRECATED(
@@ -336,26 +337,25 @@ WIN_EXPORT void YGConfigSetExperimentalFeatureEnabled(
     YGExperimentalFeature feature,
     bool enabled);
 WIN_EXPORT bool YGConfigIsExperimentalFeatureEnabled(
-    YGConfigRef config,
+    YGConfigConstRef config,
     YGExperimentalFeature feature);
 
 // Using the web defaults is the preferred configuration for new projects. Usage
 // of non web defaults should be considered as legacy.
 WIN_EXPORT void YGConfigSetUseWebDefaults(YGConfigRef config, bool enabled);
-WIN_EXPORT bool YGConfigGetUseWebDefaults(YGConfigRef config);
+WIN_EXPORT bool YGConfigGetUseWebDefaults(YGConfigConstRef config);
 
 WIN_EXPORT void YGConfigSetCloneNodeFunc(
     YGConfigRef config,
     YGCloneNodeFunc callback);
 
-// Export only for C#
 WIN_EXPORT YGConfigRef YGConfigGetDefault(void);
 
 WIN_EXPORT void YGConfigSetContext(YGConfigRef config, void* context);
-WIN_EXPORT void* YGConfigGetContext(YGConfigRef config);
+WIN_EXPORT void* YGConfigGetContext(YGConfigConstRef config);
 
 WIN_EXPORT void YGConfigSetErrata(YGConfigRef config, YGErrata errata);
-WIN_EXPORT YGErrata YGConfigGetErrata(YGConfigRef config);
+WIN_EXPORT YGErrata YGConfigGetErrata(YGConfigConstRef config);
 
 WIN_EXPORT float YGRoundValueToPixelGrid(
     double value,

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
@@ -34,8 +34,8 @@ float calculateBaseline(const yoga::Node* node, void* layoutContext) {
   }
 
   yoga::Node* baselineChild = nullptr;
-  const uint32_t childCount = YGNodeGetChildCount(node);
-  for (uint32_t i = 0; i < childCount; i++) {
+  const size_t childCount = node->getChildCount();
+  for (size_t i = 0; i < childCount; i++) {
     auto child = node->getChild(i);
     if (child->getLineIndex() > 0) {
       break;

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -965,8 +965,8 @@ static CollectFlexItemsRowValues calculateCollectFlexItemsRowValues(
     const float mainAxisownerSize,
     const float availableInnerWidth,
     const float availableInnerMainDim,
-    const uint32_t startOfLineIndex,
-    const uint32_t lineCount) {
+    const size_t startOfLineIndex,
+    const size_t lineCount) {
   CollectFlexItemsRowValues flexAlgoRowMeasurement = {};
   flexAlgoRowMeasurement.relativeChildren.reserve(node->getChildren().size());
 
@@ -977,7 +977,7 @@ static CollectFlexItemsRowValues calculateCollectFlexItemsRowValues(
   const float gap = node->getGapForAxis(mainAxis, availableInnerWidth).unwrap();
 
   // Add items to the current line until it's full or we run out of items.
-  uint32_t endOfLineIndex = startOfLineIndex;
+  size_t endOfLineIndex = startOfLineIndex;
   for (; endOfLineIndex < node->getChildren().size(); endOfLineIndex++) {
     auto child = node->getChild(endOfLineIndex);
     if (child->getStyle().display() == YGDisplayNone ||
@@ -1408,7 +1408,7 @@ static void resolveFlexibleLength(
 static void YGJustifyMainAxis(
     yoga::Node* const node,
     CollectFlexItemsRowValues& collectedFlexItemsValues,
-    const uint32_t startOfLineIndex,
+    const size_t startOfLineIndex,
     const YGFlexDirection mainAxis,
     const YGFlexDirection crossAxis,
     const YGMeasureMode measureModeMainDim,
@@ -1456,8 +1456,7 @@ static void YGJustifyMainAxis(
   }
 
   int numberOfAutoMarginsOnCurrentLine = 0;
-  for (uint32_t i = startOfLineIndex;
-       i < collectedFlexItemsValues.endOfLineIndex;
+  for (size_t i = startOfLineIndex; i < collectedFlexItemsValues.endOfLineIndex;
        i++) {
     auto child = node->getChild(i);
     if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
@@ -1517,8 +1516,7 @@ static void YGJustifyMainAxis(
   float maxAscentForCurrentLine = 0;
   float maxDescentForCurrentLine = 0;
   bool isNodeBaselineLayout = isBaselineLayout(node);
-  for (uint32_t i = startOfLineIndex;
-       i < collectedFlexItemsValues.endOfLineIndex;
+  for (size_t i = startOfLineIndex; i < collectedFlexItemsValues.endOfLineIndex;
        i++) {
     const auto child = node->getChild(i);
     const Style& childStyle = child->getStyle();
@@ -1906,11 +1904,11 @@ static void calculateLayoutImpl(
   // STEP 4: COLLECT FLEX ITEMS INTO FLEX LINES
 
   // Indexes of children that represent the first and last items in the line.
-  uint32_t startOfLineIndex = 0;
-  uint32_t endOfLineIndex = 0;
+  size_t startOfLineIndex = 0;
+  size_t endOfLineIndex = 0;
 
   // Number of lines.
-  uint32_t lineCount = 0;
+  size_t lineCount = 0;
 
   // Accumulated cross dimensions of all lines so far.
   float totalLineCrossDim = 0;
@@ -2093,7 +2091,7 @@ static void calculateLayoutImpl(
     // STEP 7: CROSS-AXIS ALIGNMENT
     // We can skip child alignment if we're just measuring the container.
     if (performLayout) {
-      for (uint32_t i = startOfLineIndex; i < endOfLineIndex; i++) {
+      for (size_t i = startOfLineIndex; i < endOfLineIndex; i++) {
         const auto child = node->getChild(i);
         if (child->getStyle().display() == YGDisplayNone) {
           continue;
@@ -2291,10 +2289,10 @@ static void calculateLayoutImpl(
           break;
       }
     }
-    uint32_t endIndex = 0;
-    for (uint32_t i = 0; i < lineCount; i++) {
-      const uint32_t startIndex = endIndex;
-      uint32_t ii;
+    size_t endIndex = 0;
+    for (size_t i = 0; i < lineCount; i++) {
+      const size_t startIndex = endIndex;
+      size_t ii;
 
       // compute the line's height and find the endIndex
       float lineHeight = 0;
@@ -2537,7 +2535,7 @@ static void calculateLayoutImpl(
   // As we only wrapped in normal direction yet, we need to reverse the
   // positions on wrap-reverse.
   if (performLayout && node->getStyle().flexWrap() == YGWrapWrapReverse) {
-    for (uint32_t i = 0; i < childCount; i++) {
+    for (size_t i = 0; i < childCount; i++) {
       const auto child = node->getChild(i);
       if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
         child->setLayoutPosition(
@@ -2586,7 +2584,7 @@ static void calculateLayoutImpl(
 
     // Set trailing position if necessary.
     if (needsMainTrailingPos || needsCrossTrailingPos) {
-      for (uint32_t i = 0; i < childCount; i++) {
+      for (size_t i = 0; i < childCount; i++) {
         const auto child = node->getChild(i);
         if (child->getStyle().display() == YGDisplayNone) {
           continue;
@@ -2710,7 +2708,7 @@ bool calculateLayoutInternal(
       cachedResults = &layout->cachedLayout;
     } else {
       // Try to use the measurement cache.
-      for (uint32_t i = 0; i < layout->nextCachedMeasurementsIndex; i++) {
+      for (size_t i = 0; i < layout->nextCachedMeasurementsIndex; i++) {
         if (canUseCachedMeasurement(
                 widthMeasureMode,
                 availableWidth,

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -827,8 +827,10 @@ static void zeroOutLayoutRecursively(
   node->setLayoutDimension(0, YGDimensionHeight);
   node->setHasNewLayout(true);
 
-  node->iterChildrenAfterCloningIfNeeded(
-      zeroOutLayoutRecursively, layoutContext);
+  node->cloneChildrenIfNeeded(layoutContext);
+  for (const auto child : node->getChildren()) {
+    zeroOutLayoutRecursively(child, layoutContext);
+  }
 }
 
 static float calculateAvailableInnerDimension(

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CollectFlexItemsRowValues.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CollectFlexItemsRowValues.h
@@ -39,11 +39,11 @@ namespace facebook::yoga {
 //   and/or grow.
 
 struct CollectFlexItemsRowValues {
-  uint32_t itemsOnLine;
+  size_t itemsOnLine;
   float sizeConsumedOnCurrentLine;
   float totalFlexGrowFactors;
   float totalFlexShrinkScaledFactors;
-  uint32_t endOfLineIndex;
+  size_t endOfLineIndex;
   std::vector<yoga::Node*> relativeChildren;
   float remainingFreeSpace;
   // The size of the mainDim for the row after considering size, padding, margin

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
@@ -125,8 +125,8 @@ void roundLayoutResultsToPixelGrid(
               absoluteNodeTop, pointScaleFactor, false, textRounding),
       YGDimensionHeight);
 
-  const uint32_t childCount = YGNodeGetChildCount(node);
-  for (uint32_t i = 0; i < childCount; i++) {
+  const size_t childCount = node->getChildCount();
+  for (size_t i = 0; i < childCount; i++) {
     roundLayoutResultsToPixelGrid(
         node->getChild(i), pointScaleFactor, absoluteNodeLeft, absoluteNodeTop);
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.cpp
@@ -131,7 +131,7 @@ void Config::setCloneNodeCallback(std::nullptr_t) {
 YGNodeRef Config::cloneNode(
     YGNodeConstRef node,
     YGNodeConstRef owner,
-    int childIndex,
+    size_t childIndex,
     void* cloneContext) const {
   YGNodeRef clone = nullptr;
   if (cloneNodeCallback_.noContext != nullptr) {

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.cpp
@@ -107,23 +107,10 @@ void Config::log(
     void* logContext,
     const char* format,
     va_list args) const {
-  // TODO: Break log callback signatures to make them const correct
-
   if (flags_.loggerUsesContext) {
-    logger_.withContext(
-        const_cast<yoga::Config*>(this),
-        const_cast<yoga::Node*>(node),
-        logLevel,
-        logContext,
-        format,
-        args);
+    logger_.withContext(this, node, logLevel, logContext, format, args);
   } else {
-    logger_.noContext(
-        const_cast<yoga::Config*>(this),
-        const_cast<yoga::Node*>(node),
-        logLevel,
-        format,
-        args);
+    logger_.noContext(this, node, logLevel, format, args);
   }
 }
 
@@ -142,8 +129,8 @@ void Config::setCloneNodeCallback(std::nullptr_t) {
 }
 
 YGNodeRef Config::cloneNode(
-    YGNodeRef node,
-    YGNodeRef owner,
+    YGNodeConstRef node,
+    YGNodeConstRef owner,
     int childIndex,
     void* cloneContext) const {
   YGNodeRef clone = nullptr;

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <yoga/config/Config.h>
+#include <yoga/node/Node.h>
 
 namespace facebook::yoga {
 
@@ -101,15 +102,28 @@ void Config::setLogger(std::nullptr_t) {
 }
 
 void Config::log(
-    YGNodeRef node,
+    const yoga::Node* node,
     YGLogLevel logLevel,
     void* logContext,
     const char* format,
-    va_list args) {
+    va_list args) const {
+  // TODO: Break log callback signatures to make them const correct
+
   if (flags_.loggerUsesContext) {
-    logger_.withContext(this, node, logLevel, logContext, format, args);
+    logger_.withContext(
+        const_cast<yoga::Config*>(this),
+        const_cast<yoga::Node*>(node),
+        logLevel,
+        logContext,
+        format,
+        args);
   } else {
-    logger_.noContext(this, node, logLevel, format, args);
+    logger_.noContext(
+        const_cast<yoga::Config*>(this),
+        const_cast<yoga::Node*>(node),
+        logLevel,
+        format,
+        args);
   }
 }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
@@ -25,15 +25,15 @@ bool configUpdateInvalidatesLayout(Config* a, Config* b);
 // Internal variants of log functions, currently used only by JNI bindings.
 // TODO: Reconcile this with the public API
 using LogWithContextFn = int (*)(
-    YGConfigRef config,
-    YGNodeRef node,
+    YGConfigConstRef config,
+    YGNodeConstRef node,
     YGLogLevel level,
     void* context,
     const char* format,
     va_list args);
 using CloneWithContextFn = YGNodeRef (*)(
-    YGNodeRef node,
-    YGNodeRef owner,
+    YGNodeConstRef node,
+    YGNodeConstRef owner,
     int childIndex,
     void* cloneContext);
 
@@ -90,8 +90,8 @@ public:
   void setCloneNodeCallback(CloneWithContextFn cloneNode);
   void setCloneNodeCallback(std::nullptr_t);
   YGNodeRef cloneNode(
-      YGNodeRef node,
-      YGNodeRef owner,
+      YGNodeConstRef node,
+      YGNodeConstRef owner,
       int childIndex,
       void* cloneContext) const;
 

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
@@ -16,6 +16,7 @@ struct YGConfig {};
 namespace facebook::yoga {
 
 class Config;
+class Node;
 
 // Whether moving a node from config "a" to config "b" should dirty previously
 // calculated layout results.
@@ -78,7 +79,12 @@ public:
   void setLogger(YGLogger logger);
   void setLogger(LogWithContextFn logger);
   void setLogger(std::nullptr_t);
-  void log(YGNodeRef, YGLogLevel, void*, const char*, va_list);
+  void log(
+      const yoga::Node* node,
+      YGLogLevel logLevel,
+      void* logContext,
+      const char* format,
+      va_list args) const;
 
   void setCloneNodeCallback(YGCloneNodeFunc cloneNode);
   void setCloneNodeCallback(CloneWithContextFn cloneNode);
@@ -105,5 +111,13 @@ private:
   float pointScaleFactor_ = 1.0f;
   void* context_ = nullptr;
 };
+
+inline Config* resolveRef(const YGConfigRef ref) {
+  return static_cast<Config*>(ref);
+}
+
+inline const Config* resolveRef(const YGConfigConstRef ref) {
+  return static_cast<const Config*>(ref);
+}
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
@@ -34,7 +34,7 @@ using LogWithContextFn = int (*)(
 using CloneWithContextFn = YGNodeRef (*)(
     YGNodeConstRef node,
     YGNodeConstRef owner,
-    int childIndex,
+    size_t childIndex,
     void* cloneContext);
 
 #pragma pack(push)
@@ -92,7 +92,7 @@ public:
   YGNodeRef cloneNode(
       YGNodeConstRef node,
       YGNodeConstRef owner,
-      int childIndex,
+      size_t childIndex,
       void* cloneContext) const;
 
 private:

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.cpp
@@ -22,43 +22,27 @@ namespace facebook::yoga {
 
 void assertFatal(const bool condition, const char* message) {
   if (!condition) {
-    yoga::log(
-        static_cast<yoga::Node*>(nullptr),
-        YGLogLevelFatal,
-        nullptr,
-        "%s\n",
-        message);
+    yoga::log(YGLogLevelFatal, nullptr, "%s\n", message);
     fatalWithMessage(message);
   }
 }
 
 void assertFatalWithNode(
-    const YGNodeConstRef node,
+    const yoga::Node* const node,
     const bool condition,
     const char* message) {
   if (!condition) {
-    yoga::log(
-        // TODO: Break log callbacks and make them const correct
-        static_cast<yoga::Node*>(const_cast<YGNodeRef>(node)),
-        YGLogLevelFatal,
-        nullptr,
-        "%s\n",
-        message);
+    yoga::log(node, YGLogLevelFatal, nullptr, "%s\n", message);
     fatalWithMessage(message);
   }
 }
 
 void assertFatalWithConfig(
-    YGConfigRef config,
+    const yoga::Config* const config,
     const bool condition,
     const char* message) {
   if (!condition) {
-    yoga::log(
-        static_cast<yoga::Config*>(config),
-        YGLogLevelFatal,
-        nullptr,
-        "%s\n",
-        message);
+    yoga::log(config, YGLogLevelFatal, nullptr, "%s\n", message);
     fatalWithMessage(message);
   }
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.h
@@ -17,11 +17,11 @@ namespace facebook::yoga {
 
 void assertFatal(bool condition, const char* message);
 void assertFatalWithNode(
-    YGNodeConstRef node,
+    const yoga::Node* node,
     bool condition,
     const char* message);
 void assertFatalWithConfig(
-    YGConfigRef config,
+    const yoga::Config* config,
     bool condition,
     const char* message);
 

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/Log.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/Log.cpp
@@ -12,21 +12,28 @@ namespace facebook::yoga {
 namespace {
 
 void vlog(
-    yoga::Config* config,
-    yoga::Node* node,
+    const yoga::Config* config,
+    const yoga::Node* node,
     YGLogLevel level,
     void* context,
     const char* format,
     va_list args) {
-  yoga::Config* logConfig = config != nullptr
-      ? config
-      : static_cast<yoga::Config*>(YGConfigGetDefault());
-  logConfig->log(node, level, context, format, args);
+  const yoga::Config* logConfig =
+      config != nullptr ? config : resolveRef(YGConfigGetDefault());
+
+  logConfig->log(const_cast<yoga::Node*>(node), level, context, format, args);
 }
 } // namespace
 
+void log(YGLogLevel level, void* context, const char* format, ...) noexcept {
+  va_list args;
+  va_start(args, format);
+  vlog(nullptr, nullptr, level, context, format, args);
+  va_end(args);
+}
+
 void log(
-    yoga::Node* node,
+    const yoga::Node* node,
     YGLogLevel level,
     void* context,
     const char* format,
@@ -44,7 +51,7 @@ void log(
 }
 
 void log(
-    yoga::Config* config,
+    const yoga::Config* config,
     YGLogLevel level,
     void* context,
     const char* format,

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/Log.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/Log.h
@@ -13,15 +13,17 @@
 
 namespace facebook::yoga {
 
+void log(YGLogLevel level, void*, const char* format, ...) noexcept;
+
 void log(
-    yoga::Node* node,
+    const yoga::Node* node,
     YGLogLevel level,
     void*,
     const char* message,
     ...) noexcept;
 
 void log(
-    yoga::Config* config,
+    const yoga::Config* config,
     YGLogLevel level,
     void*,
     const char* format,

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -117,7 +117,7 @@ static void appendEdgeIfNotUndefined(
 
 void nodeToString(
     std::string& str,
-    yoga::Node* node,
+    const yoga::Node* node,
     YGPrintOptions options,
     uint32_t level) {
   indent(str, level);

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -227,9 +227,9 @@ void nodeToString(
   }
   appendFormattedString(str, ">");
 
-  const uint32_t childCount = static_cast<uint32_t>(node->getChildren().size());
+  const size_t childCount = node->getChildCount();
   if (options & YGPrintOptionsChildren && childCount > 0) {
-    for (uint32_t i = 0; i < childCount; i++) {
+    for (size_t i = 0; i < childCount; i++) {
       appendFormattedString(str, "\n");
       nodeToString(str, node->getChild(i), options, level + 1);
     }

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.h
@@ -18,7 +18,7 @@ namespace facebook::yoga {
 
 void nodeToString(
     std::string& str,
-    yoga::Node* node,
+    const yoga::Node* node,
     YGPrintOptions options,
     uint32_t level);
 

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -484,7 +484,14 @@ YOGA_EXPORT void Node::clearChildren() {
 // Other Methods
 
 void Node::cloneChildrenIfNeeded(void* cloneContext) {
-  iterChildrenAfterCloningIfNeeded([](Node*, void*) {}, cloneContext);
+  int i = 0;
+  for (Node*& child : children_) {
+    if (child->getOwner() != this) {
+      child = resolveRef(config_->cloneNode(child, this, i, cloneContext));
+      child->setOwner(this);
+    }
+    i += 1;
+  }
 }
 
 void Node::markDirtyAndPropagate() {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -484,7 +484,7 @@ YOGA_EXPORT void Node::clearChildren() {
 // Other Methods
 
 void Node::cloneChildrenIfNeeded(void* cloneContext) {
-  int i = 0;
+  size_t i = 0;
   for (Node*& child : children_) {
     if (child->getOwner() != this) {
       child = resolveRef(config_->cloneNode(child, this, i, cloneContext));

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -11,6 +11,8 @@
 #include <stdio.h>
 #include <vector>
 
+#include <yoga/Yoga.h>
+
 #include <yoga/config/Config.h>
 #include <yoga/node/LayoutResults.h>
 #include <yoga/style/CompactValue.h>
@@ -139,7 +141,7 @@ public:
 
   uint32_t getLineIndex() const { return lineIndex_; }
 
-  bool isReferenceBaseline() { return flags_.isReferenceBaseline; }
+  bool isReferenceBaseline() const { return flags_.isReferenceBaseline; }
 
   // returns the Node that owns this Node. An owner is used to identify
   // the YogaTree that a Node belongs to. This method will return the parent
@@ -151,23 +153,6 @@ public:
   Node* getParent() const { return getOwner(); }
 
   const std::vector<Node*>& getChildren() const { return children_; }
-
-  // Applies a callback to all children, after cloning them if they are not
-  // owned.
-  template <typename T>
-  void iterChildrenAfterCloningIfNeeded(T callback, void* cloneContext) {
-    int i = 0;
-    for (Node*& child : children_) {
-      if (child->getOwner() != this) {
-        child = static_cast<Node*>(
-            config_->cloneNode(child, this, i, cloneContext));
-        child->setOwner(this);
-      }
-      i += 1;
-
-      callback(child, cloneContext);
-    }
-  }
 
   Node* getChild(size_t index) const { return children_.at(index); }
 
@@ -342,5 +327,13 @@ public:
   bool isNodeFlexible();
   void reset();
 };
+
+inline Node* resolveRef(const YGNodeRef ref) {
+  return static_cast<Node*>(ref);
+}
+
+inline const Node* resolveRef(const YGNodeConstRef ref) {
+  return static_cast<const Node*>(ref);
+}
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -38,10 +38,17 @@ struct NodeFlags {
 
 class YOGA_EXPORT Node : public ::YGNode {
 public:
-  using MeasureWithContextFn =
-      YGSize (*)(YGNode*, float, YGMeasureMode, float, YGMeasureMode, void*);
-  using BaselineWithContextFn = float (*)(YGNode*, float, float, void*);
-  using PrintWithContextFn = void (*)(YGNode*, void*);
+  // Internal variants of callbacks, currently used only by JNI bindings.
+  // TODO: Reconcile this with the public API
+  using MeasureWithContextFn = YGSize (*)(
+      YGNodeConstRef,
+      float,
+      YGMeasureMode,
+      float,
+      YGMeasureMode,
+      void*);
+  using BaselineWithContextFn = float (*)(YGNodeConstRef, float, float, void*);
+  using PrintWithContextFn = void (*)(YGNodeConstRef, void*);
 
 private:
   void* context_ = nullptr;

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -68,7 +68,7 @@ private:
   YGDirtiedFunc dirtied_ = nullptr;
   Style style_ = {};
   LayoutResults layout_ = {};
-  uint32_t lineIndex_ = 0;
+  size_t lineIndex_ = 0;
   Node* owner_ = nullptr;
   std::vector<Node*> children_ = {};
   Config* config_;
@@ -146,7 +146,7 @@ public:
 
   const LayoutResults& getLayout() const { return layout_; }
 
-  uint32_t getLineIndex() const { return lineIndex_; }
+  size_t getLineIndex() const { return lineIndex_; }
 
   bool isReferenceBaseline() const { return flags_.isReferenceBaseline; }
 
@@ -276,7 +276,7 @@ public:
 
   void setLayout(const LayoutResults& layout) { layout_ = layout; }
 
-  void setLineIndex(uint32_t lineIndex) { lineIndex_ = lineIndex; }
+  void setLineIndex(size_t lineIndex) { lineIndex_ = lineIndex; }
 
   void setIsReferenceBaseline(bool isReferenceBaseline) {
     flags_.isReferenceBaseline = isReferenceBaseline;


### PR DESCRIPTION
Summary: These were marked as deprecated as part of the public Yoga 2.0 release, and were alredy emitting deprecation warnings. Remove them.

Differential Revision: D49131250

