### PR TITLE
Fix tests - remove folly/File.h import in jsbigstring test

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/tests/jsbigstring.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/tests/jsbigstring.cpp
@@ -9,7 +9,6 @@
 #include <sys/mman.h>
 
 #include <cxxreact/JSBigString.h>
-#include <folly/File.h>
 #include <gtest/gtest.h>
 
 using namespace facebook::react;


### PR DESCRIPTION
Summary:
Remove unused import that was breaking tests

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D50380976


