### PR TITLE
Enable fast refresh banner

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -86,9 +86,6 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
         surfaceDelegateFactory,
         devLoadingViewManager);
 
-    mReactInstanceManagerHelper = reactInstanceManagerHelper;
-    mDevLoadingViewManager = devLoadingViewManager;
-
     if (getDevSettings().isStartSamplingProfilerOnInit()) {
       // Only start the profiler. If its already running, there is an error
       if (!mIsSamplingProfilerEnabled) {
@@ -110,14 +107,6 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
             toggleJSSamplingProfiler();
           }
         });
-  }
-
-  public DevLoadingViewManager getDevLoadingViewManager() {
-    return mDevLoadingViewManager;
-  }
-
-  public ReactInstanceDevHelper getReactInstanceManagerHelper() {
-    return mReactInstanceManagerHelper;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -695,7 +695,11 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     return mDevServerHelper;
   }
 
-  protected ReactInstanceDevHelper getReactInstanceDevHelper() {
+  public DevLoadingViewManager getDevLoadingViewManager() {
+    return mDevLoadingViewManager;
+  }
+
+  public ReactInstanceDevHelper getReactInstanceDevHelper() {
     return mReactInstanceDevHelper;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.java
@@ -13,8 +13,7 @@ import com.facebook.react.bridge.JSExceptionHandler;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
-import com.facebook.react.devsupport.BridgeDevSupportManager;
-import com.facebook.react.devsupport.DefaultDevLoadingViewImplementation;
+import com.facebook.react.devsupport.DevSupportManagerBase;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.module.annotations.ReactModule;
 
@@ -28,14 +27,9 @@ public class DevLoadingModule extends NativeDevLoadingViewSpec {
   public DevLoadingModule(ReactApplicationContext reactContext) {
     super(reactContext);
     mJSExceptionHandler = reactContext.getJSExceptionHandler();
-    if (mJSExceptionHandler != null && mJSExceptionHandler instanceof BridgeDevSupportManager) {
+    if (mJSExceptionHandler != null && mJSExceptionHandler instanceof DevSupportManagerBase) {
       mDevLoadingViewManager =
-          ((BridgeDevSupportManager) mJSExceptionHandler).getDevLoadingViewManager();
-      mDevLoadingViewManager =
-          mDevLoadingViewManager != null
-              ? mDevLoadingViewManager
-              : new DefaultDevLoadingViewImplementation(
-                  ((BridgeDevSupportManager) mJSExceptionHandler).getReactInstanceManagerHelper());
+          ((DevSupportManagerBase) mJSExceptionHandler).getDevLoadingViewManager();
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -922,6 +922,7 @@ public class ReactHostImpl implements ReactHost {
                     final JSBundleLoader bundleLoader = task.getResult();
                     final BridgelessReactContext reactContext = getOrCreateReactContext();
                     final DevSupportManager devSupportManager = getDevSupportManager();
+                    reactContext.setJSExceptionHandler(devSupportManager);
 
                     log(method, "Creating ReactInstance");
                     final ReactInstance instance =
@@ -1036,6 +1037,7 @@ public class ReactHostImpl implements ReactHost {
 
           final BridgelessReactContext reactContext = getOrCreateReactContext();
           final DevSupportManager devSupportManager = getDevSupportManager();
+          reactContext.setJSExceptionHandler(devSupportManager);
 
           return getJsBundleLoader()
               .onSuccess(


### PR DESCRIPTION
Summary:
Fast refresh banner for Android was introduced for Bridge-only (D42286425), in this diff we enable it for Bridgeless as well.

Changelog:
[Android][Changed] - Enable fast refresh banner for Bridgeless

Differential Revision: D50318991


