### PR TITLE
Fix race condition in Binding::reportMount

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -98,7 +98,7 @@ void Binding::driveCxxAnimations() {
 }
 
 void Binding::reportMount(SurfaceId surfaceId) {
-  const auto& scheduler = getScheduler();
+  auto scheduler = getScheduler();
   if (!scheduler) {
     LOG(ERROR) << "Binding::reportMount: scheduler disappeared";
     return;


### PR DESCRIPTION
Summary:
changelog: [internal]

The intent of the code is to retain shared_ptr<Scheduler> but by using a reference, it didn't do that. Leading to a race condition.

bypass-github-export-checks

Reviewed By: rubennorte

Differential Revision: D49227147


