### PR TITLE
Remove deprecated automaticallyAdjustsScrollViewInsets

### DIFF
--- a/packages/react-native/React/Views/RCTWrapperViewController.m
+++ b/packages/react-native/React/Views/RCTWrapperViewController.m
@@ -29,7 +29,6 @@
 
   if ((self = [super initWithNibName:nil bundle:nil])) {
     _contentView = contentView;
-    self.automaticallyAdjustsScrollViewInsets = NO;
   }
   return self;
 }


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] - Removing usage of `automaticallyAdjustsScrollViewInsets`

Differential Revision: D49609523


