### PR TITLE
Reduce visibility of NativeArrayInterface

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromArray.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromArray.java
@@ -11,7 +11,7 @@ import androidx.annotation.Nullable;
 import androidx.core.util.Pools;
 
 /** Implementation of Dynamic wrapping a ReadableArray. */
-public class DynamicFromArray implements Dynamic {
+class DynamicFromArray implements Dynamic {
   private static final Pools.SimplePool<DynamicFromArray> sPool = new Pools.SimplePool<>(10);
 
   private @Nullable ReadableArray mArray;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
@@ -11,7 +11,7 @@ import androidx.annotation.Nullable;
 import androidx.core.util.Pools.SimplePool;
 
 /** Implementation of Dynamic wrapping a ReadableMap. */
-public class DynamicFromMap implements Dynamic {
+class DynamicFromMap implements Dynamic {
   private static final ThreadLocal<SimplePool<DynamicFromMap>> sPool =
       new ThreadLocal<SimplePool<DynamicFromMap>>() {
         @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutorFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutorFactory.java
@@ -9,7 +9,7 @@ package com.facebook.react.bridge;
 
 /** @deprecated use {@link com.facebook.react.jscexecutor.JSCExecutorFactory} instead. */
 @Deprecated
-public class JSCJavaScriptExecutorFactory implements JavaScriptExecutorFactory {
+class JSCJavaScriptExecutorFactory implements JavaScriptExecutorFactory {
   private final String mAppName;
   private final String mDeviceName;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModuleHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModuleHolder.java
@@ -7,7 +7,7 @@
 
 package com.facebook.react.bridge;
 
-public class JSIModuleHolder {
+class JSIModuleHolder {
 
   private JSIModule mModule;
   private final JSIModuleSpec mSpec;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModuleRegistry.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class JSIModuleRegistry {
+class JSIModuleRegistry {
 
   private final Map<JSIModuleType, JSIModuleHolder> mModules = new HashMap<>();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSInstance.java
@@ -11,7 +11,7 @@ package com.facebook.react.bridge;
  * This interface includes the methods needed to use a running JS instance, without specifying any
  * of the bridge-specific initialization or lifecycle management.
  */
-public interface JSInstance {
+interface JSInstance {
   void invokeCallback(int callbackID, NativeArrayInterface arguments);
   // TODO if this interface survives refactoring, think about adding
   // callFunction.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArgumentsParseException.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArgumentsParseException.java
@@ -10,7 +10,7 @@ package com.facebook.react.bridge;
 import androidx.annotation.Nullable;
 
 /** Exception thrown when a native module method call receives unexpected arguments from JS. */
-public class NativeArgumentsParseException extends JSApplicationCausedNativeException {
+class NativeArgumentsParseException extends JSApplicationCausedNativeException {
 
   public NativeArgumentsParseException(String detailMessage) {
     super(detailMessage);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArrayInterface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArrayInterface.java
@@ -7,7 +7,7 @@
 
 package com.facebook.react.bridge;
 
-public interface NativeArrayInterface {
+interface NativeArrayInterface {
   @Override
   String toString();
 }


### PR DESCRIPTION
Summary:
In an attempt to reduce footprint of React Native Android public APIs we are reducing visibility of classes and interfaces that are not meant to be used publicly OR are public but have no usages.
As part of our analysis, which involved looking for usages inside the Meta codebase and code search in OSS, we've detected that this class/interface is public but it's not used from other packages.

If you are using this class or interface please comment in this PR and we will restate the public access.

changelog: [Android][Changed] Reducing visibility of NativeArrayInterface

Reviewed By: arushikesarwani94

Differential Revision: D49803296

