### PR TITLE
Fix local e2e script by copying the hermes' ruby files to the right folder

### DIFF
--- a/scripts/testing-utils.js
+++ b/scripts/testing-utils.js
@@ -217,6 +217,14 @@ function buildArtifactsLocally(
   // need to move the scripts inside the local hermes cloned folder
   // cp sdks/hermes-engine/utils/*.sh <your_hermes_checkout>/utils/.
   cp(
+    `${reactNativePackagePath}/sdks/hermes-engine/hermes-engine.podspec`,
+    `${reactNativePackagePath}/sdks/hermes/hermes-engine.podspec`,
+  );
+  cp(
+    `${reactNativePackagePath}/sdks/hermes-engine/hermes-utils.rb`,
+    `${reactNativePackagePath}/sdks/hermes/hermes-utils.rb`,
+  );
+  cp(
     `${reactNativePackagePath}/sdks/hermes-engine/utils/*.sh`,
     `${reactNativePackagePath}/sdks/hermes/utils/.`,
   );


### PR DESCRIPTION
Summary:
While testing other features, I realized that the script to generate a project locally, starting from the template, has a bug for which we were using the outdated `hermes-engine.podspec` coming from the Hermes repo to build hermes.

This change fixes this by moving our files to the right folder.

## Changelog:
[Internal] - Fix local e2e test script copying hermes rubyscript over

Reviewed By: dmytrorykun

Differential Revision: D49497716


