### PR TITLE
Enable Explicit API mode warning in React Native Android

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -807,6 +807,8 @@ if (rootProject.name == "react-native-build-from-source") {
 
 kotlin {
     jvmToolchain(17)
+
+    explicitApi()
 }
 
 apply plugin: "org.jetbrains.kotlin.android"


### PR DESCRIPTION
Summary:
Enable Explicit API mode warning to let product developers get notified of Explicit API checks (similar to deprecation mechanism). Explicit API mode will be enabled as strict in a future version

changelog: [Android] Enabling Explicit API warning, this will be changed as Strict in a future version

Differential Revision: D50295069


