### PR TITLE
Expose Qpl.isMarkerOn to React Native

### DIFF
--- a/packages/react-native/Libraries/Performance/QuickPerformanceLogger.js
+++ b/packages/react-native/Libraries/Performance/QuickPerformanceLogger.js
@@ -121,6 +121,19 @@ const QuickPerformanceLogger = {
     }
   },
 
+  // Checks whether the given QPL marker is going to be sent to server or not
+  // (the latter may be the case due to e.g. downsampling).
+  // Note that markerStart is expected to have been already called at this point.
+  isMarkerOn(
+    markerId: number,
+    instanceKey?: number = DUMMY_INSTANCE_KEY,
+  ): boolean {
+    if (global.nativeQPLIsMarkerOn) {
+      return global.nativeQPLIsMarkerOn(markerId, instanceKey);
+    }
+    return true;
+  },
+
   markEvent(
     markerId: number,
     type: string,


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

Add `QuickPerformanceLogger.isMarkerOn` API, which allows to check whether the given QPL marker is going to be sent to the server or not (the latter may happen due to e.g. downsampling).

This allows to avoid some extra unneeded overhead when logging QPL events in some heavily sampled scenarios.

Reviewed By: rubennorte

Differential Revision: D49949527


