### PR TITLE
Enable build config feature for third-party libraries

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -33,6 +33,13 @@ internal object AgpConfiguratorUtils {
         }
     project.pluginManager.withPlugin("com.android.application", action)
     project.pluginManager.withPlugin("com.android.library", action)
+    project.rootProject.allprojects { subproject ->
+      subproject.pluginManager.withPlugin("com.android.library") {
+        subproject.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
+          ext.buildFeatures.buildConfig = true
+        }
+      }
+    }
   }
 
   fun configureDevPorts(project: Project) {


### PR DESCRIPTION
## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix #40559

Automatically enable the build config feature for third-party libraries so that no extra modification is required.

## Changelog:

[ANDROID] [FIXED] - Automatically enable the build config feature for third-party libraries

## Test Plan:

- Create a fresh `react-native@0.73.0-rc.2` project
- Install `react-native-webview`
- Build application
- (Expected) Application fail to build
- Apply this PR
- (Expected) Application build successfully
