### PR TITLE
Disable max WebSocket message size validation in CDP proxy

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -176,6 +176,9 @@ export default class InspectorProxy implements InspectorProxyQueries {
     const wss = new WS.Server({
       noServer: true,
       perMessageDeflate: true,
+      // Don't crash on exceptionally large messages - assume the device is
+      // well-behaved and the debugger is prepared to handle large messages.
+      maxPayload: 0,
     });
     // $FlowFixMe[value-as-type]
     wss.on('connection', async (socket: WS, req) => {
@@ -228,6 +231,9 @@ export default class InspectorProxy implements InspectorProxyQueries {
     const wss = new WS.Server({
       noServer: true,
       perMessageDeflate: false,
+      // Don't crash on exceptionally large messages - assume the debugger is
+      // well-behaved and the device is prepared to handle large messages.
+      maxPayload: 0,
     });
     // $FlowFixMe[value-as-type]
     wss.on('connection', async (socket: WS, req) => {


### PR DESCRIPTION
Summary:
Reland of D49642047 which got reverted because of a CI infra error.

---

It's currently possible for RN to crash the dev server by sending down an exceptionally large CDP response/event. Instead of making assumptions on the protocol spoken over the proxy, let's assume clients on either side of the proxy can be trusted to be well behaved (and to degrade gracefully when a large message is encountered).

Changelog: [General][Fixed] JS debugging: prevent dev server crash when a large CDP payload is returned from the device

Differential Revision: D49955025


