### PR TITLE
Remove mTurboModuleManagerJSIModule from CatalystInstanceImpl

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -370,7 +370,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
                       public void run() {
                         // We need to destroy the TurboModuleManager on the JS Thread
                         if (mTurboModuleManagerJSIModule != null) {
-                          mTurboModuleManagerJSIModule.onCatalystInstanceDestroy();
+                          mTurboModuleManagerJSIModule.invalidate();
                         }
 
                         getReactQueueConfiguration()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -103,7 +103,6 @@ public class CatalystInstanceImpl implements CatalystInstance {
 
   private JavaScriptContextHolder mJavaScriptContextHolder;
   private volatile @Nullable TurboModuleRegistry mTurboModuleRegistry = null;
-  private @Nullable JSIModule mTurboModuleManagerJSIModule = null;
 
   // C++ parts
   private final HybridData mHybridData;
@@ -369,8 +368,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
                       @Override
                       public void run() {
                         // We need to destroy the TurboModuleManager on the JS Thread
-                        if (mTurboModuleManagerJSIModule != null) {
-                          mTurboModuleManagerJSIModule.invalidate();
+                        if (mTurboModuleRegistry != null) {
+                          mTurboModuleRegistry.invalidate();
                         }
 
                         getReactQueueConfiguration()
@@ -586,7 +585,6 @@ public class CatalystInstanceImpl implements CatalystInstance {
 
   public void setTurboModuleManager(JSIModule module) {
     mTurboModuleRegistry = (TurboModuleRegistry) module;
-    mTurboModuleManagerJSIModule = module;
   }
 
   private void decrementPendingJSCalls() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModule.java
@@ -18,5 +18,5 @@ public interface JSIModule {
   void initialize();
 
   /** Called before {CatalystInstance#onHostDestroy} */
-  void onCatalystInstanceDestroy();
+  void invalidate();
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModuleHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModuleHolder.java
@@ -31,7 +31,7 @@ public class JSIModuleHolder {
 
   public void notifyJSInstanceDestroy() {
     if (mModule != null) {
-      mModule.onCatalystInstanceDestroy();
+      mModule.invalidate();
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -411,7 +411,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   @Override
   @AnyThread
   @ThreadConfined(ANY)
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     FLog.i(TAG, "FabricUIManager.onCatalystInstanceDestroy");
 
     if (mDevToolsReactPerfLogger != null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -414,8 +414,8 @@ final class ReactInstance {
   /* package */ void destroy() {
     FLog.d(TAG, "ReactInstance.destroy() is called.");
     mQueueConfiguration.destroy();
-    mTurboModuleManager.onCatalystInstanceDestroy();
-    mFabricUIManager.onCatalystInstanceDestroy();
+    mTurboModuleManager.invalidate();
+    mFabricUIManager.invalidate();
     mHybridData.resetNative();
     mComponentNameResolverManager = null;
     mUIConstantsProviderManager = null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
@@ -423,7 +423,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
   public void initialize() {}
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     /*
      * Halt the production of new TurboModules.
      *

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.kt
@@ -34,4 +34,10 @@ interface TurboModuleRegistry {
    * NativeModules.
    */
   val eagerInitModuleNames: List<String>
+
+  /**
+   * Called during the turn down process of ReactHost. This method is called before React Native is
+   * stopped.
+   */
+  fun invalidate()
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -195,7 +195,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     super.onCatalystInstanceDestroy();
     mEventDispatcher.onCatalystInstanceDestroyed();
     mUIImplementation.onCatalystInstanceDestroyed();


### PR DESCRIPTION
Summary:
I'm removing mTurboModuleManagerJSIModule from CatalystInstanceImpl, as this is a duplicated variable.

changelog: [internal] internal

Reviewed By: christophpurrer

Differential Revision: D49483637

