### PR TITLE
Fix start command exit behaviour

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -137,7 +137,6 @@ async function runServer(
         attachKeyHandlers({
           cliConfig: ctx,
           devServerUrl,
-          serverInstance,
           messageSocket: messageSocketEndpoint,
         });
       }


### PR DESCRIPTION
Summary:
Hotfix for exiting `npx react-native start` when a session is connected. Partially reverts D49422206.

This lines back up with the original RN CLI and Expo implementations — explicitly calling `process.exit()`. We still aim to follow this up with graceful server shutdown.

Changelog: [Internal]

Differential Revision: D49880226


