### PR TITLE
Adding UIManagerProvider interface

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge;
+
+/**
+ * @deprecated since this would be deprecated later as part of Stable APIs with bridge removal and
+ *     not encouraged usage.
+ */
+@Deprecated
+public interface UIManagerProvider {
+
+  UIManager createUIManager(ReactApplicationContext context);
+}


### PR DESCRIPTION
Summary:
For the removal of JSI Module adding the `UIManagerProvider` interface as this will replace the `JSIModuleProvider`

Adding the `Deprecated` annotation since this would be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.

Changelog:
[Internal] Adding UIManagerProvider interface

Differential Revision: D49257901


