### PR TITLE
Add simple constructor for JSError

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -450,6 +450,12 @@ JSError::JSError(std::string what, Runtime& rt, Value&& value)
   setValue(rt, std::move(value));
 }
 
+JSError::JSError(Value&& value, std::string message, std::string stack)
+    : JSIException(message + "\n\n" + stack),
+      value_(std::make_shared<Value>(std::move(value))),
+      message_(std::move(message)),
+      stack_(std::move(stack)) {}
+
 void JSError::setValue(Runtime& rt, Value&& value) {
   value_ = std::make_shared<Value>(std::move(value));
 

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -1468,6 +1468,11 @@ class JSI_EXPORT JSError : public JSIException {
   /// but necessary to avoid ambiguity with the above.
   JSError(std::string what, Runtime& rt, Value&& value);
 
+  /// Creates a JSError referring to the provided value, message and stack. This
+  /// constructor does not take a Runtime parameter, and therefore cannot result
+  /// in recursively invoking the JSError constructor.
+  JSError(Value&& value, std::string message, std::string stack);
+
   JSError(const JSError&) = default;
 
   virtual ~JSError();


### PR DESCRIPTION
Summary:
Add a simple constructor for `JSError` which does not accept a
`jsi::Runtime` and cannot call back into JSI. This guarantees that the
constructor cannot recursively invoke itself, leading to stack
overflows.

Changelog: [Internal]

Differential Revision: D48796703

