### PR TITLE
deprecate mHasConstants in ReactModuleInfo

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -115,10 +115,6 @@ class JavaModuleWrapper {
 
   @DoNotStrip
   public @Nullable NativeMap getConstants() {
-    if (!mModuleHolder.getHasConstants()) {
-      return null;
-    }
-
     final String moduleName = getName();
     SystraceMessage.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "JavaModuleWrapper.getConstants")
         .arg("moduleName", moduleName)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
@@ -120,10 +120,6 @@ public class ModuleHolder {
     return mReactModuleInfo.canOverrideExistingModule();
   }
 
-  public boolean getHasConstants() {
-    return mReactModuleInfo.hasConstants();
-  }
-
   public boolean isTurboModule() {
     return mReactModuleInfo.isTurboModule();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.java
@@ -16,7 +16,6 @@ public class ReactModuleInfo {
   private final String mName;
   private final boolean mCanOverrideExistingModule;
   private final boolean mNeedsEagerInit;
-  private final boolean mHasConstants;
   private final boolean mIsCxxModule;
   private final String mClassName;
   private final boolean mIsTurboModule;
@@ -33,7 +32,6 @@ public class ReactModuleInfo {
     mClassName = className;
     mCanOverrideExistingModule = canOverrideExistingModule;
     mNeedsEagerInit = needsEagerInit;
-    mHasConstants = hasConstants;
     mIsCxxModule = isCxxModule;
     mIsTurboModule = isTurboModule;
   }
@@ -54,8 +52,10 @@ public class ReactModuleInfo {
     return mNeedsEagerInit;
   }
 
+  /** @deprecated this is hardcoded to return true, regardless if the module has constants or not */
+  @Deprecated
   public boolean hasConstants() {
-    return mHasConstants;
+    return true;
   }
 
   public boolean isCxxModule() {


### PR DESCRIPTION
Summary:
## Changelog
[Android][Deprecated] - hasConstants in ReactModuleInfo is marked as deprecated

getting rid of `mHasConstants` ivar here and marking the getter as deprecated

Reviewed By: cortinico

Differential Revision: D49262577

