### PR TITLE
Enable TurboModule interop in Bridgeless Mode

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -89,6 +89,11 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 #if RCT_NEW_ARCH_ENABLED
     // Enable native view config interop only if both bridgeless mode and Fabric is enabled.
     RCTSetUseNativeViewConfigsInBridgelessMode([self fabricEnabled]);
+
+    // Enable TurboModule interop by default in Bridgeless mode
+    RCTEnableTurboModuleInterop(YES);
+    RCTEnableTurboModuleInteropBridgeProxy(YES);
+
     [self createReactHost];
     [self unstable_registerLegacyComponents];
     [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -35,6 +35,7 @@ object DefaultNewArchitectureEntryPoint {
     ReactFeatureFlags.unstable_useFabricInterop = fabricEnabled
     ReactFeatureFlags.enableBridgelessArchitecture = bridgelessEnabled
     ReactFeatureFlags.useNativeViewConfigsInBridgelessMode = fabricEnabled && bridgelessEnabled
+    ReactFeatureFlags.unstable_useTurboModuleInterop = bridgelessEnabled
 
     this.privateFabricEnabled = fabricEnabled
     this.privateTurboModulesEnabled = turboModulesEnabled


### PR DESCRIPTION
Summary:
Bridgeless mode is releasing in 0.73.

Bridgeless mode isn't stable inside RNTester (in 0.73) without the TurboModule interop layer: T164853040.

**Changes:** Enable the TurboModule interop layer in RNTester (Bridgeless Mode).

**Urgency:** This will unblock the 0.73.

Changelog: [General][Added] - Enable TurboModule interop in Bridgeless mode

Reviewed By: fkgozali, dmytrorykun, luluwu2032

Differential Revision: D49653919


