### PR TITLE
Fix .gitignore for packages/react-native/sdks/downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ DerivedData
 *.xcuserstate
 project.xcworkspace
 **/.xcode.env.local
-/poackages/react-native/sdks/downloads/
 
 # Gradle
 /build/
@@ -135,6 +134,7 @@ package-lock.json
 
 # Additional SDKs
 /packages/react-native/sdks/download
+/packages/react-native/sdks/downloads
 /packages/react-native/sdks/hermes
 /packages/react-native/sdks/hermesc
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Fix typo in .gitignore for downloaded sdks

ignore-github-export-checks

Reviewed By: huntie

Differential Revision: D50018994


