### PR TITLE
[RN][CI] Make hermes build more robust to avoid cache poisoning

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -877,6 +877,22 @@ jobs:
 
             echo "Moving from build_$SLICE to $FINAL_PATH"
             mv build_"$SLICE" "$FINAL_PATH"
+
+            # check whether everything is there
+            if [[ -d "$FINAL_PATH/API/hermes/hermes.framework" ]]; then
+              echo "Successfully built hermes.framework for $SLICE in $FLAVOR"
+            else
+              echo "Failed to built hermes.framework for $SLICE in $FLAVOR"
+              exit 1
+            fi
+
+            if [[ -d "$FINAL_PATH/API/hermes/hermes.framework.dSYM" ]]; then
+              echo "Successfully built hermes.framework.dSYM for $SLICE in $FLAVOR"
+            else
+              echo "Failed to built hermes.framework.dSYM for $SLICE in $FLAVOR"
+              echo "Please try again"
+              exit 1
+            fi
       - save_cache:
           key: << parameters.slice_base_cache_key >>-<< parameters.slice >>-<< parameters.flavor >>
           paths:

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -82,7 +82,7 @@ references:
     hermes_windows_cache_key: &hermes_windows_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-windows-{{ checksum "/Users/circleci/project/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     # Hermes iOS
     hermesc_apple_cache_key: &hermesc_apple_cache_key v2-hermesc-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    hermes_apple_slices_cache_key: &hermes_apple_slices_cache_key v2-hermes-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
+    hermes_apple_slices_cache_key: &hermes_apple_slices_cache_key v3-hermes-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v4-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v3-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_macosx_bin_release_cache_key: &hermes_macosx_bin_release_cache_key v1-hermes-release-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}


### PR DESCRIPTION
## Summary:

In one of the latests commits on main, Hermes failed somehow to build dSYMs in some slices.
However, the slices were cached (so the cache is poisoned) and the overall process failed.

With this change, we aim to make the slice's build process fail if the dSYM or the actual framework is not built properly, before caching, so they are not poisoned

## Changelog:
[Internal] - Fail the build if dSYM or hermes.frameworks are not built

## Test Plan:
CircleCI is green
