### PR TITLE
Bump fmt to 9.1.0

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/fmt/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/fmt/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++11 -fexceptions)
+add_compile_options(-std=c++20 -fexceptions)
 
 add_library(fmt STATIC src/format.cc)
 

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "glog"
   s.dependency "DoubleConversion"
-  s.dependency 'fmt' , '~> 6.2.1'
+  s.dependency "fmt", "9.1.0"
   s.dependency "React-Core"
   s.dependency "React-debug"
   s.dependency "React-utils"

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -78,7 +78,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "glog"
   s.dependency "DoubleConversion"
-  s.dependency 'fmt' , '~> 6.2.1'
+  s.dependency "fmt", "9.1.0"
   s.dependency "React-ImageManager"
   s.dependency "React-Fabric"
   s.dependency "React-utils"

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
     ss.dependency "RCT-Folly", folly_version
     s.dependency "React-logger", version
     ss.dependency "DoubleConversion"
-    ss.dependency 'fmt' , '~> 6.2.1'
+    ss.dependency "fmt", "9.1.0"
     ss.dependency "glog"
     if using_hermes
       ss.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
 
   s.dependency "boost", "1.83.0"
   s.dependency "DoubleConversion"
-  s.dependency 'fmt' , '~> 6.2.1'
+  s.dependency "fmt", "9.1.0"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
   s.dependency "React-jsinspector", version

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
-  s.dependency 'fmt' , '~> 6.2.1'
+  s.dependency "fmt", "9.1.0"
   s.dependency "glog"
   s.dependency "RCT-Folly/Futures", folly_version
   s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
 
   s.dependency "boost", "1.83.0"
   s.dependency "DoubleConversion"
-  s.dependency 'fmt' , '~> 6.2.1'
+  s.dependency "fmt", "9.1.0"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
 

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
-  s.dependency 'fmt' , '~> 6.2.1'
+  s.dependency "fmt", "9.1.0"
   s.dependency "glog"
 
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
 
   s.dependency "RCT-Folly"
   s.dependency "DoubleConversion"
-  s.dependency 'fmt' , '~> 6.2.1'
+  s.dependency "fmt", "9.1.0"
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-NativeModulesApple"
   s.dependency "React-Core"

--- a/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
@@ -58,5 +58,5 @@ Pod::Spec.new do |s|
   s.dependency "React-debug"
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
-  s.dependency 'fmt' , '~> 6.2.1'
+  s.dependency "fmt", "9.1.0"
 end

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ yoga-proguard-annotations = "1.19.0"
 # Native Dependencies
 boost="1_83_0"
 doubleconversion="1.1.6"
-fmt="6.2.1"
+fmt="9.1.0"
 folly="2022.05.16.00"
 glog="0.3.5"
 libevent="2.1.12"

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -155,6 +155,7 @@ def use_react_native! (
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
+  pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec"
   pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
 
   run_codegen!(

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'boost'
   spec.dependency 'DoubleConversion'
   spec.dependency 'glog'
-  spec.dependency 'fmt' , '~> 6.2.1'
+  spec.dependency "fmt", "9.1.0"
   spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_PTHREAD=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-documentation -faligned-new'
   spec.source_files = 'folly/String.cpp',
                       'folly/Conv.cpp',

--- a/packages/react-native/third-party-podspecs/fmt.podspec
+++ b/packages/react-native/third-party-podspecs/fmt.podspec
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+Pod::Spec.new do |spec|
+  spec.name = "fmt"
+  spec.version = "9.1.0"
+  spec.license = { :type => "MIT" }
+  spec.homepage = "https://github.com/fmtlib/fmt"
+  spec.summary = "{fmt} is an open-source formatting library for C++. It can be used as a safe and fast alternative to (s)printf and iostreams."
+  spec.authors = "The fmt contributors"
+  spec.source = {
+    :git => "https://github.com/fmtlib/fmt.git",
+    :tag => "9.1.0"
+  }
+  spec.pod_target_xcconfig = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
+  }
+  spec.platforms = min_supported_versions
+  spec.libraries = "c++"
+  spec.public_header_files = "include/fmt/*.h"
+  spec.header_mappings_dir = "include"
+  spec.source_files = ["include/fmt/*.h", "src/format.cc"]
+end

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
   - FlipperKit/SKIOSNetworkPlugin (0.201.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitNetworkPlugin
-  - fmt (6.2.1)
+  - fmt (9.1.0)
   - glog (0.3.5)
   - hermes-engine (1000.0.0):
     - hermes-engine/Hermes (= 1000.0.0)
@@ -83,23 +83,23 @@ PODS:
   - RCT-Folly (2022.05.16.00):
     - boost
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Default (= 2022.05.16.00)
   - RCT-Folly/Default (2022.05.16.00):
     - boost
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
   - RCT-Folly/Fabric (2022.05.16.00):
     - boost
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
   - RCT-Folly/Futures (2022.05.16.00):
     - boost
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - libevent
   - RCTRequired (1000.0.0)
@@ -365,7 +365,7 @@ PODS:
   - React-cxxreact (1000.0.0):
     - boost (= 1.83.0)
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -379,7 +379,7 @@ PODS:
   - React-debug (1000.0.0)
   - React-Fabric (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -390,7 +390,6 @@ PODS:
     - React-debug
     - React-Fabric/animations (= 1000.0.0)
     - React-Fabric/attributedstring (= 1000.0.0)
-    - React-Fabric/butter (= 1000.0.0)
     - React-Fabric/componentregistry (= 1000.0.0)
     - React-Fabric/componentregistrynative (= 1000.0.0)
     - React-Fabric/components (= 1000.0.0)
@@ -413,7 +412,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/animations (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -432,26 +431,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/attributedstring (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired (= 1000.0.0)
-    - RCTTypeSafety (= 1000.0.0)
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics (= 1000.0.0)
-    - React-jsi (= 1000.0.0)
-    - React-jsiexecutor (= 1000.0.0)
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core (= 1000.0.0)
-  - React-Fabric/butter (1000.0.0):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -470,7 +450,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/componentregistry (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -489,7 +469,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/componentregistrynative (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -508,7 +488,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -538,7 +518,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/inputaccessory (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -557,7 +537,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/legacyviewmanagerinterop (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -576,7 +556,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/modal (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -595,7 +575,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/rncore (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -614,7 +594,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/root (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -633,7 +613,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/safeareaview (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -652,7 +632,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/scrollview (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -671,7 +651,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/text (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -690,7 +670,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/textinput (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -709,7 +689,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/unimplementedview (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -728,7 +708,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/view (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -748,7 +728,7 @@ PODS:
     - Yoga
   - React-Fabric/core (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -767,7 +747,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/imagemanager (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -786,7 +766,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/leakchecker (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -805,7 +785,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/mounting (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -824,7 +804,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/scheduler (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -843,7 +823,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/telemetry (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -862,7 +842,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/templateprocessor (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -881,7 +861,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/textlayoutmanager (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -901,7 +881,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/uimanager (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -920,7 +900,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-FabricImage (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -940,9 +920,10 @@ PODS:
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-Core/Default (= 1000.0.0)
+    - React-utils
   - React-hermes (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -968,12 +949,12 @@ PODS:
   - React-jsi (1000.0.0):
     - boost (= 1.83.0)
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
   - React-jsiexecutor (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -1097,7 +1078,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-rendererdebug (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
   - React-rncore (1000.0.0)
@@ -1110,6 +1091,7 @@ PODS:
     - React-callinvoker
     - React-debug
     - React-jsi
+    - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
   - React-utils (1000.0.0):
@@ -1118,7 +1100,7 @@ PODS:
     - React-debug
   - ReactCommon-Samples (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - hermes-engine
     - RCT-Folly
     - React-Codegen
@@ -1128,7 +1110,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - ReactCommon/turbomodule/bridging (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -1139,7 +1121,7 @@ PODS:
     - React-perflogger (= 1000.0.0)
   - ReactCommon/turbomodule/core (1000.0.0):
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -1180,6 +1162,7 @@ DEPENDENCIES:
   - FlipperKit/FlipperKitReactPlugin (= 0.201.0)
   - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.201.0)
   - FlipperKit/SKIOSNetworkPlugin (= 0.201.0)
+  - fmt (from `../react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
@@ -1246,7 +1229,6 @@ SPEC REPOS:
     - Flipper-Glog
     - Flipper-PeerTalk
     - FlipperKit
-    - fmt
     - libevent
     - OCMock
     - OpenSSL-Universal
@@ -1261,6 +1243,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
     :path: "../react-native/React/FBReactNativeSpec"
+  fmt:
+    :podspec: "../react-native/third-party-podspecs/fmt.podspec"
   glog:
     :podspec: "../react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
@@ -1363,8 +1347,8 @@ SPEC CHECKSUMS:
   boost: 26fad476bfa736552bbfa698a06cc530475c1505
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  FBLazyVector: b233b98f08056318bc56f4deccea817b00edeac5
-  FBReactNativeSpec: 9c14dc03023715c92c7d01a9c78e8475fe012718
+  FBLazyVector: 5151fd0812335f38a10ee094a9f7ec890f10ef21
+  FBReactNativeSpec: 508d9048374cd5ce4915e3a086d6c80a85d79ff4
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -1373,60 +1357,60 @@ SPEC CHECKSUMS:
   Flipper-Glog: 70c50ce58ddaf67dc35180db05f191692570f446
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 37525a5d056ef9b93d1578e04bc3ea1de940094f
-  fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
+  fmt: 1e664e35cebe13573b0a255ba28121bc29c2765a
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 2f192f79eb5fd8674ca08d663cfdb1a7f4ca2afc
+  hermes-engine: 742b1cd6923bd4dadfed9d2d304a35487f3d2473
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 870a45f398f8ee9ca60cd021b23ab144d56fd3ad
-  RCTRequired: 5091117ce5c99db5af024aa1ec15c6a4c4ad7f1c
-  RCTTypeSafety: 95672f6742bf7b5d16bd8700a65e7bffb63cd9f8
-  React: 2806c7b904a5f8e1279bb1fcf829b6a43bc71e15
-  React-callinvoker: 2d96a4479c0b440a4b24f7eb0ae73a95c0a7e5d9
+  RCT-Folly: 9343647b58e324b13eea8fd2a6a721246aa51379
+  RCTRequired: ba6e6c0a16c67b5cebead2283c240d05eba8b7e6
+  RCTTypeSafety: de0389d18d87bd0b6efca63dbff22c5bb9484379
+  React: 86100f56dc3b059a4f13d2f76331a2744b5c8ebd
+  React-callinvoker: 85c49fe79d257fb682e3c9450fee550e5f26c662
   React-Codegen: 5ad0601f4a0960e6ad81412fdfb270aafba6e4e1
-  React-Core: 2e70e151812a6ad68a95b676d05e13ee38466d96
-  React-CoreModules: 69643fe30d8e8f214584cb5336e47307e458d9d9
-  React-cxxreact: 420ec1c09edf4291fa3cfee30371572572ccb2e5
-  React-debug: 42965d54926dad1d171d60bdb89e000efb4eb9b4
-  React-Fabric: d3aecfadeb3077c2396cbd305895b025eed4123d
-  React-FabricImage: de13a9ca5eb2819ac729564e98a40a9af54452f5
-  React-graphics: cfcaab89e7d1aa59bb97d99c25ef5f28d9ced5f1
-  React-hermes: 11fcf1dd7dff109b40160e75eb4447af3ceae85d
-  React-ImageManager: ec2b27c090514ca96f78753767a3fb4682be78f3
-  React-jserrorhandler: 87d904b84cedbf897a4ed59aceca5724f03cf9af
-  React-jsi: 990673de5500c55224e52e7235863b1511ad6375
-  React-jsiexecutor: ae9ed28dbcf5273f4916fbabf4958ec891f47c0e
-  React-jsinspector: e845240c20daa428639125e0e5623a3237203ff7
-  React-logger: 5bb7c5f3a5ef404c197941167c8cc7628e928f97
-  React-Mapbuffer: e741b31b558f7679bc6b8a848fb3605f8d357998
-  React-nativeconfig: 7b4ebf6e90de842fd0e6f5df6d9ad1f624955bde
-  React-NativeModulesApple: 6306a1e80f8f09e8689a43e9072e9be25dbcfcc6
-  React-perflogger: 24428a1beeb9754b41ecec09f62cbd8ff15ddb46
-  React-RCTActionSheet: fb44d26d484d53f7e5debf2346f9871336e5ac70
-  React-RCTAnimation: b54290477ef258b6981a6822f5b52673cc08399a
-  React-RCTAppDelegate: 122a35fd62d94993c7370d25cc85c7e65315711e
-  React-RCTBlob: bff18b190ffe3a48b2d78dbb027c24067b6314c1
-  React-RCTFabric: 42070e4bfab8370c081def852e5e31e047eae192
-  React-RCTImage: 0329f6197bb95cf9f4e37f9270b278e4037abdc0
-  React-RCTLinking: 79e3f58ad1b65dba4cb2c53c2b09eec75d858c20
-  React-RCTNetwork: b603998f6a23cf652395ffe84d5dea67cd4c49de
-  React-RCTPushNotification: 317b76a7c6c576898580472a1394a3844328c95e
-  React-RCTSettings: 866e76786094fc7f5037719b767e9adffd8dda87
-  React-RCTTest: bad53a62901f602dd919cb3c47d91a0c76ec7f38
-  React-RCTText: 6b8c71ab09e7480ffaa5fd353f5b8646019a1cf3
-  React-RCTVibration: cf14ac74b9f1d676d56111216d1a6e1b0df06d51
-  React-rendererdebug: bcfb7fa48f8a0f62f87522a8f47e72787761884c
-  React-rncore: 28bd4658bf02ba5302822b8c6ddc0052f7566277
-  React-runtimeexecutor: 963711d915734cd2a24fae6edec7f0572d19ecce
-  React-runtimescheduler: 6e7519d2003b5ab8aa8a79b60478fd13cd5f6681
-  React-utils: b842f2d7fe9d81138a486512f44fe1565e2bb987
-  ReactCommon: 9ab719868580941d77be0f90e4d310580868753d
-  ReactCommon-Samples: 9bdd25d3e637c98e314fa9f507292b4c4ddb3edd
+  React-Core: 8a61111ea85bf31d23f3800c167e6861bf39e675
+  React-CoreModules: b6d88f6f29de91bca2a6048e29324f6c86febadc
+  React-cxxreact: c4808346bb6ff1b6bbc5ccf7999e4d2267be96b4
+  React-debug: b4915acf30f97857ceb6e809bcd641b1793e0cca
+  React-Fabric: 920f01c88cede2046d7a8668e66a4b874a0604bd
+  React-FabricImage: 3ac6940fc9011846884ae5f00d1a6ba4b867018c
+  React-graphics: af3a57205af5c0f0ca68006d4e1b9320985523c6
+  React-hermes: ef3c86df2c49c785d139e07c2e1fd8e468c9d79f
+  React-ImageManager: 27cb75ea062ba1e1506a613f06bd31c7c202a6bd
+  React-jserrorhandler: 6b0df194f43c40f9f3428675b6e5b4bcf73748c7
+  React-jsi: 4dda10102dac6ade8dfa8aca92eae6d846c634be
+  React-jsiexecutor: ece914f0e1288637c2f8d82ac5178ab4d1449cb3
+  React-jsinspector: 12477c0e019edaab17df04aa3595496ab87157ff
+  React-logger: 20f279e03c9a6f274f95cc9b9a43daccb36c0c14
+  React-Mapbuffer: 4e1dbb7e364b1e5290c808650bdd2d86153c8eb1
+  React-nativeconfig: e096a997284ee757946820ca801df07797e4ab55
+  React-NativeModulesApple: dcca30cd7e04007a48d024ad65a23d26e083d8c7
+  React-perflogger: 17f9706f2133da530b7d784dcdc6c27c2eea8cb9
+  React-RCTActionSheet: 3776cabaa18a13ccaeac5c0ce8f930e9703064bb
+  React-RCTAnimation: 49d23dcbe6409883df2f277575111a2da578e535
+  React-RCTAppDelegate: 422899c7af3f7301491999911d1fd1fabcf4df43
+  React-RCTBlob: ab81f0609ca3096dbfa93e10991969b6d6d13b81
+  React-RCTFabric: d9795c236775d0803b6f51fba44f5294eeb78171
+  React-RCTImage: 6fcd6ef9d2946c0d2962a6f76461235f28ceaec2
+  React-RCTLinking: a901ce89a51ef7c10754c8c389d852a3d076bc33
+  React-RCTNetwork: de0910a36fc623a8abffdda1b890f80f3d4787e7
+  React-RCTPushNotification: 8840cdc9bc8941e369d0b519e96f388dd161a30e
+  React-RCTSettings: f3c1a94f8e63ec8e3471a13729f9f8786c3016e7
+  React-RCTTest: bf230faad83bc6be0179ae72cbdda2116614ac7e
+  React-RCTText: 7805bc1b0a5ef7bf91aca462526768a8da58b5eb
+  React-RCTVibration: 800172cf446a3fb9f1a8e7425349dd9f460d91a3
+  React-rendererdebug: ad7eea3f653c0aa00ca0fb1438c3c869338b774d
+  React-rncore: 413f2932477380b82dd5b6c9fc2641b0b27575c4
+  React-runtimeexecutor: 125a0de52f5dbb585ad852c3cf4e5690dfe94af7
+  React-runtimescheduler: cfbbe9b714e46f9c0c9786d8ae8ed15a4413fa2a
+  React-utils: 93c97bf9fce7527051f953b33328a1bcac22f842
+  ReactCommon: 14c52400dbc545155b26e6b44c7a6ecaff0b4b60
+  ReactCommon-Samples: d4549883e75923dce187103203c53f3631036d20
   ScreenshotManager: 338d56378199c1e9fb50d896a7ce4400cd250b5e
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 5c39c7ead1a63357070b8bef4a9a57b9a1cd1ccb
+  Yoga: bdf9f35e09c0e9552bf37646319f7cbf7900b7e5
 
-PODFILE CHECKSUM: ae1f2365c7aaade1c3f51a182c545de8df389f81
+PODFILE CHECKSUM: 7d1b558e28efc972a185230c56fef43ed86910a1
 
 COCOAPODS: 1.12.1

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -939,6 +939,8 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;
@@ -1023,6 +1025,8 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
This is what Folly is built against internally. Bump the version we use, and the standard we compile with, to take some different paths, and see if we fix some warnings caused by FMT with the ndk bump.

Changelog: [Internal]