### PR TITLE
Make sure onIntArrayChanged is invoked on RN Tester

### DIFF
--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -87,6 +87,7 @@ export default function MyNativeView(props: {}): React.Node {
   const ref = useRef<React.ElementRef<MyNativeViewType> | null>(null);
   const legacyRef = useRef<React.ElementRef<MyLegacyViewType> | null>(null);
   const [opacity, setOpacity] = useState(1.0);
+  const [arrayValues, setArrayValues] = useState([1, 2, 3]);
   const [hsba, setHsba] = useState<HSBA>(new HSBA());
   const [cornerRadiusIndex, setCornerRadiusIndex] = useState<number>(0);
   const [legacyMeasure, setLegacyMeasure] =
@@ -102,7 +103,7 @@ export default function MyNativeView(props: {}): React.Node {
         ref={ref}
         style={{flex: 1}}
         opacity={opacity}
-        values={[0, 1, 2, 3, 4]}
+        values={arrayValues}
         onIntArrayChanged={event => {
           console.log(event.nativeEvent.values);
           console.log(event.nativeEvent.boolValues);
@@ -154,6 +155,11 @@ export default function MyNativeView(props: {}): React.Node {
         title="Set Opacity"
         onPress={() => {
           setOpacity(Math.random());
+          setArrayValues([
+            Math.floor(Math.random() * 100),
+            Math.floor(Math.random() * 100),
+            Math.floor(Math.random() * 100),
+          ]);
         }}
       />
       <Button


### PR DESCRIPTION
Summary:
Currently the `onIntArrayChanged` event is invoked
 only once inside RN Tester. I'm changing the logic to make sure it fires whenever we click "Set Opacity"

Changelog:
[Internal] [Changed] - Make sure onIntArrayChanged is invoked on RN Tester

Reviewed By: dmytrorykun

Differential Revision: D50264765


