### PR TITLE
Android: fix ClassCastException in ReactRootView.java when software keyboard is shown

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -40,6 +40,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -12,9 +12,7 @@ import static com.facebook.react.uimanager.common.UIManagerType.DEFAULT;
 import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
-import android.app.Activity;
 import android.content.Context;
-import android.content.ContextWrapper;
 import android.graphics.Canvas;
 import android.graphics.Insets;
 import android.graphics.Point;
@@ -856,14 +854,6 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       checkForDeviceDimensionsChanges();
     }
 
-    private @Nullable Activity getActivity() {
-      Context context = getContext();
-      while (!(context instanceof Activity) && context instanceof ContextWrapper) {
-        context = ((ContextWrapper) context).getBaseContext();
-      }
-      return context instanceof Activity ? (Activity) context : null;
-    }
-
     private @Nullable WindowManager.LayoutParams getWindowLayoutParams() {
       View view = ReactRootView.this;
       if (view.getLayoutParams() instanceof WindowManager.LayoutParams) {
@@ -896,18 +886,12 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
           int height = imeInsets.bottom - barInsets.bottom;
 
           int softInputMode;
-          Activity activity = getActivity();
-          if (activity != null) {
-            softInputMode = activity.getWindow().getAttributes().softInputMode;
+          WindowManager.LayoutParams windowLayoutParams = getWindowLayoutParams();
+          if (windowLayoutParams != null) {
+            softInputMode = windowLayoutParams.softInputMode;
           } else {
-            WindowManager.LayoutParams windowLayoutParams = getWindowLayoutParams();
-            if (windowLayoutParams != null) {
-              softInputMode = windowLayoutParams.softInputMode;
-            } else {
-              return;
-            }
+            return;
           }
-
           int screenY =
               softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
                   ? mVisibleViewArea.bottom - height

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -856,7 +856,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       checkForDeviceDimensionsChanges();
     }
 
-    private Activity getActivity() {
+    private @Nullable Activity getActivity() {
       Context context = getContext();
       while (!(context instanceof Activity) && context instanceof ContextWrapper) {
         context = ((ContextWrapper) context).getBaseContext();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -861,7 +861,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       while (!(context instanceof Activity) && context instanceof ContextWrapper) {
         context = ((ContextWrapper) context).getBaseContext();
       }
-      return (Activity) context;
+      return context instanceof Activity ? (Activity) context : null;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.R)
@@ -881,7 +881,11 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
           Insets barInsets = rootInsets.getInsets(WindowInsets.Type.systemBars());
           int height = imeInsets.bottom - barInsets.bottom;
 
-          int softInputMode = getActivity().getWindow().getAttributes().softInputMode;
+          Activity activity = getActivity();
+          if (activity == null) {
+            return;
+          }
+          int softInputMode = activity.getWindow().getAttributes().softInputMode;
           int screenY =
               softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
                   ? mVisibleViewArea.bottom - height

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -858,6 +858,15 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
     private Activity getActivity() {
       Context context = getContext();
+      if (context instanceof ReactApplicationContext) {
+        View viewParent = ReactRootView.this;
+        while (!(viewParent.getContext() instanceof Activity)
+                && viewParent.getParent() instanceof View) {
+          viewParent = (View) viewParent.getParent();
+        }
+        context = viewParent.getContext();
+      }
+
       while (!(context instanceof Activity) && context instanceof ContextWrapper) {
         context = ((ContextWrapper) context).getBaseContext();
       }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -213,10 +213,10 @@ class RootViewTest {
                   .build()
         }
     val rootViewSpy = spy(rootView)
-    whenever(rootView.getWindowLayoutParams()).thenReturn(WindowManager.LayoutParams())
+    whenever(rootViewSpy.getWindowLayoutParams()).thenReturn(WindowManager.LayoutParams())
 
-    rootView.startReactApplication(instanceManager, "")
-    rootView.simulateCheckForKeyboardForTesting()
+    rootViewSpy.startReactApplication(instanceManager, "")
+    rootViewSpy.simulateCheckForKeyboardForTesting()
 
     val params = Arguments.createMap()
     val endCoordinates = Arguments.createMap()

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -13,6 +13,7 @@ import android.graphics.Insets
 import android.graphics.Rect
 import android.view.MotionEvent
 import android.view.WindowInsets
+import android.view.WindowManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyArray
@@ -211,6 +212,8 @@ class RootViewTest {
                   .setVisible(WindowInsets.Type.ime(), true)
                   .build()
         }
+    val rootViewSpy = spy(rootView)
+    whenever(rootView.getWindowLayoutParams()).thenReturn(WindowManager.LayoutParams())
 
     rootView.startReactApplication(instanceManager, "")
     rootView.simulateCheckForKeyboardForTesting()

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -213,7 +213,7 @@ class RootViewTest {
                   .build()
         }
     val rootViewSpy = spy(rootView)
-    whenever(rootViewSpy.getWindowLayoutParams()).thenReturn(WindowManager.LayoutParams())
+    whenever(rootViewSpy.getLayoutParams()).thenReturn(WindowManager.LayoutParams())
 
     rootViewSpy.startReactApplication(instanceManager, "")
     rootViewSpy.simulateCheckForKeyboardForTesting()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes #40754

Hi all!
We noticed that our app started to crash after bumping to RN v0.71.13, anyways after a deeper investigation we also found that the crash occurs in the latest version as well.

Crash log:
```
E  FATAL EXCEPTION: main
Process: com.nfl.fantasy.core.android.debug, PID: 6034
java.lang.ClassCastException: android.app.ContextImpl cannot be cast to android.app.Activity
at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.getActivity(ReactRootView.java:926)
at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.checkForKeyboardEvents(ReactRootView.java:946)
at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.onGlobalLayout(ReactRootView.java:912)
at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:1061)
```
The code which causes ClassCastException is following [here](https://github.com/facebook/react-native/blob/ea88fbe229e1d276753ee8e118184274fc872138/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java#L864).
In this code explicit type conversion to Activity is not safe because it's not guaranteed by the compiler that context will be compatible with Activity type.
The appropriate issue [has been filed](https://github.com/facebook/react-native/issues/40754).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Fixed crash occurring in certain native views when keyboard events are fired.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested it manually with the [reference application](https://github.com/kot331107/rnCrashReproducer).  Repro steps are as follows:

- Build and run the app on Android
- Tap the button "Open Modal"
- You should see the red popup fragment to the bottom of the screen
- Tap on the text input to open software keyboard
- Expected: it should show the keyboard and no crash happens.
