### PR TITLE
Docs update: PixelRatio.getFontScale

### DIFF
--- a/packages/react-native/Libraries/Utilities/PixelRatio.d.ts
+++ b/packages/react-native/Libraries/Utilities/PixelRatio.d.ts
@@ -32,11 +32,11 @@ export interface PixelRatioStatic {
           used to calculate the absolute font size, so any elements that
           heavily depend on that should use this to do calculations.
 
-          If a font scale is not set, this returns the device pixel ratio.
+          * on Android value reflects the user preference set in Settings > Display > Font size
+          * on iOS value reflects the user preference set in Settings > Display & Brightness > Text Size,
+            value can also be updated in Settings > Accessibility > Display & Text Size > Larger Text
 
-          Currently this is only implemented on Android and reflects the user
-          preference set in Settings > Display > Font size,
-          on iOS it will always return the default pixel ratio.
+          If a font scale is not set, this returns the device pixel ratio.
           */
   getFontScale(): number;
 


### PR DESCRIPTION
## Summary:

Addresses this issue: https://github.com/facebook/react-native/issues/39708

The embedded docs for `PixelRatio.getFontScale` haven't been updated in a while and it is still claiming lack of support for iOS when this is not the reality anymore. This was confusing for me when looking for docs through my local workspace.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[INTERNAL] [CHANGED] - Updated PixelRatio.getFontScale docs to match the latest website

## Test Plan:

N/A
