### PR TITLE
[iOS] Deprecate RCTGetMultiplierForContentSizeCategory

### DIFF
--- a/packages/react-native/React/UIUtils/RCTUIUtils.h
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.h
@@ -25,7 +25,7 @@ extern __attribute__((visibility("default"))) RCTDimensions RCTGetDimensions(CGF
 
 // Get font size multiplier for font base size (Large) by content size category
 extern __attribute__((visibility("default"))) CGFloat RCTGetMultiplierForContentSizeCategory(
-    UIContentSizeCategory category);
+    UIContentSizeCategory category) __deprecated;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary:

Back port of https://github.com/facebook/react-native/commit/f174f028cfae29735e3f04ad5f42079b67658642 to 0.73-stable, so we can remove the method altogether for 0.74+.

Original notes:
> Per https://github.com/facebook/react-native/pull/39617#issuecomment-1734330041 , let's deprecate this method first.


## Changelog:


[IOS] [DEPRECATED] - Deprecate RCTGetMultiplierForContentSizeCategory


## Test Plan:

CI should pass
