### PR TITLE
[iOS] Rename `RCTRootViewFrameDidChangeNotification` as it's not trac…

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -192,7 +192,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
         interfaceOrientation:(UIInterfaceOrientation)previousInterfaceOrientation
              traitCollection:(UITraitCollection *)previousTraitCollection API_AVAILABLE(ios(13.0))
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTRootViewFrameDidChangeNotification object:self];
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTWindowFrameDidChangeNotification object:self];
 }
 
 #pragma mark - RCTCxxBridgeDelegate

--- a/packages/react-native/React/Base/RCTConstants.h
+++ b/packages/react-native/React/Base/RCTConstants.h
@@ -12,7 +12,7 @@ RCT_EXTERN NSString *const RCTPlatformName;
 RCT_EXTERN NSString *const RCTUserInterfaceStyleDidChangeNotification;
 RCT_EXTERN NSString *const RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey;
 
-RCT_EXTERN NSString *const RCTRootViewFrameDidChangeNotification;
+RCT_EXTERN NSString *const RCTWindowFrameDidChangeNotification;
 
 /**
  * This notification fires when the bridge initializes.

--- a/packages/react-native/React/Base/RCTConstants.m
+++ b/packages/react-native/React/Base/RCTConstants.m
@@ -12,7 +12,7 @@ NSString *const RCTPlatformName = @"ios";
 NSString *const RCTUserInterfaceStyleDidChangeNotification = @"RCTUserInterfaceStyleDidChangeNotification";
 NSString *const RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey = @"traitCollection";
 
-NSString *const RCTRootViewFrameDidChangeNotification = @"RCTRootViewFrameDidChangeNotification";
+NSString *const RCTWindowFrameDidChangeNotification = @"RCTWindowFrameDidChangeNotification";
 
 NSString *const RCTJavaScriptDidFailToLoadNotification = @"RCTJavaScriptDidFailToLoadNotification";
 NSString *const RCTJavaScriptDidLoadNotification = @"RCTJavaScriptDidLoadNotification";

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -73,7 +73,7 @@ RCT_EXPORT_MODULE()
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceFrameDidChange)
-                                               name:RCTRootViewFrameDidChangeNotification
+                                               name:RCTWindowFrameDidChangeNotification
                                              object:nil];
 }
 


### PR DESCRIPTION
…king root view frame changes

## Summary:

Looking through where this was introduced (https://github.com/facebook/react-native/pull/37649), it seems the notification went from tracking root view size changes to window size changes. However, it was not renamed. I was using it for root view changes in RN-macOS, which.. I guess I'll refactor. Meanwhile, let's update the name?

## Changelog:

[IOS] [CHANGED] - Rename `RCTRootViewFrameDidChangeNotification` as it's not tracking root view frame changes


## Test Plan:

CI should pass