### PR TITLE
Update boost to 1.83.0

### DIFF
--- a/packages/react-native/React/third-party.xcconfig
+++ b/packages/react-native/React/third-party.xcconfig
@@ -8,5 +8,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-HEADER_SEARCH_PATHS = $(SRCROOT)/../third-party/boost_1_76_0 $(SRCROOT)/../third-party/folly-2022.05.16.00 $(SRCROOT)/../third-party/glog-0.3.5/src
+HEADER_SEARCH_PATHS = $(SRCROOT)/../third-party/boost_1_83_0 $(SRCROOT)/../third-party/folly-2022.05.16.00 $(SRCROOT)/../third-party/glog-0.3.5/src
 OTHER_CFLAGS = -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -45,7 +45,7 @@ def cmakeVersion = System.getenv("CMAKE_VERSION") ?: "3.22.1"
 ext.cmake_version = cmakeVersion
 
 // You need to have following folders in this directory:
-//   - boost_1_76_0
+//   - boost_1_83_0
 //   - double-conversion-1.1.6
 //   - folly-deprecate-dynamic-initializer
 //   - glog-0.3.5
@@ -164,14 +164,14 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
                 [
                     new Pair(new File(buildDir, "third-party-ndk/fmt/include/").absolutePath, ""),
                     new Pair(new File(buildDir, "third-party-ndk/folly/").absolutePath, ""),
-                    new Pair(new File(buildDir, "third-party-ndk/boost/boost_1_76_0/").absolutePath, ""),
+                    new Pair(new File(buildDir, "third-party-ndk/boost/boost_1_83_0/").absolutePath, ""),
                     new Pair(new File(buildDir, "third-party-ndk/double-conversion/").absolutePath, ""),
                 ]
             ),
             new PrefabPreprocessingEntry(
                 "react_nativemodule_core",
                 [
-                    new Pair(new File(buildDir, "third-party-ndk/boost/boost_1_76_0/").absolutePath, ""),
+                    new Pair(new File(buildDir, "third-party-ndk/boost/boost_1_83_0/").absolutePath, ""),
                     new Pair(new File(buildDir, "third-party-ndk/double-conversion/").absolutePath, ""),
                     new Pair(new File(buildDir, "third-party-ndk/fmt/include/").absolutePath, ""),
                     new Pair(new File(buildDir, "third-party-ndk/folly/").absolutePath, ""),

--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/boost/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/boost/CMakeLists.txt
@@ -18,5 +18,5 @@ add_library(boost STATIC ${boostasm_SRC})
 
 set_target_properties(boost PROPERTIES LINKER_LANGUAGE CXX)
 
-target_include_directories(boost PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/boost_1_76_0)
+target_include_directories(boost PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/boost_1_83_0)
 

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   }
   s.header_dir             = "cxxreact"
 
-  s.dependency "boost", "1.76.0"
+  s.dependency "boost", "1.83.0"
   s.dependency "DoubleConversion"
   s.dependency 'fmt' , '~> 6.2.1'
   s.dependency "RCT-Folly", folly_version

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\"",
                                "DEFINES_MODULE" => "YES" }
 
-  s.dependency "boost", "1.76.0"
+  s.dependency "boost", "1.83.0"
   s.dependency "DoubleConversion"
   s.dependency 'fmt' , '~> 6.2.1'
   s.dependency "RCT-Folly", folly_version

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ soloader = "0.10.5"
 xstream = "1.4.20"
 yoga-proguard-annotations = "1.19.0"
 # Native Dependencies
-boost="1_76_0"
+boost="1_83_0"
 doubleconversion="1.1.6"
 fmt="6.2.1"
 folly="2022.05.16.00"

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -567,7 +567,6 @@ class UtilsTests < Test::Unit::TestCase
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal("$(inherited) _LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION", config.build_settings["GCC_PREPROCESSOR_DEFINITIONS"])
             assert_equal("$(inherited) ", config.build_settings["OTHER_LDFLAGS"])
         end
 
@@ -614,7 +613,6 @@ class UtilsTests < Test::Unit::TestCase
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal("$(inherited) _LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION", config.build_settings["GCC_PREPROCESSOR_DEFINITIONS"])
             assert_equal("$(inherited) -Wl -ld_classic ", config.build_settings["OTHER_LDFLAGS"])
         end
 
@@ -664,7 +662,6 @@ class UtilsTests < Test::Unit::TestCase
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal("$(inherited) _LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION", config.build_settings["GCC_PREPROCESSOR_DEFINITIONS"])
             assert_equal("$(inherited) ", config.build_settings["OTHER_LDFLAGS"])
         end
 

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -155,17 +155,11 @@ class ReactNativePodsUtils
     def self.apply_xcode_15_patch(installer, xcodebuild_manager: Xcodebuild)
         projects = self.extract_projects(installer)
 
-        gcc_preprocessor_definition_key = 'GCC_PREPROCESSOR_DEFINITIONS'
         other_ld_flags_key = 'OTHER_LDFLAGS'
-        libcpp_cxx17_fix = '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION'
         xcode15_compatibility_flags = '-Wl -ld_classic '
 
         projects.each do |project|
             project.build_configurations.each do |config|
-                # fix for unary_function and binary_function
-                self.safe_init(config, gcc_preprocessor_definition_key)
-                self.add_value_to_setting_if_missing(config, gcc_preprocessor_definition_key, libcpp_cxx17_fix)
-
                 # fix for weak linking
                 self.safe_init(config, other_ld_flags_key)
                 if self.is_using_xcode15_or_greter(:xcodebuild_manager => xcodebuild_manager)

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -5,13 +5,13 @@
 
 Pod::Spec.new do |spec|
   spec.name = 'boost'
-  spec.version = '1.76.0'
+  spec.version = '1.83.0'
   spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
-  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
-                  :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
+  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2',
+                  :sha256 => '6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e' }
 
   # Pinning to the same version as React.podspec.
   spec.platforms = min_supported_versions

--- a/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
+++ b/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
@@ -7,7 +7,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "../" "package.json")))
 
-boost_version = '1.76.0'
+boost_version = '1.83.0'
 boost_compiler_flags = '-Wno-documentation'
 
 Pod::Spec.new do |s|

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - boost (1.76.0)
+  - boost (1.83.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (1000.0.0)
@@ -363,7 +363,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
     - SocketRocket (= 0.6.0)
   - React-cxxreact (1000.0.0):
-    - boost (= 1.76.0)
+    - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -966,7 +966,7 @@ PODS:
     - React-jsi (= 1000.0.0)
     - React-Mapbuffer
   - React-jsi (1000.0.0):
-    - boost (= 1.76.0)
+    - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -1360,7 +1360,7 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: a0b90ce379cb01df2495a908c5f8a795fe08c25d
+  boost: 26fad476bfa736552bbfa698a06cc530475c1505
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: b233b98f08056318bc56f4deccea817b00edeac5


### PR DESCRIPTION
## Summary:

Since folly is updated from https://github.com/facebook/react-native/commit/17154a661fe06ed25bf599f47bd4193eba011971, it is good to bump boost too.

After updating boost, we can remove the Xcode 15 `_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION` workaround which originally to fix Xcode 15 for boost.

## Changelog:

[GENERAL][CHANGED] - Update boost to 1.83.0

## Test Plan:

- CI passed
- Build and launch RNTester on Android and iOS
