### PR TITLE
respect shouldVoidMethodsExecuteSync_ configuration when invoking void methods

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -45,6 +45,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     std::shared_ptr<CallInvoker> jsInvoker;
     std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker;
     bool isSyncModule;
+    bool shouldVoidMethodsExecuteSync;
   };
 
   ObjCTurboModule(const InitParams &params);
@@ -111,6 +112,9 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
  private:
   // Does the NativeModule dispatch async methods to the JS thread?
   const bool isSyncModule_;
+
+  // Should void methods execute synchronously?
+  const bool shouldVoidMethodsExecuteSync_;
 
   /**
    * TODO(ramanpreet):

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -680,6 +680,10 @@ NSInvocation *ObjCTurboModule::createMethodInvocation(
 
 bool ObjCTurboModule::isMethodSync(TurboModuleMethodValueKind returnType)
 {
+  if (returnType == VoidKind && shouldVoidMethodsExecuteSync_) {
+    return true;
+  }
+
   return !(returnType == VoidKind || returnType == PromiseKind);
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -687,7 +687,8 @@ ObjCTurboModule::ObjCTurboModule(const InitParams &params)
     : TurboModule(params.moduleName, params.jsInvoker),
       instance_(params.instance),
       nativeMethodCallInvoker_(params.nativeMethodCallInvoker),
-      isSyncModule_(params.isSyncModule)
+      isSyncModule_(params.isSyncModule),
+      shouldVoidMethodsExecuteSync_(params.shouldVoidMethodsExecuteSync)
 {
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -717,32 +717,43 @@ jsi::Value ObjCTurboModule::invokeObjCMethod(
 
   jsi::Value returnValue = jsi::Value::undefined();
 
-  if (returnType == PromiseKind) {
-    returnValue = createPromise(
-        runtime, methodNameStr, ^(RCTPromiseResolveBlock resolveBlock, RCTPromiseRejectBlock rejectBlock) {
-          RCTPromiseResolveBlock resolveCopy = [resolveBlock copy];
-          RCTPromiseRejectBlock rejectCopy = [rejectBlock copy];
-
-          [inv setArgument:(void *)&resolveCopy atIndex:count + 2];
-          [inv setArgument:(void *)&rejectCopy atIndex:count + 3];
-          [retainedObjectsForInvocation addObject:resolveCopy];
-          [retainedObjectsForInvocation addObject:rejectCopy];
-          // The return type becomes void in the ObjC side.
-          performMethodInvocation(runtime, isSyncInvocation, methodName, inv, retainedObjectsForInvocation);
-        });
-  } else {
-    id result =
-        performMethodInvocation(runtime, isSyncInvocation, methodName, inv, retainedObjectsForInvocation);
-
-    if (isSyncInvocation) {
+  switch (returnType) {
+    case PromiseKind: {
+      returnValue = createPromise(
+          runtime, methodNameStr, ^(RCTPromiseResolveBlock resolveBlock, RCTPromiseRejectBlock rejectBlock) {
+            RCTPromiseResolveBlock resolveCopy = [resolveBlock copy];
+            RCTPromiseRejectBlock rejectCopy = [rejectBlock copy];
+            [inv setArgument:(void *)&resolveCopy atIndex:count + 2];
+            [inv setArgument:(void *)&rejectCopy atIndex:count + 3];
+            [retainedObjectsForInvocation addObject:resolveCopy];
+            [retainedObjectsForInvocation addObject:rejectCopy];
+            // The return type becomes void in the ObjC side.
+            performMethodInvocation(runtime, isSyncInvocation, methodName, inv, retainedObjectsForInvocation);
+          });
+      break;
+    }
+    case VoidKind: {
+      id result = performMethodInvocation(runtime, isSyncInvocation, methodName, inv, retainedObjectsForInvocation);
+      if (isSyncInvocation) {
+        TurboModulePerfLogger::syncMethodCallReturnConversionStart(moduleName, methodName);
+      }
+      returnValue = convertReturnIdToJSIValue(runtime, methodName, returnType, result);
+      if (isSyncInvocation) {
+        TurboModulePerfLogger::syncMethodCallReturnConversionEnd(moduleName, methodName);
+      }
+      break;
+    }
+    case BooleanKind:
+    case NumberKind:
+    case StringKind:
+    case ObjectKind:
+    case ArrayKind:
+    case FunctionKind: {
+      id result = performMethodInvocation(runtime, true, methodName, inv, retainedObjectsForInvocation);
       TurboModulePerfLogger::syncMethodCallReturnConversionStart(moduleName, methodName);
-    }
-
-    returnValue = convertReturnIdToJSIValue(runtime, methodName, returnType, result);
-
-    if (isSyncInvocation) {
+      returnValue = convertReturnIdToJSIValue(runtime, methodName, returnType, result);
       TurboModulePerfLogger::syncMethodCallReturnConversionEnd(moduleName, methodName);
-    }
+    } break;
   }
 
   if (isSyncInvocation) {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -375,6 +375,7 @@ static Class getFallbackClassFromName(const char *name)
         .jsInvoker = _jsInvoker,
         .nativeMethodCallInvoker = nativeMethodCallInvoker,
         .isSyncModule = methodQueue == RCTJSThread,
+        .shouldVoidMethodsExecuteSync = false,
     };
 
     auto turboModule = [(id<RCTTurboModule>)module getTurboModule:params];
@@ -437,6 +438,7 @@ static Class getFallbackClassFromName(const char *name)
       .jsInvoker = _jsInvoker,
       .nativeMethodCallInvoker = std::move(nativeMethodCallInvoker),
       .isSyncModule = methodQueue == RCTJSThread,
+      .shouldVoidMethodsExecuteSync = false,
   };
 
   auto turboModule = std::make_shared<ObjCInteropTurboModule>(params);


### PR DESCRIPTION
Summary:
Changelog: [Internal]

if the return type is void and this config is true, we will execute the void method synchronously

Differential Revision: D49521865

