### PR TITLE
C++ style enums 17/N: Gutter

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -195,14 +195,14 @@ static inline T const getFieldValue(
   REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(                         \
       field, setter, yoga::Dimension::Height, heightStr);
 
-#define REBUILD_FIELD_YG_GUTTER(                    \
-    field, setter, rowGapStr, columnGapStr, gapStr) \
-  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(      \
-      field, setter, YGGutterRow, rowGapStr);       \
-  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(      \
-      field, setter, YGGutterColumn, columnGapStr); \
-  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(      \
-      field, setter, YGGutterAll, gapStr);
+#define REBUILD_FIELD_YG_GUTTER(                          \
+    field, setter, rowGapStr, columnGapStr, gapStr)       \
+  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(            \
+      field, setter, yoga::Gutter::Row, rowGapStr);       \
+  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(            \
+      field, setter, yoga::Gutter::Column, columnGapStr); \
+  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED_SETTER(            \
+      field, setter, yoga::Gutter::All, gapStr);
 
 #define REBUILD_FIELD_YG_EDGES(field, prefix, suffix)                          \
   REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(                                        \
@@ -329,14 +329,16 @@ SharedDebugStringConvertibleList YogaStylableProps::getDebugProps() const {
           "flexGrow", yogaStyle.flexGrow(), defaultYogaStyle.flexGrow()),
       debugStringConvertibleItem(
           "rowGap",
-          yogaStyle.gap(YGGutterRow),
-          defaultYogaStyle.gap(YGGutterRow)),
+          yogaStyle.gap(yoga::Gutter::Row),
+          defaultYogaStyle.gap(yoga::Gutter::Row)),
       debugStringConvertibleItem(
           "columnGap",
-          yogaStyle.gap(YGGutterColumn),
-          defaultYogaStyle.gap(YGGutterColumn)),
+          yogaStyle.gap(yoga::Gutter::Column),
+          defaultYogaStyle.gap(yoga::Gutter::Column)),
       debugStringConvertibleItem(
-          "gap", yogaStyle.gap(YGGutterAll), defaultYogaStyle.gap(YGGutterAll)),
+          "gap",
+          yogaStyle.gap(yoga::Gutter::All),
+          defaultYogaStyle.gap(yoga::Gutter::All)),
       debugStringConvertibleItem(
           "flexShrink", yogaStyle.flexShrink(), defaultYogaStyle.flexShrink()),
       debugStringConvertibleItem(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -245,31 +245,31 @@ static inline yoga::Style convertRawProp(
       yogaStyle.padding());
 
   yogaStyle.setGap(
-      YGGutterRow,
+      yoga::Gutter::Row,
       convertRawProp(
           context,
           rawProps,
           "rowGap",
-          sourceValue.gap(YGGutterRow),
-          yogaStyle.gap(YGGutterRow)));
+          sourceValue.gap(yoga::Gutter::Row),
+          yogaStyle.gap(yoga::Gutter::Row)));
 
   yogaStyle.setGap(
-      YGGutterColumn,
+      yoga::Gutter::Column,
       convertRawProp(
           context,
           rawProps,
           "columnGap",
-          sourceValue.gap(YGGutterColumn),
-          yogaStyle.gap(YGGutterColumn)));
+          sourceValue.gap(yoga::Gutter::Column),
+          yogaStyle.gap(yoga::Gutter::Column)));
 
   yogaStyle.setGap(
-      YGGutterAll,
+      yoga::Gutter::All,
       convertRawProp(
           context,
           rawProps,
           "gap",
-          sourceValue.gap(YGGutterAll),
-          yogaStyle.gap(YGGutterAll)));
+          sourceValue.gap(yoga::Gutter::All),
+          yogaStyle.gap(yoga::Gutter::All)));
 
   yogaStyle.border() = convertRawProp(
       context,

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -635,11 +635,12 @@ void YGNodeStyleSetGap(
     const YGGutter gutter,
     const float gapLength) {
   auto length = CompactValue::ofMaybe<YGUnitPoint>(gapLength);
-  updateIndexedStyleProp<&Style::gap, &Style::setGap>(node, gutter, length);
+  updateIndexedStyleProp<&Style::gap, &Style::setGap>(
+      node, scopedEnum(gutter), length);
 }
 
 float YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
-  auto gapLength = resolveRef(node)->getStyle().gap(gutter);
+  auto gapLength = resolveRef(node)->getStyle().gap(scopedEnum(gutter));
   if (gapLength.isUndefined() || gapLength.isAuto()) {
     return YGUndefined;
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -177,11 +177,11 @@ void nodeToString(
     appendEdges(str, "padding", style.padding());
     appendEdges(str, "border", style.border());
 
-    if (!style.gap(YGGutterAll).isUndefined()) {
-      appendNumberIfNotUndefined(str, "gap", style.gap(YGGutterAll));
+    if (!style.gap(Gutter::All).isUndefined()) {
+      appendNumberIfNotUndefined(str, "gap", style.gap(Gutter::All));
     } else {
-      appendNumberIfNotUndefined(str, "column-gap", style.gap(YGGutterColumn));
-      appendNumberIfNotUndefined(str, "row-gap", style.gap(YGGutterRow));
+      appendNumberIfNotUndefined(str, "column-gap", style.gap(Gutter::Column));
+      appendNumberIfNotUndefined(str, "row-gap", style.gap(Gutter::Row));
     }
 
     appendNumberIfNotAuto(str, "width", style.dimension(Dimension::Width));

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -20,6 +20,7 @@
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Display.h>
 #include <yoga/enums/FlexDirection.h>
+#include <yoga/enums/Gutter.h>
 #include <yoga/enums/Justify.h>
 #include <yoga/enums/Overflow.h>
 #include <yoga/enums/PositionType.h>
@@ -36,7 +37,7 @@ class YG_EXPORT Style {
  public:
   using Dimensions = Values<Dimension>;
   using Edges = Values<YGEdge>;
-  using Gutters = Values<YGGutter>;
+  using Gutters = Values<Gutter>;
 
   static constexpr float DefaultFlexGrow = 0.0f;
   static constexpr float DefaultFlexShrink = 0.0f;
@@ -274,11 +275,11 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  CompactValue gap(YGGutter gutter) const {
-    return gap_[gutter];
+  CompactValue gap(Gutter gutter) const {
+    return gap_[yoga::to_underlying(gutter)];
   }
-  void setGap(YGGutter gutter, CompactValue value) {
-    gap_[gutter] = value;
+  void setGap(Gutter gutter, CompactValue value) {
+    gap_[yoga::to_underlying(gutter)] = value;
   }
 
   CompactValue dimension(Dimension axis) const {
@@ -311,18 +312,18 @@ class YG_EXPORT Style {
   }
 
   CompactValue resolveColumnGap() const {
-    if (!gap_[YGGutterColumn].isUndefined()) {
-      return gap_[YGGutterColumn];
+    if (!gap_[yoga::to_underlying(Gutter::Column)].isUndefined()) {
+      return gap_[yoga::to_underlying(Gutter::Column)];
     } else {
-      return gap_[YGGutterAll];
+      return gap_[yoga::to_underlying(Gutter::All)];
     }
   }
 
   CompactValue resolveRowGap() const {
-    if (!gap_[YGGutterRow].isUndefined()) {
-      return gap_[YGGutterRow];
+    if (!gap_[yoga::to_underlying(Gutter::Row)].isUndefined()) {
+      return gap_[yoga::to_underlying(Gutter::Row)];
     } else {
-      return gap_[YGGutterAll];
+      return gap_[yoga::to_underlying(Gutter::All)];
     }
   }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1407

Replaces internal usages of YGGutter with Gutter.

Changelog: [Internal]

Differential Revision: D49532100

