### PR TITLE
Remove stale task/comment in FabricUIManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -232,7 +232,6 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     mReactApplicationContext.registerComponentCallbacks(viewManagerRegistry);
   }
 
-  // TODO (T47819352): Rename this to startSurface for consistency with xplat/iOS
   @Override
   @UiThread
   @ThreadConfined(UI)


### PR DESCRIPTION
Summary:
The task referenced is 4 years old and it doesn't seem to be relevant anymore given that:
* `addRootView` has been marked as deprecated
* there is an explicit check in `addRootView` mentioning:

> Do not call addRootView in Fabric; it is unsupported. Call startSurface instead

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D50122192


