### PR TITLE
[CI] Verdaccio: proxy `@react-native/normalize-colors` from NPM

### DIFF
--- a/.circleci/verdaccio.yml
+++ b/.circleci/verdaccio.yml
@@ -15,8 +15,8 @@ uplinks:
       maxSockets: 40
       maxFreeSockets: 10
 packages:
-  # Get @react-native/normalize-color from npm registry, since its used in deprecated-react-native-prop-types package
-  '@react-native/normalize-color':
+  # Get @react-native/normalize-colors from npm registry, since its used in deprecated-react-native-prop-types package
+  '@react-native/normalize-colors':
     access: $all
     publish: $authenticated
     proxy: npmjs


### PR DESCRIPTION
## Summary:

To address the root cause of a recurring issue (https://github.com/facebook/react-native/issues/40797, https://github.com/facebook/react-native/issues/39692) where breaking changes to `@react-native/normalize-colors` would be pulled into old versions of `deprecated-react-native-prop-types`, we recently changed the dependency in the latter to use a semver range (https://github.com/facebook/react-native-deprecated-modules/pull/27, https://github.com/facebook/react-native/pull/40869). 

For CI, we generally force `@react-native/*` to be resolved only from Verdaccio locally published packages - ie, the current versions at source. The source version (currently `0.74.1`) isn't semver-compatible with `deprecated-react-native-prop-types`'s dependency (`^0.73.0`), so `npm install` was failing in CI with "no package found". We should be getting `0.73.2` from the public registry in this case.

This restores a previous workaround added in https://github.com/facebook/react-native/pull/34571 but not updated since https://github.com/facebook/react-native-deprecated-modules/pull/11 meant the dependency was now on the pluralised package. We have no dependency on the old non-plural package any more.

## Changelog:

[INTERNAL] [FIXED] - CI/Verdaccio: Proxy `@react-native/normalize-colors` from NPM for the `deprecated-react-native-prop-types` dependency.

## Test Plan:

CI