### PR TITLE
Default to native view configs in bridged mode and to static view configs in bridgeless mode

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
+++ b/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
@@ -55,14 +55,20 @@ export function get<Config>(
 ): HostComponent<Config> {
   ReactNativeViewConfigRegistry.register(name, () => {
     const {native, strict, verify} = getRuntimeConfig?.(name) ?? {
-      native: true,
+      native: !global.RN$Bridgeless,
       strict: false,
       verify: false,
     };
 
-    const viewConfig = native
-      ? getNativeComponentAttributes(name)
-      : createViewConfig(viewConfigProvider());
+    let viewConfig;
+    if (native) {
+      viewConfig = getNativeComponentAttributes(name);
+    } else {
+      viewConfig = createViewConfig(viewConfigProvider());
+      if (viewConfig == null) {
+        viewConfig = getNativeComponentAttributes(name);
+      }
+    }
 
     if (verify) {
       const nativeViewConfig = native

--- a/packages/react-native/template/index.js
+++ b/packages/react-native/template/index.js
@@ -6,13 +6,4 @@ import {AppRegistry} from 'react-native';
 import App from './App';
 import {name as appName} from './app.json';
 
-if (global.RN$Bridgeless) {
-  require('react-native/Libraries/NativeComponent/NativeComponentRegistry').setRuntimeConfigProvider(
-    name => {
-      // In bridgeless mode, never load native ViewConfig.
-      return {native: false, strict: false, verify: false};
-    },
-  );
-}
-
 AppRegistry.registerComponent(appName, () => App);

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -29,15 +29,6 @@ import {BackHandler, StyleSheet, View, useColorScheme} from 'react-native';
 
 // RNTester App currently uses in memory storage for storing navigation state
 
-if (global.RN$Bridgeless) {
-  require('react-native/Libraries/NativeComponent/NativeComponentRegistry').setRuntimeConfigProvider(
-    name => {
-      // In bridgeless mode, never load native ViewConfig.
-      return {native: false, strict: false, verify: false};
-    },
-  );
-}
-
 const RNTesterApp = (): React.Node => {
   const [state, dispatch] = React.useReducer(
     RNTesterNavigationReducer,


### PR DESCRIPTION
Summary:
Default to native view configs in bridged mode and to static view configs in bridgeless mode.
Remove `setRuntimeConfigProvider` calls from RNTester and from the Template.
Changelog: [Internal]

Reviewed By: RSNara

Differential Revision: D49687252


