### PR TITLE
deprecate hasConstants from ReactModuleInfo

### DIFF
--- a/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/ReactRootViewTest.java
+++ b/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/ReactRootViewTest.java
@@ -79,7 +79,6 @@ public class ReactRootViewTest {
                       moduleClass.getName(),
                       reactModule.canOverrideExistingModule(),
                       reactModule.needsEagerInit(),
-                      reactModule.hasConstants(),
                       reactModule.isCxxModule(),
                       false));
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -114,7 +114,6 @@ public class CoreModulesPackage extends TurboReactPackage implements ReactPackag
                 moduleClass.getName(),
                 reactModule.canOverrideExistingModule(),
                 reactModule.needsEagerInit(),
-                reactModule.hasConstants(),
                 reactModule.isCxxModule(),
                 TurboModule.class.isAssignableFrom(moduleClass)));
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -73,7 +73,6 @@ public class DebugCorePackage extends TurboReactPackage implements ViewManagerOn
                 moduleClass.getName(),
                 reactModule.canOverrideExistingModule(),
                 reactModule.needsEagerInit(),
-                reactModule.hasConstants(),
                 reactModule.isCxxModule(),
                 TurboModule.class.isAssignableFrom(moduleClass)));
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -108,14 +108,12 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
                       moduleClass.getName(),
                       reactModule.canOverrideExistingModule(),
                       true,
-                      reactModule.hasConstants(),
                       reactModule.isCxxModule(),
                       TurboModule.class.isAssignableFrom(moduleClass))
                   : new ReactModuleInfo(
                       moduleName,
                       moduleClass.getName(),
                       module.canOverrideExistingModule(),
-                      true,
                       true,
                       CxxModuleWrapper.class.isAssignableFrom(moduleClass),
                       TurboModule.class.isAssignableFrom(moduleClass));

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
@@ -71,7 +71,6 @@ public class ModuleHolder {
             nativeModule.getClass().getSimpleName(),
             nativeModule.canOverrideExistingModule(),
             true,
-            true,
             CxxModuleWrapper.class.isAssignableFrom(nativeModule.getClass()),
             TurboModule.class.isAssignableFrom(nativeModule.getClass()));
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.java
@@ -25,7 +25,6 @@ public class ReactModuleInfo {
       String className,
       boolean canOverrideExistingModule,
       boolean needsEagerInit,
-      boolean hasConstants,
       boolean isCxxModule,
       boolean isTurboModule) {
     mName = name;
@@ -34,6 +33,22 @@ public class ReactModuleInfo {
     mNeedsEagerInit = needsEagerInit;
     mIsCxxModule = isCxxModule;
     mIsTurboModule = isTurboModule;
+  }
+
+  /**
+   * @deprecated use {@link ReactModuleInfo#ReactModuleInfo(String, String, boolean, boolean,
+   *     boolean, boolean)}
+   */
+  @Deprecated
+  public ReactModuleInfo(
+      String name,
+      String className,
+      boolean canOverrideExistingModule,
+      boolean needsEagerInit,
+      boolean hasConstants,
+      boolean isCxxModule,
+      boolean isTurboModule) {
+    this(name, className, canOverrideExistingModule, needsEagerInit, isCxxModule, isTurboModule);
   }
 
   public String name() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/processing/ReactModuleSpecProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/processing/ReactModuleSpecProcessor.java
@@ -228,8 +228,6 @@ public class ReactModuleSpecProcessor extends AbstractProcessor {
                 .append(", ")
                 .append(reactModule.needsEagerInit())
                 .append(", ")
-                .append(hasConstants)
-                .append(", ")
                 .append(reactModule.isCxxModule())
                 .append(", ")
                 .append(isTurboModule)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
@@ -97,7 +97,6 @@ class CoreReactPackage extends TurboReactPackage {
                   moduleClass.getName(),
                   reactModule.canOverrideExistingModule(),
                   reactModule.needsEagerInit(),
-                  reactModule.hasConstants(),
                   reactModule.isCxxModule(),
                   TurboModule.class.isAssignableFrom(moduleClass)));
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -283,7 +283,6 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
       final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();
       for (Class<? extends NativeModule> moduleClass : moduleList) {
         ReactModule reactModule = moduleClass.getAnnotation(ReactModule.class);
-
         if (reactModule != null) {
           reactModuleInfoMap.put(
               reactModule.name(),
@@ -292,12 +291,10 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
                   moduleClass.getName(),
                   reactModule.canOverrideExistingModule(),
                   reactModule.needsEagerInit(),
-                  reactModule.hasConstants(),
                   reactModule.isCxxModule(),
                   TurboModule.class.isAssignableFrom(moduleClass)));
         }
       }
-
       return () -> reactModuleInfoMap;
     } catch (InstantiationException e) {
       throw new RuntimeException(

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -102,7 +102,6 @@ public class RNTesterApplication extends Application implements ReactApplication
                                 "SampleTurboModule",
                                 false, // canOverrideExistingModule
                                 false, // needsEagerInit
-                                true, // hasConstants
                                 false, // isCxxModule
                                 true // isTurboModule
                                 ));
@@ -114,7 +113,6 @@ public class RNTesterApplication extends Application implements ReactApplication
                                 "SampleLegacyModule",
                                 false, // canOverrideExistingModule
                                 false, // needsEagerInit
-                                true, // hasConstants
                                 false, // isCxxModule
                                 false // isTurboModule
                                 ));

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterReactHostDelegate.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterReactHostDelegate.kt
@@ -90,7 +90,6 @@ class RNTesterReactHostDelegate internal constructor(context: Context) : ReactHo
                               "SampleTurboModule",
                               false, // canOverrideExistingModule
                               false, // needsEagerInit
-                              true, // hasConstants
                               false, // isCxxModule
                               true // isTurboModule
                               ),
@@ -100,7 +99,6 @@ class RNTesterReactHostDelegate internal constructor(context: Context) : ReactHo
                               "SampleLegacyModule",
                               false, // canOverrideExistingModule
                               false, // needsEagerInit
-                              true, // hasConstants
                               false, // isCxxModule
                               false // isTurboModule
                               ),


### PR DESCRIPTION
Summary:
## Changelog
[Android][Deprecated] - ReactModuleInfo constructor with getConstants arg is deprecated

introducing a new constructor that doesn't use getConstants and updating the internal codebase to use it. deprecated the old one since it's been copypasta'd a lot in oss.

Reviewed By: cortinico

Differential Revision: D49262824

