### PR TITLE
make topContentSizeChange event direct

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -31,12 +31,6 @@ const RCTTextInputViewConfig = {
         captured: 'onChangeCapture',
       },
     },
-    topContentSizeChange: {
-      phasedRegistrationNames: {
-        captured: 'onContentSizeChangeCapture',
-        bubbled: 'onContentSizeChange',
-      },
-    },
     topEndEditing: {
       phasedRegistrationNames: {
         bubbled: 'onEndEditing',
@@ -96,6 +90,9 @@ const RCTTextInputViewConfig = {
     },
     topChangeSync: {
       registrationName: 'onChangeSync',
+    },
+    topContentSizeChange: {
+      registrationName: 'onContentSizeChange',
     },
   },
   validAttributes: {


### PR DESCRIPTION
Summary:
changelog: [internal]

topContentSizeChange should be a direct event. Otherwise it collides with ScrollView's `onContentSizeChange` any may break FlatList

Reviewed By: javache

Differential Revision: D50323281

