### PR TITLE
Remove JS-side Platform checks For Android <= 23

### DIFF
--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -19,7 +19,6 @@ import type {DirectEventHandler} from '../../Types/CodegenTypes';
 
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import dismissKeyboard from '../../Utilities/dismissKeyboard';
-import Platform from '../../Utilities/Platform';
 import StatusBar from '../StatusBar/StatusBar';
 import View from '../View/View';
 import AndroidDrawerLayoutNativeComponent, {
@@ -180,10 +179,7 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
       onDrawerClose,
       ...props
     } = this.props;
-    const drawStatusBar =
-      Platform.OS === 'android' &&
-      Platform.Version >= 21 &&
-      this.props.statusBarBackgroundColor != null;
+    const drawStatusBar = this.props.statusBarBackgroundColor != null;
     const drawerViewWrapper = (
       <View
         style={[

--- a/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -53,7 +53,6 @@ export default function useAndroidRippleForView(
   return useMemo(() => {
     if (
       Platform.OS === 'android' &&
-      Platform.Version >= 21 &&
       (color != null || borderless != null || radius != null)
     ) {
       const processedColor = processColor(color);
@@ -71,7 +70,7 @@ export default function useAndroidRippleForView(
 
       return {
         viewProps:
-          foreground === true && Platform.Version >= 23
+          foreground === true
             ? {nativeForegroundAndroid: nativeRippleValue}
             : {nativeBackgroundAndroid: nativeRippleValue},
         onPressIn(event: PressEvent): void {

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -156,7 +156,7 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
    * Whether `useForeground` is supported.
    */
   static canUseNativeForeground: () => boolean = () =>
-    Platform.OS === 'android' && Platform.Version >= 23;
+    Platform.OS === 'android';
 
   state: State = {
     pressability: new Pressability(this._createPressabilityConfig()),


### PR DESCRIPTION
Summary:
We now support SDK 23 as a minimum. That means we can drop JS side checks.

Because Android has `Platform.Version` as a number, and iOS as a string, it's common to do an Android check before checking version, even if in Android only code. I tried to remove those where it was super clear the code was Android only (i.e. the file is `.android.js`), but otherwise leave the Android platform check to not give the possibility of changing behavior.

Changelog:
[Internal]

Reviewed By: luluwu2032

Differential Revision: D49814610


