### PR TITLE
Deprecate default_flags in Podfile

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -181,6 +181,91 @@ class NewArchitectureTests < Test::Unit::TestCase
             ]
         )
     end
+
+    # ========================== #
+    # Test - Is New Arch Enabled #
+    # ========================== #
+
+    def test_isNewArchEnabled_whenOnMainAndFlagTrue_returnTrue
+        version = '1000.0.0'
+        new_arch_enabled = true
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOnMainAndFlagFalse_returnFalse
+        version = '1000.0.0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("0", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOnStableAndFlagTrue_returnTrue
+        version = '0.73.0'
+        new_arch_enabled = true
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOnStableAndFlagFalse_returnFalse
+        version = '0.73.0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("0", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOn100AndFlagTrue_returnTrue
+        version = '1.0.0-prealpha.0'
+        new_arch_enabled = true
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOn100PrealphaWithDotsAndFlagFalse_returnTrue
+        version = '1.0.0-prealpha.0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOn100PrealphaWithDashAndFlagFalse_returnTrue
+        version = '1.0.0-prealpha-0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOn100PrealphaOnlyWordsAndFlagFalse_returnTrue
+        version = '1.0.0-prealpha0'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
+
+    def test_isNewArchEnabled_whenOnGreaterThan100AndFlagFalse_returnTrue
+        version = '3.2.1'
+        new_arch_enabled = false
+
+        isEnabled = NewArchitectureHelper.is_new_arch_enabled(new_arch_enabled, version)
+
+        assert_equal("1", isEnabled)
+    end
 end
 
 # ================ #

--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -8,10 +8,12 @@ require_relative "../new_architecture.rb"
 require_relative "./test_utils/InstallerMock.rb"
 require_relative "./test_utils/PodMock.rb"
 require_relative "./test_utils/SpecMock.rb"
+require_relative "./test_utils/FileMock.rb"
 
 class NewArchitectureTests < Test::Unit::TestCase
     def teardown
         Pod::UI.reset()
+        FileMock.reset()
     end
 
     # ============================= #
@@ -266,6 +268,34 @@ class NewArchitectureTests < Test::Unit::TestCase
 
         assert_equal("1", isEnabled)
     end
+
+    # =================================== #
+    # Test - Extract React Native Version #
+    # =================================== #
+    def test_extractReactNativeVersion_whenFileDoesNotExists_raiseError()
+        react_native_path = './node_modules/react-native/'
+
+        exception = assert_raise(RuntimeError) do
+            NewArchitectureHelper.extract_react_native_version(react_native_path, :file_manager => FileMock)
+        end
+
+        assert_equal("Couldn't find the React Native package.json file at ./node_modules/react-native/package.json", exception.message)
+    end
+
+    def test_extractReactNativeVersion_whenFileExists_returnTheRightVersion()
+        react_native_path = "./node_modules/react-native/"
+        full_path = File.join(react_native_path, "package.json")
+        json = "{\"version\": \"1.0.0-prealpha.0\"}"
+        FileMock.mocked_existing_files([full_path])
+        FileMock.files_to_read({
+            full_path => json
+        })
+
+        version = NewArchitectureHelper.extract_react_native_version(react_native_path, :file_manager => FileMock)
+
+        assert_equal("1.0.0-prealpha.0", version)
+    end
+
 end
 
 # ================ #

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -158,4 +158,27 @@ class NewArchitectureHelper
     def self.folly_compiler_flags
         return @@folly_compiler_flags
     end
+
+    def self.is_new_arch_enabled(new_arch_enabled, react_native_version)
+        # Regex that identify a version with the syntax `<major>.<minor>.<patch>[-<prerelease>[.-]k]
+        # where
+        # - major is a number
+        # - minor is a number
+        # - patch is a number
+        # - prerelease is a string (can include numbers)
+        # - k is a number
+        version_regex = /^(\d+)\.(\d+)\.(\d+)(?:-(\w+(?:[-.]\d+)?))?$/
+
+        if match_data = react_native_version.match(version_regex)
+
+            major = match_data[1].to_i
+
+            # We want to enforce the new architecture for 1.0.0 and greater,
+            # but not for 1000 as version 1000 is currently main.
+            if major > 0 && major < 1000
+                return "1"
+            end
+        end
+        return new_arch_enabled ? "1" : "0"
+    end
 end

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+require 'json'
+
 class NewArchitectureHelper
     @@shared_flags = "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
 
@@ -157,6 +159,15 @@ class NewArchitectureHelper
 
     def self.folly_compiler_flags
         return @@folly_compiler_flags
+    end
+
+    def self.extract_react_native_version(react_native_path, file_manager: File, json_parser: JSON)
+        package_json_file = File.join(react_native_path, "package.json")
+        if !file_manager.exist?(package_json_file)
+            raise "Couldn't find the React Native package.json file at #{package_json_file}"
+        end
+        package = json_parser.parse(file_manager.read(package_json_file))
+        return package["version"]
     end
 
     def self.is_new_arch_enabled(new_arch_enabled, react_native_version)

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -16,6 +16,9 @@ class ReactNativePodsUtils
         end
     end
 
+    # deprecated. These checks are duplicated in the react_native_pods function
+    # and we don't really need them. Removing this function will make it easy to
+    # move forward.
     def self.get_default_flags
         flags = {
             :fabric_enabled => false,

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -217,7 +217,10 @@ def install_modules_dependencies(spec, new_arch_enabled: ENV['RCT_NEW_ARCH_ENABL
 end
 
 # It returns the default flags.
+# deprecated.
 def get_default_flags()
+  warn 'get_default_flags is deprecated. Please remove the keys from the `use_react_native!` function'
+  warn 'if you are using the default already and pass the value you need in case you don\'t want the default'
   return ReactNativePodsUtils.get_default_flags()
 end
 

--- a/packages/react-native/template/ios/Podfile
+++ b/packages/react-native/template/ios/Podfile
@@ -28,14 +28,8 @@ end
 target 'HelloWorld' do
   config = use_native_modules!
 
-  # Flags change depending on the env values.
-  flags = get_default_flags()
-
   use_react_native!(
     :path => config[:reactNativePath],
-    # Hermes is now enabled by default. Disable by setting this flag to false.
-    :hermes_enabled => flags[:hermes_enabled],
-    :fabric_enabled => flags[:fabric_enabled],
     # Enables Flipper.
     #
     # Note that if you have use_frameworks! enabled, Flipper will not work and


### PR DESCRIPTION
Summary:
The Podfile of the Template is using a function called `get_default_flags` to get the default flags.
Its behavior is duplicated in both the default value of the `use_react_native!` function and in the body of the same function, making that helper actually redundant.

In this change, we are deprecating it so we can remove it in 0.74 with no breakages.

## Changelog:
[iOS][Deprecated] - Deprecate `get_default_flags` in Ruby scripts

Differential Revision: D49147290

