### PR TITLE
SafeAreaView shouldn't dirty layout on clone by default

### DIFF
--- a/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -14,8 +14,6 @@ import Platform from '../../Utilities/Platform';
 import View from '../View/View';
 import * as React from 'react';
 
-let exported: React.AbstractComponent<ViewProps, React.ElementRef<typeof View>>;
-
 /**
  * Renders nested content and automatically applies paddings reflect the portion
  * of the view that is not covered by navigation bars, tab bars, toolbars, and
@@ -25,7 +23,10 @@ let exported: React.AbstractComponent<ViewProps, React.ElementRef<typeof View>>;
  * limitation of the screen, such as rounded corners or camera notches (aka
  * sensor housing area on iPhone X).
  */
-exported = Platform.select({
+const exported: React.AbstractComponent<
+  ViewProps,
+  React.ElementRef<typeof View>,
+> = Platform.select({
   ios: require('./RCTSafeAreaViewNativeComponent').default,
   default: View,
 });

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
@@ -25,13 +25,6 @@ class SafeAreaViewShadowNode final : public ConcreteViewShadowNode<
                                          ViewEventEmitter,
                                          SafeAreaViewState> {
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
-
- public:
-  static ShadowNodeTraits BaseTraits() {
-    auto traits = ConcreteViewShadowNode::BaseTraits();
-    traits.set(ShadowNodeTraits::Trait::DirtyYogaNode);
-    return traits;
-  }
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary: There's no need to auto-dirty this component on clone (which will happen every time one of its children is cloned), if we update the padding values in `ComponentDescriptor::adopt` this will [already dirty as necessary](https://github.com/facebook/react-native/blob/7888338295476f4d4f00733309e54b8d22318e1e/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h#L28).

Differential Revision: D49058812


