### PR TITLE
add explicit check for empty preMountItems

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -312,6 +312,11 @@ public class MountItemDispatcher {
   @UiThread
   @ThreadConfined(UI)
   public void dispatchPreMountItems(long frameTimeNanos) {
+    if (mPreMountItems.isEmpty()) {
+      // Avoid starting systrace if there are no pre mount items.
+      return;
+    }
+
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "FabricUIManager::premountViews");
 
     // dispatchPreMountItems cannot be reentrant, but we want to prevent dispatchMountItems from


### PR DESCRIPTION
Summary:
changelog: [internal]

Avoid going into a while loop if there are no preMountItems.

Reviewed By: javache

Differential Revision: D50407034


