### PR TITLE
Export Commands and Constants only if native view config interop is enabled

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -1489,9 +1489,10 @@ NSMutableDictionary<NSString *, id> *RCTModuleConstantsForDestructuredComponent(
   // lazifyViewManagerConfig function in JS. This fuction uses NativeModules global object that is not available in the
   // New Architecture. To make native view configs work in the New Architecture we will populate these properties in
   // native.
-  moduleConstants[@"Commands"] = viewConfig[@"Commands"];
-  moduleConstants[@"Constants"] = viewConfig[@"Constants"];
-
+  if (RCTGetUseNativeViewConfigsInBridgelessMode()) {
+    moduleConstants[@"Commands"] = viewConfig[@"Commands"];
+    moduleConstants[@"Constants"] = viewConfig[@"Constants"];
+  }
   // Add direct events
   for (NSString *eventName in viewConfig[@"directEvents"]) {
     if (!directEvents[eventName]) {

--- a/packages/react-native/React/Views/RCTComponentData.m
+++ b/packages/react-native/React/Views/RCTComponentData.m
@@ -480,11 +480,6 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
     }
   }
 
-  NSDictionary<NSString *, NSNumber *> *commands = [self commandsForViewMangerClass:managerClass
-                                                                            methods:methods
-                                                                        methodCount:count];
-  free(methods);
-
 #if RCT_DEBUG
   for (NSString *event in bubblingEvents) {
     if ([directEvents containsObject:event]) {
@@ -499,15 +494,22 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
 
   Class superClass = [managerClass superclass];
 
-  return @{
+  NSMutableDictionary *result = [[NSMutableDictionary alloc] initWithDictionary:@{
     @"propTypes" : propTypes,
     @"directEvents" : directEvents,
     @"bubblingEvents" : bubblingEvents,
     @"capturingEvents" : capturingEvents,
     @"baseModuleName" : superClass == [NSObject class] ? (id)kCFNull : RCTViewManagerModuleNameForClass(superClass),
-    @"Commands" : commands,
-    @"Constants" : [self constantsForViewMangerClass:managerClass],
-  };
+  }];
+
+  if (RCTGetUseNativeViewConfigsInBridgelessMode()) {
+    result[@"Commands"] = [self commandsForViewMangerClass:managerClass methods:methods methodCount:count];
+    result[@"Constants"] = [self constantsForViewMangerClass:managerClass];
+  }
+
+  free(methods);
+
+  return result;
 }
 
 - (NSDictionary<NSString *, id> *)viewConfig


### PR DESCRIPTION
Summary:
`Commands` and `Constants` should be set in native only if component data is instantiated via native view config interop layer.
Changelog: [Internal]

Differential Revision: D49684166


