### PR TITLE
Reduce visibility of CanvasUtil

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/CanvasUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/CanvasUtil.java
@@ -19,7 +19,8 @@ import javax.annotation.Nullable;
  * href="https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-graphics/src/androidMain/kotlin/androidx/compose/ui/graphics/CanvasUtils.android.kt;drc=3b2dde134afab8d58b9c39ad4820eaf9a6e014a9">
  * Compose canvas utils </a>
  */
-public class CanvasUtil {
+class CanvasUtil {
+
   private CanvasUtil() {}
 
   private @Nullable static Method mReorderBarrierMethod = null;


### PR DESCRIPTION
Summary:
In an attempt to reduce footprint of React Native Android public APIs we are reducing visibility of classes and interfaces that are not meant to be used publicly OR are public but have no usages.
As part of our analysis, which involved looking for usages inside the Meta codebase and code search in OSS, we've detected that this class/interface is public but it's not used from other packages.

If you are using this class or interface please comment in this PR and we will restate the public access.

changelog: [Android][Changed] Reducing visibility of CanvasUtil

Reviewed By: RSNara

Differential Revision: D49752146


