### PR TITLE
Add ld_classic flag to Hermes when building for Xcode 15

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -52,7 +52,7 @@ function build_host_hermesc {
 
 # Utility function to configure an Apple framework
 function configure_apple_framework {
-  local enable_debugger cmake_build_type
+  local enable_debugger cmake_build_type xcode_15_flags xcode_major_version
 
   if [[ $BUILD_TYPE == "Debug" ]]; then
     enable_debugger="true"
@@ -67,8 +67,15 @@ function configure_apple_framework {
     cmake_build_type="MinSizeRel"
   fi
 
+  xcode_15_flags=""
+  xcode_major_version=$(xcodebuild -version | grep -oE '[0-9]*' | head -n 1)
+  if [[ $xcode_major_version -ge 15 ]]; then
+    xcode_15_flags="LINKER:-ld_classic"
+  fi
+
   pushd "$HERMES_PATH" > /dev/null || exit 1
     cmake -S . -B "build_$1" \
+      -DHERMES_EXTRA_LINKER_FLAGS="$xcode_15_flags" \
       -DHERMES_APPLE_TARGET_PLATFORM:STRING="$1" \
       -DCMAKE_OSX_ARCHITECTURES:STRING="$2" \
       -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="$3" \

--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -29,6 +29,13 @@ if [ -z "$deployment_target" ]; then
   deployment_target=${MACOSX_DEPLOYMENT_TARGET}
 fi
 
+xcode_15_flags=""
+xcode_major_version=$(xcodebuild -version | grep -oE '[0-9]*' | head -n 1)
+if [[ $xcode_major_version -ge 15 ]]; then
+  echo "########### Using LINKER:-ld_classic ###########"
+  xcode_15_flags="LINKER:-ld_classic"
+fi
+
 architectures=$( echo "$ARCHS" | tr  " " ";" )
 
 echo "Configure Apple framework"
@@ -36,6 +43,7 @@ echo "Configure Apple framework"
 "$CMAKE_BINARY" \
   -S "${PODS_ROOT}/hermes-engine" \
   -B "${PODS_ROOT}/hermes-engine/build/${PLATFORM_NAME}" \
+  -DHERMES_EXTRA_LINKER_FLAGS="$xcode_15_flags" \
   -DHERMES_APPLE_TARGET_PLATFORM:STRING="$PLATFORM_NAME" \
   -DCMAKE_OSX_ARCHITECTURES:STRING="$architectures" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="$deployment_target" \


### PR DESCRIPTION
Summary:
With Xcode15, Apple rewrote the C++ linker.
This is a breaking change that does not work with weak symbols.
As a workaround, apple is suggesting to add `-ld_classic` to the linker in order to readd support for weak symbols. The flag does not exists for Xcode 14.3 or lower, so we need to add it conditionally.

With this change, we introduce a couple of checks in the Hermes build logic:
1. Detect the version of Xcode that is used
2. Add the new flag to `HERMES_EXTRA_LINKER_FLAGS` if Xcode version is 15.

## Changelog:
[Internal] - Make hermes build properly with Xcode 15

Differential Revision: D49368675


