### PR TITLE
Support grouped focus for switch

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -629,11 +629,6 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
         final boolean boolValue = value.asBoolean();
         info.setCheckable(true);
         info.setChecked(boolValue);
-        if (info.getClassName().equals(AccessibilityRole.getValue(AccessibilityRole.SWITCH))) {
-          info.setStateDescription(
-              context.getString(
-                  boolValue ? R.string.state_on_description : R.string.state_off_description));
-        }
       }
     }
   }


### PR DESCRIPTION
Summary:
Adding support for grouped accessibility focus on switch.  This is when the switch itself shouldn't be directly focusable.  Instead, the parent element should be focusable, including announcing the switch role and state changes, e.g. "on" and "off".

Fix this issue in a couple ways:
1. Make sure to set the proper role for switch in FbReactSwitchCompat.java.
2. Set the state description in SwitchCompat.java so that uses the correct announcement of "off" and "on" instead of "checked" and "unchecked".

Reviewed By: blavalla

Differential Revision: D50068169


