### PR TITLE
Fix style resolution functions returning FloatOptional

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
@@ -21,9 +21,8 @@ inline float paddingAndBorderForAxis(
     const yoga::Node* const node,
     const FlexDirection axis,
     const float widthSize) {
-  return (node->getLeadingPaddingAndBorder(axis, widthSize) +
-          node->getTrailingPaddingAndBorder(axis, widthSize))
-      .unwrap();
+  return node->getLeadingPaddingAndBorder(axis, widthSize) +
+      node->getTrailingPaddingAndBorder(axis, widthSize);
 }
 
 inline FloatOptional boundAxisWithinMinAndMax(

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -55,8 +55,7 @@ static inline float dimensionWithMargin(
     const float widthSize) {
   return node->getLayout().measuredDimension(dimension(axis)) +
       (node->getLeadingMargin(axis, widthSize) +
-       node->getTrailingMargin(axis, widthSize))
-          .unwrap();
+       node->getTrailingMargin(axis, widthSize));
 }
 
 static inline bool styleDefinesDimension(
@@ -187,10 +186,9 @@ static void computeFlexBasisForChild(
     childWidthMeasureMode = MeasureMode::Undefined;
     childHeightMeasureMode = MeasureMode::Undefined;
 
-    auto marginRow =
-        child->getMarginForAxis(FlexDirection::Row, ownerWidth).unwrap();
+    auto marginRow = child->getMarginForAxis(FlexDirection::Row, ownerWidth);
     auto marginColumn =
-        child->getMarginForAxis(FlexDirection::Column, ownerWidth).unwrap();
+        child->getMarginForAxis(FlexDirection::Column, ownerWidth);
 
     if (isRowStyleDimDefined) {
       childWidth =
@@ -335,9 +333,8 @@ static void layoutAbsoluteChild(
   MeasureMode childWidthMeasureMode = MeasureMode::Undefined;
   MeasureMode childHeightMeasureMode = MeasureMode::Undefined;
 
-  auto marginRow = child->getMarginForAxis(FlexDirection::Row, width).unwrap();
-  auto marginColumn =
-      child->getMarginForAxis(FlexDirection::Column, width).unwrap();
+  auto marginRow = child->getMarginForAxis(FlexDirection::Row, width);
+  auto marginColumn = child->getMarginForAxis(FlexDirection::Column, width);
 
   if (styleDefinesDimension(child, FlexDirection::Row, width)) {
     childWidth =
@@ -353,8 +350,7 @@ static void layoutAbsoluteChild(
           (node->getLeadingBorder(FlexDirection::Row) +
            node->getTrailingBorder(FlexDirection::Row)) -
           (child->getLeadingPosition(FlexDirection::Row, width) +
-           child->getTrailingPosition(FlexDirection::Row, width))
-              .unwrap();
+           child->getTrailingPosition(FlexDirection::Row, width));
       childWidth =
           boundAxis(child, FlexDirection::Row, childWidth, width, width);
     }
@@ -374,8 +370,7 @@ static void layoutAbsoluteChild(
           (node->getLeadingBorder(FlexDirection::Column) +
            node->getTrailingBorder(FlexDirection::Column)) -
           (child->getLeadingPosition(FlexDirection::Column, height) +
-           child->getTrailingPosition(FlexDirection::Column, height))
-              .unwrap();
+           child->getTrailingPosition(FlexDirection::Column, height));
       childHeight =
           boundAxis(child, FlexDirection::Column, childHeight, height, width);
     }
@@ -432,9 +427,9 @@ static void layoutAbsoluteChild(
         depth,
         generationCount);
     childWidth = child->getLayout().measuredDimension(Dimension::Width) +
-        child->getMarginForAxis(FlexDirection::Row, width).unwrap();
+        child->getMarginForAxis(FlexDirection::Row, width);
     childHeight = child->getLayout().measuredDimension(Dimension::Height) +
-        child->getMarginForAxis(FlexDirection::Column, width).unwrap();
+        child->getMarginForAxis(FlexDirection::Column, width);
   }
 
   calculateLayoutInternal(
@@ -458,10 +453,9 @@ static void layoutAbsoluteChild(
         node->getLayout().measuredDimension(dimension(mainAxis)) -
             child->getLayout().measuredDimension(dimension(mainAxis)) -
             node->getTrailingBorder(mainAxis) -
-            child->getTrailingMargin(mainAxis, isMainAxisRow ? width : height)
-                .unwrap() -
-            child->getTrailingPosition(mainAxis, isMainAxisRow ? width : height)
-                .unwrap(),
+            child->getTrailingMargin(mainAxis, isMainAxisRow ? width : height) -
+            child->getTrailingPosition(
+                mainAxis, isMainAxisRow ? width : height),
         leadingEdge(mainAxis));
   } else if (
       !child->isLeadingPositionDefined(mainAxis) &&
@@ -484,15 +478,12 @@ static void layoutAbsoluteChild(
       child->isLeadingPositionDefined(mainAxis)) {
     child->setLayoutPosition(
         child->getLeadingPosition(
-                 mainAxis,
-                 node->getLayout().measuredDimension(dimension(mainAxis)))
-                .unwrap() +
+            mainAxis,
+            node->getLayout().measuredDimension(dimension(mainAxis))) +
             node->getLeadingBorder(mainAxis) +
-            child
-                ->getLeadingMargin(
-                    mainAxis,
-                    node->getLayout().measuredDimension(dimension(mainAxis)))
-                .unwrap(),
+            child->getLeadingMargin(
+                mainAxis,
+                node->getLayout().measuredDimension(dimension(mainAxis))),
         leadingEdge(mainAxis));
   }
 
@@ -502,11 +493,10 @@ static void layoutAbsoluteChild(
         node->getLayout().measuredDimension(dimension(crossAxis)) -
             child->getLayout().measuredDimension(dimension(crossAxis)) -
             node->getTrailingBorder(crossAxis) -
-            child->getTrailingMargin(crossAxis, isMainAxisRow ? height : width)
-                .unwrap() -
-            child
-                ->getTrailingPosition(crossAxis, isMainAxisRow ? height : width)
-                .unwrap(),
+            child->getTrailingMargin(
+                crossAxis, isMainAxisRow ? height : width) -
+            child->getTrailingPosition(
+                crossAxis, isMainAxisRow ? height : width),
         leadingEdge(crossAxis));
 
   } else if (
@@ -531,15 +521,12 @@ static void layoutAbsoluteChild(
       child->isLeadingPositionDefined(crossAxis)) {
     child->setLayoutPosition(
         child->getLeadingPosition(
-                 crossAxis,
-                 node->getLayout().measuredDimension(dimension(crossAxis)))
-                .unwrap() +
+            crossAxis,
+            node->getLayout().measuredDimension(dimension(crossAxis))) +
             node->getLeadingBorder(crossAxis) +
-            child
-                ->getLeadingMargin(
-                    crossAxis,
-                    node->getLayout().measuredDimension(dimension(crossAxis)))
-                .unwrap(),
+            child->getLeadingMargin(
+                crossAxis,
+                node->getLayout().measuredDimension(dimension(crossAxis))),
         leadingEdge(crossAxis));
   }
 }
@@ -844,9 +831,8 @@ static float computeFlexBasisForChildren(
     }
 
     totalOuterFlexBasis +=
-        (child->getLayout().computedFlexBasis +
-         child->getMarginForAxis(mainAxis, availableInnerWidth))
-            .unwrap();
+        (child->getLayout().computedFlexBasis.unwrap() +
+         child->getMarginForAxis(mainAxis, availableInnerWidth));
   }
 
   return totalOuterFlexBasis;
@@ -934,11 +920,9 @@ static float distributeFreeSpaceSecondPass(
     deltaFreeSpace += updatedMainSize - childFlexBasis;
 
     const float marginMain =
-        currentLineChild->getMarginForAxis(mainAxis, availableInnerWidth)
-            .unwrap();
+        currentLineChild->getMarginForAxis(mainAxis, availableInnerWidth);
     const float marginCross =
-        currentLineChild->getMarginForAxis(crossAxis, availableInnerWidth)
-            .unwrap();
+        currentLineChild->getMarginForAxis(crossAxis, availableInnerWidth);
 
     float childCrossSize;
     float childMainSize = updatedMainSize + marginMain;
@@ -1212,9 +1196,9 @@ static void justifyMainAxis(
     const bool performLayout) {
   const auto& style = node->getStyle();
   const float leadingPaddingAndBorderMain =
-      node->getLeadingPaddingAndBorder(mainAxis, ownerWidth).unwrap();
+      node->getLeadingPaddingAndBorder(mainAxis, ownerWidth);
   const float trailingPaddingAndBorderMain =
-      node->getTrailingPaddingAndBorder(mainAxis, ownerWidth).unwrap();
+      node->getTrailingPaddingAndBorder(mainAxis, ownerWidth);
   const float gap = node->getGapForAxis(mainAxis);
   // If we are using "at most" rules in the main axis, make sure that
   // remainingFreeSpace is 0 when min main dimension is not given
@@ -1317,10 +1301,9 @@ static void justifyMainAxis(
         // defined, we override the position to whatever the user said (and
         // margin/border).
         child->setLayoutPosition(
-            child->getLeadingPosition(mainAxis, availableInnerMainDim)
-                    .unwrap() +
+            child->getLeadingPosition(mainAxis, availableInnerMainDim) +
                 node->getLeadingBorder(mainAxis) +
-                child->getLeadingMargin(mainAxis, availableInnerWidth).unwrap(),
+                child->getLeadingMargin(mainAxis, availableInnerWidth),
             leadingEdge(mainAxis));
       }
     } else {
@@ -1355,7 +1338,7 @@ static void justifyMainAxis(
           // because they weren't computed. This means we can't call
           // dimensionWithMargin.
           flexLine.layout.mainDim +=
-              child->getMarginForAxis(mainAxis, availableInnerWidth).unwrap() +
+              child->getMarginForAxis(mainAxis, availableInnerWidth) +
               childLayout.computedFlexBasis.unwrap();
           flexLine.layout.crossDim = availableInnerCrossDim;
         } else {
@@ -1368,16 +1351,12 @@ static void justifyMainAxis(
             // If the child is baseline aligned then the cross dimension is
             // calculated by adding maxAscent and maxDescent from the baseline.
             const float ascent = calculateBaseline(child) +
-                child
-                    ->getLeadingMargin(
-                        FlexDirection::Column, availableInnerWidth)
-                    .unwrap();
+                child->getLeadingMargin(
+                    FlexDirection::Column, availableInnerWidth);
             const float descent =
                 child->getLayout().measuredDimension(Dimension::Height) +
-                child
-                    ->getMarginForAxis(
-                        FlexDirection::Column, availableInnerWidth)
-                    .unwrap() -
+                child->getMarginForAxis(
+                    FlexDirection::Column, availableInnerWidth) -
                 ascent;
 
             maxAscentForCurrentLine =
@@ -1519,16 +1498,16 @@ static void calculateLayoutImpl(
   const YGEdge endEdge = direction == Direction::LTR ? YGEdgeRight : YGEdgeLeft;
 
   const float marginRowLeading =
-      node->getLeadingMargin(flexRowDirection, ownerWidth).unwrap();
+      node->getLeadingMargin(flexRowDirection, ownerWidth);
   node->setLayoutMargin(marginRowLeading, startEdge);
   const float marginRowTrailing =
-      node->getTrailingMargin(flexRowDirection, ownerWidth).unwrap();
+      node->getTrailingMargin(flexRowDirection, ownerWidth);
   node->setLayoutMargin(marginRowTrailing, endEdge);
   const float marginColumnLeading =
-      node->getLeadingMargin(flexColumnDirection, ownerWidth).unwrap();
+      node->getLeadingMargin(flexColumnDirection, ownerWidth);
   node->setLayoutMargin(marginColumnLeading, YGEdgeTop);
   const float marginColumnTrailing =
-      node->getTrailingMargin(flexColumnDirection, ownerWidth).unwrap();
+      node->getTrailingMargin(flexColumnDirection, ownerWidth);
   node->setLayoutMargin(marginColumnTrailing, YGEdgeBottom);
 
   const float marginAxisRow = marginRowLeading + marginRowTrailing;
@@ -1541,16 +1520,13 @@ static void calculateLayoutImpl(
       node->getTrailingBorder(flexColumnDirection), YGEdgeBottom);
 
   node->setLayoutPadding(
-      node->getLeadingPadding(flexRowDirection, ownerWidth).unwrap(),
-      startEdge);
+      node->getLeadingPadding(flexRowDirection, ownerWidth), startEdge);
   node->setLayoutPadding(
-      node->getTrailingPadding(flexRowDirection, ownerWidth).unwrap(), endEdge);
+      node->getTrailingPadding(flexRowDirection, ownerWidth), endEdge);
   node->setLayoutPadding(
-      node->getLeadingPadding(flexColumnDirection, ownerWidth).unwrap(),
-      YGEdgeTop);
+      node->getLeadingPadding(flexColumnDirection, ownerWidth), YGEdgeTop);
   node->setLayoutPadding(
-      node->getTrailingPadding(flexColumnDirection, ownerWidth).unwrap(),
-      YGEdgeBottom);
+      node->getTrailingPadding(flexColumnDirection, ownerWidth), YGEdgeBottom);
 
   if (node->hasMeasureFunc()) {
     measureNodeWithMeasureFunc(
@@ -1612,9 +1588,9 @@ static void calculateLayoutImpl(
   const float paddingAndBorderAxisMain =
       paddingAndBorderForAxis(node, mainAxis, ownerWidth);
   const float leadingPaddingAndBorderCross =
-      node->getLeadingPaddingAndBorder(crossAxis, ownerWidth).unwrap();
+      node->getLeadingPaddingAndBorder(crossAxis, ownerWidth);
   const float trailingPaddingAndBorderCross =
-      node->getTrailingPaddingAndBorder(crossAxis, ownerWidth).unwrap();
+      node->getTrailingPaddingAndBorder(crossAxis, ownerWidth);
   const float paddingAndBorderAxisCross =
       leadingPaddingAndBorderCross + trailingPaddingAndBorderCross;
 
@@ -1871,11 +1847,9 @@ static void calculateLayoutImpl(
               child->isLeadingPositionDefined(crossAxis);
           if (isChildLeadingPosDefined) {
             child->setLayoutPosition(
-                child->getLeadingPosition(crossAxis, availableInnerCrossDim)
-                        .unwrap() +
+                child->getLeadingPosition(crossAxis, availableInnerCrossDim) +
                     node->getLeadingBorder(crossAxis) +
-                    child->getLeadingMargin(crossAxis, availableInnerWidth)
-                        .unwrap(),
+                    child->getLeadingMargin(crossAxis, availableInnerWidth),
                 leadingEdge(crossAxis));
           }
           // If leading position is not defined or calculations result in Nan,
@@ -1885,8 +1859,7 @@ static void calculateLayoutImpl(
                   child->getLayout().position[leadingEdge(crossAxis)])) {
             child->setLayoutPosition(
                 node->getLeadingBorder(crossAxis) +
-                    child->getLeadingMargin(crossAxis, availableInnerWidth)
-                        .unwrap(),
+                    child->getLeadingMargin(crossAxis, availableInnerWidth),
                 leadingEdge(crossAxis));
           }
         } else {
@@ -1911,16 +1884,14 @@ static void calculateLayoutImpl(
                   child->getLayout().measuredDimension(dimension(mainAxis));
               const auto& childStyle = child->getStyle();
               float childCrossSize = !childStyle.aspectRatio().isUndefined()
-                  ? child->getMarginForAxis(crossAxis, availableInnerWidth)
-                          .unwrap() +
+                  ? child->getMarginForAxis(crossAxis, availableInnerWidth) +
                       (isMainAxisRow
                            ? childMainSize / childStyle.aspectRatio().unwrap()
                            : childMainSize * childStyle.aspectRatio().unwrap())
                   : flexLine.layout.crossDim;
 
               childMainSize +=
-                  child->getMarginForAxis(mainAxis, availableInnerWidth)
-                      .unwrap();
+                  child->getMarginForAxis(mainAxis, availableInnerWidth);
 
               MeasureMode childMainMeasureMode = MeasureMode::Exactly;
               MeasureMode childCrossMeasureMode = MeasureMode::Exactly;
@@ -2077,21 +2048,16 @@ static void calculateLayoutImpl(
             lineHeight = yoga::maxOrDefined(
                 lineHeight,
                 child->getLayout().measuredDimension(dimension(crossAxis)) +
-                    child->getMarginForAxis(crossAxis, availableInnerWidth)
-                        .unwrap());
+                    child->getMarginForAxis(crossAxis, availableInnerWidth));
           }
           if (resolveChildAlignment(node, child) == Align::Baseline) {
             const float ascent = calculateBaseline(child) +
-                child
-                    ->getLeadingMargin(
-                        FlexDirection::Column, availableInnerWidth)
-                    .unwrap();
+                child->getLeadingMargin(
+                    FlexDirection::Column, availableInnerWidth);
             const float descent =
                 child->getLayout().measuredDimension(Dimension::Height) +
-                child
-                    ->getMarginForAxis(
-                        FlexDirection::Column, availableInnerWidth)
-                    .unwrap() -
+                child->getMarginForAxis(
+                    FlexDirection::Column, availableInnerWidth) -
                 ascent;
             maxAscentForCurrentLine =
                 yoga::maxOrDefined(maxAscentForCurrentLine, ascent);
@@ -2117,16 +2083,15 @@ static void calculateLayoutImpl(
               case Align::FlexStart: {
                 child->setLayoutPosition(
                     currentLead +
-                        child->getLeadingMargin(crossAxis, availableInnerWidth)
-                            .unwrap(),
+                        child->getLeadingMargin(crossAxis, availableInnerWidth),
                     leadingEdge(crossAxis));
                 break;
               }
               case Align::FlexEnd: {
                 child->setLayoutPosition(
                     currentLead + lineHeight -
-                        child->getTrailingMargin(crossAxis, availableInnerWidth)
-                            .unwrap() -
+                        child->getTrailingMargin(
+                            crossAxis, availableInnerWidth) -
                         child->getLayout().measuredDimension(
                             dimension(crossAxis)),
                     leadingEdge(crossAxis));
@@ -2144,8 +2109,7 @@ static void calculateLayoutImpl(
               case Align::Stretch: {
                 child->setLayoutPosition(
                     currentLead +
-                        child->getLeadingMargin(crossAxis, availableInnerWidth)
-                            .unwrap(),
+                        child->getLeadingMargin(crossAxis, availableInnerWidth),
                     leadingEdge(crossAxis));
 
                 // Remeasure child with the line height as it as been only
@@ -2155,15 +2119,14 @@ static void calculateLayoutImpl(
                   const float childWidth = isMainAxisRow
                       ? (child->getLayout().measuredDimension(
                              Dimension::Width) +
-                         child->getMarginForAxis(mainAxis, availableInnerWidth)
-                             .unwrap())
+                         child->getMarginForAxis(mainAxis, availableInnerWidth))
                       : lineHeight;
 
                   const float childHeight = !isMainAxisRow
                       ? (child->getLayout().measuredDimension(
                              Dimension::Height) +
-                         child->getMarginForAxis(crossAxis, availableInnerWidth)
-                             .unwrap())
+                         child->getMarginForAxis(
+                             crossAxis, availableInnerWidth))
                       : lineHeight;
 
                   if (!(yoga::inexactEquals(
@@ -2196,10 +2159,8 @@ static void calculateLayoutImpl(
                 child->setLayoutPosition(
                     currentLead + maxAscentForCurrentLine -
                         calculateBaseline(child) +
-                        child
-                            ->getLeadingPosition(
-                                FlexDirection::Column, availableInnerCrossDim)
-                            .unwrap(),
+                        child->getLeadingPosition(
+                            FlexDirection::Column, availableInnerCrossDim),
                     YGEdgeTop);
 
                 break;
@@ -2446,9 +2407,9 @@ bool calculateLayoutInternal(
   // measurements if at all possible.
   if (node->hasMeasureFunc()) {
     const float marginAxisRow =
-        node->getMarginForAxis(FlexDirection::Row, ownerWidth).unwrap();
+        node->getMarginForAxis(FlexDirection::Row, ownerWidth);
     const float marginAxisColumn =
-        node->getMarginForAxis(FlexDirection::Column, ownerWidth).unwrap();
+        node->getMarginForAxis(FlexDirection::Column, ownerWidth);
 
     // First, try to use the layout cache.
     if (canUseCachedMeasurement(
@@ -2679,11 +2640,12 @@ void calculateLayout(
   MeasureMode widthMeasureMode = MeasureMode::Undefined;
   const auto& style = node->getStyle();
   if (styleDefinesDimension(node, FlexDirection::Row, ownerWidth)) {
-    width = (yoga::resolveValue(
-                 node->getResolvedDimension(dimension(FlexDirection::Row)),
-                 ownerWidth) +
-             node->getMarginForAxis(FlexDirection::Row, ownerWidth))
-                .unwrap();
+    width =
+        (yoga::resolveValue(
+             node->getResolvedDimension(dimension(FlexDirection::Row)),
+             ownerWidth)
+             .unwrap() +
+         node->getMarginForAxis(FlexDirection::Row, ownerWidth));
     widthMeasureMode = MeasureMode::Exactly;
   } else if (!yoga::resolveValue(
                   style.maxDimension(Dimension::Width), ownerWidth)
@@ -2700,11 +2662,12 @@ void calculateLayout(
   float height = YGUndefined;
   MeasureMode heightMeasureMode = MeasureMode::Undefined;
   if (styleDefinesDimension(node, FlexDirection::Column, ownerHeight)) {
-    height = (yoga::resolveValue(
-                  node->getResolvedDimension(dimension(FlexDirection::Column)),
-                  ownerHeight) +
-              node->getMarginForAxis(FlexDirection::Column, ownerWidth))
-                 .unwrap();
+    height =
+        (yoga::resolveValue(
+             node->getResolvedDimension(dimension(FlexDirection::Column)),
+             ownerHeight)
+             .unwrap() +
+         node->getMarginForAxis(FlexDirection::Column, ownerWidth));
     heightMeasureMode = MeasureMode::Exactly;
   } else if (!yoga::resolveValue(
                   style.maxDimension(Dimension::Height), ownerHeight)

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
@@ -53,7 +53,7 @@ FlexLine calculateFlexLine(
 
     child->setLineIndex(lineCount);
     const float childMarginMainAxis =
-        child->getMarginForAxis(mainAxis, availableInnerWidth).unwrap();
+        child->getMarginForAxis(mainAxis, availableInnerWidth);
     const float childLeadingGapMainAxis = isFirstElementInLine ? 0.0f : gap;
     const float flexBasisWithMinAndMaxConstraints =
         boundAxisWithinMinAndMax(

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -91,9 +91,8 @@ static void appendEdges(
     const std::string& key,
     const Style::Edges& edges) {
   if (areFourValuesEqual(edges)) {
-    auto edgeValue = yoga::Node::computeEdgeValueForColumn(
-        edges, YGEdgeLeft, CompactValue::ofZero());
-    appendNumberIfNotZero(base, key, edgeValue);
+    auto edgeValue = yoga::Node::computeEdgeValueForColumn(edges, YGEdgeLeft);
+    appendNumberIfNotUndefined(base, key, edgeValue);
   } else {
     for (int edge = YGEdgeLeft; edge != YGEdgeAll; ++edge) {
       std::string str = key + "-" + YGEdgeToString(static_cast<YGEdge>(edge));
@@ -109,10 +108,8 @@ static void appendEdgeIfNotUndefined(
     const YGEdge edge) {
   // TODO: this doesn't take RTL / YGEdgeStart / YGEdgeEnd into account
   auto value = (edge == YGEdgeLeft || edge == YGEdgeRight)
-      ? yoga::Node::computeEdgeValueForRow(
-            edges, edge, edge, CompactValue::ofUndefined())
-      : yoga::Node::computeEdgeValueForColumn(
-            edges, edge, CompactValue::ofUndefined());
+      ? yoga::Node::computeEdgeValueForRow(edges, edge, edge)
+      : yoga::Node::computeEdgeValueForColumn(edges, edge);
   appendNumberIfNotUndefined(base, str, value);
 }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -59,131 +59,131 @@ void Node::print() {
 CompactValue Node::computeEdgeValueForRow(
     const Style::Edges& edges,
     YGEdge rowEdge,
-    YGEdge edge,
-    CompactValue defaultValue) {
+    YGEdge edge) {
   if (!edges[rowEdge].isUndefined()) {
     return edges[rowEdge];
   } else if (!edges[edge].isUndefined()) {
     return edges[edge];
   } else if (!edges[YGEdgeHorizontal].isUndefined()) {
     return edges[YGEdgeHorizontal];
-  } else if (!edges[YGEdgeAll].isUndefined()) {
-    return edges[YGEdgeAll];
   } else {
-    return defaultValue;
+    return edges[YGEdgeAll];
   }
 }
 
 CompactValue Node::computeEdgeValueForColumn(
     const Style::Edges& edges,
-    YGEdge edge,
-    CompactValue defaultValue) {
+    YGEdge edge) {
   if (!edges[edge].isUndefined()) {
     return edges[edge];
   } else if (!edges[YGEdgeVertical].isUndefined()) {
     return edges[YGEdgeVertical];
-  } else if (!edges[YGEdgeAll].isUndefined()) {
-    return edges[YGEdgeAll];
   } else {
-    return defaultValue;
+    return edges[YGEdgeAll];
   }
 }
 
-FloatOptional Node::getLeadingPosition(
-    const FlexDirection axis,
-    const float axisSize) const {
+bool Node::isLeadingPositionDefined(FlexDirection axis) const {
   auto leadingPosition = isRow(axis)
       ? computeEdgeValueForRow(
-            style_.position(),
-            YGEdgeStart,
-            leadingEdge(axis),
-            CompactValue::ofZero())
-      : computeEdgeValueForColumn(
-            style_.position(), leadingEdge(axis), CompactValue::ofZero());
-  return yoga::resolveValue(leadingPosition, axisSize);
-}
+            style_.position(), YGEdgeStart, leadingEdge(axis))
+      : computeEdgeValueForColumn(style_.position(), leadingEdge(axis));
 
-FloatOptional Node::getTrailingPosition(
-    const FlexDirection axis,
-    const float axisSize) const {
-  auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.position(),
-            YGEdgeEnd,
-            trailingEdge(axis),
-            CompactValue::ofZero())
-      : computeEdgeValueForColumn(
-            style_.position(), trailingEdge(axis), CompactValue::ofZero());
-  return yoga::resolveValue(trailingPosition, axisSize);
-}
-
-bool Node::isLeadingPositionDefined(const FlexDirection axis) const {
-  auto leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.position(),
-            YGEdgeStart,
-            leadingEdge(axis),
-            CompactValue::ofUndefined())
-      : computeEdgeValueForColumn(
-            style_.position(), leadingEdge(axis), CompactValue::ofUndefined());
   return !leadingPosition.isUndefined();
 }
 
-bool Node::isTrailingPosDefined(const FlexDirection axis) const {
+bool Node::isTrailingPosDefined(FlexDirection axis) const {
   auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.position(),
-            YGEdgeEnd,
-            trailingEdge(axis),
-            CompactValue::ofUndefined())
-      : computeEdgeValueForColumn(
-            style_.position(), trailingEdge(axis), CompactValue::ofUndefined());
+      ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, trailingEdge(axis))
+      : computeEdgeValueForColumn(style_.position(), trailingEdge(axis));
+
   return !trailingPosition.isUndefined();
 }
 
-FloatOptional Node::getLeadingMargin(
-    const FlexDirection axis,
-    const float widthSize) const {
+float Node::getLeadingPosition(FlexDirection axis, float axisSize) const {
+  auto leadingPosition = isRow(axis)
+      ? computeEdgeValueForRow(
+            style_.position(), YGEdgeStart, leadingEdge(axis))
+      : computeEdgeValueForColumn(style_.position(), leadingEdge(axis));
+
+  return resolveValue(leadingPosition, axisSize).unwrapOrDefault(0.0f);
+}
+
+float Node::getTrailingPosition(FlexDirection axis, float axisSize) const {
+  auto trailingPosition = isRow(axis)
+      ? computeEdgeValueForRow(style_.position(), YGEdgeEnd, trailingEdge(axis))
+      : computeEdgeValueForColumn(style_.position(), trailingEdge(axis));
+
+  return resolveValue(trailingPosition, axisSize).unwrapOrDefault(0.0f);
+}
+
+float Node::getLeadingMargin(FlexDirection axis, float widthSize) const {
   auto leadingMargin = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.margin(),
-            YGEdgeStart,
-            leadingEdge(axis),
-            CompactValue::ofZero())
-      : computeEdgeValueForColumn(
-            style_.margin(), leadingEdge(axis), CompactValue::ofZero());
-  return leadingMargin.isAuto() ? FloatOptional{0}
-                                : yoga::resolveValue(leadingMargin, widthSize);
+      ? computeEdgeValueForRow(style_.margin(), YGEdgeStart, leadingEdge(axis))
+      : computeEdgeValueForColumn(style_.margin(), leadingEdge(axis));
+
+  return resolveValue(leadingMargin, widthSize).unwrapOrDefault(0.0f);
 }
 
-FloatOptional Node::getTrailingMargin(
-    const FlexDirection axis,
-    const float widthSize) const {
+float Node::getTrailingMargin(FlexDirection axis, float widthSize) const {
   auto trailingMargin = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.margin(),
-            YGEdgeEnd,
-            trailingEdge(axis),
-            CompactValue::ofZero())
-      : computeEdgeValueForColumn(
-            style_.margin(), trailingEdge(axis), CompactValue::ofZero());
-  return trailingMargin.isAuto()
-      ? FloatOptional{0}
-      : yoga::resolveValue(trailingMargin, widthSize);
+      ? computeEdgeValueForRow(style_.margin(), YGEdgeEnd, trailingEdge(axis))
+      : computeEdgeValueForColumn(style_.margin(), trailingEdge(axis));
+
+  return resolveValue(trailingMargin, widthSize).unwrapOrDefault(0.0f);
 }
 
-FloatOptional Node::getMarginForAxis(
-    const FlexDirection axis,
-    const float widthSize) const {
+float Node::getLeadingBorder(FlexDirection axis) const {
+  YGValue leadingBorder = isRow(axis)
+      ? computeEdgeValueForRow(style_.border(), YGEdgeStart, leadingEdge(axis))
+      : computeEdgeValueForColumn(style_.border(), leadingEdge(axis));
+
+  return maxOrDefined(leadingBorder.value, 0.0f);
+}
+
+float Node::getTrailingBorder(FlexDirection axis) const {
+  YGValue trailingBorder = isRow(axis)
+      ? computeEdgeValueForRow(style_.border(), YGEdgeEnd, trailingEdge(axis))
+      : computeEdgeValueForColumn(style_.border(), trailingEdge(axis));
+
+  return maxOrDefined(trailingBorder.value, 0.0f);
+}
+
+float Node::getLeadingPadding(FlexDirection axis, float widthSize) const {
+  auto leadingPadding = isRow(axis)
+      ? computeEdgeValueForRow(style_.padding(), YGEdgeStart, leadingEdge(axis))
+      : computeEdgeValueForColumn(style_.padding(), leadingEdge(axis));
+
+  return maxOrDefined(resolveValue(leadingPadding, widthSize).unwrap(), 0.0f);
+}
+
+float Node::getTrailingPadding(FlexDirection axis, float widthSize) const {
+  auto trailingPadding = isRow(axis)
+      ? computeEdgeValueForRow(style_.padding(), YGEdgeEnd, trailingEdge(axis))
+      : computeEdgeValueForColumn(style_.padding(), trailingEdge(axis));
+
+  return maxOrDefined(resolveValue(trailingPadding, widthSize).unwrap(), 0.0f);
+}
+
+float Node::getLeadingPaddingAndBorder(FlexDirection axis, float widthSize)
+    const {
+  return getLeadingPadding(axis, widthSize) + getLeadingBorder(axis);
+}
+
+float Node::getTrailingPaddingAndBorder(FlexDirection axis, float widthSize)
+    const {
+  return getTrailingPadding(axis, widthSize) + getTrailingBorder(axis);
+}
+
+float Node::getMarginForAxis(FlexDirection axis, float widthSize) const {
   return getLeadingMargin(axis, widthSize) + getTrailingMargin(axis, widthSize);
 }
 
-float Node::getGapForAxis(const FlexDirection axis) const {
+float Node::getGapForAxis(FlexDirection axis) const {
   auto gap = isRow(axis) ? style_.resolveColumnGap() : style_.resolveRowGap();
   // TODO: Validate percentage gap, and expose ability to set percentage to
   // public API
-  auto resolvedGap = yoga::resolveValue(gap, 0.0f /*ownerSize*/);
-  return maxOrDefined(resolvedGap.unwrap(), 0.0f);
+  return maxOrDefined(resolveValue(gap, 0.0f /*ownerSize*/).unwrap(), 0.0f);
 }
 
 YGSize Node::measure(
@@ -328,18 +328,12 @@ void Node::setLayoutDimension(float dimensionValue, Dimension dimension) {
 
 // If both left and right are defined, then use left. Otherwise return +left or
 // -right depending on which is defined.
-FloatOptional Node::relativePosition(
-    const FlexDirection axis,
-    const float axisSize) const {
+float Node::relativePosition(FlexDirection axis, float axisSize) const {
   if (isLeadingPositionDefined(axis)) {
     return getLeadingPosition(axis, axisSize);
   }
 
-  FloatOptional trailingPosition = getTrailingPosition(axis, axisSize);
-  if (!trailingPosition.isUndefined()) {
-    trailingPosition = FloatOptional{-1 * trailingPosition.unwrap()};
-  }
-  return trailingPosition;
+  return -1 * getTrailingPosition(axis, axisSize);
 }
 
 void Node::setPosition(
@@ -359,28 +353,24 @@ void Node::setPosition(
   // Here we should check for `PositionType::Static` and in this case zero inset
   // properties (left, right, top, bottom, begin, end).
   // https://www.w3.org/TR/css-position-3/#valdef-position-static
-  const FloatOptional relativePositionMain =
-      relativePosition(mainAxis, mainSize);
-  const FloatOptional relativePositionCross =
-      relativePosition(crossAxis, crossSize);
+  const float relativePositionMain = relativePosition(mainAxis, mainSize);
+  const float relativePositionCross = relativePosition(crossAxis, crossSize);
 
   setLayoutPosition(
-      (getLeadingMargin(mainAxis, ownerWidth) + relativePositionMain).unwrap(),
+      (getLeadingMargin(mainAxis, ownerWidth) + relativePositionMain),
       leadingEdge(mainAxis));
   setLayoutPosition(
-      (getTrailingMargin(mainAxis, ownerWidth) + relativePositionMain).unwrap(),
+      (getTrailingMargin(mainAxis, ownerWidth) + relativePositionMain),
       trailingEdge(mainAxis));
   setLayoutPosition(
-      (getLeadingMargin(crossAxis, ownerWidth) + relativePositionCross)
-          .unwrap(),
+      (getLeadingMargin(crossAxis, ownerWidth) + relativePositionCross),
       leadingEdge(crossAxis));
   setLayoutPosition(
-      (getTrailingMargin(crossAxis, ownerWidth) + relativePositionCross)
-          .unwrap(),
+      (getTrailingMargin(crossAxis, ownerWidth) + relativePositionCross),
       trailingEdge(crossAxis));
 }
 
-YGValue Node::marginLeadingValue(const FlexDirection axis) const {
+YGValue Node::marginLeadingValue(FlexDirection axis) const {
   if (isRow(axis) && !style_.margin()[YGEdgeStart].isUndefined()) {
     return style_.margin()[YGEdgeStart];
   } else {
@@ -388,7 +378,7 @@ YGValue Node::marginLeadingValue(const FlexDirection axis) const {
   }
 }
 
-YGValue Node::marginTrailingValue(const FlexDirection axis) const {
+YGValue Node::marginTrailingValue(FlexDirection axis) const {
   if (isRow(axis) && !style_.margin()[YGEdgeEnd].isUndefined()) {
     return style_.margin()[YGEdgeEnd];
   } else {
@@ -496,74 +486,6 @@ bool Node::isNodeFlexible() {
   return (
       (style_.positionType() != PositionType::Absolute) &&
       (resolveFlexGrow() != 0 || resolveFlexShrink() != 0));
-}
-
-float Node::getLeadingBorder(const FlexDirection axis) const {
-  YGValue leadingBorder = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.border(),
-            YGEdgeStart,
-            leadingEdge(axis),
-            CompactValue::ofZero())
-      : computeEdgeValueForColumn(
-            style_.border(), leadingEdge(axis), CompactValue::ofZero());
-  return fmaxf(leadingBorder.value, 0.0f);
-}
-
-float Node::getTrailingBorder(const FlexDirection axis) const {
-  YGValue trailingBorder = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.border(),
-            YGEdgeEnd,
-            trailingEdge(axis),
-            CompactValue::ofZero())
-      : computeEdgeValueForColumn(
-            style_.border(), trailingEdge(axis), CompactValue::ofZero());
-  return fmaxf(trailingBorder.value, 0.0f);
-}
-
-FloatOptional Node::getLeadingPadding(
-    const FlexDirection axis,
-    const float widthSize) const {
-  auto leadingPadding = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.padding(),
-            YGEdgeStart,
-            leadingEdge(axis),
-            CompactValue::ofZero())
-      : computeEdgeValueForColumn(
-            style_.padding(), leadingEdge(axis), CompactValue::ofZero());
-  return yoga::maxOrDefined(
-      yoga::resolveValue(leadingPadding, widthSize), FloatOptional(0.0f));
-}
-
-FloatOptional Node::getTrailingPadding(
-    const FlexDirection axis,
-    const float widthSize) const {
-  auto trailingPadding = isRow(axis)
-      ? computeEdgeValueForRow(
-            style_.padding(),
-            YGEdgeEnd,
-            trailingEdge(axis),
-            CompactValue::ofZero())
-      : computeEdgeValueForColumn(
-            style_.padding(), trailingEdge(axis), CompactValue::ofZero());
-  return yoga::maxOrDefined(
-      yoga::resolveValue(trailingPadding, widthSize), FloatOptional(0.0f));
-}
-
-FloatOptional Node::getLeadingPaddingAndBorder(
-    const FlexDirection axis,
-    const float widthSize) const {
-  return getLeadingPadding(axis, widthSize) +
-      FloatOptional(getLeadingBorder(axis));
-}
-
-FloatOptional Node::getTrailingPaddingAndBorder(
-    const FlexDirection axis,
-    const float widthSize) const {
-  return getTrailingPadding(axis, widthSize) +
-      FloatOptional(getTrailingBorder(axis));
 }
 
 void Node::reset() {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -48,8 +48,7 @@ class YG_EXPORT Node : public ::YGNode {
   std::array<YGValue, 2> resolvedDimensions_ = {
       {YGValueUndefined, YGValueUndefined}};
 
-  FloatOptional relativePosition(const FlexDirection axis, const float axisSize)
-      const;
+  float relativePosition(FlexDirection axis, const float axisSize) const;
 
   void useWebDefaults() {
     style_.flexDirection() = FlexDirection::Row;
@@ -182,48 +181,28 @@ class YG_EXPORT Node : public ::YGNode {
 
   static CompactValue computeEdgeValueForColumn(
       const Style::Edges& edges,
-      YGEdge edge,
-      CompactValue defaultValue);
+      YGEdge edge);
 
   static CompactValue computeEdgeValueForRow(
       const Style::Edges& edges,
       YGEdge rowEdge,
-      YGEdge edge,
-      CompactValue defaultValue);
+      YGEdge edge);
 
   // Methods related to positions, margin, padding and border
-  FloatOptional getLeadingPosition(
-      const FlexDirection axis,
-      const float axisSize) const;
-  bool isLeadingPositionDefined(const FlexDirection axis) const;
-  bool isTrailingPosDefined(const FlexDirection axis) const;
-  FloatOptional getTrailingPosition(
-      const FlexDirection axis,
-      const float axisSize) const;
-  FloatOptional getLeadingMargin(
-      const FlexDirection axis,
-      const float widthSize) const;
-  FloatOptional getTrailingMargin(
-      const FlexDirection axis,
-      const float widthSize) const;
-  float getLeadingBorder(const FlexDirection flexDirection) const;
-  float getTrailingBorder(const FlexDirection flexDirection) const;
-  FloatOptional getLeadingPadding(
-      const FlexDirection axis,
-      const float widthSize) const;
-  FloatOptional getTrailingPadding(
-      const FlexDirection axis,
-      const float widthSize) const;
-  FloatOptional getLeadingPaddingAndBorder(
-      const FlexDirection axis,
-      const float widthSize) const;
-  FloatOptional getTrailingPaddingAndBorder(
-      const FlexDirection axis,
-      const float widthSize) const;
-  FloatOptional getMarginForAxis(
-      const FlexDirection axis,
-      const float widthSize) const;
-  float getGapForAxis(const FlexDirection axis) const;
+  bool isLeadingPositionDefined(FlexDirection axis) const;
+  bool isTrailingPosDefined(FlexDirection axis) const;
+  float getLeadingPosition(FlexDirection axis, float axisSize) const;
+  float getTrailingPosition(FlexDirection axis, float axisSize) const;
+  float getLeadingMargin(FlexDirection axis, float widthSize) const;
+  float getTrailingMargin(FlexDirection axis, float widthSize) const;
+  float getLeadingBorder(FlexDirection flexDirection) const;
+  float getTrailingBorder(FlexDirection flexDirection) const;
+  float getLeadingPadding(FlexDirection axis, float widthSize) const;
+  float getTrailingPadding(FlexDirection axis, float widthSize) const;
+  float getLeadingPaddingAndBorder(FlexDirection axis, float widthSize) const;
+  float getTrailingPaddingAndBorder(FlexDirection axis, float widthSize) const;
+  float getMarginForAxis(FlexDirection axis, float widthSize) const;
+  float getGapForAxis(FlexDirection axis) const;
   // Setters
 
   void setContext(void* context) {
@@ -301,8 +280,8 @@ class YG_EXPORT Node : public ::YGNode {
   void markDirtyAndPropagateDownwards();
 
   // Other methods
-  YGValue marginLeadingValue(const FlexDirection axis) const;
-  YGValue marginTrailingValue(const FlexDirection axis) const;
+  YGValue marginLeadingValue(FlexDirection axis) const;
+  YGValue marginTrailingValue(FlexDirection axis) const;
   YGValue resolveFlexBasisPtr() const;
   void resolveDimension();
   Direction resolveDirection(const Direction ownerDirection);

--- a/packages/react-native/ReactCommon/yoga/yoga/numeric/FloatOptional.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/numeric/FloatOptional.h
@@ -25,6 +25,10 @@ struct FloatOptional {
     return value_;
   }
 
+  constexpr float unwrapOrDefault(float defaultValue) const {
+    return isUndefined() ? defaultValue : value_;
+  }
+
   bool isUndefined() const {
     return std::isnan(value_);
   }


### PR DESCRIPTION
Summary: These functions all ensure their returns are defined, but return FloatOptional anyway, making their callers have to deal with that possibility. Return `float` instead of `FloatOptional`, and do some additional cleanup.

Differential Revision: D49531421

