### PR TITLE
Interop example: Make argument to getRootTag deterministic

### DIFF
--- a/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
@@ -135,7 +135,7 @@ class SampleLegacyModuleExample extends React.Component<{||}, State> {
           getObjectInteger: () => getSampleLegacyModule()?.getObjectInteger(99),
           getObjectFloat: () => getSampleLegacyModule()?.getObjectFloat(99.95),
           getString: () => getSampleLegacyModule()?.getString('Hello'),
-          getRootTag: () => getSampleLegacyModule()?.getRootTag(this.context),
+          getRootTag: () => getSampleLegacyModule()?.getRootTag(11),
           getObject: () =>
             getSampleLegacyModule()?.getObject({a: 1, b: 'foo', c: null}),
           getUnsafeObject: () =>


### PR DESCRIPTION
Summary: This shows up as this.context shows up as 1 sometimes. Let's just hard-code this to 11, to make the test more reliable.

Reviewed By: mdvacca

Differential Revision: D50253990


