### PR TITLE
This fix improving logging during running e2e tests.

### DIFF
--- a/packages/rn-tester-e2e/jest.config.js
+++ b/packages/rn-tester-e2e/jest.config.js
@@ -14,4 +14,5 @@ module.exports = {
   setupFilesAfterEnv: ['./jest.setup.js'],
   testMatch: ['**/specs/**/*.js'],
   maxWorkers: 1,
+  verbose: true,
 };

--- a/packages/rn-tester-e2e/jest.setup.js
+++ b/packages/rn-tester-e2e/jest.setup.js
@@ -27,12 +27,23 @@ const config = {
 };
 
 beforeEach(async () => {
+  let testName = expect.getState().currentTestName;
+  console.info(
+    '------------------------------------------------------------ Test is starting... ------------------------------------------------------------',
+  );
+  console.info(
+    '------------------------------ Test name: ' +
+      testName +
+      ' ------------------------------',
+  );
   driver = await wdio.remote(config);
 });
 
 afterEach(async () => {
-  console.info('[afterAll] Done with testing!');
   await driver.deleteSession();
+  console.info(
+    '------------------------------------------------------------ Done with testing. ------------------------------------------------------------',
+  );
 });
 
 export {driver};

--- a/packages/rn-tester-e2e/jest.setup.js
+++ b/packages/rn-tester-e2e/jest.setup.js
@@ -26,7 +26,8 @@ const config = {
 };
 
 beforeEach(async () => {
-  let testName = expect.getState().currentTestName;
+  // $FlowFixMe
+  let testName: any = expect.getState().currentTestName;
   console.info(
     '------------------------------------------------------------ Test is starting... ------------------------------------------------------------',
   );

--- a/packages/rn-tester-e2e/jest.setup.js
+++ b/packages/rn-tester-e2e/jest.setup.js
@@ -20,7 +20,6 @@ const config = {
   host: 'localhost',
   port: 4723,
   waitforTimeout: 60000,
-  logLevel: 'error',
   capabilities: {
     ...capabilities,
   },


### PR DESCRIPTION
## Summary:

Motivation was to improve logging for RNTester e2e tests.

## Changelog:

[INTERNAL] - Add logging.

## Test Plan:

Check logs during 2e automation is running.
