### PR TITLE
Set hermes for Android template project in testing

### DIFF
--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -252,6 +252,16 @@ async function testRNTestProject(circleCIArtifacts) {
     `echo "react.internal.mavenLocalRepo=${mavenLocalPath}" >> android/gradle.properties`,
   );
 
+  // Update gradle properties to set Hermes as false
+  if (!argv.hermes) {
+    sed(
+      '-i',
+      'hermesEnabled=true',
+      'hermesEnabled=false',
+      'android/gradle.properties',
+    );
+  }
+
   // doing the pod install here so that it's easier to play around RNTestProject
   cd('ios');
   exec('bundle install');


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Set the hermes value as specified by the test-e2e-local script flag. Right now, the script incorrectly ignores the flag

By default, the template project has `hermesEnabled=true`

Reviewed By: cipolleschi

Differential Revision: D49831355


