### PR TITLE
Revert "Temporary hotfix for broken view flattening on Android"

### DIFF
--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -10,7 +10,6 @@
 
 import type {ViewProps} from './ViewPropTypes';
 
-import ReactNativeFeatureFlags from '../../ReactNative/ReactNativeFeatureFlags';
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import TextAncestor from '../../Text/TextAncestor';
 import ViewNativeComponent from './ViewNativeComponent';
@@ -102,20 +101,10 @@ const View: React.AbstractComponent<
 
     // $FlowFixMe[sketchy-null-mixed]
     const newPointerEvents = style?.pointerEvents || pointerEvents;
-    const collapsableOverride =
-      ReactNativeFeatureFlags.shouldForceUnflattenForElevation()
-        ? {
-            collapsable:
-              style != null && style.elevation != null && style.elevation !== 0
-                ? false
-                : otherProps.collapsable,
-          }
-        : {};
 
     const actualView = (
       <ViewNativeComponent
         {...otherProps}
-        {...collapsableOverride}
         accessibilityLiveRegion={
           ariaLive === 'off' ? 'none' : ariaLive ?? accessibilityLiveRegion
         }

--- a/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
@@ -54,10 +54,6 @@ export type FeatureFlags = {|
    * Enables use of setNativeProps in JS driven animations.
    */
   shouldUseSetNativePropsInFabric: () => boolean,
-  /**
-   * Enables a hotfix for forcing materialization of views with elevation set.
-   */
-  shouldForceUnflattenForElevation: () => boolean,
 |};
 
 const ReactNativeFeatureFlags: FeatureFlags = {
@@ -70,7 +66,6 @@ const ReactNativeFeatureFlags: FeatureFlags = {
   enableAccessToHostTreeInFabric: () => false,
   shouldUseAnimatedObjectForTransform: () => false,
   shouldUseSetNativePropsInFabric: () => false,
-  shouldForceUnflattenForElevation: () => false,
 };
 
 module.exports = ReactNativeFeatureFlags;


### PR DESCRIPTION
Summary:
We no longer need this hotfix since the native fix has been stable for some time now. Cleans up the feature flags and forced `collapsable={false}` prop in View.

## Changelog

[General][Internal]

Differential Revision: D50241092


