### PR TITLE
[0.73] Hotfix: Remove node engines constraint for normalize-color

### DIFF
--- a/packages/normalize-color/package.json
+++ b/packages/normalize-color/package.json
@@ -15,8 +15,5 @@
     "normalize-colors",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
-  "engines": {
-    "node": ">=18"
-  }
+  "bugs": "https://github.com/facebook/react-native/issues"
 }


### PR DESCRIPTION
Intends to resolve #39692 once published.

We believe this bug is caused by a `"*"` version specifier for the `@react-native/normalize-color` package inside the `deprecated-react-native-prop-types` dependency.

https://github.com/facebook/react-native-deprecated-modules/blob/b34e786d1566d8ef2459875d51388d0e6b1ac399/deprecated-react-native-prop-types/package.json#L8

**Changes**

- Fixes the above issue in `@react-native/normalize-color`.
    - This **removes** the `"node": ">=18"` `engines` constraint. This is to be as lenient as possible for this hotfix, where the Node version should already be suitably constrained by other deps in a 0.72 project. (We will restore this constraint if/when we align versioning in `deprecated-react-native-prop-types` — or remove this package from the dependency tree.)

When this is merged, we will publish a new release of `normalize-color`, which should fix new 0.72 installations.

Changelog: [Internal]