### PR TITLE
Sort object properties in interop test

### DIFF
--- a/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
@@ -50,6 +50,22 @@ function getSampleLegacyModule() {
   return module;
 }
 
+function stringify(obj: mixed): string {
+  function replacer(_: string, value: mixed) {
+    if (value instanceof Object && !(value instanceof Array)) {
+      return Object.keys(value ?? {})
+        .sort()
+        .reduce((sorted: {[key: string]: mixed}, key: string) => {
+          sorted[key] = (value ?? {})[key];
+          return sorted;
+        }, {});
+    }
+    return value;
+  }
+
+  return (JSON.stringify(obj, replacer) || '').replaceAll('"', "'");
+}
+
 class SampleLegacyModuleExample extends React.Component<{||}, State> {
   static contextType: React$Context<RootTag> = RootTagContext;
 
@@ -171,7 +187,7 @@ class SampleLegacyModuleExample extends React.Component<{||}, State> {
     return (
       <View style={styles.result}>
         <Text testID={name + '-result'} style={[styles.value]}>
-          {(JSON.stringify(result.value) || '').replaceAll('"', "'")}
+          {stringify(result.value)}
         </Text>
         <Text style={[styles.type]}>{result.type}</Text>
       </View>


### PR DESCRIPTION
Summary:
It looks like objects properties aren't guaranteed to have a stable order. Sort them, before we serializae and print them to the screen in the interop test. This should reduce interop test flakyness.

Changelog: [Internal]

Reviewed By: makovkastar

Differential Revision: D50148860


