### PR TITLE
Introduce StableReactNativeAPI annotation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -52,7 +52,7 @@ public interface NativeModule {
    *
    * @deprecated use {@link #invalidate()} instead.
    */
-  @DeprecatedInNewArchitecture(message = "Use invalidate method instead")
+  @Deprecated(since = "Use invalidate method instead", forRemoval = true)
   void onCatalystInstanceDestroy();
 
   /** Allow NativeModule to clean up. Called before React Native instance is destroyed. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/StableReactNativeAPI.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/StableReactNativeAPI.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations
+
+/** This API is stable and is likely not to change in the New Architecture of React Native. */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class StableReactNativeAPI


### PR DESCRIPTION
Summary:
Introduce StableReactNativeAPI annotation, the goal of this annotation is to describe classes, interfaces and members that are considered Stable and will remain part of the new architecture of React Native

changelog: [internal] internal

Reviewed By: arushikesarwani94

Differential Revision: D50195996

