### PR TITLE
Fix various typos

### DIFF
--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -28,7 +28,7 @@ type Options = $ReadOnly<{
   projectRoot: string,
 
   /**
-   * The base URL to the dev server, as addressible from the local developer
+   * The base URL to the dev server, as addressable from the local developer
    * machine. This is used in responses which return URLs to other endpoints,
    * e.g. the debugger frontend and inspector proxy targets.
    *

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -400,7 +400,7 @@ export default class Device {
 
     // We already had a debugger connected to React Native page and a
     // new one appeared - in this case we need to emulate execution context
-    // detroy and resend Debugger.enable and Runtime.enable commands to new
+    // destroy and resend Debugger.enable and Runtime.enable commands to new
     // page.
 
     if (oldPageId != null) {

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
@@ -27,7 +27,7 @@ fileList.forEach(file => {
       .sync(`${filePattern}/**/*.{js,ts,tsx}`, {
         nodir: true,
         // TODO: This will remove the need of slash substitution above for Windows,
-        // but it requires glob@v9+; with the package currenlty relying on
+        // but it requires glob@v9+; with the package currently relying on
         // glob@7.1.1; and flow-typed repo not having definitions for glob@9+.
         // windowsPathsNoEscape: true,
       })

--- a/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
@@ -133,7 +133,7 @@ function getNativeTypeFromAnnotation(
 }
 
 /// This function process some types if we need to customize them
-/// For example, the ImageSource and the reserved types could be trasformed into
+/// For example, the ImageSource and the reserved types could be transformed into
 /// const address instead of using them as plain types.
 function convertTypesToConstAddressIfNeeded(
   type: string,

--- a/packages/react-native-codegen/src/generators/components/GenerateComponentHObjCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateComponentHObjCpp.js
@@ -159,7 +159,7 @@ function getObjCParamType(param: Param): string {
           return 'double';
         default:
           (typeAnnotation.name: empty);
-          throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
+          throw new Error(`Received invalid type: ${typeAnnotation.name}`);
       }
     case 'BooleanTypeAnnotation':
       return 'BOOL';
@@ -187,7 +187,7 @@ function getObjCExpectedKindParamType(param: Param): string {
           return '[NSNumber class]';
         default:
           (typeAnnotation.name: empty);
-          throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
+          throw new Error(`Received invalid type: ${typeAnnotation.name}`);
       }
     case 'BooleanTypeAnnotation':
       return '[NSNumber class]';
@@ -215,7 +215,7 @@ function getReadableExpectedKindParamType(param: Param): string {
           return 'double';
         default:
           (typeAnnotation.name: empty);
-          throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
+          throw new Error(`Received invalid type: ${typeAnnotation.name}`);
       }
     case 'BooleanTypeAnnotation':
       return 'boolean';
@@ -246,7 +246,7 @@ function getObjCRightHandAssignmentParamType(
           return `[(NSNumber *)arg${index} doubleValue]`;
         default:
           (typeAnnotation.name: empty);
-          throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
+          throw new Error(`Received invalid type: ${typeAnnotation.name}`);
       }
     case 'BooleanTypeAnnotation':
       return `[(NSNumber *)arg${index} boolValue]`;

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
@@ -190,7 +190,7 @@ function getCommandArgJavaType(
           return `args.getDouble(${index})`;
         default:
           (typeAnnotation.name: empty);
-          throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
+          throw new Error(`Received invalid type: ${typeAnnotation.name}`);
       }
     case 'BooleanTypeAnnotation':
       return `args.getBoolean(${index})`;
@@ -204,7 +204,7 @@ function getCommandArgJavaType(
       return `args.getString(${index})`;
     default:
       (typeAnnotation.type: empty);
-      throw new Error(`Receieved invalid type: ${typeAnnotation.type}`);
+      throw new Error(`Received invalid type: ${typeAnnotation.type}`);
   }
 }
 

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaInterface.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaInterface.js
@@ -159,7 +159,7 @@ function getCommandArgJavaType(param: NamedShape<CommandParamTypeAnnotation>) {
           return 'double';
         default:
           (typeAnnotation.name: empty);
-          throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
+          throw new Error(`Received invalid type: ${typeAnnotation.name}`);
       }
     case 'BooleanTypeAnnotation':
       return 'boolean';
@@ -173,7 +173,7 @@ function getCommandArgJavaType(param: NamedShape<CommandParamTypeAnnotation>) {
       return 'String';
     default:
       (typeAnnotation.type: empty);
-      throw new Error('Receieved invalid typeAnnotation');
+      throw new Error('Received invalid typeAnnotation');
   }
 }
 

--- a/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
@@ -141,7 +141,7 @@ export default NativeComponentRegistry.get(nativeComponentName, () => __INTERNAL
 };
 
 // Check whether the native component exists in the app binary.
-// Old getViewManagerConfig() checks for the existance of the native Paper view manager. Not available in Bridgeless.
+// Old getViewManagerConfig() checks for the existence of the native Paper view manager. Not available in Bridgeless.
 // New hasViewManagerConfig() queries Fabric’s native component registry directly.
 const DeprecatedComponentNameCheckTemplate = ({
   componentName,

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -361,7 +361,7 @@ function buildGetConstantsMethod(
     unwrapNullable<NativeModuleFunctionTypeAnnotation>(method.typeAnnotation);
   let returnTypeAnnotation = methodTypeAnnotation.returnTypeAnnotation;
   if (returnTypeAnnotation.type === 'TypeAliasTypeAnnotation') {
-    // The return type is an alias, resolve it to get the expected undelying object literal type
+    // The return type is an alias, resolve it to get the expected underlying object literal type
     returnTypeAnnotation = resolveAlias(returnTypeAnnotation.name);
   }
 

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
@@ -15,7 +15,7 @@ const {capitalize} = require('../../../Utils');
 
 import type {Nullable} from '../../../../CodegenSchema';
 import type {StructTypeAnnotation, ConstantsStruct} from '../StructCollector';
-import type {StructSerilizationOutput} from './serializeStruct';
+import type {StructSerializationOutput} from './serializeStruct';
 
 const {unwrapNullable} = require('../../../../parsers/parsers-commons');
 
@@ -234,7 +234,7 @@ function toObjCValue(
 function serializeConstantsStruct(
   hasteModuleName: string,
   struct: ConstantsStruct,
-): StructSerilizationOutput {
+): StructSerializationOutput {
   const declaration = StructTemplate({
     hasteModuleName,
     structName: struct.name,

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
@@ -15,7 +15,7 @@ const {capitalize} = require('../../../Utils');
 
 import type {Nullable} from '../../../../CodegenSchema';
 import type {StructTypeAnnotation, RegularStruct} from '../StructCollector';
-import type {StructSerilizationOutput} from './serializeStruct';
+import type {StructSerializationOutput} from './serializeStruct';
 
 const {unwrapNullable} = require('../../../../parsers/parsers-commons');
 
@@ -225,7 +225,7 @@ function toObjCValue(
 function serializeRegularStruct(
   hasteModuleName: string,
   struct: RegularStruct,
-): StructSerilizationOutput {
+): StructSerializationOutput {
   const declaration = StructTemplate({
     hasteModuleName: hasteModuleName,
     structName: struct.name,

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeStruct.js
@@ -15,7 +15,7 @@ import type {Struct} from '../StructCollector';
 const {serializeConstantsStruct} = require('./serializeConstantsStruct');
 const {serializeRegularStruct} = require('./serializeRegularStruct');
 
-export type StructSerilizationOutput = $ReadOnly<{
+export type StructSerializationOutput = $ReadOnly<{
   methods: string,
   declaration: string,
 }>;
@@ -23,7 +23,7 @@ export type StructSerilizationOutput = $ReadOnly<{
 function serializeStruct(
   hasteModuleName: string,
   struct: Struct,
-): StructSerilizationOutput {
+): StructSerializationOutput {
   if (struct.context === 'REGULAR') {
     return serializeRegularStruct(hasteModuleName, struct);
   }

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -334,7 +334,7 @@ function getReturnObjCType(
       }
     case 'StringTypeAnnotation':
       // TODO: Can NSString * returns not be _Nullable?
-      // In the legacy codegen, we don't surround NSSTring * with _Nullable
+      // In the legacy codegen, we don't surround NSString * with _Nullable
       return wrapIntoNullableIfNeeded('NSString *');
     case 'NumberTypeAnnotation':
       return wrapIntoNullableIfNeeded('NSNumber *');
@@ -462,7 +462,7 @@ function serializeConstantsProtocolMethods(
   let {returnTypeAnnotation} = propertyTypeAnnotation;
 
   if (returnTypeAnnotation.type === 'TypeAliasTypeAnnotation') {
-    // The return type is an alias, resolve it to get the expected undelying object literal type
+    // The return type is an alias, resolve it to get the expected underlying object literal type
     returnTypeAnnotation = resolveAlias(returnTypeAnnotation.name);
   }
 

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -734,7 +734,7 @@ describe('throwIfArrayElementTypeAnnotationIsUnsupported', () => {
 describe('throwIfPartialNotAnnotatingTypeParameter', () => {
   const flowParser = new FlowParser();
   const typescriptParser = new TypeScriptParser();
-  const typerscriptTypeAnnotation = {
+  const typescriptTypeAnnotation = {
     typeParameters: {
       params: [
         {
@@ -774,7 +774,7 @@ describe('throwIfPartialNotAnnotatingTypeParameter', () => {
 
     expect(() => {
       throwIfPartialNotAnnotatingTypeParameter(
-        typerscriptTypeAnnotation,
+        typescriptTypeAnnotation,
         types,
         typescriptParser,
       );
@@ -798,7 +798,7 @@ describe('throwIfPartialNotAnnotatingTypeParameter', () => {
 
     expect(() => {
       throwIfPartialNotAnnotatingTypeParameter(
-        typerscriptTypeAnnotation,
+        typescriptTypeAnnotation,
         types,
         typescriptParser,
       );

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -867,7 +867,7 @@ describe('parseModuleName', () => {
       ).toThrow(expected);
     });
 
-    it("doesn't throw an 'MoreThanOneModuleRegistryCallsParserError' error if 'callExpressions' array contains extactly one 'callExpression'", () => {
+    it("doesn't throw an 'MoreThanOneModuleRegistryCallsParserError' error if 'callExpressions' array contains exactly one 'callExpression'", () => {
       expect(() =>
         parseModuleName(
           hasteModuleName,
@@ -1081,7 +1081,7 @@ describe('buildModuleSchema', () => {
   });
 
   describe('throwIfMoreThanOneModuleInterfaceParser', () => {
-    it('should throw an error if mulitple module interfaces are found', () => {
+    it('should throw an error if multiple module interfaces are found', () => {
       const contents = `
       import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
         import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -220,7 +220,7 @@ export interface Parser {
   parseEnumMembersType(typeAnnotation: $FlowFixMe): NativeModuleEnumMemberType;
 
   /**
-   * Throws if enum mebers are not supported
+   * Throws if enum members are not supported
    */
   validateEnumMembersSupported(
     typeAnnotation: $FlowFixMe,

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
@@ -100,7 +100,7 @@ internal object ProjectUtils {
     // major is a number
     // minor is a number
     // patch is a number
-    // <prerelease>[-.]k is optional, but if present is preceeded by a `-`
+    // <prerelease>[-.]k is optional, but if present is preceded by a `-`
     // the <prerelease> tag is a string.
     // it can be followed by `-` or `.` and k is a number.
     val regex = """^(\d+)\.(\d+)\.(\d+)(?:-(\w+(?:[-.]\d+)?))?$""".toRegex()

--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -92,7 +92,7 @@
 #endif
 
 /**
- * Controls for the core packgaer loading functionality
+ * Controls for the core packager loading functionality
  * By default, this inherits from RCT_DEV_MENU but it also gives the capability to
  * enable the packager functionality without the rest of the dev tools from RCT_DEV_MENU
  */

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -510,7 +510,7 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
 - (void)jsLoaded:(NSNotification *)notification
 {
   // In bridge mode, the bridge that sent the notif must be the same as the one stored in this module.
-  // In bridgless mode, we don't care about this.
+  // In bridgeless mode, we don't care about this.
   if ([notification.name isEqualToString:RCTJavaScriptDidLoadNotification] &&
       notification.userInfo[@"bridge"] != self.bridge) {
     return;

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -231,12 +231,12 @@ static void RCTPerformMountInstructions(
     // Already on the proper thread, so:
     // * No need to do a thread jump;
     // * No need to allocate a block.
-    [self synchronouslyDispatchAccessbilityEventOnUIThread:reactTag eventType:eventType];
+    [self synchronouslyDispatchAccessibilityEventOnUIThread:reactTag eventType:eventType];
     return;
   }
 
   RCTExecuteOnMainQueue(^{
-    [self synchronouslyDispatchAccessbilityEventOnUIThread:reactTag eventType:eventType];
+    [self synchronouslyDispatchAccessibilityEventOnUIThread:reactTag eventType:eventType];
   });
 }
 
@@ -335,7 +335,7 @@ static void RCTPerformMountInstructions(
   [componentView handleCommand:commandName args:args];
 }
 
-- (void)synchronouslyDispatchAccessbilityEventOnUIThread:(ReactTag)reactTag eventType:(NSString *)eventType
+- (void)synchronouslyDispatchAccessibilityEventOnUIThread:(ReactTag)reactTag eventType:(NSString *)eventType
 {
   if ([@"focus" isEqualToString:eventType]) {
     UIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag];

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -775,7 +775,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 
 /**
  * Private method which is used for tracking the location of pointer events to manage the entering/leaving events.
- * The primary idea is that a pointer's presence & movement is dicated by a variety of underlying events such as down,
+ * The primary idea is that a pointer's presence & movement is dictated by a variety of underlying events such as down,
  * move, and up — and they should all be treated the same when it comes to tracking the entering & leaving of pointers
  * to views. This method accomplishes that by receiving the pointer event, the target view (can be null in cases when
  * the event indicates that the pointer has left the screen entirely), and a block/callback where the underlying event

--- a/packages/react-native/React/Fabric/Utils/RCTReactTaggedView.h
+++ b/packages/react-native/React/Fabric/Utils/RCTReactTaggedView.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Lightweight wrapper class around a UIView with a react tag which registers a
  * constant react tag at initialization time for a stable hash and provides the
- * udnerlying view to a caller if that underlying view's react tag has not
+ * underlying view to a caller if that underlying view's react tag has not
  * changed from the one provided at initialization time (i.e. recycled).
  */
 @interface RCTReactTaggedView : NSObject {

--- a/packages/react-native/React/Modules/RCTUIManager.h
+++ b/packages/react-native/React/Modules/RCTUIManager.h
@@ -57,7 +57,7 @@ RCT_EXTERN NSString *const RCTUIManagerWillUpdateViewsDueToContentSizeMultiplier
 /**
  * Set the available size (`availableSize` property) for a root view.
  * This might be used in response to changes in external layout constraints.
- * This value will be directly trasmitted to layout engine and defines how big viewport is;
+ * This value will be directly transmitted to layout engine and defines how big viewport is;
  * this value does not affect root node size style properties.
  * Can be considered as something similar to `setSize:forView:` but applicable only for root view.
  */

--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -1489,7 +1489,7 @@ NSMutableDictionary<NSString *, id> *RCTModuleConstantsForDestructuredComponent(
   moduleConstants[@"bubblingEventTypes"] = bubblingEventTypes;
   moduleConstants[@"directEventTypes"] = directEventTypes;
   // In the Old Architecture the "Commands" and "Constants" properties of view manager config are populated by
-  // lazifyViewManagerConfig function in JS. This fuction uses NativeModules global object that is not available in the
+  // lazifyViewManagerConfig function in JS. This function uses NativeModules global object that is not available in the
   // New Architecture. To make native view configs work in the New Architecture we will populate these properties in
   // native.
   if (RCTGetUseNativeViewConfigsInBridgelessMode()) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -88,7 +88,7 @@ public class CoreModulesPackage extends TurboReactPackage implements ReactPackag
           Class.forName("com.facebook.react.CoreModulesPackage$$ReactModuleInfoProvider");
       return (ReactModuleInfoProvider) reactModuleInfoProviderClass.newInstance();
     } catch (ClassNotFoundException e) {
-      // In OSS case, the annotation processor does not run. We fall back on creating this byhand
+      // In OSS case, the annotation processor does not run. We fall back on creating this by hand
       Class<? extends NativeModule>[] moduleList =
           new Class[] {
             AndroidInfoModule.class,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -94,7 +94,7 @@ interface ReactHost {
    * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
    * reload is finished, before destroying.
    *
-   * @param reason describing why ReactHost is being destroyed (e.g. memmory pressure)
+   * @param reason describing why ReactHost is being destroyed (e.g. memory pressure)
    * @param ex exception that caused the trigger to destroy ReactHost (or null) This exception will
    *   be used to log properly the cause of destroy operation.
    * @return A task that completes when React Native gets destroyed.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -29,7 +29,7 @@ public class ReactFeatureFlags {
   public static volatile boolean unstable_useTurboModuleInterop = false;
 
   /**
-   * Temporary flag that will be used to validate the staibility of the TurboModule interop layer.
+   * Temporary flag that will be used to validate the stability of the TurboModule interop layer.
    * Force all Java NativeModules that are TurboModule-compatible (that would have otherwise gone
    * through the C++ codegen method dispatch path) instead through the TurboModule interop layer
    * (i.e: the JavaInteropTurboModule method dispatch path).

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -433,7 +433,7 @@ public class MountingManager {
       @EventCategoryDef int eventCategory) {
     @Nullable SurfaceMountingManager smm = getSurfaceManager(surfaceId);
     if (smm == null) {
-      // Cannot queue event without valid surface mountng manager. Do nothing here.
+      // Cannot queue event without valid surface mounting manager. Do nothing here.
       return;
     }
     smm.enqueuePendingEvent(reactTag, eventName, canCoalesceEvent, params, eventCategory);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
@@ -80,7 +80,7 @@ class CoreReactPackage extends TurboReactPackage {
           Class.forName("com.facebook.react.CoreModulesPackage$$ReactModuleInfoProvider");
       return (ReactModuleInfoProvider) reactModuleInfoProviderClass.newInstance();
     } catch (ClassNotFoundException e) {
-      // In OSS case, the annotation processor does not run. We fall back on creating this byhand
+      // In OSS case, the annotation processor does not run. We fall back on creating this by hand
       Class<? extends NativeModule>[] moduleList =
           new Class[] {
             AndroidInfoModule.class,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -476,7 +476,7 @@ public class ReactHostImpl implements ReactHost {
    * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
    * reload is finished, before destroying.
    *
-   * @param reason {@link String} describing why ReactHost is being destroyed (e.g. memmory
+   * @param reason {@link String} describing why ReactHost is being destroyed (e.g. memory
    *     pressure)
    * @param ex {@link Exception} exception that caused the trigger to destroy ReactHost (or null)
    *     This exception will be used to log properly the cause of destroy operation.
@@ -1219,7 +1219,7 @@ public class ReactHostImpl implements ReactHost {
     ReactInstance unwrap(Task<ReactInstance> task, String stage);
   }
 
-  private ReactInstanceTaskUnwrapper createReactInstanceUnwraper(
+  private ReactInstanceTaskUnwrapper createReactInstanceUnwrapper(
       String tag, String method, String reason) {
 
     return (task, stage) -> {
@@ -1287,7 +1287,7 @@ public class ReactHostImpl implements ReactHost {
     raiseSoftException(method, reason);
 
     ReactInstanceTaskUnwrapper reactInstanceTaskUnwrapper =
-        createReactInstanceUnwraper("Reload", method, reason);
+        createReactInstanceUnwrapper("Reload", method, reason);
 
     if (mReloadTask == null) {
       mReloadTask =
@@ -1459,7 +1459,7 @@ public class ReactHostImpl implements ReactHost {
     raiseSoftException(method, reason, ex);
 
     ReactInstanceTaskUnwrapper reactInstanceTaskUnwrapper =
-        createReactInstanceUnwraper("Destroy", method, reason);
+        createReactInstanceUnwrapper("Destroy", method, reason);
 
     if (mDestroyTask == null) {
       mDestroyTask =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -243,12 +243,12 @@ final class ReactInstance {
           new UIConstantsProviderManager(
               // Use unbuffered RuntimeExecutor to install binding
               unbufferedRuntimeExecutor,
-              // Here we are construncting the return value for UIManager.getConstants call.
-              // The old architectre relied on the constatnts struct to contain:
+              // Here we are constructing the return value for UIManager.getConstants call.
+              // The old architecture relied on the constants struct to contain:
               // 1. Eagerly loaded view configs for all native components.
               // 2. genericBubblingEventTypes.
               // 3. genericDirectEventTypes.
-              // We want to match this beahavior.
+              // We want to match this behavior.
               (UIConstantsProvider)
                   () -> {
                     return getUIManagerConstants();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingProhibitedView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingProhibitedView.java
@@ -10,12 +10,12 @@ package com.facebook.react.uimanager;
 /**
  * Some Views may not function if added directly to a ViewGroup that clips them. For example, TTRC
  * markers may rely on `onDraw` functionality to work properly, and will break if they're clipped
- * out of the View hierarchy for any resaon.
+ * out of the View hierarchy for any reason.
  *
  * <p>This situation can occur more often in Fabric with View Flattening. We may prevent this sort
  * of View Flattening from occurring in the future, but the connection is not entirely certain.
  *
- * <p>This can occur either because ReactViewGroup clips them out, using the ordinarary subview
+ * <p>This can occur either because ReactViewGroup clips them out, using the ordinary subview
  * clipping feature. It is also possible if a View is added directly to a ReactRootView below the
  * fold of the screen.
  *

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -1377,7 +1377,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   private void adjustPositionForContentChangeRTL(int left, int right, int oldLeft, int oldRight) {
-    // If we have any pending custon flings (e.g. from aninmated `scrollTo`, or flinging to a snap
+    // If we have any pending custom flings (e.g. from animated `scrollTo`, or flinging to a snap
     // point), finish them, commiting the final `scrollX`.
     // TODO: Can we be more graceful (like OverScroller flings)?
     if (getFlingAnimator().isRunning()) {
@@ -1393,8 +1393,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     // (OverScroller is in `FLING_MODE`), we must cancel and recreate the existing fling animation
     // since it was calculated against outdated scroll offsets.
     if (mScroller != null && !mScroller.isFinished()) {
-      // Calculate the veliocity and position of the fling animation at the time of this layout
-      // event, which may be later than the last ScrollView tick. These values are not commited to
+      // Calculate the velocity and position of the fling animation at the time of this layout
+      // event, which may be later than the last ScrollView tick. These values are not committed to
       // the underlying ScrollView, which will recalculate positions on its next tick.
       int scrollerXBeforeTick = mScroller.getCurrX();
       boolean hasMoreTicks = mScroller.computeScrollOffset();

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedGlobalRef.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedGlobalRef.h
@@ -33,7 +33,7 @@ namespace facebook::yoga::vanillajni {
  *
  * This class is very explicit in its behavior, and it does not allow to perform
  * unexpected conversions or unexpected ownership transfer. In practice, this
- * class acts as a unique pointer where the underying JNI reference can have one
+ * class acts as a unique pointer where the underlying JNI reference can have one
  * and just one owner. Transferring ownership is allowed but it is an explicit
  * operation (implemented via move semantics and also via explicitly API calls).
  *

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedLocalRef.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedLocalRef.h
@@ -35,7 +35,7 @@ namespace facebook::yoga::vanillajni {
  *
  * This class is very explicit in its behavior, and it does not allow to perform
  * unexpected conversions or unexpected ownership transfer. In practice, this
- * class acts as a unique pointer where the underying JNI reference can have one
+ * class acts as a unique pointer where the underlying JNI reference can have one
  * and just one owner. Transferring ownership is allowed but it is an explicit
  * operation (implemented via move semantics and also via explicitly API calls).
  *

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
@@ -1194,7 +1194,7 @@ class NativeAnimatedNodeTraversalTest {
 
     // we run several steps of animation until the value starts bouncing, has negative speed and
     // passes the final point (that is 1) while going backwards
-    var isBoucingBack: Boolean = false
+    var isBouncingBack: Boolean = false
     var previousValue: Double =
         (nativeAnimatedNodesManager.getNodeById(3) as ValueAnimatedNode).value
     for (i in 500 downTo 0) {
@@ -1202,12 +1202,12 @@ class NativeAnimatedNodeTraversalTest {
       val currentValue: Double =
           (nativeAnimatedNodesManager.getNodeById(3) as ValueAnimatedNode).value
       if (previousValue >= 1.0 && currentValue < 1.0) {
-        isBoucingBack = true
+        isBouncingBack = true
         break
       }
       previousValue = currentValue
     }
-    assertThat(isBoucingBack).isTrue
+    assertThat(isBouncingBack).isTrue
 
     // we now update "toValue" to 1.5 but since the value have negative speed and has also
     // pretty

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
@@ -53,7 +53,7 @@ public class UIManagerModuleTest {
   private ArrayList<Choreographer.FrameCallback> mPendingFrameCallbacks;
 
   private MockedStatic<Arguments> arguments;
-  private MockedStatic<ReactChoreographer> reactCoreographer;
+  private MockedStatic<ReactChoreographer> reactChoreographer;
 
   @Before
   public void setUp() {
@@ -61,9 +61,9 @@ public class UIManagerModuleTest {
     arguments.when(Arguments::createArray).thenAnswer(invocation -> new JavaOnlyArray());
     arguments.when(Arguments::createMap).thenAnswer(invocation -> new JavaOnlyMap());
 
-    reactCoreographer = mockStatic(ReactChoreographer.class);
+    reactChoreographer = mockStatic(ReactChoreographer.class);
     ReactChoreographer choreographerMock = mock(ReactChoreographer.class);
-    reactCoreographer
+    reactChoreographer
         .when(ReactChoreographer::getInstance)
         .thenAnswer(invocation -> choreographerMock);
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
@@ -56,7 +56,7 @@ import org.robolectric.RuntimeEnvironment;
 public class ReactTextTest {
 
   private MockedStatic<Arguments> arguments;
-  private MockedStatic<ReactChoreographer> reactCoreographer;
+  private MockedStatic<ReactChoreographer> reactChoreographer;
   private ArrayList<Choreographer.FrameCallback> mPendingFrameCallbacks;
 
   @Before
@@ -65,8 +65,8 @@ public class ReactTextTest {
     arguments = mockStatic(Arguments.class);
     arguments.when(Arguments::createMap).thenAnswer(invocation -> new JavaOnlyMap());
 
-    reactCoreographer = mockStatic(ReactChoreographer.class);
-    reactCoreographer.when(ReactChoreographer::getInstance).thenAnswer(invocation -> uiDriverMock);
+    reactChoreographer = mockStatic(ReactChoreographer.class);
+    reactChoreographer.when(ReactChoreographer::getInstance).thenAnswer(invocation -> uiDriverMock);
 
     mPendingFrameCallbacks = new ArrayList<>();
     doAnswer(

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
@@ -44,16 +44,16 @@ public class TextInputTest {
   private ArrayList<Choreographer.FrameCallback> mPendingChoreographerCallbacks;
 
   private MockedStatic<Arguments> arguments;
-  private MockedStatic<ReactChoreographer> reactCoreographer;
+  private MockedStatic<ReactChoreographer> reactChoreographer;
 
   @Before
   public void setUp() {
     arguments = mockStatic(Arguments.class);
     arguments.when(Arguments::createMap).thenAnswer(invocation -> new JavaOnlyMap());
 
-    reactCoreographer = mockStatic(ReactChoreographer.class);
+    reactChoreographer = mockStatic(ReactChoreographer.class);
     ReactChoreographer choreographerMock = mock(ReactChoreographer.class);
-    reactCoreographer
+    reactChoreographer
         .when(ReactChoreographer::getInstance)
         .thenAnswer(invocation -> choreographerMock);
 

--- a/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.cpp
@@ -170,7 +170,7 @@ void CxxNativeModule::invoke(
   // This lets all the java and red box handling work ok, but the only info I
   // can capture about the C++ exception is the what() string, not the stack.
   // I can std::terminate() the app.  This causes the full, accurate C++
-  // stack trace to be added to logcat by debuggerd.  The java state is lost,
+  // stack trace to be added to logcat by debugger.  The java state is lost,
   // but in practice, the java stack is always the same in this case since
   // the javascript stack is not visible, and the crash is unfriendly to js
   // developers, but crucial to C++ developers.  The what() value is also

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -966,14 +966,14 @@ TEST_P(JSITest, PreparedJavaScriptURLInBacktrace) {
 
 namespace {
 
-unsigned countOccurences(const std::string& of, const std::string& in) {
-  unsigned occurences = 0;
-  std::string::size_type lastOccurence = -1;
-  while ((lastOccurence = in.find(of, lastOccurence + 1)) !=
+unsigned countOccurrences(const std::string& of, const std::string& in) {
+  unsigned occurrences = 0;
+  std::string::size_type lastOccurrence = -1;
+  while ((lastOccurrence = in.find(of, lastOccurrence + 1)) !=
          std::string::npos) {
-    occurences++;
+    occurrences++;
   }
-  return occurences;
+  return occurrences;
 }
 
 } // namespace
@@ -1002,10 +1002,10 @@ TEST_P(JSITest, JSErrorsArePropagatedNicely) {
     sometimesThrows.call(rt, false, callback);
   } catch (JSError& error) {
     EXPECT_EQ(error.getMessage(), "Omg, what a nasty exception");
-    EXPECT_EQ(countOccurences("sometimesThrows", error.getStack()), 6);
+    EXPECT_EQ(countOccurrences("sometimesThrows", error.getStack()), 6);
 
     // system JSC JSI does not implement host function names
-    // EXPECT_EQ(countOccurences("callback", error.getStack(rt)), 5);
+    // EXPECT_EQ(countOccurrences("callback", error.getStack(rt)), 5);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -137,7 +137,7 @@ TEST_F(BridgingTest, hostObjectTest) {
       hostobject, bridging::fromJs<decltype(hostobject)>(rt, object, invoker));
 }
 
-TEST_F(BridgingTest, weakbjectTest) {
+TEST_F(BridgingTest, weakObjectTest) {
   auto object = jsi::Object(rt);
   auto weakobject = jsi::WeakObject(rt, object);
 

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleLegacyModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleLegacyModule.mm
@@ -175,7 +175,7 @@ RCT_EXPORT_METHOD(getValueWithPromise
 
 RCT_EXPORT_METHOD(voidFuncThrows)
 {
-  NSException *myException = [NSException exceptionWithName:@"Excepption"
+  NSException *myException = [NSException exceptionWithName:@"Exception"
                                                      reason:@"Intentional exception from ObjC voidFuncThrows"
                                                    userInfo:nil];
   @throw myException;
@@ -183,7 +183,7 @@ RCT_EXPORT_METHOD(voidFuncThrows)
 
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, getObjectThrows : (NSDictionary *)arg)
 {
-  NSException *myException = [NSException exceptionWithName:@"Excepption"
+  NSException *myException = [NSException exceptionWithName:@"Exception"
                                                      reason:@"Intentional exception from ObjC getObjectThrows"
                                                    userInfo:nil];
   @throw myException;
@@ -194,7 +194,7 @@ RCT_EXPORT_METHOD(promiseThrows
                   : (RCTPromiseResolveBlock)resolve reject
                   : (RCTPromiseRejectBlock)reject)
 {
-  NSException *myException = [NSException exceptionWithName:@"Excepption"
+  NSException *myException = [NSException exceptionWithName:@"Exception"
                                                      reason:@"Intentional exception from ObjC promiseThrows"
                                                    userInfo:nil];
   @throw myException;

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -148,7 +148,7 @@ RCT_EXPORT_METHOD(getValueWithPromise
 
 RCT_EXPORT_METHOD(voidFuncThrows)
 {
-  NSException *myException = [NSException exceptionWithName:@"Excepption"
+  NSException *myException = [NSException exceptionWithName:@"Exception"
                                                      reason:@"Intentional exception from ObjC voidFuncThrows"
                                                    userInfo:nil];
   @throw myException;
@@ -156,7 +156,7 @@ RCT_EXPORT_METHOD(voidFuncThrows)
 
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, getObjectThrows : (NSDictionary *)arg)
 {
-  NSException *myException = [NSException exceptionWithName:@"Excepption"
+  NSException *myException = [NSException exceptionWithName:@"Exception"
                                                      reason:@"Intentional exception from ObjC getObjectThrows"
                                                    userInfo:nil];
   @throw myException;
@@ -167,7 +167,7 @@ RCT_EXPORT_METHOD(promiseThrows
                   : (RCTPromiseResolveBlock)resolve reject
                   : (RCTPromiseRejectBlock)reject)
 {
-  NSException *myException = [NSException exceptionWithName:@"Excepption"
+  NSException *myException = [NSException exceptionWithName:@"Exception"
                                                      reason:@"Intentional exception from ObjC promiseThrows"
                                                    userInfo:nil];
   @throw myException;

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
@@ -35,7 +35,7 @@ class ComponentDescriptorProviderRegistry final {
   void add(const ComponentDescriptorProvider& provider) const;
 
   /*
-   * ComponenDescriptorRegistry will call the `request` in case if a component
+   * ComponentDescriptorRegistry will call the `request` in case if a component
    * with given name wasn't registered yet.
    * The request handler must register a ComponentDescriptor with requested name
    * synchronously during handling the request.

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
@@ -47,9 +47,9 @@ Size AndroidProgressBarMeasurementsManager::measure(
 
   local_ref<JString> componentName = make_jstring("AndroidProgressBar");
 
-  auto serialiazedProps = toDynamic(props);
+  auto serializedProps = toDynamic(props);
   local_ref<ReadableNativeMap::javaobject> propsRNM =
-      ReadableNativeMap::newObjectCxxArgs(serialiazedProps);
+      ReadableNativeMap::newObjectCxxArgs(serializedProps);
   local_ref<ReadableMap::javaobject> propsRM =
       make_local(reinterpret_cast<ReadableMap::javaobject>(propsRNM.get()));
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -150,7 +150,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   YGErrata resolveErrata(YGErrata defaultErrata) const;
 
   /**
-   * Replcaes a child with a mutable clone of itself, returning the clone.
+   * Replaces a child with a mutable clone of itself, returning the clone.
    */
   YogaLayoutableShadowNode& cloneChildInPlace(size_t layoutableChildIndex);
 
@@ -181,7 +181,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    * - borderBottom(Left|Right)Radius → borderBottom(Start|End)Radius
    * - border(Left|Right)Width → border(Start|End)Width
    * - border(Left|Right)Color → border(Start|End)Color
-   * This is neccesarry to be backwards compatible with old renderer, it swaps
+   * This is necessary to be backwards compatible with old renderer, it swaps
    * the values as well in https://fburl.com/diffusion/kl7bjr3h
    */
   void swapStyleLeftAndRight();

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
@@ -356,7 +356,7 @@ TEST_F(LayoutTest, overflowInsetTransformScaleTest) {
   auto layoutMetricsABC = viewShadowNodeABC_->getLayoutMetrics();
 
   // The frame of box ABC won't actually scale up. The transform matrix is
-  // purely cosmatic and should apply later in mounting phase.
+  // purely cosmetic and should apply later in mounting phase.
   EXPECT_EQ(layoutMetricsABC.frame.size.width, 110);
   EXPECT_EQ(layoutMetricsABC.frame.size.height, 20);
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -21,7 +21,7 @@ struct RawEvent;
 
 /*
  * Represents event-delivery infrastructure.
- * Particular `EventEmitter` clases use this for sending events.
+ * Particular `EventEmitter` classes use this for sending events.
  */
 class EventDispatcher {
  public:

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -19,7 +19,7 @@ namespace facebook::react {
 // TODO(T29874519): Get rid of "top" prefix once and for all.
 /*
  * Capitalizes the first letter of the event type and adds "top" prefix if
- * necessary (e.g. "layout" becames "topLayout").
+ * necessary (e.g. "layout" becomes "topLayout").
  */
 static std::string normalizeEventType(std::string type) {
   auto prefixedType = std::move(type);

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/DynamicPropsUtilitiesTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/DynamicPropsUtilitiesTest.cpp
@@ -14,7 +14,7 @@ using namespace facebook::react;
 /*
   Tests that verify expected behaviour from `folly::dynamic::merge_patch`.
   `merge_patch` is used for props forwarding on Android to enable Background
-  Executor and will be removed once JNI layer is reimplmeneted.
+  Executor and will be removed once JNI layer is reimplemented.
  */
 TEST(DynamicPropsUtilitiesTest, handleNestedObjects) {
   dynamic map1 = dynamic::object;

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -178,7 +178,7 @@ TEST_F(ShadowNodeTest, handleShadowNodeCreation) {
   EXPECT_EQ(nodeZ_->getChildren().size(), 0);
 }
 
-TEST_F(ShadowNodeTest, handleSealRecusive) {
+TEST_F(ShadowNodeTest, handleSealRecursive) {
   nodeZ_->sealRecursive();
   EXPECT_TRUE(nodeZ_->getSealed());
   EXPECT_TRUE(nodeZ_->getProps()->getSealed());

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/Float.h
@@ -12,7 +12,7 @@
 namespace facebook::react {
 
 /*
- * Exact type of float numbers which ideally should match a type behing
+ * Exact type of float numbers which ideally should match a type being
  * platform- and chip-architecture-specific float type.
  */
 using Float = float;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Float.h
@@ -12,7 +12,7 @@
 namespace facebook::react {
 
 /*
- * Exact type of float numbers which ideally should match a type behing
+ * Exact type of float numbers which ideally should match a type being
  * platform- and chip-architecture-specific float type.
  */
 using Float = float;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/Float.h
@@ -13,7 +13,7 @@
 namespace facebook::react {
 
 /*
- * Exact type of float numbers which ideally should match a type behing
+ * Exact type of float numbers which ideally should match a type being
  * platform- and chip-architecture-specific float type.
  */
 using Float = CGFloat;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -700,7 +700,7 @@ TEST_F(StackingContextTest, zIndexAndFlattenedNodes) {
     EXPECT_EQ(viewTree.getRootStubView().children.at(5)->tag, 3);
   });
 
-  // And now, let's hide BB completety.
+  // And now, let's hide BB completely.
 
   //  ┌────────────── (Root) ──────────────┐     ┌────────── (Root) ──────────┐
   //  │ ┌─ A (tag: 2) ───────────────────┐ │     │ ┏━ BD (tag: 10) ━━━━━━━━━┓ │

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
@@ -290,7 +290,7 @@ TEST_P(StateReconciliationTest, testCloneslessStateReconciliationDoesntClone) {
   EXPECT_EQ(scrollViewShadowNode->getState(), state3);
 
   if (GetParam()) {
-    // Checking that newlyClonedShadowNode was not cloned unnecessarly by state
+    // Checking that newlyClonedShadowNode was not cloned unnecessarily by state
     // progression. This fails with the old algorithm.
     EXPECT_EQ(scrollViewShadowNode, newlyClonedShadowNode.get());
   }

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
@@ -112,7 +112,7 @@ void MutationObserver::recordMutationsInTarget(
     bool observeSubtree,
     std::vector<const MutationRecord>& recordedMutations,
     SetOfShadowNodePointers& processedNodes) const {
-  // If the node isnt't present in the old tree, it's either:
+  // If the node isn't present in the old tree, it's either:
   // - A new node. In that case, the mutation happened in its parent, not in the
   //   node itself.
   // - A non-existent node. In that case, there are no new mutations.

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
@@ -26,7 +26,7 @@ NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(
     const facebook::react::TextAttributes &textAttributes);
 
 /*
- * Conversions amond `NSAttributedString`, `AttributedString` and `AttributedStringBox`.
+ * Conversions among `NSAttributedString`, `AttributedString` and `AttributedStringBox`.
  */
 NSAttributedString *RCTNSAttributedStringFromAttributedString(
     const facebook::react::AttributedString &attributedString);

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -94,11 +94,11 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
     CGRect rect = [layoutManager usedRectForTextContainer:textContainer];
     static auto threshold = 1.0 / RCTScreenScale() + 0.01; // Size of a pixel plus some small threshold.
 
-    // `rect`'s width is stored in double precesion.
-    // `frame`'s width is also in double precesion but was stored as float in Yoga previously, precesion was lost.
+    // `rect`'s width is stored in double precision.
+    // `frame`'s width is also in double precision but was stored as float in Yoga previously, precision was lost.
     if (std::abs(RCTCeilPixelValue(rect.size.width) - frame.size.width) < threshold) {
       // `textStorage` passed to this method was used to calculate size of frame. If that's the case, it's
-      // width is the same as frame's width. Origin must be adjusted, otherwise glyhps will be painted in wrong
+      // width is the same as frame's width. Origin must be adjusted, otherwise glyphs will be painted in wrong
       // place.
       // We could create new `NSTextStorage` for the specific frame, but that is expensive.
       origin.x -= RCTCeilPixelValue(rect.origin.x);

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -68,9 +68,9 @@ class UIManager final : public ShadowTreeDelegate {
   void animationTick() const;
 
   /*
-   * Provides access to a UIManagerBindging.
+   * Provides access to a UIManagerBinding.
    * The `callback` methods will not be called if the internal pointer to
-   * `UIManagerBindging` is `nullptr`.
+   * `UIManagerBinding` is `nullptr`.
    * The callback is called synchronously on the same thread.
    */
   void visitBinding(

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJSThreadManager.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJSThreadManager.mm
@@ -52,7 +52,7 @@ static NSString *const RCTJSThreadName = @"com.facebook.react.runtime.JavaScript
 - (void)dealloc
 {
   // This avoids a race condition, where work can be executed on JS thread after
-  // other peices of infra are cleaned up.
+  // other pieces of infra are cleaned up.
   _jsMessageThread->quitSynchronous();
 }
 

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
@@ -48,7 +48,7 @@ class CoreFeatures {
   static bool enableCleanParagraphYogaNode;
 
   // Fire `onScroll` events continuously on iOS without a `scrollEventThrottle`
-  // props, and provide continuous `onScroll` upates like other platforms.
+  // props, and provide continuous `onScroll` updates like other platforms.
   static bool disableScrollEventThrottleRequirement;
 
   // When enabled, the renderer would only fail commits when they propagate

--- a/packages/react-native/ReactCommon/react/utils/tests/hash_combineTests.cpp
+++ b/packages/react-native/ReactCommon/react/utils/tests/hash_combineTests.cpp
@@ -44,7 +44,7 @@ TEST(hash_combineTests, testIntegerCombinationsHashing) {
   EXPECT_NE(hash_combine(1, 2), hash_combine(2, 1));
 }
 
-TEST(hash_combineTests, testContiniousIntegerHashing) {
+TEST(hash_combineTests, testContinuousIntegerHashing) {
   std::size_t seed = 0;
 
   for (int i = 1; i <= 200; ++i) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -1031,7 +1031,7 @@ static float distributeFreeSpaceSecondPass(
 
 // It distributes the free space to the flexible items.For those flexible items
 // whose min and max constraints are triggered, those flex item's clamped size
-// is removed from the remaingfreespace.
+// is removed from the remainingfreespace.
 static void distributeFreeSpaceFirstPass(
     FlexLine& flexLine,
     const FlexDirection mainAxis,

--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -41,7 +41,7 @@ async function getLatestVersion(registryHost = DEFAULT_REGISTRY_HOST) {
 }
 
 /**
- * npx react-native -> @react-native-comminity/cli
+ * npx react-native -> @react-native-community/cli
  *
  * Will perform a version check and warning if you're not running the latest community cli when executed using npx. If
  * you know what you're doing, you can skip this check:

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -257,7 +257,7 @@ class CodegenUtils
         relative_config_file_dir = Pathname.new(config_file_dir).relative_path_from(Pod::Config.instance.installation_root)
       end
 
-      # Generate input files for in-app libaraies which will be used to check if the script needs to be run.
+      # Generate input files for in-app libraries which will be used to check if the script needs to be run.
       # TODO: Ideally, we generate the input_files list from generate-codegen-artifacts.js and read the result here.
       #       Or, generate this podspec in generate-codegen-artifacts.js as well.
       app_package_path = file_manager.join(app_path, 'package.json')

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -79,7 +79,7 @@ class NewArchitectureHelper
                 Pod::UI.puts "Setting -DRCT_DYNAMIC_FRAMEWORKS=1 to React-RCTFabric".green
                 rct_dynamic_framework_flag = " -DRCT_DYNAMIC_FRAMEWORKS=1"
                 target_installation_result.native_target.build_configurations.each do |config|
-                    prev_build_settings = config.build_settings['OTHER_CPLUSPLUSFLAGS'] != nil ? config.build_settings['OTHER_CPLUSPLUSFLAGS'] : "$(inherithed)"
+                    prev_build_settings = config.build_settings['OTHER_CPLUSPLUSFLAGS'] != nil ? config.build_settings['OTHER_CPLUSPLUSFLAGS'] : "$(inherited)"
                     config.build_settings['OTHER_CPLUSPLUSFLAGS'] = prev_build_settings + rct_dynamic_framework_flag
                 end
             end

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -167,7 +167,7 @@ end
 
 def podspec_source_build_from_github_tag(react_native_path)
     tag = File.read(hermestag_file(react_native_path)).strip
-    hermes_log("Using tag difined in sdks/.hermesversion: #{tag}")
+    hermes_log("Using tag defined in sdks/.hermesversion: #{tag}")
     return {:git => HERMES_GITHUB_URL, :tag => tag}
 end
 
@@ -249,13 +249,13 @@ def hermes_log(message, level = :warning)
     if !Object.const_defined?("Pod::UI")
         return
     end
-    hermes_log_messgae = '[Hermes] ' + message
+    hermes_log_message = '[Hermes] ' + message
     case level
     when :info
-        Pod::UI.puts hermes_log_messgae.green
+        Pod::UI.puts hermes_log_message.green
     when :error
-        Pod::UI.puts hermes_log_messgae.red
+        Pod::UI.puts hermes_log_message.red
     else
-        Pod::UI.puts hermes_log_messgae.yellow
+        Pod::UI.puts hermes_log_message.yellow
     end
 end

--- a/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -14,7 +14,7 @@ function get_architecture {
     elif [[ $1 == "catalyst" ]]; then
       echo "x86_64;arm64"
     else
-      echo "Error: unknown arkitecture passed $1"
+      echo "Error: unknown architecture passed $1"
       exit 1
     fi
 }

--- a/packages/rn-tester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
@@ -315,7 +315,7 @@ static id RCTPropChecker(NSString *prop, NSNumber *value)
                           isCriticallyDamped:NO];
 }
 
-- (void)testCritcallyDampedSpringAnimation
+- (void)testCriticallyDampedSpringAnimation
 {
   [self performSpringAnimationTestWithConfig:@{
     @"type" : @"spring",
@@ -1040,17 +1040,17 @@ static id RCTPropChecker(NSString *prop, NSNumber *value)
 
   // we run several steps of animation until the value starts bouncing, has negative speed and
   // passes the final point (that is 1) while going backwards
-  BOOL isBoucingBack = NO;
+  BOOL isBouncingBack = NO;
   CGFloat previousValue = 0;
   for (int maxFrames = 500; maxFrames > 0; maxFrames--) {
     [_nodesManager stepAnimations:_displayLink]; // kick off the tracking
     if (previousValue >= 1. && lastTranslateX < 1.) {
-      isBoucingBack = YES;
+      isBouncingBack = YES;
       break;
     }
     previousValue = lastTranslateX;
   }
-  XCTAssert(isBoucingBack);
+  XCTAssert(isBouncingBack);
 
   // we now update "toValue" to 1.5 but since the value have negative speed and has also pretty
   // low friction we expect it to keep going in the opposite direction for a few more frames

--- a/packages/rn-tester/js/examples/Experimental/Compatibility/CompatibilityNativeGestureHandling.js
+++ b/packages/rn-tester/js/examples/Experimental/Compatibility/CompatibilityNativeGestureHandling.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     height: 100,
     width: '100%',
   },
-  lighblue: {
+  lightblue: {
     backgroundColor: 'lightblue',
   },
   item: {
@@ -44,7 +44,7 @@ function CompatibilityNativeGestureHandling(): React.Node {
                 onCancel
                 key={index}
                 name={`${index}`}
-                style={[styles.item, index % 2 === 0 ? styles.lighblue : null]}
+                style={[styles.item, index % 2 === 0 ? styles.lightblue : null]}
               />
             );
           })}

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventCaptureMouse.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventCaptureMouse.js
@@ -203,7 +203,7 @@ export default function PointerEventCaptureMouse(
         'Move your mouse over the purple rectangle. pointerover event should be logged in the purple rectangle',
         'Press and hold left mouse button over "Set Capture" button. "gotpointercapture" should be logged in the black rectangle',
         'Move your mouse anywhere. pointermove should be logged in the black rectangle',
-        'Move your mouse over the purple rectangle. Nothig should happen',
+        'Move your mouse over the purple rectangle. Nothing should happen',
         'Move your mouse over the black rectangle. pointermove should be logged in the black rectangle',
         'Release left mouse button. "lostpointercapture" should be logged in the black rectangle',
       ]}

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
@@ -23,7 +23,7 @@ function PointerEventPointerCancelTouchTestCase(
 ) {
   const {harness} = props;
 
-  const testPointerEvent = harness.useAsyncTest('pointercancel event recieved');
+  const testPointerEvent = harness.useAsyncTest('pointercancel event received');
 
   const pointerDownEventRef = useRef<PointerEvent | null>(null);
   const pointerCancelEventRef = useRef<PointerEvent | null>(null);
@@ -40,7 +40,7 @@ function PointerEventPointerCancelTouchTestCase(
 
       testPointerEvent.step(({assert_equals, assert_not_equals}) => {
         const pointerDownEvent = pointerDownEventRef.current;
-        assert_not_equals(pointerDownEvent, null, 'pointerdown was recieved: ');
+        assert_not_equals(pointerDownEvent, null, 'pointerdown was received: ');
         if (pointerDownEvent != null) {
           assert_equals(
             event.nativeEvent.pointerId,
@@ -87,7 +87,7 @@ function PointerEventPointerCancelTouchTestCase(
         assert_not_equals(
           pointerCancelEvent,
           null,
-          'pointercancel was recieved: ',
+          'pointercancel was received: ',
         );
         if (pointerCancelEvent != null) {
           assert_equals(
@@ -118,7 +118,7 @@ function PointerEventPointerCancelTouchTestCase(
         assert_not_equals(
           pointerCancelEvent,
           null,
-          'pointercancel was recieved: ',
+          'pointercancel was received: ',
         );
         if (pointerCancelEvent != null) {
           assert_equals(

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
@@ -166,7 +166,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = $ReadOnly<{}>;
-export default function PoitnerEventPointerCancelTouch(
+export default function PointerEventPointerCancelTouch(
   props: Props,
 ): React.MixedElement {
   return (

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveBetween.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveBetween.js
@@ -127,7 +127,7 @@ export default function PointerEventPointerMoveBetween(
       description=""
       instructions={[
         'Move your cursor over the blue element, later over the green one, later back to the blue one.',
-        'Move the mosue from the blue element to the yellow one, later to the white background.',
+        'Move the mouse from the blue element to the yellow one, later to the white background.',
       ]}
       title="Pointermove handling between elements"
     />

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
@@ -103,7 +103,7 @@ function PointerEventPointerOverOutTestCase(
         assert_equals(
           innerOverRef.current,
           innerOutRef.current,
-          'pointerover is recieved before pointerout',
+          'pointerover is received before pointerout',
         );
         switch (innerOverRef.current) {
           case 0: {
@@ -169,7 +169,7 @@ function PointerEventPointerOverOutTestCase(
           assert_equals(
             outerOwnOverRef.current,
             outerOwnOutRef.current,
-            'outer: pointerover is recieved before pointerout',
+            'outer: pointerover is received before pointerout',
           );
           outerOwnOverRef.current++;
         } else {
@@ -192,7 +192,7 @@ function PointerEventPointerOverOutTestCase(
           assert_equals(
             outerOwnOverRef.current,
             outerOwnOutRef.current + 1,
-            'outer: pointerout is recieved after pointerover',
+            'outer: pointerout is received after pointerover',
           );
           if (outerOwnOutRef.current === 1) {
             assert_equals(innerOutRef.current, 2, 'inner should be done now');
@@ -203,7 +203,7 @@ function PointerEventPointerOverOutTestCase(
           assert_equals(
             outerOutRef.current - outerOwnOutRef.current,
             innerOutRef.current - 1,
-            'pointerout: should only recieve this via bubbling',
+            'pointerout: should only receive this via bubbling',
           );
         }
       });

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventsExample.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventsExample.js
@@ -242,7 +242,7 @@ export default {
       },
     },
     {
-      name: 'pointerevent_caapture_mouse',
+      name: 'pointerevent_capture_mouse',
       title: 'WPT 12: Pointer Events capture test',
       render(): React.Node {
         return <PointerEventCaptureMouse />;

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -1411,7 +1411,7 @@ exports.examples = [
   {
     title: 'Accessibility',
     description:
-      ('If the `accessible` (boolean) prop is set to True, the image will be indicated as an accessbility element.': string),
+      ('If the `accessible` (boolean) prop is set to True, the image will be indicated as an accessibility element.': string),
     render: function (): React.Node {
       return <Image accessible source={fullImage} style={styles.base} />;
     },
@@ -1419,7 +1419,7 @@ exports.examples = [
   {
     title: 'Accessibility Label',
     description:
-      ('When an element is marked as accessibile (using the accessibility prop), it is good practice to set an accessibilityLabel on the image to provide a description of the element to people who use VoiceOver. VoiceOver will read this string when people select this element.': string),
+      ('When an element is marked as accessible (using the accessibility prop), it is good practice to set an accessibilityLabel on the image to provide a description of the element to people who use VoiceOver. VoiceOver will read this string when people select this element.': string),
     render: function (): React.Node {
       return (
         <Image
@@ -1434,7 +1434,7 @@ exports.examples = [
   {
     title: 'Accessibility Label via alt prop',
     description:
-      'Using the alt prop markes an element as being accessibile, and passes the alt text to accessibilityLabel',
+      'Using the alt prop marks an element as being accessible, and passes the alt text to accessibilityLabel',
     render: function (): React.Node {
       return (
         <Image
@@ -1448,7 +1448,7 @@ exports.examples = [
   {
     title: 'Fade Duration',
     description:
-      ('The time (in miliseconds) that an image will fade in for when it appears (default = 300).': string),
+      ('The time (in milliseconds) that an image will fade in for when it appears (default = 300).': string),
     render: function (): React.Node {
       return (
         <>

--- a/packages/virtualized-lists/Lists/StateSafePureComponent.js
+++ b/packages/virtualized-lists/Lists/StateSafePureComponent.js
@@ -73,7 +73,7 @@ export default class StateSafePureComponent<
       get() {
         invariant(
           !that._inAsyncStateUpdate,
-          '"this.state" should not be acceessed during state updates',
+          '"this.state" should not be accessed during state updates',
         );
         return state;
       },

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -508,7 +508,7 @@ function ItemWithSeparator(props: ItemWithSeparatorProps): React.Node {
     inverted,
   } = props;
 
-  const [leadingSeparatorHiglighted, setLeadingSeparatorHighlighted] =
+  const [leadingSeparatorHighlighted, setLeadingSeparatorHighlighted] =
     React.useState(false);
 
   const [separatorHighlighted, setSeparatorHighlighted] = React.useState(false);
@@ -583,7 +583,7 @@ function ItemWithSeparator(props: ItemWithSeparatorProps): React.Node {
   });
   const leadingSeparator = LeadingSeparatorComponent != null && (
     <LeadingSeparatorComponent
-      highlighted={leadingSeparatorHiglighted}
+      highlighted={leadingSeparatorHighlighted}
       {...leadingSeparatorProps}
     />
   );

--- a/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
@@ -444,7 +444,7 @@ describe('onUpdate', function () {
 
   it('should account for imprecision on measurements of width of viewport and item', () => {
     // This test assures we round down the calculations of the item cell layout
-    // to avoid cases of imprecison when measuring layout
+    // to avoid cases of imprecision when measuring layout
     const helper = new ViewabilityHelper({itemVisiblePercentThreshold: 100});
     const testProps = {
       getItemCount: () => 1,

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -1136,12 +1136,12 @@ it('does not over-render when there is less than initialNumToRender cells', () =
     />,
   );
 
-  // Check that the first render clamps to the last item when intialNumToRender
+  // Check that the first render clamps to the last item when initialNumToRender
   // goes over it.
   expect(component).toMatchSnapshot();
 });
 
-it('retains intitial render if initialScrollIndex == 0', () => {
+it('retains initial render if initialScrollIndex == 0', () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
@@ -1177,7 +1177,7 @@ it('retains intitial render if initialScrollIndex == 0', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('discards intitial render if initialScrollIndex != 0', () => {
+it('discards initial render if initialScrollIndex != 0', () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
@@ -1470,7 +1470,7 @@ it('renders no spacers up to initialScrollIndex on first render when virtualizat
   });
 
   // There should be no spacers present in an offset initial render with
-  // virtualiztion disabled. Only initialNumToRender items starting at
+  // virtualization disabled. Only initialNumToRender items starting at
   // initialScrollIndex.
   expect(component).toMatchSnapshot();
 });

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -2098,7 +2098,7 @@ exports[`constrains batch render region when an item is removed 1`] = `
 </RCTScrollView>
 `;
 
-exports[`discards intitial render if initialScrollIndex != 0 1`] = `
+exports[`discards initial render if initialScrollIndex != 0 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -5937,7 +5937,7 @@ exports[`retains initial render region when an item is appended 1`] = `
 </RCTScrollView>
 `;
 
-exports[`retains intitial render if initialScrollIndex == 0 1`] = `
+exports[`retains initial render if initialScrollIndex == 0 1`] = `
 <RCTScrollView
   data={
     Array [

--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -95,7 +95,7 @@ describe('npm-utils', () => {
       publishPackage(
         'path/to/my-package',
         {tag: 'latest', otp: 'otp'},
-        {silent: true, cwd: 'i/expect/this/to/be/overriden'},
+        {silent: true, cwd: 'i/expect/this/to/be/overridden'},
       );
       expect(execMock).toHaveBeenCalledWith(
         'npm publish --tag latest --otp otp',

--- a/scripts/monorepo/check-for-git-changes.js
+++ b/scripts/monorepo/check-for-git-changes.js
@@ -26,7 +26,7 @@ const checkForGitChanges = () => {
 
   if (stderr) {
     console.log(
-      '\u274c An error occured while running `git status --porcelain`:',
+      '\u274c An error occurred while running `git status --porcelain`:',
     );
     console.log(stderr);
 

--- a/scripts/monorepo/get-and-update-packages.js
+++ b/scripts/monorepo/get-and-update-packages.js
@@ -60,7 +60,7 @@ function getPackagesToPublish() /*: PackageMap */ {
     (packageAbsolutePath, packageRelativePathFromRoot, packageManifest) => {
       if (packageManifest.private || !isPublishedOnNPM(packageManifest.name)) {
         console.log(
-          `\u23F1 Skipping publishing for ${packageManifest.name}. It is either pivate or unpublished`,
+          `\u23F1 Skipping publishing for ${packageManifest.name}. It is either private or unpublished`,
         );
         return;
       }
@@ -85,7 +85,7 @@ function isPublishedOnNPM(packageName /*: string */) /*: boolean */ {
 
 /**
  * Update the dependencies in the packages to the passed version.
- * The function update the packages dependencies and devDepenencies if they contains other packages in the monorepo.
+ * The function update the packages dependencies and devDependencies if they contains other packages in the monorepo.
  * The function also writes the updated package.json to disk.
  */
 function updateDependencies(packages /*: PackageMap */, version /*: string */) {

--- a/tools/eslint/rules/no-haste-imports.js
+++ b/tools/eslint/rules/no-haste-imports.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     messages: {
       hasteImport:
-        "'{{importPath}}' seems to be a Haste module name; use path-based imports intead",
+        "'{{importPath}}' seems to be a Haste module name; use path-based imports instead",
     },
     schema: [],
   },


### PR DESCRIPTION
## Summary:
Makes documentation easier to read and makes finding things in the code easier to find when searching for exact strings.

I ran cspell locally and made various suggested typo fixes. The first three commits may impact functionality, while the last commit (the largest) makes non-functional changes to comments, test descriptions, error messages, function names, etc.

## Changelog:
[INTERNAL] [FIXED] - Fix various typos

## Test Plan:
n/a