### PR TITLE
[RN][CI]Skip publishing of normalize-colors

### DIFF
--- a/scripts/template/initialize.js
+++ b/scripts/template/initialize.js
@@ -66,6 +66,11 @@ async function install() {
           return;
         }
 
+        // TODO: Fix normalize-colors publishing in Verdaccio
+        if (packageManifest.name === '@react-native/normalize-colors') {
+          return;
+        }
+
         execSync(
           'npm publish --registry http://localhost:4873 --access public',
           {


### PR DESCRIPTION
## Summary:

CircleCI is red because verdaccio fails to publish `normalize-colors`. 
For some old dependencies, normalize-colors has been published on the official npmjs with the version we needs.

In order to mitigate the RN red ci, we can consume them directly from NPMJS.
As a followup, we created a task to investigate it next week.

## Changelog:
[Internal] - Skip publishing or normalize colors

## Test Plan:
Tested locally, running verdaccio and simulating CI. It worked.
CircleCI is green
