### PR TITLE
Fix android platform border color (#39893)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -204,6 +204,11 @@ import java.util.Map;
       mDefaultValue = defaultValue;
     }
 
+    public ColorPropSetter(ReactPropGroup prop, Method setter, int index, int defaultValue) {
+      super(prop, "mixed", setter, index);
+      mDefaultValue = defaultValue;
+    }
+
     @Override
     protected Object getValueOrDefault(Object value, Context context) {
       if (value == null) {
@@ -329,6 +334,10 @@ import java.util.Map;
 
     public BoxedColorPropSetter(ReactProp prop, Method setter) {
       super(prop, "mixed", setter);
+    }
+
+    public BoxedColorPropSetter(ReactPropGroup prop, Method setter, int index) {
+      super(prop, "mixed", setter, index);
     }
 
     @Override
@@ -463,7 +472,11 @@ import java.util.Map;
       }
     } else if (propTypeClass == int.class) {
       for (int i = 0; i < names.length; i++) {
-        props.put(names[i], new IntPropSetter(annotation, method, i, annotation.defaultInt()));
+        if ("Color".equals(annotation.customType())) {
+          props.put(names[i], new ColorPropSetter(annotation, method, i, annotation.defaultInt()));
+        } else {
+          props.put(names[i], new IntPropSetter(annotation, method, i, annotation.defaultInt()));
+        }
       }
     } else if (propTypeClass == float.class) {
       for (int i = 0; i < names.length; i++) {
@@ -476,7 +489,11 @@ import java.util.Map;
       }
     } else if (propTypeClass == Integer.class) {
       for (int i = 0; i < names.length; i++) {
-        props.put(names[i], new BoxedIntPropSetter(annotation, method, i));
+        if ("Color".equals(annotation.customType())) {
+          props.put(names[i], new BoxedColorPropSetter(annotation, method, i));
+        } else {
+          props.put(names[i], new BoxedIntPropSetter(annotation, method, i));
+        }
       }
     } else {
       throw new RuntimeException(


### PR DESCRIPTION
At Chime X Software Mansion we need this fix to be cherry-picked to RN `0.71+` as currently there is no option for us to upgrade to the next version ( this fix has not been released anyway) and we are blocked with our next project there.

It would be amazing if you could release it!

--------

Summary:
If you try to apply PlatformColor to borders on Android app will crash with the next error:

"Error while updating property 'borderColor' of a view managed by: RCTView"

## Changelog:

[ANDROID] [FIXED] - Fix android crash when apply PlatformColor to borders

Pull Request resolved: https://github.com/facebook/react-native/pull/39893

Test Plan:
In RNTester example, go to APIs -> PlatformColor
|    Before  | After |
| ----------- | ----------- |
|  <img src="https://github.com/facebook/react-native/assets/70860930/66ac2880-53da-4438-bd9a-332f8ea40645" alt="drawing" width="200"/>    | <img src="https://github.com/facebook/react-native/assets/70860930/151f58a1-d857-4b3d-9ec6-de74eb065127" alt="drawing" width="200"/>      |

Reviewed By: NickGerleman

Differential Revision: D50011758

Pulled By: javache

fbshipit-source-id: ea06c18c6aef4b6731e9b9b87422a1e0d13de208 (cherry picked from commit 265af222aa8acb3b514e22a7db191d66755f553b)
