### PR TITLE
[RFC] Android template - dynamically resolve paths to node_modules packages from .gradle files

### DIFF
--- a/packages/react-native/template/android/app/build.gradle
+++ b/packages/react-native/template/android/app/build.gradle
@@ -116,4 +116,7 @@ dependencies {
     }
 }
 
-apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+def reactNativeRoot = resolveNodePackage('react-native', rootDir)
+def cliPlatformAndroidPath = resolveNodePackage('@react-native-community/cli-platform-android', reactNativeRoot)
+
+apply from: new File(cliPlatformAndroidPath, "native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/packages/react-native/template/android/buildSrc/resolveNodePackage.gradle
+++ b/packages/react-native/template/android/buildSrc/resolveNodePackage.gradle
@@ -1,0 +1,14 @@
+ext.resolveNodePackage = { String packageName, File startDir ->
+    def candidate = new File(startDir, "node_modules/$packageName")
+
+    if (candidate.exists()) {
+        return candidate.canonicalFile
+    }
+
+    def parentDir = startDir.parentFile
+    if (parentDir == null || startDir.canonicalPath == parentDir.canonicalPath) {
+        throw new GradleException("Failed to find the package '$packageName'. Ensure you have installed node_modules.")
+    }
+
+    return resolveNodePackage(packageName, parentDir)
+}

--- a/packages/react-native/template/android/settings.gradle
+++ b/packages/react-native/template/android/settings.gradle
@@ -1,4 +1,10 @@
 rootProject.name = 'HelloWorld'
-apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+
+def reactNativePath = resolveNodePackage('react-native', rootDir)
+def cliPlatformAndroidPath = resolveNodePackage('@react-native-community/cli-platform-android', reactNativePath)
+def gradlePluginPath = resolveNodePackage("@react-native/gradle-plugin", reactNativePath)
+
+apply from: new File(cliPlatformAndroidPath, "native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+
 include ':app'
-includeBuild('../node_modules/@react-native/gradle-plugin')
+includeBuild(gradlePluginPath)


### PR DESCRIPTION
Summary:
## Goal
Provide out-of-the-box support in `template`-based projects for setups other than a hoisted, Yarn classic-style package layout. In particular, we want to correctly support workspaces (monorepos) and default PNPM setups, such as to allow easier code sharing between RN/React/etc.

## Problem
The template Gradle project needs to be able to pull dependencies that are installed by the JavaScript package manager, and obviously Gradle has no knowledge of node modules resolution, so we currently hardcode paths which are typically correct in Yarn classic.

## Proposal
Gradle doesn't need to be aware of *all* of the [gory details](https://nodejs.org/api/esm.html#resolution-algorithm-specification) of Node's resolution algorithm - we only need to know where package roots are. It's fairly straightforward to implement this in Groovy/Kotlin and perform the resolutions we need natively. This PR does that.

## Alternatives
 - Status quo: keep a string literal path and require the user to change it.
 - Perform the resolution in a `postinstall` script and write its output somewhere well-known (eg, create a symlink always at `node_modules/react-native` that aways points to the right place). The main problem with this is that `postinstall` scripts aren't run consistently across package managers, and are often disabled for security reasons.
 - Perform the resolution just ahead of time, eg in the CLI command. The main problem with this is that it doesn't support folks starting the build directly from Android studio.
 - Shell out to `node` from within `settings.gradle` and `build.gradle` (or a shared function) to resolve just in time. IMO, this is unnecessarily invoking a separate process (which may not be on the `PATH` everywhere) to save ~15 lines of Groovy or Kotlin.

## Further work
The template project directly depends on `react-native/gradle-plugin` and `react-native-community/cli-plugin-android`, but they are not specified as `package.json#dependencies` of the template project. This means they're not guaranteed to be resolvable starting from the app entry point, and we have to build in some fragile knowledge about `react-native`'s own `dependencies` in order to resolve them correctly. We could simplify this by re-exporting them from the `react-native` package instead, and reduce complexity in the template.

This isn't the end of it - `react-native-gradle-plugin` itself has the same package layout assumptions, but we have more options there once we're in RN-owned code. This PR is scoped to the first problem of *getting to `react-native`*.

## Disclaimer
I'm not a gradle expert, hence RFC :)

Differential Revision: D49374219


