### PR TITLE
[LOCAL] Copy hermes ruby files to hermes folder in local E2E test

### DIFF
--- a/scripts/testing-utils.js
+++ b/scripts/testing-utils.js
@@ -214,7 +214,19 @@ function buildArtifactsLocally(
     expandHermesSourceTarball();
   }
 
-  // need to move the scripts inside the local hermes cloned folder
+  // need to move the podspec file from hermes-engine to hermes folder
+  // cp sdks/hermes-engine/hermes-engine.podspec <your_hermes_checkout>/hermes-engine.podspec
+  cp(
+    `${reactNativePackagePath}/sdks/hermes-engine/hermes-engine.podspec`,
+    `${reactNativePackagePath}/sdks/hermes/hermes-engine.podspec`,
+  );
+  // need to move the hermes-utils file from hermes-engine to hermes folder
+  // cp sdks/hermes-engine/hermes-utils.rb <your_hermes_checkout>/hermes-utils.rb
+  cp(
+    `${reactNativePackagePath}/sdks/hermes-engine/hermes-utils.rb`,
+    `${reactNativePackagePath}/sdks/hermes/hermes-utils.rb`,
+  );
+  // need to move the shell scripts file from hermes-engine to hermes folder
   // cp sdks/hermes-engine/utils/*.sh <your_hermes_checkout>/utils/.
   cp(
     `${reactNativePackagePath}/sdks/hermes-engine/utils/*.sh`,


### PR DESCRIPTION
## Summary:

When testing another feature, I realized that we were not copying the `hermes-engine.podspec` and the `hermes-utils.rb` files from the `hermes-engine` folder to the `hermes` one.

This means that the script was building Hermes for local testing using an outdated `hermes-engine.podspec` that is downloaded from the `hermes` repo. 

## Changelog:

[INTERNAL] [Changed] - Copy over the `hermes-engine.podspec` and `hermes-utils.rb` files in the `test-e2e-local` script

## Test Plan:
Tested locally