### PR TITLE
Enable Bridgeless for template

### DIFF
--- a/packages/react-native/template/ios/HelloWorld/AppDelegate.mm
+++ b/packages/react-native/template/ios/HelloWorld/AppDelegate.mm
@@ -16,6 +16,11 @@
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
+  return [self getBundleURL];
+}
+
+- (NSURL *)getBundleURL
+{
 #if DEBUG
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else


### PR DESCRIPTION
Summary: So that Templace is able to switch to Bridgeless

Reviewed By: mdvacca

Differential Revision: D49150891


