### PR TITLE
add copyright header to BlobRegistry-test.js

### DIFF
--- a/packages/react-native/Libraries/Blob/__tests__/BlobRegistry-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/BlobRegistry-test.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
 'use strict';
 
 const BlobRegistry = require('../BlobRegistry');


### PR DESCRIPTION
Summary:
Every file in the react-native-github repo should have the right copyright header. This was missed for this file.

Changelog: Internal

Reviewed By: rubennorte

Differential Revision: D50319271


