### PR TITLE
Remove use of folly::F14FastMap from React Native

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -87,7 +87,7 @@ struct ArrayPropsNativeComponentViewObjectStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewObjectStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_prop = map.find(\\"prop\\");
   if (tmp_prop != map.end()) {
@@ -115,7 +115,7 @@ struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewArrayOfObjectsStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_prop1 = map.find(\\"prop1\\");
   if (tmp_prop1 != map.end()) {
@@ -796,7 +796,7 @@ struct ObjectPropsNativeComponentObjectPropStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPropStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_stringProp = map.find(\\"stringProp\\");
   if (tmp_stringProp != map.end()) {
@@ -833,7 +833,7 @@ struct ObjectPropsNativeComponentObjectArrayPropStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectArrayPropStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_array = map.find(\\"array\\");
   if (tmp_array != map.end()) {
@@ -852,7 +852,7 @@ struct ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_image = map.find(\\"image\\");
   if (tmp_image != map.end()) {

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -161,7 +161,7 @@ const StructTemplate = ({
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ${structName} &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   ${fromCases}
 }

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -86,7 +86,7 @@ struct ArrayPropsNativeComponentObjectStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentObjectStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_stringProp = map.find(\\"stringProp\\");
   if (tmp_stringProp != map.end()) {
@@ -113,7 +113,7 @@ struct ArrayPropsNativeComponentArrayObjectStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayObjectStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_stringProp = map.find(\\"stringProp\\");
   if (tmp_stringProp != map.end()) {
@@ -140,7 +140,7 @@ struct ArrayPropsNativeComponentArrayStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_object = map.find(\\"object\\");
   if (tmp_object != map.end()) {
@@ -167,7 +167,7 @@ struct ArrayPropsNativeComponentArrayOfArrayOfObjectStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayOfArrayOfObjectStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_stringProp = map.find(\\"stringProp\\");
   if (tmp_stringProp != map.end()) {
@@ -251,7 +251,7 @@ struct ArrayPropsNativeComponentNativePrimitivesStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentNativePrimitivesStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_colors = map.find(\\"colors\\");
   if (tmp_colors != map.end()) {
@@ -1151,7 +1151,7 @@ struct ObjectPropsObjectPropObjectArrayPropStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropObjectArrayPropStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_array = map.find(\\"array\\");
   if (tmp_array != map.end()) {
@@ -1170,7 +1170,7 @@ struct ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_image = map.find(\\"image\\");
   if (tmp_image != map.end()) {
@@ -1195,7 +1195,7 @@ struct ObjectPropsObjectPropNestedPropANestedPropBStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedPropANestedPropBStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_nestedPropC = map.find(\\"nestedPropC\\");
   if (tmp_nestedPropC != map.end()) {
@@ -1212,7 +1212,7 @@ struct ObjectPropsObjectPropNestedPropAStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedPropAStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_nestedPropB = map.find(\\"nestedPropB\\");
   if (tmp_nestedPropB != map.end()) {
@@ -1229,7 +1229,7 @@ struct ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_stringProp = map.find(\\"stringProp\\");
   if (tmp_stringProp != map.end()) {
@@ -1256,7 +1256,7 @@ struct ObjectPropsObjectPropNestedArrayAsPropertyStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedArrayAsPropertyStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_arrayProp = map.find(\\"arrayProp\\");
   if (tmp_arrayProp != map.end()) {
@@ -1282,7 +1282,7 @@ struct ObjectPropsObjectPropStruct {
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropStruct &result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto tmp_stringProp = map.find(\\"stringProp\\");
   if (tmp_stringProp != map.end()) {

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -11,8 +11,8 @@
 #import <React/RCTConversions.h>
 #import <React/RCTLog.h>
 
-#import <butter/map.h>
 #import <shared_mutex>
+#import <unordered_map>
 #import <unordered_set>
 
 #import <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
@@ -59,7 +59,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
 }
 
 @implementation RCTComponentViewFactory {
-  butter::map<ComponentHandle, RCTComponentViewClassDescriptor> _componentViewClasses;
+  std::unordered_map<ComponentHandle, RCTComponentViewClassDescriptor> _componentViewClasses;
   std::unordered_set<std::string> _registeredComponentsNames;
   ComponentDescriptorProviderRegistry _providerRegistry;
   std::shared_mutex _mutex;

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -14,8 +14,7 @@
 #import <React/RCTImageComponentView.h>
 #import <React/RCTParagraphComponentView.h>
 #import <React/RCTViewComponentView.h>
-
-#import <butter/map.h>
+#import <unordered_map>
 
 using namespace facebook;
 using namespace facebook::react;
@@ -23,8 +22,8 @@ using namespace facebook::react;
 const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
 
 @implementation RCTComponentViewRegistry {
-  butter::map<Tag, RCTComponentViewDescriptor> _registry;
-  butter::map<ComponentHandle, std::vector<RCTComponentViewDescriptor>> _recyclePool;
+  std::unordered_map<Tag, RCTComponentViewDescriptor> _registry;
+  std::unordered_map<ComponentHandle, std::vector<RCTComponentViewDescriptor>> _recyclePool;
 }
 
 - (instancetype)init

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -8,7 +8,6 @@
 #import "RCTMountingManager.h"
 
 #import <QuartzCore/QuartzCore.h>
-#import <butter/map.h>
 
 #import <React/RCTAssert.h>
 #import <React/RCTComponent.h>

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingTransactionObserverCoordinator.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingTransactionObserverCoordinator.h
@@ -6,10 +6,10 @@
  */
 
 #import <React/RCTComponentViewDescriptor.h>
+#import <unordered_map>
 #import <unordered_set>
-#import "RCTMountingTransactionObserverCoordinator.h"
 
-#import <butter/map.h>
+#import "RCTMountingTransactionObserverCoordinator.h"
 
 #include <react/renderer/mounting/MountingTransaction.h>
 
@@ -38,7 +38,7 @@ class RCTMountingTransactionObserverCoordinator final {
       const facebook::react::SurfaceTelemetry& surfaceTelemetry) const;
 
  private:
-  facebook::butter::map<
+  std::unordered_map<
       facebook::react::SurfaceId,
       std::unordered_set<RCTComponentViewDescriptor>>
       registry_;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <shared_mutex>
+#include <unordered_map>
 
 #include <fbjni/fbjni.h>
 #include <react/jni/JRuntimeExecutor.h>
@@ -139,7 +140,7 @@ class Binding : public jni::HybridClass<Binding>,
 
   BackgroundExecutor backgroundExecutor_;
 
-  butter::map<SurfaceId, SurfaceHandler> surfaceHandlerRegistry_{};
+  std::unordered_map<SurfaceId, SurfaceHandler> surfaceHandlerRegistry_{};
   std::shared_mutex
       surfaceHandlerRegistryMutex_; // Protects `surfaceHandlerRegistry_`.
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <mutex>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <fbjni/fbjni.h>
@@ -58,7 +59,8 @@ class FabricMountingManager final {
 
   std::recursive_mutex commitMutex_;
 
-  butter::map<SurfaceId, std::unordered_set<Tag>> allocatedViewRegistry_{};
+  std::unordered_map<SurfaceId, std::unordered_set<Tag>>
+      allocatedViewRegistry_{};
   std::recursive_mutex allocatedViewsMutex_;
 
   const bool reduceDeleteCreateMutation_{false};

--- a/packages/react-native/ReactCommon/react/bridging/Object.h
+++ b/packages/react-native/ReactCommon/react/bridging/Object.h
@@ -10,7 +10,6 @@
 #include <react/bridging/AString.h>
 #include <react/bridging/Base.h>
 
-#include <butter/map.h>
 #include <map>
 #include <unordered_map>
 
@@ -82,12 +81,6 @@ struct Bridging {
 };
 
 } // namespace map_detail
-
-#ifdef BUTTER_USE_FOLLY_CONTAINERS
-template <typename... Args>
-struct Bridging<butter::map<std::string, Args...>>
-    : map_detail::Bridging<butter::map<std::string, Args...>> {};
-#endif
 
 template <typename... Args>
 struct Bridging<std::map<std::string, Args...>>

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -99,15 +99,11 @@ TEST_F(BridgingTest, objectTest) {
       bridging::fromJs<std::map<std::string, std::string>>(rt, object, invoker);
   auto umap = bridging::fromJs<std::unordered_map<std::string, std::string>>(
       rt, object, invoker);
-  auto bmap = bridging::fromJs<butter::map<std::string, std::string>>(
-      rt, object, invoker);
 
   EXPECT_EQ(1, omap.size());
   EXPECT_EQ(1, umap.size());
-  EXPECT_EQ(1, bmap.size());
   EXPECT_EQ("bar"s, omap["foo"]);
   EXPECT_EQ("bar"s, umap["foo"]);
-  EXPECT_EQ("bar"s, bmap["foo"]);
 
   EXPECT_EQ(
       "bar"s,
@@ -118,12 +114,6 @@ TEST_F(BridgingTest, objectTest) {
   EXPECT_EQ(
       "bar"s,
       bridging::toJs(rt, umap, invoker)
-          .getProperty(rt, "foo")
-          .asString(rt)
-          .utf8(rt));
-  EXPECT_EQ(
-      "bar"s,
-      bridging::toJs(rt, bmap, invoker)
           .getProperty(rt, "foo")
           .asString(rt)
           .utf8(rt));

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -23,6 +23,7 @@
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <cmath>
+#include <unordered_map>
 
 #ifdef ANDROID
 #include <react/renderer/mapbuffer/MapBuffer.h>
@@ -747,7 +748,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     AttributedString::Range& result) {
-  auto map = (butter::map<std::string, int>)value;
+  auto map = (std::unordered_map<std::string, int>)value;
 
   auto start = map.find("start");
   if (start != map.end()) {

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <shared_mutex>
+#include <unordered_map>
 
 #include <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
@@ -60,7 +61,7 @@ class ComponentDescriptorProviderRegistry final {
   mutable std::shared_mutex mutex_;
   mutable std::vector<std::weak_ptr<const ComponentDescriptorRegistry>>
       componentDescriptorRegistries_;
-  mutable butter::map<ComponentHandle, ComponentDescriptorProvider const>
+  mutable std::unordered_map<ComponentHandle, ComponentDescriptorProvider const>
       componentDescriptorProviders_;
   mutable ComponentDescriptorProviderRequest
       componentDescriptorProviderRequest_{};

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.h
@@ -9,8 +9,7 @@
 
 #include <memory>
 #include <shared_mutex>
-
-#include <butter/map.h>
+#include <unordered_map>
 
 #include <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 #include <react/renderer/core/ComponentDescriptor.h>
@@ -82,9 +81,10 @@ class ComponentDescriptorRegistry {
   void add(ComponentDescriptorProvider componentDescriptorProvider) const;
 
   mutable std::shared_mutex mutex_;
-  mutable butter::map<ComponentHandle, SharedComponentDescriptor>
+  mutable std::unordered_map<ComponentHandle, SharedComponentDescriptor>
       _registryByHandle;
-  mutable butter::map<std::string, SharedComponentDescriptor> _registryByName;
+  mutable std::unordered_map<std::string, SharedComponentDescriptor>
+      _registryByName;
   ComponentDescriptor::Shared _fallbackComponentDescriptor;
   ComponentDescriptorParameters parameters_{};
   const ComponentDescriptorProviderRegistry& providerRegistry_;

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <butter/map.h>
+#include <unordered_map>
+
 #include <folly/dynamic.h>
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
@@ -29,8 +30,8 @@ inline void fromRawValue(
     return;
   }
 
-  if (value.hasType<butter::map<std::string, RawValue>>()) {
-    auto items = (butter::map<std::string, RawValue>)value;
+  if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
+    auto items = (std::unordered_map<std::string, RawValue>)value;
     result = {};
 
     result.type = ImageSource::Type::Remote;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
@@ -11,6 +11,7 @@
 #include <react/renderer/components/scrollview/primitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
+#include <unordered_map>
 
 namespace facebook::react {
 
@@ -102,7 +103,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     ScrollViewMaintainVisibleContentPosition& result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto minIndexForVisible = map.find("minIndexForVisible");
   if (minIndexForVisible != map.end()) {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -15,6 +15,8 @@
 #include <yoga/YGValue.h>
 #include <yoga/style/CompactValue.h>
 
+#include <unordered_map>
+
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
 namespace facebook::react {
@@ -171,7 +173,8 @@ class AndroidTextInputComponentDescriptor final
       "com/facebook/react/fabric/FabricUIManager";
 
   SharedTextLayoutManager textLayoutManager_;
-  mutable butter::map<int, yoga::Style::Edges> surfaceIdToThemePaddingMap_;
+  mutable std::unordered_map<int, yoga::Style::Edges>
+      surfaceIdToThemePaddingMap_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -7,9 +7,6 @@
 
 #pragma once
 
-// foo bar 2
-
-// #include <react/renderer/components/text/BaseTextProps.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/graphics/Color.h>
 
@@ -22,6 +19,7 @@
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/imagemanager/primitives.h>
 #include <cinttypes>
+#include <unordered_map>
 #include <vector>
 
 namespace facebook::react {
@@ -35,7 +33,7 @@ static inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     AndroidTextInputTextShadowOffsetStruct& result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto width = map.find("width");
   if (width != map.end()) {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/propsConversions.h
@@ -155,8 +155,8 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     Selection& result) {
-  if (value.hasType<butter::map<std::string, int>>()) {
-    auto map = (butter::map<std::string, int>)value;
+  if (value.hasType<std::unordered_map<std::string, int>>()) {
+    auto map = (std::unordered_map<std::string, int>)value;
     for (const auto& pair : map) {
       if (pair.first == "start") {
         result.start = pair.second;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -15,6 +15,8 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
 
+#include <unordered_map>
+
 namespace facebook::react {
 
 inline void fromString(const std::string& string, AccessibilityTraits& result) {
@@ -133,7 +135,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     AccessibilityState& result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
   auto selected = map.find("selected");
   if (selected != map.end()) {
     fromRawValue(context, selected->second, result.selected);
@@ -213,7 +215,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     AccessibilityAction& result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto name = map.find("name");
   react_native_assert(name != map.end() && name->second.hasType<std::string>());
@@ -233,7 +235,7 @@ inline void fromRawValue(
     const PropsParserContext&,
     const RawValue& value,
     AccessibilityValue& result) {
-  auto map = (butter::map<std::string, RawValue>)value;
+  auto map = (std::unordered_map<std::string, RawValue>)value;
 
   auto min = map.find("min");
   if (min != map.end()) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <butter/map.h>
 #include <folly/Conv.h>
 #include <folly/dynamic.h>
 #include <glog/logging.h>
@@ -23,6 +22,7 @@
 #include <algorithm>
 #include <cmath>
 #include <optional>
+#include <unordered_map>
 
 namespace facebook::react {
 
@@ -488,14 +488,14 @@ inline void fromRawValue(
 
   auto configurations = static_cast<std::vector<RawValue>>(value);
   for (const auto& configuration : configurations) {
-    if (!configuration.hasType<butter::map<std::string, RawValue>>()) {
+    if (!configuration.hasType<std::unordered_map<std::string, RawValue>>()) {
       // TODO: The following checks have to be removed after codegen is shipped.
       // See T45151459.
       continue;
     }
 
     auto configurationPair =
-        static_cast<butter::map<std::string, RawValue>>(configuration);
+        static_cast<std::unordered_map<std::string, RawValue>>(configuration);
     auto pair = configurationPair.begin();
     auto operation = pair->first;
     auto& parameters = pair->second;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
@@ -10,6 +10,7 @@
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Float.h>
+#include <unordered_map>
 
 namespace facebook::react {
 
@@ -58,7 +59,7 @@ static inline void fromRawValue(
     const PropsParserContext& /*context*/,
     const RawValue& rawValue,
     NativeDrawable& result) {
-  auto map = (butter::map<std::string, RawValue>)rawValue;
+  auto map = (std::unordered_map<std::string, RawValue>)rawValue;
 
   auto typeIterator = map.find("type");
   react_native_expect(

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -10,8 +10,6 @@
 #include <limits>
 #include <optional>
 
-#include <butter/map.h>
-
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <butter/map.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <butter/map.h>
+#include <unordered_map>
+
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>
@@ -186,7 +187,7 @@ class RawValue {
   template <typename T>
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      butter::map<std::string, T>* type) noexcept {
+      std::unordered_map<std::string, T>* type) noexcept {
     if (!dynamic.isObject()) {
       return false;
     }
@@ -264,11 +265,11 @@ class RawValue {
   }
 
   template <typename T>
-  static butter::map<std::string, T> castValue(
+  static std::unordered_map<std::string, T> castValue(
       const folly::dynamic& dynamic,
-      butter::map<std::string, T>* type) {
+      std::unordered_map<std::string, T>* type) {
     react_native_assert(dynamic.isObject());
-    auto result = butter::map<std::string, T>{};
+    auto result = std::unordered_map<std::string, T>{};
     for (const auto& item : dynamic.items()) {
       react_native_assert(item.first.isString());
       result[item.first.getString()] = castValue(item.second, (T*)nullptr);

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <butter/map.h>
+#include <unordered_map>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -77,8 +78,8 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     Point& result) {
-  if (value.hasType<butter::map<std::string, Float>>()) {
-    auto map = (butter::map<std::string, Float>)value;
+  if (value.hasType<std::unordered_map<std::string, Float>>()) {
+    auto map = (std::unordered_map<std::string, Float>)value;
     for (const auto& pair : map) {
       if (pair.first == "x") {
         result.x = pair.second;
@@ -108,8 +109,8 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     Size& result) {
-  if (value.hasType<butter::map<std::string, Float>>()) {
-    auto map = (butter::map<std::string, Float>)value;
+  if (value.hasType<std::unordered_map<std::string, Float>>()) {
+    auto map = (std::unordered_map<std::string, Float>)value;
     for (const auto& pair : map) {
       if (pair.first == "width") {
         result.width = pair.second;
@@ -148,8 +149,8 @@ inline void fromRawValue(
     return;
   }
 
-  if (value.hasType<butter::map<std::string, Float>>()) {
-    auto map = (butter::map<std::string, Float>)value;
+  if (value.hasType<std::unordered_map<std::string, Float>>()) {
+    auto map = (std::unordered_map<std::string, Float>)value;
     for (const auto& pair : map) {
       if (pair.first == "top") {
         result.top = pair.second;
@@ -192,8 +193,8 @@ inline void fromRawValue(
     return;
   }
 
-  if (value.hasType<butter::map<std::string, Float>>()) {
-    auto map = (butter::map<std::string, Float>)value;
+  if (value.hasType<std::unordered_map<std::string, Float>>()) {
+    auto map = (std::unordered_map<std::string, Float>)value;
     for (const auto& pair : map) {
       if (pair.first == "topLeft") {
         result.topLeft = pair.second;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
@@ -11,6 +11,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawProps.h>
 #include <react/renderer/graphics/Color.h>
+#include <unordered_map>
 
 namespace facebook::react {
 
@@ -19,7 +20,8 @@ inline SharedColor parsePlatformColor(
     const RawValue& value) {
   ColorComponents colorComponents = {0, 0, 0, 0};
 
-  if (value.hasType<butter::map<std::string, std::vector<std::string>>>()) {
+  if (value.hasType<
+          std::unordered_map<std::string, std::vector<std::string>>>()) {
     const auto& fabricUIManager =
         context.contextContainer.at<jni::global_ref<jobject>>(
             "FabricUIManager");
@@ -27,7 +29,7 @@ inline SharedColor parsePlatformColor(
         fabricUIManager->getClass()
             ->getMethod<jint(jint, jni::JArrayClass<jni::JString>)>("getColor");
 
-    auto map = (butter::map<std::string, std::vector<std::string>>)value;
+    auto map = (std::unordered_map<std::string, std::vector<std::string>>)value;
     auto& resourcePaths = map["resource_paths"];
 
     auto javaResourcePaths =

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.h
@@ -11,14 +11,15 @@
 #include <react/renderer/core/RawProps.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/RCTPlatformColorUtils.h>
+#include <unordered_map>
 
 namespace facebook::react {
 
 inline SharedColor parsePlatformColor(
     const PropsParserContext& context,
     const RawValue& value) {
-  if (value.hasType<butter::map<std::string, RawValue>>()) {
-    auto items = (butter::map<std::string, RawValue>)value;
+  if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
+    auto items = (std::unordered_map<std::string, RawValue>)value;
     if (items.find("semantic") != items.end() &&
         items.at("semantic").hasType<std::vector<std::string>>()) {
       auto semanticItems = (std::vector<std::string>)items.at("semantic");

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -7,7 +7,6 @@
 
 #include "Differentiator.h"
 
-#include <butter/map.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <react/renderer/debug/SystraceSection.h>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
@@ -8,8 +8,7 @@
 #pragma once
 
 #include <shared_mutex>
-
-#include <butter/map.h>
+#include <unordered_map>
 
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/mounting/ShadowTree.h>
@@ -63,7 +62,7 @@ class ShadowTreeRegistry final {
 
  private:
   mutable std::shared_mutex mutex_;
-  mutable butter::map<SurfaceId, std::unique_ptr<ShadowTree>>
+  mutable std::unordered_map<SurfaceId, std::unique_ptr<ShadowTree>>
       registry_; // Protected by `mutex_`.
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <butter/map.h>
 #include <mutex>
 #include <shared_mutex>
+#include <unordered_map>
 
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/mounting/MountingCoordinator.h>
@@ -60,7 +60,7 @@ class SurfaceManager final {
 
   const Scheduler& scheduler_;
   mutable std::shared_mutex mutex_; // Protects `registry_`.
-  mutable butter::map<SurfaceId, SurfaceHandler> registry_{};
+  mutable std::unordered_map<SurfaceId, SurfaceHandler> registry_{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineController.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineController.h
@@ -9,8 +9,7 @@
 
 #include <memory>
 #include <shared_mutex>
-
-#include <butter/map.h>
+#include <unordered_map>
 
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/timeline/Timeline.h>
@@ -67,7 +66,7 @@ class TimelineController final : public UIManagerCommitHook {
   /*
    * Owning collection of all running `Timeline` instances.
    */
-  mutable butter::map<SurfaceId, std::unique_ptr<Timeline>> timelines_;
+  mutable std::unordered_map<SurfaceId, std::unique_ptr<Timeline>> timelines_;
 
   mutable const UIManager* uiManager_;
   mutable SurfaceId lastUpdatedSurface_;

--- a/packages/react-native/ReactCommon/react/utils/ContextContainer.h
+++ b/packages/react-native/ReactCommon/react/utils/ContextContainer.h
@@ -12,8 +12,7 @@
 #include <optional>
 #include <shared_mutex>
 #include <string>
-
-#include <butter/map.h>
+#include <unordered_map>
 
 #include <react/debug/flags.h>
 #include <react/debug/react_native_assert.h>
@@ -105,7 +104,7 @@ class ContextContainer final {
  private:
   mutable std::shared_mutex mutex_;
   // Protected by mutex_`.
-  mutable butter::map<std::string, std::shared_ptr<void>> instances_;
+  mutable std::unordered_map<std::string, std::shared_ptr<void>> instances_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

Remove use of folly::F14FastMap in favour of std::unordered_map.

Reviewed By: fkgozali

Differential Revision: D48968297

