### PR TITLE
Align Podfile.lock with the right versions on main

### DIFF
--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1347,8 +1347,8 @@ SPEC CHECKSUMS:
   boost: 26fad476bfa736552bbfa698a06cc530475c1505
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  FBLazyVector: 9efa2420b88992b1eda40354ba0cc0aae2d0c3d3
-  FBReactNativeSpec: b9dfd737f7442d6a5df5fab7b3c14e374948895d
+  FBLazyVector: f4492a543c5a8fa1502d3a5867e3f7252497cfe8
+  FBReactNativeSpec: 03da6018f583d64c5944bc4afffb12368e3642a8
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -1359,58 +1359,58 @@ SPEC CHECKSUMS:
   FlipperKit: 37525a5d056ef9b93d1578e04bc3ea1de940094f
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 3eb69bfc4c3e106b2e611369e161b108d5fe04eb
+  hermes-engine: 829010bf94080d7782b61350a4a111238c353ae4
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 3edb9330ce752fe48b85e6c8a65506033f95f4b9
-  RCTRequired: 5548e533128bc26ebd8e8ed7cb3b14e4d56a6223
-  RCTTypeSafety: f5e305cb2f7e2910b2c529a7dc9facf371d2b218
-  React: 78a5cd0062adb251037ab54793ef1c2b51a41c1a
-  React-callinvoker: fd43340e9aa38b774a01fb61e1e46c8354764c6b
+  RCTRequired: 82c56a03b3efd524bfdb581a906add903f78f978
+  RCTTypeSafety: 5f57d4ae5dfafc85a0f575d756c909b584722c52
+  React: cb6dc75e09f32aeddb4d8fb58a394a67219a92fe
+  React-callinvoker: bae59cbd6affd712bbfc703839dad868ff35069d
   React-Codegen: 05b37234a5252f99c890f3e2544b278827b613ca
-  React-Core: be3a57d0e4f81b86c00dfc39aef9a071e4c248de
-  React-CoreModules: 1a3ebdfeba6c13aacd27bdeb224a7ab8c0b327fc
-  React-cxxreact: ef020b104574bdc0c11b9e97216110ccfa3ebd7a
-  React-debug: 25099c0c3751fb09bbae97696e4deb8a53f82593
-  React-Fabric: 40f6d706a42195a112e2d610bebc998744c8df40
-  React-FabricImage: a4cd09149f75afa9275af8ad65c826596efe06d5
-  React-graphics: 24b5d0b9f889764c75f4e6cc7c8ae4079452d65d
-  React-hermes: 62bcf4a6c382ef7398fed8b7f532dc002325749f
-  React-ImageManager: c6cbfb029e24a60a07fb1aec56e4168e25322d7d
-  React-jserrorhandler: 62e327b4f33dd4f115ac3a1791197017921cb63d
-  React-jsi: 0b2e26a7855006faa8f0dcb6d3fc56b8326ad115
-  React-jsiexecutor: 6ae3c165b135e7235df5b245e4d9ad82377ac9d5
-  React-jsinspector: 0e97bc40aec64803ab36bf3395ffee312c6b3957
-  React-logger: 38f6e91fa64a6ad1dd8ae66a69cfd0ebb07e7a6d
-  React-Mapbuffer: 05889b942e3937765fbacc5ebf194a0ad0ebbfd8
-  React-nativeconfig: a5573117479c54d0df95722ef421ba8fff260b7a
-  React-NativeModulesApple: b1aea709e0782702f07bd12ef2aa8db67f71dafe
-  React-perflogger: 3aa5d2c085de1ba512940cd6c64c0591d896d29c
-  React-RCTActionSheet: 47e62ad0547aeef5c98395ad3d9fadb594a401e7
-  React-RCTAnimation: 77a73c05593c83f0adae33f254e3cd5f0deae4ed
-  React-RCTAppDelegate: 3c7e0daacbbea9d72bbbdf4ef9ff34707aff2a10
-  React-RCTBlob: b2cf51dc6fdf3789bfc06345eb53829f11e5fa75
-  React-RCTFabric: b77cfa83d50f5a869d7236ea438edc218b673054
-  React-RCTImage: 3ae92a7bd8aa29b93f24289b4164640aa4e88fee
-  React-RCTLinking: 6cb887793b3030cbc3f6429b5730087cc3ffa6fe
-  React-RCTNetwork: a322dc10073445fb288b5524f8ed756ac9908d14
-  React-RCTPushNotification: 17ea6e62f6b8dc48266b8977628e8de5c0dbecae
-  React-RCTSettings: d37093ad0b9094fa222226f79213c72364101d1e
-  React-RCTTest: d37b49f8ef9ced2f3409a6aaab3efaf16b4430ed
-  React-RCTText: 142b6d88aa384455412a39d9870a45bfc0df8875
-  React-RCTVibration: 7c0d1c3645b9e386baea14f875ed4da066bb8f5e
-  React-rendererdebug: ff934455f14701a4852d9d0574c0732ef44b55ef
-  React-rncore: 7291f6a0d4446605c7f6bc0c8e55218548cb2cca
-  React-runtimeexecutor: 8876a87a512c06719d0f140d22c03865364a1e33
-  React-runtimescheduler: d2d20324d97633c450b08cc5a0fd4619d37acc0f
-  React-utils: a292918d2999555af3a4bd5e84e46d613c37afd6
-  ReactCommon: 425c3f816258bf0371759668869186d41bc73f24
-  ReactCommon-Samples: 4fdff497535bc53e0ff66fcaf6e1c3da7ec5e1f7
+  React-Core: 2ea829947dba8e566cef62fbaa84b65ccd4de6c0
+  React-CoreModules: b0501a35540da49bc3fe9f845b49f63ce74d8251
+  React-cxxreact: 04bf6a12caa850f5d2c7bd6d66dfecd4741989b5
+  React-debug: 296b501a90c41f83961f58c6d96a01330d499da5
+  React-Fabric: 8baf0995aaea1d6230cc8ca5704675f33781d67a
+  React-FabricImage: d16bb9db167efd349360c5ca26a5aaf3df10d87c
+  React-graphics: fe23f0be844a21d42642596183f8ce0e54861ecf
+  React-hermes: 068605f9b6befeeb1582d20053021f7dbdb3810a
+  React-ImageManager: 32c0b66c8ff9f93940f59e3d1413f6da8df2197b
+  React-jserrorhandler: 6a52e1f34a4e5cfcca406df3544ee46c148b2f41
+  React-jsi: 3c1d8048abf3eaca913944bd9835333bb7b415d4
+  React-jsiexecutor: 1212e26a01ce4de7443123f0ce090ec1affb3220
+  React-jsinspector: c867db3338992200616103b2f0ca6882c0c0482d
+  React-logger: 47d2e615daa673cf46b3793a357b0ff8146a9140
+  React-Mapbuffer: 4e45db3d43a6c06deac17bea49fc5b2664074e21
+  React-nativeconfig: 40a2c848083ef4065c163c854e1c82b5f9e9db84
+  React-NativeModulesApple: 2c87d9ea3534e36ed2d483f834c817398c2bc0d8
+  React-perflogger: 70d009f755dd10002183454cdf5ad9b22de4a1d7
+  React-RCTActionSheet: 943bd5f540f3af1e5a149c13c4de81858edf718a
+  React-RCTAnimation: 01584a674b84b8fa6c4b1699ce4b8b8655ffb0f4
+  React-RCTAppDelegate: 7d4fc5a07fe28f02fec64c22ba4c03fd627c8693
+  React-RCTBlob: 8452b324b72348846d725176f73b998c35cc6fd8
+  React-RCTFabric: 7823d2a4b1fc804b6a00dea7195f8a3225f49291
+  React-RCTImage: 91fbb6bee9aac13d26f0f6becb82485bd5dd0128
+  React-RCTLinking: 4371cedd2f009f8a6caabf8836fd8300793811cd
+  React-RCTNetwork: b02398d9b811039465f82df7fdc274902293805b
+  React-RCTPushNotification: 8e5b9a0cb64b131d4eb089ea02fb8d5c22a40f68
+  React-RCTSettings: a48ef30d7a4abcef5a86c5ae2c45ecd976868aca
+  React-RCTTest: b4eefa65f8440c9de3ce8959407cad3f0698c935
+  React-RCTText: d9925903524a7b179cf7803162a98038e0bfb4fd
+  React-RCTVibration: 5045ec6871c2745bd0c38391b34d38b9ee27f424
+  React-rendererdebug: e055263340fed29c752ca131d8e6a4abfff2c16b
+  React-rncore: 63aced0ca8aff46f8e762663ca4afebb5eedb627
+  React-runtimeexecutor: e1c32bc249dd3cf3919cb4664fd8dc84ef70cff7
+  React-runtimescheduler: 7aba838c68ab7a2309cebe945150fb1c27f47f29
+  React-utils: 0dec498e683e489e8107b97cc93880e415adfbf6
+  ReactCommon: 4511ea0e8f349de031de7cad88c2ecf871ab69f9
+  ReactCommon-Samples: 3da301b53ee9942acda795da23fb1df4e61b416f
   ScreenshotManager: 2b23b74d25f5e307f7b4d21173a61a3934e69475
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: c17be32c49fe31647121373886786019855be3a7
+  Yoga: 6ac60634494e651c29c947ffbc7ed0bbd49eb053
 
 PODFILE CHECKSUM: 7d1b558e28efc972a185230c56fef43ed86910a1
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0


### PR DESCRIPTION
Summary:
The Podfile.lock was not aligned properly with the versions of the Pods on main.

## Changelog:
[Internal] - Align the Podfile.lock with the status of podspecs on main

Differential Revision: D50084954


