### PR TITLE
Inconsistent documentation: `onShouldBlockNativeResponder` works on iOS

### DIFF
--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -104,7 +104,7 @@ const currentCentroidY = TouchHistoryMath.currentCentroidY;
  *       },
  *       onShouldBlockNativeResponder: (evt, gestureState) => {
  *         // Returns whether this component should block native components from becoming the JS
- *         // responder. Returns true by default. Is currently only supported on android.
+ *         // responder. Returns true by default.
  *         return true;
  *       },
  *     });


### PR DESCRIPTION
## Summary:

This line of the documentation says that `onShouldBlockNativeResponder` in PanResponder only works on Android. However, I just tried it and it seems to be working very nicely on iOS.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [FIXED] - Inconsistent documentation: `onShouldBlockNativeResponder` works on iOS

## Test Plan:

Code comment change only. No functional changes should require no testing