### PR TITLE
Fix iOS Paper Scroll Event RTL check

### DIFF
--- a/packages/react-native/React/Base/Surface/RCTSurfaceRootShadowView.h
+++ b/packages/react-native/React/Base/Surface/RCTSurfaceRootShadowView.h
@@ -27,6 +27,6 @@
  */
 @property (nonatomic, assign) YGDirection baseDirection;
 
-- (void)layoutWithAffectedShadowViews:(NSHashTable<RCTShadowView *> *)affectedShadowViews;
+- (void)layoutWithAffectedShadowViews:(NSPointerArray *)affectedShadowViews;
 
 @end

--- a/packages/react-native/React/Base/Surface/RCTSurfaceRootShadowView.m
+++ b/packages/react-native/React/Base/Surface/RCTSurfaceRootShadowView.m
@@ -41,7 +41,7 @@
   }
 }
 
-- (void)layoutWithAffectedShadowViews:(NSHashTable<RCTShadowView *> *)affectedShadowViews
+- (void)layoutWithAffectedShadowViews:(NSPointerArray *)affectedShadowViews
 {
   NSHashTable<NSString *> *other = [NSHashTable new];
 

--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -534,7 +534,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
 {
   RCTAssertUIManagerQueue();
 
-  NSHashTable<RCTShadowView *> *affectedShadowViews = [NSHashTable weakObjectsHashTable];
+  NSPointerArray *affectedShadowViews = [NSPointerArray weakObjectsPointerArray];
   [rootShadowView layoutWithAffectedShadowViews:affectedShadowViews];
 
   if (!affectedShadowViews.count) {

--- a/packages/react-native/React/Views/RCTLayout.h
+++ b/packages/react-native/React/Views/RCTLayout.h
@@ -31,7 +31,7 @@ typedef struct CG_BOXABLE RCTLayoutMetrics RCTLayoutMetrics;
 
 struct RCTLayoutContext {
   CGPoint absolutePosition;
-  __unsafe_unretained NSHashTable<RCTShadowView *> *_Nonnull affectedShadowViews;
+  __unsafe_unretained NSPointerArray *_Nonnull affectedShadowViews;
   __unsafe_unretained NSHashTable<NSString *> *_Nonnull other;
 };
 typedef struct CG_BOXABLE RCTLayoutContext RCTLayoutContext;

--- a/packages/react-native/React/Views/RCTRootShadowView.h
+++ b/packages/react-native/React/Views/RCTRootShadowView.h
@@ -29,6 +29,6 @@
  */
 @property (nonatomic, assign) YGDirection baseDirection;
 
-- (void)layoutWithAffectedShadowViews:(NSHashTable<RCTShadowView *> *)affectedShadowViews;
+- (void)layoutWithAffectedShadowViews:(NSPointerArray *)affectedShadowViews;
 
 @end

--- a/packages/react-native/React/Views/RCTRootShadowView.m
+++ b/packages/react-native/React/Views/RCTRootShadowView.m
@@ -23,7 +23,7 @@
   return self;
 }
 
-- (void)layoutWithAffectedShadowViews:(NSHashTable<RCTShadowView *> *)affectedShadowViews
+- (void)layoutWithAffectedShadowViews:(NSPointerArray *)affectedShadowViews
 {
   NSHashTable<NSString *> *other = [NSHashTable new];
 

--- a/packages/react-native/React/Views/RCTShadowView.m
+++ b/packages/react-native/React/Views/RCTShadowView.m
@@ -304,7 +304,7 @@ static void RCTProcessMetaPropsBorder(const YGValue metaProps[META_PROP_COUNT], 
 {
   if (!RCTLayoutMetricsEqualToLayoutMetrics(self.layoutMetrics, layoutMetrics)) {
     self.layoutMetrics = layoutMetrics;
-    [layoutContext.affectedShadowViews addObject:self];
+    [layoutContext.affectedShadowViews addPointer:((__bridge void *)self)];
   }
 }
 

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -1058,7 +1058,7 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, scrollIndicatorInsets, UIE
   }
 
   CGPoint offset = scrollView.contentOffset;
-  if ([UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+  if ([self reactLayoutDirection] == UIUserInterfaceLayoutDirectionRightToLeft) {
     offset.x = scrollView.contentSize.width - scrollView.frame.size.width - offset.x;
   }
 

--- a/packages/rn-tester/RNTesterUnitTests/RCTShadowViewTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTShadowViewTests.m
@@ -84,7 +84,7 @@
   [self.parentView insertReactSubview:mainView atIndex:1];
   [self.parentView insertReactSubview:footerView atIndex:2];
 
-  [self.parentView layoutWithAffectedShadowViews:[NSHashTable weakObjectsHashTable]];
+  [self.parentView layoutWithAffectedShadowViews:[NSPointerArray weakObjectsPointerArray]];
 
   XCTAssertTrue(
       CGRectEqualToRect([self.parentView measureLayoutRelativeToAncestor:self.parentView], CGRectMake(0, 0, 440, 440)));
@@ -187,7 +187,7 @@
   RCTShadowView *view = [self _shadowViewWithConfig:configBlock];
   [self.parentView insertReactSubview:view atIndex:0];
   view.intrinsicContentSize = contentSize;
-  [self.parentView layoutWithAffectedShadowViews:[NSHashTable weakObjectsHashTable]];
+  [self.parentView layoutWithAffectedShadowViews:[NSPointerArray weakObjectsPointerArray]];
   CGRect actualRect = [view measureLayoutRelativeToAncestor:self.parentView];
   XCTAssertTrue(
       CGRectEqualToRect(expectedRect, actualRect),

--- a/packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js
@@ -437,6 +437,11 @@ describe('ListMetricsAggregator', () => {
       getItem: (i: number) => nullthrows(props.data)[i],
     };
 
+    listMetrics.notifyListContentLayout({
+      layout: {width: 100, height: 5},
+      orientation,
+    });
+
     listMetrics.notifyCellLayout({
       cellIndex: 0,
       cellKey: '0',
@@ -459,11 +464,6 @@ describe('ListMetricsAggregator', () => {
         x: 70,
         y: 0,
       },
-    });
-
-    listMetrics.notifyListContentLayout({
-      layout: {width: 100, height: 5},
-      orientation,
     });
 
     expect(listMetrics.getCellMetrics(1, props)).toEqual({
@@ -489,6 +489,11 @@ describe('ListMetricsAggregator', () => {
       getItem: (i: number) => nullthrows(props.data)[i],
     };
 
+    listMetrics.notifyListContentLayout({
+      layout: {width: 100, height: 5},
+      orientation,
+    });
+
     listMetrics.notifyCellLayout({
       cellIndex: 0,
       cellKey: '0',
@@ -511,11 +516,6 @@ describe('ListMetricsAggregator', () => {
         x: 70,
         y: 0,
       },
-    });
-
-    listMetrics.notifyListContentLayout({
-      layout: {width: 100, height: 5},
-      orientation,
     });
 
     expect(listMetrics.getCellMetrics(2, props)).toBeNull();
@@ -537,6 +537,11 @@ describe('ListMetricsAggregator', () => {
       getItemLayout: () => ({index: 2, length: 40, offset: 30}),
     };
 
+    listMetrics.notifyListContentLayout({
+      layout: {width: 100, height: 5},
+      orientation,
+    });
+
     listMetrics.notifyCellLayout({
       cellIndex: 0,
       cellKey: '0',
@@ -559,11 +564,6 @@ describe('ListMetricsAggregator', () => {
         x: 70,
         y: 0,
       },
-    });
-
-    listMetrics.notifyListContentLayout({
-      layout: {width: 100, height: 5},
-      orientation,
     });
 
     expect(listMetrics.getCellMetrics(2, props)).toMatchObject({
@@ -713,98 +713,7 @@ describe('ListMetricsAggregator', () => {
     });
   });
 
-  it('resolves metrics of unmounted cell after list shift when using bottom-up layout propagation', () => {
-    const listMetrics = new ListMetricsAggregator();
-    const orientation = {horizontal: true, rtl: true};
-    const props: CellMetricProps = {
-      data: [1, 2, 3, 4, 5],
-      getItemCount: () => nullthrows(props.data).length,
-      getItem: (i: number) => nullthrows(props.data)[i],
-    };
-
-    listMetrics.notifyCellLayout({
-      cellIndex: 0,
-      cellKey: '0',
-      orientation,
-      layout: {
-        height: 5,
-        width: 10,
-        x: 90,
-        y: 0,
-      },
-    });
-
-    listMetrics.notifyCellLayout({
-      cellIndex: 1,
-      cellKey: '1',
-      orientation,
-      layout: {
-        height: 5,
-        width: 20,
-        x: 70,
-        y: 0,
-      },
-    });
-
-    listMetrics.notifyListContentLayout({
-      layout: {width: 100, height: 5},
-      orientation,
-    });
-
-    expect(listMetrics.getCellMetrics(1, props)).toEqual({
-      index: 1,
-      length: 20,
-      offset: 10,
-      isMounted: true,
-    });
-
-    listMetrics.notifyCellLayout({
-      cellIndex: 2,
-      cellKey: '2',
-      orientation,
-      layout: {
-        height: 5,
-        width: 20,
-        x: 50,
-        y: 0,
-      },
-    });
-
-    listMetrics.notifyListContentLayout({
-      layout: {width: 120, height: 5},
-      orientation,
-    });
-
-    expect(listMetrics.getCellMetrics(1, props)).toEqual({
-      index: 1,
-      length: 20,
-      offset: 10,
-      isMounted: true,
-    });
-
-    listMetrics.notifyCellUnmounted('1');
-
-    expect(listMetrics.getCellMetrics(1, props)).toEqual({
-      index: 1,
-      length: 20,
-      offset: 10,
-      isMounted: false,
-    });
-
-    listMetrics.notifyListContentLayout({
-      layout: {width: 100, height: 5},
-      orientation,
-    });
-
-    expect(listMetrics.getCellMetrics(1, props)).toEqual({
-      index: 1,
-      length: 20,
-      offset: 10,
-      isMounted: false,
-    });
-  });
-
-  it('resolves metrics of unmounted cell after list shift when using top-down layout propagation', () => {
+  it('resolves metrics of unmounted cell after list shift', () => {
     const listMetrics = new ListMetricsAggregator();
     const orientation = {horizontal: true, rtl: true};
     const props: CellMetricProps = {
@@ -1089,18 +998,18 @@ describe('ListMetricsAggregator', () => {
       getItem: (i: number) => nullthrows(props.data)[i],
     };
 
-    listMetrics.notifyCellLayout({
-      cellIndex: 0,
-      cellKey: '0',
-      orientation,
-      layout: {
-        height: 10,
-        width: 5,
-        x: 0,
-        y: 0,
-      },
-    });
-
-    expect(() => listMetrics.getCellMetrics(0, props)).toThrow();
+    expect(() =>
+      listMetrics.notifyCellLayout({
+        cellIndex: 0,
+        cellKey: '0',
+        orientation,
+        layout: {
+          height: 10,
+          width: 5,
+          x: 0,
+          y: 0,
+        },
+      }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
Summary:
In D48379915 I fixed inverted `contentOffset` in `onScroll` events on iOS. I thought I tested on Paper, but I think this was during a period where the Paper route in Catalyst was actually launching Fabric (oops).

In Paper, at least under `forceRTL` and English, `[UIApplication sharedApplication].userInterfaceLayoutDirection` is not set to RTL. We instead have a per-view `reactLayoutDirection` we should be reading.

This sort of thing isn't currently set on Fabric, which checks application-level RTL. This seems... not right with being able to set `direction` in a subtree context, but Android does the same thing, and that would take some greater changes.

Changelog:
[iOS][Fixed] - Fix iOS Paper Scroll Event RTL check

Differential Revision: D50098310

