### PR TITLE
Bump AGP to 8.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,6 @@ org.gradle.caching=true
 
 android.useAndroidX=true
 
-# Can be removed once we bump to AGP 8.2.0
-android.suppressUnsupportedCompileSdk=34
-
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64

--- a/packages/react-native-gradle-plugin/gradle/libs.versions.toml
+++ b/packages/react-native-gradle-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.1.0"
+agp = "8.1.1"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ targetSdk = "34"
 compileSdk = "34"
 buildTools = "34.0.0"
 # Dependencies versions
-agp = "8.1.0"
+agp = "8.1.1"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.6.1"
 androidx-autofill = "1.1.0"


### PR DESCRIPTION
Summary:
This fixes a warning that would fire for all the users on 0.73 and is not actionable in any form: https://issuetracker.google.com/issues/295235385

Changelog:
[Internal] [Changed] - Bump AGP to 8.1.1

Differential Revision: D49155866


