### PR TITLE
Prevent Babel registration from transforming plugins with arbitrary config

### DIFF
--- a/scripts/build/babel-register.js
+++ b/scripts/build/babel-register.js
@@ -44,11 +44,16 @@ function registerForMonorepo() {
 function registerPackage(packageName /*: string */) {
   const packageDir = path.join(PACKAGES_DIR, packageName);
 
-  require('@babel/register')({
+  // Prepare the config object before calling `require('@babel/register')` to
+  // prevent `require` calls within `getBabelConfig` triggering Babel to
+  // attempt to load its config from a babel.config file.
+  const registerConfig = {
     ...getBabelConfig(packageName),
     root: packageDir,
     ignore: [/\/node_modules\//],
-  });
+  };
+
+  require('@babel/register')(registerConfig);
 }
 
 module.exports = {registerForMonorepo};


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/metro/pull/1082

Using `require` after `const registerFn = require('babel/register')` but before `registerFn(config)` causes Babel to transform required code with the default configuration (ie, using a nearby `babel.config.js`, if available).

This was causing the Babel plugins loaded by `metro-babel-register` to be (unnecessarily) transformed according to `babel.config.js`, which actually fails if the plugins/presets referenced in `babel.config.js` themselves require transformation.

This ensures no code is loaded in between registering Babel as a side effect of requiring Babel register, and replacing that hook with something explicitly configured.

## React Native
Changelog: [Internal]

## Metro
```
* **[Fix]:** `metro-babel-register` prevent arbitrary transformation of Babel plugins during registration setup
```

Differential Revision: D49238671


