### PR TITLE
Align all the pods to 13.4

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -265,24 +265,13 @@ class ReactNativePodsUtils
     end
 
     def self.updateOSDeploymentTarget(installer)
-        pod_to_update = Set.new([
-            "boost",
-            "CocoaAsyncSocket",
-            "fmt",
-            "libevent",
-            "OpenSSL-Universal",
-            "RCT-Folly",
-            "SocketRocket",
-            "YogaKit"
-        ])
-
         installer.target_installation_results.pod_target_installation_results
             .each do |pod_name, target_installation_result|
-                unless pod_to_update.include?(pod_name)
-                    next
-                end
                 target_installation_result.native_target.build_configurations.each do |config|
-                    config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = Helpers::Constants.min_ios_version_supported
+                    old_iphone_deploy_target = config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] ?
+                        config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] :
+                        Helpers::Constants.min_ios_version_supported
+                    config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = [Helpers::Constants.min_ios_version_supported.to_f, old_iphone_deploy_target.to_f].max.to_s
                 end
             end
     end


### PR DESCRIPTION
Summary:
This change aligns all the podspecs to 13.4, including 3rd party libraries. This should fix https://github.com/facebook/react-native/issues/39826

## Changelog
[iOS][Changed] - Align all pods to 13.4

Differential Revision: D50405114


