### PR TITLE
Mark BaseJavaModule.getConstants as DeprecatedInNewArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -14,6 +14,7 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.build.ReactBuildConfig;
 import java.util.Map;
 
@@ -62,6 +63,7 @@ public abstract class BaseJavaModule implements NativeModule {
   }
 
   /** @return a map of constants this module exports to JS. Supports JSON types. */
+  @DeprecatedInNewArchitecture()
   public @Nullable Map<String, Object> getConstants() {
     return null;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -52,7 +52,7 @@ public interface NativeModule {
    *
    * @deprecated use {@link #invalidate()} instead.
    */
-  @DeprecatedInNewArchitecture(message = "Use invalidate method instead")
+  @Deprecated(since = "Use invalidate method instead", forRemoval = true)
   void onCatalystInstanceDestroy();
 
   /** Allow NativeModule to clean up. Called before React Native instance is destroyed. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/StableReactNativeAPI.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/StableReactNativeAPI.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations
+
+/** This API is stable and is likely not to change in the New Architecture of React Native. */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class StableReactNativeAPI


### PR DESCRIPTION
Summary:
Mark BaseJavaModule.getConstants as DeprecatedInNewArchitecture

changelog: [internal] internal

Reviewed By: arushikesarwani94

Differential Revision: D50233130

