### PR TITLE
Fix crash in AsyncCallback::callWithFunction

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/CallbackWrapper.h
+++ b/packages/react-native/ReactCommon/react/bridging/CallbackWrapper.h
@@ -8,9 +8,12 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include "LongLivedObject.h"
 
 #include <memory>
+
+#include <ReactCommon/CallInvoker.h>
+
+#include "LongLivedObject.h"
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
+++ b/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
@@ -19,9 +19,12 @@ namespace facebook::react {
  * collection when needed.
  *
  * The subclass of this class must be created using std::make_shared<T>().
- * After creation, add it to the `LongLivedObjectCollection`.
- * When done with the object, call `allowRelease()` to allow the OS to release
- * it.
+ * After creation, add it to the `LongLivedObjectCollection`. When done with the
+ * object, call `allowRelease()` to reclaim its memory.
+ *
+ * When using LongLivedObject to keep JS values alive, ensure you only hold weak
+ * references to the object outside the JS thread to avoid accessing deallocated
+ * values when the JS VM is shutdown.
  */
 class LongLivedObject {
  public:


### PR DESCRIPTION
Summary:
I believe this is due to a race condition between VM teardown and callback invocation. Because we were previously retaining the CallbackWrapper across the invokeAsync call, we may potentially have been holding onto the JSI::Function after it was already destroyed.

Changelog: [Internal]

Differential Revision: D50286876


