### PR TITLE
Do not attempt to translate devsupport strings

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-af/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-af/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: af_ZA -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Toestelspesifieke ontwikkelaarkieslys vir reaksies (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Wys %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ar/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ar/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ar_AR -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">التفاعل مع قائمة التطوير الأصلي (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">تشغيل %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-as/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-as/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: as_IN -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-az/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-az/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: az_AZ -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-be/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-be/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: be_BY -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-bg/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-bg/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: bg_BG -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Управление на %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-bn/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-bn/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: bn_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">রিয়েকশন নেটিভ ডেভেলপার মেনু (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s চলছে</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-bs/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-bs/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: bs_BA -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Prikazuje %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ca/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ca/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ca_ES -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-cb/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-cb/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: cb_IQ -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-cs/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-cs/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: cs_CZ -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Nabídka React Native Dev (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Spuštěno: %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-da/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-da/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: da_DK -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Kører %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-de/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-de/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: de_DE -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-el/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-el/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: el_GR -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Προβάλλεται: %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-en-rGB/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-en-rGB/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: en_GB -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React native dev menu (%1$s)</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-es-rES/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-es-rES/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: es_ES -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menú del desarrollador de React Native (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Se está ejecutando %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-es/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-es/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: es_LA -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menú de desarrollador nativo de reacción (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Se está ejecutando %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-et/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-et/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: et_EE -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native’i arendaja menüü (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Töötab %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fa/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fa/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: fa_IR -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">واکنش منوی (%1$s) انحراف محلی</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">اجرای %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fb-rLS/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fb-rLS/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: fb_LS -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native Dev Menu (%1$s)\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Running %1$s\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@\@</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fb/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fb/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: fb_HA -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">[React Native Dev Menu (%1$s)#f560753940a8856cdc2de8717c0295df:1]</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">[Running %1$s#c566f94d6bbe163799a3235b4b55f9d1:1]</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fi/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fi/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: fi_FI -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Reagointien natiivikehittäjävalikko (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Näytetään %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fr-rCA/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fr-rCA/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: fr_CA -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s en cours</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fr/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: fr_FR -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">En cours %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-gu/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-gu/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: gu_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">મૂળ ડેવ મેનૂ (%1$s) પર પ્રતિક્રિયા આપો</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s ચાલુ છે</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ha/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ha/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ha_NG -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Mazaɓar Martanin Native Dev (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Gudanar da %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-hi/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-hi/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: hi_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">रिएक्शन नेटिव डेवलपर मेनू (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s चला रहे हैं</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-hr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-hr/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: hr_HR -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React native dev izbornik (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Pokretanje %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-hu/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-hu/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: hu_HU -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native-fejlesztői menü – (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Futó %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-hy/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-hy/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: hy_AM -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-in/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-in/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: id_ID -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menanggapi Menu Dev Asli (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Menjalankan %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-is/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-is/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: is_IS -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-it/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-it/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: it_IT -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menu sviluppatori React Native (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s in esecuzione</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-iw/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-iw/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: he_IL -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">תפריט מקומי למפתחים (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s בפעילות</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ja/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ja/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ja_JP -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native開発メニュー(%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$sの実行中</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-jv/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-jv/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: jv_ID -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menu React Native Dev (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Lagi tayang %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ka/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ka/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ka_GE -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native-ის დეველოპერთა მენიუ (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">გაშვებულია %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-kk/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-kk/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: kk_KZ -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-km/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-km/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: km_KH -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">ប្រតិកម្ម​ម៉ឺនុយ​​អភិវឌ្ឍដើម (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">ដំណើរការ %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-kn/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-kn/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: kn_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">ಸ್ಥಳೀಯ ದೇವ್ ಮೆನುವನ್ನು ಪ್ರತಿಕ್ರಿಯಿಸಿ (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s ರನ್ ಆಗುತ್ತಿದೆ</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ko/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ko/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ko_KR -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native 개발자 메뉴 (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s 실행 중</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ku/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ku/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ku_TR -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ky/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ky/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ky_KG -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-lo/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-lo/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: lo_LA -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-lt/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-lt/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: lt_LT -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Reagavimo savasis kūrėjo meniu „(%1$s)“</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Rodoma „%1$s“</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-lv/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-lv/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: lv_LV -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Reakciju vietējā izstrādātāju izvēlne (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Darbojas %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-mk/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-mk/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: mk_MK -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Реакција на нативно програмерско мени (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Се извршува %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ml/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ml/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ml_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">പ്രതികരണ നേറ്റീവ് ഡെവ മെനു (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">റൺ ചെയ്യുന്നു %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-mn/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-mn/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: mn_MN -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-mr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-mr/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: mr_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">मुळ डीईव्ही मेनू प्रतिक्रिया द्या (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">प्रसारित होत आहे %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ms/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ms/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ms_MY -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menu Pembangun Asli Bereaksi (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Sedang berjalan %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-my/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-my/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: my_MM -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Native Dev မီနူး (%1$s) ကို တုံ့ပြန်ရန်</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s ကို ပြသနေပါတယ်</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-nb/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-nb/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: nb_NO -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native-utviklermenyen (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Kjører %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ne/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ne/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ne_NP -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-nl/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-nl/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: nl_NL -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Native ontwikkelaarsmenu (%1$s) opnieuw activeren</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s actief</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-pa/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-pa/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: pa_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">ਨੇਟਿਵ ਡਿਵੈ ਮੀਨੂ (%1$s) \'ਤੇ ਪ੍ਰਤੀਕਿਰਿਆ ਦਿਓ</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s ਚੱਲ ਰਿਹਾ ਹੈ</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-pl/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-pl/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: pl_PL -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menu dewelopera React Native (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Wyświetlanie: %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ps/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ps/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ps_AF -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-pt-rPT/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-pt-rPT/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: pt_PT -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menu de desenvolvimento do React Native (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">A apresentar %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-pt/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-pt/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: pt_BR -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menu de desenvolvedor de reações nativas (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s em veiculação</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-qz/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-qz/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: qz_MM -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ro/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ro/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ro_RO -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Meniu dezvoltare React Native (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s în derulare</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ru/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ru/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ru_RU -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Меню разработчика React Native (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Текущий показ %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-si/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-si/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: si_LK -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">(%1$s) React Native Dev මෙනුව</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s ප්‍රචාරය කරමින් පවතී</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sk/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sk/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: sk_SK -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Natívna vývojárska ponuka reakcie (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Spustené: %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sl/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sl/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: sl_SI -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">V teku %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sn/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sn/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: sn_ZW -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-so/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-so/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: so_SO -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sq/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sq/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: sq_AL -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menyja e zhvilluesit e React Native (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Duke ekzekutuar %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sr/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: sr_RS -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native мени за програмере: (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Покренуто: %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sv/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sv/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: sv_SE -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Kör %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sw/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-sw/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: sw_KE -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Linaendeshwa %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ta/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ta/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ta_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">ரியாக்ட் நேட்டிவ் டேவ் மெனு (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">இயங்குகிறது %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-te/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-te/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: te_IN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">స్థానిక డెవలపర్ మెనూ (%1$s)పై ప్రతిస్పందించండి</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s ప్రదర్శించబడుతోంది</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-tg/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-tg/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: tg_TJ -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-th/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-th/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: th_TH -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">แสดงความรู้สึกต่อเมนูผู้พัฒนาแบบเนทีฟ (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">กำลังเผยแพร่ %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-tk/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-tk/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: tk_TM -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-tl/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-tl/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: tl_PH -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Tumatakbong %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-tr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-tr/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: tr_TR -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s çalıştırıyor</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-uk/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-uk/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: uk_UA -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Меню розробника React Native «(%1$s)»</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Поточний показ «%1$s»</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ur/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-ur/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: ur_PK -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">مقامی ڈویلپمنٹ مینیو (%1$s) پر رد عمل دیں</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">%1$s چل رہا ہے</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-uz/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-uz/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: uz_UZ -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-vi/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-vi/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: vi_VN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">Menu phát triển React Native (%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">Đang chạy %1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-wo/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-wo/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: wo_SN -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-zh-rCN/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-zh-rCN/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: zh_CN -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native 开发者菜单(%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">正在运行%1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-zh-rHK/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-zh-rHK/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: zh_HK -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native 開發人員選單(%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">正在執行%1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-zh-rTW/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-zh-rTW/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: zh_TW -->
-<resources exclude-from-buck-resource-map="true">
-    <string name="catalyst_dev_menu_header" gender="unknown">React Native 開發人員功能表(%1$s)</string>
-    <string name="catalyst_dev_menu_sub_header" gender="unknown">正在執行%1$s</string>
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-zu/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-zu/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- See fburl.com/140690840 for information about i18n on Android -->
-<!-- @generated -->
-<!-- FB Locale: zu_ZA -->
-<resources exclude-from-buck-resource-map="true">
-</resources>

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources>
   <string name="catalyst_reload" project="catalyst" translatable="false">Reload</string>
   <string name="catalyst_reload_error" project="catalyst" translatable="false">Failed to load bundle. Try restarting the bundler or reconnecting your device.</string>
   <string name="catalyst_change_bundle_location" project="catalyst" translatable="false">Change Bundle Location</string>
@@ -25,6 +25,6 @@
   <string name="catalyst_loading_from_url" project="catalyst" translatable="false">Loading from %1$s…</string>
   <string name="catalyst_sample_profiler_disable" project="catalyst" translatable="false">Disable Sampling Profiler</string>
   <string name="catalyst_sample_profiler_enable" project="catalyst" translatable="false">Enable Sampling Profiler</string>
-  <string name="catalyst_dev_menu_header">React Native Dev Menu <xliff:g id="menu_header_name">(%1$s)</xliff:g></string>
-  <string name="catalyst_dev_menu_sub_header">Running <xliff:g id="menu_sub_header_name">%1$s</xliff:g></string>
+  <string name="catalyst_dev_menu_header" project="catalyst" translatable="false">React Native Dev Menu (%1$s)</string>
+  <string name="catalyst_dev_menu_sub_header" project="catalyst" translatable="false">Running %1$s</string>
 </resources>


### PR DESCRIPTION
Summary:
I've realized that some of the DevMenu strings were missing the `project="catalyst" translatable="false"`
tags so they ended up being fed to the translation pipeline.
We don't need those strings to be translated so I'm cleaning this up.

Changelog:
[Internal] [Changed] - Do not attempt to translate devsupport strings

Reviewed By: arushikesarwani94

Differential Revision: D49870688


