### PR TITLE
Use AsyncCallback in RCTTurboModule

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
@@ -37,6 +37,7 @@ jsi::Value createPromiseAsJSIValue(
     jsi::Runtime& rt,
     PromiseSetupFunctionType&& func);
 
+// Deprecated. Use AsyncCallback instead.
 class RAIICallbackWrapperDestroyer {
  public:
   RAIICallbackWrapperDestroyer(std::weak_ptr<CallbackWrapper> callbackWrapper)

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -17,6 +17,7 @@
 #include <ReactCommon/TurboModulePerfLogger.h>
 #include <ReactCommon/TurboModuleUtils.h>
 #include <jsi/JSIDynamic.h>
+#include <react/bridging/Bridging.h>
 #include <react/debug/react_native_assert.h>
 #include <react/jni/NativeMap.h>
 #include <react/jni/ReadableNativeMap.h>
@@ -63,60 +64,42 @@ struct JNIArgs {
   std::vector<jobject> globalRefs_;
 };
 
-jni::local_ref<JCxxCallbackImpl::JavaPart> createJavaCallbackFromJSIFunction(
-    jsi::Function&& function,
+auto createJavaCallback(
     jsi::Runtime& rt,
-    const std::shared_ptr<CallInvoker>& jsInvoker) {
-  auto weakWrapper =
-      CallbackWrapper::createWeak(std::move(function), rt, jsInvoker);
-
-  // This needs to be a shared_ptr because:
-  // 1. It cannot be unique_ptr. std::function is copyable but unique_ptr is
-  // not.
-  // 2. It cannot be weak_ptr since we need this object to live on.
-  // 3. It cannot be a value, because that would be deleted as soon as this
-  // function returns.
-  auto callbackWrapperOwner =
-      std::make_shared<RAIICallbackWrapperDestroyer>(weakWrapper);
-
+    jsi::Function&& function,
+    std::shared_ptr<CallInvoker> jsInvoker) {
+  std::optional<AsyncCallback<>> callback(
+      {rt, std::move(function), std::move(jsInvoker)});
   return JCxxCallbackImpl::newObjectCxxArgs(
-      [weakWrapper = std::move(weakWrapper),
-       callbackWrapperOwner = std::move(callbackWrapperOwner),
-       wrapperWasCalled = false](folly::dynamic responses) mutable {
-        if (wrapperWasCalled) {
-          LOG(FATAL) << "callback arg cannot be called more than once";
-        }
-
-        auto strongWrapper = weakWrapper.lock();
-        if (!strongWrapper) {
+      [callback = std::move(callback)](folly::dynamic args) mutable {
+        if (!callback) {
+          LOG(FATAL) << "Callback arg cannot be called more than once";
           return;
         }
 
-        strongWrapper->jsInvoker().invokeAsync(
-            [weakWrapper = std::move(weakWrapper),
-             callbackWrapperOwner = std::move(callbackWrapperOwner),
-             responses = std::move(responses)]() {
-              auto strongWrapper2 = weakWrapper.lock();
-              if (!strongWrapper2) {
-                return;
-              }
-
-              std::vector<jsi::Value> args;
-              args.reserve(responses.size());
-              for (const auto& val : responses) {
-                args.emplace_back(
-                    jsi::valueFromDynamic(strongWrapper2->runtime(), val));
-              }
-
-              strongWrapper2->callback().call(
-                  strongWrapper2->runtime(),
-                  (const jsi::Value*)args.data(),
-                  args.size());
-            });
-
-        wrapperWasCalled = true;
+        callback->call([args = std::move(args)](
+                           jsi::Runtime& rt, jsi::Function& jsFunction) {
+          std::vector<jsi::Value> jsArgs;
+          jsArgs.reserve(args.size());
+          for (const auto& val : args) {
+            jsArgs.emplace_back(jsi::valueFromDynamic(rt, val));
+          }
+          jsFunction.call(rt, (const jsi::Value*)jsArgs.data(), jsArgs.size());
+        });
+        callback = std::nullopt;
       });
 }
+
+struct JPromiseImpl : public jni::JavaClass<JPromiseImpl> {
+  constexpr static auto kJavaDescriptor =
+      "Lcom/facebook/react/bridge/PromiseImpl;";
+
+  static jni::local_ref<javaobject> create(
+      jni::local_ref<JCallback::javaobject> resolve,
+      jni::local_ref<JCallback::javaobject> reject) {
+    return newInstance(resolve, reject);
+  }
+};
 
 // This is used for generating short exception strings.
 std::string stringifyJSIValue(const jsi::Value& v, jsi::Runtime* rt = nullptr) {
@@ -356,8 +339,7 @@ JNIArgs convertJSIArgsToJNIArgs(
       }
       jsi::Function fn = arg->getObject(rt).getFunction(rt);
       jarg->l = makeGlobalIfNecessary(
-          createJavaCallbackFromJSIFunction(std::move(fn), rt, jsInvoker)
-              .release());
+          createJavaCallback(rt, std::move(fn), jsInvoker).release());
     } else if (type == "Lcom/facebook/react/bridge/ReadableArray;") {
       if (!(arg->isObject() && arg->getObject(rt).isArray(rt))) {
         throw JavaTurboModuleArgumentConversionException(
@@ -759,16 +741,14 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
            instance_ = jni::make_weak(instance_),
            moduleNameStr = name_,
            methodNameStr,
-           id = getUniqueId()]() mutable -> void {
+           id = getUniqueId()]() mutable {
             auto instance = instance_.lockLocal();
             if (!instance) {
               return;
             }
-            /**
-             * TODO(ramanpreet): Why do we have to require the environment
-             * again? Why does JNI crash when we use the env from the upper
-             * scope?
-             */
+
+            // Require the env from the current scope, which may be
+            // different from the original invocation's scope
             JNIEnv* env = jni::Environment::current();
             const char* moduleName = moduleNameStr.c_str();
             const char* methodName = methodNameStr.c_str();
@@ -792,115 +772,85 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
       return jsi::Value::undefined();
     }
     case PromiseKind: {
+      // We could use AsyncPromise here, but this avoids the overhead of
+      // the shared_ptr for PromiseHolder
       jsi::Function Promise =
           runtime.global().getPropertyAsFunction(runtime, "Promise");
 
-      jsi::Function promiseConstructorArg = jsi::Function::createFromHostFunction(
+      // The promise constructor runs its arg immediately, so this is safe
+      jobject javaPromise;
+      jsi::Value jsPromise = Promise.callAsConstructor(
           runtime,
-          jsi::PropNameID::forAscii(runtime, "fn"),
-          2,
-          [this,
-           &jargs,
-           &globalRefs,
-           argCount,
+          jsi::Function::createFromHostFunction(
+              runtime,
+              jsi::PropNameID::forAscii(runtime, "fn"),
+              2,
+              [&](jsi::Runtime& runtime,
+                  const jsi::Value&,
+                  const jsi::Value* args,
+                  size_t argCount) {
+                if (argCount != 2) {
+                  throw jsi::JSError(runtime, "Incorrect number of arguments");
+                }
+
+                auto resolve = createJavaCallback(
+                    runtime,
+                    args[0].getObject(runtime).getFunction(runtime),
+                    jsInvoker_);
+                auto reject = createJavaCallback(
+                    runtime,
+                    args[1].getObject(runtime).getFunction(runtime),
+                    jsInvoker_);
+                javaPromise = JPromiseImpl::create(resolve, reject).release();
+
+                return jsi::Value::undefined();
+              }));
+
+      jobject globalPromise = env->NewGlobalRef(javaPromise);
+      globalRefs.push_back(globalPromise);
+      env->DeleteLocalRef(javaPromise);
+      jargs[argCount].l = globalPromise;
+
+      const char* moduleName = name_.c_str();
+      const char* methodName = methodNameStr.c_str();
+      TMPL::asyncMethodCallArgConversionEnd(moduleName, methodName);
+
+      TMPL::asyncMethodCallDispatch(moduleName, methodName);
+      nativeMethodCallInvoker_->invokeAsync(
+          methodName,
+          [jargs,
+           globalRefs,
            methodID,
+           instance_ = jni::make_weak(instance_),
            moduleNameStr = name_,
            methodNameStr,
-           env](
-              jsi::Runtime& runtime,
-              const jsi::Value& thisVal,
-              const jsi::Value* promiseConstructorArgs,
-              size_t promiseConstructorArgCount) {
-            if (promiseConstructorArgCount != 2) {
-              throw std::invalid_argument("Promise fn arg count must be 2");
+           id = getUniqueId()]() mutable {
+            auto instance = instance_.lockLocal();
+            if (!instance) {
+              return;
             }
 
-            jsi::Function resolveJSIFn =
-                promiseConstructorArgs[0].getObject(runtime).getFunction(
-                    runtime);
-            jsi::Function rejectJSIFn =
-                promiseConstructorArgs[1].getObject(runtime).getFunction(
-                    runtime);
-
-            auto resolve = createJavaCallbackFromJSIFunction(
-                               std::move(resolveJSIFn), runtime, jsInvoker_)
-                               .release();
-            auto reject = createJavaCallbackFromJSIFunction(
-                              std::move(rejectJSIFn), runtime, jsInvoker_)
-                              .release();
-
-            jclass jPromiseImpl =
-                env->FindClass("com/facebook/react/bridge/PromiseImpl");
-            jmethodID jPromiseImplConstructor = env->GetMethodID(
-                jPromiseImpl,
-                "<init>",
-                "(Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V");
-
-            jobject promise = env->NewObject(
-                jPromiseImpl, jPromiseImplConstructor, resolve, reject);
-
+            // Require the env from the current scope, which may be
+            // different from the original invocation's scope
+            JNIEnv* env = jni::Environment::current();
             const char* moduleName = moduleNameStr.c_str();
             const char* methodName = methodNameStr.c_str();
+            TMPL::asyncMethodCallExecutionStart(moduleName, methodName, id);
+            env->CallVoidMethodA(instance.get(), methodID, jargs.data());
+            try {
+              FACEBOOK_JNI_THROW_PENDING_EXCEPTION();
+            } catch (...) {
+              TMPL::asyncMethodCallExecutionFail(moduleName, methodName, id);
+              throw;
+            }
 
-            jobject globalPromise = env->NewGlobalRef(promise);
-
-            globalRefs.push_back(globalPromise);
-            env->DeleteLocalRef(promise);
-
-            jargs[argCount].l = globalPromise;
-            TMPL::asyncMethodCallArgConversionEnd(moduleName, methodName);
-            TMPL::asyncMethodCallDispatch(moduleName, methodName);
-
-            nativeMethodCallInvoker_->invokeAsync(
-                methodName,
-                [jargs,
-                 globalRefs,
-                 methodID,
-                 instance_ = jni::make_weak(instance_),
-                 moduleNameStr,
-                 methodNameStr,
-                 id = getUniqueId()]() mutable -> void {
-                  auto instance = instance_.lockLocal();
-
-                  if (!instance) {
-                    return;
-                  }
-                  /**
-                   * TODO(ramanpreet): Why do we have to require the
-                   * environment again? Why does JNI crash when we use the env
-                   * from the upper scope?
-                   */
-                  JNIEnv* env = jni::Environment::current();
-                  const char* moduleName = moduleNameStr.c_str();
-                  const char* methodName = methodNameStr.c_str();
-
-                  TMPL::asyncMethodCallExecutionStart(
-                      moduleName, methodName, id);
-                  env->CallVoidMethodA(instance.get(), methodID, jargs.data());
-                  try {
-                    FACEBOOK_JNI_THROW_PENDING_EXCEPTION();
-                  } catch (...) {
-                    TMPL::asyncMethodCallExecutionFail(
-                        moduleName, methodName, id);
-                    throw;
-                  }
-
-                  for (auto globalRef : globalRefs) {
-                    env->DeleteGlobalRef(globalRef);
-                  }
-                  TMPL::asyncMethodCallExecutionEnd(moduleName, methodName, id);
-                });
-
-            return jsi::Value::undefined();
+            for (auto globalRef : globalRefs) {
+              env->DeleteGlobalRef(globalRef);
+            }
+            TMPL::asyncMethodCallExecutionEnd(moduleName, methodName, id);
           });
-
-      jsi::Value promise =
-          Promise.callAsConstructor(runtime, promiseConstructorArg);
-      checkJNIErrorForMethodCall();
-
       TMPL::asyncMethodCallEnd(moduleName, methodName);
-
-      return promise;
+      return jsPromise;
     }
     default:
       throw std::runtime_error(

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -6,15 +6,6 @@
  */
 
 #import "RCTTurboModule.h"
-#import "RCTBlockGuard.h"
-
-#include <glog/logging.h>
-#import <objc/message.h>
-#import <objc/runtime.h>
-#import <atomic>
-#import <iostream>
-#import <sstream>
-#import <vector>
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
@@ -26,7 +17,16 @@
 #import <ReactCommon/LongLivedObject.h>
 #import <ReactCommon/TurboModule.h>
 #import <ReactCommon/TurboModulePerfLogger.h>
-#import <ReactCommon/TurboModuleUtils.h>
+#import <react/bridging/Bridging.h>
+
+#include <glog/logging.h>
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+#import <atomic>
+#import <iostream>
+#import <sstream>
+#import <vector>
 
 using namespace facebook;
 using namespace facebook::react;
@@ -142,7 +142,23 @@ convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value, 
 }
 
 static RCTResponseSenderBlock
-convertJSIFunctionToCallback(jsi::Runtime &runtime, const jsi::Function &value, std::shared_ptr<CallInvoker> jsInvoker);
+convertJSIFunctionToCallback(jsi::Runtime &rt, jsi::Function &&function, std::shared_ptr<CallInvoker> jsInvoker)
+{
+  __block std::optional<AsyncCallback<>> callback({rt, std::move(function), std::move(jsInvoker)});
+  return ^(NSArray *args) {
+    if (!callback) {
+      LOG(FATAL) << "Callback arg cannot be called more than once";
+      return;
+    }
+
+    callback->call([args](jsi::Runtime &rt, jsi::Function &jsFunction) {
+      auto jsArgs = convertNSArrayToStdVector(rt, args);
+      jsFunction.call(rt, (const jsi::Value *)jsArgs.data(), jsArgs.size());
+    });
+    callback = std::nullopt;
+  };
+}
+
 id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker)
 {
   if (value.isUndefined() || value.isNull()) {
@@ -163,54 +179,12 @@ id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, s
       return convertJSIArrayToNSArray(runtime, o.getArray(runtime), jsInvoker);
     }
     if (o.isFunction(runtime)) {
-      return convertJSIFunctionToCallback(runtime, std::move(o.getFunction(runtime)), jsInvoker);
+      return convertJSIFunctionToCallback(runtime, o.getFunction(runtime), jsInvoker);
     }
     return convertJSIObjectToNSDictionary(runtime, o, jsInvoker);
   }
 
   throw std::runtime_error("Unsupported jsi::jsi::Value kind");
-}
-
-static RCTResponseSenderBlock
-convertJSIFunctionToCallback(jsi::Runtime &runtime, const jsi::Function &value, std::shared_ptr<CallInvoker> jsInvoker)
-{
-  auto weakWrapper = CallbackWrapper::createWeak(value.getFunction(runtime), runtime, jsInvoker);
-  RCTBlockGuard *blockGuard = [[RCTBlockGuard alloc] initWithCleanup:^() {
-    auto strongWrapper = weakWrapper.lock();
-    if (strongWrapper) {
-      strongWrapper->destroy();
-    }
-  }];
-
-  BOOL __block wrapperWasCalled = NO;
-  RCTResponseSenderBlock callback = ^(NSArray *responses) {
-    if (wrapperWasCalled) {
-      LOG(FATAL) << "callback arg cannot be called more than once";
-    }
-
-    auto strongWrapper = weakWrapper.lock();
-    if (!strongWrapper) {
-      return;
-    }
-
-    strongWrapper->jsInvoker().invokeAsync([weakWrapper, responses, blockGuard]() {
-      auto strongWrapper2 = weakWrapper.lock();
-      if (!strongWrapper2) {
-        return;
-      }
-
-      std::vector<jsi::Value> args = convertNSArrayToStdVector(strongWrapper2->runtime(), responses);
-      strongWrapper2->callback().call(strongWrapper2->runtime(), (const jsi::Value *)args.data(), args.size());
-      strongWrapper2->destroy();
-
-      // Delete the CallbackWrapper when the block gets dealloced without being invoked.
-      (void)blockGuard;
-    });
-
-    wrapperWasCalled = YES;
-  };
-
-  return [callback copy];
 }
 
 static jsi::Value createJSRuntimeError(jsi::Runtime &runtime, const std::string &message)
@@ -246,124 +220,78 @@ jsi::Value ObjCTurboModule::createPromise(jsi::Runtime &runtime, std::string met
   }
 
   jsi::Function Promise = runtime.global().getPropertyAsFunction(runtime, "Promise");
-  std::string moduleName = name_;
 
   // Note: the passed invoke() block is not retained by default, so let's retain it here to help keep it longer.
   // Otherwise, there's a risk of it getting released before the promise function below executes.
   PromiseInvocationBlock invokeCopy = [invoke copy];
-  jsi::Function fn = jsi::Function::createFromHostFunction(
+  return Promise.callAsConstructor(
       runtime,
-      jsi::PropNameID::forAscii(runtime, "fn"),
-      2,
-      [invokeCopy, jsInvoker = jsInvoker_, moduleName, methodName](
-          jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) {
-        std::string moduleMethod = moduleName + "." + methodName + "()";
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "fn"),
+          2,
+          [invokeCopy, jsInvoker = jsInvoker_, moduleName = name_, methodName](
+              jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) {
+            std::string moduleMethod = moduleName + "." + methodName + "()";
 
-        if (count != 2) {
-          throw std::invalid_argument(
-              moduleMethod + ": Promise must pass constructor function two args. Passed " + std::to_string(count) +
-              " args.");
-        }
-        if (!invokeCopy) {
-          return jsi::Value::undefined();
-        }
-
-        auto weakResolveWrapper = CallbackWrapper::createWeak(args[0].getObject(rt).getFunction(rt), rt, jsInvoker);
-        auto weakRejectWrapper = CallbackWrapper::createWeak(args[1].getObject(rt).getFunction(rt), rt, jsInvoker);
-
-        __block BOOL resolveWasCalled = NO;
-        __block BOOL rejectWasCalled = NO;
-
-        RCTBlockGuard *blockGuard = [[RCTBlockGuard alloc] initWithCleanup:^() {
-          auto strongResolveWrapper = weakResolveWrapper.lock();
-          if (strongResolveWrapper) {
-            strongResolveWrapper->destroy();
-          }
-
-          auto strongRejectWrapper = weakRejectWrapper.lock();
-          if (strongRejectWrapper) {
-            strongRejectWrapper->destroy();
-          }
-        }];
-
-        RCTPromiseResolveBlock resolveBlock = ^(id result) {
-          if (rejectWasCalled) {
-            RCTLogError(@"%s: Tried to resolve a promise after it's already been rejected.", moduleMethod.c_str());
-            return;
-          }
-
-          if (resolveWasCalled) {
-            RCTLogError(@"%s: Tried to resolve a promise more than once.", moduleMethod.c_str());
-            return;
-          }
-
-          auto strongResolveWrapper = weakResolveWrapper.lock();
-          auto strongRejectWrapper = weakRejectWrapper.lock();
-          if (!strongResolveWrapper || !strongRejectWrapper) {
-            return;
-          }
-
-          strongResolveWrapper->jsInvoker().invokeAsync([weakResolveWrapper, weakRejectWrapper, result, blockGuard]() {
-            auto strongResolveWrapper2 = weakResolveWrapper.lock();
-            auto strongRejectWrapper2 = weakRejectWrapper.lock();
-            if (!strongResolveWrapper2 || !strongRejectWrapper2) {
-              return;
+            if (count != 2) {
+              throw std::invalid_argument(
+                  moduleMethod + ": Promise must pass constructor function two args. Passed " + std::to_string(count) +
+                  " args.");
+            }
+            if (!invokeCopy) {
+              return jsi::Value::undefined();
             }
 
-            jsi::Runtime &rt = strongResolveWrapper2->runtime();
-            jsi::Value arg = convertObjCObjectToJSIValue(rt, result);
-            strongResolveWrapper2->callback().call(rt, arg);
+            __block BOOL resolveWasCalled = NO;
+            __block std::optional<AsyncCallback<>> resolve(
+                {rt, args[0].getObject(rt).getFunction(rt), std::move(jsInvoker)});
+            __block std::optional<AsyncCallback<>> reject(
+                {rt, args[1].getObject(rt).getFunction(rt), std::move(jsInvoker)});
 
-            strongResolveWrapper2->destroy();
-            strongRejectWrapper2->destroy();
-            (void)blockGuard;
-          });
+            RCTPromiseResolveBlock resolveBlock = ^(id result) {
+              if (!resolve || !reject) {
+                if (resolveWasCalled) {
+                  RCTLogError(@"%s: Tried to resolve a promise more than once.", moduleMethod.c_str());
+                } else {
+                  RCTLogError(
+                      @"%s: Tried to resolve a promise after it's already been rejected.", moduleMethod.c_str());
+                }
+                return;
+              }
 
-          resolveWasCalled = YES;
-        };
+              resolve->call([result](jsi::Runtime &rt, jsi::Function &jsFunction) {
+                jsFunction.call(rt, convertObjCObjectToJSIValue(rt, result));
+              });
 
-        RCTPromiseRejectBlock rejectBlock = ^(NSString *code, NSString *message, NSError *error) {
-          if (resolveWasCalled) {
-            RCTLogError(@"%s: Tried to reject a promise after it's already been resolved.", moduleMethod.c_str());
-            return;
-          }
+              resolveWasCalled = YES;
+              resolve = std::nullopt;
+              reject = std::nullopt;
+            };
 
-          if (rejectWasCalled) {
-            RCTLogError(@"%s: Tried to reject a promise more than once.", moduleMethod.c_str());
-            return;
-          }
+            RCTPromiseRejectBlock rejectBlock = ^(NSString *code, NSString *message, NSError *error) {
+              if (!resolve || !reject) {
+                if (resolveWasCalled) {
+                  RCTLogError(@"%s: Tried to reject a promise after it's already been resolved.", moduleMethod.c_str());
+                } else {
+                  RCTLogError(@"%s: Tried to reject a promise more than once.", moduleMethod.c_str());
+                }
+                return;
+              }
 
-          auto strongResolveWrapper = weakResolveWrapper.lock();
-          auto strongRejectWrapper = weakRejectWrapper.lock();
-          if (!strongResolveWrapper || !strongRejectWrapper) {
-            return;
-          }
+              NSDictionary *jsError = RCTJSErrorFromCodeMessageAndNSError(code, message, error);
+              reject->call([jsError](jsi::Runtime &rt, jsi::Function &jsFunction) {
+                jsFunction.call(rt, convertObjCObjectToJSIValue(rt, jsError));
+              });
 
-          NSDictionary *jsError = RCTJSErrorFromCodeMessageAndNSError(code, message, error);
-          strongRejectWrapper->jsInvoker().invokeAsync([weakResolveWrapper, weakRejectWrapper, jsError, blockGuard]() {
-            auto strongResolveWrapper2 = weakResolveWrapper.lock();
-            auto strongRejectWrapper2 = weakRejectWrapper.lock();
-            if (!strongResolveWrapper2 || !strongRejectWrapper2) {
-              return;
-            }
+              resolveWasCalled = NO;
+              resolve = std::nullopt;
+              reject = std::nullopt;
+            };
 
-            jsi::Runtime &rt = strongRejectWrapper2->runtime();
-            jsi::Value arg = convertNSDictionaryToJSIObject(rt, jsError);
-            strongRejectWrapper2->callback().call(rt, arg);
-
-            strongResolveWrapper2->destroy();
-            strongRejectWrapper2->destroy();
-            (void)blockGuard;
-          });
-
-          rejectWasCalled = YES;
-        };
-
-        invokeCopy(resolveBlock, rejectBlock);
-        return jsi::Value::undefined();
-      });
-
-  return Promise.callAsConstructor(runtime, fn);
+            invokeCopy(resolveBlock, rejectBlock);
+            return jsi::Value::undefined();
+          }));
 }
 
 /**

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -44,7 +44,8 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec {
   @SuppressWarnings("unused")
   @Override
   public boolean getBool(boolean arg) {
-    throw new RuntimeException("getBool is not implemented");
+    log("getBool", arg, arg);
+    return arg;
   }
 
   @DoNotStrip


### PR DESCRIPTION
Summary:
Similarly to D49792717, simplify the careful logic we have with CallbackWrapper and RCTBlockGuard and instead rely on bridging's `AsyncCallback` so safely handle jsi::Function for us.

Changelog: [Internal]

Reviewed By: RSNara

Differential Revision: D49862756

