### PR TITLE
Symbolicate unhandled promise rejections

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -11,7 +11,6 @@
 ('use strict');
 import type {ExtendedError} from '../../Core/ExtendedError';
 import type {LogLevel} from './LogBoxLog';
-import type {Stack} from './LogBoxSymbolication';
 import type {
   Category,
   ComponentStack,
@@ -30,7 +29,7 @@ export type LogData = $ReadOnly<{|
   message: Message,
   category: Category,
   componentStack: ComponentStack,
-  stack?: Stack,
+  stack?: string,
 |}>;
 
 export type Observer = (
@@ -199,7 +198,7 @@ export function addLog(log: LogData): void {
   // otherwise spammy logs would pause rendering.
   setImmediate(() => {
     try {
-      const stack = log.stack ?? parseErrorStack(errorForStackTrace?.stack);
+      const stack = parseErrorStack(log.stack ?? errorForStackTrace?.stack);
 
       appendNewLog(
         new LogBoxLog({

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -201,14 +201,14 @@ export function addLog(log: LogData): void {
   // otherwise spammy logs would pause rendering.
   setImmediate(() => {
     try {
-      const defaultStack = parseErrorStack(errorForStackTrace?.stack);
+      const stack = log.stack ?? parseErrorStack(errorForStackTrace?.stack);
 
       appendNewLog(
         new LogBoxLog({
           level: log.level,
           message: log.message,
           isComponentError: false,
-          stack: log.stack ?? defaultStack,
+          stack,
           category: log.category,
           componentStack: log.componentStack,
           codeFrame: log.codeFrame,

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -9,6 +9,7 @@
  */
 
 ('use strict');
+
 import type {ExtendedError} from '../../Core/ExtendedError';
 import type {LogLevel} from './LogBoxLog';
 import type {

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -30,6 +30,7 @@ export type LogData = $ReadOnly<{|
   message: Message,
   category: Category,
   componentStack: ComponentStack,
+  codeFrame?: string,
 |}>;
 
 export type Observer = (
@@ -208,6 +209,7 @@ export function addLog(log: LogData): void {
           stack,
           category: log.category,
           componentStack: log.componentStack,
+          codeFrame: log.codeFrame,
         }),
       );
     } catch (error) {

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -9,7 +9,7 @@
  */
 
 ('use strict');
-
+import type {CodeFrame} from '../../Core/Devtools/symbolicateStackTrace';
 import type {ExtendedError} from '../../Core/ExtendedError';
 import type {LogLevel} from './LogBoxLog';
 import type {
@@ -30,7 +30,7 @@ export type LogData = $ReadOnly<{|
   message: Message,
   category: Category,
   componentStack: ComponentStack,
-  codeFrame?: string,
+  codeFrame?: ?CodeFrame,
 |}>;
 
 export type Observer = (

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -9,7 +9,6 @@
  */
 
 ('use strict');
-import type {CodeFrame} from '../../Core/Devtools/symbolicateStackTrace';
 import type {ExtendedError} from '../../Core/ExtendedError';
 import type {LogLevel} from './LogBoxLog';
 import type {Stack} from './LogBoxSymbolication';
@@ -31,7 +30,6 @@ export type LogData = $ReadOnly<{|
   message: Message,
   category: Category,
   componentStack: ComponentStack,
-  codeFrame?: ?CodeFrame,
   stack?: Stack,
 |}>;
 
@@ -211,7 +209,6 @@ export function addLog(log: LogData): void {
           stack,
           category: log.category,
           componentStack: log.componentStack,
-          codeFrame: log.codeFrame,
         }),
       );
     } catch (error) {

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -12,6 +12,7 @@
 import type {CodeFrame} from '../../Core/Devtools/symbolicateStackTrace';
 import type {ExtendedError} from '../../Core/ExtendedError';
 import type {LogLevel} from './LogBoxLog';
+import type {Stack} from './LogBoxSymbolication';
 import type {
   Category,
   ComponentStack,
@@ -31,6 +32,7 @@ export type LogData = $ReadOnly<{|
   category: Category,
   componentStack: ComponentStack,
   codeFrame?: ?CodeFrame,
+  stack?: Stack,
 |}>;
 
 export type Observer = (
@@ -199,14 +201,14 @@ export function addLog(log: LogData): void {
   // otherwise spammy logs would pause rendering.
   setImmediate(() => {
     try {
-      const stack = parseErrorStack(errorForStackTrace?.stack);
+      const defaultStack = parseErrorStack(errorForStackTrace?.stack);
 
       appendNewLog(
         new LogBoxLog({
           level: log.level,
           message: log.message,
           isComponentError: false,
-          stack,
+          stack: log.stack ?? defaultStack,
           category: log.category,
           componentStack: log.componentStack,
           codeFrame: log.codeFrame,

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -10,7 +10,7 @@
 
 import typeof {enable} from 'promise/setimmediate/rejection-tracking';
 
-const LogBox = require('./LogBox/LogBox').default;
+import LogBox from './LogBox/LogBox';
 
 let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
   allRejections: true,
@@ -25,16 +25,16 @@ let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
       message = Error.prototype.toString.call(rejection);
       const error: Error = (rejection: $FlowFixMe);
 
-      const warning =
-        `Possible Unhandled Promise Rejection (id: ${id}):\n` +
-        `${message ?? ''}\n` +
-        (stack == null ? '' : stack);
-
-      // Print pretty unhandled rejections while on DEV
+      // Print correct unhandled rejections stack while on DEV
       if (__DEV__) {
         LogBox.addLog({
           level: 'warn',
-          message: {content: warning, substitutions: []},
+          message: {
+            content:
+              `Possible Unhandled Promise Rejection (id: ${id}):\n` +
+              `${message ?? ''}\n`,
+            substitutions: [],
+          },
           componentStack: [],
           stack: error.stack,
           category: 'possible_unhandled_promise_rejection',
@@ -42,7 +42,7 @@ let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
 
         return;
       } else {
-        console.warn(warning);
+        stack = error.stack;
       }
     } else {
       try {

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -27,9 +27,9 @@ let rejectionTrackingOptions: $Call<ExtractOptionsType, enable> = {
 
       // Print pretty unhandled rejections while on DEV
       if (__DEV__) {
-        const parseErrorStack = require('Libraries/Core/Devtools/parseErrorStack');
-        const symbolicateStackTrace = require('Libraries/Core/Devtools/symbolicateStackTrace');
-        const LogBox = require('Libraries/LogBox/LogBox').default;
+        const parseErrorStack = require('react-native/Libraries/Core/Devtools/parseErrorStack');
+        const symbolicateStackTrace = require('react-native/Libraries/Core/Devtools/symbolicateStackTrace');
+        const LogBox = require('react-native/Libraries/LogBox/LogBox').default;
 
         stack = parseErrorStack(error.stack);
         stack = await symbolicateStackTrace(stack);

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -27,9 +27,9 @@ let rejectionTrackingOptions: $Call<ExtractOptionsType, enable> = {
 
       // Print pretty unhandled rejections while on DEV
       if (__DEV__) {
-        const parseErrorStack = require('react-native/Libraries/Core/Devtools/parseErrorStack');
-        const symbolicateStackTrace = require('react-native/Libraries/Core/Devtools/symbolicateStackTrace');
-        const LogBox = require('react-native/Libraries/LogBox/LogBox').default;
+        const parseErrorStack = require('Libraries/Core/Devtools/parseErrorStack');
+        const symbolicateStackTrace = require('Libraries/Core/Devtools/symbolicateStackTrace');
+        const LogBox = require('Libraries/LogBox/LogBox').default;
 
         stack = parseErrorStack(error.stack);
         stack = await symbolicateStackTrace(stack);
@@ -39,7 +39,7 @@ let rejectionTrackingOptions: $Call<ExtractOptionsType, enable> = {
             `${message ?? ''}\n` +
             `at File: ${stack.codeFrame.fileName}, row: ${stack.codeFrame.location.row}, column: ${stack.codeFrame.location.column}`;
 
-          console.log(stack.codeFrame.content)
+          console.log(stack.codeFrame.content);
 
           LogBox.addLog({
             level: 'warn',

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -10,6 +10,9 @@
 
 import typeof {enable} from 'promise/setimmediate/rejection-tracking';
 
+const parseErrorStack = require('./Core/Devtools/parseErrorStack');
+const LogBox = require('./LogBox/LogBox').default;
+
 type ExtractOptionsType = <P>(((options?: ?P) => void)) => P;
 
 let rejectionTrackingOptions: $Call<ExtractOptionsType, enable> = {
@@ -25,48 +28,26 @@ let rejectionTrackingOptions: $Call<ExtractOptionsType, enable> = {
       message = Error.prototype.toString.call(rejection);
       const error: Error = (rejection: $FlowFixMe);
 
+      const warning =
+        `Possible Unhandled Promise Rejection (id: ${id}):\n` +
+        `${message ?? ''}\n` +
+        (stack == null ? '' : stack);
+
       // Print pretty unhandled rejections while on DEV
       if (__DEV__) {
-        const parseErrorStack = require('./Core/Devtools/parseErrorStack');
-        const symbolicateStackTrace = require('./Core/Devtools/symbolicateStackTrace');
-        const LogBox = require('./LogBox/LogBox').default;
-
         const parsedStack = parseErrorStack(error.stack);
 
-        symbolicateStackTrace(parsedStack)
-          .then(prettyStack => {
-            let warning =
-              `Possible Unhandled Promise Rejection (id: ${id}):\n` +
-              `${message ?? ''}\n`;
+        LogBox.addLog({
+          level: 'warn',
+          message: {content: warning, substitutions: []},
+          componentStack: [],
+          stack: parsedStack,
+          category: 'possible_unhandled_promise_rejection',
+        });
 
-            if (prettyStack.codeFrame != null) {
-              warning += `at File: ${prettyStack.codeFrame.fileName}, row: ${
-                prettyStack.codeFrame.location?.row ?? 'Unknown'
-              }, column: ${
-                prettyStack.codeFrame.location?.column ?? 'Unknown'
-              }`;
-
-              LogBox.addLog({
-                level: 'warn',
-                message: {content: warning, substitutions: []},
-                componentStack: [],
-                codeFrame: prettyStack.codeFrame,
-                category: `${prettyStack.codeFrame.fileName}-${
-                  prettyStack.codeFrame.location?.row ?? 'unknown'
-                }-${prettyStack.codeFrame.location?.column ?? 'unknown'}`,
-              });
-            } else {
-              console.warn(warning);
-            }
-          })
-          .catch(() => {
-            const warning =
-              `Possible Unhandled Promise Rejection (id: ${id}):\n` +
-              `${message ?? ''}\n` +
-              (stack == null ? '' : stack);
-            console.warn(warning);
-          });
         return;
+      } else {
+        console.warn(warning);
       }
     } else {
       try {

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -10,7 +10,6 @@
 
 import typeof {enable} from 'promise/setimmediate/rejection-tracking';
 
-const parseErrorStack = require('./Core/Devtools/parseErrorStack');
 const LogBox = require('./LogBox/LogBox').default;
 
 let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
@@ -33,13 +32,11 @@ let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
 
       // Print pretty unhandled rejections while on DEV
       if (__DEV__) {
-        const parsedStack = parseErrorStack(error.stack);
-
         LogBox.addLog({
           level: 'warn',
           message: {content: warning, substitutions: []},
           componentStack: [],
-          stack: parsedStack,
+          stack: error.stack,
           category: 'possible_unhandled_promise_rejection',
         });
 

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -13,9 +13,7 @@ import typeof {enable} from 'promise/setimmediate/rejection-tracking';
 const parseErrorStack = require('./Core/Devtools/parseErrorStack');
 const LogBox = require('./LogBox/LogBox').default;
 
-type ExtractOptionsType = <P>(((options?: ?P) => void)) => P;
-
-let rejectionTrackingOptions: $Call<ExtractOptionsType, enable> = {
+let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
   allRejections: true,
   onUnhandled: (id, rejection = {}) => {
     let message: string;

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -27,9 +27,9 @@ let rejectionTrackingOptions: $Call<ExtractOptionsType, enable> = {
 
       // Print pretty unhandled rejections while on DEV
       if (__DEV__) {
-        const parseErrorStack = require('react-native/Libraries/Core/Devtools/parseErrorStack');
-        const symbolicateStackTrace = require('react-native/Libraries/Core/Devtools/symbolicateStackTrace');
-        const LogBox = require('react-native/Libraries/LogBox/LogBox').default;
+        const parseErrorStack = require('./Core/Devtools/parseErrorStack');
+        const symbolicateStackTrace = require('./Core/Devtools/symbolicateStackTrace');
+        const LogBox = require('./LogBox/LogBox').default;
 
         stack = parseErrorStack(error.stack);
         stack = await symbolicateStackTrace(stack);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

For a very long time when a promise rejects without an attached catch we get this warning screen without a correct stack trace, only some internal calls to the RN internals.

<img src="https://github.com/facebook/react-native/assets/1634213/75aa7615-ee3e-4229-80d6-1744130de6e5" width="200" />

I created [an issue for discussion](https://github.com/react-native-community/discussions-and-proposals/discussions/718) in the react-native-community repo and we figured out it was only a matter of symbolication. While it cannot be done on release without external packages and source maps, at least while developing we can provide a symbolicated stack-trace so developers can better debug the source of rejected promise.

I got the stack trace symbolicated and the correct code frame. I'm missing some help trying to display it in the warning view but at the very least I can now correctly show the line of the error and log the codeframe to the console.
## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Show correct stack frame on unhandled promise rejections on development mode.

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

I simply created a throwing function on a dummy app, and checked the output of the console and the warning view:

```ts
import React from 'react';
import {SafeAreaView, Text} from 'react-native';

async function throwme() {
  throw new Error('UNHANDLED');
}

function App(): JSX.Element {
  throwme();

  return (
    <SafeAreaView>
      <Text>Throw test</Text>
    </SafeAreaView>
  );
}

export default App;
```

Here is the output

<img src="https://github.com/facebook/react-native/assets/1634213/2c100e4d-618e-4143-8d64-4095e8370f4f" width="200" />


Edit: I got the warning window working properly:


<img src="https://github.com/facebook/react-native/assets/1634213/f02a2568-da3e-4daa-8132-e05cbe591737" width="200" />
