### PR TITLE
Add missing ping() method into WebSocket interface

### DIFF
--- a/packages/react-native/types/modules/globals.d.ts
+++ b/packages/react-native/types/modules/globals.d.ts
@@ -460,6 +460,7 @@ interface WebSocket extends EventTarget {
   readonly readyState: number;
   send(data: string | ArrayBuffer | ArrayBufferView | Blob): void;
   close(code?: number, reason?: string): void;
+  ping(): void;
   onopen: (() => void) | null;
   onmessage: ((event: WebSocketMessageEvent) => void) | null;
   onerror: ((event: WebSocketErrorEvent) => void) | null;


### PR DESCRIPTION
The `ping()` method seems missing in `WebSocket` interface. The implementation can be found in different places :

https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java#L323

https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/WebSocket/NativeWebSocketModule.js#L24

https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/WebSocket/WebSocket.js#L209

## Summary:

The change adds missing `ping()` method into `WebSocket` TypeScript interface.

## Changelog:

[GENERAL] [FIXED] - Add missing `ping()` method into `WebSocket` interface

## Test Plan:

Running `yarn test-typescript` and `yarn test-typescript-offline` works with no errors.
