### PR TITLE
Make some accessibility props optional

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -335,10 +335,11 @@ using namespace facebook::react;
   // `accessibilityState`
   if (oldViewProps.accessibilityState != newViewProps.accessibilityState) {
     self.accessibilityTraits &= ~(UIAccessibilityTraitNotEnabled | UIAccessibilityTraitSelected);
-    if (newViewProps.accessibilityState.selected) {
+    const auto accessibilityState = newViewProps.accessibilityState.value_or(AccessibilityState{});
+    if (accessibilityState.selected) {
       self.accessibilityTraits |= UIAccessibilityTraitSelected;
     }
-    if (newViewProps.accessibilityState.disabled) {
+    if (accessibilityState.disabled) {
       self.accessibilityTraits |= UIAccessibilityTraitNotEnabled;
     }
   }
@@ -725,12 +726,13 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 - (NSString *)accessibilityValue
 {
   const auto &props = static_cast<const ViewProps &>(*_props);
+  const auto accessibilityState = props.accessibilityState.value_or(AccessibilityState{});
 
   // Handle Switch.
   if ((self.accessibilityTraits & AccessibilityTraitSwitch) == AccessibilityTraitSwitch) {
-    if (props.accessibilityState.checked == AccessibilityState::Checked) {
+    if (accessibilityState.checked == AccessibilityState::Checked) {
       return @"1";
-    } else if (props.accessibilityState.checked == AccessibilityState::Unchecked) {
+    } else if (accessibilityState.checked == AccessibilityState::Unchecked) {
       return @"0";
     }
   }
@@ -756,25 +758,25 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   }
 
   // Handle states which haven't already been handled.
-  if (props.accessibilityState.checked == AccessibilityState::Checked) {
+  if (accessibilityState.checked == AccessibilityState::Checked) {
     [valueComponents
         addObject:RCTLocalizedString("checked", "a checkbox, radio button, or other widget which is checked")];
   }
-  if (props.accessibilityState.checked == AccessibilityState::Unchecked) {
+  if (accessibilityState.checked == AccessibilityState::Unchecked) {
     [valueComponents
         addObject:RCTLocalizedString("unchecked", "a checkbox, radio button, or other widget which is unchecked")];
   }
-  if (props.accessibilityState.checked == AccessibilityState::Mixed) {
+  if (accessibilityState.checked == AccessibilityState::Mixed) {
     [valueComponents
         addObject:RCTLocalizedString(
                       "mixed", "a checkbox, radio button, or other widget which is both checked and unchecked")];
   }
-  if (props.accessibilityState.expanded) {
+  if (accessibilityState.expanded.value_or(false)) {
     [valueComponents
         addObject:RCTLocalizedString("expanded", "a menu, dialog, accordian panel, or other widget which is expanded")];
   }
 
-  if (props.accessibilityState.busy) {
+  if (accessibilityState.busy) {
     [valueComponents addObject:RCTLocalizedString("busy", "an element currently being updated or modified")];
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/viewPropConversions.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/viewPropConversions.h
@@ -55,7 +55,7 @@ MapBuffer convertAccessibilityState(const AccessibilityState& state) {
   MapBufferBuilder builder(5);
   builder.putBool(ACCESSIBILITY_STATE_BUSY, state.busy);
   builder.putBool(ACCESSIBILITY_STATE_DISABLED, state.disabled);
-  builder.putBool(ACCESSIBILITY_STATE_EXPANDED, state.expanded);
+  builder.putBool(ACCESSIBILITY_STATE_EXPANDED, state.expanded.value_or(false));
   builder.putBool(ACCESSIBILITY_STATE_SELECTED, state.selected);
   int checked;
   switch (state.checked) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -69,7 +69,7 @@ struct AccessibilityState {
   bool disabled{false};
   bool selected{false};
   bool busy{false};
-  bool expanded{false};
+  std::optional<bool> expanded{std::nullopt};
   enum { Unchecked, Checked, Mixed, None } checked{None};
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -37,7 +37,7 @@ class AccessibilityProps {
 #pragma mark - Props
 
   bool accessible{false};
-  AccessibilityState accessibilityState;
+  std::optional<AccessibilityState> accessibilityState{std::nullopt};
   std::string accessibilityLabel{""};
   AccessibilityLabelledBy accessibilityLabelledBy{};
   AccessibilityLiveRegion accessibilityLiveRegion{

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/AccessibilityPropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/AccessibilityPropsMapBuffer.cpp
@@ -46,7 +46,7 @@ MapBuffer convertAccessibilityState(const AccessibilityState& state) {
   MapBufferBuilder builder(5);
   builder.putBool(ACCESSIBILITY_STATE_BUSY, state.busy);
   builder.putBool(ACCESSIBILITY_STATE_DISABLED, state.disabled);
-  builder.putBool(ACCESSIBILITY_STATE_EXPANDED, state.expanded);
+  builder.putBool(ACCESSIBILITY_STATE_EXPANDED, state.expanded.value_or(false));
   builder.putBool(ACCESSIBILITY_STATE_SELECTED, state.selected);
   int checked;
   switch (state.checked) {
@@ -125,7 +125,8 @@ void AccessibilityProps::propsDiffMapBuffer(
   if (oldProps.accessibilityState != newProps.accessibilityState) {
     builder.putMapBuffer(
         AP_ACCESSIBILITY_STATE,
-        convertAccessibilityState(newProps.accessibilityState));
+        convertAccessibilityState(
+            newProps.accessibilityState.value_or(AccessibilityState{})));
   }
 
   if (oldProps.accessibilityValue != newProps.accessibilityValue) {


### PR DESCRIPTION
Summary:
Some host platforms (e.g., Windows) may have different semantics for accessibility props. For example, not setting `accessibilityState` at all is different from setting all accessibilityState values to false.

Similarly, setting AccessibilityState::expanded to false is different than not setting AccessibilityState::expanded at all because Windows inverts the AccessibilityState::expanded value for it's semantics: an explicitly false value for AccessibilityState::expanded sets the component to a collapsed accessibility state.

## Changelog

[General][Internal]

Differential Revision: D50236747


