### PR TITLE
Make template pods resilient to changes to internal podspec

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -95,8 +95,8 @@ references:
     rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v6-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
 
     # Cocoapods - Template
-    template_cocoapods_cache_key: &template_cocoapods_cache_key v4-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
-    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v4-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    template_cocoapods_cache_key: &template_cocoapods_cache_key v4-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock }}
+    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v4-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock }}
 
     # Windows
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
## Summary:
With this small change, we are binding the cache for the template to the cache of RNTester.
This is helpful because, by default, templates don't have a Podfile.lock of their own. It is normal, as they are app created from the template and we don't enforce the initial 
lock of those dependencies.

However, this can cause some hassle when we bump some internal podspec as the cache that is restored in CI will be outdated.
With this change, the podfile.lock for RNTester is different --  we push it when we change the internal podspecs -- so the cache for the template will be invalidated too. 

## Changelog:
[Internal] - Invalidate Template caches when we bump internal podspecs

## Test Plan:
CircleCI is green
