### PR TITLE
Improve start command interactive behaviour

### DIFF
--- a/flow-typed/npm/@react-native-community/cli-tools_v12.x.x.js
+++ b/flow-typed/npm/@react-native-community/cli-tools_v12.x.x.js
@@ -10,10 +10,6 @@
  */
 
 declare module '@react-native-community/cli-tools' {
-  declare export function addInteractionListener(
-    callback: (options: {pause: boolean, canEscape?: boolean}) => void,
-  ): void;
-
   declare export class CLIError extends Error {
     constructor(msg: string, originalError?: Error | mixed | string): this;
   }

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -132,11 +132,12 @@ async function runServer(
       if (reportEvent) {
         reportEvent(event);
       }
-      if (args.interactive && event.type === 'dep_graph_loaded') {
+      if (args.interactive && event.type === 'initialize_done') {
         logger.info('Dev server ready');
         attachKeyHandlers({
           cliConfig: ctx,
           devServerUrl,
+          serverInstance,
           messageSocket: messageSocketEndpoint,
         });
       }


### PR DESCRIPTION
Summary:
Misc improvements to `npx react-native start` interactive behaviour:

- Attaches key handlers on Metro `initialize_done` event — printing key command info earlier (once the server starts listening to bundle requests).
- Shutdown behaviour:
    - Awaits closing of Metro's HTTP server.
    - Pauses key listener while awaiting shutdown (dependency on `cli-tools` `addInteractionListener` dropped).
    - Now observes `ctrl+d` (`ctrl+z` pause behaviour removed).
- Updates reload handler message to 'Reloading connected app(s)...' (since ).
- Adds newline below key commands printout (even spacing).

Changelog: [Internal]

Differential Revision: D49422206

