### PR TITLE
Remove unused downloadAll task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,18 +74,6 @@ tasks.register("build") {
   dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":build"))
 }
 
-tasks.register("downloadAll") {
-  description = "Download all the depedencies needed locally so they can be cached on CI."
-  dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":dependencies"))
-  dependsOn(":packages:react-native:ReactAndroid:downloadNdkBuildDependencies")
-  dependsOn(":packages:react-native:ReactAndroid:dependencies")
-  dependsOn(":packages:react-native:ReactAndroid:androidDependencies")
-  dependsOn(":packages:react-native:ReactAndroid:hermes-engine:dependencies")
-  dependsOn(":packages:react-native:ReactAndroid:hermes-engine:androidDependencies")
-  dependsOn(":packages:rn-tester:android:app:dependencies")
-  dependsOn(":packages:rn-tester:android:app:androidDependencies")
-}
-
 tasks.register("publishAllInsideNpmPackage") {
   description =
       "Publish all the artifacts to be available inside the NPM package in the `android` folder."

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -382,18 +382,6 @@ tasks.register('prepareJSC', PrepareJSCTask) {
     it.outputDir = project.layout.buildDirectory.dir("third-party-ndk/jsc")
 }
 
-task downloadNdkBuildDependencies {
-    if (!boostPath) {
-        dependsOn(downloadBoost)
-    }
-    dependsOn(downloadDoubleConversion)
-    dependsOn(downloadFolly)
-    dependsOn(downloadGlog)
-    dependsOn(downloadFmt)
-    dependsOn(downloadLibevent)
-    dependsOn(downloadGtest)
-}
-
 task prepareKotlinBuildScriptModel {
     // This task is run when Gradle Sync is running.
     // We create it here so we can let it depend on preBuild inside the android{}


### PR DESCRIPTION
Summary:
This task is unused in CI now and we can safely remove it from our build files.

Changelog:
[Internal] [Changed] - Remove unused downloadAll task

Reviewed By: cipolleschi

Differential Revision: D49233339

