### PR TITLE
Change assertion to avoid crash in ReactScrollView.java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1188,7 +1188,8 @@ public class ReactScrollView extends ScrollView
     int count = getChildCount();
 
     Assertions.assertCondition(
-        count == 1, "React Native ScrollView always has exactly 1 child; a content View");
+        count <= 1,
+        "React Native ScrollView should not have more than one child, it should have exactly 1 child; a content View");
 
     if (count > 0) {
       for (int i = 0; i < count; i++) {


### PR DESCRIPTION
Summary: Looking into a crash leads by assertion error in this line, I talked to NickGerleman and we think there might be some case when ContentView is not rendered, so it would have 0 child. Changing the assertion to allow 0 child to see if the error goes away.

Differential Revision: D49508540


