### PR TITLE
Back out "Make sure template is consuming the right buildToolsVersion"

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -25,7 +25,7 @@ references:
   android-defaults: &android-defaults
     working_directory: ~/react-native
     docker:
-      - image: reactnativecommunity/react-native-android:v12.0
+      - image: reactnativecommunity/react-native-android:v11.0
     environment:
       - TERM: "dumb"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false'

--- a/packages/react-native/template/android/app/build.gradle
+++ b/packages/react-native/template/android/app/build.gradle
@@ -71,7 +71,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 
 android {
     ndkVersion rootProject.ext.ndkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+
     compileSdk rootProject.ext.compileSdkVersion
 
     namespace "com.helloworld"


### PR DESCRIPTION
Summary:
This [commit](https://github.com/facebook/react-native/commit/a5d5ead1a474832a911c3a6e44b6d6450bca3fd6) seems to break all the Android template tests: [CircleCI](https://app.circleci.com/pipelines/github/facebook/react-native/34139/workflows/b203bbea-d3c4-45aa-9ce1-1ddde6d88bc0).

Original Phabricator Diff: D50019777

Differential Revision: D50217952


