### PR TITLE
Add `number | null` to `ViewProps['hitSlop']` TypeScript type

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
@@ -184,7 +184,7 @@ export interface ViewProps
    * the Z-index of sibling views always takes precedence if a touch
    * hits two overlapping views.
    */
-  hitSlop?: Insets | undefined;
+  hitSlop?: null | Insets | number | undefined;
 
   /**
    * Used to reference react managed views from native code.


### PR DESCRIPTION
## Summary:

Setting the `hitSlop` of a `View` to be a `number` didn't work. The Flow type already allows `number`:
https://github.com/facebook/react-native/blob/6e42c98aa3423cfbc389e4fe877b5c6b559c8a81/packages/react-native/Libraries/Components/View/ViewPropTypes.js#L618

 I updated it to match the [`TouchableWithoutFeedbackProps['hitSlop']`](https://github.com/facebook/react-native/blob/6e42c98aa3423cfbc389e4fe877b5c6b559c8a81/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.d.ts#L72) and [`PressableProps['hitSlop']`](https://github.com/facebook/react-native/blob/6e42c98aa3423cfbc389e4fe877b5c6b559c8a81/packages/react-native/Libraries/Components/Pressable/Pressable.d.ts#L126) types.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] Add `number | null` to `ViewProps['hitSlop']` TypeScript type

## Test Plan:

Ran `yarn test-typescript` and `yarn test-typescript-offline` and there were no errors.
