### PR TITLE
introduce flag to determine if turbomodule void method should run sync

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -45,6 +45,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     std::shared_ptr<CallInvoker> jsInvoker;
     std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker;
     bool isSyncModule;
+    bool shouldVoidMethodsExecuteSync;
   };
 
   ObjCTurboModule(const InitParams &params);
@@ -111,6 +112,9 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
  private:
   // Does the NativeModule dispatch async methods to the JS thread?
   const bool isSyncModule_;
+
+  // Should void methods execute synchronously?
+  const bool shouldVoidMethodsExecuteSync_;
 
   /**
    * TODO(ramanpreet):

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -680,6 +680,10 @@ NSInvocation *ObjCTurboModule::createMethodInvocation(
 
 bool ObjCTurboModule::isMethodSync(TurboModuleMethodValueKind returnType)
 {
+  if (returnType == VoidKind && shouldVoidMethodsExecuteSync_) {
+    return true;
+  }
+
   return isSyncModule_ || !(returnType == VoidKind || returnType == PromiseKind);
 }
 
@@ -687,7 +691,8 @@ ObjCTurboModule::ObjCTurboModule(const InitParams &params)
     : TurboModule(params.moduleName, params.jsInvoker),
       instance_(params.instance),
       nativeMethodCallInvoker_(params.nativeMethodCallInvoker),
-      isSyncModule_(params.isSyncModule)
+      isSyncModule_(params.isSyncModule),
+      shouldVoidMethodsExecuteSync_(params.shouldVoidMethodsExecuteSync)
 {
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -375,6 +375,7 @@ static Class getFallbackClassFromName(const char *name)
         .jsInvoker = _jsInvoker,
         .nativeMethodCallInvoker = nativeMethodCallInvoker,
         .isSyncModule = methodQueue == RCTJSThread,
+        .shouldVoidMethodsExecuteSync = false,
     };
 
     auto turboModule = [(id<RCTTurboModule>)module getTurboModule:params];
@@ -437,6 +438,7 @@ static Class getFallbackClassFromName(const char *name)
       .jsInvoker = _jsInvoker,
       .nativeMethodCallInvoker = std::move(nativeMethodCallInvoker),
       .isSyncModule = methodQueue == RCTJSThread,
+      .shouldVoidMethodsExecuteSync = false,
   };
 
   auto turboModule = std::make_shared<ObjCInteropTurboModule>(params);


### PR DESCRIPTION
Summary:
Changelog: [Internal]

currently, turbomodule void methods run async by default, unless the consumer returns `RCTJSThread` in the `methodQueue` API.

we're looking to update this, so i'm introducing a flag at the module level that allows us to configure this behavior.

Differential Revision: D49521864


