### PR TITLE
Create new version of RuntimeScheduler

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RuntimeScheduler.h"
+#include "RuntimeScheduler_Legacy.h"
 #include "SchedulerPriorityUtils.h"
 
 #include <react/renderer/debug/SystraceSection.h>
@@ -14,177 +15,55 @@
 
 namespace facebook::react {
 
-#pragma mark - Public
-
 RuntimeScheduler::RuntimeScheduler(
     RuntimeExecutor runtimeExecutor,
     std::function<RuntimeSchedulerTimePoint()> now)
-    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+    : runtimeSchedulerImpl_(std::make_unique<RuntimeScheduler_Legacy>(
+          std::move(runtimeExecutor),
+          std::move(now))) {}
 
 void RuntimeScheduler::scheduleWork(RawCallback&& callback) const noexcept {
-  SystraceSection s("RuntimeScheduler::scheduleWork");
-
-  runtimeAccessRequests_ += 1;
-
-  runtimeExecutor_(
-      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
-        SystraceSection s2("RuntimeScheduler::scheduleWork callback");
-        runtimeAccessRequests_ -= 1;
-        callback(runtime);
-        startWorkLoop(runtime);
-      });
+  return runtimeSchedulerImpl_->scheduleWork(std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
     SchedulerPriority priority,
     jsi::Function&& callback) noexcept {
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
-  auto task =
-      std::make_shared<Task>(priority, std::move(callback), expirationTime);
-  taskQueue_.push(task);
-
-  scheduleWorkLoopIfNecessary();
-
-  return task;
+  return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
     SchedulerPriority priority,
     RawCallback&& callback) noexcept {
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
-  auto task =
-      std::make_shared<Task>(priority, std::move(callback), expirationTime);
-  taskQueue_.push(task);
-
-  scheduleWorkLoopIfNecessary();
-
-  return task;
+  return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 
 bool RuntimeScheduler::getShouldYield() const noexcept {
-  return runtimeAccessRequests_ > 0;
+  return runtimeSchedulerImpl_->getShouldYield();
 }
 
 bool RuntimeScheduler::getIsSynchronous() const noexcept {
-  return isSynchronous_;
+  return runtimeSchedulerImpl_->getIsSynchronous();
 }
 
 void RuntimeScheduler::cancelTask(Task& task) noexcept {
-  task.callback.reset();
+  return runtimeSchedulerImpl_->cancelTask(task);
 }
 
 SchedulerPriority RuntimeScheduler::getCurrentPriorityLevel() const noexcept {
-  return currentPriority_;
+  return runtimeSchedulerImpl_->getCurrentPriorityLevel();
 }
 
 RuntimeSchedulerTimePoint RuntimeScheduler::now() const noexcept {
-  return now_();
+  return runtimeSchedulerImpl_->now();
 }
 
 void RuntimeScheduler::executeNowOnTheSameThread(RawCallback&& callback) {
-  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
-
-  runtimeAccessRequests_ += 1;
-  executeSynchronouslyOnSameThread_CAN_DEADLOCK(
-      runtimeExecutor_,
-      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
-        SystraceSection s2(
-            "RuntimeScheduler::executeNowOnTheSameThread callback");
-
-        runtimeAccessRequests_ -= 1;
-        isSynchronous_ = true;
-        callback(runtime);
-        isSynchronous_ = false;
-      });
-
-  // Resume work loop if needed. In synchronous mode
-  // only expired tasks are executed. Tasks with lower priority
-  // might be still in the queue.
-  scheduleWorkLoopIfNecessary();
+  return runtimeSchedulerImpl_->executeNowOnTheSameThread(std::move(callback));
 }
 
 void RuntimeScheduler::callExpiredTasks(jsi::Runtime& runtime) {
-  SystraceSection s("RuntimeScheduler::callExpiredTasks");
-
-  auto previousPriority = currentPriority_;
-  try {
-    while (!taskQueue_.empty()) {
-      auto topPriorityTask = taskQueue_.top();
-      auto now = now_();
-      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
-
-      if (!didUserCallbackTimeout) {
-        break;
-      }
-
-      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
-    }
-  } catch (jsi::JSError& error) {
-    handleFatalError(runtime, error);
-  }
-
-  currentPriority_ = previousPriority;
-}
-
-#pragma mark - Private
-
-void RuntimeScheduler::scheduleWorkLoopIfNecessary() const {
-  if (!isWorkLoopScheduled_ && !isPerformingWork_) {
-    isWorkLoopScheduled_ = true;
-    runtimeExecutor_([this](jsi::Runtime& runtime) {
-      isWorkLoopScheduled_ = false;
-      startWorkLoop(runtime);
-    });
-  }
-}
-
-void RuntimeScheduler::startWorkLoop(jsi::Runtime& runtime) const {
-  SystraceSection s("RuntimeScheduler::startWorkLoop");
-
-  auto previousPriority = currentPriority_;
-  isPerformingWork_ = true;
-  try {
-    while (!taskQueue_.empty()) {
-      auto topPriorityTask = taskQueue_.top();
-      auto now = now_();
-      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
-
-      if (!didUserCallbackTimeout && getShouldYield()) {
-        // This currentTask hasn't expired, and we need to yield.
-        break;
-      }
-
-      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
-    }
-  } catch (jsi::JSError& error) {
-    handleFatalError(runtime, error);
-  }
-
-  currentPriority_ = previousPriority;
-  isPerformingWork_ = false;
-}
-
-void RuntimeScheduler::executeTask(
-    jsi::Runtime& runtime,
-    const std::shared_ptr<Task>& task,
-    bool didUserCallbackTimeout) const {
-  SystraceSection s(
-      "RuntimeScheduler::executeTask",
-      "priority",
-      serialize(task->priority),
-      "didUserCallbackTimeout",
-      didUserCallbackTimeout);
-
-  currentPriority_ = task->priority;
-  auto result = task->execute(runtime, didUserCallbackTimeout);
-
-  if (result.isObject() && result.getObject(runtime).isFunction(runtime)) {
-    task->callback = result.getObject(runtime).getFunction(runtime);
-  } else {
-    if (taskQueue_.top() == task) {
-      taskQueue_.pop();
-    }
-  }
+  return runtimeSchedulerImpl_->callExpiredTasks(runtime);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -18,14 +18,20 @@ namespace facebook::react {
 class RuntimeSchedulerBase {
  public:
   virtual ~RuntimeSchedulerBase() = default;
+  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
+  // refactor has been shipped.
   virtual void scheduleWork(RawCallback&& callback) const noexcept = 0;
   virtual void executeNowOnTheSameThread(RawCallback&& callback) = 0;
+  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
+  // refactor has been shipped.
   virtual std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      jsi::Function&& callback) noexcept = 0;
+      jsi::Function&& callback) const noexcept = 0;
+  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
+  // refactor has been shipped.
   virtual std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      RawCallback&& callback) noexcept = 0;
+      RawCallback&& callback) const noexcept = 0;
   virtual void cancelTask(Task& task) noexcept = 0;
   virtual bool getShouldYield() const noexcept = 0;
   virtual bool getIsSynchronous() const noexcept = 0;
@@ -38,8 +44,9 @@ class RuntimeSchedulerBase {
 // at runtime based on a feature flag.
 class RuntimeScheduler final : RuntimeSchedulerBase {
  public:
-  RuntimeScheduler(
+  explicit RuntimeScheduler(
       RuntimeExecutor runtimeExecutor,
+      bool useModernRuntimeScheduler = false,
       std::function<RuntimeSchedulerTimePoint()> now =
           RuntimeSchedulerClock::now);
 
@@ -74,11 +81,11 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
    */
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      jsi::Function&& callback) noexcept override;
+      jsi::Function&& callback) const noexcept override;
 
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      RawCallback&& callback) noexcept override;
+      RawCallback&& callback) const noexcept override;
 
   /*
    * Cancelled task will never be executed.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -38,7 +38,14 @@ void RuntimeScheduler_Legacy::scheduleWork(
 
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
-    jsi::Function&& callback) noexcept {
+    jsi::Function&& callback) const noexcept {
+  SystraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(priority),
+      "callbackType",
+      "jsi::Function");
+
   auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);
@@ -51,7 +58,14 @@ std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
 
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
-    RawCallback&& callback) noexcept {
+    RawCallback&& callback) const noexcept {
+  SystraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(priority),
+      "callbackType",
+      "RawCallback");
+
   auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RuntimeScheduler_Legacy.h"
+#include "SchedulerPriorityUtils.h"
+
+#include <react/renderer/debug/SystraceSection.h>
+#include <utility>
+#include "ErrorUtils.h"
+
+namespace facebook::react {
+
+#pragma mark - Public
+
+RuntimeScheduler_Legacy::RuntimeScheduler_Legacy(
+    RuntimeExecutor runtimeExecutor,
+    std::function<RuntimeSchedulerTimePoint()> now)
+    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+
+void RuntimeScheduler_Legacy::scheduleWork(
+    RawCallback&& callback) const noexcept {
+  SystraceSection s("RuntimeScheduler::scheduleWork");
+
+  runtimeAccessRequests_ += 1;
+
+  runtimeExecutor_(
+      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
+        SystraceSection s2("RuntimeScheduler::scheduleWork callback");
+        runtimeAccessRequests_ -= 1;
+        callback(runtime);
+        startWorkLoop(runtime);
+      });
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
+    SchedulerPriority priority,
+    jsi::Function&& callback) noexcept {
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+  taskQueue_.push(task);
+
+  scheduleWorkLoopIfNecessary();
+
+  return task;
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
+    SchedulerPriority priority,
+    RawCallback&& callback) noexcept {
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+  taskQueue_.push(task);
+
+  scheduleWorkLoopIfNecessary();
+
+  return task;
+}
+
+bool RuntimeScheduler_Legacy::getShouldYield() const noexcept {
+  return runtimeAccessRequests_ > 0;
+}
+
+bool RuntimeScheduler_Legacy::getIsSynchronous() const noexcept {
+  return isSynchronous_;
+}
+
+void RuntimeScheduler_Legacy::cancelTask(Task& task) noexcept {
+  task.callback.reset();
+}
+
+SchedulerPriority RuntimeScheduler_Legacy::getCurrentPriorityLevel()
+    const noexcept {
+  return currentPriority_;
+}
+
+RuntimeSchedulerTimePoint RuntimeScheduler_Legacy::now() const noexcept {
+  return now_();
+}
+
+void RuntimeScheduler_Legacy::executeNowOnTheSameThread(
+    RawCallback&& callback) {
+  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
+
+  runtimeAccessRequests_ += 1;
+  executeSynchronouslyOnSameThread_CAN_DEADLOCK(
+      runtimeExecutor_,
+      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
+        SystraceSection s2(
+            "RuntimeScheduler::executeNowOnTheSameThread callback");
+
+        runtimeAccessRequests_ -= 1;
+        isSynchronous_ = true;
+        callback(runtime);
+        isSynchronous_ = false;
+      });
+
+  // Resume work loop if needed. In synchronous mode
+  // only expired tasks are executed. Tasks with lower priority
+  // might be still in the queue.
+  scheduleWorkLoopIfNecessary();
+}
+
+void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
+  SystraceSection s("RuntimeScheduler::callExpiredTasks");
+
+  auto previousPriority = currentPriority_;
+  try {
+    while (!taskQueue_.empty()) {
+      auto topPriorityTask = taskQueue_.top();
+      auto now = now_();
+      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
+
+      if (!didUserCallbackTimeout) {
+        break;
+      }
+
+      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
+    }
+  } catch (jsi::JSError& error) {
+    handleFatalError(runtime, error);
+  }
+
+  currentPriority_ = previousPriority;
+}
+
+#pragma mark - Private
+
+void RuntimeScheduler_Legacy::scheduleWorkLoopIfNecessary() const {
+  if (!isWorkLoopScheduled_ && !isPerformingWork_) {
+    isWorkLoopScheduled_ = true;
+    runtimeExecutor_([this](jsi::Runtime& runtime) {
+      isWorkLoopScheduled_ = false;
+      startWorkLoop(runtime);
+    });
+  }
+}
+
+void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) const {
+  SystraceSection s("RuntimeScheduler::startWorkLoop");
+
+  auto previousPriority = currentPriority_;
+  isPerformingWork_ = true;
+  try {
+    while (!taskQueue_.empty()) {
+      auto topPriorityTask = taskQueue_.top();
+      auto now = now_();
+      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
+
+      if (!didUserCallbackTimeout && getShouldYield()) {
+        // This currentTask hasn't expired, and we need to yield.
+        break;
+      }
+
+      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
+    }
+  } catch (jsi::JSError& error) {
+    handleFatalError(runtime, error);
+  }
+
+  currentPriority_ = previousPriority;
+  isPerformingWork_ = false;
+}
+
+void RuntimeScheduler_Legacy::executeTask(
+    jsi::Runtime& runtime,
+    const std::shared_ptr<Task>& task,
+    bool didUserCallbackTimeout) const {
+  SystraceSection s(
+      "RuntimeScheduler::executeTask",
+      "priority",
+      serialize(task->priority),
+      "didUserCallbackTimeout",
+      didUserCallbackTimeout);
+
+  currentPriority_ = task->priority;
+  auto result = task->execute(runtime, didUserCallbackTimeout);
+
+  if (result.isObject() && result.getObject(runtime).isFunction(runtime)) {
+    task->callback = result.getObject(runtime).getFunction(runtime);
+  } else {
+    if (taskQueue_.top() == task) {
+      taskQueue_.pop();
+    }
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RuntimeScheduler_Modern.h"
+#include "SchedulerPriorityUtils.h"
+
+#include <react/renderer/debug/SystraceSection.h>
+#include <utility>
+#include "ErrorUtils.h"
+
+namespace facebook::react {
+
+#pragma mark - Public
+
+RuntimeScheduler_Modern::RuntimeScheduler_Modern(
+    RuntimeExecutor runtimeExecutor,
+    std::function<RuntimeSchedulerTimePoint()> now)
+    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+
+void RuntimeScheduler_Modern::scheduleWork(
+    RawCallback&& callback) const noexcept {
+  SystraceSection s("RuntimeScheduler::scheduleWork");
+  scheduleTask(SchedulerPriority::ImmediatePriority, std::move(callback));
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
+    SchedulerPriority priority,
+    jsi::Function&& callback) const noexcept {
+  SystraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(priority),
+      "callbackType",
+      "jsi::Function");
+
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+
+  scheduleTask(task);
+
+  return task;
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
+    SchedulerPriority priority,
+    RawCallback&& callback) const noexcept {
+  SystraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(priority),
+      "callbackType",
+      "RawCallback");
+
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+
+  scheduleTask(task);
+
+  return task;
+}
+
+bool RuntimeScheduler_Modern::getShouldYield() const noexcept {
+  std::shared_lock lock(schedulingMutex_);
+
+  return syncTaskRequests_ > 0 ||
+      (!taskQueue_.empty() && taskQueue_.top() != currentTask_);
+}
+
+bool RuntimeScheduler_Modern::getIsSynchronous() const noexcept {
+  return isSynchronous_;
+}
+
+void RuntimeScheduler_Modern::cancelTask(Task& task) noexcept {
+  task.callback.reset();
+}
+
+SchedulerPriority RuntimeScheduler_Modern::getCurrentPriorityLevel()
+    const noexcept {
+  return currentPriority_;
+}
+
+RuntimeSchedulerTimePoint RuntimeScheduler_Modern::now() const noexcept {
+  return now_();
+}
+
+void RuntimeScheduler_Modern::executeNowOnTheSameThread(
+    RawCallback&& callback) {
+  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
+
+  syncTaskRequests_++;
+
+  executeSynchronouslyOnSameThread_CAN_DEADLOCK(
+      runtimeExecutor_,
+      [this, callback = std::move(callback)](jsi::Runtime& runtime) mutable {
+        SystraceSection s2(
+            "RuntimeScheduler::executeNowOnTheSameThread callback");
+
+        syncTaskRequests_--;
+
+        isSynchronous_ = true;
+
+        auto currentTime = now_();
+        auto priority = SchedulerPriority::ImmediatePriority;
+        auto expirationTime =
+            currentTime + timeoutForSchedulerPriority(priority);
+        auto task = std::make_shared<Task>(
+            priority, std::move(callback), expirationTime);
+
+        executeTask(runtime, task, currentTime);
+
+        isSynchronous_ = false;
+      });
+
+  bool shouldScheduleWorkLoop = false;
+
+  {
+    // Unique access because we might write to `isWorkLoopScheduled_`.
+    std::unique_lock lock(schedulingMutex_);
+
+    // We only need to schedule the work loop if there any remaining tasks
+    // in the queue.
+    if (!taskQueue_.empty() && !isWorkLoopScheduled_) {
+      isWorkLoopScheduled_ = true;
+      shouldScheduleWorkLoop = true;
+    }
+  }
+
+  if (shouldScheduleWorkLoop) {
+    scheduleWorkLoop();
+  }
+}
+
+// This will be replaced by microtasks
+void RuntimeScheduler_Modern::callExpiredTasks(jsi::Runtime& runtime) {
+  SystraceSection s("RuntimeScheduler::callExpiredTasks");
+  startWorkLoop(runtime, true);
+}
+
+#pragma mark - Private
+
+void RuntimeScheduler_Modern::scheduleTask(std::shared_ptr<Task> task) const {
+  bool shouldScheduleWorkLoop = false;
+
+  {
+    std::unique_lock lock(schedulingMutex_);
+
+    // We only need to schedule the work loop if the task we're about to
+    // schedule is the only one in the queue.
+    // Otherwise, we don't need to schedule it because there's another one
+    // running already that will pick up the new task.
+    if (taskQueue_.empty() && !isWorkLoopScheduled_) {
+      isWorkLoopScheduled_ = true;
+      shouldScheduleWorkLoop = true;
+    }
+
+    taskQueue_.push(task);
+  }
+
+  if (shouldScheduleWorkLoop) {
+    scheduleWorkLoop();
+  }
+}
+
+void RuntimeScheduler_Modern::scheduleWorkLoop() const {
+  runtimeExecutor_(
+      [this](jsi::Runtime& runtime) { startWorkLoop(runtime, false); });
+}
+
+void RuntimeScheduler_Modern::startWorkLoop(
+    jsi::Runtime& runtime,
+    bool onlyExpired) const {
+  SystraceSection s("RuntimeScheduler::startWorkLoop");
+
+  auto previousPriority = currentPriority_;
+
+  try {
+    while (syncTaskRequests_ == 0) {
+      auto currentTime = now_();
+      auto topPriorityTask = selectTask(currentTime, onlyExpired);
+
+      if (!topPriorityTask) {
+        // No pending work to do.
+        // Events will restart the loop when necessary.
+        break;
+      }
+
+      executeTask(runtime, topPriorityTask, currentTime);
+    }
+  } catch (jsi::JSError& error) {
+    handleFatalError(runtime, error);
+  }
+
+  currentPriority_ = previousPriority;
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Modern::selectTask(
+    RuntimeSchedulerTimePoint currentTime,
+    bool onlyExpired) const {
+  // We need a unique lock here because we'll also remove executed tasks from
+  // the top of the queue.
+  std::unique_lock lock(schedulingMutex_);
+
+  // It's safe to reset the flag here, as its access is also synchronized with
+  // the access to the task queue.
+  isWorkLoopScheduled_ = false;
+
+  // Skip executed tasks
+  while (!taskQueue_.empty() && !taskQueue_.top()->callback) {
+    taskQueue_.pop();
+  }
+
+  if (!taskQueue_.empty()) {
+    auto task = taskQueue_.top();
+    auto didUserCallbackTimeout = task->expirationTime <= currentTime;
+    if (!onlyExpired || didUserCallbackTimeout) {
+      return task;
+    }
+  }
+
+  return nullptr;
+}
+
+void RuntimeScheduler_Modern::executeTask(
+    jsi::Runtime& runtime,
+    const std::shared_ptr<Task>& task,
+    RuntimeSchedulerTimePoint currentTime) const {
+  auto didUserCallbackTimeout = task->expirationTime <= currentTime;
+
+  SystraceSection s(
+      "RuntimeScheduler::executeTask",
+      "priority",
+      serialize(task->priority),
+      "didUserCallbackTimeout",
+      didUserCallbackTimeout);
+
+  currentTask_ = task;
+  currentPriority_ = task->priority;
+
+  auto result = task->execute(runtime, didUserCallbackTimeout);
+
+  if (result.isObject() && result.getObject(runtime).isFunction(runtime)) {
+    // If the task returned a continuation callback, we re-assign it to the task
+    // and keep the task in the queue.
+    task->callback = result.getObject(runtime).getFunction(runtime);
+  }
+
+  // TODO execute microtasks
+  // TODO report long tasks
+  // TODO update rendering
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -16,7 +16,7 @@
 
 namespace facebook::react {
 
-class RuntimeScheduler;
+class RuntimeScheduler_Legacy;
 class TaskPriorityComparer;
 
 using RawCallback = std::function<void(jsi::Runtime&)>;
@@ -33,7 +33,7 @@ struct Task final : public jsi::NativeState {
       std::chrono::steady_clock::time_point expirationTime);
 
  private:
-  friend RuntimeScheduler;
+  friend RuntimeScheduler_Legacy;
   friend TaskPriorityComparer;
 
   SchedulerPriority priority;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -17,6 +17,7 @@
 namespace facebook::react {
 
 class RuntimeScheduler_Legacy;
+class RuntimeScheduler_Modern;
 class TaskPriorityComparer;
 
 using RawCallback = std::function<void(jsi::Runtime&)>;
@@ -34,6 +35,7 @@ struct Task final : public jsi::NativeState {
 
  private:
   friend RuntimeScheduler_Legacy;
+  friend RuntimeScheduler_Modern;
   friend TaskPriorityComparer;
 
   SchedulerPriority priority;

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -24,30 +24,6 @@
 
 namespace facebook::react {
 
-// Looping on \c drainMicrotasks until it completes or hits the retries bound.
-static void performMicrotaskCheckpoint(jsi::Runtime& runtime) {
-  uint8_t retries = 0;
-  // A heuristic number to guard inifinite or absurd numbers of retries.
-  constexpr unsigned int kRetriesBound = 255;
-
-  while (retries < kRetriesBound) {
-    try {
-      // The default behavior of \c drainMicrotasks is unbounded execution.
-      // We may want to make it bounded in the future.
-      if (runtime.drainMicrotasks()) {
-        break;
-      }
-    } catch (jsi::JSError& error) {
-      handleJSError(runtime, error, true);
-    }
-    retries++;
-  }
-
-  if (retries == kRetriesBound) {
-    throw std::runtime_error("Hits microtasks retries bound.");
-  }
-}
-
 ReactInstance::ReactInstance(
     std::unique_ptr<jsi::Runtime> runtime,
     std::shared_ptr<MessageQueueThread> jsMessageQueueThread,
@@ -91,7 +67,6 @@ ReactInstance::ReactInstance(
                 if (auto strongTimerManager = weakTimerManager.lock()) {
                   strongTimerManager->callReactNativeMicrotasks(*strongRuntime);
                 }
-                performMicrotaskCheckpoint(*strongRuntime);
               } catch (jsi::JSError& originalError) {
                 handleJSError(*strongRuntime, originalError, true);
               }


### PR DESCRIPTION
Summary:
## Summary

This creates a new version of `RuntimeScheduler` that's intended to be backwards compatible but with a few notable changes:
1. `scheduleTask` is now thread-safe.
2. `scheduleWork` is now just an alias of `scheduleTask` with immediate priority (to preserve the yielding semantics it had over other tasks).
3. Yielding mechanism has changed, to make lower priority tasks to yield to higher priority tasks, instead of just yielding to `scheduleWork` and `executeNowOnTheSameThread`.

We don't expect this to have any impact in performance or user perceivable behavior, so we consider it a short-lived refactor. When we validate this assumptions in a complex application we'll delete the old version and only keep the fork.

## Motivation

The main motivation for this refactor is to reduce the amount of unnecessary interruptions of running tasks (via `shouldYield`) that are only used to schedule asynchronous tasks from native.

The `scheduleWork` method is the only available mechanism exposed to native APIs to schedule work in the JS thread (as the existing version of `scheduleTask` is only meant to be called from JS). This mechanism **always** asks for any running tasks in the scheduler to yield, so these tasks are always considered to have the highest priority. This makes sense for discrete user events, but not for many other use cases coming from native (e.g.: notifying network responses could be UserBlocking, Normal or Low depending on the use case).

We need a way to schedule tasks from native with other kinds of priorities, so we don't always have to interrupt what's currently executing if it has a higher priority than what we're scheduling.

## Changes

**General APIs:**

This centralizes scheduling in only 2 APIs in `RuntimeScheduler` (which already exist in the legacy version):
* `scheduleTask`, which is non-blocking for the caller and can be used from any thread. This always uses the task queue in the scheduler and a new yielding mechanism.
* `executeNowOnTheSameThread`, which is blocking for the caller and asks any task executing in the scheduler to yield. These tasks don't go through the task queue and instead queue through the existing synchronization mechanism in `RuntimeExecutor`. The yielding mechanism for these tasks is preserved.

`scheduleWork` will be deprecated and it's just an alias for `scheduleTask` with an immediate priority (to preserve a similar behavior).

**Yielding behavior:**

Before, tasks would only yield to tasks scheduled via `scheduleWork` and `executeNowOnTheSameThread` (those tasks didn't go through the task queue).

With this implementation, tasks would now yield to any task that has a higher position in the task queue. That means we reuse the existing mechanism to avoid lower priority tasks to never execute because higher priority tasks never stop coming.

All tasks would yield to requests for synchronous access (via `executeNowOnTheSameThread`) as did the current implementation.

Changelog: [internal]

Differential Revision: D49316881

