### PR TITLE
Fix RuntimeScheduler tests on iOS

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -170,7 +170,7 @@ TEST_P(RuntimeSchedulerTest, scheduleTwoTasksWithSamePriority) {
   runtimeScheduler_->scheduleTask(
       SchedulerPriority::NormalPriority, std::move(callbackOne));
 
-  uint secondTaskCallOrder;
+  uint secondTaskCallOrder = 0;
   auto callbackTwo = createHostFunctionFromLambda(
       [this, &secondTaskCallOrder](bool /*unused*/) {
         secondTaskCallOrder = hostFunctionCallCount_;
@@ -203,7 +203,7 @@ TEST_P(RuntimeSchedulerTest, scheduleTwoTasksWithDifferentPriorities) {
   runtimeScheduler_->scheduleTask(
       SchedulerPriority::LowPriority, std::move(callbackOne));
 
-  uint userBlockingPriorityTaskCallOrder;
+  uint userBlockingPriorityTaskCallOrder = 0;
   auto callbackTwo = createHostFunctionFromLambda(
       [this, &userBlockingPriorityTaskCallOrder](bool /*unused*/) {
         userBlockingPriorityTaskCallOrder = hostFunctionCallCount_;


### PR DESCRIPTION
Summary:
Some tests for RuntimeScheduler broke because we used uninitialized values incorrectly (they're initialized with 0 on Android but with something like `0101010101...` on iOS).

This fixes the tests by assigning the right initial value.

Changelog: [internal]

Reviewed By: sammy-SC

Differential Revision: D50413220


