### PR TITLE
Remove support for Android API < 23 in RequestBodyUtil

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
+++ b/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
    up from the file to lint until it find an AndroidManifest with a minSdkVersion. This is then used
    as the min SDK to lint the file.-->
   <uses-sdk
-      android:minSdkVersion="21"
+      android:minSdkVersion="23"
       android:targetSdkVersion="34"
       />
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -7,12 +7,10 @@
 
 package com.facebook.react;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.annotation.Nullable;
@@ -204,7 +202,6 @@ public class ReactActivityDelegate {
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.M)
   public void requestPermissions(
       String[] permissions, int requestCode, PermissionListener listener) {
     mPermissionListener = listener;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -7,10 +7,8 @@
 
 package com.facebook.react;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -161,13 +159,11 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     return getActivity().checkPermission(permission, pid, uid);
   }
 
-  @TargetApi(Build.VERSION_CODES.M)
   @Override
   public int checkSelfPermission(String permission) {
     return getActivity().checkSelfPermission(permission);
   }
 
-  @TargetApi(Build.VERSION_CODES.M)
   @Override
   public void requestPermissions(
       String[] permissions, int requestCode, PermissionListener listener) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -7,14 +7,12 @@
 
 package com.facebook.react.devsupport;
 
-import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.PixelFormat;
 import android.net.Uri;
-import android.os.Build;
 import android.provider.Settings;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
@@ -31,36 +29,26 @@ import com.facebook.react.common.ReactConstants;
 /* package */ class DebugOverlayController {
 
   public static void requestPermission(Context context) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      // Get permission to show debug overlay in dev builds.
-      if (!Settings.canDrawOverlays(context)) {
-        Intent intent =
-            new Intent(
-                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                Uri.parse("package:" + context.getPackageName()));
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        FLog.w(
-            ReactConstants.TAG,
-            "Overlay permissions needs to be granted in order for react native apps to run in dev mode");
-        if (canHandleIntent(context, intent)) {
-          context.startActivity(intent);
-        }
+    // Get permission to show debug overlay in dev builds.
+    if (!Settings.canDrawOverlays(context)) {
+      Intent intent =
+          new Intent(
+              Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+              Uri.parse("package:" + context.getPackageName()));
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      FLog.w(
+          ReactConstants.TAG,
+          "Overlay permissions needs to be granted in order for react native apps to run in dev mode");
+      if (canHandleIntent(context, intent)) {
+        context.startActivity(intent);
       }
     }
   }
 
   private static boolean permissionCheck(Context context) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      // Get permission to show debug overlay in dev builds.
-      if (!Settings.canDrawOverlays(context)) {
-        // overlay permission not yet granted
-        return false;
-      } else {
-        return true;
-      }
-    }
-    // on pre-M devices permission needs to be specified in manifest
-    return hasPermission(context, Manifest.permission.SYSTEM_ALERT_WINDOW);
+    // Get permission to show debug overlay in dev builds.
+    // overlay permission not yet granted
+    return Settings.canDrawOverlays(context);
   }
 
   private static boolean hasPermission(Context context, String permission) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/WindowOverlayCompat.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/WindowOverlayCompat.java
@@ -16,15 +16,10 @@ import android.view.WindowManager;
  */
 /* package */ class WindowOverlayCompat {
 
-  private static final int ANDROID_OREO = 26;
   private static final int TYPE_APPLICATION_OVERLAY = 2038;
 
-  static final int TYPE_SYSTEM_ALERT =
-      Build.VERSION.SDK_INT < ANDROID_OREO
-          ? WindowManager.LayoutParams.TYPE_SYSTEM_ALERT
-          : TYPE_APPLICATION_OVERLAY;
   static final int TYPE_SYSTEM_OVERLAY =
-      Build.VERSION.SDK_INT < ANDROID_OREO
+      Build.VERSION.SDK_INT < Build.VERSION_CODES.O
           ? WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY
           : TYPE_APPLICATION_OVERLAY;
 }

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Android versions
-minSdk = "21"
+minSdk = "23"
 targetSdk = "34"
 compileSdk = "34"
 buildTools = "34.0.0"

--- a/packages/react-native/template/android/build.gradle
+++ b/packages/react-native/template/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 34
         targetSdkVersion = 34
         ndkVersion = "25.1.8937393"


### PR DESCRIPTION
Summary:
Since minsdk version was increased to 23, we are deleting code using Android APIs < 23 for class RequestBodyUtil

chnagelog: [Android][Breaking] Remove support for Android API < 23 in RequestBodyUtil

Reviewed By: NickGerleman

Differential Revision: D48545515

