### PR TITLE
Add helper types and function for double publishing

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -137,7 +137,7 @@ class ReactPlugin : Plugin<Project> {
               // the `jsRootDir` @Input property of this task & the onlyIf. Therefore, the
               // parsePackageJson should be invoked inside this lambda.
               val packageJson = findPackageJsonFile(project, rootExtension.root)
-              val parsedPackageJson = packageJson?.let { JsonUtils.fromCodegenJson(it) }
+              val parsedPackageJson = packageJson?.let { JsonUtils.fromPackageJson(it) }
 
               val jsSrcsDirInPackageJson = parsedPackageJson?.codegenConfig?.jsSrcsDir
               if (jsSrcsDirInPackageJson != null) {

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelPackageJson.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelPackageJson.kt
@@ -7,4 +7,4 @@
 
 package com.facebook.react.model
 
-data class ModelPackageJson(val codegenConfig: ModelCodegenConfig?)
+data class ModelPackageJson(val version: String, val codegenConfig: ModelCodegenConfig?)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTask.kt
@@ -53,7 +53,7 @@ abstract class GenerateCodegenArtifactsTask : Exec() {
   internal fun resolveTaskParameters(): Pair<String, String> {
     val parsedPackageJson =
         if (packageJsonFile.isPresent && packageJsonFile.get().asFile.exists()) {
-          JsonUtils.fromCodegenJson(packageJsonFile.get().asFile)
+          JsonUtils.fromPackageJson(packageJsonFile.get().asFile)
         } else {
           null
         }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JsonUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JsonUtils.kt
@@ -14,7 +14,7 @@ import java.io.File
 object JsonUtils {
   private val gsonConverter = Gson()
 
-  fun fromCodegenJson(input: File): ModelPackageJson? =
+  fun fromPackageJson(input: File): ModelPackageJson? =
       input.bufferedReader().use {
         runCatching { gsonConverter.fromJson(it, ModelPackageJson::class.java) }.getOrNull()
       }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -103,8 +103,8 @@ private fun detectCliFile(reactNativeRoot: File, preconfiguredCliFile: File?): F
   error(
       """
       Couldn't determine CLI location!
-      
-      Please set `react { cliFile = file(...) }` inside your 
+
+      Please set `react { cliFile = file(...) }` inside your
       build.gradle to the path of the react-native cli.js file.
       This file typically resides in `node_modules/react-native/cli.js`
     """
@@ -224,7 +224,7 @@ internal fun readPackageJsonFile(
     rootProperty: DirectoryProperty
 ): ModelPackageJson? {
   val packageJson = findPackageJsonFile(project, rootProperty)
-  return packageJson?.let { JsonUtils.fromCodegenJson(it) }
+  return packageJson?.let { JsonUtils.fromPackageJson(it) }
 }
 
 private const val HERMESC_IN_REACT_NATIVE_DIR = "node_modules/react-native/sdks/hermesc/%OS-BIN%/"

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/JsonUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/JsonUtilsTest.kt
@@ -21,14 +21,14 @@ class JsonUtilsTest {
   fun withInvalidJson_returnsNull() {
     val invalidJson = createJsonFile("""¯\_(ツ)_/¯""")
 
-    assertNull(JsonUtils.fromCodegenJson(invalidJson))
+    assertNull(JsonUtils.fromPackageJson(invalidJson))
   }
 
   @Test
   fun withEmptyJson_returnsEmptyObject() {
     val invalidJson = createJsonFile("""{}""")
 
-    val parsed = JsonUtils.fromCodegenJson(invalidJson)
+    val parsed = JsonUtils.fromPackageJson(invalidJson)
 
     assertNotNull(parsed)
     assertNull(parsed?.codegenConfig)
@@ -54,7 +54,7 @@ class JsonUtilsTest {
       """
                 .trimIndent())
 
-    val parsed = JsonUtils.fromCodegenJson(oldJsonConfig)!!
+    val parsed = JsonUtils.fromPackageJson(oldJsonConfig)!!
 
     assertNull(parsed.codegenConfig?.name)
     assertNull(parsed.codegenConfig?.jsSrcsDir)
@@ -82,11 +82,43 @@ class JsonUtilsTest {
       """
                 .trimIndent())
 
-    val parsed = JsonUtils.fromCodegenJson(validJson)!!
+    val parsed = JsonUtils.fromPackageJson(validJson)!!
 
     assertEquals("an awesome library", parsed.codegenConfig!!.name)
     assertEquals("../js/", parsed.codegenConfig!!.jsSrcsDir)
     assertEquals("com.awesome.library", parsed.codegenConfig!!.android!!.javaPackageName)
+  }
+
+  @Test
+  fun fromReactNativePackageJson_withInvalidJson_returnsNull() {
+    val invalidJson = createJsonFile("""¯\_(ツ)_/¯""")
+
+    assertNull(JsonUtils.fromPackageJson(invalidJson))
+  }
+
+  @Test
+  fun fromReactNativePackageJson_withEmptyJson_returnsEmptyObject() {
+    val invalidJson = createJsonFile("""{}""")
+
+    val parsed = JsonUtils.fromPackageJson(invalidJson)
+
+    assertNotNull(parsed)
+    assertNull(parsed?.version)
+  }
+
+  @Test
+  fun fromReactNativePackageJson_withValidJson_parsesJsonCorrectly() {
+    val validJson =
+        createJsonFile(
+            """
+      {
+        "version": "1000.0.0"
+      }
+      """
+                .trimIndent())
+    val parsed = JsonUtils.fromPackageJson(validJson)!!
+
+    assertEquals("1000.0.0", parsed.version)
   }
 
   private fun createJsonFile(@Language("JSON") input: String) =

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
@@ -149,7 +149,7 @@ class ProjectUtilsTest {
   @Test
   fun needsCodegenFromPackageJson_withCodegenConfigInModel_returnsTrue() {
     val project = createProject()
-    val model = ModelPackageJson(ModelCodegenConfig(null, null, null, null))
+    val model = ModelPackageJson("1000.0.0", ModelCodegenConfig(null, null, null, null))
 
     assertTrue(project.needsCodegenFromPackageJson(model))
   }
@@ -157,7 +157,7 @@ class ProjectUtilsTest {
   @Test
   fun needsCodegenFromPackageJson_withMissingCodegenConfigInModel_returnsFalse() {
     val project = createProject()
-    val model = ModelPackageJson(null)
+    val model = ModelPackageJson("1000.0.0", null)
 
     assertFalse(project.needsCodegenFromPackageJson(model))
   }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
@@ -53,7 +53,7 @@ internal class MyNativeViewManager :
   @ReactProp(name = "values")
   override fun setValues(view: MyNativeView, value: ReadableArray?) {
     val values = mutableListOf<Int>()
-    value?.toArrayList()?.forEach { values.add(it as Int) }
+    value?.toArrayList()?.forEach { values.add((it as Double).toInt()) }
     view.emitOnArrayChangedEvent(values)
   }
 


### PR DESCRIPTION
Summary:
This change introduce a new model to parse the React Native package.json.
The objects are not connected but they will be used in the next diff

## Changelog:
[Android][Added] - Add a couple of types in the RNGP for json parsing.

Differential Revision: D49270044

