### PR TITLE
Store hermes stable artifacts inside Pods directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,6 @@ package-lock.json
 
 # Additional SDKs
 /packages/react-native/sdks/download
-/packages/react-native/sdks/downloads
 /packages/react-native/sdks/hermes
 /packages/react-native/sdks/hermesc
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -60,7 +60,7 @@ Pod::Spec.new do |spec|
         :execution_position => :before_compile,
         :script => <<-EOS
         . "$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh"
-        "$NODE_BINARY" "$REACT_NATIVE_PATH/sdks/hermes-engine/utils/replace_hermes_version.js" -c "$CONFIGURATION" -r "#{version}" -p "$REACT_NATIVE_PATH"
+        "$NODE_BINARY" "$REACT_NATIVE_PATH/sdks/hermes-engine/utils/replace_hermes_version.js" -c "$CONFIGURATION" -r "#{version}" -p "$PODS_ROOT"
         EOS
       }
     end

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -125,7 +125,7 @@ def podspec_source_build_from_local_source_dir(react_native_path)
     source_dir_path = ENV['REACT_NATIVE_OVERRIDE_HERMES_DIR']
     if Dir.exist?(source_dir_path)
         hermes_log("Using source code from local path: #{source_dir_path}")
-        tarball_path = File.join(react_native_path, "sdks", "hermes-engine", "hermes-engine-from-local-source-dir.tar.gz")
+        tarball_path = File.join(artifacts_dir(), "hermes-engine-from-local-source-dir.tar.gz")
         exclude_paths = [
             "__tests__",
             "./external/flowtest",
@@ -192,6 +192,10 @@ end
 
 # HELPERS
 
+def artifacts_dir()
+    return File.join(Pod::Config.instance.project_pods_root, "hermes-engine-artifacts")
+end
+
 def hermestag_file(react_native_path)
     return File.join(react_native_path, "sdks", ".hermesversion")
 end
@@ -208,15 +212,14 @@ def download_stable_hermes(react_native_path, version, configuration)
 end
 
 def download_hermes_tarball(react_native_path, tarball_url, version, configuration)
-    destination_folder = "#{react_native_path}/sdks/downloads"
     destination_path = configuration == nil ?
-        "#{destination_folder}/hermes-ios-#{version}.tar.gz" :
-        "#{destination_folder}/hermes-ios-#{version}-#{configuration}.tar.gz"
+        "#{artifacts_dir()}/hermes-ios-#{version}.tar.gz" :
+        "#{artifacts_dir()}/hermes-ios-#{version}-#{configuration}.tar.gz"
 
     unless File.exist?(destination_path)
       # Download to a temporary file first so we don't cache incomplete downloads.
-      tmp_file = "#{destination_folder}/hermes-ios.download"
-      `mkdir -p "#{destination_folder}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+      tmp_file = "#{artifacts_dir()}/hermes-ios.download"
+      `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
     end
     return destination_path
 end

--- a/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
+++ b/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
@@ -52,8 +52,8 @@ function shouldReplaceHermesConfiguration(configuration) {
   return true;
 }
 
-function replaceHermesConfiguration(configuration, version, reactNativePath) {
-  const tarballURLPath = `${reactNativePath}/sdks/downloads/hermes-ios-${version}-${configuration}.tar.gz`;
+function replaceHermesConfiguration(configuration, version, podsRoot) {
+  const tarballURLPath = `${podsRoot}/hermes-engine-artifacts/hermes-ios-${version}-${configuration}.tar.gz`;
 
   const finalLocation = 'hermes-engine';
   console.log('Preparing the final location');
@@ -68,7 +68,7 @@ function updateLastBuildConfiguration(configuration) {
   fs.writeFileSync(LAST_BUILD_FILENAME, configuration);
 }
 
-function main(configuration, version, reactNativePath) {
+function main(configuration, version, podsRoot) {
   validateBuildConfiguration(configuration);
   validateVersion(version);
 
@@ -76,7 +76,7 @@ function main(configuration, version, reactNativePath) {
     return;
   }
 
-  replaceHermesConfiguration(configuration, version, reactNativePath);
+  replaceHermesConfiguration(configuration, version, podsRoot);
   updateLastBuildConfiguration(configuration);
   console.log('Done replacing hermes-engine');
 }
@@ -94,13 +94,13 @@ const argv = yargs
       'The Version of React Native associated with the Hermes tarball.',
   })
   .option('p', {
-    alias: 'reactNativePath',
-    description: 'The path to the React Native root folder',
+    alias: 'podsRoot',
+    description: 'The path to the Pods root folder',
   })
   .usage('Usage: $0 -c Debug -r <version> -p <path/to/react-native>').argv;
 
 const configuration = argv.configuration;
 const version = argv.reactNativeVersion;
-const reactNativePath = argv.reactNativePath;
+const podsRoot = argv.podsRoot;
 
-main(configuration, version, reactNativePath);
+main(configuration, version, podsRoot);


### PR DESCRIPTION
Summary:
Node package managers may purge or recreate `node_modules/react-native` when adding/removenf project dependencies. Storing hermes iOS artifacts inside `node_modules/react-native/sdks` is not reliable.
This diff moves those artifacts to `Pods/hermes-engine-artifacts`.
Should fix https://github.com/facebook/react-native/issues/39903
Changelog: [Internal]

Differential Revision: D50081559


