### PR TITLE
Mark initHybrid as @JvmStatic

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
@@ -31,6 +31,6 @@ class JSCExecutor internal constructor(jscConfig: ReadableNativeMap) :
       SoLoader.loadLibrary("jscexecutor")
     }
 
-    private external fun initHybrid(jscConfig: ReadableNativeMap): HybridData?
+    @JvmStatic private external fun initHybrid(jscConfig: ReadableNativeMap): HybridData?
   }
 }


### PR DESCRIPTION
Summary:
The goal of this diff is to fix:
```
JNI DETECTED ERROR IN APPLICATION: JNI NewGlobalRef called with pending exception java.lang.NoSuchMethodError: no static or non-static method
"Lcom/facebook/react/jscexecutor/JSCExecutor;.initHybrid(Lcom/facebook/react/bridge/ReadableNativeMap;)Lcom/facebook/jni/HybridData;"

```

changelog: [internal] internal

Reviewed By: luluwu2032

Differential Revision: D49831595


