### PR TITLE
Fix RawProps folly::dynamic ctor to give option to avoid copy

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -1672,7 +1672,7 @@ Props::Shared LayoutAnimationKeyFrameManager::interpolateProps(
   Props::Shared interpolatedPropsShared =
       (newProps != nullptr
            ? componentDescriptor.cloneProps(
-                 context, newProps, newProps->rawProps)
+                 context, newProps, RawProps(newProps->rawProps))
            : componentDescriptor.cloneProps(context, newProps, {}));
 #else
   Props::Shared interpolatedPropsShared =

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -117,7 +117,7 @@ inline RawProps filterYogaProps(const RawProps& rawProps) {
     }
   }
 
-  return RawProps(filteredRawProps);
+  return RawProps(std::move(filteredRawProps));
 }
 } // namespace
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
@@ -37,14 +37,14 @@ RawProps::RawProps(jsi::Runtime& runtime, const jsi::Value& value) noexcept {
  * We need this temporary, only because we have a callsite that does not have
  * a `jsi::Runtime` behind the data.
  */
-RawProps::RawProps(const folly::dynamic& dynamic) noexcept {
+RawProps::RawProps(folly::dynamic dynamic) noexcept {
   if (dynamic.isNull()) {
     mode_ = Mode::Empty;
     return;
   }
 
   mode_ = Mode::Dynamic;
-  dynamic_ = dynamic;
+  dynamic_ = std::move(dynamic);
 }
 
 void RawProps::parse(

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -59,7 +59,7 @@ class RawProps final {
    * We need this temporary, only because we have a callsite that does not have
    * a `jsi::Runtime` behind the data.
    */
-  RawProps(const folly::dynamic& dynamic) noexcept;
+  explicit RawProps(folly::dynamic dynamic) noexcept;
 
   /*
    * Not moveable.


### PR DESCRIPTION
Summary:
changelog: [internal]

avoid copy of folly::dynamic if possible.

Reviewed By: javache

Differential Revision: D49312487


