### PR TITLE
refactor: don't include `DevtoolsOverlay` & `TraceUpdateOverlay` in the production bundle

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppContainer.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer.js
@@ -52,14 +52,16 @@ class AppContainer extends React.Component<Props, State> {
   static getDerivedStateFromError: any = undefined;
 
   mountReactDevToolsOverlays(): void {
-    const DevtoolsOverlay = require('../Inspector/DevtoolsOverlay').default;
-    const devtoolsOverlay = <DevtoolsOverlay inspectedView={this._mainRef} />;
+    if (__DEV__) {
+      const DevtoolsOverlay = require('../Inspector/DevtoolsOverlay').default;
+      const devtoolsOverlay = <DevtoolsOverlay inspectedView={this._mainRef} />;
 
-    const TraceUpdateOverlay =
-      require('../Components/TraceUpdateOverlay/TraceUpdateOverlay').default;
-    const traceUpdateOverlay = <TraceUpdateOverlay />;
+      const TraceUpdateOverlay =
+        require('../Components/TraceUpdateOverlay/TraceUpdateOverlay').default;
+      const traceUpdateOverlay = <TraceUpdateOverlay />;
 
-    this.setState({devtoolsOverlay, traceUpdateOverlay});
+      this.setState({devtoolsOverlay, traceUpdateOverlay});
+    }
   }
 
   componentDidMount(): void {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Currently, when we build the app in production mode the `DevtoolsOverlay` & `TraceUpdateOverlay` are bundle

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL][REMOVED]: removed `DevtoolsOverlay` & `TraceUpdateOverlay` from production bundle

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

1. Build the app in production mode
2. Check that both `DevtoolsOverlay` & `TraceUpdateOverlay` are included in the bundle

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
