### PR TITLE
cleanup warnOnLegacyNativeModuleSystemUse

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -140,10 +140,6 @@ public class CatalystInstanceImpl implements CatalystInstance {
     FLog.d(ReactConstants.TAG, "Initializing React Xplat Bridge before initializeBridge");
     Systrace.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "initializeCxxBridge");
 
-    if (ReactFeatureFlags.warnOnLegacyNativeModuleSystemUse) {
-      warnOnLegacyNativeModuleSystemUse();
-    }
-
     initializeBridge(
         new BridgeCallback(this),
         jsExecutor,
@@ -210,8 +206,6 @@ public class CatalystInstanceImpl implements CatalystInstance {
 
   private native void jniExtendNativeModules(
       Collection<JavaModuleWrapper> javaModules, Collection<ModuleHolder> cxxModules);
-
-  private native void warnOnLegacyNativeModuleSystemUse();
 
   private native void initializeBridge(
       ReactCallback callback,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -15,7 +15,6 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
 import androidx.annotation.Nullable;
 import com.facebook.proguard.annotations.DoNotStrip;
-import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
@@ -116,17 +115,6 @@ class JavaModuleWrapper {
 
   @DoNotStrip
   public @Nullable NativeMap getConstants() {
-    if (ReactFeatureFlags.warnOnLegacyNativeModuleSystemUse) {
-      ReactSoftExceptionLogger.logSoftException(
-          TAG,
-          new ReactNoCrashSoftException(
-              "Calling getConstants() on Java NativeModule (name = \""
-                  + mModuleHolder.getName()
-                  + "\", className = "
-                  + mModuleHolder.getClassName()
-                  + ")."));
-    }
-
     if (!mModuleHolder.getHasConstants()) {
       return null;
     }
@@ -158,32 +146,8 @@ class JavaModuleWrapper {
 
   @DoNotStrip
   public void invoke(int methodId, ReadableNativeArray parameters) {
-    if (ReactFeatureFlags.warnOnLegacyNativeModuleSystemUse) {
-      ReactSoftExceptionLogger.logSoftException(
-          TAG,
-          new ReactNoCrashSoftException(
-              "Calling method on Java NativeModule (name = \""
-                  + mModuleHolder.getName()
-                  + "\", className = "
-                  + mModuleHolder.getClassName()
-                  + ")."));
-    }
-
     if (mMethods == null || methodId >= mMethods.size()) {
       return;
-    }
-
-    if (ReactFeatureFlags.warnOnLegacyNativeModuleSystemUse) {
-      ReactSoftExceptionLogger.logSoftException(
-          TAG,
-          new ReactNoCrashSoftException(
-              "Calling "
-                  + mDescs.get(methodId).name
-                  + "() on Java NativeModule (name = \""
-                  + mModuleHolder.getName()
-                  + "\", className = "
-                  + mModuleHolder.getClassName()
-                  + ")."));
     }
 
     mMethods.get(methodId).invoke(mJSInstance, parameters);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
@@ -8,7 +8,6 @@
 package com.facebook.react.bridge;
 
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.systrace.Systrace;
 import java.util.ArrayList;
@@ -42,17 +41,6 @@ public class NativeModuleRegistry {
     ArrayList<JavaModuleWrapper> javaModules = new ArrayList<>();
     for (Map.Entry<String, ModuleHolder> entry : mModules.entrySet()) {
       if (!entry.getValue().isCxxModule()) {
-        if (ReactFeatureFlags.warnOnLegacyNativeModuleSystemUse) {
-          ReactSoftExceptionLogger.logSoftException(
-              TAG,
-              new ReactNoCrashSoftException(
-                  "Registering legacy NativeModule: Java NativeModule (name = \""
-                      + entry.getValue().getName()
-                      + "\", className = "
-                      + entry.getValue().getClassName()
-                      + ")."));
-        }
-
         javaModules.add(new JavaModuleWrapper(jsInstance, entry.getValue()));
       }
     }
@@ -63,16 +51,6 @@ public class NativeModuleRegistry {
     ArrayList<ModuleHolder> cxxModules = new ArrayList<>();
     for (Map.Entry<String, ModuleHolder> entry : mModules.entrySet()) {
       if (entry.getValue().isCxxModule()) {
-        if (ReactFeatureFlags.warnOnLegacyNativeModuleSystemUse) {
-          ReactSoftExceptionLogger.logSoftException(
-              TAG,
-              new ReactNoCrashSoftException(
-                  "Registering legacy NativeModule: Cxx NativeModule (name = \""
-                      + entry.getValue().getName()
-                      + "\", className = "
-                      + entry.getValue().getClassName()
-                      + ")."));
-        }
         cxxModules.add(entry.getValue());
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -74,13 +74,6 @@ public class ReactFeatureFlags {
   /** Does the bridgeless architecture use the new create/reload/destroy routines */
   public static volatile boolean enableBridgelessArchitectureNewCreateReloadDestroy = false;
 
-  /**
-   * After TurboModules and Fabric are enabled, we need to ensure that the legacy NativeModule isn't
-   * isn't used. So, turn this flag on to trigger warnings whenever the legacy NativeModule system
-   * is used.
-   */
-  public static volatile boolean warnOnLegacyNativeModuleSystemUse = false;
-
   /** This feature flag enables logs for Fabric */
   public static boolean enableFabricLogs = false;
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -99,10 +99,6 @@ CatalystInstanceImpl::initHybrid(jni::alias_ref<jclass>) {
 CatalystInstanceImpl::CatalystInstanceImpl()
     : instance_(std::make_unique<Instance>()) {}
 
-void CatalystInstanceImpl::warnOnLegacyNativeModuleSystemUse() {
-  CxxNativeModule::setShouldWarnOnUse(true);
-}
-
 void CatalystInstanceImpl::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", CatalystInstanceImpl::initHybrid),
@@ -140,9 +136,6 @@ void CatalystInstanceImpl::registerNatives() {
           "getRuntimeExecutor", CatalystInstanceImpl::getRuntimeExecutor),
       makeNativeMethod(
           "getRuntimeScheduler", CatalystInstanceImpl::getRuntimeScheduler),
-      makeNativeMethod(
-          "warnOnLegacyNativeModuleSystemUse",
-          CatalystInstanceImpl::warnOnLegacyNativeModuleSystemUse),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
@@ -62,10 +62,6 @@ class CatalystInstanceImpl : public jni::HybridClass<CatalystInstanceImpl> {
       jni::alias_ref<jni::JCollection<ModuleHolder::javaobject>::javaobject>
           cxxModules);
 
-  // When called from CatalystInstanceImpl.java, warnings will be logged when
-  // CxxNativeModules are used. Java NativeModule usages log error in Java.
-  void warnOnLegacyNativeModuleSystemUse();
-
   void extendNativeModules(
       jni::alias_ref<jni::JCollection<
           JavaModuleWrapper::javaobject>::javaobject> javaModules,


### PR DESCRIPTION
Summary:
## Changelog
[Android][Breaking] - Deleting warnOnLegacyNativeModuleSystemUse

this has not fired in over a year, we should clean it up. there's an argument we want to keep this for consumers that are in the middle of upgrading, but personally i think that this needs to be built into the interop layer - currently we can only configure this in Fb specific infra.

Differential Revision: D49209540

