### PR TITLE
Improve remote debugging LogBox message, cleanup unused openURL method

### DIFF
--- a/packages/react-native/React/CoreModules/RCTWebSocketExecutor.mm
+++ b/packages/react-native/React/CoreModules/RCTWebSocketExecutor.mm
@@ -165,7 +165,10 @@ RCT_EXPORT_MODULE()
 
   dispatch_async(_jsQueue, ^{
     if (!self.valid) {
-      callback(RCTErrorWithMessage(@"Runtime is not ready for debugging. Make sure Metro is running."), nil);
+      callback(
+          RCTErrorWithMessage(
+              @"Runtime is not ready for debugging. Make sure Metro is running and the Remote Debugging browser window is open."),
+          nil);
       return;
     }
 

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.h
@@ -17,7 +17,6 @@
 
 + (RCTInspectorPackagerConnection *)connectWithBundleURL:(NSURL *)bundleURL;
 + (void)disableDebugger;
-+ (void)openURL:(NSString *)url withBundleURL:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage;
 + (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage;
 @end
 

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -51,10 +51,7 @@ static NSURL *getInspectorDeviceUrl(NSURL *bundleURL)
                                                          escapedDeviceName,
                                                          escapedAppName]];
 }
-static NSURL *getOpenUrlEndpoint(NSURL *bundleURL)
-{
-  return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/open-url", getServerHost(bundleURL)]];
-}
+
 @implementation RCTInspectorDevServerHelper
 
 RCT_NOT_IMPLEMENTED(-(instancetype)init)
@@ -66,27 +63,6 @@ static void sendEventToAllConnections(NSString *event)
   for (NSString *socketId in socketConnections) {
     [socketConnections[socketId] sendEventToAllConnections:event];
   }
-}
-
-+ (void)openURL:(NSString *)url withBundleURL:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage
-{
-  NSURL *endpoint = getOpenUrlEndpoint(bundleURL);
-
-  NSDictionary *jsonBodyDict = @{@"url" : url};
-  NSData *jsonBodyData = [NSJSONSerialization dataWithJSONObject:jsonBodyDict options:kNilOptions error:nil];
-
-  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:endpoint];
-  [request setHTTPMethod:@"POST"];
-  [request setHTTPBody:jsonBodyData];
-
-  [[[NSURLSession sharedSession]
-      dataTaskWithRequest:request
-        completionHandler:^(
-            __unused NSData *_Nullable data, __unused NSURLResponse *_Nullable response, NSError *_Nullable error) {
-          if (error != nullptr) {
-            RCTLogWarn(@"%@", errorMessage);
-          }
-        }] resume];
 }
 
 + (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage


### PR DESCRIPTION
Summary:
Some tidying up around remote JS debugging while testing. See also https://github.com/react-native-community/cli/pull/2083.

Changelog: [iOS][Breaking] Remove `openURL` method from `RCTInspectorDevServerHelper`

Differential Revision: D49499068

