### PR TITLE
Bumping the resource class for Analyze-pr to Medium

### DIFF
--- a/.circleci/configurations/executors.yml
+++ b/.circleci/configurations/executors.yml
@@ -18,6 +18,11 @@ executors:
     docker:
       - image: *nodelts_browser_image
     resource_class: "small"
+  node-browsers-medium:
+    <<: *defaults
+    docker:
+      - image: *nodelts_browser_image
+    resource_class: "medium"
   reactnativeandroid-xlarge:
     <<: *android-defaults
     resource_class: "xlarge"

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -9,7 +9,7 @@ jobs:
   # Issues will be posted to the PR itself via GitHub bots.
   # This workflow should only fail if the bots fail to run.
   analyze_pr:
-    executor: node-browsers-small
+    executor: node-browsers-medium
     steps:
       - checkout
       - run_yarn


### PR DESCRIPTION
Summary:
We are receiving "killed" signals in CircleCI for the analyze_pr jobs.
Looking at the doc, it seems that it is due to us allocating to much memory.

As a mitigation, let's bumpt the executor to Medium.

## Changelog:
[Internal] - Bump executors for Analyze-PR to Medium to avoid choking

## Facebook:

Small machines consume 5 cred/min. Medium consume 10.
On average, the job takes 7 min to complete. So we are paying 35 credits per job. We will be paying 70 creds.
The upper bound cost is $ 0.042 per execution.
In the past month we were running 1820 jobs. We will be spending 1820 * 0.042  = $76.44 per month, rather than $38.22.
This is roughly $500/year.

We can fix the script with a different approach in the future.

Reviewed By: dmytrorykun

Differential Revision: D49368118


