### PR TITLE
[iOS] Rearrange RNComponentViewUpdateMask value

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -22,8 +22,8 @@ typedef NS_OPTIONS(NSInteger, RNComponentViewUpdateMask) {
   RNComponentViewUpdateMaskNone = 0,
   RNComponentViewUpdateMaskProps = 1 << 0,
   RNComponentViewUpdateMaskEventEmitter = 1 << 1,
-  RNComponentViewUpdateMaskState = 1 << 3,
-  RNComponentViewUpdateMaskLayoutMetrics = 1 << 4,
+  RNComponentViewUpdateMaskState = 1 << 2,
+  RNComponentViewUpdateMaskLayoutMetrics = 1 << 3,
 
   RNComponentViewUpdateMaskAll = RNComponentViewUpdateMaskProps | RNComponentViewUpdateMaskEventEmitter |
       RNComponentViewUpdateMaskState | RNComponentViewUpdateMaskLayoutMetrics


### PR DESCRIPTION
## Summary:

We removed `RNComponentViewUpdateMaskLocalData ` in https://github.com/facebook/react-native/commit/b920bf87368a295b4296ce004094d138b9c4ee20, so we rearrange RNComponentViewUpdateMask value in sequential order.

cc @sammy-SC .

## Changelog:

[IOS] [CHANGED] - Rearrange RNComponentViewUpdateMask value

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
No need :)
