### PR TITLE
feat(tm-android): TM SyncVoidKind methods throws JSError

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -738,13 +738,10 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
     case VoidKind: {
       if (shouldVoidMethodsExecuteSync_) {
         env->CallVoidMethodA(instance, methodID, jargs.data());
+        checkJNIErrorForMethodCall();
+
         TMPL::syncMethodCallExecutionEnd(moduleName, methodName);
         TMPL::syncMethodCallEnd(moduleName, methodName);
-        try {
-          FACEBOOK_JNI_THROW_PENDING_EXCEPTION();
-        } catch (...) {
-          throw;
-        }
         return jsi::Value::undefined();
       }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Other RM Sync method calls do return JSError with the throwable information.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [ADDED] - TM SyncVoidKind methods throws JSError

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Output of caught error `console.log(e, e.stack, e.cause);`

```js
 LOG  [Error: Exception in HostFunction: Intentional exception from JVM voidFuncThrows] Error: Exception in HostFunction: Intentional exception from JVM voidFuncThrows
    at voidFuncThrows (native)
    at voidFuncThrows (http://10.0.2.2:8081/js/examples/TurboModule/SampleTurboModuleExample.bundle//&platform=android&lazy=true&app=com.facebook.react.uiapp&modulesOnly=true&dev=true&minify=false&runModule=true&shallow=true:100:127)
    at onPress (http://10.0.2.2:8081/js/examples/TurboModule/SampleTurboModuleExample.bundle//&platform=android&lazy=true&app=com.facebook.react.uiapp&modulesOnly=true&dev=true&minify=false&runModule=true&shallow=true:235:71)
    at _performTransitionSideEffects (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:67991:22)
    at _receiveSignal (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:67941:45)
    at onResponderRelease (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:67784:34)
    at apply (native)
    at invokeGuardedCallbackProd (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:4727:21)
    at apply (native)
    at invokeGuardedCallback (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:4903:42)
    at apply (native)
    at invokeGuardedCallbackAndCatchFirstError (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:4917:36)
    at executeDispatch (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:4994:48)
    at executeDispatchesInOrder (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:5016:26)
    at executeDispatchesAndRelease (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:7640:35)
    at executeDispatchesAndReleaseTopLevel (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:7647:43)
    at forEach (native)
    at forEachAccumulated (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:5610:22)
    at runEventsInBatch (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:7660:27)
    at runExtractedPluginEventsInBatch (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:7693:25)
    at anonymous (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:7734:42)
    at batchedUpdates$1 (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:20049:20)
    at batchedUpdates (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:7616:36)
    at dispatchEvent (http://10.0.2.2:8081/js/RNTesterApp.android.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.facebook.react.uiapp&modulesOnly=false&runModule=true:7705:23)
{"message": "Intentional exception from JVM voidFuncThrows", "name": "java.lang.RuntimeException", "stackElements": [{"className": "com.facebook.fbreact.specs.SampleTurboModule", "fileName": "SampleTurboModule.java", "lineNumber": 186, "methodName": "voidFuncThrows"}, {"className": "com.facebook.jni.NativeRunnable", "fileName": "NativeRunnable.java", "lineNumber": -2, "methodName": "run"}, {"className": "android.os.Handler", "fileName": "Handler.java", "lineNumber": 958, "methodName": "handleCallback"}, {"className": "android.os.Handler", "fileName": "Handler.java", "lineNumber": 99, "methodName": "dispatchMessage"}, {"className": "com.facebook.react.bridge.queue.MessageQueueThreadHandler", "fileName": "MessageQueueThreadHandler.java", "lineNumber": 27, "methodName": "dispatchMessage"}, {"className": "android.os.Looper", "fileName": "Looper.java", "lineNumber": 205, "methodName": "loopOnce"}, {"className": "android.os.Looper", "fileName": "Looper.java", "lineNumber": 294, "methodName": "loop"}, {"className": "com.facebook.react.bridge.queue.MessageQueueThreadImpl$4", "fileName": "MessageQueueThreadImpl.java", "lineNumber": 234, "methodName": "run"}, {"className": "java.lang.Thread", "fileName": "Thread.java", "lineNumber": 1012, "methodName": "run"}]}
```