### PR TITLE
Parse isPressable from BaseTextProps

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -165,6 +165,12 @@ static TextAttributes convertRawProp(
       "isHighlighted",
       sourceTextAttributes.isHighlighted,
       defaultTextAttributes.isHighlighted);
+  textAttributes.isPressable = convertRawProp(
+      context,
+      rawProps,
+      "isPressable",
+      sourceTextAttributes.isPressable,
+      defaultTextAttributes.isPressable);
 
   // In general, we want this class to access props in the same order
   // that ViewProps accesses them in, so that RawPropParser can optimize
@@ -294,6 +300,8 @@ void BaseTextProps::setProp(
         defaults, value, textAttributes, textShadowColor, "textShadowColor");
     REBUILD_FIELD_SWITCH_CASE(
         defaults, value, textAttributes, isHighlighted, "isHighlighted");
+    REBUILD_FIELD_SWITCH_CASE(
+        defaults, value, textAttributes, isPressable, "isPressable");
     REBUILD_FIELD_SWITCH_CASE(
         defaults,
         value,


### PR DESCRIPTION
Summary:
The isPressable prop was previously added to TextAttributes. It also needs to be parsed from RawProps in BaseTextProps for platforms to use it.

## Changelog

[General][Internal]

Differential Revision: D50235306


