### PR TITLE
Revert undeprecation of onCatalystInstanceDestroy

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -52,7 +52,7 @@ public interface NativeModule {
    *
    * @deprecated use {@link #invalidate()} instead.
    */
-  @DeprecatedInNewArchitecture(message = "Use invalidate method instead")
+  @Deprecated(since = "Use invalidate method instead", forRemoval = true)
   void onCatalystInstanceDestroy();
 
   /** Allow NativeModule to clean up. Called before React Native instance is destroyed. */


### PR DESCRIPTION
Summary:
Revert undeprecation of onCatalystInstanceDestroy

revert of D50141027

changelog: [Android][Changed] Deprecated NativeModule.onCatalystInstanceDestroy

Reviewed By: christophpurrer

Differential Revision: D50195995


