### PR TITLE
Fix Glog for earlier versions of Xcode

### DIFF
--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -29,10 +29,23 @@ Pod::Spec.new do |spec|
                         'src/base/*.h'
   spec.exclude_files       = "src/windows/**/*"
   spec.compiler_flags      = '-Wno-shorten-64-to-32'
+
+  # TODO: T167482718 Remove this code after April 2024, when Apple will
+  # push the lower version of Xcode required to upload apps to the Store.
+  xcode_path = `xcodebuild -version` # This return the current version of Xcode
+
+  match = xcode_path.match(/Xcode (\d+)\.(\d+)/)
+  major_version = match[1].to_i
+  minor_version = match[2].to_i
+  is_greater_than_15 = major_version >= 15
+  is_greater_than_14_3 = major_version == 14 && minor_version >= 3
+  should_define_modules = is_greater_than_15 ? "YES" : is_greater_than_14_3 ? "YES" : "NO"
+  # End TODO.
+
   spec.pod_target_xcconfig = {
     "USE_HEADERMAP" => "NO",
     "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src",
-    "DEFINES_MODULE" => "YES"
+    "DEFINES_MODULE" => should_define_modules # When the workaround is removed, set this var to "YES"
   }
 
   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
Summary:
Glog has a piece of code which looks like this:
```
namespace google {

// They need the definitions of integer types.
#include "glog/log_severity.h"
#include "glog/vlog_is_on.h"
```

This fragment is:
- Always valid when the pod does not define a module
- Valid for Xcode >= 14.3, when the pod do define a module
- Invalid for Xcode < 14.3, when the pod do define a module

Modules are required to support Swift, so, in the long run, we want to have `DEFINES_MODULE` set to `YES` for `Glog`.

This is a temporary workaround to keep supporting older versions of Xcode while Apple keeps allowing to use Xcode 14.1 to submit apps to the store.
Historically, Apple pushes the minimum version of Xcode every April, so we expect to be able to remove this workaround in April 2024.

## Changelog:
[Internal] - Make Glog work with older versions of Xcode

Differential Revision: D50410487


