### PR TITLE
Fix Gemfile, setting Active support to < 7.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.12'
-gem 'activesupport', '>= 6.1.7.3'
+gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'

--- a/packages/react-native/template/Gemfile
+++ b/packages/react-native/template/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '~> 1.12'
+gem 'cocoapods', '~> 1.13'
+gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 
 gem 'cocoapods', '~> 1.12'
 gem 'rexml'
+gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'


### PR DESCRIPTION
Summary:
Active Suppert released a new Gem which is incompatible with Cocoapods 1.13.0, the latest release, as they removed a method used by cocoapods.

This fix ensures that we install compatible versions of the Gem.

## Changelog:
[iOS][Fixed] - Set the max version of Active support to 7.0.8

Differential Revision: D49949782


