### PR TITLE
Deprecate CompositeReactPackage

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackage.java
@@ -26,7 +26,12 @@ import java.util.Set;
 /**
  * {@code CompositeReactPackage} allows to create a single package composed of views and modules
  * from several other packages.
+ *
+ * @deprecated
  */
+@Deprecated(
+    since = "CompositeReactPackage is deprecated and will be deleted, use ReactPackage instead",
+    forRemoval = true)
 public class CompositeReactPackage implements ViewManagerOnDemandReactPackage, ReactPackage {
 
   private final List<ReactPackage> mChildReactPackages = new ArrayList<>();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -95,11 +95,8 @@ public abstract class LazyReactPackage implements ReactPackage {
   protected abstract List<ModuleSpec> getNativeModules(ReactApplicationContext reactContext);
 
   /**
-   * This is only used when a LazyReactPackage is a part of {@link CompositeReactPackage} Once we
-   * deprecate {@link CompositeReactPackage}, this can be removed too
-   *
    * @param reactContext react application context that can be used to create modules
-   * @return
+   * @return {@link List<NativeModule>} to register
    */
   @Override
   public final List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/CompositeReactPackageTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/CompositeReactPackageTest.kt
@@ -37,6 +37,7 @@ class CompositeReactPackageTest {
   }
 
   @Test
+  @Suppress("DEPRECATION")
   fun testThatCreateNativeModulesIsCalledOnAllPackages() {
     // Given
     val composite = CompositeReactPackage(packageNo1, packageNo2, packageNo3)
@@ -51,6 +52,7 @@ class CompositeReactPackageTest {
   }
 
   @Test
+  @Suppress("DEPRECATION")
   fun testThatCreateViewManagersIsCalledOnAllPackages() {
     // Given
     val composite = CompositeReactPackage(packageNo1, packageNo2, packageNo3)
@@ -65,6 +67,7 @@ class CompositeReactPackageTest {
   }
 
   @Test
+  @Suppress("DEPRECATION")
   fun testThatCompositeReturnsASumOfNativeModules() {
     // Given
     val composite = CompositeReactPackage(packageNo1, packageNo2)
@@ -95,6 +98,7 @@ class CompositeReactPackageTest {
   }
 
   @Test
+  @Suppress("DEPRECATION")
   fun testThatCompositeReturnsASumOfViewManagers() {
     // Given
     val composite = CompositeReactPackage(packageNo1, packageNo2)


### PR DESCRIPTION
Summary:
CompositeReactPackage is not used at Meta neither in github public repositories, we are deprecating it in v0.73 with the goal to remove it in v0.74

changelog: [Android][Breaking] Deprecate CompositeReactPackage from RN Android

Reviewed By: christophpurrer

Differential Revision: D49440130

