### PR TITLE
Ensure systrace events are always stopped

### DIFF
--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -388,10 +388,13 @@ class MessageQueue {
 
   __callReactNativeMicrotasks() {
     Systrace.beginEvent('JSTimers.callReactNativeMicrotasks()');
-    if (this._reactNativeMicrotasksCallback != null) {
-      this._reactNativeMicrotasksCallback();
+    try {
+      if (this._reactNativeMicrotasksCallback != null) {
+        this._reactNativeMicrotasksCallback();
+      }
+    } finally {
+      Systrace.endEvent();
     }
-    Systrace.endEvent();
   }
 
   __callFunction(module: string, method: string, args: mixed[]): void {
@@ -402,31 +405,35 @@ class MessageQueue {
     } else {
       Systrace.beginEvent(`${module}.${method}(...)`);
     }
-    if (this.__spy) {
-      this.__spy({type: TO_JS, module, method, args});
-    }
-    const moduleMethods = this.getCallableModule(module);
-    if (!moduleMethods) {
-      const callableModuleNames = Object.keys(this._lazyCallableModules);
-      const n = callableModuleNames.length;
-      const callableModuleNameList = callableModuleNames.join(', ');
+    try {
+      if (this.__spy) {
+        this.__spy({type: TO_JS, module, method, args});
+      }
+      const moduleMethods = this.getCallableModule(module);
+      if (!moduleMethods) {
+        const callableModuleNames = Object.keys(this._lazyCallableModules);
+        const n = callableModuleNames.length;
+        const callableModuleNameList = callableModuleNames.join(', ');
 
-      // TODO(T122225939): Remove after investigation: Why are we getting to this line in bridgeless mode?
-      const isBridgelessMode = global.RN$Bridgeless === true ? 'true' : 'false';
-      invariant(
-        false,
-        `Failed to call into JavaScript module method ${module}.${method}(). Module has not been registered as callable. Bridgeless Mode: ${isBridgelessMode}. Registered callable JavaScript modules (n = ${n}): ${callableModuleNameList}.
-        A frequent cause of the error is that the application entry file path is incorrect. This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native.`,
-      );
+        // TODO(T122225939): Remove after investigation: Why are we getting to this line in bridgeless mode?
+        const isBridgelessMode =
+          global.RN$Bridgeless === true ? 'true' : 'false';
+        invariant(
+          false,
+          `Failed to call into JavaScript module method ${module}.${method}(). Module has not been registered as callable. Bridgeless Mode: ${isBridgelessMode}. Registered callable JavaScript modules (n = ${n}): ${callableModuleNameList}.
+          A frequent cause of the error is that the application entry file path is incorrect. This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native.`,
+        );
+      }
+      if (!moduleMethods[method]) {
+        invariant(
+          false,
+          `Failed to call into JavaScript module method ${module}.${method}(). Module exists, but the method is undefined.`,
+        );
+      }
+      moduleMethods[method].apply(moduleMethods, args);
+    } finally {
+      Systrace.endEvent();
     }
-    if (!moduleMethods[method]) {
-      invariant(
-        false,
-        `Failed to call into JavaScript module method ${module}.${method}(). Module exists, but the method is undefined.`,
-      );
-    }
-    moduleMethods[method].apply(moduleMethods, args);
-    Systrace.endEvent();
   }
 
   __invokeCallback(cbID: number, args: mixed[]): void {
@@ -465,16 +472,18 @@ class MessageQueue {
       );
     }
 
-    if (!callback) {
-      return;
-    }
+    try {
+      if (!callback) {
+        return;
+      }
 
-    this._successCallbacks.delete(callID);
-    this._failureCallbacks.delete(callID);
-    callback(...args);
-
-    if (__DEV__) {
-      Systrace.endEvent();
+      this._successCallbacks.delete(callID);
+      this._failureCallbacks.delete(callID);
+      callback(...args);
+    } finally {
+      if (__DEV__) {
+        Systrace.endEvent();
+      }
     }
   }
 }

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
@@ -108,8 +108,7 @@ describe('MessageQueue', function () {
     const unknownModule = 'UnknownModule',
       unknownMethod = 'UnknownMethod';
     expect(() => queue.__callFunction(unknownModule, unknownMethod)).toThrow(
-      `Failed to call into JavaScript module method ${unknownModule}.${unknownMethod}(). Module has not been registered as callable. Bridgeless Mode: false. Registered callable JavaScript modules (n = 1): MessageQueueTestModule.
-        A frequent cause of the error is that the application entry file path is incorrect. This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native.`,
+      `Failed to call into JavaScript module method ${unknownModule}.${unknownMethod}()`,
     );
   });
 


### PR DESCRIPTION
Summary: Trying to investigate an issue where Systrace events aren't properly ended. For correctness, we should make sure to always end markers that we started.

Differential Revision: D49413689


