### PR TITLE
Make TextInput.onContentSizeChange event direct

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
@@ -71,7 +71,7 @@ RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 
 RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
 RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
-RCT_EXPORT_SHADOW_PROPERTY(onContentSizeChange, RCTBubblingEventBlock)
+RCT_EXPORT_SHADOW_PROPERTY(onContentSizeChange, RCTDirectEventBlock)
 
 RCT_CUSTOM_VIEW_PROPERTY(multiline, BOOL, UIView)
 {


### PR DESCRIPTION
Summary:
changelog: [iOS][Breaking] Make TextInput.onContentSizeChange a direct event

TextInput.onContentSizeChange should be a direct event. It is a [direct event on Android](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js#L126C3-L126C23) and even on iOS there are traits that it was meant to be a direct event (https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.h#L19C47-L19C47)

Seems like an oversight.

Reviewed By: javache

Differential Revision: D50323402

