### PR TITLE
remove use of folly::hash from attributedstring module

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
@@ -7,15 +7,14 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
 
-#include <folly/Hash.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/core/Sealable.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/mounting/ShadowView.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -123,8 +122,7 @@ template <>
 struct hash<facebook::react::AttributedString::Fragment> {
   size_t operator()(
       const facebook::react::AttributedString::Fragment& fragment) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         fragment.string,
         fragment.textAttributes,
         fragment.parentShadowView,
@@ -139,7 +137,7 @@ struct hash<facebook::react::AttributedString> {
     auto seed = size_t{0};
 
     for (const auto& fragment : attributedString.getFragments()) {
-      seed = folly::hash::hash_combine(seed, fragment);
+      facebook::react::hash_combine(seed, fragment);
     }
 
     return seed;

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -9,10 +9,10 @@
 
 #include <limits>
 
-#include <folly/Hash.h>
 #include <react/renderer/attributedstring/primitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Float.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -88,8 +88,7 @@ template <>
 struct hash<facebook::react::ParagraphAttributes> {
   size_t operator()(
       const facebook::react::ParagraphAttributes& attributes) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         attributes.maximumNumberOfLines,
         attributes.ellipsizeMode,
         attributes.textBreakStrategy,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "ParagraphLayoutManager.h"
-#include <folly/Hash.h>
 #include <react/utils/CoreFeatures.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -43,7 +43,7 @@ bool ParagraphLayoutManager::shoudMeasureString(
     const ParagraphAttributes& paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   size_t newParagraphInputHash =
-      folly::hash::hash_combine(0, attributedString, paragraphAttributes);
+      hash_combine(attributedString, paragraphAttributes);
 
   if (newParagraphInputHash != paragraphInputHash_) {
     // AttributedString or ParagraphAttributes have changed.

--- a/packages/react-native/ReactCommon/react/utils/SharedFunction.h
+++ b/packages/react-native/ReactCommon/react/utils/SharedFunction.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <functional>
 #include <memory>
 #include <shared_mutex>

--- a/packages/react-native/ReactCommon/react/utils/hash_combine.h
+++ b/packages/react-native/ReactCommon/react/utils/hash_combine.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace facebook::react {
+
+template <
+    typename T,
+    typename... Rest,
+    bool Enabled = !std::is_same<T, const char*>::value,
+    typename = typename std::enable_if<Enabled>::type>
+void hash_combine(std::size_t& seed, const T& v, const Rest&... rest) {
+  seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  (hash_combine(seed, rest), ...);
+}
+
+template <typename T, typename... Args>
+std::size_t hash_combine(const T& v, const Args&... args) {
+  std::size_t seed = 0;
+  hash_combine<T, Args...>(seed, v, args...);
+  return seed;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/tests/hash_combineTests.cpp
+++ b/packages/react-native/ReactCommon/react/utils/tests/hash_combineTests.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/utils/hash_combine.h>
+
+struct Person {
+  std::string firstName;
+  std::string lastName;
+};
+
+namespace std {
+template <>
+struct hash<Person> {
+  size_t operator()(const Person& person) const {
+    return facebook::react::hash_combine(person.firstName, person.lastName);
+  }
+};
+} // namespace std
+
+namespace facebook::react {
+
+TEST(hash_combineTests, testIntegerTemplating) {
+  std::size_t seed = 0;
+  hash_combine(seed, 1);
+
+  auto hashedValue = hash_combine(1);
+  EXPECT_EQ(hashedValue, seed);
+
+  EXPECT_NE(hash_combine(1), hash_combine(2));
+}
+
+TEST(hash_combineTests, testIntegerCombinationsHashing) {
+  std::size_t seed = 0;
+  hash_combine(seed, 1, 2);
+
+  auto hashedValue = hash_combine(1, 2);
+  EXPECT_EQ(hashedValue, seed);
+
+  EXPECT_NE(hash_combine(1, 2), hash_combine(2, 1));
+}
+
+TEST(hash_combineTests, testContiniousIntegerHashing) {
+  std::size_t seed = 0;
+
+  for (int i = 1; i <= 200; ++i) {
+    auto previousSeed = seed;
+    hash_combine(seed, i);
+    EXPECT_NE(seed, previousSeed);
+  }
+}
+
+TEST(hash_combineTests, testStrings) {
+  std::size_t seed = 0;
+  hash_combine<std::string>(seed, "react");
+
+  auto hashedValue = hash_combine<std::string>("react");
+  EXPECT_EQ(hashedValue, seed);
+
+  EXPECT_NE(
+      hash_combine<std::string>("react"),
+      hash_combine<std::string>("react native"));
+}
+
+TEST(hash_combineTests, testCustomTypes) {
+  auto person1 = Person{"John", "Doe"};
+  auto person2 = Person{"Jane", "Doe"};
+
+  std::size_t seed = 0;
+  hash_combine(seed, person1);
+
+  auto hashedValue = hash_combine(person1);
+  EXPECT_EQ(hashedValue, seed);
+
+  EXPECT_NE(hash_combine(person1), hash_combine(person2));
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary: changelog: [internal]

Differential Revision: D49349658

