### PR TITLE
[0.73] Make sure template is consuming the right buildToolsVersion

### DIFF
--- a/packages/react-native/template/android/app/build.gradle
+++ b/packages/react-native/template/android/app/build.gradle
@@ -71,7 +71,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 
 android {
     ndkVersion rootProject.ext.ndkVersion
-
+    buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
     namespace "com.helloworld"


### PR DESCRIPTION
## Summary:

This is the equivalent of https://github.com/facebook/react-native/pull/39956 but for the 0.73 release branch.

## Changelog:

[INTERNAL] [FIXED] - Make sure template is consuming the right buildToolsVersion

## Test Plan:

CI should be green