### PR TITLE
Breaking: Use C++ 20

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/SampleTurboCxxModuleLegacyImpl.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/SampleTurboCxxModuleLegacyImpl.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#import <cxxreact/CxxModule.h>
+#include <cxxreact/CxxModule.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/yoga/Yoga.podspec
+++ b/packages/react-native/ReactCommon/yoga/Yoga.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |spec|
       '-fexceptions',
       '-Wall',
       '-Werror',
-      '-std=c++17',
+      '-std=c++20',
       '-fPIC'
   ]
 

--- a/packages/react-native/ReactCommon/yoga/cmake/project-defaults.cmake
+++ b/packages/react-native/ReactCommon/yoga/cmake/project-defaults.cmake
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/packages/react-native/ReactCommon/yoga/yoga/bits/BitCast.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/bits/BitCast.h
@@ -14,6 +14,7 @@ namespace facebook::yoga {
 
 // Polyfill for std::bit_cast() from C++20, to allow safe type punning
 // https://en.cppreference.com/w/cpp/numeric/bit_cast
+// TODO: Remove when we upgrade to NDK 26+
 template <class To, class From>
 std::enable_if_t<
     sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<From> &&


### PR DESCRIPTION
Summary:
Have been running into places where C++ 20 makes life easier for use like `std::bit_cast` (that one is easy to polyfill), in-class member initializer support for bitfields, designated initializers, defaulted comparison operator, concepts instead of SFINAE, and probably more.

Our other infra is in the process of making this jump, or already has. This tests it out everywhere, across the various reference builds, to see if we have any issues.

This is a bit more aggressive than I had previously, but n - 1 is going to be a better long term place than n - 2. I think it is likely everything will be buildable for a while under Clang 10 (released 3.5 years ago), GCC 10 (releaseed 3.5 years ago), and VS 16.11 (released 2 years ago).

Differential Revision: D49261607


