### PR TITLE
Fix podspecs building with C++ 14

### DIFF
--- a/packages/react-native/Libraries/Text/React-RCTText.podspec
+++ b/packages/react-native/Libraries/Text/React-RCTText.podspec
@@ -30,6 +30,7 @@ Pod::Spec.new do |s|
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTText"
   s.framework              = ["MobileCoreServices"]
+  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
 
   s.dependency "Yoga"
   s.dependency "React-Core/RCTTextHeaders", version

--- a/packages/react-native/ReactCommon/React-nativeconfig.podspec
+++ b/packages/react-native/ReactCommon/React-nativeconfig.podspec
@@ -27,6 +27,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "react/config/*.{m,mm,cpp,h}"
   s.header_dir             = "react/config"
+  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
 
   if ENV['USE_FRAMEWORKS']
     s.header_mappings_dir     = './'

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -51,7 +51,8 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig  = { "USE_HEADERMAP" => "NO",
                              "HEADER_SEARCH_PATHS" => header_search_paths.join(" "),
-                             "DEFINES_MODULE" => "YES" }
+                             "DEFINES_MODULE" => "YES",
+                             "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
 
   s.dependency "glog"
   s.dependency "RCT-Folly/Fabric", folly_version

--- a/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -31,4 +31,5 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "reactperflogger"
+  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
 end


### PR DESCRIPTION
Summary:
We currently have 854 warnings emitted due to nested namespaces being a C++ 17 extension lol.

This sets the standard explicitly to C++ 20 in the specs emitting the warnings (mostly RCT-Text).

It is undesirable that we add hundreds of warnings to the CocoaPods build without signal. Our Buck build and OSS Android build both treat warnings as errors. But... that is for another day.

Changelog: [Intenrnal]

Differential Revision: D49303081

