### PR TITLE
use string_view instead of const char* in PerformanceObserver APIs

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -153,7 +153,7 @@ void PerformanceEntryReporter::mark(
 
 void PerformanceEntryReporter::clearEntries(
     PerformanceEntryType entryType,
-    const char* entryName) {
+    std::string_view entryName) {
   if (entryType == PerformanceEntryType::UNDEFINED) {
     // Clear all entry types
     for (int i = 1; i < NUM_PERFORMANCE_ENTRY_TYPES; i++) {
@@ -161,10 +161,10 @@ void PerformanceEntryReporter::clearEntries(
     }
   } else {
     auto& buffer = getBuffer(entryType);
-    if (entryName != nullptr) {
+    if (!entryName.empty()) {
       if (buffer.hasNameLookup) {
         RawPerformanceEntry entry{
-            entryName,
+            std::string(entryName),
             static_cast<int>(entryType),
             0.0,
             0.0,
@@ -174,7 +174,7 @@ void PerformanceEntryReporter::clearEntries(
         buffer.nameLookup.erase(&entry);
       }
       buffer.entries.clear([entryName](const RawPerformanceEntry& entry) {
-        return std::strcmp(entry.name.c_str(), entryName) == 0;
+        return entry.name == entryName;
       });
     } else {
       buffer.entries.clear();
@@ -185,7 +185,7 @@ void PerformanceEntryReporter::clearEntries(
 
 void PerformanceEntryReporter::getEntries(
     PerformanceEntryType entryType,
-    const char* entryName,
+    std::string_view entryName,
     std::vector<RawPerformanceEntry>& res) const {
   if (entryType == PerformanceEntryType::UNDEFINED) {
     // Collect all entry types
@@ -194,11 +194,11 @@ void PerformanceEntryReporter::getEntries(
     }
   } else {
     const auto& entries = getBuffer(entryType).entries;
-    if (entryName == nullptr) {
+    if (entryName.empty()) {
       entries.getEntries(res);
     } else {
       entries.getEntries(res, [entryName](const RawPerformanceEntry& entry) {
-        return std::strcmp(entry.name.c_str(), entryName) == 0;
+        return entry.name == entryName;
       });
     }
   }
@@ -206,7 +206,7 @@ void PerformanceEntryReporter::getEntries(
 
 std::vector<RawPerformanceEntry> PerformanceEntryReporter::getEntries(
     PerformanceEntryType entryType,
-    const char* entryName) const {
+    std::string_view entryName) const {
   std::vector<RawPerformanceEntry> res;
   getEntries(entryType, entryName, res);
   return res;
@@ -285,7 +285,8 @@ void PerformanceEntryReporter::scheduleFlushBuffer() {
 
 struct StrKey {
   uint32_t key;
-  StrKey(const char* s) : key(folly::hash::fnv32_buf(s, std::strlen(s))) {}
+  StrKey(std::string_view s)
+      : key(folly::hash::fnv32_buf(s.data(), s.length())) {}
 
   bool operator==(const StrKey& rhs) const {
     return key == rhs.key;
@@ -303,51 +304,51 @@ struct StrKeyHash {
 // Not all of these are currently supported by RN, but we map them anyway for
 // future-proofing.
 using SupportedEventTypeRegistry =
-    std::unordered_map<StrKey, const char*, StrKeyHash>;
+    std::unordered_map<StrKey, std::string_view, StrKeyHash>;
 
 static const SupportedEventTypeRegistry& getSupportedEvents() {
   static SupportedEventTypeRegistry SUPPORTED_EVENTS = {
-      {"topAuxClick", "auxclick"},
-      {"topClick", "click"},
-      {"topContextMenu", "contextmenu"},
-      {"topDblClick", "dblclick"},
-      {"topMouseDown", "mousedown"},
-      {"topMouseEnter", "mouseenter"},
-      {"topMouseLeave", "mouseleave"},
-      {"topMouseOut", "mouseout"},
-      {"topMouseOver", "mouseover"},
-      {"topMouseUp", "mouseup"},
-      {"topPointerOver", "pointerover"},
-      {"topPointerEnter", "pointerenter"},
-      {"topPointerDown", "pointerdown"},
-      {"topPointerUp", "pointerup"},
-      {"topPointerCancel", "pointercancel"},
-      {"topPointerOut", "pointerout"},
-      {"topPointerLeave", "pointerleave"},
-      {"topGotPointerCapture", "gotpointercapture"},
-      {"topLostPointerCapture", "lostpointercapture"},
-      {"topTouchStart", "touchstart"},
-      {"topTouchEnd", "touchend"},
-      {"topTouchCancel", "touchcancel"},
-      {"topKeyDown", "keydown"},
-      {"topKeyPress", "keypress"},
-      {"topKeyUp", "keyup"},
-      {"topBeforeInput", "beforeinput"},
-      {"topInput", "input"},
-      {"topCompositionStart", "compositionstart"},
-      {"topCompositionUpdate", "compositionupdate"},
-      {"topCompositionEnd", "compositionend"},
-      {"topDragStart", "dragstart"},
-      {"topDragEnd", "dragend"},
-      {"topDragEnter", "dragenter"},
-      {"topDragLeave", "dragleave"},
-      {"topDragOver", "dragover"},
-      {"topDrop", "drop"},
+      {StrKey("topAuxClick"), "auxclick"},
+      {StrKey("topClick"), "click"},
+      {StrKey("topContextMenu"), "contextmenu"},
+      {StrKey("topDblClick"), "dblclick"},
+      {StrKey("topMouseDown"), "mousedown"},
+      {StrKey("topMouseEnter"), "mouseenter"},
+      {StrKey("topMouseLeave"), "mouseleave"},
+      {StrKey("topMouseOut"), "mouseout"},
+      {StrKey("topMouseOver"), "mouseover"},
+      {StrKey("topMouseUp"), "mouseup"},
+      {StrKey("topPointerOver"), "pointerover"},
+      {StrKey("topPointerEnter"), "pointerenter"},
+      {StrKey("topPointerDown"), "pointerdown"},
+      {StrKey("topPointerUp"), "pointerup"},
+      {StrKey("topPointerCancel"), "pointercancel"},
+      {StrKey("topPointerOut"), "pointerout"},
+      {StrKey("topPointerLeave"), "pointerleave"},
+      {StrKey("topGotPointerCapture"), "gotpointercapture"},
+      {StrKey("topLostPointerCapture"), "lostpointercapture"},
+      {StrKey("topTouchStart"), "touchstart"},
+      {StrKey("topTouchEnd"), "touchend"},
+      {StrKey("topTouchCancel"), "touchcancel"},
+      {StrKey("topKeyDown"), "keydown"},
+      {StrKey("topKeyPress"), "keypress"},
+      {StrKey("topKeyUp"), "keyup"},
+      {StrKey("topBeforeInput"), "beforeinput"},
+      {StrKey("topInput"), "input"},
+      {StrKey("topCompositionStart"), "compositionstart"},
+      {StrKey("topCompositionUpdate"), "compositionupdate"},
+      {StrKey("topCompositionEnd"), "compositionend"},
+      {StrKey("topDragStart"), "dragstart"},
+      {StrKey("topDragEnd"), "dragend"},
+      {StrKey("topDragEnter"), "dragenter"},
+      {StrKey("topDragLeave"), "dragleave"},
+      {StrKey("topDragOver"), "dragover"},
+      {StrKey("topDrop"), "drop"},
   };
   return SUPPORTED_EVENTS;
 }
 
-EventTag PerformanceEntryReporter::onEventStart(const char* name) {
+EventTag PerformanceEntryReporter::onEventStart(std::string_view name) {
   if (!isReporting(PerformanceEntryType::EVENT)) {
     return 0;
   }
@@ -357,7 +358,7 @@ EventTag PerformanceEntryReporter::onEventStart(const char* name) {
     return 0;
   }
 
-  const char* reportedName = it->second;
+  auto reportedName = it->second;
 
   sCurrentEventTag_++;
   if (sCurrentEventTag_ == 0) {
@@ -406,7 +407,7 @@ void PerformanceEntryReporter::onEventEnd(EventTag tag) {
     // (T141358175)
     const uint32_t interactionId = 0;
     event(
-        name,
+        std::string(name),
         entry.startTime,
         timeStamp - entry.startTime,
         entry.dispatchTime,

--- a/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <mutex>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include "BoundedConsumableBuffer.h"
@@ -125,11 +126,11 @@ class PerformanceEntryReporter : public EventLogger {
 
   void clearEntries(
       PerformanceEntryType entryType = PerformanceEntryType::UNDEFINED,
-      const char* entryName = nullptr);
+      std::string_view entryName = {});
 
   std::vector<RawPerformanceEntry> getEntries(
       PerformanceEntryType entryType = PerformanceEntryType::UNDEFINED,
-      const char* entryName = nullptr) const;
+      std::string_view entryName = {}) const;
 
   void event(
       std::string name,
@@ -139,7 +140,7 @@ class PerformanceEntryReporter : public EventLogger {
       double processingEnd,
       uint32_t interactionId);
 
-  EventTag onEventStart(const char* name) override;
+  EventTag onEventStart(std::string_view name) override;
   void onEventDispatch(EventTag tag) override;
   void onEventEnd(EventTag tag) override;
 
@@ -163,7 +164,7 @@ class PerformanceEntryReporter : public EventLogger {
   uint32_t droppedEntryCount_{0};
 
   struct EventEntry {
-    const char* name;
+    std::string_view name;
     double startTime{0.0};
     double dispatchTime{0.0};
   };
@@ -186,7 +187,7 @@ class PerformanceEntryReporter : public EventLogger {
 
   void getEntries(
       PerformanceEntryType entryType,
-      const char* entryName,
+      std::string_view entryName,
       std::vector<RawPerformanceEntry>& res) const;
 
   double getCurrentTimeStamp() const;

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
@@ -7,15 +7,14 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
 
-#include <folly/Hash.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/core/Sealable.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/mounting/ShadowView.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -123,8 +122,7 @@ template <>
 struct hash<facebook::react::AttributedString::Fragment> {
   size_t operator()(
       const facebook::react::AttributedString::Fragment& fragment) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         fragment.string,
         fragment.textAttributes,
         fragment.parentShadowView,
@@ -139,7 +137,7 @@ struct hash<facebook::react::AttributedString> {
     auto seed = size_t{0};
 
     for (const auto& fragment : attributedString.getFragments()) {
-      seed = folly::hash::hash_combine(seed, fragment);
+      facebook::react::hash_combine(seed, fragment);
     }
 
     return seed;

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -9,10 +9,10 @@
 
 #include <limits>
 
-#include <folly/Hash.h>
 #include <react/renderer/attributedstring/primitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Float.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -88,8 +88,7 @@ template <>
 struct hash<facebook::react::ParagraphAttributes> {
   size_t operator()(
       const facebook::react::ParagraphAttributes& attributes) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         attributes.maximumNumberOfLines,
         attributes.ellipsizeMode,
         attributes.textBreakStrategy,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "ParagraphLayoutManager.h"
-#include <folly/Hash.h>
 #include <react/utils/CoreFeatures.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -43,7 +43,7 @@ bool ParagraphLayoutManager::shoudMeasureString(
     const ParagraphAttributes& paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   size_t newParagraphInputHash =
-      folly::hash::hash_combine(0, attributedString, paragraphAttributes);
+      hash_combine(attributedString, paragraphAttributes);
 
   if (newParagraphInputHash != paragraphInputHash_) {
     // AttributedString or ParagraphAttributes have changed.

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -43,7 +43,7 @@ void EventDispatcher::dispatchEvent(RawEvent&& rawEvent, EventPriority priority)
 
   auto eventLogger = getEventLogger();
   if (eventLogger != nullptr) {
-    rawEvent.loggingTag = eventLogger->onEventStart(rawEvent.type.c_str());
+    rawEvent.loggingTag = eventLogger->onEventStart(rawEvent.type);
   }
   getEventQueue(priority).enqueueEvent(std::move(rawEvent));
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventLogger.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventLogger.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <string_view>
+
 namespace facebook::react {
 
 using EventTag = unsigned int;
@@ -24,7 +26,7 @@ class EventLogger {
    * Called when an event is first created, returns and unique tag for this
    * event, which can be used to log further event processing stages.
    */
-  virtual EventTag onEventStart(const char* name) = 0;
+  virtual EventTag onEventStart(std::string_view name) = 0;
 
   /*
    * Called when event starts getting dispatched (processed by the handlers, if

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutConstraints.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutConstraints.h
@@ -9,9 +9,9 @@
 
 #include <limits>
 
-#include <folly/Hash.h>
 #include <react/renderer/core/LayoutPrimitives.h>
 #include <react/renderer/graphics/Size.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -52,8 +52,7 @@ template <>
 struct hash<facebook::react::LayoutConstraints> {
   size_t operator()(
       const facebook::react::LayoutConstraints& constraints) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         constraints.minimumSize,
         constraints.maximumSize,
         constraints.layoutDirection);

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -7,12 +7,12 @@
 
 #pragma once
 
-#include <folly/Hash.h>
 #include <react/renderer/core/LayoutPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/debug/flags.h>
 #include <react/renderer/graphics/Rect.h>
 #include <react/renderer/graphics/RectangleEdges.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -111,8 +111,7 @@ namespace std {
 template <>
 struct hash<facebook::react::LayoutMetrics> {
   size_t operator()(const facebook::react::LayoutMetrics& layoutMetrics) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         layoutMetrics.frame,
         layoutMetrics.contentInsets,
         layoutMetrics.borderWidth,

--- a/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -24,4 +24,4 @@ target_include_directories(react_render_graphics
           ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
         )
 
-target_link_libraries(react_render_graphics glog fb fbjni folly_runtime react_debug)
+target_link_libraries(react_render_graphics glog fb fbjni folly_runtime react_debug react_utils)

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
@@ -9,8 +9,8 @@
 
 #include <tuple>
 
-#include <folly/Hash.h>
 #include <react/renderer/graphics/Float.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -63,7 +63,7 @@ namespace std {
 template <>
 struct hash<facebook::react::Point> {
   size_t operator()(const facebook::react::Point& point) const noexcept {
-    return folly::hash::hash_combine(0, point.x, point.y);
+    return facebook::react::hash_combine(point.x, point.y);
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -57,4 +57,5 @@ Pod::Spec.new do |s|
   s.dependency "glog"
   s.dependency "RCT-Folly/Fabric", folly_version
   s.dependency "React-Core/Default", version
+  s.dependency "React-utils"
 end

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
@@ -10,10 +10,10 @@
 #include <algorithm>
 #include <tuple>
 
-#include <folly/Hash.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/Size.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -125,7 +125,7 @@ namespace std {
 template <>
 struct hash<facebook::react::Rect> {
   size_t operator()(const facebook::react::Rect& rect) const noexcept {
-    return folly::hash::hash_combine(0, rect.origin, rect.size);
+    return facebook::react::hash_combine(rect.origin, rect.size);
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
@@ -9,8 +9,8 @@
 
 #include <tuple>
 
-#include <folly/Hash.h>
 #include <react/renderer/graphics/Float.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -57,8 +57,7 @@ template <typename T>
 struct hash<facebook::react::RectangleCorners<T>> {
   size_t operator()(
       const facebook::react::RectangleCorners<T>& corners) const noexcept {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         corners.topLeft,
         corners.bottomLeft,
         corners.topRight,

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
@@ -9,9 +9,9 @@
 
 #include <tuple>
 
-#include <folly/Hash.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Rect.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -100,8 +100,8 @@ template <typename T>
 struct hash<facebook::react::RectangleEdges<T>> {
   size_t operator()(
       const facebook::react::RectangleEdges<T>& edges) const noexcept {
-    return folly::hash::hash_combine(
-        0, edges.left, edges.right, edges.top, edges.bottom);
+    return facebook::react::hash_combine(
+        edges.left, edges.right, edges.top, edges.bottom);
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Size.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Size.h
@@ -9,9 +9,9 @@
 
 #include <tuple>
 
-#include <folly/Hash.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Point.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -50,7 +50,7 @@ namespace std {
 template <>
 struct hash<facebook::react::Size> {
   size_t operator()(const facebook::react::Size& size) const {
-    return folly::hash::hash_combine(0, size.width, size.height);
+    return facebook::react::hash_combine(size.width, size.height);
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -10,13 +10,13 @@
 #include <array>
 #include <vector>
 
-#include <folly/Hash.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/renderer/graphics/Size.h>
 #include <react/renderer/graphics/ValueUnit.h>
 #include <react/renderer/graphics/Vector.h>
+#include <react/utils/hash_combine.h>
 
 #ifdef ANDROID
 #include <folly/dynamic.h>
@@ -232,8 +232,7 @@ namespace std {
 template <>
 struct hash<facebook::react::Transform> {
   size_t operator()(const facebook::react::Transform& transform) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         transform.matrix[0],
         transform.matrix[1],
         transform.matrix[2],

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
@@ -7,13 +7,13 @@
 
 #pragma once
 
-#include <folly/Hash.h>
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/debug/flags.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -124,7 +124,7 @@ namespace std {
 template <>
 struct hash<facebook::react::ShadowView> {
   size_t operator()(const facebook::react::ShadowView& shadowView) const {
-    return folly::hash::hash_combine(
+    return facebook::react::hash_combine(
         0,
         shadowView.surfaceId,
         shadowView.componentHandle,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -7,12 +7,12 @@
 
 #pragma once
 
-#include <folly/Hash.h>
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/FloatComparison.h>
 #include <react/utils/SimpleThreadSafeCache.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -114,8 +114,7 @@ inline size_t textAttributesHashLayoutWise(
     const TextAttributes& textAttributes) {
   // Taking into account the same props as
   // `areTextAttributesEquivalentLayoutWise` mentions.
-  return folly::hash::hash_combine(
-      0,
+  return facebook::react::hash_combine(
       textAttributes.fontFamily,
       textAttributes.fontSize,
       textAttributes.fontSizeMultiplier,

--- a/packages/react-native/ReactCommon/react/utils/SharedFunction.h
+++ b/packages/react-native/ReactCommon/react/utils/SharedFunction.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <functional>
 #include <memory>
 #include <shared_mutex>

--- a/packages/react-native/ReactCommon/react/utils/hash_combine.h
+++ b/packages/react-native/ReactCommon/react/utils/hash_combine.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace facebook::react {
+
+template <
+    typename T,
+    typename... Rest,
+    bool Enabled = !std::is_same<T, const char*>::value,
+    typename = typename std::enable_if<Enabled>::type>
+void hash_combine(std::size_t& seed, const T& v, const Rest&... rest) {
+  seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  (hash_combine(seed, rest), ...);
+}
+
+template <typename T, typename... Args>
+std::size_t hash_combine(const T& v, const Args&... args) {
+  std::size_t seed = 0;
+  hash_combine<T, Args...>(seed, v, args...);
+  return seed;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/tests/hash_combineTests.cpp
+++ b/packages/react-native/ReactCommon/react/utils/tests/hash_combineTests.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/utils/hash_combine.h>
+
+struct Person {
+  std::string firstName;
+  std::string lastName;
+};
+
+namespace std {
+template <>
+struct hash<Person> {
+  size_t operator()(const Person& person) const {
+    return facebook::react::hash_combine(person.firstName, person.lastName);
+  }
+};
+} // namespace std
+
+namespace facebook::react {
+
+TEST(hash_combineTests, testIntegerTemplating) {
+  std::size_t seed = 0;
+  hash_combine(seed, 1);
+
+  auto hashedValue = hash_combine(1);
+  EXPECT_EQ(hashedValue, seed);
+
+  EXPECT_NE(hash_combine(1), hash_combine(2));
+}
+
+TEST(hash_combineTests, testIntegerCombinationsHashing) {
+  std::size_t seed = 0;
+  hash_combine(seed, 1, 2);
+
+  auto hashedValue = hash_combine(1, 2);
+  EXPECT_EQ(hashedValue, seed);
+
+  EXPECT_NE(hash_combine(1, 2), hash_combine(2, 1));
+}
+
+TEST(hash_combineTests, testContiniousIntegerHashing) {
+  std::size_t seed = 0;
+
+  for (int i = 1; i <= 200; ++i) {
+    auto previousSeed = seed;
+    hash_combine(seed, i);
+    EXPECT_NE(seed, previousSeed);
+  }
+}
+
+TEST(hash_combineTests, testStrings) {
+  std::size_t seed = 0;
+  hash_combine<std::string>(seed, "react");
+
+  auto hashedValue = hash_combine<std::string>("react");
+  EXPECT_EQ(hashedValue, seed);
+
+  EXPECT_NE(
+      hash_combine<std::string>("react"),
+      hash_combine<std::string>("react native"));
+}
+
+TEST(hash_combineTests, testCustomTypes) {
+  auto person1 = Person{"John", "Doe"};
+  auto person2 = Person{"Jane", "Doe"};
+
+  std::size_t seed = 0;
+  hash_combine(seed, person1);
+
+  auto hashedValue = hash_combine(person1);
+  EXPECT_EQ(hashedValue, seed);
+
+  EXPECT_NE(hash_combine(person1), hash_combine(person2));
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

using std::string_view to make use of std::hash easier.

Differential Revision: D49355536

