### PR TITLE
[iOS] Remove Xcode 12.5 post install workaround

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -379,23 +379,3 @@ def use_react_native_codegen!(spec, options={})
     :show_env_vars_in_log => true
   }
 end
-
-# This provides a post_install workaround for build issues related Xcode 12.5 and Apple Silicon machines.
-# Call this in the app's main Podfile's post_install hook.
-# See https://github.com/facebook/react-native/issues/31480#issuecomment-902912841 for more context.
-# Actual fix was authored by https://github.com/mikehardy.
-# New app template will call this for now until the underlying issue is resolved.
-def __apply_Xcode_12_5_M1_post_install_workaround(installer)
-  # NOTE: This fix is still required due to RCT-Folly
-  # creating a function with a better name but keeping the
-  # previous for backward compatibility
-  __fix_double_definition_of_clockid_in_folly()
-end
-
-def __fix_double_definition_of_clockid_in_folly()
-  # "Time.h:52:17: error: typedef redefinition with different types"
-  # We need to make a patch to RCT-Folly - remove the `__IPHONE_OS_VERSION_MIN_REQUIRED` check.
-  # See https://github.com/facebook/flipper/issues/834 for more details.
-  time_header = "#{Pod::Config.instance.installation_root.to_s}/Pods/RCT-Folly/folly/portability/Time.h"
-  `sed -i -e  $'s/ && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)//' '#{time_header}'`
-end

--- a/packages/react-native/template/ios/Podfile
+++ b/packages/react-native/template/ios/Podfile
@@ -51,6 +51,5 @@ target 'HelloWorld' do
       config[:reactNativePath],
       :mac_catalyst_enabled => false
     )
-    __fix_double_definition_of_clockid_in_folly()
   end
 end

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -87,5 +87,4 @@ end
 
 post_install do |installer|
   react_native_post_install(installer, @prefix_path, :mac_catalyst_enabled => false)
-  __fix_double_definition_of_clockid_in_folly()
 end


### PR DESCRIPTION
## Summary:

Now that we updated folly in https://github.com/facebook/react-native/commit/17154a661fe06ed25bf599f47bd4193eba011971, we should pick up https://github.com/facebook/folly/commit/4a8837f3226152c2106be366ecae3a228cde4f45 and probably don't need this post install phase anymore

## Changelog:

[IOS] [REMOVED] - Remove Xcode 12.5 post install workaround


## Test Plan:

CI should pass
