### PR TITLE
Update version-utils to accept new versions

### DIFF
--- a/packages/react-native/ReactAndroid/publish.gradle
+++ b/packages/react-native/ReactAndroid/publish.gradle
@@ -8,7 +8,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-def isNightly = findProperty("isNightly")?.toBoolean()
+def isSnapshot = findProperty("isSnapshot")?.toBoolean()
 def signingKey = findProperty("SIGNING_KEY")
 def signingPwd = findProperty("SIGNING_PWD")
 
@@ -28,8 +28,8 @@ publishing {
             }
 
             // We populate the publishing version using the project version,
-            // appending -SNAPSHOT if on nightly.
-            if (isNightly) {
+            // appending -SNAPSHOT if on nightly or prerelase.
+            if (isSnapshot) {
                 version = this.version + "-SNAPSHOT"
             } else {
                 version = this.version

--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -11,11 +11,18 @@ const {
   applyPackageVersions,
   getPackageVersionStrByTag,
   publishPackage,
+  getNpmInfo,
 } = require('../npm-utils');
 
 const execMock = jest.fn();
+const getCurrentCommitMock = jest.fn();
+
 jest.mock('shelljs', () => ({
   exec: execMock,
+}));
+
+jest.mock('./../scm-utils', () => ({
+  getCurrentCommit: getCurrentCommitMock,
 }));
 
 describe('npm-utils', () => {
@@ -102,6 +109,20 @@ describe('npm-utils', () => {
         'npm publish --tag latest --otp otp',
         {cwd: 'path/to/my-package'},
       );
+    });
+  });
+
+  describe('getNpmInfo', () => {
+    it('return the expected format for prealpha', () => {
+      const isoStringSpy = jest.spyOn(Date.prototype, 'toISOString');
+      isoStringSpy.mockReturnValue('2023-10-04T15:43:55.123Z');
+      getCurrentCommitMock.mockImplementation(() => 'abcd1234');
+
+      const returnedValue = getNpmInfo('prealpha');
+      expect(returnedValue).toMatchObject({
+        version: `0.0.0-prealpha-2023100415`,
+        tag: 'prealpha',
+      });
     });
   });
 });

--- a/scripts/__tests__/publish-npm-test.js
+++ b/scripts/__tests__/publish-npm-test.js
@@ -98,7 +98,7 @@ describe('publish-npm', () => {
 
       expect(publishAndroidArtifactsToMavenMock).toHaveBeenCalledWith(
         expectedVersion,
-        true,
+        'nightly',
       );
       expect(execMock.mock.calls[0][0]).toBe(
         `npm view react-native@next version`,
@@ -150,7 +150,7 @@ describe('publish-npm', () => {
       const expectedVersion = '0.81.1';
       expect(publishAndroidArtifactsToMavenMock).toHaveBeenCalledWith(
         expectedVersion,
-        false,
+        'release',
       );
       expect(execMock).toHaveBeenCalledWith(
         `npm publish --tag 0.81-stable --otp otp`,
@@ -174,7 +174,7 @@ describe('publish-npm', () => {
       const expectedVersion = '0.81.1';
       expect(publishAndroidArtifactsToMavenMock).toHaveBeenCalledWith(
         expectedVersion,
-        false,
+        'release',
       );
       expect(execMock).toHaveBeenCalledWith(
         `npm publish --tag latest --otp ${process.env.NPM_CONFIG_OTP}`,
@@ -198,7 +198,7 @@ describe('publish-npm', () => {
       const expectedVersion = '0.81.1';
       expect(publishAndroidArtifactsToMavenMock).toHaveBeenCalledWith(
         expectedVersion,
-        false,
+        'release',
       );
       expect(execMock).toHaveBeenCalledWith(
         `npm publish --tag latest --otp ${process.env.NPM_CONFIG_OTP}`,
@@ -220,7 +220,7 @@ describe('publish-npm', () => {
       const expectedVersion = '0.81.0-rc.4';
       expect(publishAndroidArtifactsToMavenMock).toHaveBeenCalledWith(
         expectedVersion,
-        false,
+        'release',
       );
       expect(execMock).toHaveBeenCalledWith(
         `npm publish --tag next --otp ${process.env.NPM_CONFIG_OTP}`,

--- a/scripts/__tests__/version-utils-test.js
+++ b/scripts/__tests__/version-utils-test.js
@@ -52,7 +52,7 @@ describe('version-utils', () => {
       );
     });
 
-    it('should throw error if buildType is not `release`, `dry-run` or `nightly`', () => {
+    it('should throw error if buildType is not `release`, `dry-run`, `prealpha`` or `nightly`', () => {
       function testInvalidVersion() {
         parseVersion('v0.10.5', 'invalid_build_type');
       }
@@ -298,6 +298,69 @@ describe('version-utils', () => {
       expect(minor).toBe('0');
       expect(patch).toBe('0');
       expect(prerelease).toBeUndefined();
+    });
+
+    it('should parse prealpha with valid value', () => {
+      const {version, major, minor, patch, prerelease} = parseVersion(
+        '0.0.0-prealpha-2023100416',
+        'prealpha',
+      );
+
+      expect(version).toBe('0.0.0-prealpha-2023100416');
+      expect(major).toBe('0');
+      expect(minor).toBe('0');
+      expect(patch).toBe('0');
+      expect(prerelease).toBe('prealpha-2023100416');
+    });
+
+    it('should reject prealpha with 1.0.0 version', () => {
+      function testInvalidFunction() {
+        parseVersion('1.0.0-prealpha-2023100416', 'prealpha');
+      }
+
+      expect(testInvalidFunction).toThrowErrorMatchingInlineSnapshot(
+        '"Version 1.0.0-prealpha-2023100416 is not valid for prealphas"',
+      );
+    });
+
+    it('should reject prealpha with invalid version', () => {
+      function testInvalidFunction() {
+        parseVersion('1.2.3-prealpha-2023100416', 'prealpha');
+      }
+
+      expect(testInvalidFunction).toThrowErrorMatchingInlineSnapshot(
+        '"Version 1.2.3-prealpha-2023100416 is not valid for prealphas"',
+      );
+    });
+
+    it('should reject prealpha with no prerelease', () => {
+      function testInvalidFunction() {
+        parseVersion('1.0.0', 'prealpha');
+      }
+
+      expect(testInvalidFunction).toThrowErrorMatchingInlineSnapshot(
+        '"Version 1.0.0 is not valid for prealphas"',
+      );
+    });
+
+    it('should reject prealpha with invalid prerelease (no timestamp)', () => {
+      function testInvalidFunction() {
+        parseVersion('1.0.0-prealpha', 'prealpha');
+      }
+
+      expect(testInvalidFunction).toThrowErrorMatchingInlineSnapshot(
+        '"Version 1.0.0-prealpha is not valid for prealphas"',
+      );
+    });
+
+    it('should reject prealpha with invalid prerelease (no prealpha)', () => {
+      function testInvalidFunction() {
+        parseVersion('1.0.0-2023100416', 'prealpha');
+      }
+
+      expect(testInvalidFunction).toThrowErrorMatchingInlineSnapshot(
+        '"Version 1.0.0-2023100416 is not valid for prealphas"',
+      );
     });
   });
 

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -47,6 +47,24 @@ function getNpmInfo(buildType) {
     };
   }
 
+  if (buildType === 'prealpha') {
+    const mainVersion = '0.0.0';
+    // Date in the format of YYYYMMDDHH.
+    // This is a progressive int that can track subsequent
+    // releases and it is smaller of 2^32-1.
+    // It is unlikely that we can trigger two prealpha in less
+    // than an hour given that nightlies take ~ 1 hr to complete.
+    const dateIdentifier = new Date()
+      .toISOString()
+      .slice(0, -10)
+      .replace(/[-T:]/g, '');
+
+    return {
+      version: `${mainVersion}-prealpha-${dateIdentifier}`,
+      tag: 'prealpha',
+    };
+  }
+
   const {version, major, minor, prerelease} = parseVersion(
     process.env.CIRCLE_TAG,
     buildType,

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -88,7 +88,7 @@ function publishNpm(buildType) {
 
   // We first publish on Maven Central all the necessary artifacts.
   // NPM publishing is done just after.
-  publishAndroidArtifactsToMaven(version, buildType === 'nightly');
+  publishAndroidArtifactsToMaven(version, buildType);
 
   const packagePath = path.join(__dirname, '..', 'packages', 'react-native');
   const result = publishPackage(packagePath, {

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -52,7 +52,7 @@ function generateAndroidArtifacts(releaseVersion) {
   });
 }
 
-function publishAndroidArtifactsToMaven(releaseVersion, isNightly) {
+function publishAndroidArtifactsToMaven(releaseVersion, buildType) {
   // -------- Publish every artifact to Maven Central
   // The GPG key is base64 encoded on CircleCI and then decoded here
   let buff = Buffer.from(env.ORG_GRADLE_PROJECT_SIGNING_KEY_ENCODED, 'base64');
@@ -60,7 +60,7 @@ function publishAndroidArtifactsToMaven(releaseVersion, isNightly) {
 
   // We want to gate ourselves against accidentally publishing a 1.x or a 1000.x on
   // maven central which will break the semver for our artifacts.
-  if (!isNightly && releaseVersion.startsWith('0.')) {
+  if (buildType === 'release' && releaseVersion.startsWith('0.')) {
     // -------- For stable releases, we also need to close and release the staging repository.
     if (
       exec(
@@ -73,8 +73,11 @@ function publishAndroidArtifactsToMaven(releaseVersion, isNightly) {
       exit(1);
     }
   } else {
+    const isSnapshot = buildType === 'nightly' || buildType === 'prealpha';
     // -------- For nightly releases, we only need to publish the snapshot to Sonatype snapshot repo.
-    if (exec('./gradlew publishAllToSonatype -PisNightly=' + isNightly).code) {
+    if (
+      exec('./gradlew publishAllToSonatype -PisSnapshot=' + isSnapshot).code
+    ) {
       echo('Failed to publish artifacts to Sonatype (Maven Central)');
       exit(1);
     }


### PR DESCRIPTION
Summary:
ignore-github-export-checks
## Changelog:
[Internal] - Update version-utils to accept more versions for double publishing

Reviewed By: cortinico

Differential Revision: D49917128

