### PR TITLE
Add ExceptionsManagerModule for RNTester

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
@@ -20,6 +20,7 @@ import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.core.ExceptionsManagerModule;
 import com.facebook.react.modules.debug.DevSettingsModule;
 import com.facebook.react.modules.debug.SourceCodeModule;
 import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
@@ -36,6 +37,7 @@ import java.util.Map;
       SourceCodeModule.class,
       LogBoxModule.class,
       DeviceEventManagerModule.class,
+      ExceptionsManagerModule.class,
     })
 class CoreReactPackage extends TurboReactPackage {
 
@@ -63,6 +65,8 @@ class CoreReactPackage extends TurboReactPackage {
         return new DeviceEventManagerModule(reactContext, mHardwareBackBtnHandler);
       case LogBoxModule.NAME:
         return new LogBoxModule(reactContext, mDevSupportManager);
+      case ExceptionsManagerModule.NAME:
+        return new ExceptionsManagerModule(mDevSupportManager);
       default:
         throw new IllegalArgumentException(
             "In BridgelessReactPackage, could not find Native module for " + name);
@@ -85,6 +89,7 @@ class CoreReactPackage extends TurboReactPackage {
             DevSettingsModule.class,
             DeviceEventManagerModule.class,
             LogBoxModule.class,
+            ExceptionsManagerModule.class,
           };
       final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();
       for (Class<? extends NativeModule> moduleClass : moduleList) {

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -39,9 +39,6 @@ import com.facebook.soloader.SoLoader
 
 class RNTesterApplication : Application(), ReactApplication {
   override val reactNativeHost: ReactNativeHost by lazy {
-    if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      throw RuntimeException("Should not use ReactNativeHost when Bridgeless enabled")
-    }
     object : DefaultReactNativeHost(this) {
       public override fun getJSMainModuleName(): String = BuildConfig.JS_MAIN_MODULE_NAME
 


### PR DESCRIPTION
Summary:
Fix the following issue:
```Invariant Violation: TurboModuleRegistry.getEnforcing(...):
'ExceptionsManager' could not be found. Verify that a module by this name is registered in the native
binary.Bridgeless mode: true. TurboModule interop: true. Modules loaded: {"NativeModules":[],"TurboModules":
["PlatformConstants","AppState","SourceCode","BlobModule","WebSocketModule","DevSettings","DevToolsSettingsManager","LogBox","Networking","Appearance","DevLoadingView","DeviceInfo","DeviceEventManager",
"SoundManager","ImageLoader","DialogManagerAndroid","NativeAnimatedModule","I18nManager","AccessibilityInfo","StatusBarManager","StatusBarManager","IntentAndroid","ToastAndroid","ShareModule","Vibration"],
"NotFound":["NativePerformanceCxx","NativePerformanceObserverCxx","RedBox","BugReporting","HeadlessJsTaskSupport","FrameRateLogger","KeyboardObserver",
"AccessibilityManager","ModalManager","LinkingManager","ActionSheetManager","ExceptionsManager"]}
```

Differential Revision: D50017783


