### PR TITLE
Fix crash in getChildDrawingOrder

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.java
@@ -11,8 +11,12 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+
+import com.facebook.common.logging.FLog;
+import com.facebook.react.common.ReactConstants;
 
 /** Helper to handle implementing ViewGroups with custom drawing order based on z-index. */
 public class ViewGroupDrawingOrderHelper {
@@ -67,6 +71,15 @@ public class ViewGroupDrawingOrderHelper {
   public int getChildDrawingOrder(int childCount, int index) {
     if (mDrawingOrderIndices != null
       && (index >= mDrawingOrderIndices.length || mDrawingOrderIndices[index] >= childCount)) {
+      FLog.w(ReactConstants.TAG,
+        "getChildDrawingOrder index out of bounds! please check your operations of addding and " +
+          "removing subview.Force updates here to prevent crash."
+          + " viewId:" + mViewGroup.getId()
+          + " childCount:" + childCount
+          + " index:" + index
+          + " mDrawingOrderIndices:" + Arrays.toString(mDrawingOrderIndices)
+          + " mNumberOfChildrenWithZIndex:" + mNumberOfChildrenWithZIndex
+      );
       update();
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.java
@@ -65,6 +65,11 @@ public class ViewGroupDrawingOrderHelper {
    * ViewGroup#getChildDrawingOrder}.
    */
   public int getChildDrawingOrder(int childCount, int index) {
+    if (mDrawingOrderIndices != null
+      && (index >= mDrawingOrderIndices.length || mDrawingOrderIndices[index] >= childCount)) {
+      update();
+    }
+
     if (mDrawingOrderIndices == null) {
       ArrayList<View> viewsToSort = new ArrayList<>();
       for (int i = 0; i < childCount; i++) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.java
@@ -72,14 +72,8 @@ public class ViewGroupDrawingOrderHelper {
     if (mDrawingOrderIndices != null
       && (index >= mDrawingOrderIndices.length || mDrawingOrderIndices[index] >= childCount)) {
       FLog.w(ReactConstants.TAG,
-        "getChildDrawingOrder index out of bounds! please check your operations of addding and " +
-          "removing subview.Force updates here to prevent crash."
-          + " viewId:" + mViewGroup.getId()
-          + " childCount:" + childCount
-          + " index:" + index
-          + " mDrawingOrderIndices:" + Arrays.toString(mDrawingOrderIndices)
-          + " mNumberOfChildrenWithZIndex:" + mNumberOfChildrenWithZIndex
-      );
+        "getChildDrawingOrder index out of bounds! Please check any custom view manipulations you" +
+          " may have done. childCount = %d, index = %d", childCount, index);
       update();
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -418,10 +418,10 @@ public class ReactViewGroup extends ViewGroup
     if (!intersects && child.getParent() != null && !isAnimating) {
       // We can try saving on invalidate call here as the view that we remove is out of visible area
       // therefore invalidation is not necessary.
-      super.removeViewsInLayout(idx - clippedSoFar, 1);
+      removeViewsInLayout(idx - clippedSoFar, 1);
       needUpdateClippingRecursive = true;
     } else if (intersects && child.getParent() == null) {
-      super.addViewInLayout(child, idx - clippedSoFar, sDefaultLayoutParam, true);
+      addViewInLayout(child, idx - clippedSoFar, sDefaultLayoutParam, true);
       invalidate();
       needUpdateClippingRecursive = true;
     } else if (intersects) {
@@ -499,23 +499,18 @@ public class ReactViewGroup extends ViewGroup
     return ViewUtil.getUIManagerType(getId()) == UIManagerType.FABRIC;
   }
 
-  @Override
-  public void addView(View child, int index, ViewGroup.LayoutParams params) {
-    // This will get called for every overload of addView so there is not need to override every
-    // method.
+  private void handleAddView(View view) {
+    UiThreadUtil.assertOnUiThread();
 
     if (!customDrawOrderDisabled()) {
-      getDrawingOrderHelper().handleAddView(child);
+      getDrawingOrderHelper().handleAddView(view);
       setChildrenDrawingOrderEnabled(getDrawingOrderHelper().shouldEnableCustomDrawingOrder());
     } else {
       setChildrenDrawingOrderEnabled(false);
     }
-
-    super.addView(child, index, params);
   }
 
-  @Override
-  public void removeView(View view) {
+  private void handleRemoveView(View view) {
     UiThreadUtil.assertOnUiThread();
 
     if (!customDrawOrderDisabled()) {
@@ -524,22 +519,60 @@ public class ReactViewGroup extends ViewGroup
     } else {
       setChildrenDrawingOrderEnabled(false);
     }
+  }
 
+  private void handleRemoveViews(int start, int count) {
+    int endIndex = start + count;
+    for (int index = start; index < endIndex; index++) {
+      if (index < getChildCount()) {
+        handleRemoveView(getChildAt(index));
+      }
+    }
+  }
+
+  @Override
+  public void addView(View child, int index, ViewGroup.LayoutParams params) {
+    // This will get called for every overload of addView so there is not need to override every
+    // method.
+    handleAddView(child);
+    super.addView(child, index, params);
+  }
+
+  @Override
+  protected boolean addViewInLayout(View child, int index, LayoutParams params,
+    boolean preventRequestLayout) {
+    handleAddView(child);
+    return super.addViewInLayout(child, index, params, preventRequestLayout);
+  }
+
+  @Override
+  public void removeView(View view) {
+    handleRemoveView(view);
     super.removeView(view);
   }
 
   @Override
   public void removeViewAt(int index) {
-    UiThreadUtil.assertOnUiThread();
-
-    if (!customDrawOrderDisabled()) {
-      getDrawingOrderHelper().handleRemoveView(getChildAt(index));
-      setChildrenDrawingOrderEnabled(getDrawingOrderHelper().shouldEnableCustomDrawingOrder());
-    } else {
-      setChildrenDrawingOrderEnabled(false);
-    }
-
+    handleRemoveView(getChildAt(index));
     super.removeViewAt(index);
+  }
+
+  @Override
+  public void removeViewInLayout(View view) {
+    handleRemoveView(view);
+    super.removeViewInLayout(view);
+  }
+
+  @Override
+  public void removeViewsInLayout(int start, int count) {
+    handleRemoveViews(start, count);
+    super.removeViewsInLayout(start, count);
+  }
+
+  @Override
+  public void removeViews(int start, int count) {
+    handleRemoveViews(start, count);
+    super.removeViews(start, count);
   }
 
   @Override
@@ -663,7 +696,7 @@ public class ReactViewGroup extends ViewGroup
           clippedSoFar++;
         }
       }
-      super.removeViewsInLayout(index - clippedSoFar, 1);
+      removeViewsInLayout(index - clippedSoFar, 1);
     }
     removeFromArray(index);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Problem Causes: In ReactViewGroup, there is a conflict between the zIndex attribute and the removeClippedSubviews optimization attribute. When both are used at the same time, the array mDrawingOrderIndices in ViewGroupDrawingOrderHelper that records the rendering order of subviews is not reset when super is called in the updateSubviewClipStatus method to add and remove subviews.

Solution: Because there are many third-party components that inherit from or depend on ReactViewGroup, all methods for adding and removing subviews in ViewGroup need to be override in ReactViewGroup, and ViewGroupDrawingOrderHelper corresponding to handleAddView and handleRemoveView needs to be called in these methods. And all the precautions for directly calling super to add and remove subviews are changed to calling the overridden method by ReactViewGroup. 

Special Note: All addView related methods in ViewGroup will eventually be called to the addView(View child, int index, LayoutParams params) method, except addViewInLayout. Regarding the method of adding subviews, we only need to override  addView(View child, int index, LayoutParams params) and addViewInLayout(View child, int index, LayoutParams params,boolean preventRequestLayout) in ReactViewGroup.

## Changelog:
[Android] [Fixed] - Fix the crash in ReactViewGroup of https://github.com/facebook/react-native/issues/30785