### PR TITLE
refactor: use ESM exports in ReactNativeViewConfigRegistry

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
+++ b/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
@@ -15,7 +15,7 @@ import type {
 
 import getNativeComponentAttributes from '../ReactNative/getNativeComponentAttributes';
 import UIManager from '../ReactNative/UIManager';
-import ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
+import * as ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
 import verifyComponentAttributeEquivalence from '../Utilities/verifyComponentAttributeEquivalence';
 import * as StaticViewConfigValidator from './StaticViewConfigValidator';
 import {createViewConfig} from './ViewConfig';

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -27,7 +27,7 @@ import typeof {
   diff as diffAttributePayloads,
 } from '../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
 import typeof UIManager from '../ReactNative/UIManager';
-import typeof ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
+import typeof * as ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
 import typeof flattenStyle from '../StyleSheet/flattenStyle';
 import type {DangerouslyImpreciseStyleProp} from '../StyleSheet/StyleSheet';
 import typeof deepFreezeAndThrowOnMutationInDev from '../Utilities/deepFreezeAndThrowOnMutationInDev';

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
@@ -16,7 +16,7 @@ import {type ViewConfig} from './ReactNativeTypes';
 import invariant from 'invariant';
 
 // Event configs
-export const customBubblingEventTypes: {
+const customBubblingEventTypes: {
   [eventName: string]: $ReadOnly<{
     phasedRegistrationNames: $ReadOnly<{
       captured: string,
@@ -26,12 +26,15 @@ export const customBubblingEventTypes: {
   }>,
   ...
 } = {};
-export const customDirectEventTypes: {
+const customDirectEventTypes: {
   [eventName: string]: $ReadOnly<{
     registrationName: string,
   }>,
   ...
 } = {};
+
+exports.customBubblingEventTypes = customBubblingEventTypes;
+exports.customDirectEventTypes = customDirectEventTypes;
 
 const viewConfigCallbacks = new Map<string, ?() => ViewConfig>();
 const viewConfigs = new Map<string, ViewConfig>();
@@ -74,7 +77,7 @@ function processEventTypes(viewConfig: ViewConfig): void {
  * A callback is provided to load the view config from UIManager.
  * The callback is deferred until the view is actually rendered.
  */
-export function register(name: string, callback: () => ViewConfig): string {
+exports.register = function (name: string, callback: () => ViewConfig): string {
   invariant(
     !viewConfigCallbacks.has(name),
     'Tried to register two views with the same name %s',
@@ -95,7 +98,7 @@ export function register(name: string, callback: () => ViewConfig): string {
  * If this is the first time the view has been used,
  * This configuration will be lazy-loaded from UIManager.
  */
-export function get(name: string): ViewConfig {
+exports.get = function (name: string): ViewConfig {
   let viewConfig;
   if (!viewConfigs.has(name)) {
     const callback = viewConfigCallbacks.get(name);

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
@@ -16,7 +16,7 @@ import {type ViewConfig} from './ReactNativeTypes';
 import invariant from 'invariant';
 
 // Event configs
-const customBubblingEventTypes: {
+export const customBubblingEventTypes: {
   [eventName: string]: $ReadOnly<{
     phasedRegistrationNames: $ReadOnly<{
       captured: string,
@@ -26,15 +26,12 @@ const customBubblingEventTypes: {
   }>,
   ...
 } = {};
-const customDirectEventTypes: {
+export const customDirectEventTypes: {
   [eventName: string]: $ReadOnly<{
     registrationName: string,
   }>,
   ...
 } = {};
-
-exports.customBubblingEventTypes = customBubblingEventTypes;
-exports.customDirectEventTypes = customDirectEventTypes;
 
 const viewConfigCallbacks = new Map<string, ?() => ViewConfig>();
 const viewConfigs = new Map<string, ViewConfig>();
@@ -77,7 +74,7 @@ function processEventTypes(viewConfig: ViewConfig): void {
  * A callback is provided to load the view config from UIManager.
  * The callback is deferred until the view is actually rendered.
  */
-exports.register = function (name: string, callback: () => ViewConfig): string {
+export function register(name: string, callback: () => ViewConfig): string {
   invariant(
     !viewConfigCallbacks.has(name),
     'Tried to register two views with the same name %s',
@@ -98,7 +95,7 @@ exports.register = function (name: string, callback: () => ViewConfig): string {
  * If this is the first time the view has been used,
  * This configuration will be lazy-loaded from UIManager.
  */
-exports.get = function (name: string): ViewConfig {
+export function get(name: string): ViewConfig {
   let viewConfig;
   if (!viewConfigs.has(name)) {
     const callback = viewConfigCallbacks.get(name);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When transpiling `react-native` with `swc` this file caused some trouble as it mixes ESM and CJS import/export syntax. This PR addresses this by converting CJS exports to ESM exports. All other affected files were aligned to support this change.
## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[INTERNAL] [CHANGED] - use ESM exports in ReactNativeViewConfigRegistry

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[INTERNAL] [CHANGED] - use ESM exports in ReactNativeViewConfigRegistry
## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
