### PR TITLE
refactor(image typing): use ImageRequireSource instead of number for defaultSource prop typing

### DIFF
--- a/packages/react-native/Libraries/Image/Image.d.ts
+++ b/packages/react-native/Libraries/Image/Image.d.ts
@@ -260,7 +260,7 @@ export interface ImagePropsBase
   /**
    * A static image to display while downloading the final image off the network.
    */
-  defaultSource?: ImageURISource | number | undefined;
+  defaultSource?: ImageURISource | ImageRequireSource | undefined;
 
   /**
    * The text that's read by the screen reader when the user interacts with


### PR DESCRIPTION
## Summary:
This is just a type refactoring to make the typing of the `defaultSource` prop of the Image component more explicit and descriptive (using the `ImageRequireSource` type makes it more clear that we can use the require statement to set an image asset as default source) and this is also more consistent with the `source` prop typing. 

Currently :
- The typing of default source is `ImageURISource | number | undefined`
- The typing of source is `ImageSourcePropType` which is equal to `ImageURISource  | ImageURISource[]  | ImageRequireSource` and `ImageRequireSource` is equal to `number`.

In this PR we change the typing of default source to `ImageURISource | ImageRequireSource | undefined` to make more clear that the number of the default source prop refers to the use of the require statement with an asset file.

## Changelog:
[GENERAL] [CHANGED] - use ImageRequireSource instead of number for the defaultSource prop typing of the Image component

## Test Plan:
No one required since it's a small typing refactoring.
