### PR TITLE
Enable Fabric interop in bridgeless mode on iOS

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -88,6 +88,8 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   if (enableBridgeless) {
 #if RCT_NEW_ARCH_ENABLED
     [self createReactHost];
+    [self unstable_registerLegacyComponents];
+    [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;
     RCTFabricSurface *surface = [_reactHost createSurfaceWithModuleName:self.moduleName
                                                       initialProperties:launchOptions];
 


### PR DESCRIPTION
Summary:
We've put `[self unstable_registerLegacyComponents]` inside `#if RCT_NEW_ARCH_ENABLED` block, but we've missed the fact that it was inside the `else` clause of the `if (enableBridgeless)` statement. So it wasn't actually enabled for bridgeless mode regardless of `RCT_NEW_ARCH_ENABLED`.
This diff fixes that, and registers legacy components for the bridgeless mode as well.

Reviewed By: NickGerleman, cipolleschi

Differential Revision: D49323913


