### PR TITLE
RN: Switch EventEmitter to `Array.from(...)`

### DIFF
--- a/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
+++ b/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
@@ -109,7 +109,9 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     const registrations: ?Set<Registration<TEventToArgsMap[TEvent]>> =
       this.#registry[eventType];
     if (registrations != null) {
-      for (const registration of [...registrations]) {
+      // Copy `registrations` to take a snapshot when we invoke `emit`, in case
+      // registrations are added or removed when listeners are invoked.
+      for (const registration of Array.from(registrations)) {
         registration.listener.apply(registration.context, args);
       }
     }


### PR DESCRIPTION
Summary:
Switches `EventEmitter#emit` to use `Array.from` instead of the spread operator.

This should be functionally identical (with marginally less overhead of the runtime having to determine the type of `registrations`), but there seems to be [some unexpected Babel configurations in the community](https://github.com/facebook/react-native/issues/35577#issuecomment-1723218934) that causes this line of code to do the wrong things.

Although we should independently root cause the Babel plugin configuration problems, this change might provide immediate relief and is also not any worse (e.g. in terms of code readability). This also adds a descriptive comment explaining the intention of the call to `Array.from`.

Changelog:
[Fixed][General] - Fix a potential bug in `EventEmitter` when used with certain Babel configurations that incorrectly polyfill the spread operator for iterables.

Differential Revision: D49389813


