### PR TITLE
Un-bump AGP to 8.1.2

### DIFF
--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ targetSdk = "34"
 compileSdk = "34"
 buildTools = "34.0.0"
 # Dependencies versions
-agp = "8.2.0-beta06"
+agp = "8.1.2"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.6.1"
 androidx-autofill = "1.1.0"


### PR DESCRIPTION
Summary:
I'm reverting the change of AGP from 8.2 beta to 8.1 as we don't need 8.2
Using 8.2 beta forces us to use Android Studio beta, which is actually not necessary.

Changelog:
[Android] [Changed] - Bump AGP to 8.1.2

Differential Revision: D50016572


