### PR TITLE
Back out "Verdaccio: proxy `@react-native/normalize-colors` from NPM"

### DIFF
--- a/.circleci/verdaccio.yml
+++ b/.circleci/verdaccio.yml
@@ -15,8 +15,8 @@ uplinks:
       maxSockets: 40
       maxFreeSockets: 10
 packages:
-  # Get @react-native/normalize-colors from npm registry, since its used in deprecated-react-native-prop-types package
-  '@react-native/normalize-colors':
+  # Get @react-native/normalize-color from npm registry, since its used in deprecated-react-native-prop-types package
+  '@react-native/normalize-color':
     access: $all
     publish: $authenticated
     proxy: npmjs


### PR DESCRIPTION
Summary:
Original commit changeset: 4bf650310833

Original Phabricator Diff: D50298291

Differential Revision: D50300100


