### PR TITLE
Remove unused `canLoadFile` function from HermesExecutor.java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
@@ -42,15 +42,6 @@ public class HermesExecutor extends JavaScriptExecutor {
     return "HermesExecutor" + mode_;
   }
 
-  /**
-   * Return whether this class can load a file at the given path, based on a binary compatibility
-   * check between the contents of the file and the Hermes VM.
-   *
-   * @param path the path containing the file to inspect.
-   * @return whether the given file is compatible with the Hermes VM.
-   */
-  public static native boolean canLoadFile(String path);
-
   private static native HybridData initHybridDefaultConfig(
       boolean enableDebugger, String debuggerName);
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
@@ -90,17 +90,12 @@ class HermesExecutorHolder
     return makeCxxInstance(std::move(factory));
   }
 
-  static bool canLoadFile(jni::alias_ref<jclass>, const std::string& path) {
-    return true;
-  }
-
   static void registerNatives() {
     registerHybrid(
         {makeNativeMethod("initHybrid", HermesExecutorHolder::initHybrid),
          makeNativeMethod(
              "initHybridDefaultConfig",
-             HermesExecutorHolder::initHybridDefaultConfig),
-         makeNativeMethod("canLoadFile", HermesExecutorHolder::canLoadFile)});
+             HermesExecutorHolder::initHybridDefaultConfig)});
   }
 
  private:


### PR DESCRIPTION
Summary:
This function is hardcoded to `true` and is never used, so I'm removing it.
I found no relevant usages in OSS so that can probably go.
Also see: https://github.com/facebook/react-native/issues/39292 where it got reported.

Changelog:
[Android] [Removed] - Remove unused `canLoadFile` function from HermesExecutor.java

Reviewed By: yungsters

Differential Revision: D49320244


