### PR TITLE
Reduce visibility of Systrace

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Systrace.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Systrace.java
@@ -11,7 +11,8 @@ import com.facebook.proguard.annotations.DoNotStrip;
 
 /** Interface to the JavaScript Systrace Module */
 @DoNotStrip
-public interface Systrace extends JavaScriptModule {
+interface Systrace extends JavaScriptModule {
+
   @DoNotStrip
   void setEnabled(boolean enabled);
 }


### PR DESCRIPTION
Summary:
In an attempt to reduce footprint of React Native Android public APIs we are reducing visibility of classes and interfaces that are not meant to be used publicly OR are public but have no usages.
As part of our analysis, which involved looking for usages inside the Meta codebase and code search in OSS, we've detected that this class/interface is public but it's not used from other packages.

If you are using this class or interface please comment in this PR and we will restate the public access.

changelog: [Android][Changed] Reducing visibility of Systrace

Reviewed By: arushikesarwani94

Differential Revision: D49803267

