### PR TITLE
Reduce visibility of DebugCorePackage

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -36,7 +36,8 @@ import javax.inject.Provider;
     nativeModules = {
       JSCHeapCapture.class,
     })
-public class DebugCorePackage extends TurboReactPackage implements ViewManagerOnDemandReactPackage {
+/* package */
+class DebugCorePackage extends TurboReactPackage implements ViewManagerOnDemandReactPackage {
   private @Nullable Map<String, ModuleSpec> mViewManagers;
 
   public DebugCorePackage() {}


### PR DESCRIPTION
Summary:
DebugCorePackage is only used from com.facebook.react, there are no interesting usages internally at Meta or in OSS, so I'm reducing the visibility to package.


changelog: [Android][Breaking] Reducing visibility of DebugCorePackage

Reviewed By: christophpurrer

Differential Revision: D50338294


