### PR TITLE
Mark ReactNativeHost as deprecated In new architecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.SurfaceDelegate;
 import com.facebook.react.common.SurfaceDelegateFactory;
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
@@ -26,6 +27,9 @@ import java.util.List;
  * Simple class that holds an instance of {@link ReactInstanceManager}. This can be used in your
  * {@link Application class} (see {@link ReactApplication}), or as a static field.
  */
+@DeprecatedInNewArchitecture(
+    message =
+        "This class will be replaced by com.facebook.react.ReactHost in the new architecture of React Native.")
 public abstract class ReactNativeHost {
 
   private final Application mApplication;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/DeprecatedInNewArchitecture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/DeprecatedInNewArchitecture.kt
@@ -13,4 +13,4 @@ package com.facebook.react.common.annotations
  */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-annotation class DeprecatedInNewArchitecture
+annotation class DeprecatedInNewArchitecture(val message: String = "")


### PR DESCRIPTION
Summary:
Mark ReactNativeHost as deprecated In new architecture

chnagelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D49834869


