### PR TITLE
Refactor `softInputMode` check in `ReactRootView.java`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -854,20 +854,6 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       checkForDeviceDimensionsChanges();
     }
 
-    private @Nullable WindowManager.LayoutParams getWindowLayoutParams() {
-      View view = ReactRootView.this;
-      if (view.getLayoutParams() instanceof WindowManager.LayoutParams) {
-        return (WindowManager.LayoutParams) view.getLayoutParams();
-      }
-      while (view.getParent() instanceof View) {
-        view = (View) view.getParent();
-        if (view.getLayoutParams() instanceof WindowManager.LayoutParams) {
-          return (WindowManager.LayoutParams) view.getLayoutParams();
-        }
-      }
-      return null;
-    }
-
     @RequiresApi(api = Build.VERSION_CODES.R)
     private void checkForKeyboardEvents() {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
@@ -885,13 +871,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
           Insets barInsets = rootInsets.getInsets(WindowInsets.Type.systemBars());
           int height = imeInsets.bottom - barInsets.bottom;
 
-          int softInputMode;
-          WindowManager.LayoutParams windowLayoutParams = getWindowLayoutParams();
-          if (windowLayoutParams != null) {
-            softInputMode = windowLayoutParams.softInputMode;
-          } else {
-            return;
-          }
+          ViewGroup.LayoutParams rootLayoutParams = getRootView().getLayoutParams();
+          Assertions.assertCondition(rootLayoutParams instanceof WindowManager.LayoutParams);
+
+          int softInputMode = ((WindowManager.LayoutParams) rootLayoutParams).softInputMode;
           int screenY =
               softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
                   ? mVisibleViewArea.bottom - height


### PR DESCRIPTION
## Summary
This cleans up https://github.com/facebook/react-native/commit/94972039571e1f3b387e0f63227a6ad13740eaf3 a bit, after I did some debugging and looking through Android source code.

1. `getRootView()` gives us constant-time access to root hierarchy, and we don't need to do instanceof check once per level. It also, at least in the sample activity I tried, gives us the Window's `LayoutParams`.
2. The root of the hierarchy is documented in code to do what we want. https://github.com/facebook/react-native/commit/94972039571e1f3b387e0f63227a6ad13740eaf3
3. Calling `getRootView().getLayoutParams()`, then casting to `WindowManager.LayoutParams`, seems to show up in a lot of other widgets (inc Unity, RoboElectric), as a solution to getting this information. https://github.com/search?q=getRootView%28%29.getLayoutParams%28%29&type=code

This still feels like not a 100% documented contract, so I added an assertion so we can catch if the contract isn't valid somewhere now or in the future, instead of silently breaking keyboard events.

Note that this code only runs on SDK 30+ (Android 11+).

## Test Plan

On Android API 34 emulator, set an explicit `windowSoftInputMode` for `RNTesterActivity` and check the keyboard events page run via ` buck install rntester-android`.

| `adjustResize` (RN default) | `adjustPan` | `adjustNothing` |
| - | - | - |
| ![image](https://github.com/facebook/react-native/assets/835219/394f08e5-aec1-4729-a5cb-52e1b906edab) |  ![image](https://github.com/facebook/react-native/assets/835219/8a787fb8-701b-4840-b4d6-4045006cba3c) | ![image](https://github.com/facebook/react-native/assets/835219/3e952557-8bbb-42ce-8dd4-3c3a294c146c) |

Differential Revision: D50297761


