### PR TITLE
Create empty constructor on ReactPackageTurboModuleManagerDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -42,18 +42,8 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
       mShouldEnableLegacyModuleInterop
           && ReactFeatureFlags.unstable_useTurboModuleInteropForAllTurboModules;
 
-  @Override
-  public boolean unstable_shouldEnableLegacyModuleInterop() {
-    return mShouldEnableLegacyModuleInterop;
-  }
-
-  @Override
-  public boolean unstable_shouldRouteTurboModulesThroughLegacyModuleInterop() {
-    return mShouldRouteTurboModulesThroughLegacyModuleInterop;
-  }
-
-  private boolean shouldSupportLegacyPackages() {
-    return unstable_shouldEnableLegacyModuleInterop();
+  protected ReactPackageTurboModuleManagerDelegate() {
+    super();
   }
 
   protected ReactPackageTurboModuleManagerDelegate(
@@ -140,6 +130,16 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
         mPackageModuleInfos.put(moduleProvider, reactModuleInfoMap);
       }
     }
+  }
+
+  @Override
+  public boolean unstable_shouldEnableLegacyModuleInterop() {
+    return mShouldEnableLegacyModuleInterop;
+  }
+
+  @Override
+  public boolean unstable_shouldRouteTurboModulesThroughLegacyModuleInterop() {
+    return mShouldRouteTurboModulesThroughLegacyModuleInterop;
   }
 
   @Nullable
@@ -251,6 +251,10 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
       }
     }
     return moduleNames;
+  }
+
+  private boolean shouldSupportLegacyPackages() {
+    return unstable_shouldEnableLegacyModuleInterop();
   }
 
   public abstract static class Builder {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
@@ -27,7 +27,7 @@ private constructor(context: ReactApplicationContext, packages: List<ReactPackag
   @DoNotStrip external override fun initHybrid(): HybridData?
 
   class Builder : ReactPackageTurboModuleManagerDelegate.Builder() {
-    public override fun build(context: ReactApplicationContext, packages: List<ReactPackage>) =
+    override fun build(context: ReactApplicationContext, packages: List<ReactPackage>) =
         DefaultTurboModuleManagerDelegate(context, packages)
   }
 }


### PR DESCRIPTION
Summary:
In this diff I'm creating an empty constructor on ReactPackageTurboModuleManagerDelegate. This will be used in the next diffs of the stack.
I'm also resorting methods for better read of the class

changelog: [intenral] internal

Reviewed By: arushikesarwani94

Differential Revision: D49172554

