### PR TITLE
Refactor publish-npm args to be more safe

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -1224,7 +1224,7 @@ jobs:
                   else
                     export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
                   fi
-                  node ./scripts/publish-npm.js --<< parameters.release_type >>
+                  node ./scripts/publish-npm.js -t << parameters.release_type >>
 
       - run:
           name: Zip Maven Artifacts from /tmp/maven-local

--- a/scripts/__tests__/publish-npm-test.js
+++ b/scripts/__tests__/publish-npm-test.js
@@ -62,6 +62,14 @@ describe('publish-npm', () => {
     jest.resetAllMocks();
   });
 
+  describe('publish-npm.js', () => {
+    it('Fails when invalid build type is passed', () => {
+      expect(() => publishNpm('invalid')).toThrowError(
+        'Unsupported build type: invalid',
+      );
+    });
+  });
+
   describe('dry-run', () => {
     it('should set version and not publish', () => {
       publishNpm('dry-run');

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -45,28 +45,15 @@ const yargs = require('yargs');
 
 if (require.main === module) {
   const argv = yargs
-    .option('n', {
-      alias: 'nightly',
-      type: 'boolean',
-      default: false,
-    })
-    .option('d', {
-      alias: 'dry-run',
-      type: 'boolean',
-      default: false,
-    })
-    .option('r', {
-      alias: 'release',
-      type: 'boolean',
-      default: false,
+    .option('t', {
+      alias: 'builtType',
+      describe: 'The type of build you want to perform.',
+      choices: ['dry-run', 'nightly', 'release', 'prealpha'],
+      default: 'dry-run',
     })
     .strict().argv;
 
-  const buildType = argv.release
-    ? 'release'
-    : argv.nightly
-    ? 'nightly'
-    : 'dry-run';
+  const buildType = argv.builtType;
 
   publishNpm(buildType);
 }


### PR DESCRIPTION
Summary:
This change refactors how we handle the parameters of publish-npm so we can only accept the build types we actually support.

## Changelog:
[Internal] - Make publish-npm args stricter

Differential Revision: D49374263


