### PR TITLE
introduce performVoidMethodInvocation

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -142,6 +142,11 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
       const char *methodName,
       NSInvocation *inv,
       NSMutableArray *retainedObjectsForInvocation);
+  void performVoidMethodInvocation(
+      jsi::Runtime &runtime,
+      const char *methodName,
+      NSInvocation *inv,
+      NSMutableArray *retainedObjectsForInvocation);
 
   using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
   jsi::Value createPromise(jsi::Runtime &runtime, std::string methodName, PromiseInvocationBlock invoke);


### PR DESCRIPTION
Summary:
Changelog: [Internal]

void functions are kinda special right now for the following reasons:
- they can be executed async or sync right now
- they don't return any value

thus, it makes sense for us to separate the invocation logic out and clean up the logic for retrieving return values specifically.

Differential Revision: D49652998

