### PR TITLE
Use `Map` instead of object in BlobRegistry

### DIFF
--- a/packages/react-native/Libraries/Blob/BlobRegistry.js
+++ b/packages/react-native/Libraries/Blob/BlobRegistry.js
@@ -8,27 +8,32 @@
  * @format
  */
 
-const registry: {[key: string]: number, ...} = {};
+const registry: Map<string, number> = new Map();
 
 const register = (id: string) => {
-  if (registry[id]) {
-    registry[id]++;
+  const used = registry.get(id);
+
+  if (used != null) {
+    registry.set(id, used + 1);
   } else {
-    registry[id] = 1;
+    registry.set(id, 1);
   }
 };
 
 const unregister = (id: string) => {
-  if (registry[id]) {
-    registry[id]--;
-    if (registry[id] <= 0) {
-      delete registry[id];
+  const used = registry.get(id);
+
+  if (used != null) {
+    if (used <= 1) {
+      registry.delete(id);
+    } else {
+      registry.set(id, used - 1);
     }
   }
 };
 
 const has = (id: string): number | boolean => {
-  return registry[id] && registry[id] > 0;
+  return registry.get(id) || false;
 };
 
 module.exports = {

--- a/packages/react-native/Libraries/Blob/__tests__/BlobRegistry-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/BlobRegistry-test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const BlobRegistry = require('../BlobRegistry');
+
+describe('BlobRegistry', () => {
+  describe('register', () => {
+    it('does not throw error', () => {
+      expect(() => BlobRegistry.register('id1')).not.toThrowError();
+    });
+
+    it('registers new id', () => {
+      BlobRegistry.register('id2');
+      expect(BlobRegistry.has('id2')).toBeTruthy();
+    });
+  });
+
+  describe('unregister', () => {
+    it('does not throw error', () => {
+      expect(() => BlobRegistry.unregister('id3')).not.toThrowError();
+    });
+
+    it('remove registered id', () => {
+      BlobRegistry.register('id4');
+      BlobRegistry.unregister('id4');
+      expect(BlobRegistry.has('id4')).toBeFalsy();
+    });
+  });
+
+  describe('has', () => {
+    it('returns true for registered id', () => {
+      BlobRegistry.register('id5');
+      expect(BlobRegistry.has('id5')).toBeTruthy();
+    });
+
+    it('returns false for unregistered id', () => {
+      expect(BlobRegistry.has('id6')).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
issue: https://github.com/facebook/react-native/issues/39441

## Summary:

For the following reasons, I have replaced an object used for id management inside BlobRegistry with `Map`.

- The polyfill used for `fetch`, [whatwg-fetch](https://github.com/JakeChampion/fetch), returns responses as `Blob` objects.
- When a `Blob` is created, it is registered with blobID in the [BlobRegistry](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Blob/BlobRegistry.js), which is not automatically released.
- This issue was previously reported in #19248 and was fixed by modifying whatwg-fetch. However, with the implementation of automatic garbage collection in #24405, the implementation was reverted in commit bccc92dfdd2d85933f2a9cb5c8d1773affb7acba, returning to the original behavior.
- Although #24405 enables `Blob` objects to be garbage collected, the Blob IDs registered in the BlobRegistry remain, causing the count to increase each time `fetch` is called.
- As a result, the `Property storage exceeds 196607 properties` error occurs

To address this issue, I have modified the implementation of `BlobRegistry` to use a `Map` instead of an object. By using a `Map`, there is no limit to the number of entries.

## Changelog:

[Internal] - [Fixed] - Fixed a bug that caused a "Property storage exceeds 196607 properties" error when sending a certain number of `fetch` requests.

## Test Plan:

I've added a new tests in `packages/react-native/Libraries/Blob/__tests__/BlobRegistry-test.js` and confirmed the test pass before and after changes.

```
$ yarn run test
...
Test Suites: 1 skipped, 219 passed, 219 of 220 total
Tests:       2 skipped, 4017 passed, 4019 total
Snapshots:   1154 passed, 1154 total
Time:        10.525 s
Ran all test suites.
✨  Done in 12.52s.
```
