### PR TITLE
Update 'cannot calculate shadow efficiently' log message

### DIFF
--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -883,7 +883,7 @@ static void RCTUpdateShadowPathForView(RCTView *view)
 
       RCTLogAdvice(
           @"View #%@ of type %@ has a shadow set but cannot calculate "
-           "shadow efficiently. Consider setting a background color to "
+           "shadow efficiently. Consider setting a solid background color to "
            "fix this, or apply the shadow to a more specific component.",
           view.reactTag,
           [view class]);


### PR DESCRIPTION
## Summary:

While working in an app I kept getting these `View X of type Y has a shadow set but cannot calculate shadow efficiently. Consider setting a background color to fix this` warnings even though I had added a background color to that view. Upon inspecting RCTView.m I notice that what is actually required to fix this is a solid background 

To make this a bit clearer to developers I believe we should update this log message to explicitly say "solid background" instead of "background" 

## Changelog:

[IOS] [CHANGED] - Update 'cannot calculate shadow efficiently' log message to explicitly say solid background 

 

## Test Plan:

N / A