### PR TITLE
Use fbsource clang-format config

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/LayoutContext.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/LayoutContext.h
@@ -14,7 +14,7 @@ namespace facebook::yoga::vanillajni {
 
 // TODO: This should not be exported or used outside of the JNI bindings
 class YG_EXPORT LayoutContext {
-public:
+ public:
   // Sets a context on the current thread for the duration of the Provider's
   // lifetime. This context should be set during the layout process to allow
   // layout callbacks to access context-data specific to the layout pass.

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedGlobalRef.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedGlobalRef.h
@@ -56,7 +56,7 @@ class ScopedGlobalRef {
           std::is_same<T, jbooleanArray>(),
       "ScopedGlobalRef instantiated for invalid type");
 
-public:
+ public:
   /**
    * Constructs a ScopedGlobalRef with a JNI global reference.
    *
@@ -82,7 +82,9 @@ public:
     return *this;
   }
 
-  ~ScopedGlobalRef() { reset(); }
+  ~ScopedGlobalRef() {
+    reset();
+  }
 
   /**
    * Deletes the currently held reference and reassigns a new one to the
@@ -111,17 +113,21 @@ public:
   /**
    * Returns the underlying JNI global reference.
    */
-  T get() const { return mGlobalRef; }
+  T get() const {
+    return mGlobalRef;
+  }
 
   /**
    * Returns true if the underlying JNI reference is not NULL.
    */
-  operator bool() const { return mGlobalRef != NULL; }
+  operator bool() const {
+    return mGlobalRef != NULL;
+  }
 
   ScopedGlobalRef(const ScopedGlobalRef& ref) = delete;
   ScopedGlobalRef& operator=(const ScopedGlobalRef& other) = delete;
 
-private:
+ private:
   T mGlobalRef;
 };
 

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedLocalRef.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedLocalRef.h
@@ -54,7 +54,7 @@ class ScopedLocalRef {
           std::is_same<T, jbooleanArray>(),
       "ScopedLocalRef instantiated for invalid type");
 
-public:
+ public:
   /**
    * Constructs a ScopedLocalRef with a JNI local reference.
    *
@@ -81,7 +81,9 @@ public:
     return *this;
   }
 
-  ~ScopedLocalRef() { reset(); }
+  ~ScopedLocalRef() {
+    reset();
+  }
 
   /**
    * Deletes the currently held reference and reassigns a new one to the
@@ -110,17 +112,21 @@ public:
   /**
    * Returns the underlying JNI local reference.
    */
-  T get() const { return mLocalRef; }
+  T get() const {
+    return mLocalRef;
+  }
 
   /**
    * Returns true if the underlying JNI reference is not NULL.
    */
-  operator bool() const { return mLocalRef != NULL; }
+  operator bool() const {
+    return mLocalRef != NULL;
+  }
 
   ScopedLocalRef(const ScopedLocalRef& ref) = delete;
   ScopedLocalRef& operator=(const ScopedLocalRef& other) = delete;
 
-private:
+ private:
   JNIEnv* mEnv;
   T mLocalRef;
 };

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNI.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNI.h
@@ -29,7 +29,7 @@ union YGNodeContext {
 class YGNodeEdges {
   int32_t edges_;
 
-public:
+ public:
   enum Edge {
     MARGIN = 1,
     PADDING = 2,
@@ -48,14 +48,18 @@ public:
     YGNodeSetContext(node, context.asVoidPtr);
   }
 
-  bool has(Edge edge) { return (edges_ & edge) == edge; }
+  bool has(Edge edge) {
+    return (edges_ & edge) == edge;
+  }
 
   YGNodeEdges& add(Edge edge) {
     edges_ |= edge;
     return *this;
   }
 
-  int get() { return edges_; }
+  int get() {
+    return edges_;
+  }
 };
 
 struct YogaValue {
@@ -64,10 +68,10 @@ struct YogaValue {
   static jlong asJavaLong(const YGValue& value) {
     uint32_t valueBytes = 0;
     memcpy(&valueBytes, &value.value, sizeof valueBytes);
-    return ((jlong) value.unit) << 32 | valueBytes;
+    return ((jlong)value.unit) << 32 | valueBytes;
   }
   constexpr static jlong undefinedAsJavaLong() {
-    return ((jlong) YGUnitUndefined) << 32 | NAN_BYTES;
+    return ((jlong)YGUnitUndefined) << 32 | NAN_BYTES;
   }
 };
 } // namespace

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -5,16 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "jni.h"
 #include "YGJNIVanilla.h"
 #include <cstring>
-#include "YGJNI.h"
-#include "common.h"
-#include "YGJTypesVanilla.h"
 #include <iostream>
 #include <memory>
-#include "YogaJniException.h"
 #include "LayoutContext.h"
+#include "YGJNI.h"
+#include "YGJTypesVanilla.h"
+#include "YogaJniException.h"
+#include "common.h"
+#include "jni.h"
 
 #include <yoga/Yoga-internal.h>
 #include <yoga/bits/BitCast.h>
@@ -39,10 +39,8 @@ static jlong jni_YGConfigNewJNI(JNIEnv* /*env*/, jobject /*obj*/) {
   return reinterpret_cast<jlong>(YGConfigNew());
 }
 
-static void jni_YGConfigFreeJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer) {
+static void
+jni_YGConfigFreeJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
   // unique_ptr will destruct the underlying global_ref, if present.
   auto context = std::unique_ptr<ScopedGlobalRef<jobject>>{
@@ -191,10 +189,8 @@ static void jni_YGConfigSetLoggerJNI(
   }
 }
 
-static void jni_YGNodeDeallocateJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer) {
+static void
+jni_YGNodeDeallocateJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   if (nativePointer == 0) {
     return;
   }
@@ -202,10 +198,8 @@ static void jni_YGNodeDeallocateJNI(
   YGNodeDeallocate(node);
 }
 
-static void jni_YGNodeResetJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer) {
+static void
+jni_YGNodeResetJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   const YGNodeRef node = _jlong2YGNodeRef(nativePointer);
   void* context = YGNodeGetContext(node);
   YGNodeReset(node);
@@ -269,10 +263,8 @@ static void jni_YGNodeRemoveChildJNI(
       _jlong2YGNodeRef(nativePointer), _jlong2YGNodeRef(childPointer));
 }
 
-static void YGTransferLayoutOutputsRecursive(
-    JNIEnv* env,
-    jobject thiz,
-    YGNodeRef root) {
+static void
+YGTransferLayoutOutputsRecursive(JNIEnv* env, jobject thiz, YGNodeRef root) {
   if (!YGNodeGetHasNewLayout(root)) {
     return;
   }
@@ -356,7 +348,6 @@ static void jni_YGNodeCalculateLayoutJNI(
     jfloat height,
     jlongArray nativePointers,
     jobjectArray javaNodes) {
-
   try {
     PtrJNodeMapVanilla* layoutContext = nullptr;
     auto map = PtrJNodeMapVanilla{};
@@ -389,10 +380,8 @@ static void jni_YGNodeCalculateLayoutJNI(
   }
 }
 
-static void jni_YGNodeMarkDirtyJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer) {
+static void
+jni_YGNodeMarkDirtyJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   YGNodeMarkDirty(_jlong2YGNodeRef(nativePointer));
 }
 
@@ -403,11 +392,9 @@ static void jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI(
   YGNodeMarkDirtyAndPropagateToDescendants(_jlong2YGNodeRef(nativePointer));
 }
 
-static jboolean jni_YGNodeIsDirtyJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer) {
-  return (jboolean) YGNodeIsDirty(_jlong2YGNodeRef(nativePointer));
+static jboolean
+jni_YGNodeIsDirtyJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
+  return (jboolean)YGNodeIsDirty(_jlong2YGNodeRef(nativePointer));
 }
 
 static void jni_YGNodeCopyStyleJNI(
@@ -422,7 +409,7 @@ static void jni_YGNodeCopyStyleJNI(
 #define YG_NODE_JNI_STYLE_PROP(javatype, type, name)                           \
   static javatype jni_YGNodeStyleGet##name##JNI(                               \
       JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {                 \
-    return (javatype) YGNodeStyleGet##name(_jlong2YGNodeRef(nativePointer));   \
+    return (javatype)YGNodeStyleGet##name(_jlong2YGNodeRef(nativePointer));    \
   }                                                                            \
                                                                                \
   static void jni_YGNodeStyleSet##name##JNI(                                   \
@@ -603,9 +590,9 @@ static jfloat jni_YGNodeStyleGetBorderJNI(
     jint edge) {
   YGNodeRef yogaNodeRef = _jlong2YGNodeRef(nativePointer);
   if (!YGNodeEdges{yogaNodeRef}.has(YGNodeEdges::BORDER)) {
-    return (jfloat) YGUndefined;
+    return (jfloat)YGUndefined;
   }
-  return (jfloat) YGNodeStyleGetBorder(yogaNodeRef, static_cast<YGEdge>(edge));
+  return (jfloat)YGNodeStyleGetBorder(yogaNodeRef, static_cast<YGEdge>(edge));
 }
 
 static void jni_YGNodeStyleSetBorderJNI(
@@ -704,24 +691,20 @@ static void jni_YGNodeSetHasBaselineFuncJNI(
       hasBaselineFunc ? YGJNIBaselineFunc : nullptr);
 }
 
-static void jni_YGNodePrintJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer) {
+static void
+jni_YGNodePrintJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
 #ifdef DEBUG
   const YGNodeRef node = _jlong2YGNodeRef(nativePointer);
   YGNodePrint(
       node,
-      (YGPrintOptions) (YGPrintOptionsStyle | YGPrintOptionsLayout | YGPrintOptionsChildren));
+      (YGPrintOptions)(YGPrintOptionsStyle | YGPrintOptionsLayout | YGPrintOptionsChildren));
 #else
-  (void) nativePointer;
+  (void)nativePointer;
 #endif
 }
 
-static jlong jni_YGNodeCloneJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer) {
+static jlong
+jni_YGNodeCloneJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   auto node = _jlong2YGNodeRef(nativePointer);
   const YGNodeRef clonedYogaNode = YGNodeClone(node);
   YGNodeSetContext(clonedYogaNode, YGNodeGetContext(node));
@@ -734,7 +717,7 @@ static jfloat jni_YGNodeStyleGetGapJNI(
     jobject /*obj*/,
     jlong nativePointer,
     jint gutter) {
-  return (jfloat) YGNodeStyleGetGap(
+  return (jfloat)YGNodeStyleGetGap(
       _jlong2YGNodeRef(nativePointer), static_cast<YGGutter>(gutter));
 }
 
@@ -754,244 +737,242 @@ static void jni_YGNodeStyleSetGapJNI(
 YG_NODE_JNI_STYLE_PROP(jfloat, float, AspectRatio);
 
 static JNINativeMethod methods[] = {
-    {"jni_YGConfigNewJNI", "()J", (void*) jni_YGConfigNewJNI},
-    {"jni_YGConfigFreeJNI", "(J)V", (void*) jni_YGConfigFreeJNI},
+    {"jni_YGConfigNewJNI", "()J", (void*)jni_YGConfigNewJNI},
+    {"jni_YGConfigFreeJNI", "(J)V", (void*)jni_YGConfigFreeJNI},
     {"jni_YGConfigSetExperimentalFeatureEnabledJNI",
      "(JIZ)V",
-     (void*) jni_YGConfigSetExperimentalFeatureEnabledJNI},
+     (void*)jni_YGConfigSetExperimentalFeatureEnabledJNI},
     {"jni_YGConfigSetUseWebDefaultsJNI",
      "(JZ)V",
-     (void*) jni_YGConfigSetUseWebDefaultsJNI},
+     (void*)jni_YGConfigSetUseWebDefaultsJNI},
     {"jni_YGConfigSetPrintTreeFlagJNI",
      "(JZ)V",
-     (void*) jni_YGConfigSetPrintTreeFlagJNI},
+     (void*)jni_YGConfigSetPrintTreeFlagJNI},
     {"jni_YGConfigSetPointScaleFactorJNI",
      "(JF)V",
-     (void*) jni_YGConfigSetPointScaleFactorJNI},
-    {"jni_YGConfigSetErrataJNI", "(JI)V", (void*) jni_YGConfigSetErrataJNI},
-    {"jni_YGConfigGetErrataJNI", "(J)I", (void*) jni_YGConfigGetErrataJNI},
+     (void*)jni_YGConfigSetPointScaleFactorJNI},
+    {"jni_YGConfigSetErrataJNI", "(JI)V", (void*)jni_YGConfigSetErrataJNI},
+    {"jni_YGConfigGetErrataJNI", "(J)I", (void*)jni_YGConfigGetErrataJNI},
     {"jni_YGConfigSetLoggerJNI",
      "(JLcom/facebook/yoga/YogaLogger;)V",
-     (void*) jni_YGConfigSetLoggerJNI},
-    {"jni_YGNodeNewJNI", "()J", (void*) jni_YGNodeNewJNI},
-    {"jni_YGNodeNewWithConfigJNI", "(J)J", (void*) jni_YGNodeNewWithConfigJNI},
-    {"jni_YGNodeDeallocateJNI", "(J)V", (void*) jni_YGNodeDeallocateJNI},
-    {"jni_YGNodeResetJNI", "(J)V", (void*) jni_YGNodeResetJNI},
-    {"jni_YGNodeInsertChildJNI", "(JJI)V", (void*) jni_YGNodeInsertChildJNI},
-    {"jni_YGNodeSwapChildJNI", "(JJI)V", (void*) jni_YGNodeSwapChildJNI},
+     (void*)jni_YGConfigSetLoggerJNI},
+    {"jni_YGNodeNewJNI", "()J", (void*)jni_YGNodeNewJNI},
+    {"jni_YGNodeNewWithConfigJNI", "(J)J", (void*)jni_YGNodeNewWithConfigJNI},
+    {"jni_YGNodeDeallocateJNI", "(J)V", (void*)jni_YGNodeDeallocateJNI},
+    {"jni_YGNodeResetJNI", "(J)V", (void*)jni_YGNodeResetJNI},
+    {"jni_YGNodeInsertChildJNI", "(JJI)V", (void*)jni_YGNodeInsertChildJNI},
+    {"jni_YGNodeSwapChildJNI", "(JJI)V", (void*)jni_YGNodeSwapChildJNI},
     {"jni_YGNodeSetIsReferenceBaselineJNI",
      "(JZ)V",
-     (void*) jni_YGNodeSetIsReferenceBaselineJNI},
+     (void*)jni_YGNodeSetIsReferenceBaselineJNI},
     {"jni_YGNodeIsReferenceBaselineJNI",
      "(J)Z",
-     (void*) jni_YGNodeIsReferenceBaselineJNI},
+     (void*)jni_YGNodeIsReferenceBaselineJNI},
     {"jni_YGNodeRemoveAllChildrenJNI",
      "(J)V",
-     (void*) jni_YGNodeRemoveAllChildrenJNI},
-    {"jni_YGNodeRemoveChildJNI", "(JJ)V", (void*) jni_YGNodeRemoveChildJNI},
+     (void*)jni_YGNodeRemoveAllChildrenJNI},
+    {"jni_YGNodeRemoveChildJNI", "(JJ)V", (void*)jni_YGNodeRemoveChildJNI},
     {"jni_YGNodeCalculateLayoutJNI",
      "(JFF[J[Lcom/facebook/yoga/YogaNodeJNIBase;)V",
-     (void*) jni_YGNodeCalculateLayoutJNI},
-    {"jni_YGNodeMarkDirtyJNI", "(J)V", (void*) jni_YGNodeMarkDirtyJNI},
+     (void*)jni_YGNodeCalculateLayoutJNI},
+    {"jni_YGNodeMarkDirtyJNI", "(J)V", (void*)jni_YGNodeMarkDirtyJNI},
     {"jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI",
      "(J)V",
-     (void*) jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI},
-    {"jni_YGNodeIsDirtyJNI", "(J)Z", (void*) jni_YGNodeIsDirtyJNI},
-    {"jni_YGNodeCopyStyleJNI", "(JJ)V", (void*) jni_YGNodeCopyStyleJNI},
+     (void*)jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI},
+    {"jni_YGNodeIsDirtyJNI", "(J)Z", (void*)jni_YGNodeIsDirtyJNI},
+    {"jni_YGNodeCopyStyleJNI", "(JJ)V", (void*)jni_YGNodeCopyStyleJNI},
     {"jni_YGNodeStyleGetDirectionJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetDirectionJNI},
+     (void*)jni_YGNodeStyleGetDirectionJNI},
     {"jni_YGNodeStyleSetDirectionJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetDirectionJNI},
+     (void*)jni_YGNodeStyleSetDirectionJNI},
     {"jni_YGNodeStyleGetFlexDirectionJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetFlexDirectionJNI},
+     (void*)jni_YGNodeStyleGetFlexDirectionJNI},
     {"jni_YGNodeStyleSetFlexDirectionJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetFlexDirectionJNI},
+     (void*)jni_YGNodeStyleSetFlexDirectionJNI},
     {"jni_YGNodeStyleGetJustifyContentJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetJustifyContentJNI},
+     (void*)jni_YGNodeStyleGetJustifyContentJNI},
     {"jni_YGNodeStyleSetJustifyContentJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetJustifyContentJNI},
+     (void*)jni_YGNodeStyleSetJustifyContentJNI},
     {"jni_YGNodeStyleGetAlignItemsJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetAlignItemsJNI},
+     (void*)jni_YGNodeStyleGetAlignItemsJNI},
     {"jni_YGNodeStyleSetAlignItemsJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetAlignItemsJNI},
+     (void*)jni_YGNodeStyleSetAlignItemsJNI},
     {"jni_YGNodeStyleGetAlignSelfJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetAlignSelfJNI},
+     (void*)jni_YGNodeStyleGetAlignSelfJNI},
     {"jni_YGNodeStyleSetAlignSelfJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetAlignSelfJNI},
+     (void*)jni_YGNodeStyleSetAlignSelfJNI},
     {"jni_YGNodeStyleGetAlignContentJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetAlignContentJNI},
+     (void*)jni_YGNodeStyleGetAlignContentJNI},
     {"jni_YGNodeStyleSetAlignContentJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetAlignContentJNI},
+     (void*)jni_YGNodeStyleSetAlignContentJNI},
     {"jni_YGNodeStyleGetPositionTypeJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetPositionTypeJNI},
+     (void*)jni_YGNodeStyleGetPositionTypeJNI},
     {"jni_YGNodeStyleSetPositionTypeJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetPositionTypeJNI},
+     (void*)jni_YGNodeStyleSetPositionTypeJNI},
     {"jni_YGNodeStyleGetFlexWrapJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetFlexWrapJNI},
+     (void*)jni_YGNodeStyleGetFlexWrapJNI},
     {"jni_YGNodeStyleSetFlexWrapJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetFlexWrapJNI},
+     (void*)jni_YGNodeStyleSetFlexWrapJNI},
     {"jni_YGNodeStyleGetOverflowJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetOverflowJNI},
+     (void*)jni_YGNodeStyleGetOverflowJNI},
     {"jni_YGNodeStyleSetOverflowJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetOverflowJNI},
+     (void*)jni_YGNodeStyleSetOverflowJNI},
     {"jni_YGNodeStyleGetDisplayJNI",
      "(J)I",
-     (void*) jni_YGNodeStyleGetDisplayJNI},
+     (void*)jni_YGNodeStyleGetDisplayJNI},
     {"jni_YGNodeStyleSetDisplayJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetDisplayJNI},
-    {"jni_YGNodeStyleGetFlexJNI", "(J)F", (void*) jni_YGNodeStyleGetFlexJNI},
-    {"jni_YGNodeStyleSetFlexJNI", "(JF)V", (void*) jni_YGNodeStyleSetFlexJNI},
+     (void*)jni_YGNodeStyleSetDisplayJNI},
+    {"jni_YGNodeStyleGetFlexJNI", "(J)F", (void*)jni_YGNodeStyleGetFlexJNI},
+    {"jni_YGNodeStyleSetFlexJNI", "(JF)V", (void*)jni_YGNodeStyleSetFlexJNI},
     {"jni_YGNodeStyleGetFlexGrowJNI",
      "(J)F",
-     (void*) jni_YGNodeStyleGetFlexGrowJNI},
+     (void*)jni_YGNodeStyleGetFlexGrowJNI},
     {"jni_YGNodeStyleSetFlexGrowJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetFlexGrowJNI},
+     (void*)jni_YGNodeStyleSetFlexGrowJNI},
     {"jni_YGNodeStyleGetFlexShrinkJNI",
      "(J)F",
-     (void*) jni_YGNodeStyleGetFlexShrinkJNI},
+     (void*)jni_YGNodeStyleGetFlexShrinkJNI},
     {"jni_YGNodeStyleSetFlexShrinkJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetFlexShrinkJNI},
+     (void*)jni_YGNodeStyleSetFlexShrinkJNI},
     {"jni_YGNodeStyleGetFlexBasisJNI",
      "(J)J",
-     (void*) jni_YGNodeStyleGetFlexBasisJNI},
+     (void*)jni_YGNodeStyleGetFlexBasisJNI},
     {"jni_YGNodeStyleSetFlexBasisJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetFlexBasisJNI},
+     (void*)jni_YGNodeStyleSetFlexBasisJNI},
     {"jni_YGNodeStyleSetFlexBasisPercentJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetFlexBasisPercentJNI},
+     (void*)jni_YGNodeStyleSetFlexBasisPercentJNI},
     {"jni_YGNodeStyleSetFlexBasisAutoJNI",
      "(J)V",
-     (void*) jni_YGNodeStyleSetFlexBasisAutoJNI},
+     (void*)jni_YGNodeStyleSetFlexBasisAutoJNI},
     {"jni_YGNodeStyleGetMarginJNI",
      "(JI)J",
-     (void*) jni_YGNodeStyleGetMarginJNI},
+     (void*)jni_YGNodeStyleGetMarginJNI},
     {"jni_YGNodeStyleSetMarginJNI",
      "(JIF)V",
-     (void*) jni_YGNodeStyleSetMarginJNI},
+     (void*)jni_YGNodeStyleSetMarginJNI},
     {"jni_YGNodeStyleSetMarginPercentJNI",
      "(JIF)V",
-     (void*) jni_YGNodeStyleSetMarginPercentJNI},
+     (void*)jni_YGNodeStyleSetMarginPercentJNI},
     {"jni_YGNodeStyleSetMarginAutoJNI",
      "(JI)V",
-     (void*) jni_YGNodeStyleSetMarginAutoJNI},
+     (void*)jni_YGNodeStyleSetMarginAutoJNI},
     {"jni_YGNodeStyleGetPaddingJNI",
      "(JI)J",
-     (void*) jni_YGNodeStyleGetPaddingJNI},
+     (void*)jni_YGNodeStyleGetPaddingJNI},
     {"jni_YGNodeStyleSetPaddingJNI",
      "(JIF)V",
-     (void*) jni_YGNodeStyleSetPaddingJNI},
+     (void*)jni_YGNodeStyleSetPaddingJNI},
     {"jni_YGNodeStyleSetPaddingPercentJNI",
      "(JIF)V",
-     (void*) jni_YGNodeStyleSetPaddingPercentJNI},
+     (void*)jni_YGNodeStyleSetPaddingPercentJNI},
     {"jni_YGNodeStyleGetBorderJNI",
      "(JI)F",
-     (void*) jni_YGNodeStyleGetBorderJNI},
+     (void*)jni_YGNodeStyleGetBorderJNI},
     {"jni_YGNodeStyleSetBorderJNI",
      "(JIF)V",
-     (void*) jni_YGNodeStyleSetBorderJNI},
+     (void*)jni_YGNodeStyleSetBorderJNI},
     {"jni_YGNodeStyleGetPositionJNI",
      "(JI)J",
-     (void*) jni_YGNodeStyleGetPositionJNI},
+     (void*)jni_YGNodeStyleGetPositionJNI},
     {"jni_YGNodeStyleSetPositionJNI",
      "(JIF)V",
-     (void*) jni_YGNodeStyleSetPositionJNI},
+     (void*)jni_YGNodeStyleSetPositionJNI},
     {"jni_YGNodeStyleSetPositionPercentJNI",
      "(JIF)V",
-     (void*) jni_YGNodeStyleSetPositionPercentJNI},
-    {"jni_YGNodeStyleGetWidthJNI", "(J)J", (void*) jni_YGNodeStyleGetWidthJNI},
-    {"jni_YGNodeStyleSetWidthJNI", "(JF)V", (void*) jni_YGNodeStyleSetWidthJNI},
+     (void*)jni_YGNodeStyleSetPositionPercentJNI},
+    {"jni_YGNodeStyleGetWidthJNI", "(J)J", (void*)jni_YGNodeStyleGetWidthJNI},
+    {"jni_YGNodeStyleSetWidthJNI", "(JF)V", (void*)jni_YGNodeStyleSetWidthJNI},
     {"jni_YGNodeStyleSetWidthPercentJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetWidthPercentJNI},
+     (void*)jni_YGNodeStyleSetWidthPercentJNI},
     {"jni_YGNodeStyleSetWidthAutoJNI",
      "(J)V",
-     (void*) jni_YGNodeStyleSetWidthAutoJNI},
-    {"jni_YGNodeStyleGetHeightJNI",
-     "(J)J",
-     (void*) jni_YGNodeStyleGetHeightJNI},
+     (void*)jni_YGNodeStyleSetWidthAutoJNI},
+    {"jni_YGNodeStyleGetHeightJNI", "(J)J", (void*)jni_YGNodeStyleGetHeightJNI},
     {"jni_YGNodeStyleSetHeightJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetHeightJNI},
+     (void*)jni_YGNodeStyleSetHeightJNI},
     {"jni_YGNodeStyleSetHeightPercentJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetHeightPercentJNI},
+     (void*)jni_YGNodeStyleSetHeightPercentJNI},
     {"jni_YGNodeStyleSetHeightAutoJNI",
      "(J)V",
-     (void*) jni_YGNodeStyleSetHeightAutoJNI},
+     (void*)jni_YGNodeStyleSetHeightAutoJNI},
     {"jni_YGNodeStyleGetMinWidthJNI",
      "(J)J",
-     (void*) jni_YGNodeStyleGetMinWidthJNI},
+     (void*)jni_YGNodeStyleGetMinWidthJNI},
     {"jni_YGNodeStyleSetMinWidthJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetMinWidthJNI},
+     (void*)jni_YGNodeStyleSetMinWidthJNI},
     {"jni_YGNodeStyleSetMinWidthPercentJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetMinWidthPercentJNI},
+     (void*)jni_YGNodeStyleSetMinWidthPercentJNI},
     {"jni_YGNodeStyleGetMinHeightJNI",
      "(J)J",
-     (void*) jni_YGNodeStyleGetMinHeightJNI},
+     (void*)jni_YGNodeStyleGetMinHeightJNI},
     {"jni_YGNodeStyleSetMinHeightJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetMinHeightJNI},
+     (void*)jni_YGNodeStyleSetMinHeightJNI},
     {"jni_YGNodeStyleSetMinHeightPercentJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetMinHeightPercentJNI},
+     (void*)jni_YGNodeStyleSetMinHeightPercentJNI},
     {"jni_YGNodeStyleGetMaxWidthJNI",
      "(J)J",
-     (void*) jni_YGNodeStyleGetMaxWidthJNI},
+     (void*)jni_YGNodeStyleGetMaxWidthJNI},
     {"jni_YGNodeStyleSetMaxWidthJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetMaxWidthJNI},
+     (void*)jni_YGNodeStyleSetMaxWidthJNI},
     {"jni_YGNodeStyleSetMaxWidthPercentJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetMaxWidthPercentJNI},
+     (void*)jni_YGNodeStyleSetMaxWidthPercentJNI},
     {"jni_YGNodeStyleGetMaxHeightJNI",
      "(J)J",
-     (void*) jni_YGNodeStyleGetMaxHeightJNI},
+     (void*)jni_YGNodeStyleGetMaxHeightJNI},
     {"jni_YGNodeStyleSetMaxHeightJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetMaxHeightJNI},
+     (void*)jni_YGNodeStyleSetMaxHeightJNI},
     {"jni_YGNodeStyleSetMaxHeightPercentJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetMaxHeightPercentJNI},
+     (void*)jni_YGNodeStyleSetMaxHeightPercentJNI},
     {"jni_YGNodeStyleGetAspectRatioJNI",
      "(J)F",
-     (void*) jni_YGNodeStyleGetAspectRatioJNI},
+     (void*)jni_YGNodeStyleGetAspectRatioJNI},
     {"jni_YGNodeStyleSetAspectRatioJNI",
      "(JF)V",
-     (void*) jni_YGNodeStyleSetAspectRatioJNI},
+     (void*)jni_YGNodeStyleSetAspectRatioJNI},
     {"jni_YGNodeSetHasMeasureFuncJNI",
      "(JZ)V",
-     (void*) jni_YGNodeSetHasMeasureFuncJNI},
-    {"jni_YGNodeStyleGetGapJNI", "(JI)F", (void*) jni_YGNodeStyleGetGapJNI},
-    {"jni_YGNodeStyleSetGapJNI", "(JIF)V", (void*) jni_YGNodeStyleSetGapJNI},
+     (void*)jni_YGNodeSetHasMeasureFuncJNI},
+    {"jni_YGNodeStyleGetGapJNI", "(JI)F", (void*)jni_YGNodeStyleGetGapJNI},
+    {"jni_YGNodeStyleSetGapJNI", "(JIF)V", (void*)jni_YGNodeStyleSetGapJNI},
     {"jni_YGNodeSetHasBaselineFuncJNI",
      "(JZ)V",
-     (void*) jni_YGNodeSetHasBaselineFuncJNI},
-    {"jni_YGNodePrintJNI", "(J)V", (void*) jni_YGNodePrintJNI},
-    {"jni_YGNodeCloneJNI", "(J)J", (void*) jni_YGNodeCloneJNI},
+     (void*)jni_YGNodeSetHasBaselineFuncJNI},
+    {"jni_YGNodePrintJNI", "(J)V", (void*)jni_YGNodePrintJNI},
+    {"jni_YGNodeCloneJNI", "(J)J", (void*)jni_YGNodeCloneJNI},
 };
 
 void YGJNIVanilla::registerNatives(JNIEnv* env) {

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJTypesVanilla.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJTypesVanilla.h
@@ -19,7 +19,7 @@ class PtrJNodeMapVanilla {
   std::map<YGNodeConstRef, jsize> ptrsToIdxs_{};
   jobjectArray javaNodes_{};
 
-public:
+ public:
   PtrJNodeMapVanilla() = default;
 
   PtrJNodeMapVanilla(jlongArray javaNativePointers, jobjectArray javaNodes)
@@ -33,7 +33,7 @@ public:
         javaNativePointers, 0, nativePointersSize, nativePointers.data());
 
     for (jsize i = 0; i < nativePointersSize; ++i) {
-      ptrsToIdxs_[(YGNodeConstRef) nativePointers[static_cast<size_t>(i)]] = i;
+      ptrsToIdxs_[(YGNodeConstRef)nativePointers[static_cast<size_t>(i)]] = i;
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YogaJniException.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YogaJniException.cpp
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "YogaJniException.h"
 #include <stdexcept>
 #include <string>
-#include "YogaJniException.h"
 #include "common.h"
 
 namespace facebook::yoga::vanillajni {

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YogaJniException.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YogaJniException.h
@@ -16,7 +16,7 @@ namespace facebook::yoga::vanillajni {
  * does not gets cleared before jni call completion
  */
 class YogaJniException : public std::exception {
-public:
+ public:
   YogaJniException();
   ~YogaJniException() override;
 
@@ -28,7 +28,7 @@ public:
 
   ScopedLocalRef<jthrowable> getThrowable() const noexcept;
 
-private:
+ private:
   ScopedGlobalRef<jthrowable> throwable_;
 };
 

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/common.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/common.cpp
@@ -76,11 +76,8 @@ DEFINE_CALL_METHOD_FOR_PRIMITIVE_INTERFACE(void, Void) {
   assertNoPendingJniException(env);
 }
 
-ScopedLocalRef<jobject> callStaticObjectMethod(
-    JNIEnv* env,
-    jclass clazz,
-    jmethodID methodId,
-    ...) {
+ScopedLocalRef<jobject>
+callStaticObjectMethod(JNIEnv* env, jclass clazz, jmethodID methodId, ...) {
   va_list args;
   va_start(args, methodId);
   jobject result = env->CallStaticObjectMethodV(clazz, methodId, args);

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/common.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/common.h
@@ -59,11 +59,8 @@ DEFINE_CALL_METHOD_FOR_PRIMITIVE_INTERFACE(void, Void);
 DEFINE_CALL_METHOD_FOR_PRIMITIVE_INTERFACE(jlong, Long);
 DEFINE_CALL_METHOD_FOR_PRIMITIVE_INTERFACE(jfloat, Float);
 
-ScopedLocalRef<jobject> callStaticObjectMethod(
-    JNIEnv* env,
-    jclass clazz,
-    jmethodID methodId,
-    ...);
+ScopedLocalRef<jobject>
+callStaticObjectMethod(JNIEnv* env, jclass clazz, jmethodID methodId, ...);
 
 /**
  * Given a local or a global reference, this method creates a new global

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/corefunctions.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/corefunctions.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "corefunctions.h"
-#include "macros.h"
 #include "YogaJniException.h"
+#include "macros.h"
 
 namespace facebook::yoga::vanillajni {
 
@@ -44,7 +44,7 @@ jint ensureInitialized(JNIEnv** env, JavaVM* vm) {
 // TODO why we need JNIEXPORT for getCurrentEnv ?
 JNIEXPORT JNIEnv* getCurrentEnv() {
   JNIEnv* env;
-  jint ret = globalVm->GetEnv((void**) &env, JNI_VERSION_1_6);
+  jint ret = globalVm->GetEnv((void**)&env, JNI_VERSION_1_6);
   if (ret != JNI_OK) {
     logErrorMessageAndDie(
         "There was an error retrieving the current JNIEnv. Make sure the "
@@ -54,7 +54,7 @@ JNIEXPORT JNIEnv* getCurrentEnv() {
 }
 
 void logErrorMessageAndDie(const char* message) {
-  (void) message;
+  (void)message;
   VANILLAJNI_LOG_ERROR(
       "VanillaJni",
       "Aborting due to error detected in native code: %s",

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <yoga/Yoga.h>
 #include <yoga/Yoga-internal.h>
+#include <yoga/Yoga.h>
 
 #include <yoga/algorithm/Cache.h>
 #include <yoga/algorithm/CalculateLayout.h>

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -71,10 +71,8 @@ YG_EXPORT YGNodeRef YGNodeGetChild(YGNodeRef node, size_t index);
 YG_EXPORT YGNodeRef YGNodeGetOwner(YGNodeRef node);
 YG_EXPORT YGNodeRef YGNodeGetParent(YGNodeRef node);
 YG_EXPORT size_t YGNodeGetChildCount(YGNodeConstRef node);
-YG_EXPORT void YGNodeSetChildren(
-    YGNodeRef owner,
-    const YGNodeRef* children,
-    size_t count);
+YG_EXPORT void
+YGNodeSetChildren(YGNodeRef owner, const YGNodeRef* children, size_t count);
 
 YG_EXPORT void YGNodeSetIsReferenceBaseline(
     YGNodeRef node,
@@ -197,41 +195,29 @@ YG_EXPORT void YGNodeStyleSetFlexBasisPercent(YGNodeRef node, float flexBasis);
 YG_EXPORT void YGNodeStyleSetFlexBasisAuto(YGNodeRef node);
 YG_EXPORT YGValue YGNodeStyleGetFlexBasis(YGNodeConstRef node);
 
-YG_EXPORT void YGNodeStyleSetPosition(
-    YGNodeRef node,
-    YGEdge edge,
-    float position);
-YG_EXPORT void YGNodeStyleSetPositionPercent(
-    YGNodeRef node,
-    YGEdge edge,
-    float position);
+YG_EXPORT void
+YGNodeStyleSetPosition(YGNodeRef node, YGEdge edge, float position);
+YG_EXPORT void
+YGNodeStyleSetPositionPercent(YGNodeRef node, YGEdge edge, float position);
 YG_EXPORT YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge);
 
 YG_EXPORT void YGNodeStyleSetMargin(YGNodeRef node, YGEdge edge, float margin);
-YG_EXPORT void YGNodeStyleSetMarginPercent(
-    YGNodeRef node,
-    YGEdge edge,
-    float margin);
+YG_EXPORT void
+YGNodeStyleSetMarginPercent(YGNodeRef node, YGEdge edge, float margin);
 YG_EXPORT void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge);
 YG_EXPORT YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge);
 
-YG_EXPORT void YGNodeStyleSetPadding(
-    YGNodeRef node,
-    YGEdge edge,
-    float padding);
-YG_EXPORT void YGNodeStyleSetPaddingPercent(
-    YGNodeRef node,
-    YGEdge edge,
-    float padding);
+YG_EXPORT void
+YGNodeStyleSetPadding(YGNodeRef node, YGEdge edge, float padding);
+YG_EXPORT void
+YGNodeStyleSetPaddingPercent(YGNodeRef node, YGEdge edge, float padding);
 YG_EXPORT YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge);
 
 YG_EXPORT void YGNodeStyleSetBorder(YGNodeRef node, YGEdge edge, float border);
 YG_EXPORT float YGNodeStyleGetBorder(YGNodeConstRef node, YGEdge edge);
 
-YG_EXPORT void YGNodeStyleSetGap(
-    YGNodeRef node,
-    YGGutter gutter,
-    float gapLength);
+YG_EXPORT void
+YGNodeStyleSetGap(YGNodeRef node, YGGutter gutter, float gapLength);
 YG_EXPORT float YGNodeStyleGetGap(YGNodeConstRef node, YGGutter gutter);
 
 YG_EXPORT void YGNodeStyleSetWidth(YGNodeRef node, float width);

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
@@ -16,7 +16,6 @@ namespace facebook::yoga {
 
 float calculateBaseline(const yoga::Node* node) {
   if (node->hasBaselineFunc()) {
-
     Event::publish<Event::NodeBaselineStart>(node);
 
     const float baseline = node->baseline(

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -2603,7 +2603,6 @@ bool calculateLayoutInternal(
     layout->lastOwnerDirection = ownerDirection;
 
     if (cachedResults == nullptr) {
-
       layoutMarkerData.maxMeasureCache = std::max(
           layoutMarkerData.maxMeasureCache,
           layout->nextCachedMeasurementsIndex + 1u);
@@ -2741,7 +2740,7 @@ void calculateLayout(
     if (node->getConfig()->shouldPrintTree()) {
       YGNodePrint(
           node,
-          (YGPrintOptions) (YGPrintOptionsLayout | YGPrintOptionsChildren | YGPrintOptionsStyle));
+          (YGPrintOptions)(YGPrintOptionsLayout | YGPrintOptionsChildren | YGPrintOptionsStyle));
     }
 #endif
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -44,7 +44,6 @@ bool calculateLayoutInternal(
     const float ownerHeight,
     const bool performLayout,
     const LayoutPassReason reason,
-    const yoga::Config* const config,
     LayoutData& layoutMarkerData,
     const uint32_t depth,
     const uint32_t generationCount);
@@ -131,7 +130,6 @@ static void computeFlexBasisForChild(
     const float ownerHeight,
     const YGMeasureMode heightMode,
     const YGDirection direction,
-    const yoga::Config* const config,
     LayoutData& layoutMarkerData,
     const uint32_t depth,
     const uint32_t generationCount) {
@@ -305,7 +303,6 @@ static void computeFlexBasisForChild(
         ownerHeight,
         false,
         LayoutPassReason::kMeasureChild,
-        config,
         layoutMarkerData,
         depth,
         generationCount);
@@ -324,7 +321,6 @@ static void layoutAbsoluteChild(
     const YGMeasureMode widthMode,
     const float height,
     const YGDirection direction,
-    const yoga::Config* const config,
     LayoutData& layoutMarkerData,
     const uint32_t depth,
     const uint32_t generationCount) {
@@ -431,7 +427,6 @@ static void layoutAbsoluteChild(
         childHeight,
         false,
         LayoutPassReason::kAbsMeasureChild,
-        config,
         layoutMarkerData,
         depth,
         generationCount);
@@ -452,7 +447,6 @@ static void layoutAbsoluteChild(
       childHeight,
       true,
       LayoutPassReason::kAbsLayout,
-      config,
       layoutMarkerData,
       depth,
       generationCount);
@@ -778,7 +772,6 @@ static float computeFlexBasisForChildren(
     YGMeasureMode heightMeasureMode,
     YGDirection direction,
     YGFlexDirection mainAxis,
-    const yoga::Config* const config,
     bool performLayout,
     LayoutData& layoutMarkerData,
     const uint32_t depth,
@@ -844,7 +837,6 @@ static float computeFlexBasisForChildren(
           availableInnerHeight,
           heightMeasureMode,
           direction,
-          config,
           layoutMarkerData,
           depth,
           generationCount);
@@ -876,7 +868,6 @@ static float distributeFreeSpaceSecondPass(
     const bool mainAxisOverflows,
     const YGMeasureMode measureModeCrossDim,
     const bool performLayout,
-    const yoga::Config* const config,
     LayoutData& layoutMarkerData,
     const uint32_t depth,
     const uint32_t generationCount) {
@@ -1040,7 +1031,6 @@ static float distributeFreeSpaceSecondPass(
         isLayoutPass,
         isLayoutPass ? LayoutPassReason::kFlexLayout
                      : LayoutPassReason::kFlexMeasure,
-        config,
         layoutMarkerData,
         depth,
         generationCount);
@@ -1172,7 +1162,6 @@ static void resolveFlexibleLength(
     const bool mainAxisOverflows,
     const YGMeasureMode measureModeCrossDim,
     const bool performLayout,
-    const yoga::Config* const config,
     LayoutData& layoutMarkerData,
     const uint32_t depth,
     const uint32_t generationCount) {
@@ -1199,7 +1188,6 @@ static void resolveFlexibleLength(
       mainAxisOverflows,
       measureModeCrossDim,
       performLayout,
-      config,
       layoutMarkerData,
       depth,
       generationCount);
@@ -1496,7 +1484,6 @@ static void calculateLayoutImpl(
     const float ownerWidth,
     const float ownerHeight,
     const bool performLayout,
-    const yoga::Config* const config,
     LayoutData& layoutMarkerData,
     const uint32_t depth,
     const uint32_t generationCount,
@@ -1673,7 +1660,6 @@ static void calculateLayoutImpl(
       heightMeasureMode,
       direction,
       mainAxis,
-      config,
       performLayout,
       layoutMarkerData,
       depth,
@@ -1812,7 +1798,6 @@ static void calculateLayoutImpl(
           mainAxisOverflows,
           measureModeCrossDim,
           performLayout,
-          config,
           layoutMarkerData,
           depth,
           generationCount);
@@ -1987,7 +1972,6 @@ static void calculateLayoutImpl(
                   availableInnerHeight,
                   true,
                   LayoutPassReason::kStretch,
-                  config,
                   layoutMarkerData,
                   depth,
                   generationCount);
@@ -2204,7 +2188,6 @@ static void calculateLayoutImpl(
                         availableInnerHeight,
                         true,
                         LayoutPassReason::kMultilineStretch,
-                        config,
                         layoutMarkerData,
                         depth,
                         generationCount);
@@ -2340,7 +2323,7 @@ static void calculateLayoutImpl(
         continue;
       }
       const bool absolutePercentageAgainstPaddingEdge =
-          config->isExperimentalFeatureEnabled(
+          node->getConfig()->isExperimentalFeatureEnabled(
               YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge);
 
       layoutAbsoluteChild(
@@ -2354,7 +2337,6 @@ static void calculateLayoutImpl(
               ? node->getLayout().measuredDimensions[YGDimensionHeight]
               : availableInnerHeight,
           direction,
-          config,
           layoutMarkerData,
           depth,
           generationCount);
@@ -2434,7 +2416,6 @@ bool calculateLayoutInternal(
     const float ownerHeight,
     const bool performLayout,
     const LayoutPassReason reason,
-    const yoga::Config* const config,
     LayoutData& layoutMarkerData,
     uint32_t depth,
     const uint32_t generationCount) {
@@ -2594,7 +2575,6 @@ bool calculateLayoutInternal(
         ownerWidth,
         ownerHeight,
         performLayout,
-        config,
         layoutMarkerData,
         depth,
         generationCount,
@@ -2750,7 +2730,6 @@ void calculateLayout(
           ownerHeight,
           true,
           LayoutPassReason::kInitial,
-          node->getConfig(),
           markerData,
           0, // tree root
           gCurrentGenerationCount.load(std::memory_order_relaxed))) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
@@ -59,7 +59,7 @@ float roundValueToPixelGrid(
   }
   return (std::isnan(scaledValue) || std::isnan(pointScaleFactor))
       ? YGUndefined
-      : (float) (scaledValue / pointScaleFactor);
+      : (float)(scaledValue / pointScaleFactor);
 }
 
 void roundLayoutResultsToPixelGrid(

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/ResolveValue.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/ResolveValue.h
@@ -26,7 +26,7 @@ inline FloatOptional resolveValue(const YGValue value, const float ownerSize) {
 }
 
 inline FloatOptional resolveValue(CompactValue value, float ownerSize) {
-  return resolveValue((YGValue) value, ownerSize);
+  return resolveValue((YGValue)value, ownerSize);
 }
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/bits/EnumBitset.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/bits/EnumBitset.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <bitset>
 #include <yoga/YGEnums.h>
+#include <bitset>
 
 namespace facebook::yoga {
 

--- a/packages/react-native/ReactCommon/yoga/yoga/bits/NumericBitfield.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/bits/NumericBitfield.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <bitset>
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
 
 #include <yoga/YGEnums.h>
 

--- a/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/config/Config.h
@@ -34,7 +34,7 @@ struct ConfigFlags {
 #pragma pack(pop)
 
 class YG_EXPORT Config : public ::YGConfig {
-public:
+ public:
   Config(YGLogger logger);
 
   void setUseWebDefaults(bool useWebDefaults);
@@ -69,14 +69,12 @@ public:
       va_list args) const;
 
   void setCloneNodeCallback(YGCloneNodeFunc cloneNode);
-  YGNodeRef cloneNode(
-      YGNodeConstRef node,
-      YGNodeConstRef owner,
-      size_t childIndex) const;
+  YGNodeRef
+  cloneNode(YGNodeConstRef node, YGNodeConstRef owner, size_t childIndex) const;
 
   static const Config& getDefault();
 
-private:
+ private:
   YGCloneNodeFunc cloneNodeCallback_;
   YGLogger logger_;
 

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <yoga/Yoga.h>
-#include <yoga/node/Node.h>
 #include <yoga/config/Config.h>
+#include <yoga/node/Node.h>
 
 namespace facebook::yoga {
 

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/Log.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/Log.h
@@ -10,8 +10,8 @@
 #include <yoga/Yoga.h>
 
 #include <yoga/YGEnums.h>
-#include <yoga/node/Node.h>
 #include <yoga/config/Config.h>
+#include <yoga/node/Node.h>
 
 namespace facebook::yoga {
 

--- a/packages/react-native/ReactCommon/yoga/yoga/event/event.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/event/event.h
@@ -9,10 +9,10 @@
 
 #include <yoga/Yoga.h>
 
+#include <stdint.h>
+#include <array>
 #include <functional>
 #include <vector>
-#include <array>
-#include <stdint.h>
 
 namespace facebook::yoga {
 
@@ -70,7 +70,7 @@ struct YG_EXPORT Event {
   class Data {
     const void* data_;
 
-  public:
+   public:
     template <Type E>
     Data(const TypedData<E>& data) : data_{&data} {}
 
@@ -89,7 +89,7 @@ struct YG_EXPORT Event {
     publish(node, E, Data{eventData});
   }
 
-private:
+ private:
   static void publish(YGNodeConstRef, Type, const Data&);
 };
 

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
@@ -10,8 +10,8 @@
 #include <array>
 
 #include <yoga/bits/NumericBitfield.h>
-#include <yoga/numeric/FloatOptional.h>
 #include <yoga/node/CachedMeasurement.h>
+#include <yoga/numeric/FloatOptional.h>
 
 namespace facebook::yoga {
 
@@ -34,10 +34,10 @@ struct LayoutResults {
   std::array<float, 4> border = {};
   std::array<float, 4> padding = {};
 
-private:
+ private:
   LayoutResultFlags flags_{};
 
-public:
+ public:
   uint32_t computedFlexBasisGeneration = 0;
   FloatOptional computedFlexBasis = {};
 
@@ -60,11 +60,17 @@ public:
     flags_.direction = static_cast<uint32_t>(direction) & 0x03;
   }
 
-  bool hadOverflow() const { return flags_.hadOverflow; }
-  void setHadOverflow(bool hadOverflow) { flags_.hadOverflow = hadOverflow; }
+  bool hadOverflow() const {
+    return flags_.hadOverflow;
+  }
+  void setHadOverflow(bool hadOverflow) {
+    flags_.hadOverflow = hadOverflow;
+  }
 
   bool operator==(LayoutResults layout) const;
-  bool operator!=(LayoutResults layout) const { return !(*this == layout); }
+  bool operator!=(LayoutResults layout) const {
+    return !(*this == layout);
+  }
 };
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <stdio.h>
+#include <cstdint>
 #include <vector>
 
 #include <yoga/Yoga.h>
@@ -34,7 +34,7 @@ struct NodeFlags {
 #pragma pack(pop)
 
 class YG_EXPORT Node : public ::YGNode {
-private:
+ private:
   void* context_ = nullptr;
   NodeFlags flags_ = {};
   YGMeasureFunc measureFunc_ = {nullptr};
@@ -66,7 +66,7 @@ private:
   // DO NOT CHANGE THE VISIBILITY OF THIS METHOD!
   Node& operator=(Node&&) = default;
 
-public:
+ public:
   Node();
   explicit Node(const Config* config);
   ~Node() = default; // cleanup of owner/children relationships in YGNodeFree
@@ -82,60 +82,98 @@ public:
   Node& operator=(const Node&) = delete;
 
   // Getters
-  void* getContext() const { return context_; }
+  void* getContext() const {
+    return context_;
+  }
 
   void print();
 
-  bool getHasNewLayout() const { return flags_.hasNewLayout; }
+  bool getHasNewLayout() const {
+    return flags_.hasNewLayout;
+  }
 
   YGNodeType getNodeType() const {
     return static_cast<YGNodeType>(flags_.nodeType);
   }
 
-  bool hasMeasureFunc() const noexcept { return measureFunc_ != nullptr; }
+  bool hasMeasureFunc() const noexcept {
+    return measureFunc_ != nullptr;
+  }
 
   YGSize measure(float, YGMeasureMode, float, YGMeasureMode);
 
-  bool hasBaselineFunc() const noexcept { return baselineFunc_ != nullptr; }
+  bool hasBaselineFunc() const noexcept {
+    return baselineFunc_ != nullptr;
+  }
 
   float baseline(float width, float height) const;
 
-  bool hasErrata(YGErrata errata) const { return config_->hasErrata(errata); }
+  bool hasErrata(YGErrata errata) const {
+    return config_->hasErrata(errata);
+  }
 
-  YGDirtiedFunc getDirtiedFunc() const { return dirtiedFunc_; }
+  YGDirtiedFunc getDirtiedFunc() const {
+    return dirtiedFunc_;
+  }
 
   // For Performance reasons passing as reference.
-  Style& getStyle() { return style_; }
+  Style& getStyle() {
+    return style_;
+  }
 
-  const Style& getStyle() const { return style_; }
+  const Style& getStyle() const {
+    return style_;
+  }
 
   // For Performance reasons passing as reference.
-  LayoutResults& getLayout() { return layout_; }
+  LayoutResults& getLayout() {
+    return layout_;
+  }
 
-  const LayoutResults& getLayout() const { return layout_; }
+  const LayoutResults& getLayout() const {
+    return layout_;
+  }
 
-  size_t getLineIndex() const { return lineIndex_; }
+  size_t getLineIndex() const {
+    return lineIndex_;
+  }
 
-  bool isReferenceBaseline() const { return flags_.isReferenceBaseline; }
+  bool isReferenceBaseline() const {
+    return flags_.isReferenceBaseline;
+  }
 
   // returns the Node that owns this Node. An owner is used to identify
   // the YogaTree that a Node belongs to. This method will return the parent
   // of the Node when a Node only belongs to one YogaTree or nullptr when
   // the Node is shared between two or more YogaTrees.
-  Node* getOwner() const { return owner_; }
+  Node* getOwner() const {
+    return owner_;
+  }
 
   // Deprecated, use getOwner() instead.
-  Node* getParent() const { return getOwner(); }
+  Node* getParent() const {
+    return getOwner();
+  }
 
-  const std::vector<Node*>& getChildren() const { return children_; }
+  const std::vector<Node*>& getChildren() const {
+    return children_;
+  }
 
-  Node* getChild(size_t index) const { return children_.at(index); }
+  Node* getChild(size_t index) const {
+    return children_.at(index);
+  }
 
-  size_t getChildCount() const { return children_.size(); }
+  size_t getChildCount() const {
+    return children_.size();
+  }
 
-  const Config* getConfig() const { return config_; }
+  const Config* getConfig() const {
+    return config_;
+  }
 
-  bool isDirty() const { return flags_.isDirty; }
+  bool isDirty() const {
+    return flags_.isDirty;
+  }
 
   std::array<YGValue, 2> getResolvedDimensions() const {
     return resolvedDimensions_;
@@ -200,9 +238,13 @@ public:
       const;
   // Setters
 
-  void setContext(void* context) { context_ = context; }
+  void setContext(void* context) {
+    context_ = context;
+  }
 
-  void setPrintFunc(YGPrintFunc printFunc) { printFunc_ = printFunc; }
+  void setPrintFunc(YGPrintFunc printFunc) {
+    printFunc_ = printFunc;
+  }
 
   void setHasNewLayout(bool hasNewLayout) {
     flags_.hasNewLayout = hasNewLayout;
@@ -218,21 +260,33 @@ public:
     baselineFunc_ = baseLineFunc;
   }
 
-  void setDirtiedFunc(YGDirtiedFunc dirtiedFunc) { dirtiedFunc_ = dirtiedFunc; }
+  void setDirtiedFunc(YGDirtiedFunc dirtiedFunc) {
+    dirtiedFunc_ = dirtiedFunc;
+  }
 
-  void setStyle(const Style& style) { style_ = style; }
+  void setStyle(const Style& style) {
+    style_ = style;
+  }
 
-  void setLayout(const LayoutResults& layout) { layout_ = layout; }
+  void setLayout(const LayoutResults& layout) {
+    layout_ = layout;
+  }
 
-  void setLineIndex(size_t lineIndex) { lineIndex_ = lineIndex; }
+  void setLineIndex(size_t lineIndex) {
+    lineIndex_ = lineIndex;
+  }
 
   void setIsReferenceBaseline(bool isReferenceBaseline) {
     flags_.isReferenceBaseline = isReferenceBaseline;
   }
 
-  void setOwner(Node* owner) { owner_ = owner; }
+  void setOwner(Node* owner) {
+    owner_ = owner;
+  }
 
-  void setChildren(const std::vector<Node*>& children) { children_ = children; }
+  void setChildren(const std::vector<Node*>& children) {
+    children_ = children;
+  }
 
   // TODO: rvalue override for setChildren
 

--- a/packages/react-native/ReactCommon/yoga/yoga/numeric/Comparison.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/numeric/Comparison.h
@@ -75,7 +75,7 @@ inline bool inexactEquals(const YGValue& a, const YGValue& b) {
 }
 
 inline bool inexactEquals(CompactValue a, CompactValue b) {
-  return inexactEquals((YGValue) a, (YGValue) b);
+  return inexactEquals((YGValue)a, (YGValue)b);
 }
 
 template <std::size_t Size, typename ElementT>

--- a/packages/react-native/ReactCommon/yoga/yoga/numeric/FloatOptional.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/numeric/FloatOptional.h
@@ -13,17 +13,21 @@
 namespace facebook::yoga {
 
 struct FloatOptional {
-private:
+ private:
   float value_ = std::numeric_limits<float>::quiet_NaN();
 
-public:
+ public:
   explicit constexpr FloatOptional(float value) : value_(value) {}
   constexpr FloatOptional() = default;
 
   // returns the wrapped value, or a value x with YGIsUndefined(x) == true
-  constexpr float unwrap() const { return value_; }
+  constexpr float unwrap() const {
+    return value_;
+  }
 
-  bool isUndefined() const { return std::isnan(value_); }
+  bool isUndefined() const {
+    return std::isnan(value_);
+  }
 };
 
 // operators take FloatOptional by value, as it is a 32bit value

--- a/packages/react-native/ReactCommon/yoga/yoga/style/CompactValue.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/CompactValue.h
@@ -44,7 +44,7 @@ namespace facebook::yoga {
 class YG_EXPORT CompactValue {
   friend constexpr bool operator==(CompactValue, CompactValue) noexcept;
 
-public:
+ public:
   static constexpr auto LOWER_BOUND = 1.08420217e-19f;
   static constexpr auto UPPER_BOUND_POINT = 36893485948395847680.0f;
   static constexpr auto UPPER_BOUND_PERCENT = 18446742974197923840.0f;
@@ -136,9 +136,11 @@ public:
         repr_ != ZERO_BITS_PERCENT && std::isnan(yoga::bit_cast<float>(repr_)));
   }
 
-  bool isAuto() const noexcept { return repr_ == AUTO_BITS; }
+  bool isAuto() const noexcept {
+    return repr_ == AUTO_BITS;
+  }
 
-private:
+ private:
   uint32_t repr_;
 
   static constexpr uint32_t BIAS = 0x20000000;
@@ -152,7 +154,9 @@ private:
 
   constexpr CompactValue(uint32_t data) noexcept : repr_(data) {}
 
-  VISIBLE_FOR_TESTING uint32_t repr() { return repr_; }
+  VISIBLE_FOR_TESTING uint32_t repr() {
+    return repr_;
+  }
 };
 
 template <>

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.cpp
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <yoga/style/Style.h>
 #include <yoga/numeric/Comparison.h>
+#include <yoga/style/Style.h>
 
 namespace facebook::yoga {
 

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -24,7 +24,7 @@ class YG_EXPORT Style {
   template <typename Enum>
   using Values = std::array<CompactValue, enums::count<Enum>()>;
 
-public:
+ public:
   using Dimensions = Values<YGDimension>;
   using Edges = Values<YGEdge>;
   using Gutters = Values<YGGutter>;
@@ -37,7 +37,9 @@ public:
   struct BitfieldRef {
     Style& style;
     uint8_t offset;
-    operator T() const { return getEnumData<T>(style.flags, offset); }
+    operator T() const {
+      return getEnumData<T>(style.flags, offset);
+    }
     BitfieldRef<T>& operator=(T x) {
       setEnumData<T>(style.flags, offset, x);
       return *this;
@@ -47,7 +49,9 @@ public:
   template <typename T, T Style::*Prop>
   struct Ref {
     Style& style;
-    operator T() const { return style.*Prop; }
+    operator T() const {
+      return style.*Prop;
+    }
     Ref<T, Prop>& operator=(T value) {
       style.*Prop = value;
       return *this;
@@ -59,8 +63,12 @@ public:
     struct Ref {
       Style& style;
       Idx idx;
-      operator CompactValue() const { return (style.*Prop)[idx]; }
-      operator YGValue() const { return (style.*Prop)[idx]; }
+      operator CompactValue() const {
+        return (style.*Prop)[idx];
+      }
+      operator YGValue() const {
+        return (style.*Prop)[idx];
+      }
       Ref& operator=(CompactValue value) {
         (style.*Prop)[idx] = value;
         return *this;
@@ -72,9 +80,15 @@ public:
       style.*Prop = values;
       return *this;
     }
-    operator const Values<Idx>&() const { return style.*Prop; }
-    Ref operator[](Idx idx) { return {style, idx}; }
-    CompactValue operator[](Idx idx) const { return (style.*Prop)[idx]; }
+    operator const Values<Idx>&() const {
+      return style.*Prop;
+    }
+    Ref operator[](Idx idx) {
+      return {style, idx};
+    }
+    CompactValue operator[](Idx idx) const {
+      return (style.*Prop)[idx];
+    }
   };
 
   Style() {
@@ -83,7 +97,7 @@ public:
   }
   ~Style() = default;
 
-private:
+ private:
   static constexpr uint8_t directionOffset = 0;
   static constexpr uint8_t flexdirectionOffset =
       directionOffset + minimumBitCount<YGDirection>();
@@ -121,14 +135,16 @@ private:
   // Yoga specific properties, not compatible with flexbox specification
   FloatOptional aspectRatio_ = {};
 
-public:
+ public:
   // for library users needing a type
   using ValueRepr = std::remove_reference<decltype(margin_[0])>::type;
 
   YGDirection direction() const {
     return getEnumData<YGDirection>(flags, directionOffset);
   }
-  BitfieldRef<YGDirection> direction() { return {*this, directionOffset}; }
+  BitfieldRef<YGDirection> direction() {
+    return {*this, directionOffset};
+  }
 
   YGFlexDirection flexDirection() const {
     return getEnumData<YGFlexDirection>(flags, flexdirectionOffset);
@@ -147,17 +163,23 @@ public:
   YGAlign alignContent() const {
     return getEnumData<YGAlign>(flags, alignContentOffset);
   }
-  BitfieldRef<YGAlign> alignContent() { return {*this, alignContentOffset}; }
+  BitfieldRef<YGAlign> alignContent() {
+    return {*this, alignContentOffset};
+  }
 
   YGAlign alignItems() const {
     return getEnumData<YGAlign>(flags, alignItemsOffset);
   }
-  BitfieldRef<YGAlign> alignItems() { return {*this, alignItemsOffset}; }
+  BitfieldRef<YGAlign> alignItems() {
+    return {*this, alignItemsOffset};
+  }
 
   YGAlign alignSelf() const {
     return getEnumData<YGAlign>(flags, alignSelfOffset);
   }
-  BitfieldRef<YGAlign> alignSelf() { return {*this, alignSelfOffset}; }
+  BitfieldRef<YGAlign> alignSelf() {
+    return {*this, alignSelfOffset};
+  }
 
   YGPositionType positionType() const {
     return getEnumData<YGPositionType>(flags, positionTypeOffset);
@@ -166,62 +188,118 @@ public:
     return {*this, positionTypeOffset};
   }
 
-  YGWrap flexWrap() const { return getEnumData<YGWrap>(flags, flexWrapOffset); }
-  BitfieldRef<YGWrap> flexWrap() { return {*this, flexWrapOffset}; }
+  YGWrap flexWrap() const {
+    return getEnumData<YGWrap>(flags, flexWrapOffset);
+  }
+  BitfieldRef<YGWrap> flexWrap() {
+    return {*this, flexWrapOffset};
+  }
 
   YGOverflow overflow() const {
     return getEnumData<YGOverflow>(flags, overflowOffset);
   }
-  BitfieldRef<YGOverflow> overflow() { return {*this, overflowOffset}; }
+  BitfieldRef<YGOverflow> overflow() {
+    return {*this, overflowOffset};
+  }
 
   YGDisplay display() const {
     return getEnumData<YGDisplay>(flags, displayOffset);
   }
-  BitfieldRef<YGDisplay> display() { return {*this, displayOffset}; }
+  BitfieldRef<YGDisplay> display() {
+    return {*this, displayOffset};
+  }
 
-  FloatOptional flex() const { return flex_; }
-  Ref<FloatOptional, &Style::flex_> flex() { return {*this}; }
+  FloatOptional flex() const {
+    return flex_;
+  }
+  Ref<FloatOptional, &Style::flex_> flex() {
+    return {*this};
+  }
 
-  FloatOptional flexGrow() const { return flexGrow_; }
-  Ref<FloatOptional, &Style::flexGrow_> flexGrow() { return {*this}; }
+  FloatOptional flexGrow() const {
+    return flexGrow_;
+  }
+  Ref<FloatOptional, &Style::flexGrow_> flexGrow() {
+    return {*this};
+  }
 
-  FloatOptional flexShrink() const { return flexShrink_; }
-  Ref<FloatOptional, &Style::flexShrink_> flexShrink() { return {*this}; }
+  FloatOptional flexShrink() const {
+    return flexShrink_;
+  }
+  Ref<FloatOptional, &Style::flexShrink_> flexShrink() {
+    return {*this};
+  }
 
-  CompactValue flexBasis() const { return flexBasis_; }
-  Ref<CompactValue, &Style::flexBasis_> flexBasis() { return {*this}; }
+  CompactValue flexBasis() const {
+    return flexBasis_;
+  }
+  Ref<CompactValue, &Style::flexBasis_> flexBasis() {
+    return {*this};
+  }
 
-  const Edges& margin() const { return margin_; }
-  IdxRef<YGEdge, &Style::margin_> margin() { return {*this}; }
+  const Edges& margin() const {
+    return margin_;
+  }
+  IdxRef<YGEdge, &Style::margin_> margin() {
+    return {*this};
+  }
 
-  const Edges& position() const { return position_; }
-  IdxRef<YGEdge, &Style::position_> position() { return {*this}; }
+  const Edges& position() const {
+    return position_;
+  }
+  IdxRef<YGEdge, &Style::position_> position() {
+    return {*this};
+  }
 
-  const Edges& padding() const { return padding_; }
-  IdxRef<YGEdge, &Style::padding_> padding() { return {*this}; }
+  const Edges& padding() const {
+    return padding_;
+  }
+  IdxRef<YGEdge, &Style::padding_> padding() {
+    return {*this};
+  }
 
-  const Edges& border() const { return border_; }
-  IdxRef<YGEdge, &Style::border_> border() { return {*this}; }
+  const Edges& border() const {
+    return border_;
+  }
+  IdxRef<YGEdge, &Style::border_> border() {
+    return {*this};
+  }
 
-  const Gutters& gap() const { return gap_; }
-  IdxRef<YGGutter, &Style::gap_> gap() { return {*this}; }
+  const Gutters& gap() const {
+    return gap_;
+  }
+  IdxRef<YGGutter, &Style::gap_> gap() {
+    return {*this};
+  }
 
-  const Dimensions& dimensions() const { return dimensions_; }
-  IdxRef<YGDimension, &Style::dimensions_> dimensions() { return {*this}; }
+  const Dimensions& dimensions() const {
+    return dimensions_;
+  }
+  IdxRef<YGDimension, &Style::dimensions_> dimensions() {
+    return {*this};
+  }
 
-  const Dimensions& minDimensions() const { return minDimensions_; }
+  const Dimensions& minDimensions() const {
+    return minDimensions_;
+  }
   IdxRef<YGDimension, &Style::minDimensions_> minDimensions() {
     return {*this};
   }
 
-  const Dimensions& maxDimensions() const { return maxDimensions_; }
+  const Dimensions& maxDimensions() const {
+    return maxDimensions_;
+  }
   IdxRef<YGDimension, &Style::maxDimensions_> maxDimensions() {
     return {*this};
   }
 
   // Yoga specific properties, not compatible with flexbox specification
-  FloatOptional aspectRatio() const { return aspectRatio_; }
-  Ref<FloatOptional, &Style::aspectRatio_> aspectRatio() { return {*this}; }
+  FloatOptional aspectRatio() const {
+    return aspectRatio_;
+  }
+  Ref<FloatOptional, &Style::aspectRatio_> aspectRatio() {
+    return {*this};
+  }
 };
 
 YG_EXPORT bool operator==(const Style& lhs, const Style& rhs);


### PR DESCRIPTION
Summary:
This mirrors the clang-format config used by fbsource to Yoga.

They are pretty similar, except for an annoying habit where Yoga's previous forced small functions in headers to be a a single line, so you would get a combination of multiline and single line functions next to each other which are hard to read. That is what motivated this change.

It also enforces header ordering (yay). I don't think we have any side-effect causing headers, so this should be safe.

Reviewed By: yungsters

Differential Revision: D49248994

