### PR TITLE
Fix Codegen build script on EdenFS

### DIFF
--- a/packages/react-native-codegen/scripts/oss/build.sh
+++ b/packages/react-native-codegen/scripts/oss/build.sh
@@ -23,6 +23,20 @@ else
 fi
 YARN_BINARY="${YARN_BINARY:-$YARN_OR_NPM}"
 
+# mv command to use when copying files into the working directory
+EDEN_SAFE_MV="mv"
+
+if [ -x "$(command -v eden)" ]; then
+  pushd "$THIS_DIR"
+
+  # Detect if we are in an EdenFS checkout
+  if [[ "$OSTYPE" == "darwin"* ]] && eden info; then
+    EDEN_SAFE_MV="cp -R -X"
+  fi
+
+  popd >/dev/null
+fi
+
 if [[ ${FBSOURCE_ENV:-0} -eq 1 ]]; then
   # Custom FB-specific setup
   pushd "$CODEGEN_DIR" >/dev/null
@@ -56,6 +70,7 @@ else
 
   popd >/dev/null
 
-  mv "$TMP_DIR/lib" "$TMP_DIR/node_modules" "$CODEGEN_DIR"
+  $EDEN_SAFE_MV "$TMP_DIR/lib" "$CODEGEN_DIR"
+  $EDEN_SAFE_MV "$TMP_DIR/node_modules" "$CODEGEN_DIR"
   rm -rf "$TMP_DIR"
 fi


### PR DESCRIPTION
Summary:
Fixes running the `build.sh` script for `react-native-codegen` when on [EdenFS](https://github.com/facebook/sapling). This would previously fail due a filesystem "unable to copy extended attributes" error.

This only affects development within the React Native monorepo. Practically, this equates to a workflow improvement for Meta engineers when creating `RNTester` builds.

> [!Note]
> **This is temporary**. The change from `mv` to `cp -R` makes this script more expensive, which will make Android builds via Gradle take slightly longer. I have a WIP cleanup planned which will 1/ move `react-native-codegen` to the [shared monorepo build setup](https://github.com/facebook/react-native/pull/38718), and 2/ drop this step entirely from the Android Gradle build.

Changelog: [Internal]

Differential Revision: D49468891


