### PR TITLE
Clean header-only SchedulerToolbox

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.cpp
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-#include "SchedulerToolbox.h"


### PR DESCRIPTION
## Summary:

Clean header-only `SchedulerToolbox.cpp`

## Changelog:

[INTERNAL] [REMOVED] - Clean header-only SchedulerToolbox

## Test Plan:

Compile success
