### PR TITLE
Reduce visibility of DynamicFromMap

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromArray.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromArray.java
@@ -11,7 +11,7 @@ import androidx.annotation.Nullable;
 import androidx.core.util.Pools;
 
 /** Implementation of Dynamic wrapping a ReadableArray. */
-public class DynamicFromArray implements Dynamic {
+class DynamicFromArray implements Dynamic {
   private static final Pools.SimplePool<DynamicFromArray> sPool = new Pools.SimplePool<>(10);
 
   private @Nullable ReadableArray mArray;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
@@ -11,7 +11,7 @@ import androidx.annotation.Nullable;
 import androidx.core.util.Pools.SimplePool;
 
 /** Implementation of Dynamic wrapping a ReadableMap. */
-public class DynamicFromMap implements Dynamic {
+class DynamicFromMap implements Dynamic {
   private static final ThreadLocal<SimplePool<DynamicFromMap>> sPool =
       new ThreadLocal<SimplePool<DynamicFromMap>>() {
         @Override


### PR DESCRIPTION
Summary:
In an attempt to reduce footprint of React Native Android public APIs we are reducing visibility of classes and interfaces that are not meant to be used publicly OR are public but have no usages.
As part of our analysis, which involved looking for usages inside the Meta codebase and code search in OSS, we've detected that this class/interface is public but it's not used from other packages.

If you are using this class or interface please comment in this PR and we will restate the public access.

changelog: [Android][Changed] Reducing visibility of DynamicFromMap

Reviewed By: RSNara

Differential Revision: D49752137

