### PR TITLE
Make hermesc build script to run in a clean build environment

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-hermesc-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermesc-xcode.sh
@@ -4,27 +4,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -x
+set -x -e
 
 hermesc_dir_path="$1"; shift
 jsi_path="$1"
 
 # This script is supposed to be executed from Xcode "run script" phase.
-# Xcode sets up its build environment based on the build target.
-# Here we override relevant envvars to make sure that we build hermesc for macosx,
-# even if Xcode build target is iphone, iponesimulator, etc.
-MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)
-export MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
+# Xcode sets up its build environment based on the build target (iphone, iphonesimulator, macodsx).
+# We want to make sure that hermesc is built for mac.
+# So we clean the environment with env -i, and explicitly set SDKROOT to macosx
 SDKROOT=$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-export SDKROOT=$SDKROOT
-
-if ! "$CMAKE_BINARY" -S "${PODS_ROOT}/hermes-engine" -B "$hermesc_dir_path" -DJSI_DIR="$jsi_path"
-then
-    echo "Failed to configure Hermesc cmake project."
-    exit 1
-fi
-if ! "$CMAKE_BINARY" --build "$hermesc_dir_path" --target hermesc -j "$(sysctl -n hw.ncpu)"
-then
-    echo "Failed to build Hermesc cmake project."
-    exit 1
-fi
+env -i SDKROOT="$SDKROOT" "$CMAKE_BINARY" -S "${PODS_ROOT}/hermes-engine" -B "$hermesc_dir_path" -DJSI_DIR="$jsi_path"
+env -i SDKROOT="$SDKROOT" "$CMAKE_BINARY" --build "$hermesc_dir_path" --target hermesc -j "$(sysctl -n hw.ncpu)"


### PR DESCRIPTION
Summary:
Hermesc is built with the build script that is executed by Xcode as a "Run script" build phase. For every build Xcode configures environment based on the build target. The Hermesc build script runs in that environment.

**The problem**
If we build for iPhone of iPhone Simulator, then the environment is configured for these platforms, but Hermesc must always be built for macosx.

**The old solution**
Previously we experimentally determined what envvars should be changed for Hermesc build to succeed. But it is not robust, because this may change with new Xcode releases.

**The new solution**
We clear the entire environment and only define `SDKROOT`. This is equivalent to running Cmake outside of Xcode.

Changelog: [Internal]

Differential Revision: D49639599


