### PR TITLE
Remove usage of Android API <23 in ReactActivityDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
+++ b/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
    up from the file to lint until it find an AndroidManifest with a minSdkVersion. This is then used
    as the min SDK to lint the file.-->
   <uses-sdk
-      android:minSdkVersion="21"
+      android:minSdkVersion="23"
       android:targetSdkVersion="34"
       />
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -7,12 +7,10 @@
 
 package com.facebook.react;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.annotation.Nullable;
@@ -204,7 +202,6 @@ public class ReactActivityDelegate {
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.M)
   public void requestPermissions(
       String[] permissions, int requestCode, PermissionListener listener) {
     mPermissionListener = listener;

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Android versions
-minSdk = "21"
+minSdk = "23"
 targetSdk = "34"
 compileSdk = "34"
 buildTools = "34.0.0"

--- a/packages/react-native/template/android/build.gradle
+++ b/packages/react-native/template/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 34
         targetSdkVersion = 34
         ndkVersion = "25.1.8937393"


### PR DESCRIPTION
Summary:
Since minSDK was bumped to Android API 23 we are removing support of code using Android API <23 in

chnagelog: [Android][Breaking] Remove support for Android API < 23 in

Reviewed By: NickGerleman

Differential Revision: D48545501

