### PR TITLE
Remove support for Android API < 23 in ReactTextAnchorViewManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.text;
 
-import android.annotation.TargetApi;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Build;
@@ -50,7 +49,6 @@ import java.util.Map;
  * <p>This also node calculates {@link Spannable} object based on subnodes of the same type, which
  * can be used in concrete classes to feed native views and compute layout.
  */
-@TargetApi(Build.VERSION_CODES.M)
 public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
   // Use a direction weak character so the placeholder doesn't change the direction of the previous
@@ -75,9 +73,9 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       ReactBaseTextShadowNode textShadowNode,
       SpannableStringBuilder sb,
       List<SetSpanOperation> ops,
-      TextAttributes parentTextAttributes,
+      @Nullable TextAttributes parentTextAttributes,
       boolean supportsInlineViews,
-      Map<Integer, ReactShadowNode> inlineViews,
+      @Nullable Map<Integer, ReactShadowNode> inlineViews,
       int start) {
 
     TextAttributes textAttributes;
@@ -226,7 +224,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   // `nativeViewHierarchyOptimizer` can be `null` as long as `supportsInlineViews` is `false`.
   protected Spannable spannedFromShadowNode(
       ReactBaseTextShadowNode textShadowNode,
-      String text,
+      @Nullable String text,
       boolean supportsInlineViews,
       NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer) {
     Assertions.assertCondition(
@@ -240,8 +238,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
     // up-to-bottom, otherwise all the spannables that are within the region for which one may set
     // a new spannable will be wiped out
     List<SetSpanOperation> ops = new ArrayList<>();
-    Map<Integer, ReactShadowNode> inlineViews =
-        supportsInlineViews ? new HashMap<Integer, ReactShadowNode>() : null;
+    Map<Integer, ReactShadowNode> inlineViews = supportsInlineViews ? new HashMap<>() : null;
 
     if (text != null) {
       // Handle text that is provided via a prop (e.g. the `value` and `defaultValue` props on
@@ -312,10 +309,8 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
   protected int mNumberOfLines = UNSET;
   protected int mTextAlign = Gravity.NO_GRAVITY;
-  protected int mTextBreakStrategy =
-      (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? 0 : Layout.BREAK_STRATEGY_HIGH_QUALITY;
-  protected int mHyphenationFrequency =
-      (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? 0 : Layout.HYPHENATION_FREQUENCY_NONE;
+  protected int mTextBreakStrategy = Layout.BREAK_STRATEGY_HIGH_QUALITY;
+  protected int mHyphenationFrequency = Layout.HYPHENATION_FREQUENCY_NONE;
   protected int mJustificationMode =
       (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE;
 
@@ -554,10 +549,6 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
   @ReactProp(name = ViewProps.TEXT_BREAK_STRATEGY)
   public void setTextBreakStrategy(@Nullable String textBreakStrategy) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-      return;
-    }
-
     if (textBreakStrategy == null || "highQuality".equals(textBreakStrategy)) {
       mTextBreakStrategy = Layout.BREAK_STRATEGY_HIGH_QUALITY;
     } else if ("simple".equals(textBreakStrategy)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.text;
 
-import android.os.Build;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.TextUtils;
@@ -118,10 +117,6 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
 
   @ReactProp(name = "android_hyphenationFrequency")
   public void setAndroidHyphenationFrequency(ReactTextView view, @Nullable String frequency) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-      FLog.w(TAG, "android_hyphenationFrequency only available since android 23");
-      return;
-    }
     if (frequency == null || frequency.equals("none")) {
       view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
     } else if (frequency.equals("full")) {


### PR DESCRIPTION
Summary:
Since minsdk version was increased to 23, we are deleting code using Android APIs < 23 for class ReactTextAnchorViewManager

chnagelog: [Android][Breaking] Remove support for Android API < 23 in ReactTextAnchorViewManager

Reviewed By: NickGerleman

Differential Revision: D48545519

