### PR TITLE
Update StyleSheet documentation

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
@@ -32,7 +32,7 @@ export namespace StyleSheet {
   type NamedStyles<T> = {[P in keyof T]: ViewStyle | TextStyle | ImageStyle};
 
   /**
-   * Creates a StyleSheet style reference from the given object.
+   * An identity function for creating style sheets.
    */
   export function create<T extends NamedStyles<T> | NamedStyles<any>>(
     // The extra & NamedStyles<any> here helps Typescript catch typos: e.g.,
@@ -49,14 +49,6 @@ export namespace StyleSheet {
 
   /**
    * Flattens an array of style objects, into one aggregated style object.
-   * Alternatively, this method can be used to lookup IDs, returned by
-   * StyleSheet.register.
-   *
-   * > **NOTE**: Exercise caution as abusing this can tax you in terms of
-   * > optimizations.
-   * >
-   * > IDs enable optimizations through the bridge and memory in general. Referring
-   * > to style objects directly will deprive you of these optimizations.
    *
    * Example:
    * ```
@@ -74,17 +66,6 @@ export namespace StyleSheet {
    * StyleSheet.flatten([styles.listItem, styles.selectedListItem])
    * // returns { flex: 1, fontSize: 16, color: 'green' }
    * ```
-   * Alternative use:
-   * ```
-   * StyleSheet.flatten(styles.listItem);
-   * // return { flex: 1, fontSize: 16, color: 'white' }
-   * // Simply styles.listItem would return its ID (number)
-   * ```
-   * This method internally uses `StyleSheetRegistry.getStyleByID(style)`
-   * to resolve style objects represented by IDs. Thus, an array of style
-   * objects (instances of StyleSheet.create), are individually resolved to,
-   * their respective objects, merged as one and then returned. This also explains
-   * the alternative use.
    */
   export function flatten<T>(
     style?: StyleProp<T>,

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -212,16 +212,12 @@ if (__DEV__) {
  * Code quality:
  *
  *  - By moving styles away from the render function, you're making the code
- *  easier to understand.
+ *    easier to understand.
  *  - Naming the styles is a good way to add meaning to the low level components
- *  in the render function.
+ *  in the render function, and encourage reuse.
+ *  - In most IDEs, using `StyleSheet.create()` will offer static type checking
+ *  and suggestions to help you write valid styles.
  *
- * Performance:
- *
- *  - Making a stylesheet from a style object makes it possible to refer to it
- * by ID instead of creating a new style object every time.
- *  - It also allows to send the style only once through the bridge. All
- * subsequent uses are going to refer an id (not implemented yet).
  */
 module.exports = {
   /**
@@ -285,14 +281,6 @@ module.exports = {
 
   /**
    * Flattens an array of style objects, into one aggregated style object.
-   * Alternatively, this method can be used to lookup IDs, returned by
-   * StyleSheet.register.
-   *
-   * > **NOTE**: Exercise caution as abusing this can tax you in terms of
-   * > optimizations.
-   * >
-   * > IDs enable optimizations through the bridge and memory in general. Referring
-   * > to style objects directly will deprive you of these optimizations.
    *
    * Example:
    * ```
@@ -310,17 +298,6 @@ module.exports = {
    * StyleSheet.flatten([styles.listItem, styles.selectedListItem])
    * // returns { flex: 1, fontSize: 16, color: 'green' }
    * ```
-   * Alternative use:
-   * ```
-   * StyleSheet.flatten(styles.listItem);
-   * // return { flex: 1, fontSize: 16, color: 'white' }
-   * // Simply styles.listItem would return its ID (number)
-   * ```
-   * This method internally uses `StyleSheetRegistry.getStyleByID(style)`
-   * to resolve style objects represented by IDs. Thus, an array of style
-   * objects (instances of StyleSheet.create), are individually resolved to,
-   * their respective objects, merged as one and then returned. This also explains
-   * the alternative use.
    */
   flatten,
 

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -338,7 +338,7 @@ module.exports = {
   },
 
   /**
-   * Creates a StyleSheet style reference from the given object.
+   * An identity function for creating style sheets.
    */
   // $FlowFixMe[unsupported-variance-annotation]
   create<+S: ____Styles_Internal>(obj: S): $ReadOnly<S> {


### PR DESCRIPTION
## Summary:

The current comments explaining the various StyleSheet methods and are misleading, often referencing the removed `StyleSheetRegistry` and old behavior related to it.

## Changelog:

Per https://github.com/facebook/react-native-website/pull/3872/files, updates comments to reflect the fact that the `StyleSheetRegistry` has been removed. 

[INTERNAL] [REMOVED] - Removed comment references to `StyleSheetRegistry` and style sheet `ID`s

## Test Plan:

`console.log(StyleSheet.create({ testClass: { color: "red" } }))` outputs `{ testClass: { color: "red" } }`
