### PR TITLE
Update Xcode 15 patches to be more robust

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -613,7 +613,7 @@ class UtilsTests < Test::Unit::TestCase
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal("$(inherited) -Wl -ld_classic ", config.build_settings["OTHER_LDFLAGS"])
+            assert_equal("$(inherited) -Wl -ld_classic", config.build_settings["OTHER_LDFLAGS"])
         end
 
         # User project and Pods project
@@ -662,7 +662,7 @@ class UtilsTests < Test::Unit::TestCase
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal("$(inherited) ", config.build_settings["OTHER_LDFLAGS"])
+            assert_equal("$(inherited)", config.build_settings["OTHER_LDFLAGS"])
         end
 
         # User project and Pods project

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -76,7 +76,7 @@ class ReactNativePodsUtils
                     excluded_archs_includes_I386 = current_setting.include?("i386")
 
                     if !excluded_archs_includes_I386
-                        # Hermes does not support `i386` architecture
+                        # Hermes does not support 'i386' architecture
                         config.build_settings[key] = "#{current_setting} i386".strip
                     end
                 end
@@ -341,20 +341,26 @@ class ReactNativePodsUtils
 
     def self.add_value_to_setting_if_missing(config, setting_name, value)
         old_config = config.build_settings[setting_name]
-        if !old_config.include?(value)
-            config.build_settings[setting_name] << value
+        if old_config.is_a?(Array)
+            old_config = old_config.join(" ")
+        end
+
+        trimmed_value = value.strip()
+        if !old_config.include?(trimmed_value)
+            config.build_settings[setting_name] = "#{old_config.strip()} #{trimmed_value}".strip()
         end
     end
 
     def self.remove_value_from_setting_if_present(config, setting_name, value)
         old_config = config.build_settings[setting_name]
-        if old_config.include?(value)
-            # Old config can be either an Array or a String
-            if old_config.is_a?(Array)
-                old_config = old_config.join(" ")
-            end
-            new_config = old_config.gsub(value,  "")
-            config.build_settings[setting_name] = new_config
+        if old_config.is_a?(Array)
+            old_config = old_config.join(" ")
+        end
+
+        trimmed_value = value.strip()
+        if old_config.include?(trimmed_value)
+            new_config = old_config.gsub(trimmed_value,  "")
+            config.build_settings[setting_name] = new_config.strip()
         end
     end
 


### PR DESCRIPTION
Summary:
Last week Apple released Xcode 15, which required us to ship a workaround for the new linker.
Unfortunately, the previous fix was not good enough and there were some edge cases that were not covered.
For example, in some occasions the flags are read as an array and the `-Wl` and the `-ld_classic` flags were separated and not properly removed when moving from Xcode 15 to Xcpde 14.3.1.

This change fixes those edge cases, with a more robust solution where:
- We convert the flags to a string.
- We trim the string and the values properly.
- We add the flags when running `pod install` with Xcode 15 as the default iOS toolchain.
- We remove the flags when running `pod install` with Xcode <15 as the default iOS toolchain.

## Changelog:
[Internal] - Make the Xcode 15 workaround more robust.

Differential Revision: D49748844

