### PR TITLE
Fix crash "lateinit property initialProps has not been initialized"

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -31,7 +31,8 @@ class RNTesterActivity : ReactActivity() {
       super.onCreate(savedInstanceState)
     }
 
-    override fun getLaunchOptions() = initialProps
+    override fun getLaunchOptions() =
+        if (this::initialProps.isInitialized) initialProps else Bundle()
   }
 
   override fun createReactActivityDelegate() = RNTesterActivityDelegate(this, mainComponentName)


### PR DESCRIPTION
Summary:
Found a new [crash](P837035842) caused by converting RNTesterActivity to kotlin in D49506304

Changelog:
[Android][Changed] - fix crash "lateinit property initialProps has not been initialized"

Reviewed By: cortinico

Differential Revision: D49594073


