### PR TITLE
Pass LayoutContext to TextLayoutManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -16,7 +16,7 @@ TextMeasurement ParagraphLayoutManager::measure(
     const ParagraphAttributes& paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   if (CoreFeatures::cacheLastTextMeasurement) {
-    bool shouldMeasure = shoudMeasureString(
+    bool shouldMeasure = shouldMeasureString(
         attributedString, paragraphAttributes, layoutConstraints);
 
     if (shouldMeasure) {
@@ -38,7 +38,7 @@ TextMeasurement ParagraphLayoutManager::measure(
   }
 }
 
-bool ParagraphLayoutManager::shoudMeasureString(
+bool ParagraphLayoutManager::shouldMeasureString(
     const AttributedString& attributedString,
     const ParagraphAttributes& paragraphAttributes,
     LayoutConstraints layoutConstraints) const {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -14,6 +14,7 @@ namespace facebook::react {
 TextMeasurement ParagraphLayoutManager::measure(
     const AttributedString& attributedString,
     const ParagraphAttributes& paragraphAttributes,
+    const TextLayoutContext& layoutContext,
     LayoutConstraints layoutConstraints) const {
   if (CoreFeatures::cacheLastTextMeasurement) {
     bool shouldMeasure = shouldMeasureString(
@@ -23,6 +24,7 @@ TextMeasurement ParagraphLayoutManager::measure(
       cachedTextMeasurement_ = textLayoutManager_->measure(
           AttributedStringBox(attributedString),
           paragraphAttributes,
+          layoutContext,
           layoutConstraints,
           hostTextStorage_);
       lastAvailableWidth_ = layoutConstraints.maximumSize.width;
@@ -33,6 +35,7 @@ TextMeasurement ParagraphLayoutManager::measure(
     return textLayoutManager_->measure(
         AttributedStringBox(attributedString),
         paragraphAttributes,
+        layoutContext,
         layoutConstraints,
         nullptr);
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
@@ -10,6 +10,7 @@
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 
 namespace facebook::react {
@@ -26,6 +27,7 @@ class ParagraphLayoutManager {
   TextMeasurement measure(
       const AttributedString& attributedString,
       const ParagraphAttributes& paragraphAttributes,
+      const TextLayoutContext& layoutContext,
       LayoutConstraints layoutConstraints) const;
 
   LinesMeasurements measureLines(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
@@ -84,7 +84,7 @@ class ParagraphLayoutManager {
    * text measurement result. Returns true if inputs have changed and measure is
    * needed.
    */
-  bool shoudMeasureString(
+  bool shouldMeasureString(
       const AttributedString& attributedString,
       const ParagraphAttributes& paragraphAttributes,
       LayoutConstraints layoutConstraints) const;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -16,6 +16,7 @@
 #include <react/renderer/core/TraitCast.h>
 #include <react/renderer/graphics/rounding.h>
 #include <react/renderer/telemetry/TransactionTelemetry.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 #include <react/utils/CoreFeatures.h>
 
 #include "ParagraphState.h"
@@ -152,9 +153,15 @@ Size ParagraphShadowNode::measureContent(
     attributedString.appendFragment({string, textAttributes, {}});
   }
 
+  TextLayoutContext textLayoutContext{};
+  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
   return getStateData()
       .paragraphLayoutManager
-      .measure(attributedString, content.paragraphAttributes, layoutConstraints)
+      .measure(
+          attributedString,
+          content.paragraphAttributes,
+          textLayoutContext,
+          layoutConstraints)
       .size;
 }
 
@@ -171,8 +178,13 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
 
   updateStateIfNeeded(content);
 
+  TextLayoutContext textLayoutContext{};
+  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
   auto measurement = getStateData().paragraphLayoutManager.measure(
-      content.attributedString, content.paragraphAttributes, layoutConstraints);
+      content.attributedString,
+      content.paragraphAttributes,
+      textLayoutContext,
+      layoutConstraints);
 
   if (getConcreteProps().onTextLayout) {
     auto linesMeasurements = getStateData().paragraphLayoutManager.measureLines(

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -16,6 +16,7 @@
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/core/conversions.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 
 #include <utility>
 
@@ -157,7 +158,7 @@ void AndroidTextInputShadowNode::updateStateIfNeeded() {
 #pragma mark - LayoutableShadowNode
 
 Size AndroidTextInputShadowNode::measureContent(
-    const LayoutContext& /*layoutContext*/,
+    const LayoutContext& layoutContext,
     const LayoutConstraints& layoutConstraints) const {
   if (getStateData().cachedAttributedStringId != 0) {
     return textLayoutManager_
@@ -183,10 +184,13 @@ Size AndroidTextInputShadowNode::measureContent(
     return {0, 0};
   }
 
+  TextLayoutContext textLayoutContext;
+  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
   return textLayoutManager_
       ->measure(
           AttributedStringBox{attributedString},
           getConcreteProps().paragraphAttributes,
+          textLayoutContext,
           layoutConstraints,
           nullptr)
       .size;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputShadowNode.cpp
@@ -13,6 +13,7 @@
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/core/conversions.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 
 namespace facebook::react {
 
@@ -106,10 +107,13 @@ void TextInputShadowNode::updateStateIfNeeded(
 Size TextInputShadowNode::measureContent(
     const LayoutContext& layoutContext,
     const LayoutConstraints& layoutConstraints) const {
+  TextLayoutContext textLayoutContext{};
+  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
   return textLayoutManager_
       ->measure(
           attributedStringBoxToMeasure(layoutContext),
           getConcreteProps().getEffectiveParagraphAttributes(),
+          textLayoutContext,
           layoutConstraints,
           nullptr)
       .size;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutContext.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/graphics/Float.h>
+
+namespace facebook::react {
+
+/*
+ * TextLayoutContext: Additional contextual information useful for text
+ * measurement.
+ */
+struct TextLayoutContext {
+  /*
+   * Reflects the scale factor needed to convert from the logical coordinate
+   * space into the device coordinate space of the physical screen.
+   * Some layout systems *might* use this to round layout metric values
+   * to `pixel value`.
+   */
+  Float pointScaleFactor{1.0};
+};
+
+inline bool operator==(
+    TextLayoutContext const& lhs,
+    TextLayoutContext const& rhs) {
+  return std::tie(lhs.pointScaleFactor) == std::tie(rhs.pointScaleFactor);
+}
+
+inline bool operator!=(
+    TextLayoutContext const& lhs,
+    TextLayoutContext const& rhs) {
+  return !(lhs == rhs);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -159,6 +159,7 @@ void* TextLayoutManager::getNativeTextLayoutManager() const {
 TextMeasurement TextLayoutManager::measure(
     const AttributedStringBox& attributedStringBox,
     const ParagraphAttributes& paragraphAttributes,
+    const TextLayoutContext& layoutContext,
     LayoutConstraints layoutConstraints,
     std::shared_ptr<void> /* hostTextStorage */) const {
   auto& attributedString = attributedStringBox.getValue();

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -11,6 +11,7 @@
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 #include <react/utils/ContextContainer.h>
 
@@ -45,6 +46,7 @@ class TextLayoutManager {
   TextMeasurement measure(
       const AttributedStringBox& attributedStringBox,
       const ParagraphAttributes& paragraphAttributes,
+      const TextLayoutContext& layoutContext,
       LayoutConstraints layoutConstraints,
       std::shared_ptr<void> /* hostTextStorage */) const;
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
@@ -16,6 +16,7 @@ void* TextLayoutManager::getNativeTextLayoutManager() const {
 TextMeasurement TextLayoutManager::measure(
     AttributedStringBox attributedStringBox,
     ParagraphAttributes paragraphAttributes,
+    const TextLayoutContext& /*layoutContext*/,
     LayoutConstraints layoutConstraints,
     std::shared_ptr<void>) const {
   TextMeasurement::Attachments attachments;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
@@ -13,6 +13,7 @@
 #include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 #include <react/utils/ContextContainer.h>
 
@@ -37,6 +38,7 @@ class TextLayoutManager {
   virtual TextMeasurement measure(
       AttributedStringBox attributedStringBox,
       ParagraphAttributes paragraphAttributes,
+      const TextLayoutContext& layoutContext,
       LayoutConstraints layoutConstraints,
       std::shared_ptr<void>) const;
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -12,6 +12,7 @@
 #include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 #include <react/utils/ContextContainer.h>
 
@@ -32,6 +33,7 @@ class TextLayoutManager {
   TextMeasurement measure(
       AttributedStringBox attributedStringBox,
       ParagraphAttributes paragraphAttributes,
+      const TextLayoutContext& layoutContext,
       LayoutConstraints layoutConstraints,
       std::shared_ptr<void> hostTextStorage) const;
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -41,6 +41,7 @@ std::shared_ptr<void> TextLayoutManager::getHostTextStorage(
 TextMeasurement TextLayoutManager::measure(
     AttributedStringBox attributedStringBox,
     ParagraphAttributes paragraphAttributes,
+    const TextLayoutContext &layoutContext,
     LayoutConstraints layoutConstraints,
     std::shared_ptr<void> hostTextStorage) const
 {


### PR DESCRIPTION
Summary:
Some host platforms may require the LayoutContext for computing the size of text, e.g. to read the pointScaleFactor value. This change passes the LayoutContext to TextLayoutManager so it can be used during text measurement.

Please note, for now, this does not wire any fields from LayoutContext through to the TextMeasureCache, TextLayoutManager::getHostTextStorage, or TextLayoutManager::measureCachedSpannableById  (on Android).

## Changelog:

[General] [Internal]

Differential Revision: D50227592

