### PR TITLE
RN: Use a Private Property in `EventEmitter`

### DIFF
--- a/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
+++ b/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
@@ -63,7 +63,7 @@ type Registry<TEventToArgsMap: {...}> = $ObjMap<
 export default class EventEmitter<TEventToArgsMap: {...}>
   implements IEventEmitter<TEventToArgsMap>
 {
-  _registry: Registry<TEventToArgsMap> = {};
+  #registry: Registry<TEventToArgsMap> = {};
 
   /**
    * Registers a listener that is called when the supplied event is emitted.
@@ -83,7 +83,7 @@ export default class EventEmitter<TEventToArgsMap: {...}>
       TEventToArgsMap,
       TEvent,
       TEventToArgsMap[TEvent],
-    >(this._registry, eventType);
+    >(this.#registry, eventType);
     const registration: Registration<TEventToArgsMap[TEvent]> = {
       context,
       listener,
@@ -107,7 +107,7 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     ...args: TEventToArgsMap[TEvent]
   ): void {
     const registrations: ?Set<Registration<TEventToArgsMap[TEvent]>> =
-      this._registry[eventType];
+      this.#registry[eventType];
     if (registrations != null) {
       for (const registration of [...registrations]) {
         registration.listener.apply(registration.context, args);
@@ -122,9 +122,9 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     eventType?: ?TEvent,
   ): void {
     if (eventType == null) {
-      this._registry = {};
+      this.#registry = {};
     } else {
-      delete this._registry[eventType];
+      delete this.#registry[eventType];
     }
   }
 
@@ -132,7 +132,7 @@ export default class EventEmitter<TEventToArgsMap: {...}>
    * Returns the number of registered listeners for the supplied event.
    */
   listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number {
-    const registrations: ?Set<Registration<mixed>> = this._registry[eventType];
+    const registrations: ?Set<Registration<mixed>> = this.#registry[eventType];
     return registrations == null ? 0 : registrations.size;
   }
 }


### PR DESCRIPTION
Summary:
Switches `EventEmitter` to use a private property.

Support for private properties was [only recently added](https://github.com/facebook/react-native/pull/39318), so this will be the first end-to-end validation of support in the `facebook/react-native` project.

Changelog:
[Internal]

Differential Revision: D49167908


