### PR TITLE
Fixed issue with first line element gap handling.

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
@@ -28,6 +28,7 @@ FlexLine calculateFlexLine(
   float totalFlexGrowFactors = 0.0f;
   float totalFlexShrinkScaledFactors = 0.0f;
   size_t endOfLineIndex = startOfLineIndex;
+  size_t firstElementInLineIndex = startOfLineIndex;
 
   float sizeConsumedIncludingMinConstraint = 0;
   const FlexDirection mainAxis = resolveDirection(
@@ -40,10 +41,15 @@ FlexLine calculateFlexLine(
     auto child = node->getChild(endOfLineIndex);
     if (child->getStyle().display() == Display::None ||
         child->getStyle().positionType() == PositionType::Absolute) {
+      if (firstElementInLineIndex == endOfLineIndex) {
+        // We haven't found the first contributing element in the line yet.
+        firstElementInLineIndex++;
+      }
       continue;
     }
 
-    const bool isFirstElementInLine = (endOfLineIndex - startOfLineIndex) == 0;
+    const bool isFirstElementInLine =
+        (endOfLineIndex - firstElementInLineIndex) == 0;
 
     child->setLineIndex(lineCount);
     const float childMarginMainAxis =


### PR DESCRIPTION
Summary:
If the first element of a line is not contributing (e.g. position absolute), an additional gap will be added to the line, because the first gap element of the line is never identified (wrong start index).
Fix: raise the index of the first line element until we find an element that is contributing to the line.

X-link: https://github.com/facebook/yoga/pull/1408

Reviewed By: yungsters

Differential Revision: D49722065

Pulled By: NickGerleman


