### PR TITLE
Update deprecated stringByAddingPercentEscapesUsingEncoding to NSCharacterSet

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
@@ -64,7 +64,8 @@ inline static NSURL *NSURLFromImageSource(const facebook::react::ImageSource &im
 
     if ([urlString rangeOfString:@":"].location != NSNotFound) {
       // The URL has a scheme.
-      urlString = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+      urlString =
+          [urlString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
       url = [NSURL URLWithString:urlString];
       return url;
     }


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] - Removing usage of stringByAddingPercentEscapesUsingEncoding

Per deprecation message:

> 'stringByAddingPercentEscapesUsingEncoding:' is deprecated: first deprecated in iOS 9.0 - Use -stringByAddingPercentEncodingWithAllowedCharacters: instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent since each URL component or subcomponent has different rules for what characters are valid.

Differential Revision: D49610243


