### PR TITLE
Do not guard initializeFlipper for bridgeless for RN Tester

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -124,11 +124,7 @@ class RNTesterApplication : Application(), ReactApplication {
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       load()
     }
-    if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      // TODO: initialize Flipper for Bridgeless
-    } else {
-      initializeFlipper(this, reactNativeHost.reactInstanceManager)
-    }
+    initializeFlipper(this, reactNativeHost.reactInstanceManager)
   }
 
   @UnstableReactNativeAPI


### PR DESCRIPTION
Summary:
We don't need this if-than-else because the initializeFlipper already checks if we're on bridgeless or not

Changelog:
[Internal] [Changed] - Do not guard initializeFlipper for bridgeless for RN Tester

Reviewed By: NickGerleman

Differential Revision: D49881903


