### PR TITLE
Bump IPHONEOS_DEPLOYMENT_TARGET to 13.4 for 3rd party pods

### DIFF
--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -26,3 +26,11 @@ class Finder
         return `find #{path} -type f \\( #{js_files} -or #{ts_files} \\)`.split("\n").sort()
     end
 end
+
+module Helpers
+    class Constants
+        def self.min_ios_version_supported
+            return '13.4'
+        end
+    end
+end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -281,6 +281,37 @@ class ReactNativePodsUtils
         end
     end
 
+    def self.updateIphoneOSDeploymentTarget(installer)
+        pod_to_update = Set.new([
+            "boost",
+            "CocoaAsyncSocket",
+            "Flipper",
+            "Flipper-DoubleConversion",
+            "Flipper-Fmt",
+            "Flipper-Boost-iOSX",
+            "Flipper-Folly",
+            "Flipper-Glog",
+            "Flipper-PeerTalk",
+            "FlipperKit",
+            "fmt",
+            "libevent",
+            "OpenSSL-Universal",
+            "RCT-Folly",
+            "SocketRocket",
+            "YogaKit"
+        ])
+
+        installer.target_installation_results.pod_target_installation_results
+            .each do |pod_name, target_installation_result|
+                unless pod_to_update.include?(pod_name)
+                    next
+                end
+                target_installation_result.native_target.build_configurations.each do |config|
+                    config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = Helpers::Constants.min_ios_version_supported
+                end
+            end
+    end
+
     # ========= #
     # Utilities #
     # ========= #

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -16,6 +16,7 @@ require_relative './cocoapods/utils.rb'
 require_relative './cocoapods/new_architecture.rb'
 require_relative './cocoapods/local_podspec_patch.rb'
 require_relative './cocoapods/runtime.rb'
+require_relative './cocoapods/helpers.rb'
 
 $CODEGEN_OUTPUT_DIR = 'build/generated/ios'
 $CODEGEN_COMPONENT_DIR = 'react/renderer/components'
@@ -37,7 +38,7 @@ require Pod::Executable.execute_command('node', ['-p',
 
 
 def min_ios_version_supported
-  return '13.4'
+  return Helpers::Constants.min_ios_version_supported
 end
 
 # This function returns the min supported OS versions supported by React Native
@@ -272,9 +273,11 @@ def react_native_post_install(
   ReactNativePodsUtils.apply_flags_for_fabric(installer, fabric_enabled: fabric_enabled)
   ReactNativePodsUtils.apply_xcode_15_patch(installer)
   ReactNativePodsUtils.apply_ats_config(installer)
+  ReactNativePodsUtils.updateIphoneOSDeploymentTarget(installer)
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   NewArchitectureHelper.modify_flags_for_new_architecture(installer, NewArchitectureHelper.new_arch_enabled)
+
 
   Pod::UI.puts "Pod install took #{Time.now.to_i - $START_TIME} [s] to run".green
 end


### PR DESCRIPTION
Summary:
When testing Xcode 15, we realized that a few pods we do not control directly have the IPHONEOS_DEPLOYMENT_TARGET set to old versions of iOS.
We can update that setting to silence the warning with Cocoapods and this is what this script does.

Notice that bumping that setting generated other warning as some APIs have been deprecated.

## Changelog:
[Internal] - Bump min IPHONEOS_DEPLOYMENT_TARGET for 3rd party pods

Reviewed By: dmytrorykun

Differential Revision: D49274837


