### PR TITLE
[Android] fix cursor position for overflowed text on TextInput

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -129,7 +129,8 @@ public class ReactEditText extends AppCompatEditText {
 
   private static final KeyListener sKeyListener = QwertyKeyListener.getInstanceForFullKeyboard();
   private @Nullable EventDispatcher mEventDispatcher;
-
+  public boolean isInitialRender = true;
+  
   public ReactEditText(Context context) {
     super(context);
     setFocusableInTouchMode(false);
@@ -671,6 +672,12 @@ public class ReactEditText extends AppCompatEditText {
     // text so, we have to set text to null, which will clear the currently composing text.
     if (reactTextUpdate.getText().length() == 0) {
       setText(null);
+      // When we call Editable#replace() Android moves the cursor to the end of the replaced text.
+      // To ensure that the cursor position remains at the beginning of the text on the initial render
+      // we call Editable#setText()
+    } else if (isInitialRender && !hasFocus()) {
+      setText(spannableStringBuilder);
+      isInitialRender = false;
     } else {
       // When we update text, we trigger onChangeText code that will
       // try to update state if the wrapper is available. Temporarily disable

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -372,7 +372,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       boolean isCurrentSelectionEmpty = view.getSelectionStart() == view.getSelectionEnd();
       int selectionStart = UNSET;
       int selectionEnd = UNSET;
-      if (isCurrentSelectionEmpty) {
+      if (isCurrentSelectionEmpty && !view.isInitialRender) {
         // if selection is not set by state, shift current selection to ensure constant gap to
         // text end
         int textLength = view.getText() == null ? 0 : view.getText().length();

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -848,6 +848,17 @@ module.exports = ([
     },
   },
   {
+    title: 'Long text behavior',
+    render: function (): React.Node {
+      return (
+        <TextInput
+          style={styles.default}
+          defaultValue="I wanted to send a shorter text, but my keyboard started a protest for word count equality!"
+        />
+      );
+    },
+  },
+  {
     name: 'maxLength',
     title: "Live Re-Write (<sp>  ->  '_') + maxLength",
     render: function (): React.Node {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR fixes an issue where the leftmost characters of the TextInput element are hidden in native Android if the text is longer than the screen size.

Currently, when the value exceeds the width of the TextInput, the cursor moves to the end of the line and the first part of the text is hidden.

This behavior is caused by the `Editable.replace()`  used to update text inside `ReactEditText`. This method involves replacing a specific range of text with new text provided by us. If the current selection (cursor) is in or near the range being replaced, Android typically moves the cursor to the end of the replaced text.

To ensure that the cursor position remains at the beginning of the text during the initial rendering, we can achieve this by using `EditText.setText()` when initially creating the EditText.

This PR introduces the `isInitialRender` flag, which allows the EditText.setText method to be called when the EditText is initially created.

## Changelog:
[ANDROID] [Fixed] - cursor position for overflowed text on Android TextInput
<!-- Help reviewers and the release process by writing your own changelog entry.


Pick one each for the category and type tags:


[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

#### RNTester
Before:
<img src="https://github.com/Expensify/App/assets/19835085/fd5e6732-862e-464a-9012-b404d399833a"  height="500">

After:

https://github.com/facebook/react-native/assets/19835085/85ce96b0-240f-4f5a-802e-4255ca86c6c4


#### App:
Before:
<img src="https://github.com/Expensify/App/assets/19835085/a8c5d5c6-e485-4f52-a60c-65e3e6abbbe8"  height="500">
After:

https://github.com/facebook/react-native/assets/19835085/28b5d131-933c-4326-a08d-d6854ca1f4ca



