### PR TITLE
[RN][CI] Make the Choose CI Job run also on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,4 +91,7 @@ jobs:
 workflows:
   always-run:
     jobs:
-      - choose_ci_jobs
+      - choose_ci_jobs:
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
## Summary:

CircleCI does not run jobs on tags by default. However, when we release a new version of React Native, we push a tag and we want to create a release from that tag only ([CircleCI Docs](https://circleci.com/docs/workflows/#executing-workflows-for-a-git-tag)).

The release job is already configured to run on tag. However, in August, we moved to the CircleCI continuation APIs and the starting job of the pipeline was not set up to run 
also on tags.

This change fixes the issue, making the Choose CI Job run also on tags.

## Changelog:

[Internal] - Make the Choose CI Job run also on tags

## Test Plan:
Tested manually on CircleCI in a separate branch with a test tag (which have been then removed).
See commit history in this PR: https://github.com/facebook/react-native/pull/39774
