### PR TITLE
Unblock `yarn android` on main

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "react-native start",
-    "android": "react-native run-android --mode HermesDebug --appId 'com.facebook.react.uiapp' --main-activity 'com.facebook.react.uiapp.RNTesterActivity'",
+    "android": "react-native run-android --mode HermesDebug",
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
     "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
     "clean-android": "rm -rf android/app/build",

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -26,6 +26,10 @@ module.exports = {
     },
     android: {
       sourceDir: '../../',
+      // To remove once the CLI fix for manifestPath search path is landed.
+      manifestPath:
+        'packages/rn-tester/android/app/src/main/AndroidManifest.xml',
+      packageName: 'com.facebook.react.uiapp',
     },
   },
 };


### PR DESCRIPTION
Summary:
`yarn android` on main is currently broken due to the CLI attempting to search for the manifest inside the src/androidTest folder.
This fixes it by specifying the exact path of the Android Manifest.
The fix to the CLI is also pending to prevent the CLI from searching inside test folders.

Fix for the CLI is here:
- https://github.com/react-native-community/cli/pull/2075

Changelog:
[Internal] [Changed] - Unblock `yarn android` on main

Differential Revision: D49190626

