### PR TITLE
Make sure buildConfig is turned on for all the 3rd party libraries (#40791)

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -12,7 +12,8 @@ import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.facebook.react.internal.PrivateReactExtension
 import com.facebook.react.tasks.GenerateCodegenArtifactsTask
 import com.facebook.react.tasks.GenerateCodegenSchemaTask
-import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFields
+import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForApp
+import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForLibraries
 import com.facebook.react.utils.AgpConfiguratorUtils.configureDevPorts
 import com.facebook.react.utils.BackwardCompatUtils.configureBackwardCompatibilityReactMap
 import com.facebook.react.utils.DependencyUtils.configureDependencies
@@ -66,7 +67,7 @@ class ReactPlugin : Plugin<Project> {
       }
 
       configureReactNativeNdk(project, extension)
-      configureBuildConfigFields(project, extension)
+      configureBuildConfigFieldsForApp(project, extension)
       configureDevPorts(project)
       configureBackwardCompatibilityReactMap(project)
 
@@ -85,6 +86,7 @@ class ReactPlugin : Plugin<Project> {
 
     // Library and App Configurations
     configureJavaToolChains(project)
+    configureBuildConfigFieldsForLibraries(project)
   }
 
   private fun checkJvmVersion(project: Project) {

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -18,7 +18,7 @@ import org.gradle.api.plugins.AppliedPlugin
 @Suppress("UnstableApiUsage")
 internal object AgpConfiguratorUtils {
 
-  fun configureBuildConfigFields(project: Project, extension: ReactExtension) {
+  fun configureBuildConfigFieldsForApp(project: Project, extension: ReactExtension) {
     val action =
         Action<AppliedPlugin> {
           project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
@@ -33,6 +33,16 @@ internal object AgpConfiguratorUtils {
         }
     project.pluginManager.withPlugin("com.android.application", action)
     project.pluginManager.withPlugin("com.android.library", action)
+  }
+
+  fun configureBuildConfigFieldsForLibraries(appProject: Project) {
+    appProject.rootProject.allprojects { subproject ->
+      subproject.pluginManager.withPlugin("com.android.library") {
+        subproject.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
+          ext.buildFeatures.buildConfig = true
+        }
+      }
+    }
   }
 
   fun configureDevPorts(project: Project) {


### PR DESCRIPTION
Summary:
Currently some libs on RN 0.73 are broken as the default for Build Config generation changed
from true to false since AGP 8.x. This reverts the behavior to the old flag.

Closes #40791
Closes #40559

Changelog:
[Internal] [Changed] - Make sure buildConfig is turned on for all the 3rd party libraries

Differential Revision: D50270382


