### PR TITLE
disable test_e2e_android job

### DIFF
--- a/.circleci/configurations/test_workflows/testE2E.yml
+++ b/.circleci/configurations/test_workflows/testE2E.yml
@@ -6,4 +6,5 @@
     jobs:
       - test_e2e_ios:
           ruby_version: "2.7.7"
-      - test_e2e_android
+      # This is not stable
+      # - test_e2e_android

--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -132,8 +132,9 @@ async function handleStatuses() {
     const data = await response.json();
     const e2e_jobs = data.filter(job => {
       return (
-        job.context === 'ci/circleci: test_e2e_ios' ||
-        job.context === 'ci/circleci: test_e2e_android'
+        job.context === 'ci/circleci: test_e2e_ios'
+        // test_e2e_android does not currently tun
+        // || job.context === 'ci/circleci: test_e2e_android'
       );
     });
     if (e2e_jobs.length <= 0) {


### PR DESCRIPTION
Summary:
Even after making these never report command failures, and allowing no output for thirty minutes, there are still failures here (though less) which cause lands to be aborted, especially for stacks with multiple diffs (it has prevented a recent stack of mine from landing after multiple attempts).

```
yarn run v1.22.19
$ node ./../../scripts/e2e/run-e2e-tests.js android
`isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`
    at isModuleDeclaration (/home/circleci/project/node_modules/babel/types/lib/validators/generated/index.js:3940:35)
    at NodePath.<computed> [as isModuleDeclaration] (/home/circleci/project/node_modules/babel/traverse/lib/path/index.js:181:12)
/bin/bash: line 2: 14063 Hangup                  yarn test-e2e android 2>&1
     14064 Done                    | tee /tmp/test_log

Too long with no output (exceeded 30m0s): context deadline exceeded
```

We are not able to detect regressions from tests while they are configured to suppress all failures, and they are still causing issues (though less), so this disables them at the job level until improvements can be made.

Differential Revision: D49175533


