### PR TITLE
Improve "Open Debugger" error guidance

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -261,23 +261,26 @@ RCT_EXPORT_MODULE()
 #if RCT_ENABLE_INSPECTOR
     if (devSettings.isDeviceDebuggingAvailable) {
       // On-device JS debugging (CDP). Render action to open debugger frontend.
-      [items addObject:[RCTDevMenuItem
-                           buttonItemWithTitleBlock:^NSString * {
-                             return @"Open Debugger";
-                           }
-                           handler:^{
-                             [RCTInspectorDevServerHelper
-                                     openDebugger:bundleManager.bundleURL
-                                 withErrorMessage:
-                                     @"Failed to open debugger. Please check that the dev server is running."];
-                           }]];
+      [items
+          addObject:
+              [RCTDevMenuItem
+                  buttonItemWithTitleBlock:^NSString * {
+                    return @"Open Debugger";
+                  }
+                  handler:^{
+                    [RCTInspectorDevServerHelper
+                            openDebugger:bundleManager.bundleURL
+                        withErrorMessage:
+                            @"Failed to open debugger. Please check that the dev server is running and reload the app."];
+                  }]];
     }
 #endif
   }
 
   [items addObject:[RCTDevMenuItem
                        buttonItemWithTitleBlock:^NSString * {
-                         return devSettings.isElementInspectorShown ? @"Hide Inspector" : @"Show Inspector";
+                         return devSettings.isElementInspectorShown ? @"Hide Element Inspector"
+                                                                    : @"Show Element Inspector";
                        }
                        handler:^{
                          [devSettings toggleElementInspector];

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -3,7 +3,7 @@
   <string name="catalyst_reload" project="catalyst" translatable="false">Reload</string>
   <string name="catalyst_reload_error" project="catalyst" translatable="false">Failed to load bundle. Try restarting the bundler or reconnecting your device.</string>
   <string name="catalyst_change_bundle_location" project="catalyst" translatable="false">Change Bundle Location</string>
-  <string name="catalyst_open_debugger_error" project="catalyst" translatable="false">Failed to open debugger. Please check that the dev server is running.</string>
+  <string name="catalyst_open_debugger_error" project="catalyst" translatable="false">Failed to open debugger. Please check that the dev server is running and reload the app.</string>
   <string name="catalyst_debug_open" project="catalyst" translatable="false">Open Debugger</string>
   <string name="catalyst_debug_connecting" project="catalyst" translatable="false">Connecting to debugger...</string>
   <string name="catalyst_debug_error" project="catalyst" translatable="false">Failed to connect to debugger!</string>


### PR DESCRIPTION
Summary:
Minor Dev Menu changes:

- Improve guidance when failing to connect to the debugger.
- Align "Show Element Inspector" wording on iOS.

Changelog: [Internal]

Differential Revision: D49375789


