### PR TITLE
Create proxy for RuntimeScheduler to allow us to use a forked version

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RuntimeScheduler.h"
+#include "RuntimeScheduler_Legacy.h"
 #include "SchedulerPriorityUtils.h"
 
 #include <react/renderer/debug/SystraceSection.h>
@@ -14,177 +15,55 @@
 
 namespace facebook::react {
 
-#pragma mark - Public
-
 RuntimeScheduler::RuntimeScheduler(
     RuntimeExecutor runtimeExecutor,
     std::function<RuntimeSchedulerTimePoint()> now)
-    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+    : runtimeSchedulerImpl_(std::make_unique<RuntimeScheduler_Legacy>(
+          std::move(runtimeExecutor),
+          std::move(now))) {}
 
 void RuntimeScheduler::scheduleWork(RawCallback&& callback) const noexcept {
-  SystraceSection s("RuntimeScheduler::scheduleWork");
-
-  runtimeAccessRequests_ += 1;
-
-  runtimeExecutor_(
-      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
-        SystraceSection s2("RuntimeScheduler::scheduleWork callback");
-        runtimeAccessRequests_ -= 1;
-        callback(runtime);
-        startWorkLoop(runtime);
-      });
+  return runtimeSchedulerImpl_->scheduleWork(std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
     SchedulerPriority priority,
     jsi::Function&& callback) noexcept {
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
-  auto task =
-      std::make_shared<Task>(priority, std::move(callback), expirationTime);
-  taskQueue_.push(task);
-
-  scheduleWorkLoopIfNecessary();
-
-  return task;
+  return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
     SchedulerPriority priority,
     RawCallback&& callback) noexcept {
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
-  auto task =
-      std::make_shared<Task>(priority, std::move(callback), expirationTime);
-  taskQueue_.push(task);
-
-  scheduleWorkLoopIfNecessary();
-
-  return task;
+  return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 
 bool RuntimeScheduler::getShouldYield() const noexcept {
-  return runtimeAccessRequests_ > 0;
+  return runtimeSchedulerImpl_->getShouldYield();
 }
 
 bool RuntimeScheduler::getIsSynchronous() const noexcept {
-  return isSynchronous_;
+  return runtimeSchedulerImpl_->getIsSynchronous();
 }
 
 void RuntimeScheduler::cancelTask(Task& task) noexcept {
-  task.callback.reset();
+  return runtimeSchedulerImpl_->cancelTask(task);
 }
 
 SchedulerPriority RuntimeScheduler::getCurrentPriorityLevel() const noexcept {
-  return currentPriority_;
+  return runtimeSchedulerImpl_->getCurrentPriorityLevel();
 }
 
 RuntimeSchedulerTimePoint RuntimeScheduler::now() const noexcept {
-  return now_();
+  return runtimeSchedulerImpl_->now();
 }
 
 void RuntimeScheduler::executeNowOnTheSameThread(RawCallback&& callback) {
-  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
-
-  runtimeAccessRequests_ += 1;
-  executeSynchronouslyOnSameThread_CAN_DEADLOCK(
-      runtimeExecutor_,
-      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
-        SystraceSection s2(
-            "RuntimeScheduler::executeNowOnTheSameThread callback");
-
-        runtimeAccessRequests_ -= 1;
-        isSynchronous_ = true;
-        callback(runtime);
-        isSynchronous_ = false;
-      });
-
-  // Resume work loop if needed. In synchronous mode
-  // only expired tasks are executed. Tasks with lower priority
-  // might be still in the queue.
-  scheduleWorkLoopIfNecessary();
+  return runtimeSchedulerImpl_->executeNowOnTheSameThread(std::move(callback));
 }
 
 void RuntimeScheduler::callExpiredTasks(jsi::Runtime& runtime) {
-  SystraceSection s("RuntimeScheduler::callExpiredTasks");
-
-  auto previousPriority = currentPriority_;
-  try {
-    while (!taskQueue_.empty()) {
-      auto topPriorityTask = taskQueue_.top();
-      auto now = now_();
-      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
-
-      if (!didUserCallbackTimeout) {
-        break;
-      }
-
-      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
-    }
-  } catch (jsi::JSError& error) {
-    handleFatalError(runtime, error);
-  }
-
-  currentPriority_ = previousPriority;
-}
-
-#pragma mark - Private
-
-void RuntimeScheduler::scheduleWorkLoopIfNecessary() const {
-  if (!isWorkLoopScheduled_ && !isPerformingWork_) {
-    isWorkLoopScheduled_ = true;
-    runtimeExecutor_([this](jsi::Runtime& runtime) {
-      isWorkLoopScheduled_ = false;
-      startWorkLoop(runtime);
-    });
-  }
-}
-
-void RuntimeScheduler::startWorkLoop(jsi::Runtime& runtime) const {
-  SystraceSection s("RuntimeScheduler::startWorkLoop");
-
-  auto previousPriority = currentPriority_;
-  isPerformingWork_ = true;
-  try {
-    while (!taskQueue_.empty()) {
-      auto topPriorityTask = taskQueue_.top();
-      auto now = now_();
-      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
-
-      if (!didUserCallbackTimeout && getShouldYield()) {
-        // This currentTask hasn't expired, and we need to yield.
-        break;
-      }
-
-      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
-    }
-  } catch (jsi::JSError& error) {
-    handleFatalError(runtime, error);
-  }
-
-  currentPriority_ = previousPriority;
-  isPerformingWork_ = false;
-}
-
-void RuntimeScheduler::executeTask(
-    jsi::Runtime& runtime,
-    const std::shared_ptr<Task>& task,
-    bool didUserCallbackTimeout) const {
-  SystraceSection s(
-      "RuntimeScheduler::executeTask",
-      "priority",
-      serialize(task->priority),
-      "didUserCallbackTimeout",
-      didUserCallbackTimeout);
-
-  currentPriority_ = task->priority;
-  auto result = task->execute(runtime, didUserCallbackTimeout);
-
-  if (result.isObject() && result.getObject(runtime).isFunction(runtime)) {
-    task->callback = result.getObject(runtime).getFunction(runtime);
-  } else {
-    if (taskQueue_.top() == task) {
-      taskQueue_.pop();
-    }
-  }
+  return runtimeSchedulerImpl_->callExpiredTasks(runtime);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RuntimeScheduler_Legacy.h"
+#include "SchedulerPriorityUtils.h"
+
+#include <react/renderer/debug/SystraceSection.h>
+#include <utility>
+#include "ErrorUtils.h"
+
+namespace facebook::react {
+
+#pragma mark - Public
+
+RuntimeScheduler_Legacy::RuntimeScheduler_Legacy(
+    RuntimeExecutor runtimeExecutor,
+    std::function<RuntimeSchedulerTimePoint()> now)
+    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+
+void RuntimeScheduler_Legacy::scheduleWork(
+    RawCallback&& callback) const noexcept {
+  SystraceSection s("RuntimeScheduler::scheduleWork");
+
+  runtimeAccessRequests_ += 1;
+
+  runtimeExecutor_(
+      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
+        SystraceSection s2("RuntimeScheduler::scheduleWork callback");
+        runtimeAccessRequests_ -= 1;
+        callback(runtime);
+        startWorkLoop(runtime);
+      });
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
+    SchedulerPriority priority,
+    jsi::Function&& callback) noexcept {
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+  taskQueue_.push(task);
+
+  scheduleWorkLoopIfNecessary();
+
+  return task;
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
+    SchedulerPriority priority,
+    RawCallback&& callback) noexcept {
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+  taskQueue_.push(task);
+
+  scheduleWorkLoopIfNecessary();
+
+  return task;
+}
+
+bool RuntimeScheduler_Legacy::getShouldYield() const noexcept {
+  return runtimeAccessRequests_ > 0;
+}
+
+bool RuntimeScheduler_Legacy::getIsSynchronous() const noexcept {
+  return isSynchronous_;
+}
+
+void RuntimeScheduler_Legacy::cancelTask(Task& task) noexcept {
+  task.callback.reset();
+}
+
+SchedulerPriority RuntimeScheduler_Legacy::getCurrentPriorityLevel()
+    const noexcept {
+  return currentPriority_;
+}
+
+RuntimeSchedulerTimePoint RuntimeScheduler_Legacy::now() const noexcept {
+  return now_();
+}
+
+void RuntimeScheduler_Legacy::executeNowOnTheSameThread(
+    RawCallback&& callback) {
+  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
+
+  runtimeAccessRequests_ += 1;
+  executeSynchronouslyOnSameThread_CAN_DEADLOCK(
+      runtimeExecutor_,
+      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
+        SystraceSection s2(
+            "RuntimeScheduler::executeNowOnTheSameThread callback");
+
+        runtimeAccessRequests_ -= 1;
+        isSynchronous_ = true;
+        callback(runtime);
+        isSynchronous_ = false;
+      });
+
+  // Resume work loop if needed. In synchronous mode
+  // only expired tasks are executed. Tasks with lower priority
+  // might be still in the queue.
+  scheduleWorkLoopIfNecessary();
+}
+
+void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
+  SystraceSection s("RuntimeScheduler::callExpiredTasks");
+
+  auto previousPriority = currentPriority_;
+  try {
+    while (!taskQueue_.empty()) {
+      auto topPriorityTask = taskQueue_.top();
+      auto now = now_();
+      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
+
+      if (!didUserCallbackTimeout) {
+        break;
+      }
+
+      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
+    }
+  } catch (jsi::JSError& error) {
+    handleFatalError(runtime, error);
+  }
+
+  currentPriority_ = previousPriority;
+}
+
+#pragma mark - Private
+
+void RuntimeScheduler_Legacy::scheduleWorkLoopIfNecessary() const {
+  if (!isWorkLoopScheduled_ && !isPerformingWork_) {
+    isWorkLoopScheduled_ = true;
+    runtimeExecutor_([this](jsi::Runtime& runtime) {
+      isWorkLoopScheduled_ = false;
+      startWorkLoop(runtime);
+    });
+  }
+}
+
+void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) const {
+  SystraceSection s("RuntimeScheduler::startWorkLoop");
+
+  auto previousPriority = currentPriority_;
+  isPerformingWork_ = true;
+  try {
+    while (!taskQueue_.empty()) {
+      auto topPriorityTask = taskQueue_.top();
+      auto now = now_();
+      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
+
+      if (!didUserCallbackTimeout && getShouldYield()) {
+        // This currentTask hasn't expired, and we need to yield.
+        break;
+      }
+
+      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
+    }
+  } catch (jsi::JSError& error) {
+    handleFatalError(runtime, error);
+  }
+
+  currentPriority_ = previousPriority;
+  isPerformingWork_ = false;
+}
+
+void RuntimeScheduler_Legacy::executeTask(
+    jsi::Runtime& runtime,
+    const std::shared_ptr<Task>& task,
+    bool didUserCallbackTimeout) const {
+  SystraceSection s(
+      "RuntimeScheduler::executeTask",
+      "priority",
+      serialize(task->priority),
+      "didUserCallbackTimeout",
+      didUserCallbackTimeout);
+
+  currentPriority_ = task->priority;
+  auto result = task->execute(runtime, didUserCallbackTimeout);
+
+  if (result.isObject() && result.getObject(runtime).isFunction(runtime)) {
+    task->callback = result.getObject(runtime).getFunction(runtime);
+  } else {
+    if (taskQueue_.top() == task) {
+      taskQueue_.pop();
+    }
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -16,7 +16,7 @@
 
 namespace facebook::react {
 
-class RuntimeScheduler;
+class RuntimeScheduler_Legacy;
 class TaskPriorityComparer;
 
 using RawCallback = std::function<void(jsi::Runtime&)>;
@@ -33,7 +33,7 @@ struct Task final : public jsi::NativeState {
       std::chrono::steady_clock::time_point expirationTime);
 
  private:
-  friend RuntimeScheduler;
+  friend RuntimeScheduler_Legacy;
   friend TaskPriorityComparer;
 
   SchedulerPriority priority;

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -24,30 +24,6 @@
 
 namespace facebook::react {
 
-// Looping on \c drainMicrotasks until it completes or hits the retries bound.
-static void performMicrotaskCheckpoint(jsi::Runtime& runtime) {
-  uint8_t retries = 0;
-  // A heuristic number to guard inifinite or absurd numbers of retries.
-  constexpr unsigned int kRetriesBound = 255;
-
-  while (retries < kRetriesBound) {
-    try {
-      // The default behavior of \c drainMicrotasks is unbounded execution.
-      // We may want to make it bounded in the future.
-      if (runtime.drainMicrotasks()) {
-        break;
-      }
-    } catch (jsi::JSError& error) {
-      handleJSError(runtime, error, true);
-    }
-    retries++;
-  }
-
-  if (retries == kRetriesBound) {
-    throw std::runtime_error("Hits microtasks retries bound.");
-  }
-}
-
 ReactInstance::ReactInstance(
     std::unique_ptr<jsi::Runtime> runtime,
     std::shared_ptr<MessageQueueThread> jsMessageQueueThread,
@@ -91,7 +67,6 @@ ReactInstance::ReactInstance(
                 if (auto strongTimerManager = weakTimerManager.lock()) {
                   strongTimerManager->callReactNativeMicrotasks(*strongRuntime);
                 }
-                performMicrotaskCheckpoint(*strongRuntime);
               } catch (jsi::JSError& originalError) {
                 handleJSError(*strongRuntime, originalError, true);
               }


### PR DESCRIPTION
Summary:
This introduces a proxy for RuntimeScheduler so we can select between 2 different implementations at runtime (current implementation vs. new implementation, done in D49316881).

Changelog: [internal]

Reviewed By: NickGerleman

Differential Revision: D49316880

