### PR TITLE
Revert accidental bridgelessEnabled=true for RN Tester

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -129,7 +129,7 @@ class RNTesterApplication : Application(), ReactApplication {
     super.onCreate()
     SoLoader.init(this, /* native exopackage */ false)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      load(bridgelessEnabled = true)
+      load()
     }
   }
 }


### PR DESCRIPTION
Summary:
As the title says,
I accidentally included this as the diff on top of it that would have made this flag toggleable was abandoned.

Changelog:
[Internal] [Changed] - Revert accidental bridgelessEnabled=true for RN Tester

Differential Revision: D50409804


