### PR TITLE
Warn when fabric is used without concurrent root

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppContainer.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer.js
@@ -22,7 +22,6 @@ const reactDevToolsHook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 type Props = $ReadOnly<{|
   children?: React.Node,
   fabric?: boolean,
-  useConcurrentRoot?: boolean,
   rootTag: number | RootTag,
   initialProps?: {...},
   showArchitectureIndicator?: boolean,

--- a/packages/react-native/Libraries/ReactNative/renderApplication.js
+++ b/packages/react-native/Libraries/ReactNative/renderApplication.js
@@ -83,6 +83,12 @@ export default function renderApplication<Props: Object>(
     );
   }
 
+  if (fabric && !useConcurrentRoot) {
+    console.warn(
+      'Using Fabric without concurrent root is deprecated. Please enable concurrent root for this application.',
+    );
+  }
+
   performanceLogger.startTimespan('renderApplication_React_render');
   performanceLogger.setExtra(
     'usedReactConcurrentRoot',


### PR DESCRIPTION
Summary:
As part of the new architecture rollout, we want to simplify our set of supported configurations. Right now it is possible to use Fabric / new architecture without using concurrent root, which prevents us from bringing the new concurrent capabilities to these applications and holds back React renderer code.

Changelog: [Deprecated] Using the new architecture without concurrent root will soon not be supported.

Differential Revision: D50425540


