### PR TITLE
Gitignore RCTLegacyInteropComponents.mm as it is generated by Xcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ package-lock.json
 /packages/react-native/template/ios/Pods/
 /packages/react-native/template/ios/Podfile.lock
 /packages/rn-tester/Gemfile.lock
+/packages/**/RCTLegacyInteropComponents.mm
 
 # Ignore RNTester specific Pods, but keep the __offline_mirrors__ here.
 /packages/rn-tester/Pods/*

--- a/packages/react-native/scripts/codegen/generate-legacy-interop-components.js
+++ b/packages/react-native/scripts/codegen/generate-legacy-interop-components.js
@@ -35,8 +35,7 @@ const outputPath = argv.outputPath;
 
 function fileBody(components) {
   // eslint-disable duplicate-license-header
-  return `
-/*
+  return `/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the


### PR DESCRIPTION
Summary:
## Changelog
[Internal] - Gitignore RCTLegacyInteropComponents.mm as it is generated by Xcode

Differential Revision: D50323800


