### PR TITLE
[RN][Android] use invalidate as NativeModule not JSIModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -195,8 +195,8 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
     mEventDispatcher.onCatalystInstanceDestroyed();
     mUIImplementation.onCatalystInstanceDestroyed();
 


### PR DESCRIPTION
## Summary:

`NativeModule.onCatalystInstanceDestroy()` is deprecated in favor of `NativeModule.invalidate()`

`BaseJavaModule.invalidate()` invokes `BaseJavaModule.invalidate()`

Override `invalidate` in `UIManagerModule` instead of `onCatalystInstanceDestroy` for more clear inheritance

Ref: https://github.com/facebook/react-native/pull/39444

## Changelog:

[ANDROID][Refactor] - use invalidate as NativeModule not JSIModule

## Test Plan:

TODO
