### PR TITLE
remove redundant method from MountItemDispatcher

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1023,7 +1023,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       final int reactTag,
       final int commandId,
       @Nullable final ReadableArray commandArgs) {
-    mMountItemDispatcher.dispatchCommandMountItem(
+    mMountItemDispatcher.addViewCommandMountItem(
         MountItemFactory.createDispatchCommandMountItem(
             surfaceId, reactTag, commandId, commandArgs));
   }
@@ -1039,10 +1039,10 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       // For Fabric Interop, we check if the commandId is an integer. If it is, we use the integer
       // overload of dispatchCommand. Otherwise, we use the string overload.
       // and the events won't be correctly dispatched.
-      mMountItemDispatcher.dispatchCommandMountItem(
+      mMountItemDispatcher.addViewCommandMountItem(
           createDispatchCommandMountItemForInterop(surfaceId, reactTag, commandId, commandArgs));
     } else {
-      mMountItemDispatcher.dispatchCommandMountItem(
+      mMountItemDispatcher.addViewCommandMountItem(
           MountItemFactory.createDispatchCommandMountItem(
               surfaceId, reactTag, commandId, commandArgs));
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -93,15 +93,11 @@ public class MountItemDispatcher {
   }
 
   /**
-   * Try to dispatch MountItems. Returns true if any items were dispatched, false otherwise. A
-   * `false` return value doesn't indicate errors, it may just indicate there was no work to be
-   * done.
-   *
-   * @return
+   * Try to dispatch MountItems. In case of the exception, we will retry 10 times before giving up.
    */
   @UiThread
   @ThreadConfined(UI)
-  public boolean tryDispatchMountItems() {
+  public void tryDispatchMountItems() {
     // If we're already dispatching, don't reenter.
     // Reentrance can potentially happen a lot on Android in Fabric because
     // `updateState` from the
@@ -111,7 +107,7 @@ public class MountItemDispatcher {
     // This is a pretty blunt tool, but we might not have better options since we really don't want
     // to execute anything out-of-order.
     if (mInDispatch) {
-      return false;
+      return;
     }
 
     final boolean didDispatchItems;
@@ -145,7 +141,6 @@ public class MountItemDispatcher {
       tryDispatchMountItems();
     }
     mReDispatchCounter = 0;
-    return didDispatchItems;
   }
 
   @UiThread

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -7,14 +7,12 @@
 
 package com.facebook.react.fabric.mounting;
 
-import static com.facebook.infer.annotation.ThreadConfined.ANY;
 import static com.facebook.infer.annotation.ThreadConfined.UI;
 import static com.facebook.react.fabric.FabricUIManager.ENABLE_FABRIC_LOGS;
 import static com.facebook.react.fabric.FabricUIManager.IS_DEVELOPMENT_ENVIRONMENT;
 
 import android.os.SystemClock;
 import android.view.View;
-import androidx.annotation.AnyThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
@@ -62,10 +60,8 @@ public class MountItemDispatcher {
     mItemDispatchListener = listener;
   }
 
-  @AnyThread
-  @ThreadConfined(ANY)
-  public void dispatchCommandMountItem(DispatchCommandMountItem command) {
-    addViewCommandMountItem(command);
+  public void addViewCommandMountItem(DispatchCommandMountItem mountItem) {
+    mViewCommandMountItems.add(mountItem);
   }
 
   public void addMountItem(MountItem mountItem) {
@@ -86,10 +82,6 @@ public class MountItemDispatcher {
           mountItem.getSurfaceId(),
           mountItem.toString());
     }
-  }
-
-  public void addViewCommandMountItem(DispatchCommandMountItem mountItem) {
-    mViewCommandMountItems.add(mountItem);
   }
 
   /**
@@ -159,7 +151,7 @@ public class MountItemDispatcher {
             mountItem.incrementRetries();
             // In case we haven't retried executing this item yet, execute in the next batch of
             // items
-            dispatchCommandMountItem(mountItem);
+            addViewCommandMountItem(mountItem);
           }
         } else {
           printMountItem(
@@ -214,7 +206,7 @@ public class MountItemDispatcher {
           // the current batch of mount items has finished executing.
           if (command.getRetries() == 0) {
             command.incrementRetries();
-            dispatchCommandMountItem(command);
+            addViewCommandMountItem(command);
           } else {
             // It's very common for commands to be executed on views that no longer exist - for
             // example, a blur event on TextInput being fired because of a navigation event away


### PR DESCRIPTION
Summary:
changelog: [internal]

Method `dispatchCommandMountItem` only calls `addViewCommandMountItem`  without adding anything on top of it. The name is inaccurate because it doesn't dispatch mount item, it queues it.

Let's remove one of them to simplify the API.

Differential Revision: D50408576


