### PR TITLE
Make events work for Fabric Interop on Bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -71,7 +71,7 @@ public class ReactContext extends ContextWrapper {
   private @Nullable JSExceptionHandler mExceptionHandlerWrapper;
   private @Nullable WeakReference<Activity> mCurrentActivity;
 
-  private @Nullable InteropModuleRegistry mInteropModuleRegistry;
+  protected @Nullable InteropModuleRegistry mInteropModuleRegistry;
   private boolean mIsInitialized = false;
 
   public ReactContext(Context base) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -22,6 +22,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.uimanager.events.EventDispatcher;
@@ -49,6 +50,9 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   BridgelessReactContext(Context context, ReactHostImpl host) {
     super(context);
     mReactHost = host;
+    if (ReactFeatureFlags.unstable_useFabricInterop) {
+      initializeInteropModules();
+    }
   }
 
   @Override
@@ -124,6 +128,10 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
 
   @Override
   public <T extends JavaScriptModule> T getJSModule(Class<T> jsInterface) {
+    if (mInteropModuleRegistry != null
+        && mInteropModuleRegistry.shouldReturnInteropModule(jsInterface)) {
+      return mInteropModuleRegistry.getInteropModule(jsInterface);
+    }
     JavaScriptModule interfaceProxy =
         (JavaScriptModule)
             Proxy.newProxyInstance(


### PR DESCRIPTION
Summary:
Events are currently not working for Fabric Interop on Bridgeless. That's because the `BridgelessReactContext` is not checking for interop modules on `getJsModule` calls, so the `InteropEventEmitter` is never returned.

This extends `BridgelessReactContext` so that  `InteropEventEmitter` is returned if the Interop Layer is turned on.

Changelog:
[Internal] [Changed] - Make events work for Fabric Interop on Bridgeless

Reviewed By: cipolleschi

Differential Revision: D50266484

