### PR TITLE
change order of build steps, delete unused drivers

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -127,6 +127,12 @@ jobs:
           package: cmake
       - setup_ruby:
           ruby_version: << parameters.ruby_version >>
+      - run:
+          name: Install appium
+          command: npm install appium@2.0.0 -g
+      - run:
+          name: Install appium drivers
+          command: appium driver install xcuitest
       - with_xcodebuild_cache:
           steps:
             - run:
@@ -149,6 +155,12 @@ jobs:
                 name: Move app to correct directory
                 command: mv /tmp/e2e/Build/Products/Debug-iphonesimulator/RNTester.app packages/rn-tester-e2e/apps/rn-tester.app
             - run:
+                name: Start Appium server and check status status
+                command: |
+                  appium --base-path /wd/hub
+                  scripts/circleci/check_appium_server_status.sh
+                background: true
+            - run:
                 name: Start Metro
                 command: |
                   cd packages/rn-tester
@@ -157,19 +169,6 @@ jobs:
             - run:
                 name: Boot iOS Simulator
                 command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
-            - run:
-                name: Install appium
-                command: npm install appium@2.0.0 -g
-            - run:
-                name: Install appium drivers
-                command: appium driver install xcuitest
-            - run:
-                name: Start Appium server
-                command: appium --base-path /wd/hub
-                background: true
-            - run:
-                name: Check Appium server status
-                command: scripts/circleci/check_appium_server_status.sh
             - run:
                 name: Run E2E tests
                 no_output_timeout: 10m
@@ -189,6 +188,12 @@ jobs:
     steps:
       - checkout_code_with_cache
       - run_yarn
+      - run:
+          name: Install appium
+          command: npm install appium@2.0.0 -g
+      - run:
+          name: Install appium drivers
+          command: appium driver install uiautomator2@2.29.1
       - android/create-avd:
           avd-name: e2e_emulator
           system-image: system-images;android-34;google_apis;x86_64
@@ -203,6 +208,12 @@ jobs:
           name: Move app to correct directory
           command: mv packages/rn-tester/android/app/build/outputs/apk/hermes/debug/app-hermes-x86_64-debug.apk packages/rn-tester-e2e/apps/rn-tester.apk
       - run:
+          name: Start Appium server and check status status
+          command: |
+            appium --base-path /wd/hub
+            scripts/circleci/check_appium_server_status.sh
+          background: true
+      - run:
           name: Start Metro
           command: |
             cd packages/rn-tester
@@ -213,24 +224,6 @@ jobs:
           no-window: true
           restore-gradle-cache-prefix: v1a
           post-emulator-launch-assemble-command: ""
-      - run:
-          name: Install appium
-          command: npm install appium@2.0.0 -g
-      - run:
-          name: Install appium drivers
-          command: |
-            appium driver install uiautomator2@2.29.1
-      - run:
-          name: Start Appium server
-          command: appium --base-path /wd/hub
-          background: true
-      - run:
-          name: Check Appium server status
-          command: |
-            if ! nc -z 127.0.0.1 4723; then
-              echo Could not find Appium server
-              exit 1
-            fi
       - run:
           name: Run E2E tests
           no_output_timeout: 10m

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -155,10 +155,8 @@ jobs:
                 name: Move app to correct directory
                 command: mv /tmp/e2e/Build/Products/Debug-iphonesimulator/RNTester.app packages/rn-tester-e2e/apps/rn-tester.app
             - run:
-                name: Start Appium server and check status status
-                command: |
-                  appium --base-path /wd/hub
-                  scripts/circleci/check_appium_server_status.sh
+                name: Start Appium server
+                command: appium --base-path /wd/hub
                 background: true
             - run:
                 name: Start Metro
@@ -169,6 +167,9 @@ jobs:
             - run:
                 name: Boot iOS Simulator
                 command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
+            - run:
+                name: Check Appium server status
+                command: scripts/circleci/check_appium_server_status.sh
             - run:
                 name: Run E2E tests
                 no_output_timeout: 10m
@@ -211,7 +212,6 @@ jobs:
           name: Start Appium server and check status status
           command: |
             appium --base-path /wd/hub
-            scripts/circleci/check_appium_server_status.sh
           background: true
       - run:
           name: Start Metro
@@ -224,6 +224,9 @@ jobs:
           no-window: true
           restore-gradle-cache-prefix: v1a
           post-emulator-launch-assemble-command: ""
+      - run:
+          name: Check Appium server status
+          command: scripts/circleci/check_appium_server_status.sh
       - run:
           name: Run E2E tests
           no_output_timeout: 10m

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -123,31 +123,10 @@ jobs:
       - checkout_code_with_cache
       - run_yarn
       - setup_hermes_version
-      - run:
-          name: Install appium
-          command: npm install appium@2.0.0 -g
-      - run:
-          name: Install appium drivers
-          command: |
-            appium driver install uiautomator2
-            appium driver install xcuitest
-      - run:
-          name: Start Appium server
-          command: appium --base-path /wd/hub
-          background: true
-      - run:
-          name: Start Metro
-          command: |
-            cd packages/rn-tester
-            yarn start
-          background: true
       - brew_install:
           package: cmake
       - setup_ruby:
           ruby_version: << parameters.ruby_version >>
-      - run:
-          name: Boot iOS Simulator
-          command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
       - with_xcodebuild_cache:
           steps:
             - run:
@@ -170,11 +149,30 @@ jobs:
                 name: Move app to correct directory
                 command: mv /tmp/e2e/Build/Products/Debug-iphonesimulator/RNTester.app packages/rn-tester-e2e/apps/rn-tester.app
             - run:
+                name: Start Metro
+                command: |
+                  cd packages/rn-tester
+                  yarn start
+                background: true
+            - run:
+                name: Boot iOS Simulator
+                command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
+            - run:
+                name: Install appium
+                command: npm install appium@2.0.0 -g
+            - run:
+                name: Install appium drivers
+                command: appium driver install xcuitest
+            - run:
+                name: Start Appium server
+                command: appium --base-path /wd/hub
+                background: true
+            - run:
                 name: Check Appium server status
                 command: scripts/circleci/check_appium_server_status.sh
             - run:
                 name: Run E2E tests
-                no_output_timeout: 30m
+                no_output_timeout: 10m
                 command: |
                   cd packages/rn-tester-e2e
                   (yarn test-e2e ios 2>&1 | tee /tmp/test_log) || true
@@ -195,6 +193,21 @@ jobs:
           avd-name: e2e_emulator
           system-image: system-images;android-34;google_apis;x86_64
           install: true
+      - with_gradle_cache:
+          steps:
+            - run:
+                name: Build app
+                command: |
+                  ./gradlew :packages:rn-tester:android:app:assembleHermesDebug -PreactNativeArchitectures=x86_64
+      - run:
+          name: Move app to correct directory
+          command: mv packages/rn-tester/android/app/build/outputs/apk/hermes/debug/app-hermes-x86_64-debug.apk packages/rn-tester-e2e/apps/rn-tester.apk
+      - run:
+          name: Start Metro
+          command: |
+            cd packages/rn-tester
+            yarn start
+          background: true
       - android/start-emulator:
           avd-name: e2e_emulator
           no-window: true
@@ -207,26 +220,10 @@ jobs:
           name: Install appium drivers
           command: |
             appium driver install uiautomator2@2.29.1
-            appium driver install xcuitest@4.32.10
       - run:
           name: Start Appium server
           command: appium --base-path /wd/hub
           background: true
-      - run:
-          name: Start Metro
-          command: |
-            cd packages/rn-tester
-            yarn start
-          background: true
-      - with_gradle_cache:
-          steps:
-            - run:
-                name: Build app
-                command: |
-                  ./gradlew :packages:rn-tester:android:app:assembleHermesDebug -PreactNativeArchitectures=x86_64
-      - run:
-          name: Move app to correct directory
-          command: mv packages/rn-tester/android/app/build/outputs/apk/hermes/debug/app-hermes-x86_64-debug.apk packages/rn-tester-e2e/apps/rn-tester.apk
       - run:
           name: Check Appium server status
           command: |
@@ -236,7 +233,7 @@ jobs:
             fi
       - run:
           name: Run E2E tests
-          no_output_timeout: 30m
+          no_output_timeout: 10m
           command: |
             cd packages/rn-tester-e2e
             (yarn test-e2e android 2>&1 | tee /tmp/test_log) || true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

After checking failed e2e jobs I've noticed that job test_e2e_android and test_e2e_ios have some steps that can be rearranged to run after the build command. This change will reduce the time of idle metro and appium server and maybe will reduce flakiness.
I've deleted installing unused appium driver(xcuitest for android, and uiautomator2 for ios)
Reduced no_output_timeout to 10min. I think that there's no case that we need to set it to as high as 30min when whole test suite only takes around 10min



