### PR TITLE
C++ style enums 16/N: Dimension

### DIFF
--- a/packages/react-native/React/Tests/Text/RCTParagraphComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Text/RCTParagraphComponentViewTests.mm
@@ -121,8 +121,8 @@ using namespace facebook::react;
             auto &props = *sharedProps;
             props.layoutConstraints = LayoutConstraints{{0, 0}, {500, 500}};
             auto &yogaStyle = props.yogaStyle;
-            yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(200));
-            yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(200));
+            yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
+            yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(200));
             return sharedProps;
           })
           .children({
@@ -136,8 +136,8 @@ using namespace facebook::react;
                     yogaStyle.positionType() = yoga::PositionType::Absolute;
                     yogaStyle.position()[YGEdgeLeft] = YGValue{0, YGUnitPoint};
                     yogaStyle.position()[YGEdgeTop] = YGValue{0, YGUnitPoint};
-                    yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(200));
-                    yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(200));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(200));
                     return sharedProps;
                   })
                   .children({
@@ -216,8 +216,8 @@ using namespace facebook::react;
                     yogaStyle.positionType() = yoga::PositionType::Absolute;
                     yogaStyle.position()[YGEdgeLeft] = YGValue{0, YGUnitPoint};
                     yogaStyle.position()[YGEdgeTop] = YGValue{30, YGUnitPoint};
-                    yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(200));
-                    yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(50));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(50));
                     return sharedProps;
                   })
                   .children({
@@ -260,8 +260,8 @@ using namespace facebook::react;
                     yogaStyle.positionType() = yoga::PositionType::Absolute;
                     yogaStyle.position()[YGEdgeLeft] = YGValue{0, YGUnitPoint};
                     yogaStyle.position()[YGEdgeTop] = YGValue{90, YGUnitPoint};
-                    yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(200));
-                    yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(50));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(50));
                     return sharedProps;
                   })
                   .children({
@@ -418,8 +418,8 @@ static ParagraphShadowNode::ConcreteState::Shared stateWithShadowNode(
                        auto &props = *sharedProps;
                        props.layoutConstraints = LayoutConstraints{{0, 0}, {500, 500}};
                        auto &yogaStyle = props.yogaStyle;
-                       yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(200));
-                       yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(200));
+                       yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
+                       yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(200));
                        return sharedProps;
                      })
                      .children({
@@ -434,8 +434,8 @@ static ParagraphShadowNode::ConcreteState::Shared stateWithShadowNode(
                                yogaStyle.positionType() = yoga::PositionType::Absolute;
                                yogaStyle.position()[YGEdgeLeft] = YGValue{0, YGUnitPoint};
                                yogaStyle.position()[YGEdgeTop] = YGValue{0, YGUnitPoint};
-                               yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(200));
-                               yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(20));
+                               yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
+                               yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(20));
                                return sharedProps;
                              })
                              .children({

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -533,9 +533,11 @@ void YogaLayoutableShadowNode::setSize(Size size) const {
 
   auto style = yogaNode_.getStyle();
   style.setDimension(
-      YGDimensionWidth, yoga::CompactValue::ofMaybe<YGUnitPoint>(size.width));
+      yoga::Dimension::Width,
+      yoga::CompactValue::ofMaybe<YGUnitPoint>(size.width));
   style.setDimension(
-      YGDimensionHeight, yoga::CompactValue::ofMaybe<YGUnitPoint>(size.height));
+      yoga::Dimension::Height,
+      yoga::CompactValue::ofMaybe<YGUnitPoint>(size.height));
   yogaNode_.setStyle(style);
   yogaNode_.setDirty(true);
 }
@@ -631,19 +633,19 @@ void YogaLayoutableShadowNode::layoutTree(
   auto ownerHeight = yogaFloatFromFloat(maximumSize.height);
 
   yogaStyle.setMaxDimension(
-      YGDimensionWidth,
+      yoga::Dimension::Width,
       yoga::CompactValue::ofMaybe<YGUnitPoint>(maximumSize.width));
 
   yogaStyle.setMaxDimension(
-      YGDimensionHeight,
+      yoga::Dimension::Height,
       yoga::CompactValue::ofMaybe<YGUnitPoint>(maximumSize.height));
 
   yogaStyle.setMinDimension(
-      YGDimensionWidth,
+      yoga::Dimension::Width,
       yoga::CompactValue::ofMaybe<YGUnitPoint>(minimumSize.width));
 
   yogaStyle.setMinDimension(
-      YGDimensionHeight,
+      yoga::Dimension::Height,
       yoga::CompactValue::ofMaybe<YGUnitPoint>(minimumSize.height));
 
   auto direction =

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -191,9 +191,9 @@ static inline T const getFieldValue(
 
 #define REBUILD_FIELD_YG_DIMENSION(field, setter, widthStr, heightStr) \
   REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(                         \
-      field, setter, YGDimensionWidth, widthStr);                      \
+      field, setter, yoga::Dimension::Width, widthStr);                \
   REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(                         \
-      field, setter, YGDimensionHeight, heightStr);
+      field, setter, yoga::Dimension::Height, heightStr);
 
 #define REBUILD_FIELD_YG_GUTTER(field, rowGapStr, columnGapStr, gapStr)      \
   REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(field, YGGutterRow, rowGapStr);       \
@@ -349,28 +349,28 @@ SharedDebugStringConvertibleList YogaStylableProps::getDebugProps() const {
           "border", yogaStyle.border(), defaultYogaStyle.border()),
       debugStringConvertibleItem(
           "width",
-          yogaStyle.dimension(YGDimensionWidth),
-          defaultYogaStyle.dimension(YGDimensionWidth)),
+          yogaStyle.dimension(yoga::Dimension::Width),
+          defaultYogaStyle.dimension(yoga::Dimension::Width)),
       debugStringConvertibleItem(
           "height",
-          yogaStyle.dimension(YGDimensionHeight),
-          defaultYogaStyle.dimension(YGDimensionHeight)),
+          yogaStyle.dimension(yoga::Dimension::Height),
+          defaultYogaStyle.dimension(yoga::Dimension::Height)),
       debugStringConvertibleItem(
           "minWidth",
-          yogaStyle.minDimension(YGDimensionWidth),
-          defaultYogaStyle.minDimension(YGDimensionWidth)),
+          yogaStyle.minDimension(yoga::Dimension::Width),
+          defaultYogaStyle.minDimension(yoga::Dimension::Width)),
       debugStringConvertibleItem(
           "minHeight",
-          yogaStyle.minDimension(YGDimensionHeight),
-          defaultYogaStyle.minDimension(YGDimensionHeight)),
+          yogaStyle.minDimension(yoga::Dimension::Height),
+          defaultYogaStyle.minDimension(yoga::Dimension::Height)),
       debugStringConvertibleItem(
           "maxWidth",
-          yogaStyle.maxDimension(YGDimensionWidth),
-          defaultYogaStyle.maxDimension(YGDimensionWidth)),
+          yogaStyle.maxDimension(yoga::Dimension::Width),
+          defaultYogaStyle.maxDimension(yoga::Dimension::Width)),
       debugStringConvertibleItem(
           "maxHeight",
-          yogaStyle.maxDimension(YGDimensionHeight),
-          defaultYogaStyle.maxDimension(YGDimensionHeight)),
+          yogaStyle.maxDimension(yoga::Dimension::Height),
+          defaultYogaStyle.maxDimension(yoga::Dimension::Height)),
       debugStringConvertibleItem(
           "aspectRatio",
           yogaStyle.aspectRatio(),

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -274,54 +274,54 @@ static inline yoga::Style convertRawProp(
       yogaStyle.border());
 
   yogaStyle.setDimension(
-      YGDimensionWidth,
+      yoga::Dimension::Width,
       convertRawProp(
           context,
           rawProps,
           "width",
-          sourceValue.dimension(YGDimensionWidth),
+          sourceValue.dimension(yoga::Dimension::Width),
           {}));
   yogaStyle.setDimension(
-      YGDimensionHeight,
+      yoga::Dimension::Height,
       convertRawProp(
           context,
           rawProps,
           "height",
-          sourceValue.dimension(YGDimensionHeight),
+          sourceValue.dimension(yoga::Dimension::Height),
           {}));
 
   yogaStyle.setMinDimension(
-      YGDimensionWidth,
+      yoga::Dimension::Width,
       convertRawProp(
           context,
           rawProps,
           "minWidth",
-          sourceValue.minDimension(YGDimensionWidth),
+          sourceValue.minDimension(yoga::Dimension::Width),
           {}));
   yogaStyle.setMinDimension(
-      YGDimensionHeight,
+      yoga::Dimension::Height,
       convertRawProp(
           context,
           rawProps,
           "minHeight",
-          sourceValue.minDimension(YGDimensionHeight),
+          sourceValue.minDimension(yoga::Dimension::Height),
           {}));
 
   yogaStyle.setMaxDimension(
-      YGDimensionWidth,
+      yoga::Dimension::Width,
       convertRawProp(
           context,
           rawProps,
           "maxWidth",
-          sourceValue.maxDimension(YGDimensionWidth),
+          sourceValue.maxDimension(yoga::Dimension::Width),
           {}));
   yogaStyle.setMaxDimension(
-      YGDimensionHeight,
+      yoga::Dimension::Height,
       convertRawProp(
           context,
           rawProps,
           "maxHeight",
-          sourceValue.maxDimension(YGDimensionHeight),
+          sourceValue.maxDimension(yoga::Dimension::Height),
           {}));
 
   yogaStyle.aspectRatio() = convertRawProp(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
@@ -77,8 +77,8 @@ class LayoutTest : public ::testing::Test {
             auto &props = *sharedProps;
             props.layoutConstraints = LayoutConstraints{{0,0}, {500, 500}};
             auto &yogaStyle = props.yogaStyle;
-            yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(200));
-            yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(200));
+            yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
+            yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(200));
             return sharedProps;
           })
           .children({
@@ -90,8 +90,8 @@ class LayoutTest : public ::testing::Test {
                 auto &props = *sharedProps;
                 auto &yogaStyle = props.yogaStyle;
                 yogaStyle.positionType() = yoga::PositionType::Absolute;
-                yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(50));
-                yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(50));
+                yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(50));
+                yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(50));
                 return sharedProps;
               })
               .children({
@@ -105,8 +105,8 @@ class LayoutTest : public ::testing::Test {
                     yogaStyle.positionType() = yoga::PositionType::Absolute;
                     yogaStyle.position()[YGEdgeLeft] = YGValue{10, YGUnitPoint};
                     yogaStyle.position()[YGEdgeTop] = YGValue{10, YGUnitPoint};
-                    yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(30));
-                    yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(90));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(30));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(90));
 
                     if (testCase == TRANSFORM_SCALE) {
                       props.transform = props.transform * Transform::Scale(2, 2, 1);
@@ -138,8 +138,8 @@ class LayoutTest : public ::testing::Test {
                         yogaStyle.positionType() = yoga::PositionType::Absolute;
                         yogaStyle.position()[YGEdgeLeft] = YGValue{10, YGUnitPoint};
                         yogaStyle.position()[YGEdgeTop] = YGValue{10, YGUnitPoint};
-                        yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(110));
-                        yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(20));
+                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(110));
+                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(20));
                         return sharedProps;
                       })
                       .children({
@@ -153,8 +153,8 @@ class LayoutTest : public ::testing::Test {
                             yogaStyle.positionType() = yoga::PositionType::Absolute;
                             yogaStyle.position()[YGEdgeLeft] = YGValue{70, YGUnitPoint};
                             yogaStyle.position()[YGEdgeTop] = YGValue{-50, YGUnitPoint};
-                            yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(30));
-                            yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(60));
+                            yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(30));
+                            yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(60));
                             return sharedProps;
                           })
                       }),
@@ -168,8 +168,8 @@ class LayoutTest : public ::testing::Test {
                         yogaStyle.positionType() = yoga::PositionType::Absolute;
                         yogaStyle.position()[YGEdgeLeft] = YGValue{-60, YGUnitPoint};
                         yogaStyle.position()[YGEdgeTop] = YGValue{50, YGUnitPoint};
-                        yogaStyle.setDimension(YGDimensionWidth, yoga::CompactValue::of<YGUnitPoint>(70));
-                        yogaStyle.setDimension(YGDimensionHeight, yoga::CompactValue::of<YGUnitPoint>(20));
+                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(70));
+                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(20));
                         return sharedProps;
                       })
                   })

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -662,97 +662,97 @@ void YGNodeStyleSetAspectRatio(const YGNodeRef node, const float aspectRatio) {
 void YGNodeStyleSetWidth(YGNodeRef node, float points) {
   auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, YGDimensionWidth, value);
+      node, Dimension::Width, value);
 }
 void YGNodeStyleSetWidthPercent(YGNodeRef node, float percent) {
   auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, YGDimensionWidth, value);
+      node, Dimension::Width, value);
 }
 void YGNodeStyleSetWidthAuto(YGNodeRef node) {
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, YGDimensionWidth, CompactValue::ofAuto());
+      node, Dimension::Width, CompactValue::ofAuto());
 }
 YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
-  return resolveRef(node)->getStyle().dimension(YGDimensionWidth);
+  return resolveRef(node)->getStyle().dimension(Dimension::Width);
 }
 
 void YGNodeStyleSetHeight(YGNodeRef node, float points) {
   auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, YGDimensionHeight, value);
+      node, Dimension::Height, value);
 }
 void YGNodeStyleSetHeightPercent(YGNodeRef node, float percent) {
   auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, YGDimensionHeight, value);
+      node, Dimension::Height, value);
 }
 void YGNodeStyleSetHeightAuto(YGNodeRef node) {
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, YGDimensionHeight, CompactValue::ofAuto());
+      node, Dimension::Height, CompactValue::ofAuto());
 }
 YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
-  return resolveRef(node)->getStyle().dimension(YGDimensionHeight);
+  return resolveRef(node)->getStyle().dimension(Dimension::Height);
 }
 
 void YGNodeStyleSetMinWidth(const YGNodeRef node, const float minWidth) {
   auto value = CompactValue::ofMaybe<YGUnitPoint>(minWidth);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, YGDimensionWidth, value);
+      node, Dimension::Width, value);
 }
 void YGNodeStyleSetMinWidthPercent(const YGNodeRef node, const float minWidth) {
   auto value = CompactValue::ofMaybe<YGUnitPercent>(minWidth);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, YGDimensionWidth, value);
+      node, Dimension::Width, value);
 }
 YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
-  return resolveRef(node)->getStyle().minDimension(YGDimensionWidth);
+  return resolveRef(node)->getStyle().minDimension(Dimension::Width);
 }
 
 void YGNodeStyleSetMinHeight(const YGNodeRef node, const float minHeight) {
   auto value = CompactValue::ofMaybe<YGUnitPoint>(minHeight);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, YGDimensionHeight, value);
+      node, Dimension::Height, value);
 }
 void YGNodeStyleSetMinHeightPercent(
     const YGNodeRef node,
     const float minHeight) {
   auto value = CompactValue::ofMaybe<YGUnitPercent>(minHeight);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, YGDimensionHeight, value);
+      node, Dimension::Height, value);
 }
 YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
-  return resolveRef(node)->getStyle().minDimension(YGDimensionHeight);
+  return resolveRef(node)->getStyle().minDimension(Dimension::Height);
 }
 
 void YGNodeStyleSetMaxWidth(const YGNodeRef node, const float maxWidth) {
   auto value = CompactValue::ofMaybe<YGUnitPoint>(maxWidth);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, YGDimensionWidth, value);
+      node, Dimension::Width, value);
 }
 void YGNodeStyleSetMaxWidthPercent(const YGNodeRef node, const float maxWidth) {
   auto value = CompactValue::ofMaybe<YGUnitPercent>(maxWidth);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, YGDimensionWidth, value);
+      node, Dimension::Width, value);
 }
 YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
-  return resolveRef(node)->getStyle().maxDimension(YGDimensionWidth);
+  return resolveRef(node)->getStyle().maxDimension(Dimension::Width);
 }
 
 void YGNodeStyleSetMaxHeight(const YGNodeRef node, const float maxHeight) {
   auto value = CompactValue::ofMaybe<YGUnitPoint>(maxHeight);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, YGDimensionHeight, value);
+      node, Dimension::Height, value);
 }
 void YGNodeStyleSetMaxHeightPercent(
     const YGNodeRef node,
     const float maxHeight) {
   auto value = CompactValue::ofMaybe<YGUnitPercent>(maxHeight);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, YGDimensionHeight, value);
+      node, Dimension::Height, value);
 }
 YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
-  return resolveRef(node)->getStyle().maxDimension(YGDimensionHeight);
+  return resolveRef(node)->getStyle().maxDimension(Dimension::Height);
 }
 
 namespace {
@@ -805,11 +805,11 @@ float YGNodeLayoutGetBottom(const YGNodeConstRef node) {
 }
 
 float YGNodeLayoutGetWidth(const YGNodeConstRef node) {
-  return resolveRef(node)->getLayout().dimension(YGDimensionWidth);
+  return resolveRef(node)->getLayout().dimension(Dimension::Width);
 }
 
 float YGNodeLayoutGetHeight(const YGNodeConstRef node) {
-  return resolveRef(node)->getLayout().dimension(YGDimensionHeight);
+  return resolveRef(node)->getLayout().dimension(Dimension::Height);
 }
 
 YGDirection YGNodeLayoutGetDirection(const YGNodeConstRef node) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
@@ -19,8 +19,8 @@ float calculateBaseline(const yoga::Node* node) {
     Event::publish<Event::NodeBaselineStart>(node);
 
     const float baseline = node->baseline(
-        node->getLayout().measuredDimension(YGDimensionWidth),
-        node->getLayout().measuredDimension(YGDimensionHeight));
+        node->getLayout().measuredDimension(Dimension::Width),
+        node->getLayout().measuredDimension(Dimension::Height));
 
     Event::publish<Event::NodeBaselineEnd>(node);
 
@@ -53,7 +53,7 @@ float calculateBaseline(const yoga::Node* node) {
   }
 
   if (baselineChild == nullptr) {
-    return node->getLayout().measuredDimension(YGDimensionHeight);
+    return node->getLayout().measuredDimension(Dimension::Height);
   }
 
   const float baseline = calculateBaseline(baselineChild);

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
@@ -9,6 +9,7 @@
 
 #include <yoga/algorithm/FlexDirection.h>
 #include <yoga/algorithm/ResolveValue.h>
+#include <yoga/enums/Dimension.h>
 #include <yoga/enums/FlexDirection.h>
 #include <yoga/node/Node.h>
 #include <yoga/numeric/Comparison.h>
@@ -35,14 +36,14 @@ inline FloatOptional boundAxisWithinMinAndMax(
 
   if (isColumn(axis)) {
     min = yoga::resolveValue(
-        node->getStyle().minDimension(YGDimensionHeight), axisSize);
+        node->getStyle().minDimension(Dimension::Height), axisSize);
     max = yoga::resolveValue(
-        node->getStyle().maxDimension(YGDimensionHeight), axisSize);
+        node->getStyle().maxDimension(Dimension::Height), axisSize);
   } else if (isRow(axis)) {
     min = yoga::resolveValue(
-        node->getStyle().minDimension(YGDimensionWidth), axisSize);
+        node->getStyle().minDimension(Dimension::Width), axisSize);
     max = yoga::resolveValue(
-        node->getStyle().maxDimension(YGDimensionWidth), axisSize);
+        node->getStyle().maxDimension(Dimension::Width), axisSize);
   }
 
   if (max >= FloatOptional{0} && value > max) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -169,7 +169,7 @@ static void computeFlexBasisForChild(
 
     child->setLayoutComputedFlexBasis(yoga::maxOrDefined(
         yoga::resolveValue(
-            child->getResolvedDimension(YGDimensionWidth), ownerWidth),
+            child->getResolvedDimension(Dimension::Width), ownerWidth),
         paddingAndBorder));
   } else if (!isMainAxisRow && isColumnStyleDimDefined) {
     // The height is definite, so use that as the flex basis.
@@ -177,7 +177,7 @@ static void computeFlexBasisForChild(
         paddingAndBorderForAxis(child, FlexDirection::Column, ownerWidth));
     child->setLayoutComputedFlexBasis(yoga::maxOrDefined(
         yoga::resolveValue(
-            child->getResolvedDimension(YGDimensionHeight), ownerHeight),
+            child->getResolvedDimension(Dimension::Height), ownerHeight),
         paddingAndBorder));
   } else {
     // Compute the flex basis and hypothetical main size (i.e. the clamped flex
@@ -195,7 +195,7 @@ static void computeFlexBasisForChild(
     if (isRowStyleDimDefined) {
       childWidth =
           yoga::resolveValue(
-              child->getResolvedDimension(YGDimensionWidth), ownerWidth)
+              child->getResolvedDimension(Dimension::Width), ownerWidth)
               .unwrap() +
           marginRow;
       childWidthMeasureMode = MeasureMode::Exactly;
@@ -203,7 +203,7 @@ static void computeFlexBasisForChild(
     if (isColumnStyleDimDefined) {
       childHeight =
           yoga::resolveValue(
-              child->getResolvedDimension(YGDimensionHeight), ownerHeight)
+              child->getResolvedDimension(Dimension::Height), ownerHeight)
               .unwrap() +
           marginColumn;
       childHeightMeasureMode = MeasureMode::Exactly;
@@ -341,7 +341,7 @@ static void layoutAbsoluteChild(
 
   if (styleDefinesDimension(child, FlexDirection::Row, width)) {
     childWidth =
-        yoga::resolveValue(child->getResolvedDimension(YGDimensionWidth), width)
+        yoga::resolveValue(child->getResolvedDimension(Dimension::Width), width)
             .unwrap() +
         marginRow;
   } else {
@@ -349,7 +349,7 @@ static void layoutAbsoluteChild(
     // the left/right offsets if they're defined.
     if (child->isLeadingPositionDefined(FlexDirection::Row) &&
         child->isTrailingPosDefined(FlexDirection::Row)) {
-      childWidth = node->getLayout().measuredDimension(YGDimensionWidth) -
+      childWidth = node->getLayout().measuredDimension(Dimension::Width) -
           (node->getLeadingBorder(FlexDirection::Row) +
            node->getTrailingBorder(FlexDirection::Row)) -
           (child->getLeadingPosition(FlexDirection::Row, width) +
@@ -362,7 +362,7 @@ static void layoutAbsoluteChild(
 
   if (styleDefinesDimension(child, FlexDirection::Column, height)) {
     childHeight = yoga::resolveValue(
-                      child->getResolvedDimension(YGDimensionHeight), height)
+                      child->getResolvedDimension(Dimension::Height), height)
                       .unwrap() +
         marginColumn;
   } else {
@@ -370,7 +370,7 @@ static void layoutAbsoluteChild(
     // the top/bottom offsets if they're defined.
     if (child->isLeadingPositionDefined(FlexDirection::Column) &&
         child->isTrailingPosDefined(FlexDirection::Column)) {
-      childHeight = node->getLayout().measuredDimension(YGDimensionHeight) -
+      childHeight = node->getLayout().measuredDimension(Dimension::Height) -
           (node->getLeadingBorder(FlexDirection::Column) +
            node->getTrailingBorder(FlexDirection::Column)) -
           (child->getLeadingPosition(FlexDirection::Column, height) +
@@ -431,9 +431,9 @@ static void layoutAbsoluteChild(
         layoutMarkerData,
         depth,
         generationCount);
-    childWidth = child->getLayout().measuredDimension(YGDimensionWidth) +
+    childWidth = child->getLayout().measuredDimension(Dimension::Width) +
         child->getMarginForAxis(FlexDirection::Row, width).unwrap();
-    childHeight = child->getLayout().measuredDimension(YGDimensionHeight) +
+    childHeight = child->getLayout().measuredDimension(Dimension::Height) +
         child->getMarginForAxis(FlexDirection::Column, width).unwrap();
   }
 
@@ -587,7 +587,7 @@ static void measureNodeWithMeasureFunc(
     node->setLayoutMeasuredDimension(
         boundAxis(
             node, FlexDirection::Row, availableWidth, ownerWidth, ownerWidth),
-        YGDimensionWidth);
+        Dimension::Width);
     node->setLayoutMeasuredDimension(
         boundAxis(
             node,
@@ -595,7 +595,7 @@ static void measureNodeWithMeasureFunc(
             availableHeight,
             ownerHeight,
             ownerWidth),
-        YGDimensionHeight);
+        Dimension::Height);
   } else {
     Event::publish<Event::MeasureCallbackStart>(node);
 
@@ -627,7 +627,7 @@ static void measureNodeWithMeasureFunc(
                 : availableWidth,
             ownerWidth,
             ownerWidth),
-        YGDimensionWidth);
+        Dimension::Width);
 
     node->setLayoutMeasuredDimension(
         boundAxis(
@@ -639,7 +639,7 @@ static void measureNodeWithMeasureFunc(
                 : availableHeight,
             ownerHeight,
             ownerWidth),
-        YGDimensionHeight);
+        Dimension::Height);
   }
 }
 
@@ -664,7 +664,7 @@ static void measureNodeWithoutChildren(
   }
   node->setLayoutMeasuredDimension(
       boundAxis(node, FlexDirection::Row, width, ownerWidth, ownerWidth),
-      YGDimensionWidth);
+      Dimension::Width);
 
   float height = availableHeight;
   if (heightMeasureMode == MeasureMode::Undefined ||
@@ -674,7 +674,7 @@ static void measureNodeWithoutChildren(
   }
   node->setLayoutMeasuredDimension(
       boundAxis(node, FlexDirection::Column, height, ownerHeight, ownerWidth),
-      YGDimensionHeight);
+      Dimension::Height);
 }
 
 static bool measureNodeWithFixedSize(
@@ -702,7 +702,7 @@ static bool measureNodeWithFixedSize(
                 : availableWidth,
             ownerWidth,
             ownerWidth),
-        YGDimensionWidth);
+        Dimension::Width);
 
     node->setLayoutMeasuredDimension(
         boundAxis(
@@ -715,7 +715,7 @@ static bool measureNodeWithFixedSize(
                 : availableHeight,
             ownerHeight,
             ownerWidth),
-        YGDimensionHeight);
+        Dimension::Height);
     return true;
   }
 
@@ -724,8 +724,8 @@ static bool measureNodeWithFixedSize(
 
 static void zeroOutLayoutRecursively(yoga::Node* const node) {
   node->getLayout() = {};
-  node->setLayoutDimension(0, YGDimensionWidth);
-  node->setLayoutDimension(0, YGDimensionHeight);
+  node->setLayoutDimension(0, Dimension::Width);
+  node->setLayoutDimension(0, Dimension::Height);
   node->setHasNewLayout(true);
 
   node->cloneChildrenIfNeeded();
@@ -736,7 +736,7 @@ static void zeroOutLayoutRecursively(yoga::Node* const node) {
 
 static float calculateAvailableInnerDimension(
     const yoga::Node* const node,
-    const YGDimension dimension,
+    const Dimension dimension,
     const float availableDim,
     const float paddingAndBorder,
     const float ownerDim) {
@@ -1373,7 +1373,7 @@ static void justifyMainAxis(
                         FlexDirection::Column, availableInnerWidth)
                     .unwrap();
             const float descent =
-                child->getLayout().measuredDimension(YGDimensionHeight) +
+                child->getLayout().measuredDimension(Dimension::Height) +
                 child
                     ->getMarginForAxis(
                         FlexDirection::Column, availableInnerWidth)
@@ -1632,13 +1632,13 @@ static void calculateLayoutImpl(
 
   float availableInnerWidth = calculateAvailableInnerDimension(
       node,
-      YGDimensionWidth,
+      Dimension::Width,
       availableWidth - marginAxisRow,
       paddingAndBorderAxisRow,
       ownerWidth);
   float availableInnerHeight = calculateAvailableInnerDimension(
       node,
-      YGDimensionHeight,
+      Dimension::Height,
       availableHeight - marginAxisColumn,
       paddingAndBorderAxisColumn,
       ownerHeight);
@@ -1725,19 +1725,19 @@ static void calculateLayoutImpl(
     if (measureModeMainDim != MeasureMode::Exactly) {
       const auto& style = node->getStyle();
       const float minInnerWidth =
-          yoga::resolveValue(style.minDimension(YGDimensionWidth), ownerWidth)
+          yoga::resolveValue(style.minDimension(Dimension::Width), ownerWidth)
               .unwrap() -
           paddingAndBorderAxisRow;
       const float maxInnerWidth =
-          yoga::resolveValue(style.maxDimension(YGDimensionWidth), ownerWidth)
+          yoga::resolveValue(style.maxDimension(Dimension::Width), ownerWidth)
               .unwrap() -
           paddingAndBorderAxisRow;
       const float minInnerHeight =
-          yoga::resolveValue(style.minDimension(YGDimensionHeight), ownerHeight)
+          yoga::resolveValue(style.minDimension(Dimension::Height), ownerHeight)
               .unwrap() -
           paddingAndBorderAxisColumn;
       const float maxInnerHeight =
-          yoga::resolveValue(style.maxDimension(YGDimensionHeight), ownerHeight)
+          yoga::resolveValue(style.maxDimension(Dimension::Height), ownerHeight)
               .unwrap() -
           paddingAndBorderAxisColumn;
 
@@ -1803,7 +1803,7 @@ static void calculateLayoutImpl(
     }
 
     node->setLayoutHadOverflow(
-        node->getLayout().hadOverflow() |
+        node->getLayout().hadOverflow() ||
         (flexLine.layout.remainingFreeSpace < 0));
 
     // STEP 6: MAIN-AXIS JUSTIFICATION & CROSS-AXIS SIZE DETERMINATION
@@ -2089,7 +2089,7 @@ static void calculateLayoutImpl(
                         FlexDirection::Column, availableInnerWidth)
                     .unwrap();
             const float descent =
-                child->getLayout().measuredDimension(YGDimensionHeight) +
+                child->getLayout().measuredDimension(Dimension::Height) +
                 child
                     ->getMarginForAxis(
                         FlexDirection::Column, availableInnerWidth)
@@ -2156,14 +2156,14 @@ static void calculateLayoutImpl(
                         child, crossAxis, availableInnerCrossDim)) {
                   const float childWidth = isMainAxisRow
                       ? (child->getLayout().measuredDimension(
-                             YGDimensionWidth) +
+                             Dimension::Width) +
                          child->getMarginForAxis(mainAxis, availableInnerWidth)
                              .unwrap())
                       : lineHeight;
 
                   const float childHeight = !isMainAxisRow
                       ? (child->getLayout().measuredDimension(
-                             YGDimensionHeight) +
+                             Dimension::Height) +
                          child->getMarginForAxis(crossAxis, availableInnerWidth)
                              .unwrap())
                       : lineHeight;
@@ -2171,11 +2171,11 @@ static void calculateLayoutImpl(
                   if (!(yoga::inexactEquals(
                             childWidth,
                             child->getLayout().measuredDimension(
-                                YGDimensionWidth)) &&
+                                Dimension::Width)) &&
                         yoga::inexactEquals(
                             childHeight,
                             child->getLayout().measuredDimension(
-                                YGDimensionHeight)))) {
+                                Dimension::Height)))) {
                     calculateLayoutInternal(
                         child,
                         childWidth,
@@ -2227,7 +2227,7 @@ static void calculateLayoutImpl(
           availableWidth - marginAxisRow,
           ownerWidth,
           ownerWidth),
-      YGDimensionWidth);
+      Dimension::Width);
 
   node->setLayoutMeasuredDimension(
       boundAxis(
@@ -2236,7 +2236,7 @@ static void calculateLayoutImpl(
           availableHeight - marginAxisColumn,
           ownerHeight,
           ownerWidth),
-      YGDimensionHeight);
+      Dimension::Height);
 
   // If the user didn't specify a width or height for the node, set the
   // dimensions based on the children.
@@ -2329,11 +2329,11 @@ static void calculateLayoutImpl(
           node,
           child,
           absolutePercentageAgainstPaddingEdge
-              ? node->getLayout().measuredDimension(YGDimensionWidth)
+              ? node->getLayout().measuredDimension(Dimension::Width)
               : availableInnerWidth,
           isMainAxisRow ? measureModeMainDim : measureModeCrossDim,
           absolutePercentageAgainstPaddingEdge
-              ? node->getLayout().measuredDimension(YGDimensionHeight)
+              ? node->getLayout().measuredDimension(Dimension::Height)
               : availableInnerHeight,
           direction,
           layoutMarkerData,
@@ -2516,9 +2516,9 @@ bool calculateLayoutInternal(
 
   if (!needToVisitNode && cachedResults != nullptr) {
     layout->setMeasuredDimension(
-        YGDimensionWidth, cachedResults->computedWidth);
+        Dimension::Width, cachedResults->computedWidth);
     layout->setMeasuredDimension(
-        YGDimensionHeight, cachedResults->computedHeight);
+        Dimension::Height, cachedResults->computedHeight);
 
     (performLayout ? layoutMarkerData.cachedLayouts
                    : layoutMarkerData.cachedMeasures) += 1;
@@ -2594,8 +2594,8 @@ bool calculateLayoutInternal(
           "wm: %s, hm: %s, d: (%f, %f) %s\n",
           measureModeName(widthMeasureMode, performLayout),
           measureModeName(heightMeasureMode, performLayout),
-          layout->measuredDimension(YGDimensionWidth),
-          layout->measuredDimension(YGDimensionHeight),
+          layout->measuredDimension(Dimension::Width),
+          layout->measuredDimension(Dimension::Height),
           LayoutPassReasonToString(reason));
     }
 
@@ -2630,19 +2630,19 @@ bool calculateLayoutInternal(
       newCacheEntry->widthMeasureMode = widthMeasureMode;
       newCacheEntry->heightMeasureMode = heightMeasureMode;
       newCacheEntry->computedWidth =
-          layout->measuredDimension(YGDimensionWidth);
+          layout->measuredDimension(Dimension::Width);
       newCacheEntry->computedHeight =
-          layout->measuredDimension(YGDimensionHeight);
+          layout->measuredDimension(Dimension::Height);
     }
   }
 
   if (performLayout) {
     node->setLayoutDimension(
-        node->getLayout().measuredDimension(YGDimensionWidth),
-        YGDimensionWidth);
+        node->getLayout().measuredDimension(Dimension::Width),
+        Dimension::Width);
     node->setLayoutDimension(
-        node->getLayout().measuredDimension(YGDimensionHeight),
-        YGDimensionHeight);
+        node->getLayout().measuredDimension(Dimension::Height),
+        Dimension::Height);
 
     node->setHasNewLayout(true);
     node->setDirty(false);
@@ -2688,9 +2688,9 @@ void calculateLayout(
                 .unwrap();
     widthMeasureMode = MeasureMode::Exactly;
   } else if (!yoga::resolveValue(
-                  style.maxDimension(YGDimensionWidth), ownerWidth)
+                  style.maxDimension(Dimension::Width), ownerWidth)
                   .isUndefined()) {
-    width = yoga::resolveValue(style.maxDimension(YGDimensionWidth), ownerWidth)
+    width = yoga::resolveValue(style.maxDimension(Dimension::Width), ownerWidth)
                 .unwrap();
     widthMeasureMode = MeasureMode::AtMost;
   } else {
@@ -2709,10 +2709,10 @@ void calculateLayout(
                  .unwrap();
     heightMeasureMode = MeasureMode::Exactly;
   } else if (!yoga::resolveValue(
-                  style.maxDimension(YGDimensionHeight), ownerHeight)
+                  style.maxDimension(Dimension::Height), ownerHeight)
                   .isUndefined()) {
     height =
-        yoga::resolveValue(style.maxDimension(YGDimensionHeight), ownerHeight)
+        yoga::resolveValue(style.maxDimension(Dimension::Height), ownerHeight)
             .unwrap();
     heightMeasureMode = MeasureMode::AtMost;
   } else {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexDirection.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexDirection.h
@@ -10,6 +10,7 @@
 #include <yoga/Yoga.h>
 
 #include <yoga/debug/AssertFatal.h>
+#include <yoga/enums/Dimension.h>
 #include <yoga/enums/FlexDirection.h>
 
 namespace facebook::yoga {
@@ -76,16 +77,16 @@ inline YGEdge trailingEdge(const FlexDirection flexDirection) {
   fatalWithMessage("Invalid FlexDirection");
 }
 
-inline YGDimension dimension(const FlexDirection flexDirection) {
+inline Dimension dimension(const FlexDirection flexDirection) {
   switch (flexDirection) {
     case FlexDirection::Column:
-      return YGDimensionHeight;
+      return Dimension::Height;
     case FlexDirection::ColumnReverse:
-      return YGDimensionHeight;
+      return Dimension::Height;
     case FlexDirection::Row:
-      return YGDimensionWidth;
+      return Dimension::Width;
     case FlexDirection::RowReverse:
-      return YGDimensionWidth;
+      return Dimension::Width;
   }
 
   fatalWithMessage("Invalid FlexDirection");

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
@@ -71,8 +71,8 @@ void roundLayoutResultsToPixelGrid(
   const double nodeLeft = node->getLayout().position[YGEdgeLeft];
   const double nodeTop = node->getLayout().position[YGEdgeTop];
 
-  const double nodeWidth = node->getLayout().dimension(YGDimensionWidth);
-  const double nodeHeight = node->getLayout().dimension(YGDimensionHeight);
+  const double nodeWidth = node->getLayout().dimension(Dimension::Width);
+  const double nodeHeight = node->getLayout().dimension(Dimension::Height);
 
   const double absoluteNodeLeft = absoluteLeft + nodeLeft;
   const double absoluteNodeTop = absoluteTop + nodeTop;
@@ -111,7 +111,7 @@ void roundLayoutResultsToPixelGrid(
             (textRounding && !hasFractionalWidth)) -
             roundValueToPixelGrid(
                 absoluteNodeLeft, pointScaleFactor, false, textRounding),
-        YGDimensionWidth);
+        Dimension::Width);
 
     node->setLayoutDimension(
         roundValueToPixelGrid(
@@ -121,7 +121,7 @@ void roundLayoutResultsToPixelGrid(
             (textRounding && !hasFractionalHeight)) -
             roundValueToPixelGrid(
                 absoluteNodeTop, pointScaleFactor, false, textRounding),
-        YGDimensionHeight);
+        Dimension::Height);
   }
 
   for (yoga::Node* child : node->getChildren()) {

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -127,9 +127,9 @@ void nodeToString(
   if ((options & PrintOptions::Layout) == PrintOptions::Layout) {
     appendFormattedString(str, "layout=\"");
     appendFormattedString(
-        str, "width: %g; ", node->getLayout().dimension(YGDimensionWidth));
+        str, "width: %g; ", node->getLayout().dimension(Dimension::Width));
     appendFormattedString(
-        str, "height: %g; ", node->getLayout().dimension(YGDimensionHeight));
+        str, "height: %g; ", node->getLayout().dimension(Dimension::Height));
     appendFormattedString(
         str, "top: %g; ", node->getLayout().position[YGEdgeTop]);
     appendFormattedString(
@@ -193,16 +193,16 @@ void nodeToString(
       appendNumberIfNotUndefined(str, "row-gap", style.gap()[YGGutterRow]);
     }
 
-    appendNumberIfNotAuto(str, "width", style.dimension(YGDimensionWidth));
-    appendNumberIfNotAuto(str, "height", style.dimension(YGDimensionHeight));
+    appendNumberIfNotAuto(str, "width", style.dimension(Dimension::Width));
+    appendNumberIfNotAuto(str, "height", style.dimension(Dimension::Height));
     appendNumberIfNotAuto(
-        str, "max-width", style.maxDimension(YGDimensionWidth));
+        str, "max-width", style.maxDimension(Dimension::Width));
     appendNumberIfNotAuto(
-        str, "max-height", style.maxDimension(YGDimensionHeight));
+        str, "max-height", style.maxDimension(Dimension::Height));
     appendNumberIfNotAuto(
-        str, "min-width", style.minDimension(YGDimensionWidth));
+        str, "min-width", style.minDimension(Dimension::Width));
     appendNumberIfNotAuto(
-        str, "min-height", style.minDimension(YGDimensionHeight));
+        str, "min-height", style.minDimension(Dimension::Height));
 
     if (style.positionType() != yoga::Node{}.getStyle().positionType()) {
       appendFormattedString(

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/YogaEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/YogaEnums.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 namespace facebook::yoga {
 
 template <typename EnumT>
@@ -14,5 +16,11 @@ constexpr inline int32_t ordinalCount();
 
 template <typename EnumT>
 constexpr inline int32_t bitCount();
+
+// Polyfill of C++ 23 to_underlying()
+// https://en.cppreference.com/w/cpp/utility/to_underlying
+constexpr auto to_underlying(auto e) noexcept {
+  return static_cast<std::underlying_type_t<decltype(e)>>(e);
+}
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
@@ -10,6 +10,7 @@
 #include <array>
 
 #include <yoga/bits/NumericBitfield.h>
+#include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/node/CachedMeasurement.h>
 #include <yoga/numeric/FloatOptional.h>
@@ -63,20 +64,20 @@ struct LayoutResults {
     hadOverflow_ = hadOverflow;
   }
 
-  float dimension(YGDimension axis) const {
-    return dimensions_[axis];
+  float dimension(Dimension axis) const {
+    return dimensions_[yoga::to_underlying(axis)];
   }
 
-  void setDimension(YGDimension axis, float dimension) {
-    dimensions_[axis] = dimension;
+  void setDimension(Dimension axis, float dimension) {
+    dimensions_[yoga::to_underlying(axis)] = dimension;
   }
 
-  float measuredDimension(YGDimension axis) const {
-    return measuredDimensions_[axis];
+  float measuredDimension(Dimension axis) const {
+    return measuredDimensions_[yoga::to_underlying(axis)];
   }
 
-  void setMeasuredDimension(YGDimension axis, float dimension) {
-    measuredDimensions_[axis] = dimension;
+  void setMeasuredDimension(Dimension axis, float dimension) {
+    measuredDimensions_[yoga::to_underlying(axis)] = dimension;
   }
 
   bool operator==(LayoutResults layout) const;

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -339,7 +339,7 @@ void Node::setLayoutComputedFlexBasisGeneration(
 
 void Node::setLayoutMeasuredDimension(
     float measuredDimension,
-    YGDimension dimension) {
+    Dimension dimension) {
   layout_.setMeasuredDimension(dimension, measuredDimension);
 }
 
@@ -347,7 +347,7 @@ void Node::setLayoutHadOverflow(bool hadOverflow) {
   layout_.setHadOverflow(hadOverflow);
 }
 
-void Node::setLayoutDimension(float dimensionValue, YGDimension dimension) {
+void Node::setLayoutDimension(float dimensionValue, Dimension dimension) {
   layout_.setDimension(dimension, dimensionValue);
 }
 
@@ -433,14 +433,13 @@ YGValue Node::resolveFlexBasisPtr() const {
 }
 
 void Node::resolveDimension() {
-  using namespace yoga;
   const Style& style = getStyle();
-  for (auto dim : {YGDimensionWidth, YGDimensionHeight}) {
+  for (auto dim : {Dimension::Width, Dimension::Height}) {
     if (!style.maxDimension(dim).isUndefined() &&
         yoga::inexactEquals(style.maxDimension(dim), style.minDimension(dim))) {
-      resolvedDimensions_[dim] = style.maxDimension(dim);
+      resolvedDimensions_[yoga::to_underlying(dim)] = style.maxDimension(dim);
     } else {
-      resolvedDimensions_[dim] = style.dimension(dim);
+      resolvedDimensions_[yoga::to_underlying(dim)] = style.dimension(dim);
     }
   }
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -14,6 +14,7 @@
 #include <yoga/Yoga.h>
 
 #include <yoga/config/Config.h>
+#include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Errata.h>
 #include <yoga/enums/MeasureMode.h>
@@ -175,7 +176,7 @@ class YG_EXPORT Node : public ::YGNode {
     return resolvedDimensions_;
   }
 
-  YGValue getResolvedDimension(YGDimension dimension) const {
+  YGValue getResolvedDimension(Dimension dimension) const {
     return resolvedDimensions_[static_cast<size_t>(dimension)];
   }
 
@@ -293,11 +294,9 @@ class YG_EXPORT Node : public ::YGNode {
   void setLayoutComputedFlexBasis(const FloatOptional computedFlexBasis);
   void setLayoutComputedFlexBasisGeneration(
       uint32_t computedFlexBasisGeneration);
-  void setLayoutMeasuredDimension(
-      float measuredDimension,
-      YGDimension dimension);
+  void setLayoutMeasuredDimension(float measuredDimension, Dimension dimension);
   void setLayoutHadOverflow(bool hadOverflow);
-  void setLayoutDimension(float dimensionValue, YGDimension dimension);
+  void setLayoutDimension(float dimensionValue, Dimension dimension);
   void setLayoutDirection(Direction direction);
   void setLayoutMargin(float margin, YGEdge edge);
   void setLayoutBorder(float border, YGEdge edge);

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -16,6 +16,7 @@
 
 #include <yoga/bits/NumericBitfield.h>
 #include <yoga/enums/Align.h>
+#include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Display.h>
 #include <yoga/enums/FlexDirection.h>
@@ -33,7 +34,7 @@ class YG_EXPORT Style {
   using Values = std::array<CompactValue, ordinalCount<Enum>()>;
 
  public:
-  using Dimensions = Values<YGDimension>;
+  using Dimensions = Values<Dimension>;
   using Edges = Values<YGEdge>;
   using Gutters = Values<YGGutter>;
 
@@ -280,25 +281,25 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  CompactValue dimension(YGDimension axis) const {
-    return dimensions_[axis];
+  CompactValue dimension(Dimension axis) const {
+    return dimensions_[yoga::to_underlying(axis)];
   }
-  void setDimension(YGDimension axis, CompactValue value) {
-    dimensions_[axis] = value;
-  }
-
-  CompactValue minDimension(YGDimension axis) const {
-    return minDimensions_[axis];
-  }
-  void setMinDimension(YGDimension axis, CompactValue value) {
-    minDimensions_[axis] = value;
+  void setDimension(Dimension axis, CompactValue value) {
+    dimensions_[yoga::to_underlying(axis)] = value;
   }
 
-  CompactValue maxDimension(YGDimension axis) const {
-    return maxDimensions_[axis];
+  CompactValue minDimension(Dimension axis) const {
+    return minDimensions_[yoga::to_underlying(axis)];
   }
-  void setMaxDimension(YGDimension axis, CompactValue value) {
-    maxDimensions_[axis] = value;
+  void setMinDimension(Dimension axis, CompactValue value) {
+    minDimensions_[yoga::to_underlying(axis)] = value;
+  }
+
+  CompactValue maxDimension(Dimension axis) const {
+    return maxDimensions_[yoga::to_underlying(axis)];
+  }
+  void setMaxDimension(Dimension axis, CompactValue value) {
+    maxDimensions_[yoga::to_underlying(axis)] = value;
   }
 
   // Yoga specific properties, not compatible with flexbox specification


### PR DESCRIPTION
Summary:
Replaces all usages of YGDimension with Dimension.

Adds `yoga::to_underlying` to act like `std::to_underlying`, added in C++ 23.

This enum is oddly only used internally, and is never an input to the public API, but it handled as any other public generated enum. Potentially some more cleanup to do there.

Differential Revision: D49475409

