### PR TITLE
Fix overriding `EXCLUDED_ARCHS` when installing Hermes on RN v0.71

### DIFF
--- a/scripts/cocoapods/__tests__/utils-test.rb
+++ b/scripts/cocoapods/__tests__/utils-test.rb
@@ -180,11 +180,33 @@ class UtilsTests < Test::Unit::TestCase
     # ============================ #
     # Test - Exclude Architectures #
     # ============================ #
-    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_excludeNothing
+    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_withNoValue_leaveUnset
+      # Arrange
+      user_project_mock = prepare_empty_user_project_mock()
+      pods_projects_mock = PodsProjectMock.new()
+      installer = InstallerMock.new(PodsProjectMock.new(), [
+          AggregatedProjectMock.new(user_project_mock)
+      ])
+
+      # Act
+      ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
+
+      # Assert
+      user_project_mock.build_configurations.each do |config|
+          assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], nil)
+      end
+      assert_equal(user_project_mock.save_invocation_count, 0)
+      assert_equal(pods_projects_mock.save_invocation_count, 0)
+    end
+
+    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_withExistingValue_preserveExistingValue
         # Arrange
         user_project_mock = prepare_empty_user_project_mock()
+        user_project_mock.build_configurations.each do |config|
+            config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+        end
         pods_projects_mock = PodsProjectMock.new()
-        installer = InstallerMock.new(PodsProjectMock.new(), [
+        installer = InstallerMock.new(pods_projects_mock, [
             AggregatedProjectMock.new(user_project_mock)
         ])
 
@@ -193,13 +215,14 @@ class UtilsTests < Test::Unit::TestCase
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "")
+            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "arm64")
         end
-        assert_equal(user_project_mock.save_invocation_count, 1)
+
+        assert_equal(user_project_mock.save_invocation_count, 0)
         assert_equal(pods_projects_mock.save_invocation_count, 0)
     end
 
-    def test_excludeArchitectures_whenHermesEngineIsIncluded_excludeI386
+    def test_excludeArchitectures_whenHermesEngineIsIncluded_withNoValue_onlyExcludeI386
         # Arrange
         user_project_mock = prepare_empty_user_project_mock()
         pods_projects_mock = PodsProjectMock.new([], {"hermes-engine" => {}})
@@ -213,6 +236,29 @@ class UtilsTests < Test::Unit::TestCase
         # Assert
         user_project_mock.build_configurations.each do |config|
             assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "i386")
+        end
+
+        assert_equal(user_project_mock.save_invocation_count, 1)
+        assert_equal(pods_projects_mock.save_invocation_count, 1)
+    end
+
+    def test_excludeArchitectures_whenHermesEngineIsIncluded_withExistingValue_appendI386
+        # Arrange
+        user_project_mock = prepare_empty_user_project_mock()
+        user_project_mock.build_configurations.each do |config|
+            config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+        end
+        pods_projects_mock = PodsProjectMock.new([], {"hermes-engine" => {}})
+        installer = InstallerMock.new(pods_projects_mock, [
+            AggregatedProjectMock.new(user_project_mock)
+        ])
+
+        # Act
+        ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
+
+        # Assert
+        user_project_mock.build_configurations.each do |config|
+            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "arm64 i386")
         end
 
         assert_equal(user_project_mock.save_invocation_count, 1)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Fix overriding `EXCLUDED_ARCHS` when installing Hermes on RN v0.71
- Extract the logic and the tests from `main`

Recommended to create a pull request against `0.71.stable` [here](https://github.com/reactwg/react-native-releases/discussions/87#discussioncomment-7141691) 

ref: https://github.com/facebook/react-native/pull/39060

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - don't override EXCLUDED_ARCHS when installing Hermes

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tests pass