### PR TITLE
chore: fix grammar in Xcode 15 helper method name

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -165,7 +165,7 @@ class ReactNativePodsUtils
                 if self.is_using_xcode15_or_greater(:xcodebuild_manager => xcodebuild_manager)
                     self.add_value_to_setting_if_missing(config, other_ld_flags_key, xcode15_compatibility_flags)
                 else
-                    self.remove_value_to_setting_if_present(config, other_ld_flags_key, xcode15_compatibility_flags)
+                    self.remove_value_from_setting_if_present(config, other_ld_flags_key, xcode15_compatibility_flags)
                 end
             end
             project.save()
@@ -346,7 +346,7 @@ class ReactNativePodsUtils
         end
     end
 
-    def self.remove_value_to_setting_if_present(config, setting_name, value)
+    def self.remove_value_from_setting_if_present(config, setting_name, value)
         old_config = config.build_settings[setting_name]
         if old_config.include?(value)
             # Old config can be either an Array or a String


### PR DESCRIPTION
## Summary:

Thanks for working through Xcode 15 compatibility issues!

I reviewed the diff of the PR (#39474) that altered Xcode 15 settings for react-native release 0.72.5 and I noticed that

- everything looked great (worth saying)
- there was a grammatical error in another of the method names

Trivial errors but, as long as I was in there, thought I'd submit a PR

## Changelog:

[IOS] [FIXED] - fix grammar in Xcode 15 helper method name

## Test Plan:

CI should catch it of course, but in general I did a full grep for the name and changed everything / typical method name refactor
