### PR TITLE
Add @DoNotStripAny to JSTimerExecutor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.java
@@ -9,20 +9,21 @@ package com.facebook.react.runtime;
 
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
-import com.facebook.jni.annotations.DoNotStrip;
+import com.facebook.jni.annotations.DoNotStripAny;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.modules.core.JavaScriptTimerExecutor;
 import com.facebook.soloader.SoLoader;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
+@DoNotStripAny
 class JSTimerExecutor implements JavaScriptTimerExecutor {
 
   static {
     SoLoader.loadLibrary("rninstance");
   }
 
-  @DoNotStrip private final HybridData mHybridData;
+  private final HybridData mHybridData;
 
   public JSTimerExecutor(HybridData hybridData) {
     mHybridData = hybridData;


### PR DESCRIPTION
Summary:
RNTester release build is crashing as following, this diff add DoNotStripAny to JSTimerExecutor to avoid over-stripping for release build.


 {F1124087084}

Changelog:
[Android][Changed] -  Add DoNotStripAny to JSTimerExecutor

Reviewed By: cortinico

Differential Revision: D50410412


