### PR TITLE
fix: over reporting trait changes

### DIFF
--- a/packages/react-native/React/Base/RCTRootView.m
+++ b/packages/react-native/React/Base/RCTRootView.m
@@ -368,6 +368,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
   [super traitCollectionDidChange:previousTraitCollection];
+  if (RCTSharedApplication().applicationState == UIApplicationStateBackground) {
+    return;
+  }
 
   [[NSNotificationCenter defaultCenter]
       postNotificationName:RCTUserInterfaceStyleDidChangeNotification

--- a/packages/react-native/React/CoreModules/RCTAppearance.h
+++ b/packages/react-native/React/CoreModules/RCTAppearance.h
@@ -17,4 +17,5 @@ RCT_EXTERN NSString *RCTCurrentOverrideAppearancePreference();
 RCT_EXTERN NSString *RCTColorSchemePreference(UITraitCollection *traitCollection);
 
 @interface RCTAppearance : RCTEventEmitter <RCTBridgeModule>
+- (instancetype)init;
 @end

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -36,6 +36,33 @@ NSString *RCTCurrentOverrideAppearancePreference()
   return sColorSchemeOverride;
 }
 
+<<<<<<< HEAD
+||||||| parent of 5715b1498ee (Make requesting the trait collection synchronous)
+static UITraitCollection *getKeyWindowTraitCollection()
+{
+  __block UITraitCollection *traitCollection = nil;
+  RCTExecuteOnMainQueue(^{
+    traitCollection = RCTSharedApplication().delegate.window.traitCollection;
+  });
+  return traitCollection;
+}
+
+=======
+static UITraitCollection *getKeyWindowTraitCollection()
+{
+  __block UITraitCollection *traitCollection = nil;
+  if (RCTIsMainQueue()) {
+    return RCTSharedApplication().delegate.window.traitCollection;
+  } else {
+    __block UITraitCollection* traitCollection = nil;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      traitCollection = RCTSharedApplication().delegate.window.traitCollection;
+    });
+    return traitCollection;
+  }
+}
+
+>>>>>>> 5715b1498ee (Make requesting the trait collection synchronous)
 NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
 {
   static NSDictionary *appearances;
@@ -59,9 +86,6 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
 
   traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
   return appearances[@(traitCollection.userInterfaceStyle)] ?: RCTAppearanceColorSchemeLight;
-
-  // Default to light on older OS version - same behavior as Android.
-  return RCTAppearanceColorSchemeLight;
 }
 
 @interface RCTAppearance () <NativeAppearanceSpec>

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -51,15 +51,10 @@ static UITraitCollection *getKeyWindowTraitCollection()
 static UITraitCollection *getKeyWindowTraitCollection()
 {
   __block UITraitCollection *traitCollection = nil;
-  if (RCTIsMainQueue()) {
-    return RCTSharedApplication().delegate.window.traitCollection;
-  } else {
-    __block UITraitCollection* traitCollection = nil;
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      traitCollection = RCTSharedApplication().delegate.window.traitCollection;
-    });
-    return traitCollection;
-  }
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    traitCollection = RCTSharedApplication().delegate.window.traitCollection;
+  });
+  return traitCollection;
 }
 
 >>>>>>> 5715b1498ee (Make requesting the trait collection synchronous)

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -140,6 +140,11 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)
 
 - (void)stopObserving
 {
+
+}
+
+- (void)invalidate {
+  [super invalidate];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -133,16 +133,6 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)
   return @[ @"appearanceChanged" ];
 }
 
-- (void)startObserving
-{
-  
-}
-
-- (void)stopObserving
-{
-
-}
-
 - (void)invalidate {
   [super invalidate];
   [[NSNotificationCenter defaultCenter] removeObserver:self];


### PR DESCRIPTION
## Summary:
Closes #35972
Closes #36713

This PR addresses a couple of issues with `useColorScheme` and the `Appearance` API.

- #38214 introduced a regression. Using to `RCTExecuteOnMainQueue` was a mistake as we need this to happen synchronously to return the result. Doing it async causes the `traitCollection` to remain uninitialized. 
- The `useColorScheme` hook is updating when the app is in the background on iOS and the OS is taking the snapshots for the app switcher. This causes a flash when returning to the app as the correct color is set again. Here, we can check for the app state in `traitCollectionDidChange` and not send these events when in the background.
- Removed a line that was left over after some OS version checks were removed when support for iOS 12 was dropped.

## Changelog:

[IOS] [FIXED] - Don't send the `RCTUserInterfaceStyleDidChangeNotification` when the app is in the background. 

## Test Plan:

Tested on `rn-tester`, logged the changes whenever `useColorScheme` updates. It no longer happens when the app is in the background. The returned interface style on the initial render is always correct now.
