### PR TITLE
Fix unstable RCTAppDelegate podspec

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -117,15 +117,19 @@ Pod::Spec.new do |s|
     s.dependency "React-debug"
     s.dependency "React-rendererdebug"
 
+    rel_path_from_pods_root_to_app = Pathname.new(ENV['APP_PATH']).relative_path_from(Pod::Config.instance.installation_root)
+    rel_path_from_pods_to_app = Pathname.new(ENV['APP_PATH']).relative_path_from(File.join(Pod::Config.instance.installation_root, 'Pods'))
+
+
     s.script_phases = {
       :name => "Generate Legacy Components Interop",
       :script => "
 WITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"
 source $WITH_ENVIRONMENT
-${NODE_BINARY} ${REACT_NATIVE_PATH}/scripts/codegen/generate-legacy-interop-components.js -p #{ENV['APP_PATH']} -o ${REACT_NATIVE_PATH}/Libraries/AppDelegate
+${NODE_BINARY} ${REACT_NATIVE_PATH}/scripts/codegen/generate-legacy-interop-components.js -p #{rel_path_from_pods_to_app} -o ${REACT_NATIVE_PATH}/Libraries/AppDelegate
       ",
       :execution_position => :before_compile,
-      :input_files => ["#{ENV['APP_PATH']}/react-native.config.js"],
+      :input_files => ["#{rel_path_from_pods_root_to_app}/react-native.config.js"],
       :output_files => ["${REACT_NATIVE_PATH}/Libraries/AppDelegate/RCTLegacyInteropComponents.mm"],
     }
   end

--- a/packages/react-native/scripts/codegen/generate-legacy-interop-components.js
+++ b/packages/react-native/scripts/codegen/generate-legacy-interop-components.js
@@ -11,6 +11,7 @@
 
 const yargs = require('yargs');
 const fs = require('fs');
+const p = require('path');
 
 const CONFIG_FILE_NAME = 'react-native.config.js';
 const PROJECT_FIELD = 'project';
@@ -92,7 +93,11 @@ function extractComponentsNames(reactNativeConfig) {
 }
 
 function generateRCTLegacyInteropComponents() {
-  const configFilePath = `${appRoot}/${CONFIG_FILE_NAME}`;
+  const cwd = process.cwd();
+  const configFilePath = p.join(cwd, appRoot, CONFIG_FILE_NAME);
+  console.log(
+    `Looking for a react-native.config.js file at ${configFilePath}...`,
+  );
   let reactNativeConfig = null;
   try {
     reactNativeConfig = require(configFilePath);
@@ -106,7 +111,7 @@ function generateRCTLegacyInteropComponents() {
     console.log('Skip LegacyInterop generation');
     return;
   }
-
+  console.log(`Components found: ${componentNames}`);
   let componentsArray = componentNames.map(name => `\t\t\t@"${name}",`);
   // Remove the last comma
   if (componentsArray.length > 0) {
@@ -117,6 +122,7 @@ function generateRCTLegacyInteropComponents() {
 
   const filePath = `${outputPath}/${OUTPUT_FILE_NAME}`;
   fs.writeFileSync(filePath, fileBody(componentsArray.join('\n')));
+  console.log(`${filePath} updated!`);
 }
 
 generateRCTLegacyInteropComponents();


### PR DESCRIPTION
Summary:
This change should fix [#39971](https://github.com/facebook/react-native/issues/39971), computing the relative path from the App path to the pod installation root and using that instead of the absolute path to the `react-native.config.js` file

## Changelog
[Internal] - Stabilize RCTAppDelegate podspec

Differential Revision: D50323710


