### PR TITLE
Reduce visibility of functions in ReactHostImpl

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -597,7 +597,8 @@ public class ReactHostImpl implements ReactHost {
     return null;
   }
 
-  public DefaultHardwareBackBtnHandler getDefaultBackButtonHandler() {
+  /* package */
+  DefaultHardwareBackBtnHandler getDefaultBackButtonHandler() {
     return () -> {
       UiThreadUtil.assertOnUiThread();
       if (mDefaultHardwareBackBtnHandler != null) {


### PR DESCRIPTION
Summary:
changelog: [internal] internal

Reducing visibility from public to package only for `ReactHostImpl.getDefaultHardwareBackBtnHandler()` since it's only used within package

Differential Revision: D49612859


