### PR TITLE
Set runtime config provider for the Template

### DIFF
--- a/packages/react-native/template/index.js
+++ b/packages/react-native/template/index.js
@@ -6,4 +6,13 @@ import {AppRegistry} from 'react-native';
 import App from './App';
 import {name as appName} from './app.json';
 
+if (global.RN$Bridgeless) {
+  require('react-native/Libraries/NativeComponent/NativeComponentRegistry').setRuntimeConfigProvider(
+    name => {
+      // In bridgeless mode, never load native ViewConfig.
+      return {native: false, strict: false, verify: false};
+    },
+  );
+}
+
 AppRegistry.registerComponent(appName, () => App);


### PR DESCRIPTION
Summary:
This diff sets runtime config provider for the template. It sets `native` to `false` to prioritize static view configs over native view configs.
Changelog: [Breaking] - Set runtime config provider for the Template.

Differential Revision: D49604628


