### PR TITLE
Delete empty didRegisterUserNotificationSettings

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -14,7 +14,6 @@ extern NSString *const RCTRemoteNotificationReceived;
 typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 
 #if !TARGET_OS_UIKITFORMAC
-+ (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -176,10 +176,6 @@ RCT_EXPORT_MODULE()
   ];
 }
 
-+ (void)didRegisterUserNotificationSettings:(__unused UIUserNotificationSettings *)notificationSettings
-{
-}
-
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
   NSMutableString *hexString = [NSMutableString string];

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -88,13 +88,6 @@ NSString *kBundlePath = @"js/RNTesterApp.ios";
 
 #if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 
-// Required to register for notifications
-- (void)application:(__unused UIApplication *)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
-{
-  [RCTPushNotificationManager didRegisterUserNotificationSettings:notificationSettings];
-}
-
 // Required for the remoteNotificationsRegistered event.
 - (void)application:(__unused UIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken


### PR DESCRIPTION
Summary:
# Changelog

[Internal] Remove no-op function in RCTPushNotificationManager which is using the deprecated UIUserNotificationSettings

Differential Revision: D50283620

