### PR TITLE
dispatch status bar methods onto main queue

### DIFF
--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -92,11 +92,6 @@ RCT_EXPORT_MODULE()
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (dispatch_queue_t)methodQueue
-{
-  return dispatch_get_main_queue();
-}
-
 - (void)emitEvent:(NSString *)eventName forNotification:(NSNotification *)notification
 {
   CGRect frame = [notification.userInfo[UIApplicationStatusBarFrameUserInfoKey] CGRectValue];
@@ -130,35 +125,41 @@ RCT_EXPORT_METHOD(getHeight : (RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(setStyle : (NSString *)style animated : (BOOL)animated)
 {
-  UIStatusBarStyle statusBarStyle = [RCTConvert UIStatusBarStyle:style];
-  if (RCTViewControllerBasedStatusBarAppearance()) {
-    RCTLogError(@"RCTStatusBarManager module requires that the \
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UIStatusBarStyle statusBarStyle = [RCTConvert UIStatusBarStyle:style];
+    if (RCTViewControllerBasedStatusBarAppearance()) {
+      RCTLogError(@"RCTStatusBarManager module requires that the \
                 UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
-  } else {
+    } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [RCTSharedApplication() setStatusBarStyle:statusBarStyle animated:animated];
-  }
+      [RCTSharedApplication() setStatusBarStyle:statusBarStyle animated:animated];
+    }
 #pragma clang diagnostic pop
+  });
 }
 
 RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (NSString *)withAnimation)
 {
-  UIStatusBarAnimation animation = [RCTConvert UIStatusBarAnimation:withAnimation];
-  if (RCTViewControllerBasedStatusBarAppearance()) {
-    RCTLogError(@"RCTStatusBarManager module requires that the \
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UIStatusBarAnimation animation = [RCTConvert UIStatusBarAnimation:withAnimation];
+    if (RCTViewControllerBasedStatusBarAppearance()) {
+      RCTLogError(@"RCTStatusBarManager module requires that the \
                 UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
-  } else {
+    } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [RCTSharedApplication() setStatusBarHidden:hidden withAnimation:animation];
+      [RCTSharedApplication() setStatusBarHidden:hidden withAnimation:animation];
 #pragma clang diagnostic pop
-  }
+    }
+  });
 }
 
 RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
 {
-  RCTSharedApplication().networkActivityIndicatorVisible = visible;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTSharedApplication().networkActivityIndicatorVisible = visible;
+  });
 }
 
 - (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)getConstants

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -142,6 +142,11 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
       const char *methodName,
       NSInvocation *inv,
       NSMutableArray *retainedObjectsForInvocation);
+  void performVoidMethodInvocation(
+      jsi::Runtime &runtime,
+      const char *methodName,
+      NSInvocation *inv,
+      NSMutableArray *retainedObjectsForInvocation);
 
   using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
   jsi::Value createPromise(jsi::Runtime &runtime, std::string methodName, PromiseInvocationBlock invoke);


### PR DESCRIPTION
Summary:
Changelog: [Internal]

as part of the sync void tm methods test, there are some modules that do not behave correctly when trying to execute their methods on the js thread.

this module accesses UIKit, so we explicitly dispatch async to the main thread

Differential Revision: D49835587

