### PR TITLE
Remove deprecation of onCatalystInstanceDestroy

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -52,7 +52,7 @@ public interface NativeModule {
    *
    * @deprecated use {@link #invalidate()} instead.
    */
-  @Deprecated(since = "Use invalidate method instead", forRemoval = true)
+  @DeprecatedInNewArchitecture(message = "Use invalidate method instead")
   void onCatalystInstanceDestroy();
 
   /** Allow NativeModule to clean up. Called before React Native instance is destroyed. */


### PR DESCRIPTION
Summary:
In this diff I'm removing the deprecation of NativeModule.onCatalystInstanceDestroy() method, changing it to DeprecatedInNewArchitecture

changelog: [Android][Breaking] Mark NativeModule.onCatalystInstanceDestroy() method as deprecated in new architecture

Reviewed By: christophpurrer

Differential Revision: D50141027


