### PR TITLE
More verbose logs on failure to launch DevTools

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -72,12 +72,14 @@ export type MessageToDevice =
 
 // Page description object that is sent in response to /json HTTP request from debugger.
 export type PageDescription = {
-  id: string,
   description: string,
-  title: string,
-  faviconUrl: string,
+  deviceName: string,
   devtoolsFrontendUrl: string,
+  faviconUrl: string,
+  id: string,
+  title: string,
   type: string,
+  vm: string,
   webSocketDebuggerUrl: string,
   ...
 };

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -86,9 +86,28 @@ export default function openDebuggerMiddleware({
       if (!target) {
         res.writeHead(404);
         res.end('Unable to find Chrome DevTools inspector target');
-        logger?.warn(
-          'No compatible apps connected. JavaScript debugging can only be used with the Hermes engine.',
-        );
+        if (targets.length === 0) {
+          logger?.warn(
+            'You have no apps connected to the dev server. If your app is running, reload it to reconnect to the dev server.',
+          );
+        } else {
+          const plural = targets.length > 1 ? 'apps' : 'app';
+          const maxSimulatorIdentifier: number = targets.reduce(
+            (max, t) => Math.max(max, t.deviceName.length),
+            0,
+          );
+          const apps = [...targets.entries()]
+            .map(
+              ([i, t]) =>
+                `${i}. [${t.deviceName.padEnd(maxSimulatorIdentifier)}]: ${
+                  t.description
+                } (vm: ${t.vm})`,
+            )
+            .join('\n ');
+          logger?.warn(
+            `JavaScript debugging can only be used with the Hermes engine. Found ${targets.length} connected ${plural}:\n ${apps}`,
+          );
+        }
         eventReporter?.logEvent({
           type: 'launch_debugger_frontend',
           launchType,


### PR DESCRIPTION
Summary:
Help our users unblock themselves differentiating between a failure to find the correct target and no targets being available. The previous error message compounded too many problem cases together. The logs now provide details about the simulator and vm found.

Changelog: [Internal]

Differential Revision: D49783382


