### PR TITLE
normalize-colors should not impose node >= 18

### DIFF
--- a/packages/normalize-color/package.json
+++ b/packages/normalize-color/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/normalize-colors",
-  "version": "0.74.0",
+  "version": "0.74.1",
   "description": "Color normalization for React Native.",
   "license": "MIT",
   "repository": {
@@ -15,8 +15,5 @@
     "normalize-colors",
     "react-native"
   ],
-  "bugs": "https://github.com/facebook/react-native/issues",
-  "engines": {
-    "node": ">=18"
-  }
+  "bugs": "https://github.com/facebook/react-native/issues"
 }


### PR DESCRIPTION
Summary:
I'm removing the node >= 18 restriction on react-native/normalize-colors as that's unnecessary
as is currently breaking the ecosystem for users on Node 16 on previous versions of React Native.

Changelog:
[General] [Fixed] - normalize-colors should not impose node >= 18

ignore-github-export-checks

#publish-packages-to-npm

Reviewed By: robhogan

Differential Revision: D50215144


