### PR TITLE
[RN][CI] Make the Choose CI Job run also on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,4 +91,7 @@ jobs:
 workflows:
   always-run:
     jobs:
-      - choose_ci_jobs
+      - choose_ci_jobs:
+          filters:
+            tags:
+              only: /.*/

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -17,6 +17,15 @@ jobs:
           name: Run linters against modified files (analysis-bot)
           command: GITHUB_TOKEN="$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A""$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B" yarn lint-ci
 
+  print_job_running:
+    docker:
+      - image: cimg/node:current
+    resource_class: small
+    steps:
+      - run:
+          name: Echo running
+          command: echo "Running test tag only job"
+
   # -------------------------
   #    JOBS: Analyze Code
   # -------------------------

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -126,6 +126,14 @@ references:
     tags:
       only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
 
+  only_test_tags: &only_test_tags
+    # Both of the following conditions must be included!
+    # Ignore any commit on any branch by default.
+    branches:
+      ignore: /.*/
+    tags:
+      only: /test/
+
 # -------------------------
 #        PIPELINE PARAMETERS
 # -------------------------

--- a/.circleci/configurations/workflows.yml
+++ b/.circleci/configurations/workflows.yml
@@ -73,6 +73,11 @@ workflows:
           requires:
             -  build_and_publish_npm_package
 
+  test_tag:
+    jobs:
+      - print_job_running:
+          filters: *only_test_tags
+
   analysis:
     when:
       and:


### PR DESCRIPTION
## Summary:
CircleCI does not run jobs on tags by default. However, when we release a new version of React Native, we push a tag and we want to create a release from that tag only. 

The release job is already configured to run on tag. However, in August, we moved to the CircleCI continuation APIs and the starting job of the pipeline was not set up to run also on tags.

This change fixes the issue, making the Choose CI Job run also on tags.

## Changelog:
[Internal] - Make the Choose CI Job run also on tags

## Test Plan:
Tested manually on CircleCI in a separate branch with a test tag (which have been then removed).