### PR TITLE
Enabale native view configs in bridgeless mode in OSS

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -87,6 +87,8 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
   if (enableBridgeless) {
 #if RCT_NEW_ARCH_ENABLED
+    // Enable native view config interop only if both bridgeless mode and Fabric is enabled.
+    RCTSetUseNativeViewConfigsInBridgelessMode([self fabricEnabled]);
     [self createReactHost];
     [self unstable_registerLegacyComponents];
     [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -13,7 +13,6 @@
 import type {RootTag} from '../Types/RootTagTypes';
 
 import {unstable_hasComponent} from '../NativeComponent/NativeComponentRegistryUnstable';
-import ReactNativeFeatureFlags from './ReactNativeFeatureFlags';
 
 let cachedConstants = null;
 
@@ -21,6 +20,10 @@ const errorMessageForMethod = (methodName: string): string =>
   "[ReactNative Architecture][JS] '" +
   methodName +
   "' is not available in the new React Native architecture.";
+
+function nativeViewConfigsInBridgelessModeEnabled(): boolean {
+  return global.RN$LegacyInterop_UIManager_getConstants !== undefined;
+}
 
 function getCachedConstants(): Object {
   if (!cachedConstants) {
@@ -31,7 +34,7 @@ function getCachedConstants(): Object {
 
 const UIManagerJS: {[string]: $FlowFixMe} = {
   getViewManagerConfig: (viewManagerName: string): mixed => {
-    if (ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode()) {
+    if (nativeViewConfigsInBridgelessModeEnabled()) {
       return getCachedConstants()[viewManagerName];
     } else {
       console.error(
@@ -46,7 +49,7 @@ const UIManagerJS: {[string]: $FlowFixMe} = {
     return unstable_hasComponent(viewManagerName);
   },
   getConstants: (): Object => {
-    if (ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode()) {
+    if (nativeViewConfigsInBridgelessModeEnabled()) {
       return getCachedConstants();
     } else {
       console.error(errorMessageForMethod('getConstants'));
@@ -179,7 +182,7 @@ const UIManagerJS: {[string]: $FlowFixMe} = {
     console.error(errorMessageForMethod('dismissPopupMenu')),
 };
 
-if (ReactNativeFeatureFlags.enableNativeViewConfigsInBridgelessMode()) {
+if (nativeViewConfigsInBridgelessModeEnabled()) {
   Object.keys(getCachedConstants()).forEach(viewConfigName => {
     UIManagerJS[viewConfigName] = getCachedConstants()[viewConfigName];
   });

--- a/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
@@ -55,10 +55,6 @@ export type FeatureFlags = {|
    */
   shouldUseSetNativePropsInFabric: () => boolean,
   /**
-   * Enables native view configs in brdgeless mode.
-   */
-  enableNativeViewConfigsInBridgelessMode: () => boolean,
-  /**
    * Enables a hotfix for forcing materialization of views with elevation set.
    */
   shouldForceUnflattenForElevation: () => boolean,
@@ -74,7 +70,6 @@ const ReactNativeFeatureFlags: FeatureFlags = {
   enableAccessToHostTreeInFabric: () => false,
   shouldUseAnimatedObjectForTransform: () => false,
   shouldUseSetNativePropsInFabric: () => false,
-  enableNativeViewConfigsInBridgelessMode: () => false,
   shouldForceUnflattenForElevation: () => false,
 };
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -34,6 +34,7 @@ object DefaultNewArchitectureEntryPoint {
     ReactFeatureFlags.enableFabricRenderer = fabricEnabled
     ReactFeatureFlags.unstable_useFabricInterop = fabricEnabled
     ReactFeatureFlags.enableBridgelessArchitecture = bridgelessEnabled
+    ReactFeatureFlags.useNativeViewConfigsInBridgelessMode = fabricEnabled && bridgelessEnabled
 
     this.privateFabricEnabled = fabricEnabled
     this.privateTurboModulesEnabled = turboModulesEnabled


### PR DESCRIPTION
Summary:
This diff enables native view config interop layer in bridgeless mode by default for OSS.
It also removes redundant `enableNativeViewConfigsInBridgelessMode` JS feature flag.
Changelog: [General][Added] - Native view config interop layer enabled in bridgeless mode.

Differential Revision: D49318325


