### PR TITLE
Add log message if App moves to background

### DIFF
--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
@@ -30,6 +30,7 @@ typedef RCTBundleStatus * (^RCTBundleStatusProvider)(void);
 @interface RCTInspectorRemoteConnection : NSObject
 - (void)onMessage:(NSString *)message;
 - (void)onDisconnect;
+- (void)handleBackgroundEvent:(NSNotification *)notification;
 @end
 
 #endif

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -328,8 +328,47 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   if (self = [super init]) {
     _owningPackagerConnection = owningPackagerConnection;
     _pageId = pageId;
+    [self addObserverFor:UIApplicationDidEnterBackgroundNotification];
+    [self addObserverFor:UIApplicationWillEnterForegroundNotification];
   }
   return self;
+}
+
+- (void)addObserverFor:(NSString *)notificationName
+{
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleBackgroundEvent:)
+                                               name:notificationName
+                                             object:nil];
+}
+
+- (void)consoleInfo:(NSString *)message format:(NSString *)format
+{
+  if (!message) {
+    return;
+  }
+  NSNumber *now = @([[NSDate date] timeIntervalSince1970] * 1000);
+  NSDictionary *json = @{
+    @"method" : @"Runtime.consoleAPICalled",
+    @"params" : @{@"type" : @"info", @"args" : format == nil ? @[ message ] : @[ message, format ], @"timestamp" : now}
+  };
+  NSError *error = nil;
+  NSData *data = [NSJSONSerialization dataWithJSONObject:json options:0 error:&error];
+  if (error != nil) {
+    NSLog(@"Unable to serialize a console.warn() message: %@", error);
+    return;
+  }
+  NSString *str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  [self onMessage:str];
+}
+
+- (void)handleBackgroundEvent:(NSNotification *)notification
+{
+  if ([notification.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
+    [self consoleInfo:@"App has moved into the %cforeground" format:@"font-weight: bold"];
+  } else if ([notification.name isEqualToString:UIApplicationDidEnterBackgroundNotification]) {
+    [self consoleInfo:@"App has moved into the %cbackground" format:@"font-weight: bold"];
+  }
 }
 
 - (void)onMessage:(NSString *)message


### PR DESCRIPTION
Summary:
When the user attaches a debugger, and the app moves to the background the debugging session persists. This
sends a CDP console.info so the debugging user is aware of the app's state. It is an easy state to get into
when debugging on multiple emulators.

[iOS][Added] - Log to DevTools on app going into background / forground.

Differential Revision: D49956535


