### PR TITLE
Try to parametrize executors to use the min Xcode version for some jobs

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -79,6 +79,18 @@ commands:
         type: string
 
     steps:
+      - run:
+          name: Move to Node 18 if Needed
+          command: |
+            node_version=$(node -v)
+            major_version=$(echo $node_version | cut -c 2- | cut -d '.' -f 1)
+
+            if [[ $major_version < 18 ]]; then
+              nvm install 18.18.0
+              nvm alias default 18.18.0
+            else
+              echo 'We have the right node version!'
+            fi
       - restore_cache:
           keys:
             - << parameters.yarn_base_cache_key >>-{{ arch }}-{{ checksum "yarn.lock" }}

--- a/.circleci/configurations/executors.yml
+++ b/.circleci/configurations/executors.yml
@@ -36,3 +36,10 @@ executors:
     resource_class: macos.x86.medium.gen2
     environment:
       - BUILD_FROM_SOURCE: true
+  reactnativeios-lts:
+    <<: *defaults
+    macos:
+      xcode: '14.1.0'
+    resource_class: macos.x86.medium.gen2
+    environment:
+      - BUILD_FROM_SOURCE: true

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -386,7 +386,6 @@ jobs:
   #    JOBS: Test iOS Template
   # -------------------------
   test_ios_template:
-    executor: reactnativeios
     parameters:
       flavor:
         default: "Debug"
@@ -424,6 +423,11 @@ jobs:
       cocoapods_cache_key:
         type: string
         default: *template_cocoapods_cache_key
+      executor:
+        description: The executor to use
+        default: reactnativeios
+        type: string
+    executor: << parameters.executor >>
     environment:
       - PROJECT_NAME: "iOSTemplateProject"
       - HERMES_WS_DIR: *hermes_workspace_root
@@ -492,7 +496,7 @@ jobs:
   #    JOBS: Test iOS RNTester
   # -------------------------
   test_ios_rntester:
-    executor: reactnativeios
+
     parameters:
       jsengine:
         default: "Hermes"
@@ -517,6 +521,11 @@ jobs:
         description: whether unit tests should run or not.
         default: false
         type: boolean
+      executor:
+        description: The executor to use
+        default: reactnativeios
+        type: string
+    executor: << parameters.executor >>
     steps:
       - checkout_code_with_cache
       - run_yarn

--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -61,6 +61,7 @@
           ruby_version: "3.2.0"
           architecture: "NewArch"
           flavor: "Debug"
+          executor: reactnativeios-lts
       - test_ios_template:
           requires:
             - build_npm_package
@@ -82,6 +83,7 @@
           name: "Test RNTester with Ruby 3.2.0"
           ruby_version: "3.2.0"
           architecture: "NewArch"
+          executor: reactnativeios-lts
       - test_ios_rntester:
           requires:
             - build_hermes_macos

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -52,6 +52,7 @@
           ruby_version: "3.2.0"
           architecture: "NewArch"
           flavor: "Debug"
+          executor: reactnativeios-lts
       - test_ios_template:
           requires:
             - build_npm_package
@@ -73,6 +74,7 @@
           name: "Test RNTester with Ruby 3.2.0"
           ruby_version: "3.2.0"
           architecture: "NewArch"
+          executor: reactnativeios-lts
       - test_ios_rntester:
           requires:
             - build_hermes_macos

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -91,12 +91,12 @@ references:
     hermes_dsym_release_cache_key: &hermes_dsym_release_cache_key v1-hermes-release-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     # Cocoapods - RNTester
     pods_cache_key: &pods_cache_key v10-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
-    cocoapods_cache_key: &cocoapods_cache_key v9-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
-    rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v7-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    cocoapods_cache_key: &cocoapods_cache_key v10-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v8-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
 
     # Cocoapods - Template
-    template_cocoapods_cache_key: &template_cocoapods_cache_key v4-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
-    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v4-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
+    template_cocoapods_cache_key: &template_cocoapods_cache_key v5-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
+    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v5-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
 
     # Windows
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
## Summary:

App can be submitted to the app store by using Xcode 14.1 as min Xcode version.
Right now we are testing everything against the latests Xcode, but it would be good to have some tests to check that we don't break the flow for people stuck on older Xcodes.
We already had issues like these in the past, unfortunately.

Plus, we are making some changes using C++20 which we don't know whether they are properly supported by older versions of Xcode.
This change should give us confidence on those changes too.

## Changelog:
[Internal] - Use Xcode 14.1 for some tests

## Test Plan:
CircleCI is green
