### PR TITLE
Fix Type Casting Warnings in ReactCommon

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fb-rLS/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values-fb-rLS/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- See fburl.com/140690840 for information about i18n on Android -->
+<!-- @generated -->
+<!-- FB Locale: fb_LS -->
+<resources exclude-from-buck-resource-map="true">
+</resources>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -276,7 +276,7 @@ void YogaLayoutableShadowNode::replaceChild(
   }
 
   bool suggestedIndexAccurate = suggestedIndex >= 0 &&
-      suggestedIndex < yogaLayoutableChildren_.size() &&
+      suggestedIndex < static_cast<int32_t>(yogaLayoutableChildren_.size()) &&
       yogaLayoutableChildren_[suggestedIndex].get() == layoutableOldChild;
 
   auto oldChildIter = suggestedIndexAccurate

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -866,7 +866,7 @@ inline std::string toString(const yoga::Style::Edges& value) {
   auto result = std::string{};
   auto separator = std::string{", "};
 
-  for (auto i = 0; i < names.size(); i++) {
+  for (size_t i = 0; i < names.size(); i++) {
     YGValue v = value[i];
     if (v.unit == YGUnitUndefined) {
       continue;

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -277,19 +277,19 @@ void Node::setLayoutDirection(Direction direction) {
 
 void Node::setLayoutMargin(float margin, YGEdge edge) {
   assertFatal(
-      edge < layout_.margin.size(), "Edge must be top/left/bottom/right");
+      edge < static_cast<int>(layout_.margin.size()), "Edge must be top/left/bottom/right");
   layout_.margin[edge] = margin;
 }
 
 void Node::setLayoutBorder(float border, YGEdge edge) {
   assertFatal(
-      edge < layout_.border.size(), "Edge must be top/left/bottom/right");
+      edge < static_cast<int>(layout_.border.size()), "Edge must be top/left/bottom/right");
   layout_.border[edge] = border;
 }
 
 void Node::setLayoutPadding(float padding, YGEdge edge) {
   assertFatal(
-      edge < layout_.padding.size(), "Edge must be top/left/bottom/right");
+      edge < static_cast<int>(layout_.padding.size()), "Edge must be top/left/bottom/right");
   layout_.padding[edge] = padding;
 }
 
@@ -303,7 +303,7 @@ void Node::setLayoutComputedFlexBasis(const FloatOptional computedFlexBasis) {
 
 void Node::setLayoutPosition(float position, YGEdge edge) {
   assertFatal(
-      edge < layout_.position.size(), "Edge must be top/left/bottom/right");
+      edge < static_cast<int>(layout_.position.size()), "Edge must be top/left/bottom/right");
   layout_.position[edge] = position;
 }
 


### PR DESCRIPTION
## Summary:

Casting warnings are treated as errors in React Native Windows. Adjusting casting to fix warnings. 

## Changelog:
[GENERAL] [FIXED] - Fixes type casting warnings that are treated as errors downstream in React Native Windows.

## Test Plan:
