### PR TITLE
rntester Android > Don't call rncore_ModuleProvider(name, params) twice

### DIFF
--- a/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
+++ b/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
@@ -14,7 +14,6 @@
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/AppSpecs/ComponentDescriptors.h>
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h>
-#include <rncore.h>
 
 namespace facebook {
 namespace react {
@@ -50,7 +49,7 @@ std::shared_ptr<TurboModule> javaModuleProvider(
   if (module != nullptr) {
     return module;
   };
-  return rncore_ModuleProvider(name, params);
+  return nullptr;
 }
 
 } // namespace react


### PR DESCRIPTION
Summary:
This is a follow up to https://github.com/facebook/react-native/pull/39987?fbclid=IwAR3qXLYUtfGSg81CpfDZFAwlnOb2J0zcJb1Wpc9ikLtd_9w2FUDovD6Xwx8

As we already call
```
  return rncore_ModuleProvider(name, params);
```
in:
https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp#L55

we don't have to do it again in:
https://github.com/facebook/react-native/blob/main/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp#L53

Changelog: [Internal]

Differential Revision: D50109991

