### PR TITLE
Makes the Jobs required for Hermes to run in tagged build while releasing

### DIFF
--- a/.circleci/configurations/workflows.yml
+++ b/.circleci/configurations/workflows.yml
@@ -43,6 +43,7 @@ workflows:
           requires:
             - prepare_hermes_workspace
       - build_apple_slices_hermes:
+          filters: *only_release_tags
           requires:
             - build_hermesc_apple
           matrix:
@@ -54,6 +55,7 @@ workflows:
           requires:
             - prepare_hermes_workspace
       - build_hermes_macos:
+          filters: *only_release_tags
           requires:
             - build_apple_slices_hermes
           matrix:


### PR DESCRIPTION
Summary:
Same issue of the previous fix: jobs do not run by default on tagged build. I forgot to add the filter parameter in the jobs that build the slices for Hermes and packages it and therefore the build failed.

I added those filters, so now we should be able to release RC.1.

What puzzles me is how it is possible that the publish-npm jobs even started, given that it was set up to depends on a job called build_hermes_macos which was not executed in the pipeline. 🤔

https://pxl.cl/3w2rr

## Changelog:
[Internal] - Make sure that the Hermes jobs starts when releasing

Reviewed By: dmytrorykun

Differential Revision: D49906898


