### PR TITLE
Catch NullPointerException for `onRequestPermissionsResult`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
@@ -172,10 +172,16 @@ public class PermissionsModule extends NativePermissionsAndroidSpec implements P
   public boolean onRequestPermissionsResult(
       int requestCode, String[] permissions, int[] grantResults) {
     try {
-      mCallbacks.get(requestCode).invoke(grantResults, getPermissionAwareActivity());
-      mCallbacks.remove(requestCode);
+      Callback callback = mCallbacks.get(requestCode);
+      if (callback != null) {
+        callback.invoke(grantResults, getPermissionAwareActivity());
+        mCallbacks.remove(requestCode);
+      } else {
+        String message = "Unable to find callback with requestCode:" + requestCode;
+        FLog.w("PermissionsModule", message);
+      }
       return mCallbacks.size() == 0;
-    } catch (IllegalStateException | NullPointerException e) {
+    } catch (IllegalStateException e) {
       FLog.e(
           "PermissionsModule",
           e,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
@@ -175,7 +175,7 @@ public class PermissionsModule extends NativePermissionsAndroidSpec implements P
       mCallbacks.get(requestCode).invoke(grantResults, getPermissionAwareActivity());
       mCallbacks.remove(requestCode);
       return mCallbacks.size() == 0;
-    } catch (IllegalStateException e) {
+    } catch (IllegalStateException | NullPointerException e) {
       FLog.e(
           "PermissionsModule",
           e,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
@@ -177,8 +177,7 @@ public class PermissionsModule extends NativePermissionsAndroidSpec implements P
         callback.invoke(grantResults, getPermissionAwareActivity());
         mCallbacks.remove(requestCode);
       } else {
-        String message = "Unable to find callback with requestCode:" + requestCode;
-        FLog.w("PermissionsModule", message);
+        FLog.w("PermissionsModule", "Unable to find callback with requestCode %d", requestCode);
       }
       return mCallbacks.size() == 0;
     } catch (IllegalStateException e) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
On Android 13 Devices, we are seeing `NullPointerException`, which should be handled with this

## Changelog:

[ANDROID] [FIXED] - Handle Crash for onRequestPermissionsResult


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
