### PR TITLE
Fix react.dev docs urls

### DIFF
--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -286,7 +286,7 @@ var invokeGuardedCallbackImpl = invokeGuardedCallbackProd;
           error = new Error(
             "A cross-origin error was thrown. React doesn't have access to " +
               "the actual error object in development. " +
-              "See https://react.dev/link/crossorigin-error for more information."
+              "See https://legacy.reactjs.org/docs/cross-origin-errors.html for more information."
           );
         }
 
@@ -857,7 +857,7 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
         "This synthetic event is reused for performance reasons. If you're seeing this, " +
           "you're %s `%s` on a released/nullified synthetic event. %s. " +
           "If you must keep the original synthetic event around, use event.persist(). " +
-          "See https://react.dev/link/event-pooling for more information.",
+          "See https://legacy.reactjs.org/docs/legacy-event-pooling.html for more information.",
         action,
         propName,
         result
@@ -4115,7 +4115,7 @@ function injectInternals(internals) {
       error(
         "The installed version of React DevTools is too old and will not work " +
           "with the current version of React. Please update React DevTools. " +
-          "https://react.dev/link/react-devtools"
+          "https://react.dev/learn/react-developer-tools"
       );
     } // DevTools exists, even though it doesn't support Fiber.
 
@@ -6628,7 +6628,7 @@ var ReactStrictModeWarnings = {
 
       error(
         "Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#unsafe_componentwillmount for details.\n\n" +
           "* Move code with side effects to componentDidMount, and set initial state in the constructor.\n" +
           "\nPlease update the following components: %s",
         sortedNames
@@ -6643,11 +6643,11 @@ var ReactStrictModeWarnings = {
       error(
         "Using UNSAFE_componentWillReceiveProps in strict mode is not recommended " +
           "and may indicate bugs in your code. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#unsafe_componentwillreceiveprops for details.\n\n" +
           "* Move data fetching code or side effects to componentDidUpdate.\n" +
           "* If you're updating state whenever props change, " +
           "refactor your code to use memoization techniques or move it to " +
-          "static getDerivedStateFromProps. Learn more at: https://react.dev/link/derived-state\n" +
+          "static getDerivedStateFromProps. Learn more at: https://react.dev/reference/react/Component#static-getderivedstatefromprops\n" +
           "\nPlease update the following components: %s",
         _sortedNames
       );
@@ -6661,7 +6661,7 @@ var ReactStrictModeWarnings = {
       error(
         "Using UNSAFE_componentWillUpdate in strict mode is not recommended " +
           "and may indicate bugs in your code. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#unsafe_componentwillupdate for details.\n\n" +
           "* Move data fetching code or side effects to componentDidUpdate.\n" +
           "\nPlease update the following components: %s",
         _sortedNames2
@@ -6673,7 +6673,7 @@ var ReactStrictModeWarnings = {
 
       warn(
         "componentWillMount has been renamed, and is not recommended for use. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#componentwillmount for details.\n\n" +
           "* Move code with side effects to componentDidMount, and set initial state in the constructor.\n" +
           "* Rename componentWillMount to UNSAFE_componentWillMount to suppress " +
           "this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. " +
@@ -6691,11 +6691,11 @@ var ReactStrictModeWarnings = {
 
       warn(
         "componentWillReceiveProps has been renamed, and is not recommended for use. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#componentwillreceiveprops for details.\n\n" +
           "* Move data fetching code or side effects to componentDidUpdate.\n" +
           "* If you're updating state whenever props change, refactor your " +
           "code to use memoization techniques or move it to " +
-          "static getDerivedStateFromProps. Learn more at: https://react.dev/link/derived-state\n" +
+          "static getDerivedStateFromProps. Learn more at: https://react.dev/reference/react/Component#static-getderivedstatefromprops\n" +
           "* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress " +
           "this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. " +
           "To rename all deprecated lifecycles to their new names, you can run " +
@@ -6710,7 +6710,7 @@ var ReactStrictModeWarnings = {
 
       warn(
         "componentWillUpdate has been renamed, and is not recommended for use. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#componentwillupdate for details.\n\n" +
           "* Move data fetching code or side effects to componentDidUpdate.\n" +
           "* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress " +
           "this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. " +
@@ -6783,7 +6783,7 @@ var ReactStrictModeWarnings = {
             "\n\nThe old API will be supported in all 16.x releases, but applications " +
             "using it should migrate to the new version." +
             "\n\nPlease update the following components: %s" +
-            "\n\nLearn more about this warning here: https://react.dev/link/legacy-context",
+            "\n\nLearn more about this warning here: https://legacy.reactjs.org/docs/legacy-context.html",
           sortedNames
         );
       } finally {
@@ -8485,7 +8485,7 @@ function constructClassInstance(workInProgress, ctor, props) {
             "Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n" +
               "%s uses %s but also contains the following legacy lifecycles:%s%s%s\n\n" +
               "The above lifecycles should be removed. Learn more about this warning here:\n" +
-              "https://react.dev/link/unsafe-component-lifecycles",
+              "https://react.dev/reference/react/Component",
             _componentName,
             newApiName,
             foundWillMountName !== null ? "\n  " + foundWillMountName : "",
@@ -9005,7 +9005,7 @@ var warnForMissingKey = function(child, returnFiber) {};
 
     error(
       "Each child in a list should have a unique " +
-        '"key" prop. See https://react.dev/link/warning-keys for ' +
+        '"key" prop. See https://react.dev/warnings/special-props for ' +
         "more information."
     );
   };
@@ -9042,7 +9042,7 @@ function coerceRef(returnFiber, current, element) {
                 "String refs are a source of potential bugs and should be avoided. " +
                 "We recommend using useRef() or createRef() instead. " +
                 "Learn more about using refs safely here: " +
-                "https://react.dev/link/strict-mode-string-ref",
+                "https://react.dev/reference/react/Component#refs",
               mixedRef
             );
           }
@@ -9064,7 +9064,7 @@ function coerceRef(returnFiber, current, element) {
             "Function components cannot have string refs. " +
               "We recommend using useRef() instead. " +
               "Learn more about using refs safely here: " +
-              "https://react.dev/link/strict-mode-string-ref"
+              "https://react.dev/reference/react/Component#refs"
           );
         }
 
@@ -9130,7 +9130,7 @@ function coerceRef(returnFiber, current, element) {
             "1. You may be adding a ref to a function component\n" +
             "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
             "3. You have multiple copies of React loaded\n" +
-            "See https://react.dev/link/refs-must-have-owner for more information."
+            "See https://legacy.reactjs.org/warnings/refs-must-have-owner.html for more information."
         );
       }
     }
@@ -10638,7 +10638,7 @@ function warnOnHookMismatchInDev(currentHookName) {
         error(
           "React has detected a change in the order of Hooks called by %s. " +
             "This will lead to bugs and errors if not fixed. " +
-            "For more information, read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n" +
+            "For more information, read the Rules of Hooks: https://react.dev/warnings/invalid-hook-call-warning\n\n" +
             "   Previous render            Next render\n" +
             "   ------------------------------------------------------\n" +
             "%s" +
@@ -10658,7 +10658,7 @@ function throwInvalidHookError() {
       "1. You might have mismatching versions of React and the renderer (such as React DOM)\n" +
       "2. You might be breaking the Rules of Hooks\n" +
       "3. You might have more than one copy of React in the same app\n" +
-      "See https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem."
+      "See https://react.dev/warnings/invalid-hook-call-warning for tips about how to debug and fix this problem."
   );
 }
 
@@ -12115,7 +12115,7 @@ var InvalidNestedHooksDispatcherOnRerenderInDEV = null;
       "Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. " +
         "You can only call Hooks at the top level of your React function. " +
         "For more information, see " +
-        "https://react.dev/link/rules-of-hooks"
+        "https://react.dev/warnings/invalid-hook-call-warning"
     );
   };
 
@@ -13183,7 +13183,7 @@ function logCapturedError(boundary, errorInfo) {
       if (boundary.tag === HostRoot) {
         errorBoundaryMessage =
           "Consider adding an error boundary to your tree to customize error handling behavior.\n" +
-          "Visit https://react.dev/link/error-boundaries to learn more about error boundaries.";
+          "Visit https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary to learn more about error boundaries.";
       } else {
         var errorBoundaryName =
           getComponentNameFromFiber(boundary) || "Anonymous";
@@ -18380,7 +18380,7 @@ function commitHookEffectListMount(flags, finishedWork) {
                 "  }\n" +
                 "  fetchData();\n" +
                 "}, [someId]); // Or [] if effect doesn't need props or state\n\n" +
-                "Learn more about data fetching with Hooks: https://react.dev/link/hooks-data-fetching";
+                "Learn more about data fetching with Hooks: https://react.dev/reference/react/useEffect#fetching-data-with-effects";
             } else {
               addendum = " You returned: " + destroy;
             }
@@ -22072,7 +22072,7 @@ function warnAboutRenderPhaseUpdatesInDEV(fiber) {
             error(
               "Cannot update a component (`%s`) while rendering a " +
                 "different component (`%s`). To locate the bad setState() call inside `%s`, " +
-                "follow the stack trace as described in https://react.dev/link/setstate-in-render",
+                "follow the stack trace as described in https://react.dev/reference/react/useState#troubleshooting",
               setStateComponentName,
               renderingComponentName,
               renderingComponentName
@@ -22189,7 +22189,7 @@ function warnIfUpdatesNotWrappedWithActDEV(fiber) {
             "/* assert on the output */\n\n" +
             "This ensures that you're testing the behavior the user would see " +
             "in the browser." +
-            " Learn more at https://react.dev/link/wrap-tests-with-act",
+            " Learn more at https://legacy.reactjs.org/docs/test-utils.html#act",
           getComponentNameFromFiber(fiber)
         );
       } finally {
@@ -22221,7 +22221,7 @@ function warnIfSuspenseResolutionNotWrappedWithActDEV(root) {
           "/* assert on the output */\n\n" +
           "This ensures that you're testing the behavior the user would see " +
           "in the browser." +
-          " Learn more at https://react.dev/link/wrap-tests-with-act"
+          " Learn more at https://legacy.reactjs.org/docs/test-utils.html#act"
       );
     }
   }
@@ -23471,7 +23471,7 @@ function findHostInstanceWithWarning(component, methodName) {
                 "%s was passed an instance of %s which is inside StrictMode. " +
                 "Instead, add a ref directly to the element you want to reference. " +
                 "Learn more about using refs safely here: " +
-                "https://react.dev/link/strict-mode-find-node",
+                "https://react.dev/reference/react-dom/findDOMNode",
               methodName,
               methodName,
               componentName
@@ -23482,7 +23482,7 @@ function findHostInstanceWithWarning(component, methodName) {
                 "%s was passed an instance of %s which renders StrictMode children. " +
                 "Instead, add a ref directly to the element you want to reference. " +
                 "Learn more about using refs safely here: " +
-                "https://react.dev/link/strict-mode-find-node",
+                "https://react.dev/reference/react-dom/findDOMNode",
               methodName,
               methodName,
               componentName

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
@@ -2782,7 +2782,7 @@ function coerceRef(returnFiber, current, element) {
       if (element) {
         if (1 !== element.tag)
           throw Error(
-            "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref"
+            "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://react.dev/reference/react/Component#refs"
           );
         var inst = element.stateNode;
       }
@@ -2817,7 +2817,7 @@ function coerceRef(returnFiber, current, element) {
       throw Error(
         "Element ref was specified as a string (" +
           returnFiber +
-          ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://react.dev/link/refs-must-have-owner for more information."
+          ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://legacy.reactjs.org/warnings/refs-must-have-owner.html for more information."
       );
   }
   return returnFiber;
@@ -3533,7 +3533,7 @@ var ReactCurrentDispatcher$1 = ReactSharedInternals.ReactCurrentDispatcher,
   globalClientIdCounter = 0;
 function throwInvalidHookError() {
   throw Error(
-    "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem."
+    "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/warnings/invalid-hook-call-warning for tips about how to debug and fix this problem."
   );
 }
 function areHookInputsEqual(nextDeps, prevDeps) {

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
@@ -2841,7 +2841,7 @@ function coerceRef(returnFiber, current, element) {
       if (element) {
         if (1 !== element.tag)
           throw Error(
-            "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref"
+            "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://react.dev/reference/react/Component#refs"
           );
         var inst = element.stateNode;
       }
@@ -2876,7 +2876,7 @@ function coerceRef(returnFiber, current, element) {
       throw Error(
         "Element ref was specified as a string (" +
           returnFiber +
-          ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://react.dev/link/refs-must-have-owner for more information."
+          ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://legacy.reactjs.org/warnings/refs-must-have-owner.html for more information."
       );
   }
   return returnFiber;
@@ -3592,7 +3592,7 @@ var ReactCurrentDispatcher$1 = ReactSharedInternals.ReactCurrentDispatcher,
   globalClientIdCounter = 0;
 function throwInvalidHookError() {
   throw Error(
-    "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem."
+    "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/warnings/invalid-hook-call-warning for tips about how to debug and fix this problem."
   );
 }
 function areHookInputsEqual(nextDeps, prevDeps) {

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -286,7 +286,7 @@ var invokeGuardedCallbackImpl = invokeGuardedCallbackProd;
           error = new Error(
             "A cross-origin error was thrown. React doesn't have access to " +
               "the actual error object in development. " +
-              "See https://react.dev/link/crossorigin-error for more information."
+              "See https://legacy.reactjs.org/docs/cross-origin-errors.html for more information."
           );
         }
 
@@ -857,7 +857,7 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
         "This synthetic event is reused for performance reasons. If you're seeing this, " +
           "you're %s `%s` on a released/nullified synthetic event. %s. " +
           "If you must keep the original synthetic event around, use event.persist(). " +
-          "See https://react.dev/link/event-pooling for more information.",
+          "See https://legacy.reactjs.org/docs/legacy-event-pooling.html for more information.",
         action,
         propName,
         result
@@ -4314,7 +4314,7 @@ function injectInternals(internals) {
       error(
         "The installed version of React DevTools is too old and will not work " +
           "with the current version of React. Please update React DevTools. " +
-          "https://react.dev/link/react-devtools"
+          "https://react.dev/learn/react-developer-tools"
       );
     } // DevTools exists, even though it doesn't support Fiber.
 
@@ -6734,7 +6734,7 @@ var ReactStrictModeWarnings = {
 
       error(
         "Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#unsafe_componentwillmount for details.\n\n" +
           "* Move code with side effects to componentDidMount, and set initial state in the constructor.\n" +
           "\nPlease update the following components: %s",
         sortedNames
@@ -6749,11 +6749,11 @@ var ReactStrictModeWarnings = {
       error(
         "Using UNSAFE_componentWillReceiveProps in strict mode is not recommended " +
           "and may indicate bugs in your code. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#unsafe_componentwillreceiveprops for details.\n\n" +
           "* Move data fetching code or side effects to componentDidUpdate.\n" +
           "* If you're updating state whenever props change, " +
           "refactor your code to use memoization techniques or move it to " +
-          "static getDerivedStateFromProps. Learn more at: https://react.dev/link/derived-state\n" +
+          "static getDerivedStateFromProps. Learn more at: https://react.dev/reference/react/Component#static-getderivedstatefromprops\n" +
           "\nPlease update the following components: %s",
         _sortedNames
       );
@@ -6767,7 +6767,7 @@ var ReactStrictModeWarnings = {
       error(
         "Using UNSAFE_componentWillUpdate in strict mode is not recommended " +
           "and may indicate bugs in your code. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#unsafe_componentwillupdate for details.\n\n" +
           "* Move data fetching code or side effects to componentDidUpdate.\n" +
           "\nPlease update the following components: %s",
         _sortedNames2
@@ -6779,7 +6779,7 @@ var ReactStrictModeWarnings = {
 
       warn(
         "componentWillMount has been renamed, and is not recommended for use. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#componentwillmount for details.\n\n" +
           "* Move code with side effects to componentDidMount, and set initial state in the constructor.\n" +
           "* Rename componentWillMount to UNSAFE_componentWillMount to suppress " +
           "this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. " +
@@ -6797,11 +6797,11 @@ var ReactStrictModeWarnings = {
 
       warn(
         "componentWillReceiveProps has been renamed, and is not recommended for use. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#componentwillreceiveprops for details.\n\n" +
           "* Move data fetching code or side effects to componentDidUpdate.\n" +
           "* If you're updating state whenever props change, refactor your " +
           "code to use memoization techniques or move it to " +
-          "static getDerivedStateFromProps. Learn more at: https://react.dev/link/derived-state\n" +
+          "static getDerivedStateFromProps. Learn more at: https://react.dev/reference/react/Component#static-getderivedstatefromprops\n" +
           "* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress " +
           "this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. " +
           "To rename all deprecated lifecycles to their new names, you can run " +
@@ -6816,7 +6816,7 @@ var ReactStrictModeWarnings = {
 
       warn(
         "componentWillUpdate has been renamed, and is not recommended for use. " +
-          "See https://react.dev/link/unsafe-component-lifecycles for details.\n\n" +
+          "See https://react.dev/reference/react/Component#componentwillupdate for details.\n\n" +
           "* Move data fetching code or side effects to componentDidUpdate.\n" +
           "* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress " +
           "this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. " +
@@ -6889,7 +6889,7 @@ var ReactStrictModeWarnings = {
             "\n\nThe old API will be supported in all 16.x releases, but applications " +
             "using it should migrate to the new version." +
             "\n\nPlease update the following components: %s" +
-            "\n\nLearn more about this warning here: https://react.dev/link/legacy-context",
+            "\n\nLearn more about this warning here: https://legacy.reactjs.org/docs/legacy-context.html",
           sortedNames
         );
       } finally {
@@ -8591,7 +8591,7 @@ function constructClassInstance(workInProgress, ctor, props) {
             "Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n" +
               "%s uses %s but also contains the following legacy lifecycles:%s%s%s\n\n" +
               "The above lifecycles should be removed. Learn more about this warning here:\n" +
-              "https://react.dev/link/unsafe-component-lifecycles",
+              "https://react.dev/reference/react/Component",
             _componentName,
             newApiName,
             foundWillMountName !== null ? "\n  " + foundWillMountName : "",
@@ -9111,7 +9111,7 @@ var warnForMissingKey = function(child, returnFiber) {};
 
     error(
       "Each child in a list should have a unique " +
-        '"key" prop. See https://react.dev/link/warning-keys for ' +
+        '"key" prop. See https://react.dev/warnings/special-props for ' +
         "more information."
     );
   };
@@ -9148,7 +9148,7 @@ function coerceRef(returnFiber, current, element) {
                 "String refs are a source of potential bugs and should be avoided. " +
                 "We recommend using useRef() or createRef() instead. " +
                 "Learn more about using refs safely here: " +
-                "https://react.dev/link/strict-mode-string-ref",
+                "https://react.dev/reference/react/Component#refs",
               mixedRef
             );
           }
@@ -9170,7 +9170,7 @@ function coerceRef(returnFiber, current, element) {
             "Function components cannot have string refs. " +
               "We recommend using useRef() instead. " +
               "Learn more about using refs safely here: " +
-              "https://react.dev/link/strict-mode-string-ref"
+              "https://react.dev/reference/react/Component#refs"
           );
         }
 
@@ -9236,7 +9236,7 @@ function coerceRef(returnFiber, current, element) {
             "1. You may be adding a ref to a function component\n" +
             "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
             "3. You have multiple copies of React loaded\n" +
-            "See https://react.dev/link/refs-must-have-owner for more information."
+            "See https://legacy.reactjs.org/warnings/refs-must-have-owner.html for more information."
         );
       }
     }
@@ -10744,7 +10744,7 @@ function warnOnHookMismatchInDev(currentHookName) {
         error(
           "React has detected a change in the order of Hooks called by %s. " +
             "This will lead to bugs and errors if not fixed. " +
-            "For more information, read the Rules of Hooks: https://react.dev/link/rules-of-hooks\n\n" +
+            "For more information, read the Rules of Hooks: https://react.dev/warnings/invalid-hook-call-warning\n\n" +
             "   Previous render            Next render\n" +
             "   ------------------------------------------------------\n" +
             "%s" +
@@ -10764,7 +10764,7 @@ function throwInvalidHookError() {
       "1. You might have mismatching versions of React and the renderer (such as React DOM)\n" +
       "2. You might be breaking the Rules of Hooks\n" +
       "3. You might have more than one copy of React in the same app\n" +
-      "See https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem."
+      "See https://react.dev/warnings/invalid-hook-call-warning for tips about how to debug and fix this problem."
   );
 }
 
@@ -12221,7 +12221,7 @@ var InvalidNestedHooksDispatcherOnRerenderInDEV = null;
       "Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. " +
         "You can only call Hooks at the top level of your React function. " +
         "For more information, see " +
-        "https://react.dev/link/rules-of-hooks"
+        "https://react.dev/warnings/invalid-hook-call-warning"
     );
   };
 
@@ -13289,7 +13289,7 @@ function logCapturedError(boundary, errorInfo) {
       if (boundary.tag === HostRoot) {
         errorBoundaryMessage =
           "Consider adding an error boundary to your tree to customize error handling behavior.\n" +
-          "Visit https://react.dev/link/error-boundaries to learn more about error boundaries.";
+          "Visit https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary to learn more about error boundaries.";
       } else {
         var errorBoundaryName =
           getComponentNameFromFiber(boundary) || "Anonymous";
@@ -18324,7 +18324,7 @@ function commitHookEffectListMount(flags, finishedWork) {
                 "  }\n" +
                 "  fetchData();\n" +
                 "}, [someId]); // Or [] if effect doesn't need props or state\n\n" +
-                "Learn more about data fetching with Hooks: https://react.dev/link/hooks-data-fetching";
+                "Learn more about data fetching with Hooks: https://react.dev/reference/react/useEffect#fetching-data-with-effects";
             } else {
               addendum = " You returned: " + destroy;
             }
@@ -22401,7 +22401,7 @@ function warnAboutRenderPhaseUpdatesInDEV(fiber) {
             error(
               "Cannot update a component (`%s`) while rendering a " +
                 "different component (`%s`). To locate the bad setState() call inside `%s`, " +
-                "follow the stack trace as described in https://react.dev/link/setstate-in-render",
+                "follow the stack trace as described in https://react.dev/reference/react/useState#troubleshooting",
               setStateComponentName,
               renderingComponentName,
               renderingComponentName
@@ -22518,7 +22518,7 @@ function warnIfUpdatesNotWrappedWithActDEV(fiber) {
             "/* assert on the output */\n\n" +
             "This ensures that you're testing the behavior the user would see " +
             "in the browser." +
-            " Learn more at https://react.dev/link/wrap-tests-with-act",
+            " Learn more at https://legacy.reactjs.org/docs/test-utils.html#act",
           getComponentNameFromFiber(fiber)
         );
       } finally {
@@ -22550,7 +22550,7 @@ function warnIfSuspenseResolutionNotWrappedWithActDEV(root) {
           "/* assert on the output */\n\n" +
           "This ensures that you're testing the behavior the user would see " +
           "in the browser." +
-          " Learn more at https://react.dev/link/wrap-tests-with-act"
+          " Learn more at https://legacy.reactjs.org/docs/test-utils.html#act"
       );
     }
   }
@@ -23800,7 +23800,7 @@ function findHostInstanceWithWarning(component, methodName) {
                 "%s was passed an instance of %s which is inside StrictMode. " +
                 "Instead, add a ref directly to the element you want to reference. " +
                 "Learn more about using refs safely here: " +
-                "https://react.dev/link/strict-mode-find-node",
+                "https://react.dev/reference/react-dom/findDOMNode",
               methodName,
               methodName,
               componentName
@@ -23811,7 +23811,7 @@ function findHostInstanceWithWarning(component, methodName) {
                 "%s was passed an instance of %s which renders StrictMode children. " +
                 "Instead, add a ref directly to the element you want to reference. " +
                 "Learn more about using refs safely here: " +
-                "https://react.dev/link/strict-mode-find-node",
+                "https://react.dev/reference/react-dom/findDOMNode",
               methodName,
               methodName,
               componentName

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
@@ -2745,7 +2745,7 @@ function coerceRef(returnFiber, current, element) {
       if (element) {
         if (1 !== element.tag)
           throw Error(
-            "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref"
+            "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://react.dev/reference/react/Component#refs"
           );
         var inst = element.stateNode;
       }
@@ -2780,7 +2780,7 @@ function coerceRef(returnFiber, current, element) {
       throw Error(
         "Element ref was specified as a string (" +
           returnFiber +
-          ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://react.dev/link/refs-must-have-owner for more information."
+          ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://legacy.reactjs.org/warnings/refs-must-have-owner.html for more information."
       );
   }
   return returnFiber;
@@ -3496,7 +3496,7 @@ var ReactCurrentDispatcher$1 = ReactSharedInternals.ReactCurrentDispatcher,
   globalClientIdCounter = 0;
 function throwInvalidHookError() {
   throw Error(
-    "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem."
+    "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/warnings/invalid-hook-call-warning for tips about how to debug and fix this problem."
   );
 }
 function areHookInputsEqual(nextDeps, prevDeps) {

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
@@ -2804,7 +2804,7 @@ function coerceRef(returnFiber, current, element) {
       if (element) {
         if (1 !== element.tag)
           throw Error(
-            "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://react.dev/link/strict-mode-string-ref"
+            "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://react.dev/reference/react/Component#refs"
           );
         var inst = element.stateNode;
       }
@@ -2839,7 +2839,7 @@ function coerceRef(returnFiber, current, element) {
       throw Error(
         "Element ref was specified as a string (" +
           returnFiber +
-          ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://react.dev/link/refs-must-have-owner for more information."
+          ") but no owner was set. This could happen for one of the following reasons:\n1. You may be adding a ref to a function component\n2. You may be adding a ref to a component that was not created inside a component's render method\n3. You have multiple copies of React loaded\nSee https://legacy.reactjs.org/warnings/refs-must-have-owner.html for more information."
       );
   }
   return returnFiber;
@@ -3555,7 +3555,7 @@ var ReactCurrentDispatcher$1 = ReactSharedInternals.ReactCurrentDispatcher,
   globalClientIdCounter = 0;
 function throwInvalidHookError() {
   throw Error(
-    "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem."
+    "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://react.dev/warnings/invalid-hook-call-warning for tips about how to debug and fix this problem."
   );
 }
 function areHookInputsEqual(nextDeps, prevDeps) {


### PR DESCRIPTION
## Summary:

All "https://react.dev/link" links give a 404 and are deprecated. I replaced all URLs with new ones or, if this was not possible, replaced them with a link to legacy documentation.

## Changelog:

[INTERNAL] [FIXED] - Fixed links to React documentation

## Test plan
All of the old links didn't work. I tried to match the content of the errors to the new documentation as best as possible. Current links have been tested and direct you to the most relevant article section.