### PR TITLE
Refactors InspectorProxy to compare pathname portion of url passed in…

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -94,12 +94,13 @@ export default class InspectorProxy implements InspectorProxyQueries {
     response: ServerResponse,
     next: (?Error) => mixed,
   ) {
+    const path = url.parse(request.url).pathname;
     if (
-      request.url === PAGES_LIST_JSON_URL ||
-      request.url === PAGES_LIST_JSON_URL_2
+      path === PAGES_LIST_JSON_URL ||
+      path === PAGES_LIST_JSON_URL_2
     ) {
       this._sendJsonResponse(response, this.getPageDescriptions());
-    } else if (request.url === PAGES_LIST_JSON_VERSION_URL) {
+    } else if (path === PAGES_LIST_JSON_VERSION_URL) {
       this._sendJsonResponse(response, {
         Browser: 'Mobile JavaScript',
         'Protocol-Version': '1.1',

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -94,15 +94,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
     response: ServerResponse,
     next: (?Error) => mixed,
   ) {
-    // When request.url is a relative path, the WHATWG URL constructor will require
-    // the second "base" param otherwise an exception will be thrown.
-    // We could use `http://${request.headers.host}` here instead however:
-    //  - We are forced to make an assumption about the scheme so if someone is running
-    //    Metro over https it could cause confusion.
-    //
-    //  - We are only extracting pathname from the parsed URL so the host portion is
-    //    irrelevant.
-    const pathname = new URL(request.url, 'http://example').pathname;
+    const pathname = url.parse(request.url).pathname;
     if (
       pathname === PAGES_LIST_JSON_URL ||
       pathname === PAGES_LIST_JSON_URL_2

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -94,13 +94,21 @@ export default class InspectorProxy implements InspectorProxyQueries {
     response: ServerResponse,
     next: (?Error) => mixed,
   ) {
-    const path = url.parse(request.url).pathname;
+    // When request.url is a relative path, the WHATWG URL constructor will require
+    // the second "base" param otherwise an exception will be thrown.
+    // We could use `http://${request.headers.host}` here instead however:
+    //  - We are forced to make an assumption about the scheme so if someone is running
+    //    Metro over https it could cause confusion.
+    //
+    //  - We are only extracting pathname from the parsed URL so the host portion is
+    //    irrelevant.
+    const pathname = new URL(request.url, 'http://example').pathname;
     if (
-      path === PAGES_LIST_JSON_URL ||
-      path === PAGES_LIST_JSON_URL_2
+      pathname === PAGES_LIST_JSON_URL ||
+      pathname === PAGES_LIST_JSON_URL_2
     ) {
       this._sendJsonResponse(response, this.getPageDescriptions());
-    } else if (path === PAGES_LIST_JSON_VERSION_URL) {
+    } else if (pathname === PAGES_LIST_JSON_VERSION_URL) {
       this._sendJsonResponse(response, {
         Browser: 'Mobile JavaScript',
         'Protocol-Version': '1.1',


### PR DESCRIPTION
… request to local pathname comparator variables to fix issue with other rightward elements of url such as query or fragment entering the comparison and causing 404 errors for key debugging routes.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
A change in Chromium appended the query "?for_tabs" to the /json/list request made by Chrome DevTools to find remote debugger targets.

The current comparison in InspectorProxy.js compares the entire node IncomingMessage url field to the local pathname constants. The issue arises as url can also contain the query and fragment portions so the original comparison of "/json/list" === "/json/list" which resolved as true would become "/json/list?for_tabs" === "/json/list" and evaluate to false ultimately resulting in a 404 for the request.

In summary, all these changes/issues caused remote debugging of Hermes code in React Native apps to become unavailable, greatly impacting developer experience.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [FIXED] JS Debugging: Fix inspector-proxy to allow for DevTools requests with query strings

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
