### PR TITLE
[RN][CI] Fix caching for Template

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -95,8 +95,8 @@ references:
     rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v6-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
 
     # Cocoapods - Template
-    template_cocoapods_cache_key: &template_cocoapods_cache_key v4-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock }}
-    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v4-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock }}
+    template_cocoapods_cache_key: &template_cocoapods_cache_key v4-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
+    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v4-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
 
     # Windows
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
## Summary:

While inspecting the pipelines for the template, I realized that the caching was failing because the keys were malformed.
This PR fixes the malformed keys adding the missing "

## Changelog:
[Internal] - Fix cache keys for the Template

## Test Plan:
The template jobs should not fail with `error computing cache key: template: cacheKey:1: unterminated quoted string`
