### PR TITLE
Fix event type mismatch in FlatList

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1258,7 +1258,17 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     const onRefresh = props.onRefresh;
     if (this._isNestedWithSameOrientation()) {
       // $FlowFixMe[prop-missing] - Typing ReactNativeComponent revealed errors
-      return <View {...props} />;
+      return (
+        <View
+          onLayout={(event: LayoutEvent) => {
+            const {width, height} = event.nativeEvent.layout;
+            props.onLayout && props.onLayout(event);
+            props.onContentSizeChange &&
+              props.onContentSizeChange(width, height);
+          }}
+          {...props}
+        />
+      );
     } else if (onRefresh) {
       invariant(
         typeof props.refreshing === 'boolean',


### PR DESCRIPTION
Summary:
changelog: [internal]

Props passed to `_defaultRenderScrollComponent` are props for <ScrollView />. <ScrollView /> has event `onContentSizeChange` but <View /> does not. But `_defaultRenderScrollComponent` returns <View /> if <FlatList /> is nested within the same orientation. `onContentSizeChange` is important event, it is used to determine how many cells should be shown.

How come it used to work?
This is very context dependent. Any update after initial render will fix it. There are many things that need to align for the bug to manifest.

Reviewed By: javache

Differential Revision: D50320323


