### PR TITLE
Clean up const and mutable modifiers in RuntimeScheduler

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -165,4 +165,10 @@ public class ReactFeatureFlags {
 
   /** Enables Stable API for TurboModule (removal of ReactModule, ReactModuleInfoProvider). */
   public static boolean enableTurboModuleStableAPI = false;
+
+  /**
+   * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with
+   * priorities from any thread.
+   */
+  public static boolean useModernRuntimeScheduler = false;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -170,6 +170,9 @@ final class ReactInstance {
     // Notify JS if profiling is enabled
     boolean isProfiling =
         Systrace.isTracing(Systrace.TRACE_TAG_REACT_APPS | Systrace.TRACE_TAG_REACT_JS_VM_CALLS);
+    // TODO(T166383606): Remove this parameter when we remove the legacy runtime scheduler or we
+    // have access to ReactNativeConfig before we initialize it.
+    boolean useModernRuntimeScheduler = ReactFeatureFlags.useModernRuntimeScheduler;
     mHybridData =
         initHybrid(
             jsEngineInstance,
@@ -179,7 +182,8 @@ final class ReactInstance {
             jsTimerExecutor,
             reactExceptionManager,
             bindingsInstaller,
-            isProfiling);
+            isProfiling,
+            useModernRuntimeScheduler);
 
     RuntimeExecutor unbufferedRuntimeExecutor = getUnbufferedRuntimeExecutor();
 
@@ -435,7 +439,8 @@ final class ReactInstance {
       JSTimerExecutor jsTimerExecutor,
       ReactJsExceptionHandler jReactExceptionsManager,
       @Nullable BindingsInstaller jBindingsInstaller,
-      boolean isProfiling);
+      boolean isProfiling,
+      boolean useModernRuntimeScheduler);
 
   @DoNotStrip
   private static native JSTimerExecutor createJSTimerExecutor();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -36,7 +36,8 @@ JReactInstance::JReactInstance(
     jni::alias_ref<JJSTimerExecutor::javaobject> jsTimerExecutor,
     jni::alias_ref<JReactExceptionManager::javaobject> jReactExceptionManager,
     jni::alias_ref<JBindingsInstaller::javaobject> jBindingsInstaller,
-    bool isProfiling) noexcept {
+    bool isProfiling,
+    bool useModernRuntimeScheduler) noexcept {
   // TODO(janzer): Lazily create runtime
   auto sharedJSMessageQueueThread =
       std::make_shared<JMessageQueueThread>(jsMessageQueueThread);
@@ -64,7 +65,8 @@ JReactInstance::JReactInstance(
       jsEngineInstance->cthis()->createJSRuntime(sharedJSMessageQueueThread),
       sharedJSMessageQueueThread,
       timerManager,
-      std::move(jsErrorHandlingFunc));
+      std::move(jsErrorHandlingFunc),
+      useModernRuntimeScheduler);
 
   auto bufferedRuntimeExecutor = instance_->getBufferedRuntimeExecutor();
   timerManager->setRuntimeExecutor(bufferedRuntimeExecutor);
@@ -115,7 +117,8 @@ jni::local_ref<JReactInstance::jhybriddata> JReactInstance::initHybrid(
     jni::alias_ref<JJSTimerExecutor::javaobject> jsTimerExecutor,
     jni::alias_ref<JReactExceptionManager::javaobject> jReactExceptionManager,
     jni::alias_ref<JBindingsInstaller::javaobject> jBindingsInstaller,
-    bool isProfiling) {
+    bool isProfiling,
+    bool useModernRuntimeScheduler) {
   return makeCxxInstance(
       jsEngineInstance,
       jsMessageQueueThread,
@@ -124,7 +127,8 @@ jni::local_ref<JReactInstance::jhybriddata> JReactInstance::initHybrid(
       jsTimerExecutor,
       jReactExceptionManager,
       jBindingsInstaller,
-      isProfiling);
+      isProfiling,
+      useModernRuntimeScheduler);
 }
 
 void JReactInstance::loadJSBundleFromAssets(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.h
@@ -45,7 +45,8 @@ class JReactInstance : public jni::HybridClass<JReactInstance> {
       jni::alias_ref<JJSTimerExecutor::javaobject> jsTimerExecutor,
       jni::alias_ref<JReactExceptionManager::javaobject> jReactExceptionManager,
       jni::alias_ref<JBindingsInstaller::javaobject> jBindingsInstaller,
-      bool isProfiling);
+      bool isProfiling,
+      bool useModernRuntimeScheduler);
 
   /*
    * Instantiates and returns an instance of `JSTimerExecutor`.
@@ -90,7 +91,8 @@ class JReactInstance : public jni::HybridClass<JReactInstance> {
       jni::alias_ref<JJSTimerExecutor::javaobject> jsTimerExecutor,
       jni::alias_ref<JReactExceptionManager::javaobject> jReactExceptionManager,
       jni::alias_ref<JBindingsInstaller::javaobject> jBindingsInstaller,
-      bool isProfiling) noexcept;
+      bool isProfiling,
+      bool useModernRuntimeScheduler) noexcept;
 
   jni::alias_ref<CallInvokerHolder::javaobject> getJSCallInvokerHolder();
   jni::alias_ref<NativeMethodCallInvokerHolder::javaobject>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -40,19 +40,19 @@ RuntimeScheduler::RuntimeScheduler(
           useModernRuntimeScheduler,
           std::move(now))) {}
 
-void RuntimeScheduler::scheduleWork(RawCallback&& callback) const noexcept {
+void RuntimeScheduler::scheduleWork(RawCallback&& callback) noexcept {
   return runtimeSchedulerImpl_->scheduleWork(std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
     SchedulerPriority priority,
-    jsi::Function&& callback) const noexcept {
+    jsi::Function&& callback) noexcept {
   return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
     SchedulerPriority priority,
-    RawCallback&& callback) const noexcept {
+    RawCallback&& callback) noexcept {
   return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RuntimeScheduler.h"
+#include "RuntimeScheduler_Legacy.h"
 #include "SchedulerPriorityUtils.h"
 
 #include <react/renderer/debug/SystraceSection.h>
@@ -14,177 +15,55 @@
 
 namespace facebook::react {
 
-#pragma mark - Public
-
 RuntimeScheduler::RuntimeScheduler(
     RuntimeExecutor runtimeExecutor,
     std::function<RuntimeSchedulerTimePoint()> now)
-    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+    : runtimeSchedulerImpl_(std::make_unique<RuntimeScheduler_Legacy>(
+          std::move(runtimeExecutor),
+          std::move(now))) {}
 
 void RuntimeScheduler::scheduleWork(RawCallback&& callback) const noexcept {
-  SystraceSection s("RuntimeScheduler::scheduleWork");
-
-  runtimeAccessRequests_ += 1;
-
-  runtimeExecutor_(
-      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
-        SystraceSection s2("RuntimeScheduler::scheduleWork callback");
-        runtimeAccessRequests_ -= 1;
-        callback(runtime);
-        startWorkLoop(runtime);
-      });
+  return runtimeSchedulerImpl_->scheduleWork(std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
     SchedulerPriority priority,
     jsi::Function&& callback) noexcept {
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
-  auto task =
-      std::make_shared<Task>(priority, std::move(callback), expirationTime);
-  taskQueue_.push(task);
-
-  scheduleWorkLoopIfNecessary();
-
-  return task;
+  return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
     SchedulerPriority priority,
     RawCallback&& callback) noexcept {
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
-  auto task =
-      std::make_shared<Task>(priority, std::move(callback), expirationTime);
-  taskQueue_.push(task);
-
-  scheduleWorkLoopIfNecessary();
-
-  return task;
+  return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 
 bool RuntimeScheduler::getShouldYield() const noexcept {
-  return runtimeAccessRequests_ > 0;
+  return runtimeSchedulerImpl_->getShouldYield();
 }
 
 bool RuntimeScheduler::getIsSynchronous() const noexcept {
-  return isSynchronous_;
+  return runtimeSchedulerImpl_->getIsSynchronous();
 }
 
 void RuntimeScheduler::cancelTask(Task& task) noexcept {
-  task.callback.reset();
+  return runtimeSchedulerImpl_->cancelTask(task);
 }
 
 SchedulerPriority RuntimeScheduler::getCurrentPriorityLevel() const noexcept {
-  return currentPriority_;
+  return runtimeSchedulerImpl_->getCurrentPriorityLevel();
 }
 
 RuntimeSchedulerTimePoint RuntimeScheduler::now() const noexcept {
-  return now_();
+  return runtimeSchedulerImpl_->now();
 }
 
 void RuntimeScheduler::executeNowOnTheSameThread(RawCallback&& callback) {
-  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
-
-  runtimeAccessRequests_ += 1;
-  executeSynchronouslyOnSameThread_CAN_DEADLOCK(
-      runtimeExecutor_,
-      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
-        SystraceSection s2(
-            "RuntimeScheduler::executeNowOnTheSameThread callback");
-
-        runtimeAccessRequests_ -= 1;
-        isSynchronous_ = true;
-        callback(runtime);
-        isSynchronous_ = false;
-      });
-
-  // Resume work loop if needed. In synchronous mode
-  // only expired tasks are executed. Tasks with lower priority
-  // might be still in the queue.
-  scheduleWorkLoopIfNecessary();
+  return runtimeSchedulerImpl_->executeNowOnTheSameThread(std::move(callback));
 }
 
 void RuntimeScheduler::callExpiredTasks(jsi::Runtime& runtime) {
-  SystraceSection s("RuntimeScheduler::callExpiredTasks");
-
-  auto previousPriority = currentPriority_;
-  try {
-    while (!taskQueue_.empty()) {
-      auto topPriorityTask = taskQueue_.top();
-      auto now = now_();
-      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
-
-      if (!didUserCallbackTimeout) {
-        break;
-      }
-
-      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
-    }
-  } catch (jsi::JSError& error) {
-    handleFatalError(runtime, error);
-  }
-
-  currentPriority_ = previousPriority;
-}
-
-#pragma mark - Private
-
-void RuntimeScheduler::scheduleWorkLoopIfNecessary() const {
-  if (!isWorkLoopScheduled_ && !isPerformingWork_) {
-    isWorkLoopScheduled_ = true;
-    runtimeExecutor_([this](jsi::Runtime& runtime) {
-      isWorkLoopScheduled_ = false;
-      startWorkLoop(runtime);
-    });
-  }
-}
-
-void RuntimeScheduler::startWorkLoop(jsi::Runtime& runtime) const {
-  SystraceSection s("RuntimeScheduler::startWorkLoop");
-
-  auto previousPriority = currentPriority_;
-  isPerformingWork_ = true;
-  try {
-    while (!taskQueue_.empty()) {
-      auto topPriorityTask = taskQueue_.top();
-      auto now = now_();
-      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
-
-      if (!didUserCallbackTimeout && getShouldYield()) {
-        // This currentTask hasn't expired, and we need to yield.
-        break;
-      }
-
-      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
-    }
-  } catch (jsi::JSError& error) {
-    handleFatalError(runtime, error);
-  }
-
-  currentPriority_ = previousPriority;
-  isPerformingWork_ = false;
-}
-
-void RuntimeScheduler::executeTask(
-    jsi::Runtime& runtime,
-    const std::shared_ptr<Task>& task,
-    bool didUserCallbackTimeout) const {
-  SystraceSection s(
-      "RuntimeScheduler::executeTask",
-      "priority",
-      serialize(task->priority),
-      "didUserCallbackTimeout",
-      didUserCallbackTimeout);
-
-  currentPriority_ = task->priority;
-  auto result = task->execute(runtime, didUserCallbackTimeout);
-
-  if (result.isObject() && result.getObject(runtime).isFunction(runtime)) {
-    task->callback = result.getObject(runtime).getFunction(runtime);
-  } else {
-    if (taskQueue_.top() == task) {
-      taskQueue_.pop();
-    }
-  }
+  return runtimeSchedulerImpl_->callExpiredTasks(runtime);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -18,20 +18,14 @@ namespace facebook::react {
 class RuntimeSchedulerBase {
  public:
   virtual ~RuntimeSchedulerBase() = default;
-  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
-  // refactor has been shipped.
-  virtual void scheduleWork(RawCallback&& callback) const noexcept = 0;
+  virtual void scheduleWork(RawCallback&& callback) noexcept = 0;
   virtual void executeNowOnTheSameThread(RawCallback&& callback) = 0;
-  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
-  // refactor has been shipped.
   virtual std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      jsi::Function&& callback) const noexcept = 0;
-  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
-  // refactor has been shipped.
+      jsi::Function&& callback) noexcept = 0;
   virtual std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      RawCallback&& callback) const noexcept = 0;
+      RawCallback&& callback) noexcept = 0;
   virtual void cancelTask(Task& task) noexcept = 0;
   virtual bool getShouldYield() const noexcept = 0;
   virtual bool getIsSynchronous() const noexcept = 0;
@@ -62,7 +56,7 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
   RuntimeScheduler(RuntimeScheduler&&) = delete;
   RuntimeScheduler& operator=(RuntimeScheduler&&) = delete;
 
-  void scheduleWork(RawCallback&& callback) const noexcept override;
+  void scheduleWork(RawCallback&& callback) noexcept override;
 
   /*
    * Grants access to the runtime synchronously on the caller's thread.
@@ -81,11 +75,11 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
    */
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      jsi::Function&& callback) const noexcept override;
+      jsi::Function&& callback) noexcept override;
 
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      RawCallback&& callback) const noexcept override;
+      RawCallback&& callback) noexcept override;
 
   /*
    * Cancelled task will never be executed.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -18,14 +18,20 @@ namespace facebook::react {
 class RuntimeSchedulerBase {
  public:
   virtual ~RuntimeSchedulerBase() = default;
+  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
+  // refactor has been shipped.
   virtual void scheduleWork(RawCallback&& callback) const noexcept = 0;
   virtual void executeNowOnTheSameThread(RawCallback&& callback) = 0;
+  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
+  // refactor has been shipped.
   virtual std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      jsi::Function&& callback) noexcept = 0;
+      jsi::Function&& callback) const noexcept = 0;
+  // FIXME(T167271466): remove `const` modified when the RuntimeScheduler
+  // refactor has been shipped.
   virtual std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      RawCallback&& callback) noexcept = 0;
+      RawCallback&& callback) const noexcept = 0;
   virtual void cancelTask(Task& task) noexcept = 0;
   virtual bool getShouldYield() const noexcept = 0;
   virtual bool getIsSynchronous() const noexcept = 0;
@@ -38,8 +44,9 @@ class RuntimeSchedulerBase {
 // at runtime based on a feature flag.
 class RuntimeScheduler final : RuntimeSchedulerBase {
  public:
-  RuntimeScheduler(
+  explicit RuntimeScheduler(
       RuntimeExecutor runtimeExecutor,
+      bool useModernRuntimeScheduler = false,
       std::function<RuntimeSchedulerTimePoint()> now =
           RuntimeSchedulerClock::now);
 
@@ -74,11 +81,11 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
    */
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      jsi::Function&& callback) noexcept override;
+      jsi::Function&& callback) const noexcept override;
 
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      RawCallback&& callback) noexcept override;
+      RawCallback&& callback) const noexcept override;
 
   /*
    * Cancelled task will never be executed.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -21,8 +21,7 @@ RuntimeScheduler_Legacy::RuntimeScheduler_Legacy(
     std::function<RuntimeSchedulerTimePoint()> now)
     : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
 
-void RuntimeScheduler_Legacy::scheduleWork(
-    RawCallback&& callback) const noexcept {
+void RuntimeScheduler_Legacy::scheduleWork(RawCallback&& callback) noexcept {
   SystraceSection s("RuntimeScheduler::scheduleWork");
 
   runtimeAccessRequests_ += 1;
@@ -38,7 +37,7 @@ void RuntimeScheduler_Legacy::scheduleWork(
 
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
-    jsi::Function&& callback) const noexcept {
+    jsi::Function&& callback) noexcept {
   SystraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
@@ -58,7 +57,7 @@ std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
 
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
-    RawCallback&& callback) const noexcept {
+    RawCallback&& callback) noexcept {
   SystraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
@@ -145,7 +144,7 @@ void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
 
 #pragma mark - Private
 
-void RuntimeScheduler_Legacy::scheduleWorkLoopIfNecessary() const {
+void RuntimeScheduler_Legacy::scheduleWorkLoopIfNecessary() {
   if (!isWorkLoopScheduled_ && !isPerformingWork_) {
     isWorkLoopScheduled_ = true;
     runtimeExecutor_([this](jsi::Runtime& runtime) {
@@ -155,7 +154,7 @@ void RuntimeScheduler_Legacy::scheduleWorkLoopIfNecessary() const {
   }
 }
 
-void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) const {
+void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) {
   SystraceSection s("RuntimeScheduler::startWorkLoop");
 
   auto previousPriority = currentPriority_;
@@ -184,7 +183,7 @@ void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) const {
 void RuntimeScheduler_Legacy::executeTask(
     jsi::Runtime& runtime,
     const std::shared_ptr<Task>& task,
-    bool didUserCallbackTimeout) const {
+    bool didUserCallbackTimeout) {
   SystraceSection s(
       "RuntimeScheduler::executeTask",
       "priority",

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -38,7 +38,14 @@ void RuntimeScheduler_Legacy::scheduleWork(
 
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
-    jsi::Function&& callback) noexcept {
+    jsi::Function&& callback) const noexcept {
+  SystraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(priority),
+      "callbackType",
+      "jsi::Function");
+
   auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);
@@ -51,7 +58,14 @@ std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
 
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
-    RawCallback&& callback) noexcept {
+    RawCallback&& callback) const noexcept {
+  SystraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(priority),
+      "callbackType",
+      "RawCallback");
+
   auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RuntimeScheduler_Legacy.h"
+#include "SchedulerPriorityUtils.h"
+
+#include <react/renderer/debug/SystraceSection.h>
+#include <utility>
+#include "ErrorUtils.h"
+
+namespace facebook::react {
+
+#pragma mark - Public
+
+RuntimeScheduler_Legacy::RuntimeScheduler_Legacy(
+    RuntimeExecutor runtimeExecutor,
+    std::function<RuntimeSchedulerTimePoint()> now)
+    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+
+void RuntimeScheduler_Legacy::scheduleWork(
+    RawCallback&& callback) const noexcept {
+  SystraceSection s("RuntimeScheduler::scheduleWork");
+
+  runtimeAccessRequests_ += 1;
+
+  runtimeExecutor_(
+      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
+        SystraceSection s2("RuntimeScheduler::scheduleWork callback");
+        runtimeAccessRequests_ -= 1;
+        callback(runtime);
+        startWorkLoop(runtime);
+      });
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
+    SchedulerPriority priority,
+    jsi::Function&& callback) noexcept {
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+  taskQueue_.push(task);
+
+  scheduleWorkLoopIfNecessary();
+
+  return task;
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
+    SchedulerPriority priority,
+    RawCallback&& callback) noexcept {
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+  taskQueue_.push(task);
+
+  scheduleWorkLoopIfNecessary();
+
+  return task;
+}
+
+bool RuntimeScheduler_Legacy::getShouldYield() const noexcept {
+  return runtimeAccessRequests_ > 0;
+}
+
+bool RuntimeScheduler_Legacy::getIsSynchronous() const noexcept {
+  return isSynchronous_;
+}
+
+void RuntimeScheduler_Legacy::cancelTask(Task& task) noexcept {
+  task.callback.reset();
+}
+
+SchedulerPriority RuntimeScheduler_Legacy::getCurrentPriorityLevel()
+    const noexcept {
+  return currentPriority_;
+}
+
+RuntimeSchedulerTimePoint RuntimeScheduler_Legacy::now() const noexcept {
+  return now_();
+}
+
+void RuntimeScheduler_Legacy::executeNowOnTheSameThread(
+    RawCallback&& callback) {
+  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
+
+  runtimeAccessRequests_ += 1;
+  executeSynchronouslyOnSameThread_CAN_DEADLOCK(
+      runtimeExecutor_,
+      [this, callback = std::move(callback)](jsi::Runtime& runtime) {
+        SystraceSection s2(
+            "RuntimeScheduler::executeNowOnTheSameThread callback");
+
+        runtimeAccessRequests_ -= 1;
+        isSynchronous_ = true;
+        callback(runtime);
+        isSynchronous_ = false;
+      });
+
+  // Resume work loop if needed. In synchronous mode
+  // only expired tasks are executed. Tasks with lower priority
+  // might be still in the queue.
+  scheduleWorkLoopIfNecessary();
+}
+
+void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
+  SystraceSection s("RuntimeScheduler::callExpiredTasks");
+
+  auto previousPriority = currentPriority_;
+  try {
+    while (!taskQueue_.empty()) {
+      auto topPriorityTask = taskQueue_.top();
+      auto now = now_();
+      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
+
+      if (!didUserCallbackTimeout) {
+        break;
+      }
+
+      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
+    }
+  } catch (jsi::JSError& error) {
+    handleFatalError(runtime, error);
+  }
+
+  currentPriority_ = previousPriority;
+}
+
+#pragma mark - Private
+
+void RuntimeScheduler_Legacy::scheduleWorkLoopIfNecessary() const {
+  if (!isWorkLoopScheduled_ && !isPerformingWork_) {
+    isWorkLoopScheduled_ = true;
+    runtimeExecutor_([this](jsi::Runtime& runtime) {
+      isWorkLoopScheduled_ = false;
+      startWorkLoop(runtime);
+    });
+  }
+}
+
+void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) const {
+  SystraceSection s("RuntimeScheduler::startWorkLoop");
+
+  auto previousPriority = currentPriority_;
+  isPerformingWork_ = true;
+  try {
+    while (!taskQueue_.empty()) {
+      auto topPriorityTask = taskQueue_.top();
+      auto now = now_();
+      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
+
+      if (!didUserCallbackTimeout && getShouldYield()) {
+        // This currentTask hasn't expired, and we need to yield.
+        break;
+      }
+
+      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
+    }
+  } catch (jsi::JSError& error) {
+    handleFatalError(runtime, error);
+  }
+
+  currentPriority_ = previousPriority;
+  isPerformingWork_ = false;
+}
+
+void RuntimeScheduler_Legacy::executeTask(
+    jsi::Runtime& runtime,
+    const std::shared_ptr<Task>& task,
+    bool didUserCallbackTimeout) const {
+  SystraceSection s(
+      "RuntimeScheduler::executeTask",
+      "priority",
+      serialize(task->priority),
+      "didUserCallbackTimeout",
+      didUserCallbackTimeout);
+
+  currentPriority_ = task->priority;
+  auto result = task->execute(runtime, didUserCallbackTimeout);
+
+  if (result.isObject() && result.getObject(runtime).isFunction(runtime)) {
+    task->callback = result.getObject(runtime).getFunction(runtime);
+  } else {
+    if (taskQueue_.top() == task) {
+      taskQueue_.pop();
+    }
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -36,7 +36,7 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
   RuntimeScheduler_Legacy(RuntimeScheduler_Legacy&&) = delete;
   RuntimeScheduler_Legacy& operator=(RuntimeScheduler_Legacy&&) = delete;
 
-  void scheduleWork(RawCallback&& callback) const noexcept override;
+  void scheduleWork(RawCallback&& callback) noexcept override;
 
   /*
    * Grants access to the runtime synchronously on the caller's thread.
@@ -55,11 +55,11 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
    */
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      jsi::Function&& callback) const noexcept override;
+      jsi::Function&& callback) noexcept override;
 
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      RawCallback&& callback) const noexcept override;
+      RawCallback&& callback) noexcept override;
 
   /*
    * Cancelled task will never be executed.
@@ -111,34 +111,34 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
   void callExpiredTasks(jsi::Runtime& runtime) override;
 
  private:
-  mutable std::priority_queue<
+  std::priority_queue<
       std::shared_ptr<Task>,
       std::vector<std::shared_ptr<Task>>,
       TaskPriorityComparer>
       taskQueue_;
 
   const RuntimeExecutor runtimeExecutor_;
-  mutable SchedulerPriority currentPriority_{SchedulerPriority::NormalPriority};
+  SchedulerPriority currentPriority_{SchedulerPriority::NormalPriority};
 
   /*
    * Counter indicating how many access to the runtime have been requested.
    */
-  mutable std::atomic<uint_fast8_t> runtimeAccessRequests_{0};
+  std::atomic<uint_fast8_t> runtimeAccessRequests_{0};
 
-  mutable std::atomic_bool isSynchronous_{false};
+  std::atomic_bool isSynchronous_{false};
 
-  void startWorkLoop(jsi::Runtime& runtime) const;
+  void startWorkLoop(jsi::Runtime& runtime);
 
   /*
    * Schedules a work loop unless it has been already scheduled
    * This is to avoid unnecessary calls to `runtimeExecutor`.
    */
-  void scheduleWorkLoopIfNecessary() const;
+  void scheduleWorkLoopIfNecessary();
 
   void executeTask(
       jsi::Runtime& runtime,
       const std::shared_ptr<Task>& task,
-      bool didUserCallbackTimeout) const;
+      bool didUserCallbackTimeout);
 
   /*
    * Returns a time point representing the current point in time. May be called
@@ -150,12 +150,12 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
    * Flag indicating if callback on JavaScript queue has been
    * scheduled.
    */
-  mutable std::atomic_bool isWorkLoopScheduled_{false};
+  std::atomic_bool isWorkLoopScheduled_{false};
 
   /*
    * This flag is set while performing work, to prevent re-entrancy.
    */
-  mutable std::atomic_bool isPerformingWork_{false};
+  std::atomic_bool isPerformingWork_{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RuntimeScheduler_Modern.h"
+#include "SchedulerPriorityUtils.h"
+
+#include <react/renderer/debug/SystraceSection.h>
+#include <utility>
+#include "ErrorUtils.h"
+
+namespace facebook::react {
+
+#pragma mark - Public
+
+RuntimeScheduler_Modern::RuntimeScheduler_Modern(
+    RuntimeExecutor runtimeExecutor,
+    std::function<RuntimeSchedulerTimePoint()> now)
+    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+
+void RuntimeScheduler_Modern::scheduleWork(
+    RawCallback&& callback) const noexcept {
+  SystraceSection s("RuntimeScheduler::scheduleWork");
+  scheduleTask(SchedulerPriority::ImmediatePriority, std::move(callback));
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
+    SchedulerPriority priority,
+    jsi::Function&& callback) const noexcept {
+  SystraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(priority),
+      "callbackType",
+      "jsi::Function");
+
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+
+  scheduleTask(task);
+
+  return task;
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
+    SchedulerPriority priority,
+    RawCallback&& callback) const noexcept {
+  SystraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(priority),
+      "callbackType",
+      "RawCallback");
+
+  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto task =
+      std::make_shared<Task>(priority, std::move(callback), expirationTime);
+
+  scheduleTask(task);
+
+  return task;
+}
+
+bool RuntimeScheduler_Modern::getShouldYield() const noexcept {
+  std::shared_lock lock(schedulingMutex_);
+
+  return syncTaskRequests_ > 0 ||
+      (!taskQueue_.empty() && taskQueue_.top() != currentTask_);
+}
+
+bool RuntimeScheduler_Modern::getIsSynchronous() const noexcept {
+  return isSynchronous_;
+}
+
+void RuntimeScheduler_Modern::cancelTask(Task& task) noexcept {
+  task.callback.reset();
+}
+
+SchedulerPriority RuntimeScheduler_Modern::getCurrentPriorityLevel()
+    const noexcept {
+  return currentPriority_;
+}
+
+RuntimeSchedulerTimePoint RuntimeScheduler_Modern::now() const noexcept {
+  return now_();
+}
+
+void RuntimeScheduler_Modern::executeNowOnTheSameThread(
+    RawCallback&& callback) {
+  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
+
+  syncTaskRequests_++;
+
+  executeSynchronouslyOnSameThread_CAN_DEADLOCK(
+      runtimeExecutor_,
+      [this, callback = std::move(callback)](jsi::Runtime& runtime) mutable {
+        SystraceSection s2(
+            "RuntimeScheduler::executeNowOnTheSameThread callback");
+
+        syncTaskRequests_--;
+
+        isSynchronous_ = true;
+
+        auto currentTime = now_();
+        auto priority = SchedulerPriority::ImmediatePriority;
+        auto expirationTime =
+            currentTime + timeoutForSchedulerPriority(priority);
+        auto task = std::make_shared<Task>(
+            priority, std::move(callback), expirationTime);
+
+        executeTask(runtime, task, currentTime);
+
+        isSynchronous_ = false;
+      });
+
+  bool shouldScheduleWorkLoop = false;
+
+  {
+    // Unique access because we might write to `isWorkLoopScheduled_`.
+    std::unique_lock lock(schedulingMutex_);
+
+    // We only need to schedule the work loop if there any remaining tasks
+    // in the queue.
+    if (!taskQueue_.empty() && !isWorkLoopScheduled_) {
+      isWorkLoopScheduled_ = true;
+      shouldScheduleWorkLoop = true;
+    }
+  }
+
+  if (shouldScheduleWorkLoop) {
+    scheduleWorkLoop();
+  }
+}
+
+// This will be replaced by microtasks
+void RuntimeScheduler_Modern::callExpiredTasks(jsi::Runtime& runtime) {
+  SystraceSection s("RuntimeScheduler::callExpiredTasks");
+  startWorkLoop(runtime, true);
+}
+
+#pragma mark - Private
+
+void RuntimeScheduler_Modern::scheduleTask(std::shared_ptr<Task> task) const {
+  bool shouldScheduleWorkLoop = false;
+
+  {
+    std::unique_lock lock(schedulingMutex_);
+
+    // We only need to schedule the work loop if the task we're about to
+    // schedule is the only one in the queue.
+    // Otherwise, we don't need to schedule it because there's another one
+    // running already that will pick up the new task.
+    if (taskQueue_.empty() && !isWorkLoopScheduled_) {
+      isWorkLoopScheduled_ = true;
+      shouldScheduleWorkLoop = true;
+    }
+
+    taskQueue_.push(task);
+  }
+
+  if (shouldScheduleWorkLoop) {
+    scheduleWorkLoop();
+  }
+}
+
+void RuntimeScheduler_Modern::scheduleWorkLoop() const {
+  runtimeExecutor_(
+      [this](jsi::Runtime& runtime) { startWorkLoop(runtime, false); });
+}
+
+void RuntimeScheduler_Modern::startWorkLoop(
+    jsi::Runtime& runtime,
+    bool onlyExpired) const {
+  SystraceSection s("RuntimeScheduler::startWorkLoop");
+
+  auto previousPriority = currentPriority_;
+
+  try {
+    while (syncTaskRequests_ == 0) {
+      auto currentTime = now_();
+      auto topPriorityTask = selectTask(currentTime, onlyExpired);
+
+      if (!topPriorityTask) {
+        // No pending work to do.
+        // Events will restart the loop when necessary.
+        break;
+      }
+
+      executeTask(runtime, topPriorityTask, currentTime);
+    }
+  } catch (jsi::JSError& error) {
+    handleFatalError(runtime, error);
+  }
+
+  currentPriority_ = previousPriority;
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Modern::selectTask(
+    RuntimeSchedulerTimePoint currentTime,
+    bool onlyExpired) const {
+  // We need a unique lock here because we'll also remove executed tasks from
+  // the top of the queue.
+  std::unique_lock lock(schedulingMutex_);
+
+  // It's safe to reset the flag here, as its access is also synchronized with
+  // the access to the task queue.
+  isWorkLoopScheduled_ = false;
+
+  // Skip executed tasks
+  while (!taskQueue_.empty() && !taskQueue_.top()->callback) {
+    taskQueue_.pop();
+  }
+
+  if (!taskQueue_.empty()) {
+    auto task = taskQueue_.top();
+    auto didUserCallbackTimeout = task->expirationTime <= currentTime;
+    if (!onlyExpired || didUserCallbackTimeout) {
+      return task;
+    }
+  }
+
+  return nullptr;
+}
+
+void RuntimeScheduler_Modern::executeTask(
+    jsi::Runtime& runtime,
+    const std::shared_ptr<Task>& task,
+    RuntimeSchedulerTimePoint currentTime) const {
+  auto didUserCallbackTimeout = task->expirationTime <= currentTime;
+
+  SystraceSection s(
+      "RuntimeScheduler::executeTask",
+      "priority",
+      serialize(task->priority),
+      "didUserCallbackTimeout",
+      didUserCallbackTimeout);
+
+  currentTask_ = task;
+  currentPriority_ = task->priority;
+
+  auto result = task->execute(runtime, didUserCallbackTimeout);
+
+  if (result.isObject() && result.getObject(runtime).isFunction(runtime)) {
+    // If the task returned a continuation callback, we re-assign it to the task
+    // and keep the task in the queue.
+    task->callback = result.getObject(runtime).getFunction(runtime);
+  }
+
+  // TODO execute microtasks
+  // TODO report long tasks
+  // TODO update rendering
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -21,15 +21,14 @@ RuntimeScheduler_Modern::RuntimeScheduler_Modern(
     std::function<RuntimeSchedulerTimePoint()> now)
     : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
 
-void RuntimeScheduler_Modern::scheduleWork(
-    RawCallback&& callback) const noexcept {
+void RuntimeScheduler_Modern::scheduleWork(RawCallback&& callback) noexcept {
   SystraceSection s("RuntimeScheduler::scheduleWork");
   scheduleTask(SchedulerPriority::ImmediatePriority, std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
     SchedulerPriority priority,
-    jsi::Function&& callback) const noexcept {
+    jsi::Function&& callback) noexcept {
   SystraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
@@ -48,7 +47,7 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
 
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
     SchedulerPriority priority,
-    RawCallback&& callback) const noexcept {
+    RawCallback&& callback) noexcept {
   SystraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
@@ -144,7 +143,7 @@ void RuntimeScheduler_Modern::callExpiredTasks(jsi::Runtime& runtime) {
 
 #pragma mark - Private
 
-void RuntimeScheduler_Modern::scheduleTask(std::shared_ptr<Task> task) const {
+void RuntimeScheduler_Modern::scheduleTask(std::shared_ptr<Task> task) {
   bool shouldScheduleWorkLoop = false;
 
   {
@@ -167,14 +166,14 @@ void RuntimeScheduler_Modern::scheduleTask(std::shared_ptr<Task> task) const {
   }
 }
 
-void RuntimeScheduler_Modern::scheduleWorkLoop() const {
+void RuntimeScheduler_Modern::scheduleWorkLoop() {
   runtimeExecutor_(
       [this](jsi::Runtime& runtime) { startWorkLoop(runtime, false); });
 }
 
 void RuntimeScheduler_Modern::startWorkLoop(
     jsi::Runtime& runtime,
-    bool onlyExpired) const {
+    bool onlyExpired) {
   SystraceSection s("RuntimeScheduler::startWorkLoop");
 
   auto previousPriority = currentPriority_;
@@ -201,7 +200,7 @@ void RuntimeScheduler_Modern::startWorkLoop(
 
 std::shared_ptr<Task> RuntimeScheduler_Modern::selectTask(
     RuntimeSchedulerTimePoint currentTime,
-    bool onlyExpired) const {
+    bool onlyExpired) {
   // We need a unique lock here because we'll also remove executed tasks from
   // the top of the queue.
   std::unique_lock lock(schedulingMutex_);
@@ -229,7 +228,7 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::selectTask(
 void RuntimeScheduler_Modern::executeTask(
     jsi::Runtime& runtime,
     const std::shared_ptr<Task>& task,
-    RuntimeSchedulerTimePoint currentTime) const {
+    RuntimeSchedulerTimePoint currentTime) {
   auto didUserCallbackTimeout = task->expirationTime <= currentTime;
 
   SystraceSection s(

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -43,7 +43,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    * To be removed when we finish testing this implementation.
    * All callers should use scheduleTask with the right priority afte that.
    */
-  void scheduleWork(RawCallback&& callback) const noexcept override;
+  void scheduleWork(RawCallback&& callback) noexcept override;
 
   /*
    * Grants access to the runtime synchronously on the caller's thread.
@@ -60,7 +60,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    */
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      jsi::Function&& callback) const noexcept override;
+      jsi::Function&& callback) noexcept override;
 
   /*
    * Adds a custom callback to the priority queue with the given priority.
@@ -68,7 +68,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    */
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
-      RawCallback&& callback) const noexcept override;
+      RawCallback&& callback) noexcept override;
 
   /*
    * Cancelled task will never be executed.
@@ -122,15 +122,15 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   void callExpiredTasks(jsi::Runtime& runtime) override;
 
  private:
-  mutable std::atomic<uint_fast8_t> syncTaskRequests_{0};
+  std::atomic<uint_fast8_t> syncTaskRequests_{0};
 
-  mutable std::priority_queue<
+  std::priority_queue<
       std::shared_ptr<Task>,
       std::vector<std::shared_ptr<Task>>,
       TaskPriorityComparer>
       taskQueue_;
 
-  mutable std::shared_ptr<Task> currentTask_;
+  std::shared_ptr<Task> currentTask_;
 
   /**
    * This protects the access to `taskQueue_` and `isWorkLoopScheduled_`.
@@ -138,18 +138,18 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   mutable std::shared_mutex schedulingMutex_;
 
   const RuntimeExecutor runtimeExecutor_;
-  mutable SchedulerPriority currentPriority_{SchedulerPriority::NormalPriority};
+  SchedulerPriority currentPriority_{SchedulerPriority::NormalPriority};
 
-  mutable std::atomic_bool isSynchronous_{false};
+  std::atomic_bool isSynchronous_{false};
 
-  void scheduleWorkLoop() const;
-  void startWorkLoop(jsi::Runtime& runtime, bool onlyExpired) const;
+  void scheduleWorkLoop();
+  void startWorkLoop(jsi::Runtime& runtime, bool onlyExpired);
 
   std::shared_ptr<Task> selectTask(
       RuntimeSchedulerTimePoint currentTime,
-      bool onlyExpired) const;
+      bool onlyExpired);
 
-  void scheduleTask(std::shared_ptr<Task> task) const;
+  void scheduleTask(std::shared_ptr<Task> task);
 
   /**
    * Follows all the steps necessary to execute the given task (in the future,
@@ -158,7 +158,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   void executeTask(
       jsi::Runtime& runtime,
       const std::shared_ptr<Task>& task,
-      RuntimeSchedulerTimePoint currentTime) const;
+      RuntimeSchedulerTimePoint currentTime);
 
   /*
    * Returns a time point representing the current point in time. May be called
@@ -170,7 +170,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    * Flag indicating if callback on JavaScript queue has been
    * scheduled.
    */
-  mutable bool isWorkLoopScheduled_{false};
+  bool isWorkLoopScheduled_{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -16,7 +16,7 @@
 
 namespace facebook::react {
 
-class RuntimeScheduler;
+class RuntimeScheduler_Legacy;
 class TaskPriorityComparer;
 
 using RawCallback = std::function<void(jsi::Runtime&)>;
@@ -33,7 +33,7 @@ struct Task final : public jsi::NativeState {
       std::chrono::steady_clock::time_point expirationTime);
 
  private:
-  friend RuntimeScheduler;
+  friend RuntimeScheduler_Legacy;
   friend TaskPriorityComparer;
 
   SchedulerPriority priority;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -17,6 +17,7 @@
 namespace facebook::react {
 
 class RuntimeScheduler_Legacy;
+class RuntimeScheduler_Modern;
 class TaskPriorityComparer;
 
 using RawCallback = std::function<void(jsi::Runtime&)>;
@@ -34,6 +35,7 @@ struct Task final : public jsi::NativeState {
 
  private:
   friend RuntimeScheduler_Legacy;
+  friend RuntimeScheduler_Modern;
   friend TaskPriorityComparer;
 
   SchedulerPriority priority;

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -24,30 +24,6 @@
 
 namespace facebook::react {
 
-// Looping on \c drainMicrotasks until it completes or hits the retries bound.
-static void performMicrotaskCheckpoint(jsi::Runtime& runtime) {
-  uint8_t retries = 0;
-  // A heuristic number to guard inifinite or absurd numbers of retries.
-  constexpr unsigned int kRetriesBound = 255;
-
-  while (retries < kRetriesBound) {
-    try {
-      // The default behavior of \c drainMicrotasks is unbounded execution.
-      // We may want to make it bounded in the future.
-      if (runtime.drainMicrotasks()) {
-        break;
-      }
-    } catch (jsi::JSError& error) {
-      handleJSError(runtime, error, true);
-    }
-    retries++;
-  }
-
-  if (retries == kRetriesBound) {
-    throw std::runtime_error("Hits microtasks retries bound.");
-  }
-}
-
 ReactInstance::ReactInstance(
     std::unique_ptr<jsi::Runtime> runtime,
     std::shared_ptr<MessageQueueThread> jsMessageQueueThread,
@@ -91,7 +67,6 @@ ReactInstance::ReactInstance(
                 if (auto strongTimerManager = weakTimerManager.lock()) {
                   strongTimerManager->callReactNativeMicrotasks(*strongRuntime);
                 }
-                performMicrotaskCheckpoint(*strongRuntime);
               } catch (jsi::JSError& originalError) {
                 handleJSError(*strongRuntime, originalError, true);
               }

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -28,7 +28,8 @@ ReactInstance::ReactInstance(
     std::unique_ptr<jsi::Runtime> runtime,
     std::shared_ptr<MessageQueueThread> jsMessageQueueThread,
     std::shared_ptr<TimerManager> timerManager,
-    JsErrorHandler::JsErrorHandlingFunc jsErrorHandlingFunc)
+    JsErrorHandler::JsErrorHandlingFunc jsErrorHandlingFunc,
+    bool useModernRuntimeScheduler)
     : runtime_(std::move(runtime)),
       jsMessageQueueThread_(jsMessageQueueThread),
       timerManager_(std::move(timerManager)),
@@ -75,8 +76,8 @@ ReactInstance::ReactInstance(
     }
   };
 
-  runtimeScheduler_ =
-      std::make_shared<RuntimeScheduler>(std::move(runtimeExecutor));
+  runtimeScheduler_ = std::make_shared<RuntimeScheduler>(
+      std::move(runtimeExecutor), useModernRuntimeScheduler);
 
   auto pipedRuntimeExecutor =
       [runtimeScheduler = runtimeScheduler_.get()](

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -32,7 +32,8 @@ class ReactInstance final {
       std::unique_ptr<jsi::Runtime> runtime,
       std::shared_ptr<MessageQueueThread> jsMessageQueueThread,
       std::shared_ptr<TimerManager> timerManager,
-      JsErrorHandler::JsErrorHandlingFunc JsErrorHandlingFunc);
+      JsErrorHandler::JsErrorHandlingFunc JsErrorHandlingFunc,
+      bool useModernRuntimeScheduler = false);
 
   RuntimeExecutor getUnbufferedRuntimeExecutor() noexcept;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -35,6 +35,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+ * This is a private protocol used to configure internal behavior of the runtime.
+ * DO NOT USE THIS OUTSIDE OF THE REACT NATIVE CODEBASE.
+ */
+@protocol RCTHostDelegateInternal <NSObject>
+
+// TODO(T166383606): Remove this method when we remove the legacy runtime scheduler or we have access to
+// ReactNativeConfig before we initialize it.
+- (BOOL)useModernRuntimeScheduler:(RCTHost *)host;
+
+@end
+
 @protocol RCTHostRuntimeDelegate <NSObject>
 
 - (void)host:(RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -23,7 +23,7 @@ RCT_MOCK_DEF(RCTHost, _RCTLogNativeInternal);
 
 using namespace facebook::react;
 
-@interface RCTHost () <RCTReloadListener, RCTInstanceDelegate>
+@interface RCTHost () <RCTReloadListener, RCTInstanceDelegate, RCTInstanceDelegateInternal>
 @end
 
 @implementation RCTHost {
@@ -245,6 +245,17 @@ using namespace facebook::react;
 - (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime
 {
   [self.runtimeDelegate host:self didInitializeRuntime:runtime];
+}
+
+#pragma mark - RCTInstanceDelegateInternal
+
+- (BOOL)useModernRuntimeScheduler:(RCTHost *)host
+{
+  if ([_hostDelegate respondsToSelector:@selector(useModernRuntimeScheduler:)]) {
+    return [(id)_hostDelegate useModernRuntimeScheduler:self];
+  }
+
+  return NO;
 }
 
 #pragma mark - RCTContextContainerHandling

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
@@ -46,6 +46,18 @@ RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *_Nullable flags);
 
 @end
 
+/**
+ * This is a private protocol used to configure internal behavior of the runtime.
+ * DO NOT USE THIS OUTSIDE OF THE REACT NATIVE CODEBASE.
+ */
+@protocol RCTInstanceDelegateInternal <NSObject>
+
+// TODO(T166383606): Remove this method when we remove the legacy runtime scheduler or we have access to
+// ReactNativeConfig before we initialize it.
+- (BOOL)useModernRuntimeScheduler:(RCTInstance *)instance;
+
+@end
+
 typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
 
 /**

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -216,12 +216,18 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   __weak __typeof(self) weakSelf = self;
   auto jsErrorHandlingFunc = [=](MapBuffer errorMap) { [weakSelf _handleJSErrorMap:std::move(errorMap)]; };
 
+  auto useModernRuntimeScheduler = false;
+  if ([_delegate respondsToSelector:@selector(useModernRuntimeScheduler:)]) {
+    useModernRuntimeScheduler = [(id)_delegate useModernRuntimeScheduler:self];
+  }
+
   // Create the React Instance
   _reactInstance = std::make_unique<ReactInstance>(
       _jsEngineInstance->createJSRuntime(_jsThreadManager.jsMessageThread),
       _jsThreadManager.jsMessageThread,
       timerManager,
-      jsErrorHandlingFunc);
+      jsErrorHandlingFunc,
+      useModernRuntimeScheduler);
   _valid = true;
 
   RuntimeExecutor bufferedRuntimeExecutor = _reactInstance->getBufferedRuntimeExecutor();


### PR DESCRIPTION
Summary:
This removes misleading `const` modifiers from some methods in `RuntimeScheduler` that shouldn't really use it, and removes the `mutable` modifiers that were only necessary because of that.

Changelog: [internal]

Reviewed By: sammy-SC

Differential Revision: D50364626

