### PR TITLE
Remove ContentSizeChangeEvent from core

### DIFF
--- a/fbandroid/java/com/facebook/catalyst/views/webview/ContentSizeChangeEvent.java
+++ b/fbandroid/java/com/facebook/catalyst/views/webview/ContentSizeChangeEvent.java
@@ -1,22 +1,13 @@
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-package com.facebook.react.uimanager.events;
+package com.facebook.react.views.webview;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.events.Event;
 
-/**
- * Event dispatched when total width or height of a view's children changes.
- *
- * @deprecated Please define your own event for custom components
- */
-@Deprecated
+/** Event dispatched when total width or height of a view's children changes */
 public class ContentSizeChangeEvent extends Event<ContentSizeChangeEvent> {
 
   public static final String EVENT_NAME = "topContentSizeChange";


### PR DESCRIPTION
Summary:
This class is not referenced anywhere. It used to be part of webview, which has been removed from RN's core.

Since we still have [external users](https://github.com/expo/expo/blob/923016204c239cdad07b89626ac65eb505623d98/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebView.java#L133) of this class, let's deprecate it first.

Changelog: [Android][Removed] Deprecated internal ContentSizeChangeEvent

Reviewed By: NickGerleman

Differential Revision: D50325736


