### PR TITLE
[iOS] Don't load RCTRootViewIntegrationTestsApp.bundle in objc-test.sh

### DIFF
--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -108,7 +108,6 @@ xcbeautifyFormat() {
 preloadBundlesRNIntegrationTests() {
   # Preload IntegrationTests bundles (packages/rn-tester/)
   curl -s 'http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=ios&dev=true' -o /dev/null
-  curl -s 'http://localhost:8081/IntegrationTests/RCTRootViewIntegrationTestApp.bundle?platform=ios&dev=true' -o /dev/null
 }
 
 preloadBundlesRNTester() {


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/pull/38871/ removed all the RCTRootViewIntegrationTest stuff. Looks like we missed a line so I'm removing now.

## Changelog:

[INTERNAL] [FIXED] - Don't load RCTRootViewIntegrationTestsApp.bundle in objc-test.sh

## Test Plan:

CI should pass
