### PR TITLE
Make New Architecture Examples in RNTester work properly

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
@@ -53,7 +53,7 @@ internal class MyNativeViewManager :
   @ReactProp(name = "values")
   override fun setValues(view: MyNativeView, value: ReadableArray?) {
     val values = mutableListOf<Int>()
-    value?.toArrayList()?.forEach { values.add(it as Int) }
+    value?.toArrayList()?.forEach { values.add((it as Double).toInt()) }
     view.emitOnArrayChangedEvent(values)
   }
 


### PR DESCRIPTION
Summary:
When working on RNTeaster, we discovered that the Kotlin migration. broke something.

This diff make sure we can test RNTester

## Changelog:
[Internal] - Make RNTester's New Architecture Example execute again

Reviewed By: cortinico

Differential Revision: D49154282


