### PR TITLE
Add typings for dismissActionSheet method

### DIFF
--- a/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.d.ts
+++ b/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.d.ts
@@ -74,6 +74,12 @@ export interface ActionSheetIOSStatic {
     failureCallback: (error: Error) => void,
     successCallback: (success: boolean, method: string) => void,
   ) => void;
+
+  /**
+   * Dismisses the most upper iOS action sheet presented, if no action sheet is
+   * present a warning is displayed.
+   */
+  dismissActionSheet: () => void;
 }
 
 export const ActionSheetIOS: ActionSheetIOSStatic;

--- a/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -145,6 +145,10 @@ const ActionSheetIOS = {
     );
   },
 
+  /**
+   * Dismisses the most upper iOS action sheet presented, if no action sheet is
+   * present a warning is displayed.
+   */
   dismissActionSheet: () => {
     invariant(RCTActionSheetManager, "ActionSheetManager doesn't exist");
     if (typeof RCTActionSheetManager.dismissActionSheet === 'function') {

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -2115,4 +2115,7 @@ const ActionSheetIOSTest = () => {
     },
     () => undefined,
   );
+
+  // test dismissActionSheet method
+  ActionSheetIOS.dismissActionSheet();
 };


### PR DESCRIPTION
## Summary:

This pull request addresses two key issues. Firstly, it adds a missing docstring to the `dismissActionSheet` function within the `ActionSheetIOS` object. Secondly, it introduces TypeScript typings for the `dismissActionSheet` function.

## Changelog:

[iOS] [Added] - Add missing docstring to the `dismissActionSheet` function in `ActionSheetIOS`.
[iOS] [Added] - Add TypeScript typings for the `dismissActionSheet` function in `ActionSheetIOS`.

## Test Plan:

To ensure the code is solid, I followed these steps:

1. Ran Flow to verify that there were no errors.
2. Added a TypeScript test related to the `dismissActionSheet` function to ensure it's typed as expected.