### PR TITLE
Make IntArray events work on Bridgeless for RN-Tester

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeView.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeView.kt
@@ -110,7 +110,7 @@ class MyNativeView(context: ThemedReactContext) : View(context) {
       viewId: Int,
       private val payload: WritableMap
   ) : Event<OnIntArrayChangedEvent>(surfaceId, viewId) {
-    override fun getEventName() = "onIntArrayChanged"
+    override fun getEventName() = "topIntArrayChanged"
 
     override fun getEventData() = payload
   }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
@@ -60,7 +60,7 @@ internal class MyNativeViewManager :
   override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> =
       MapBuilder.builder<String, Any>()
           .put(
-              "onIntArrayChanged",
+              "topIntArrayChanged",
               MapBuilder.of<String, Any>(
                   "phasedRegistrationNames",
                   MapBuilder.of(


### PR DESCRIPTION
Summary:
Array events are currently broken in the sample for RN Tester. This is because the event name is not registered correctly.

I'm updating the event registration to be correct.

Changelog:
[Internal] [Changed] - Make IntArray events work on Bridgeless for RN-Tester

Reviewed By: cipolleschi

Differential Revision: D50266485


