### PR TITLE
Fix Codegen build script on EdenFS

### DIFF
--- a/packages/react-native-codegen/scripts/oss/build.sh
+++ b/packages/react-native-codegen/scripts/oss/build.sh
@@ -46,7 +46,7 @@ else
   if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
     tar cf - --exclude='*.lock' "$CODEGEN_DIR" | (cd "$TMP_DIR" && tar xvf - );
   else
-    cp -R "$CODEGEN_DIR/." "$TMP_DIR";
+    cp -R -X "$CODEGEN_DIR/." "$TMP_DIR";
   fi
 
   pushd "$TMP_DIR" >/dev/null
@@ -56,6 +56,7 @@ else
 
   popd >/dev/null
 
-  mv "$TMP_DIR/lib" "$TMP_DIR/node_modules" "$CODEGEN_DIR"
+  cp -R -X "$TMP_DIR/lib" "$CODEGEN_DIR"
+  cp -R -X "$TMP_DIR/node_modules" "$CODEGEN_DIR"
   rm -rf "$TMP_DIR"
 fi


### PR DESCRIPTION
Summary:
Fixes running the `build.sh` script for `react-native-codegen` when on [EdenFS](https://github.com/facebook/sapling). This would previously fail due a filesystem "unable to copy extended attributes" error.

NOTE: The change from `mv` to `cp -R` makes this script more expensive, which will make Android builds via Gradle take slightly longer. I have a WIP cleanup planned which will 1/ move `react-native-codegen` to the [shared monorepo build setup](https://github.com/facebook/react-native/pull/38718), and 2/ drop this step entirely from the Android Gradle build.

Differential Revision: D49230445


