### PR TITLE
Reuse Yoga enum ToString functions

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaAlign.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaAlign.java
@@ -17,7 +17,8 @@ public enum YogaAlign {
   STRETCH(4),
   BASELINE(5),
   SPACE_BETWEEN(6),
-  SPACE_AROUND(7);
+  SPACE_AROUND(7),
+  SPACE_EVENLY(8);
 
   private final int mIntValue;
 
@@ -39,6 +40,7 @@ public enum YogaAlign {
       case 5: return BASELINE;
       case 6: return SPACE_BETWEEN;
       case 7: return SPACE_AROUND;
+      case 8: return SPACE_EVENLY;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -746,41 +746,11 @@ inline std::string toString(const yoga::FlexDirection& value) {
 }
 
 inline std::string toString(const yoga::Justify& value) {
-  switch (value) {
-    case yoga::Justify::FlexStart:
-      return "flex-start";
-    case yoga::Justify::Center:
-      return "center";
-    case yoga::Justify::FlexEnd:
-      return "flex-end";
-    case yoga::Justify::SpaceBetween:
-      return "space-between";
-    case yoga::Justify::SpaceAround:
-      return "space-around";
-    case yoga::Justify::SpaceEvenly:
-      return "space-evenly";
-  }
+  return YGJustifyToString(yoga::unscopedEnum(value));
 }
 
 inline std::string toString(const yoga::Align& value) {
-  switch (value) {
-    case yoga::Align::Auto:
-      return "auto";
-    case yoga::Align::FlexStart:
-      return "flex-start";
-    case yoga::Align::Center:
-      return "center";
-    case yoga::Align::FlexEnd:
-      return "flex-end";
-    case yoga::Align::Stretch:
-      return "stretch";
-    case yoga::Align::Baseline:
-      return "baseline";
-    case yoga::Align::SpaceBetween:
-      return "space-between";
-    case yoga::Align::SpaceAround:
-      return "space-around";
-  }
+  return YGAlignToString(yoga::unscopedEnum(value));
 }
 
 inline std::string toString(const yoga::PositionType& value) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -722,27 +722,11 @@ inline std::string toString(const std::array<float, N> vec) {
 }
 
 inline std::string toString(const yoga::Direction& value) {
-  switch (value) {
-    case yoga::Direction::Inherit:
-      return "inherit";
-    case yoga::Direction::LTR:
-      return "ltr";
-    case yoga::Direction::RTL:
-      return "rtl";
-  }
+  return YGDirectionToString(yoga::unscopedEnum(value));
 }
 
 inline std::string toString(const yoga::FlexDirection& value) {
-  switch (value) {
-    case yoga::FlexDirection::Column:
-      return "column";
-    case yoga::FlexDirection::ColumnReverse:
-      return "column-reverse";
-    case yoga::FlexDirection::Row:
-      return "row";
-    case yoga::FlexDirection::RowReverse:
-      return "row-reverse";
-  }
+  return YGFlexDirectionToString(yoga::unscopedEnum(value));
 }
 
 inline std::string toString(const yoga::Justify& value) {
@@ -754,45 +738,19 @@ inline std::string toString(const yoga::Align& value) {
 }
 
 inline std::string toString(const yoga::PositionType& value) {
-  switch (value) {
-    case yoga::PositionType::Static:
-      return "static";
-    case yoga::PositionType::Relative:
-      return "relative";
-    case yoga::PositionType::Absolute:
-      return "absolute";
-  }
+  return YGPositionTypeToString(yoga::unscopedEnum(value));
 }
 
 inline std::string toString(const yoga::Wrap& value) {
-  switch (value) {
-    case yoga::Wrap::NoWrap:
-      return "no-wrap";
-    case yoga::Wrap::Wrap:
-      return "wrap";
-    case yoga::Wrap::WrapReverse:
-      return "wrap-reverse";
-  }
+  return YGWrapToString(yoga::unscopedEnum(value));
 }
 
 inline std::string toString(const yoga::Overflow& value) {
-  switch (value) {
-    case yoga::Overflow::Visible:
-      return "visible";
-    case yoga::Overflow::Scroll:
-      return "scroll";
-    case yoga::Overflow::Hidden:
-      return "hidden";
-  }
+  return YGOverflowToString(yoga::unscopedEnum(value));
 }
 
 inline std::string toString(const yoga::Display& value) {
-  switch (value) {
-    case yoga::Display::Flex:
-      return "flex";
-    case yoga::Display::None:
-      return "none";
-  }
+  return YGDisplayToString(yoga::unscopedEnum(value));
 }
 
 inline std::string toString(const YGValue& value) {

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -27,6 +27,8 @@ const char* YGAlignToString(const YGAlign value) {
       return "space-between";
     case YGAlignSpaceAround:
       return "space-around";
+    case YGAlignSpaceEvenly:
+      return "space-evenly";
   }
   return "unknown";
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -21,7 +21,8 @@ YG_ENUM_SEQ_DECL(
     YGAlignStretch,
     YGAlignBaseline,
     YGAlignSpaceBetween,
-    YGAlignSpaceAround)
+    YGAlignSpaceAround,
+    YGAlignSpaceEvenly)
 
 YG_ENUM_SEQ_DECL(
     YGDimension,

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -2036,6 +2036,18 @@ static void calculateLayoutImpl(
             currentLead += remainingAlignContentDim / 2;
           }
           break;
+        case Align::SpaceEvenly:
+          if (availableInnerCrossDim > totalLineCrossDim) {
+            currentLead +=
+                remainingAlignContentDim / static_cast<float>(lineCount + 1);
+            if (lineCount > 1) {
+              crossDimLead =
+                  remainingAlignContentDim / static_cast<float>(lineCount + 1);
+            }
+          } else {
+            currentLead += remainingAlignContentDim / 2;
+          }
+          break;
         case Align::SpaceBetween:
           if (availableInnerCrossDim > totalLineCrossDim && lineCount > 1) {
             crossDimLead =
@@ -2192,6 +2204,7 @@ static void calculateLayoutImpl(
               case Align::Auto:
               case Align::SpaceBetween:
               case Align::SpaceAround:
+              case Align::SpaceEvenly:
                 break;
             }
           }

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/Align.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/Align.h
@@ -24,16 +24,17 @@ enum class Align : uint8_t {
   Baseline = YGAlignBaseline,
   SpaceBetween = YGAlignSpaceBetween,
   SpaceAround = YGAlignSpaceAround,
+  SpaceEvenly = YGAlignSpaceEvenly,
 };
 
 template <>
 constexpr inline int32_t ordinalCount<Align>() {
-  return 8;
+  return 9;
 } 
 
 template <>
 constexpr inline int32_t bitCount<Align>() {
-  return 3;
+  return 4;
 } 
 
 constexpr inline Align scopedEnum(YGAlign unscoped) {


### PR DESCRIPTION
Summary:
Yoga has generated public `ToString` functions for enums already. Don't duplicate in Fabric.

Changelog: [Internal]

Differential Revision: D50347728

