### PR TITLE
Fix UIManager Flow type

### DIFF
--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {RootTag} from '../Types/RootTagTypes';
+import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
 import {unstable_hasComponent} from '../NativeComponent/NativeComponentRegistryUnstable';
 
@@ -32,7 +33,7 @@ function getCachedConstants(): Object {
   return cachedConstants;
 }
 
-const UIManagerJS: {[string]: $FlowFixMe} = {
+const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
   getViewManagerConfig: (viewManagerName: string): mixed => {
     if (nativeViewConfigsInBridgelessModeEnabled()) {
       return getCachedConstants()[viewManagerName];

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -9,6 +9,7 @@
  */
 
 import type {RootTag} from '../Types/RootTagTypes';
+import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
 import NativeUIManager from './NativeUIManager';
 
@@ -77,10 +78,8 @@ function getViewManagerConfig(viewManagerName: string): any {
   return viewManagerConfigs[viewManagerName];
 }
 
-/* $FlowFixMe[cannot-spread-interface] (>=0.123.0 site=react_native_fb) This
- * comment suppresses an error found when Flow v0.123.0 was deployed. To see
- * the error, delete this comment and run Flow. */
-const UIManagerJS = {
+// $FlowFixMe[cannot-spread-interface]
+const UIManagerJS: UIManagerJSInterface = {
   ...NativeUIManager,
   createView(
     reactTag: ?number,

--- a/packages/react-native/Libraries/ReactNative/UIManager.js
+++ b/packages/react-native/Libraries/ReactNative/UIManager.js
@@ -8,31 +8,10 @@
  * @format
  */
 
-import type {RootTag} from '../Types/RootTagTypes';
-import type {Spec} from './NativeUIManager';
+import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
 import {getFabricUIManager} from './FabricUIManager';
 import nullthrows from 'nullthrows';
-
-export interface UIManagerJSInterface extends Spec {
-  +getViewManagerConfig: (viewManagerName: string) => Object;
-  +hasViewManagerConfig: (viewManagerName: string) => boolean;
-  +createView: (
-    reactTag: ?number,
-    viewName: string,
-    rootTag: RootTag,
-    props: Object,
-  ) => void;
-  +updateView: (reactTag: number, viewName: string, props: Object) => void;
-  +manageChildren: (
-    containerTag: ?number,
-    moveFromIndices: Array<number>,
-    moveToIndices: Array<number>,
-    addChildReactTags: Array<number>,
-    addAtIndices: Array<number>,
-    removeAtIndices: Array<number>,
-  ) => void;
-}
 
 function isFabricReactTag(reactTag: number): boolean {
   // React reserves even numbers for Fabric.
@@ -45,7 +24,7 @@ const UIManagerImpl: UIManagerJSInterface =
     : require('./PaperUIManager');
 
 // $FlowFixMe[cannot-spread-interface]
-const UIManager = {
+const UIManager: UIManagerJSInterface = {
   ...UIManagerImpl,
   measure(
     reactTag: number,

--- a/packages/react-native/Libraries/Types/UIManagerJSInterface.js
+++ b/packages/react-native/Libraries/Types/UIManagerJSInterface.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {Spec} from '../ReactNative/NativeUIManager';
+
+export interface UIManagerJSInterface extends Spec {
+  +getViewManagerConfig: (viewManagerName: string) => Object;
+  +hasViewManagerConfig: (viewManagerName: string) => boolean;
+}

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -135,7 +135,7 @@ export default function MyNativeView(props: {}): React.Node {
       </Text>
       <Text style={{color: 'green', textAlign: 'center'}}>
         Constants From Interop Layer:{' '}
-        {UIManager.RNTMyLegacyNativeView.Constants.PI}
+        {UIManager.getViewManagerConfig('RNTMyLegacyNativeView').Constants.PI}
       </Text>
       <Button
         title="Change Background"


### PR DESCRIPTION
Summary:
I accidentally stumbled upon the `UIManager` object on JS side and realised it was being exported as `any`. So I've extracted the interface `UIManagerJSInterface` and applied where it seems to make sense, although, after chatting with javache it could be useful to further narrow down the interface given what's currently implemented by the `BridgelessUIManager`.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D50137691


