### PR TITLE
Fix and re-introduce interop test

### DIFF
--- a/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
@@ -86,7 +86,7 @@ class SampleLegacyModuleExample extends React.Component<{||}, State> {
           getNSNumber: () => getSampleLegacyModule()?.getNSNumber(20.0),
           getUnsafeObject: () =>
             getSampleLegacyModule()?.getObject({a: 1, b: 'foo', c: null}),
-          getRootTag: () => getSampleLegacyModule()?.getRootTag(this.context),
+          getRootTag: () => getSampleLegacyModule()?.getRootTag(11),
           getValue: () =>
             getSampleLegacyModule()?.getValue(5, 'test', {a: 1, b: 'foo'}),
           callback: () =>


### PR DESCRIPTION
Summary:
This diff re-introduces the test for the TurboModule interop layer.

This test was originally reverted in D49200360, because it was broken.

***New:*** This test runs in Bridgeless mode, with the interop layer enabled. (Catalyst is now native mobileconfig ready).

Changelog: [Internal]

Reviewed By: makovkastar

Differential Revision: D49208528

