### PR TITLE
filter yoga props 2/x - filter out yoga props at creation of YogaStylableProps

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -159,4 +159,7 @@ public class ReactFeatureFlags {
 
   /** When enabled, Fabric will avoid cloning notes to perform state progression. */
   public static boolean enableClonelessStateProgression = false;
+
+  /** When enabled, rawProps in Props will not include Yoga specific props. */
+  public static boolean excludeYogaFromRawProps = false;
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -438,6 +438,8 @@ void Binding::installFabricUIManager(
       getFeatureFlagValue("enableDefaultAsyncBatchedPriority");
   CoreFeatures::enableClonelessStateProgression =
       getFeatureFlagValue("enableClonelessStateProgression");
+  CoreFeatures::excludeYogaFromRawProps =
+      getFeatureFlagValue("excludeYogaFromRawProps");
 
   // RemoveDelete mega-op
   ShadowViewMutation::PlatformSupportsRemoveDeleteTreeInstruction =

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -13,22 +13,140 @@
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
 #include <react/utils/CoreFeatures.h>
 #include <yoga/Yoga.h>
+#include <unordered_set>
 
 #include "conversions.h"
 
 namespace facebook::react {
 
+namespace {
+inline RawProps filterYogaProps(const RawProps& rawProps) {
+  const static std::unordered_set<std::string> yogaStylePropNames = {
+      {"direction",
+       "flexDirection",
+       "justifyContent",
+       "alignContent",
+       "alignItems",
+       "alignSelf",
+       "position",
+       "flexWrap",
+       "display",
+       "flex",
+       "flexGrow",
+       "flexShrink",
+       "flexBasis",
+       "margin",
+       "padding",
+       "rowGap",
+       "columnGap",
+       "gap",
+       // TODO: T163711275 also filter out width/height when SVG no longer read
+       // them from RawProps
+       "minWidth",
+       "maxWidth",
+       "minHeight",
+       "maxHeight",
+       "aspectRatio",
+
+       // edges
+       "left",
+       "right",
+       "top",
+       "bottom",
+       "start",
+       "end",
+
+       // variants of inset
+       "inset",
+       "insetStart",
+       "insetEnd",
+       "insetInline",
+       "insetInlineStart",
+       "insetInlineEnd",
+       "insetBlock",
+       "insetBlockEnd",
+       "insetBlockStart",
+       "insetVertical",
+       "insetHorizontal",
+       "insetTop",
+       "insetBottom",
+       "insetLeft",
+       "insetRight",
+
+       // variants of margin
+       "marginStart",
+       "marginEnd",
+       "marginInline",
+       "marginInlineStart",
+       "marginInlineEnd",
+       "marginBlock",
+       "marginBlockStart",
+       "marginBlockEnd",
+       "marginVertical",
+       "marginHorizontal",
+       "marginTop",
+       "marginBottom",
+       "marginLeft",
+       "marginRight",
+
+       // variants of padding
+       "paddingStart",
+       "paddingEnd",
+       "paddingInline",
+       "paddingInlineStart",
+       "paddingInlineEnd",
+       "paddingBlock",
+       "paddingBlockStart",
+       "paddingBlockEnd",
+       "paddingVertical",
+       "paddingHorizontal",
+       "paddingTop",
+       "paddingBottom",
+       "paddingLeft",
+       "paddingRight"}};
+
+  auto filteredRawProps = (folly::dynamic)rawProps;
+
+  auto it = filteredRawProps.items().begin();
+  while (it != filteredRawProps.items().end()) {
+    auto key = it->first.asString();
+    if (yogaStylePropNames.find(key) != yogaStylePropNames.end()) {
+      it = filteredRawProps.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  return RawProps(filteredRawProps);
+}
+} // namespace
+
 YogaStylableProps::YogaStylableProps(
     const PropsParserContext& context,
     const YogaStylableProps& sourceProps,
     const RawProps& rawProps)
-    : Props(context, sourceProps, rawProps),
-      yogaStyle(
-          CoreFeatures::enablePropIteratorSetter
-              ? sourceProps.yogaStyle
-              : convertRawProp(context, rawProps, sourceProps.yogaStyle)) {
-  if (!CoreFeatures::enablePropIteratorSetter) {
-    convertRawPropAliases(context, sourceProps, rawProps);
+    : Props() {
+  if (CoreFeatures::excludeYogaFromRawProps) {
+    const auto filteredRawProps = filterYogaProps(rawProps);
+    initialize(context, sourceProps, filteredRawProps);
+
+    yogaStyle = CoreFeatures::enablePropIteratorSetter
+        ? sourceProps.yogaStyle
+        : convertRawProp(context, filteredRawProps, sourceProps.yogaStyle);
+
+    if (!CoreFeatures::enablePropIteratorSetter) {
+      convertRawPropAliases(context, sourceProps, filteredRawProps);
+    }
+  } else {
+    initialize(context, sourceProps, rawProps);
+
+    yogaStyle = CoreFeatures::enablePropIteratorSetter
+        ? sourceProps.yogaStyle
+        : convertRawProp(context, rawProps, sourceProps.yogaStyle);
+
+    if (!CoreFeatures::enablePropIteratorSetter) {
+      convertRawPropAliases(context, sourceProps, rawProps);
+    }
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
@@ -16,20 +16,20 @@ namespace facebook::react {
 Props::Props(
     const PropsParserContext& context,
     const Props& sourceProps,
-    const RawProps& rawProps)
-    : nativeId(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.nativeId
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "nativeID",
-                                                       sourceProps.nativeId,
-                                                       {}))
+    const RawProps& rawProps) {
+  initialize(context, sourceProps, rawProps);
+}
+
+void Props::initialize(
+    const PropsParserContext& context,
+    const Props& sourceProps,
+    const RawProps& rawProps) {
+  nativeId = CoreFeatures::enablePropIteratorSetter
+      ? sourceProps.nativeId
+      : convertRawProp(context, rawProps, "nativeID", sourceProps.nativeId, {});
 #ifdef ANDROID
-      ,
-      rawProps((folly::dynamic)rawProps)
+  this->rawProps = (folly::dynamic)rawProps;
 #endif
-{
 }
 
 void Props::setProp(

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -61,6 +61,13 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
       const Props* oldProps,
       MapBufferBuilder& builder) const;
 #endif
+
+ protected:
+  /** Initialize member variables of Props instance */
+  void initialize(
+      const PropsParserContext& context,
+      const Props& sourceProps,
+      const RawProps& rawProps);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
@@ -22,5 +22,6 @@ bool CoreFeatures::disableScrollEventThrottleRequirement = false;
 bool CoreFeatures::enableGranularShadowTreeStateReconciliation = false;
 bool CoreFeatures::enableDefaultAsyncBatchedPriority = false;
 bool CoreFeatures::enableClonelessStateProgression = false;
+bool CoreFeatures::excludeYogaFromRawProps = false;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
@@ -64,6 +64,9 @@ class CoreFeatures {
 
   // When enabled, Fabric will avoid cloning notes to perform state progression.
   static bool enableClonelessStateProgression;
+
+  // When enabled, rawProps in Props will not include Yoga specific props.
+  static bool excludeYogaFromRawProps;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [Android][Breaking] - Do not enable `excludeYogaFromRawProps` feature flag, if you need to pass layout props to Java view managers when using new architecture
[Internal]

Differential Revision: D49114771

