### PR TITLE
switch on return types for invokeObjCMethod instead of cascading if else

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -45,6 +45,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     std::shared_ptr<CallInvoker> jsInvoker;
     std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker;
     bool isSyncModule;
+    bool shouldVoidMethodsExecuteSync;
   };
 
   ObjCTurboModule(const InitParams &params);
@@ -111,6 +112,9 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
  private:
   // Does the NativeModule dispatch async methods to the JS thread?
   const bool isSyncModule_;
+
+  // Should void methods execute synchronously?
+  const bool shouldVoidMethodsExecuteSync_;
 
   /**
    * TODO(ramanpreet):

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -680,11 +680,15 @@ NSInvocation *ObjCTurboModule::createMethodInvocation(
 
 bool ObjCTurboModule::isMethodSync(TurboModuleMethodValueKind returnType)
 {
+  if (isSyncModule_) {
+    return true;
+  }
+
   if (returnType == VoidKind && shouldVoidMethodsExecuteSync_) {
     return true;
   }
 
-  return isSyncModule_ || !(returnType == VoidKind || returnType == PromiseKind);
+  return !(returnType == VoidKind || returnType == PromiseKind);
 }
 
 ObjCTurboModule::ObjCTurboModule(const InitParams &params)
@@ -707,7 +711,9 @@ jsi::Value ObjCTurboModule::invokeObjCMethod(
   const char *moduleName = name_.c_str();
   const char *methodName = methodNameStr.c_str();
 
-  if (isMethodSync(returnType)) {
+  bool isSyncInvocation = isMethodSync(returnType);
+
+  if (isSyncInvocation) {
     TurboModulePerfLogger::syncMethodCallStart(moduleName, methodName);
   } else {
     TurboModulePerfLogger::asyncMethodCallStart(moduleName, methodName);
@@ -715,7 +721,7 @@ jsi::Value ObjCTurboModule::invokeObjCMethod(
 
   NSMutableArray *retainedObjectsForInvocation = [NSMutableArray arrayWithCapacity:count + 2];
   NSInvocation *inv = createMethodInvocation(
-      runtime, isMethodSync(returnType), methodName, selector, args, count, retainedObjectsForInvocation);
+      runtime, isSyncInvocation, methodName, selector, args, count, retainedObjectsForInvocation);
 
   jsi::Value returnValue = jsi::Value::undefined();
 
@@ -730,24 +736,23 @@ jsi::Value ObjCTurboModule::invokeObjCMethod(
           [retainedObjectsForInvocation addObject:resolveCopy];
           [retainedObjectsForInvocation addObject:rejectCopy];
           // The return type becomes void in the ObjC side.
-          performMethodInvocation(runtime, isMethodSync(VoidKind), methodName, inv, retainedObjectsForInvocation);
+          performMethodInvocation(runtime, isSyncInvocation, methodName, inv, retainedObjectsForInvocation);
         });
   } else {
-    id result =
-        performMethodInvocation(runtime, isMethodSync(returnType), methodName, inv, retainedObjectsForInvocation);
+    id result = performMethodInvocation(runtime, isSyncInvocation, methodName, inv, retainedObjectsForInvocation);
 
-    if (isMethodSync(returnType)) {
+    if (isSyncInvocation) {
       TurboModulePerfLogger::syncMethodCallReturnConversionStart(moduleName, methodName);
     }
 
     returnValue = convertReturnIdToJSIValue(runtime, methodName, returnType, result);
 
-    if (isMethodSync(returnType)) {
+    if (isSyncInvocation) {
       TurboModulePerfLogger::syncMethodCallReturnConversionEnd(moduleName, methodName);
     }
   }
 
-  if (isMethodSync(returnType)) {
+  if (isSyncInvocation) {
     TurboModulePerfLogger::syncMethodCallEnd(moduleName, methodName);
   } else {
     TurboModulePerfLogger::asyncMethodCallEnd(moduleName, methodName);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -680,6 +680,10 @@ NSInvocation *ObjCTurboModule::createMethodInvocation(
 
 bool ObjCTurboModule::isMethodSync(TurboModuleMethodValueKind returnType)
 {
+  if (returnType == VoidKind && shouldVoidMethodsExecuteSync_) {
+    return true;
+  }
+
   return isSyncModule_ || !(returnType == VoidKind || returnType == PromiseKind);
 }
 
@@ -687,7 +691,8 @@ ObjCTurboModule::ObjCTurboModule(const InitParams &params)
     : TurboModule(params.moduleName, params.jsInvoker),
       instance_(params.instance),
       nativeMethodCallInvoker_(params.nativeMethodCallInvoker),
-      isSyncModule_(params.isSyncModule)
+      isSyncModule_(params.isSyncModule),
+      shouldVoidMethodsExecuteSync_(params.shouldVoidMethodsExecuteSync)
 {
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -375,6 +375,7 @@ static Class getFallbackClassFromName(const char *name)
         .jsInvoker = _jsInvoker,
         .nativeMethodCallInvoker = nativeMethodCallInvoker,
         .isSyncModule = methodQueue == RCTJSThread,
+        .shouldVoidMethodsExecuteSync = false,
     };
 
     auto turboModule = [(id<RCTTurboModule>)module getTurboModule:params];
@@ -437,6 +438,7 @@ static Class getFallbackClassFromName(const char *name)
       .jsInvoker = _jsInvoker,
       .nativeMethodCallInvoker = std::move(nativeMethodCallInvoker),
       .isSyncModule = methodQueue == RCTJSThread,
+      .shouldVoidMethodsExecuteSync = false,
   };
 
   auto turboModule = std::make_shared<ObjCInteropTurboModule>(params);


### PR DESCRIPTION
Summary:
Changelog: [Internal]

I'm refactoring this for a couple of reasons:
1) it isolates the void execution path, which we are changing now
2) switch case is safer than if else, in the future if we introduce new return types

Differential Revision: D49521866

