### PR TITLE
Make sure template is consuming the right buildToolsVersion

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -25,7 +25,7 @@ references:
   android-defaults: &android-defaults
     working_directory: ~/react-native
     docker:
-      - image: reactnativecommunity/react-native-android:v11.0
+      - image: reactnativecommunity/react-native-android:v12.0
     environment:
       - TERM: "dumb"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false'

--- a/packages/react-native/template/android/app/build.gradle
+++ b/packages/react-native/template/android/app/build.gradle
@@ -71,7 +71,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 
 android {
     ndkVersion rootProject.ext.ndkVersion
-
+    buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
     namespace "com.helloworld"


### PR DESCRIPTION
## Summary:

Currently, the template has a `buildToolsVersion = '34.0.0'` specified in the top level .gradle file but it's not currently using it.

This is causing the build to fallback to the default version provided by AGP which is 33.x
This is also causing the CI to download buildtools 34.0.0 as they're not in the container (causing network flakyness).

I'm also bumping the docker container to v12 as we bumped NDK 26 which is missing in the v11 container.

## Changelog:

[INTERNAL] [FIXED] - Make sure template is consuming the right buildToolsVersion

## Test Plan:

CI should be green
