### PR TITLE
Turn CXX implementation of TextLayoutManager into interface

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
@@ -29,10 +29,12 @@ class TextLayoutManager {
  public:
   TextLayoutManager(const ContextContainer::Shared& contextContainer) {}
 
+  virtual ~TextLayoutManager() = default;
+
   /*
    * Measures `attributedStringBox` using native text rendering infrastructure.
    */
-  TextMeasurement measure(
+  virtual TextMeasurement measure(
       AttributedStringBox attributedStringBox,
       ParagraphAttributes paragraphAttributes,
       LayoutConstraints layoutConstraints,
@@ -42,7 +44,7 @@ class TextLayoutManager {
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  LinesMeasurements measureLines(
+  virtual LinesMeasurements measureLines(
       AttributedString attributedString,
       ParagraphAttributes paragraphAttributes,
       Size size) const;
@@ -53,7 +55,7 @@ class TextLayoutManager {
    */
   void* getNativeTextLayoutManager() const;
 
-  std::shared_ptr<void> getHostTextStorage(
+  virtual std::shared_ptr<void> getHostTextStorage(
       AttributedString attributedStringBox,
       ParagraphAttributes paragraphAttributes,
       LayoutConstraints layoutConstraints) const;


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

This makes corresponsing text measure methods inside `TextLayoutManager` overridable, so that it can be substituted with a custom implementation without introducing a new "platform".

Rationale: CXX platform is rather general and less specific than Android or iOS, so we may potentially have multiple alternative implementations of text layout there.

An alternative could be making `TextLayoutManager` an interface across all the platforms, and actual implementations called e.g. `TextLayoutManagerImpl` in each of them, however this would be quite a bit bigger blast radius without much added benefit for Android/iOS.

Differential Revision: D49907594

