### PR TITLE
SVC Codegen: Handle TSAsExpression when looking for the codegen declaration

### DIFF
--- a/packages/babel-plugin-codegen/index.js
+++ b/packages/babel-plugin-codegen/index.js
@@ -83,6 +83,14 @@ function isCodegenDeclaration(declaration) {
     declaration.expression.callee.name === 'codegenNativeComponent'
   ) {
     return true;
+  } else if (
+    declaration.type === 'TSAsExpression' &&
+    declaration.expression &&
+    declaration.expression.callee &&
+    declaration.expression.callee.name &&
+    declaration.expression.callee.name === 'codegenNativeComponent'
+  ) {
+    return true;
   }
 
   return false;


### PR DESCRIPTION
Summary:
This diff adds support for the `AS` expression in TS sources. The following codegen declaration should work now:
```
export default codegenNativeComponent<NativeProps>(
  'MyComponentView',
) as HostComponent<NativeProps>;
```
Changelog: [General][Added] - Handle TSAsExpression when looking for the codegen declaration

Differential Revision: D50225241


