### PR TITLE
remove rarely used bridge module optimization

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -115,10 +115,6 @@ class JavaModuleWrapper {
 
   @DoNotStrip
   public @Nullable NativeMap getConstants() {
-    if (!mModuleHolder.getHasConstants()) {
-      return null;
-    }
-
     final String moduleName = getName();
     SystraceMessage.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "JavaModuleWrapper.getConstants")
         .arg("moduleName", moduleName)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
@@ -120,10 +120,6 @@ public class ModuleHolder {
     return mReactModuleInfo.canOverrideExistingModule();
   }
 
-  public boolean getHasConstants() {
-    return mReactModuleInfo.hasConstants();
-  }
-
   public boolean isTurboModule() {
     return mReactModuleInfo.isTurboModule();
   }


### PR DESCRIPTION
Summary:
## Changelog
[Android][General] - hasConstants in ReactModuleInfo does nothing now

we can get rid of this. currently, the default value of hasConstants true, and the only library setting this value to false is `WebSocketModule`. this value is only read in bridge mode - it is an optimization that will not initialize the constants dictionary for native modules in bridge.

however, we have plenty of native modules that don't provide constants that have not set this flag, so this is only turned on for `WebSocketModule`, which is probably not moving anything significant.

i would recommend we get rid of this to simplify the ReactModuleInfo deprecation plan.

Reviewed By: cortinico

Differential Revision: D49210251


