### PR TITLE
[iOS] Remove `<Webkit/Webkit.h>` import in `RCTConvert.h`

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -84,6 +84,9 @@ type DataDetectorTypes =
   | 'link'
   | 'address'
   | 'calendarEvent'
+  | 'trackingNumber'
+  | 'flightNumber'
+  | 'lookupSuggestion'
   | 'none'
   | 'all';
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -99,6 +99,9 @@ type DataDetectorTypesType =
   | 'link'
   | 'address'
   | 'calendarEvent'
+  | 'trackingNumber'
+  | 'flightNumber'
+  | 'lookupSuggestion'
   | 'none'
   | 'all';
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -137,6 +137,9 @@ type DataDetectorTypesType =
   | 'link'
   | 'address'
   | 'calendarEvent'
+  | 'trackingNumber'
+  | 'flightNumber'
+  | 'lookupSuggestion'
   | 'none'
   | 'all';
 

--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -16,9 +16,6 @@
 #import <React/RCTPointerEvents.h>
 #import <React/RCTTextDecorationLineType.h>
 #import <yoga/Yoga.h>
-#if TARGET_OS_IPHONE
-#import <WebKit/WebKit.h>
-#endif
 
 /**
  * This class provides a collection of conversion functions for mapping
@@ -76,10 +73,6 @@ typedef NSURL RCTFileURL;
 
 #if !TARGET_OS_TV
 + (UIDataDetectorTypes)UIDataDetectorTypes:(id)json;
-#endif
-
-#if TARGET_OS_IPHONE
-+ (WKDataDetectorTypes)WKDataDetectorTypes:(id)json;
 #endif
 
 + (UIViewContentMode)UIViewContentMode:(id)json;

--- a/packages/react-native/React/Base/RCTConvert.m
+++ b/packages/react-native/React/Base/RCTConvert.m
@@ -450,26 +450,13 @@ RCT_MULTI_ENUM_CONVERTER(
       @"link" : @(UIDataDetectorTypeLink),
       @"address" : @(UIDataDetectorTypeAddress),
       @"calendarEvent" : @(UIDataDetectorTypeCalendarEvent),
+      @"trackingNumber" : @(UIDataDetectorTypeShipmentTrackingNumber),
+      @"flightNumber" : @(UIDataDetectorTypeFlightNumber),
+      @"lookupSuggestion" : @(UIDataDetectorTypeLookupSuggestion),
       @"none" : @(UIDataDetectorTypeNone),
       @"all" : @(UIDataDetectorTypeAll),
     }),
     UIDataDetectorTypePhoneNumber,
-    unsignedLongLongValue)
-
-RCT_MULTI_ENUM_CONVERTER(
-    WKDataDetectorTypes,
-    (@{
-      @"phoneNumber" : @(WKDataDetectorTypePhoneNumber),
-      @"link" : @(WKDataDetectorTypeLink),
-      @"address" : @(WKDataDetectorTypeAddress),
-      @"calendarEvent" : @(WKDataDetectorTypeCalendarEvent),
-      @"trackingNumber" : @(WKDataDetectorTypeTrackingNumber),
-      @"flightNumber" : @(WKDataDetectorTypeFlightNumber),
-      @"lookupSuggestion" : @(WKDataDetectorTypeLookupSuggestion),
-      @"none" : @(WKDataDetectorTypeNone),
-      @"all" : @(WKDataDetectorTypeAll),
-    }),
-    WKDataDetectorTypePhoneNumber,
     unsignedLongLongValue)
 
 RCT_ENUM_CONVERTER(


### PR DESCRIPTION
## Summary:

This PR is in response to https://github.com/facebook/react-native/pull/39758#discussion_r1344839022 .

`RCTConvert.h` currently takes an import of `<Webkit/Webkit.h>` for... one enum: `WKDataDetectorTypes`. This has a few problems:

1) RCTConvert is JS engine agnostic, it shouldn't be depending on Webkit
2) As far as I can tell, this code is dead, we also define (and use) the UIKit equivalent `UIDataDetectorTypes`. 

Let's just combine the two, update some JS typing, and get rid of the Webkit header import. 

## Changelog:

[IOS] [CHANGED] - Remove `<Webkit/Webkit.h>` import in `RCTConvert.h`

## Test Plan:

CI should pass