### PR TITLE
updateIphoneOSDeploymentTarget -> updateOSDeploymentTarget

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -290,7 +290,7 @@ class ReactNativePodsUtils
         end
     end
 
-    def self.updateIphoneOSDeploymentTarget(installer)
+    def self.updateOSDeploymentTarget(installer)
         pod_to_update = Set.new([
             "boost",
             "CocoaAsyncSocket",

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -273,7 +273,7 @@ def react_native_post_install(
   ReactNativePodsUtils.apply_flags_for_fabric(installer, fabric_enabled: fabric_enabled)
   ReactNativePodsUtils.apply_xcode_15_patch(installer)
   ReactNativePodsUtils.apply_ats_config(installer)
-  ReactNativePodsUtils.updateIphoneOSDeploymentTarget(installer)
+  ReactNativePodsUtils.updateOSDeploymentTarget(installer)
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   NewArchitectureHelper.modify_flags_for_new_architecture(installer, NewArchitectureHelper.new_arch_enabled)


### PR DESCRIPTION
## Summary:

While merging new commits into React Native macOS, I noticed https://github.com/facebook/react-native/pull/39478/

I would like to also set `MACOS_DEPLOYMENT_TARGET` in our fork, and thought this slight rename would be something I can do upstream

## Changelog:

[Internal] - updateIphoneOSDeploymentTarget -> updateOSDeploymentTarget

## Test Plan:

CI should pass
