### PR TITLE
Make PerformanceObserver report correctly supported performance entry types

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -107,4 +107,13 @@ std::vector<RawPerformanceEntry> NativePerformanceObserver::getEntries(
       entryName ? entryName->c_str() : nullptr);
 }
 
+std::vector<RawPerformanceEntryType>
+NativePerformanceObserver::getSupportedPerformanceEntryTypes(jsi::Runtime& rt) {
+  return {
+      static_cast<RawPerformanceEntryType>(PerformanceEntryType::MARK),
+      static_cast<RawPerformanceEntryType>(PerformanceEntryType::MEASURE),
+      static_cast<RawPerformanceEntryType>(PerformanceEntryType::EVENT),
+  };
+}
+
 } // namespace facebook::react

--- a/packages/react-native/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -18,9 +18,11 @@ class PerformanceEntryReporter;
 
 #pragma mark - Structs
 
+using RawPerformanceEntryType = int32_t;
+
 using RawPerformanceEntry = NativePerformanceObserverCxxBaseRawPerformanceEntry<
     std::string,
-    int32_t,
+    RawPerformanceEntryType,
     double,
     double,
     // For "event" entries only:
@@ -32,7 +34,7 @@ template <>
 struct Bridging<RawPerformanceEntry>
     : NativePerformanceObserverCxxBaseRawPerformanceEntryBridging<
           std::string,
-          int32_t,
+          RawPerformanceEntryType,
           double,
           double,
           std::optional<double>,
@@ -93,6 +95,9 @@ class NativePerformanceObserver
       jsi::Runtime& rt,
       std::optional<int32_t> entryType,
       std::optional<std::string> entryName);
+
+  std::vector<RawPerformanceEntryType> getSupportedPerformanceEntryTypes(
+      jsi::Runtime& rt);
 
  private:
 };

--- a/packages/react-native/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -53,6 +53,7 @@ export interface Spec extends TurboModule {
     entryType?: RawPerformanceEntryType,
     entryName?: string,
   ) => $ReadOnlyArray<RawPerformanceEntry>;
+  +getSupportedPerformanceEntryTypes: () => $ReadOnlyArray<RawPerformanceEntryType>;
 }
 
 export default (TurboModuleRegistry.get<Spec>(

--- a/packages/react-native/Libraries/WebPerformance/PerformanceObserver.js
+++ b/packages/react-native/Libraries/WebPerformance/PerformanceObserver.js
@@ -16,6 +16,7 @@ import {PerformanceEntry} from './PerformanceEntry';
 import {
   performanceEntryTypeToRaw,
   rawToPerformanceEntry,
+  rawToPerformanceEntryType,
 } from './RawPerformanceEntry';
 
 export type PerformanceEntryList = $ReadOnlyArray<PerformanceEntry>;
@@ -127,6 +128,21 @@ function applyDurationThresholds() {
       durationThreshold ?? 0,
     );
   }
+}
+
+function getSupportedPerformanceEntryTypes(): $ReadOnlyArray<PerformanceEntryType> {
+  if (!NativePerformanceObserver) {
+    return Object.freeze([]);
+  }
+  if (!NativePerformanceObserver.getSupportedPerformanceEntryTypes) {
+    // fallback if getSupportedPerformanceEntryTypes is not defined on native side
+    return Object.freeze(['mark', 'measure', 'event']);
+  }
+  return Object.freeze(
+    NativePerformanceObserver.getSupportedPerformanceEntryTypes().map(
+      rawToPerformanceEntryType,
+    ),
+  );
 }
 
 /**
@@ -294,7 +310,7 @@ export default class PerformanceObserver {
   }
 
   static supportedEntryTypes: $ReadOnlyArray<PerformanceEntryType> =
-    Object.freeze(['mark', 'measure', 'event']);
+    getSupportedPerformanceEntryTypes();
 }
 
 // As a Set union, except if value exists in both, we take minimum

--- a/packages/react-native/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
+++ b/packages/react-native/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
@@ -114,6 +114,15 @@ const NativePerformanceObserverMock: NativePerformanceObserver = {
         (entryName == null || e.name === entryName),
     );
   },
+
+  getSupportedPerformanceEntryTypes:
+    (): $ReadOnlyArray<RawPerformanceEntryType> => {
+      return [
+        RawPerformanceEntryTypeValues.MARK,
+        RawPerformanceEntryTypeValues.MEASURE,
+        RawPerformanceEntryTypeValues.EVENT,
+      ];
+    },
 };
 
 export default NativePerformanceObserverMock;


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

This makes PerformanceObserver API more robust in regards of telling which exactly types of the performance entries are supported.

At this point, we either tell that we support mark/measure/event ones on the New Architecture, or none otherwise. The source of truth of this information should be on the native side.

Differential Revision: D50010982


