### PR TITLE
Create helper to enforce the New Arch enabled for double released

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -181,6 +181,91 @@ class NewArchitectureTests < Test::Unit::TestCase
             ]
         )
     end
+
+    # ========================== #
+    # Test - Is New Arch Enabled #
+    # ========================== #
+
+    def test_isNewArchEnabled_whenOnMainAndFlagTrue_returnTrue
+        version = '1000.0.0'
+        new_arch_enabled = true
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOnMainAndFlagFalse_returnFalse
+        version = '1000.0.0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("0", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOnStableAndFlagTrue_returnTrue
+        version = '0.73.0'
+        new_arch_enabled = true
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOnStableAndFlagFalse_returnFalse
+        version = '0.73.0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("0", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOn100AndFlagTrue_returnTrue
+        version = '1.0.0-prealpha.0'
+        new_arch_enabled = true
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOn100PrealphaWithDotsAndFlagFalse_returnTrue
+        version = '1.0.0-prealpha.0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOn100PrealphaWithDashAndFlagFalse_returnTrue
+        version = '1.0.0-prealpha-0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOn100PrealphaOnlyWordsAndFlagFalse_returnTrue
+        version = '1.0.0-prealpha0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOnGreaterThan100AndFlagFalse_returnTrue
+        version = '3.2.1'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
 end
 
 # ================ #

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -158,4 +158,27 @@ class NewArchitectureHelper
     def self.folly_compiler_flags
         return @@folly_compiler_flags
     end
+
+    def self.is_new_arch_enabled(new_arch_enabled, react_native_version)
+        # Regex that identify a version with the syntax `<major>.<minor>.<patch>[-<prerelease>[.-]k]
+        # where
+        # - major is a number
+        # - minor is a number
+        # - patch is a number
+        # - prerelease is a string (can include numbers)
+        # - k is a number
+        version_regex = /^(\d+)\.(\d+)\.(\d+)(?:-(\w+(?:[-.]\d+)?))?$/
+
+        if match_data = react_native_version.match(version_regex)
+
+            major = match_data[1].to_i
+
+            # We want to enforce the new architecture for 1.0.0 and greater,
+            # but not for 1000 as version 1000 is currently main.
+            if major > 0 && major < 1000
+                return "1"
+            end
+        end
+        return new_arch_enabled ? "1" : "0"
+    end
 end


### PR DESCRIPTION
Summary:
This change creates an helper function and tests to set the right value for the new arch enabled flag based on the react native version

## Changelog:
[iOS][Added] - add helper to set New Arch enabled flag based on RN version.

Differential Revision: D49145515


