### PR TITLE
bump react-refresh to latest

### DIFF
--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -55,7 +55,7 @@
     "@babel/template": "^7.0.0",
     "@react-native/babel-plugin-codegen": "*",
     "babel-plugin-transform-flow-enums": "^0.0.2",
-    "react-refresh": "^0.4.0"
+    "react-refresh": "^0.14.0"
   },
   "peerDependencies": {
     "@babel/core": "*"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -120,7 +120,7 @@
     "pretty-format": "^26.5.2",
     "promise": "^8.3.0",
     "react-devtools-core": "^4.27.7",
-    "react-refresh": "^0.4.0",
+    "react-refresh": "^0.14.0",
     "react-shallow-renderer": "^16.15.0",
     "regenerator-runtime": "^0.13.2",
     "scheduler": "0.24.0-canary-efb381bbf-20230505",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8037,6 +8037,11 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-refresh@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
+  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
 react-refresh@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.0.tgz#d421f9bd65e0e4b9822a399f14ac56bda9c92292"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

- Companion PR to https://github.com/facebook/metro/pull/1085
- The Fast Refresh changes appear to be required for using static rendering and React DOM. In frameworks like Expo Router which support both native and web, this causes users to not be able to use Fast Refresh on web.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [CHANGED] - Upgrade React Refresh package from 0.4.0 to 0.14.0

## Test Plan:

1. In a React Native project's `package.json`:
```json
 "resolutions": {
    "react-refresh": "~0.14.0"
  },
```
2. Start the server with a clear Metro cache.
3. Changes should update while preserving React state.
