### PR TITLE
Reduce visibility of ReactTextInputKeyPressEvent

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/EagerModuleProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/EagerModuleProvider.java
@@ -11,7 +11,7 @@ import com.facebook.react.bridge.NativeModule;
 import javax.inject.Provider;
 
 /** Provider for an already initialized and non-lazy NativeModule. */
-public class EagerModuleProvider implements Provider<NativeModule> {
+class EagerModuleProvider implements Provider<NativeModule> {
 
   private final NativeModule mModule;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -15,7 +15,7 @@ import com.facebook.react.common.MapBuilder;
 import java.util.Map;
 
 /** Responsible for dispatching events specific for hardware inputs. */
-public class ReactAndroidHWInputDeviceHelper {
+class ReactAndroidHWInputDeviceHelper {
 
   /**
    * Contains a mapping between handled KeyEvents and the corresponding navigation event that should

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputKeyPressEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputKeyPressEvent.java
@@ -14,7 +14,7 @@ import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by EditText native view when key pressed */
-public class ReactTextInputKeyPressEvent extends Event<ReactTextInputEvent> {
+class ReactTextInputKeyPressEvent extends Event<ReactTextInputEvent> {
 
   public static final String EVENT_NAME = "topKeyPress";
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/CanvasUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/CanvasUtil.java
@@ -19,7 +19,8 @@ import javax.annotation.Nullable;
  * href="https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-graphics/src/androidMain/kotlin/androidx/compose/ui/graphics/CanvasUtils.android.kt;drc=3b2dde134afab8d58b9c39ad4820eaf9a6e014a9">
  * Compose canvas utils </a>
  */
-public class CanvasUtil {
+class CanvasUtil {
+
   private CanvasUtil() {}
 
   private @Nullable static Method mReorderBarrierMethod = null;


### PR DESCRIPTION
Summary:
In an attempt to reduce footprint of React Native Android public APIs we are reducing visibility of classes and interfaces that are not meant to be used publicly OR are public but have no usages.
As part of our analysis, which involved looking for usages inside the Meta codebase and code search in OSS, we've detected that this class/interface is public but it's not used from other packages.

If you are using this class or interface please comment in this PR and we will restate the public access.

changelog: [Android][Changed] Reducing visibility of ReactTextInputKeyPressEvent

Reviewed By: RSNara

Differential Revision: D49752135

