### PR TITLE
Remove remote JS debugging (Android)

### DIFF
--- a/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactSettingsForTests.java
+++ b/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactSettingsForTests.java
@@ -42,14 +42,6 @@ public class ReactSettingsForTests implements DeveloperSettings {
   }
 
   @Override
-  public boolean isRemoteJSDebugEnabled() {
-    return false;
-  }
-
-  @Override
-  public void setRemoteJSDebugEnabled(boolean remoteJSDebugEnabled) {}
-
-  @Override
   public boolean isStartSamplingProfilerOnInit() {
     return false;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -57,12 +57,10 @@ import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JSExceptionHandler;
 import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.react.bridge.JSIModuleType;
-import com.facebook.react.bridge.JavaJSExecutor;
 import com.facebook.react.bridge.JavaScriptExecutor;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.NativeModuleRegistry;
 import com.facebook.react.bridge.NotThreadSafeBridgeIdleDebugListener;
-import com.facebook.react.bridge.ProxyJavaScriptExecutor;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactCxxErrorHandler;
@@ -298,11 +296,6 @@ public class ReactInstanceManager {
   private ReactInstanceDevHelper createDevHelperInterface() {
     return new ReactInstanceDevHelper() {
       @Override
-      public void onReloadWithJSDebugger(JavaJSExecutor.Factory jsExecutorFactory) {
-        ReactInstanceManager.this.onReloadWithJSDebugger(jsExecutorFactory);
-      }
-
-      @Override
       public void onJSBundleLoadedFromServer() {
         ReactInstanceManager.this.onJSBundleLoadedFromServer();
       }
@@ -448,14 +441,9 @@ public class ReactInstanceManager {
                         if (packagerIsRunning) {
                           mDevSupportManager.handleReloadJS();
                         } else if (mDevSupportManager.hasUpToDateJSBundleInCache()
-                            && !devSettings.isRemoteJSDebugEnabled()
                             && !mUseFallbackBundle) {
-                          // If there is a up-to-date bundle downloaded from server,
-                          // with remote JS debugging disabled, always use that.
                           onJSBundleLoadedFromServer();
                         } else {
-                          // If dev server is down, disable the remote JS debugging.
-                          devSettings.setRemoteJSDebugEnabled(false);
                           recreateReactContextInBackgroundFromBundleLoader();
                         }
                       });
@@ -1021,16 +1009,6 @@ public class ReactInstanceManager {
 
   public String getJsExecutorName() {
     return mJavaScriptExecutorFactory.toString();
-  }
-
-  @ThreadConfined(UI)
-  private void onReloadWithJSDebugger(JavaJSExecutor.Factory jsExecutorFactory) {
-    FLog.d(ReactConstants.TAG, "ReactInstanceManager.onReloadWithJSDebugger()");
-    recreateReactContextInBackground(
-        new ProxyJavaScriptExecutor.Factory(jsExecutorFactory),
-        JSBundleLoader.createRemoteDebuggerBundleLoader(
-            mDevSupportManager.getJSBundleURLForRemoteDebugging(),
-            mDevSupportManager.getSourceUrl()));
   }
 
   @ThreadConfined(UI)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
@@ -92,21 +92,6 @@ public abstract class JSBundleLoader {
     };
   }
 
-  /**
-   * This loader is used when proxy debugging is enabled. In that case there is no point in fetching
-   * the bundle from device as remote executor will have to do it anyway.
-   */
-  public static JSBundleLoader createRemoteDebuggerBundleLoader(
-      final String proxySourceURL, final String realSourceURL) {
-    return new JSBundleLoader() {
-      @Override
-      public String loadScript(JSBundleLoaderDelegate delegate) {
-        delegate.setSourceURLs(realSourceURL, proxySourceURL);
-        return realSourceURL;
-      }
-    };
-  }
-
   /** Loads the script, returning the URL of the source it loaded. */
   public abstract String loadScript(JSBundleLoaderDelegate delegate);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -16,14 +16,12 @@ import com.facebook.debug.tags.ReactDebugOverlayTags;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.JSBundleLoader;
-import com.facebook.react.bridge.JavaJSExecutor;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.SurfaceDelegateFactory;
-import com.facebook.react.common.futures.SimpleSettableFuture;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevOptionHandler;
@@ -33,9 +31,6 @@ import com.facebook.react.packagerconnection.RequestHandler;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Interface for accessing and interacting with development features. Following features
@@ -136,54 +131,6 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
         });
   }
 
-  private WebsocketJavaScriptExecutor.JSExecutorConnectCallback getExecutorConnectCallback(
-      final SimpleSettableFuture<Boolean> future) {
-    return new WebsocketJavaScriptExecutor.JSExecutorConnectCallback() {
-      @Override
-      public void onSuccess() {
-        future.set(true);
-        hideDevLoadingView();
-      }
-
-      @Override
-      public void onFailure(final Throwable cause) {
-        hideDevLoadingView();
-        FLog.e(ReactConstants.TAG, "Failed to connect to debugger!", cause);
-        future.setException(
-            new IOException(
-                getApplicationContext().getString(com.facebook.react.R.string.catalyst_debug_error),
-                cause));
-      }
-    };
-  }
-
-  private void reloadJSInProxyMode() {
-    // When using js proxy, there is no need to fetch JS bundle as proxy executor will do that
-    // anyway
-    getDevServerHelper().launchJSDevtools();
-
-    JavaJSExecutor.Factory factory =
-        new JavaJSExecutor.Factory() {
-          @Override
-          public JavaJSExecutor create() throws Exception {
-            WebsocketJavaScriptExecutor executor = new WebsocketJavaScriptExecutor();
-            SimpleSettableFuture<Boolean> future = new SimpleSettableFuture<>();
-            executor.connect(
-                getDevServerHelper().getWebsocketProxyURL(), getExecutorConnectCallback(future));
-            // TODO(t9349129) Don't use timeout
-            try {
-              future.get(90, TimeUnit.SECONDS);
-              return executor;
-            } catch (ExecutionException e) {
-              throw (Exception) e.getCause();
-            } catch (InterruptedException | TimeoutException e) {
-              throw new RuntimeException(e);
-            }
-          }
-        };
-    getReactInstanceDevHelper().onReloadWithJSDebugger(factory);
-  }
-
   @Override
   public void handleReloadJS() {
 
@@ -196,19 +143,11 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
     // dismiss redbox if exists
     hideRedboxDialog();
 
-    if (getDevSettings().isRemoteJSDebugEnabled()) {
-      PrinterHolder.getPrinter()
-          .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Proxy");
-      showDevLoadingViewForRemoteJSEnabled();
-      reloadJSInProxyMode();
-    } else {
-      PrinterHolder.getPrinter()
-          .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server");
-      String bundleURL =
-          getDevServerHelper()
-              .getDevServerBundleURL(Assertions.assertNotNull(getJSAppBundleName()));
-      reloadJSFromServer(bundleURL);
-    }
+    PrinterHolder.getPrinter()
+        .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server");
+    String bundleURL =
+        getDevServerHelper().getDevServerBundleURL(Assertions.assertNotNull(getJSAppBundleName()));
+    reloadJSFromServer(bundleURL);
   }
 
   /** Starts of stops the sampling profiler */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -28,7 +28,6 @@ class DevInternalSettings
   private static final String PREFS_ANIMATIONS_DEBUG_KEY = "animations_debug";
   private static final String PREFS_INSPECTOR_DEBUG_KEY = "inspector_debug";
   private static final String PREFS_HOT_MODULE_REPLACEMENT_KEY = "hot_module_replacement";
-  private static final String PREFS_REMOTE_JS_DEBUG_KEY = "remote_js_debug";
   private static final String PREFS_START_SAMPLING_PROFILER_ON_INIT =
       "start_sampling_profiler_on_init";
 
@@ -83,16 +82,6 @@ class DevInternalSettings
   @Override
   public boolean isDeviceDebugEnabled() {
     return ReactBuildConfig.DEBUG;
-  }
-
-  @Override
-  public boolean isRemoteJSDebugEnabled() {
-    return mPreferences.getBoolean(PREFS_REMOTE_JS_DEBUG_KEY, false);
-  }
-
-  @Override
-  public void setRemoteJSDebugEnabled(boolean remoteJSDebugEnabled) {
-    mPreferences.edit().putBoolean(PREFS_REMOTE_JS_DEBUG_KEY, remoteJSDebugEnabled).apply();
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -154,12 +154,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
           public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
             if (getReloadAppAction(context).equals(action)) {
-              if (intent.getBooleanExtra(DevServerHelper.RELOAD_APP_EXTRA_JS_PROXY, false)) {
-                mDevSettings.setRemoteJSDebugEnabled(true);
-                mDevServerHelper.launchJSDevtools();
-              } else {
-                mDevSettings.setRemoteJSDebugEnabled(false);
-              }
               handleReloadJS();
             }
           }
@@ -367,13 +361,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
     if (mDevSettings.isDeviceDebugEnabled()) {
       // On-device JS debugging (CDP). Render action to open debugger frontend.
-
-      // Reset the old debugger setting so no one gets stuck.
-      // TODO: Remove in a few weeks.
-      if (mDevSettings.isRemoteJSDebugEnabled()) {
-        mDevSettings.setRemoteJSDebugEnabled(false);
-        handleReloadJS();
-      }
       options.put(
           mApplicationContext.getString(R.string.catalyst_debug_open),
           () ->
@@ -593,12 +580,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     }
 
     return mDevServerHelper.getSourceUrl(Assertions.assertNotNull(mJSAppBundleName));
-  }
-
-  @Override
-  public String getJSBundleURLForRemoteDebugging() {
-    return mDevServerHelper.getJSBundleURLForRemoteDebugging(
-        Assertions.assertNotNull(mJSAppBundleName));
   }
 
   @Override
@@ -962,19 +943,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     UiThreadUtil.runOnUiThread(
         () -> {
           mDevSettings.setHotModuleReplacementEnabled(isHotModuleReplacementEnabled);
-          handleReloadJS();
-        });
-  }
-
-  @Override
-  public void setRemoteJSDebugEnabled(final boolean isRemoteJSDebugEnabled) {
-    if (!mIsDevSupportEnabled) {
-      return;
-    }
-
-    UiThreadUtil.runOnUiThread(
-        () -> {
-          mDevSettings.setRemoteJSDebugEnabled(isRemoteJSDebugEnabled);
           handleReloadJS();
         });
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -78,9 +78,6 @@ public class DisabledDevSupportManager implements DevSupportManager {
   public void setHotModuleReplacementEnabled(boolean isHotModuleReplacementEnabled) {}
 
   @Override
-  public void setRemoteJSDebugEnabled(boolean isRemoteJSDebugEnabled) {}
-
-  @Override
   public void setFpsDebugEnabled(boolean isFpsDebugEnabled) {}
 
   @Override
@@ -114,11 +111,6 @@ public class DisabledDevSupportManager implements DevSupportManager {
 
   @Override
   public String getSourceUrl() {
-    return null;
-  }
-
-  @Override
-  public String getJSBundleURLForRemoteDebugging() {
     return null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReactInstanceDevHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReactInstanceDevHelper.java
@@ -10,7 +10,6 @@ package com.facebook.react.devsupport;
 import android.app.Activity;
 import android.view.View;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.JavaJSExecutor;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 
 /**
@@ -19,9 +18,6 @@ import com.facebook.react.bridge.JavaScriptExecutorFactory;
  * developer menu options.
  */
 public interface ReactInstanceDevHelper {
-
-  /** Request react instance recreation with JS debugging enabled. */
-  void onReloadWithJSDebugger(JavaJSExecutor.Factory proxyExecutorFactory);
 
   /** Notify react instance manager about new JS bundle version downloaded from the server. */
   void onJSBundleLoadedFromServer();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -62,8 +62,6 @@ public interface DevSupportManager extends JSExceptionHandler {
 
   String getSourceUrl();
 
-  String getJSBundleURLForRemoteDebugging();
-
   String getDownloadedJSBundleFile();
 
   boolean hasUpToDateJSBundleInCache();
@@ -81,8 +79,6 @@ public interface DevSupportManager extends JSExceptionHandler {
   void isPackagerRunning(PackagerStatusCallback callback);
 
   void setHotModuleReplacementEnabled(final boolean isHotModuleReplacementEnabled);
-
-  void setRemoteJSDebugEnabled(final boolean isRemoteJSDebugEnabled);
 
   void setFpsDebugEnabled(final boolean isFpsDebugEnabled);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.java
@@ -61,7 +61,7 @@ public class DevSettingsModule extends NativeDevSettingsSpec {
 
   @Override
   public void setIsDebuggingRemotely(boolean isDebugginRemotelyEnabled) {
-    mDevSupportManager.setRemoteJSDebugEnabled(isDebugginRemotelyEnabled);
+    // Not implemented
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.java
@@ -28,12 +28,6 @@ public interface DeveloperSettings {
   /** @return Whether Nuclide JS debugging is enabled. */
   boolean isDeviceDebugEnabled();
 
-  /** @return Whether remote JS debugging is enabled. */
-  boolean isRemoteJSDebugEnabled();
-
-  /** Enable/Disable remote JS debugging. */
-  void setRemoteJSDebugEnabled(boolean remoteJSDebugEnabled);
-
   /** @return Whether Start Sampling Profiler on App Start is enabled. */
   boolean isStartSamplingProfilerOnInit();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessDevSupportManager.java
@@ -12,7 +12,6 @@ import android.content.Context;
 import android.view.View;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JSBundleLoader;
-import com.facebook.react.bridge.JavaJSExecutor;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.devsupport.DevSupportManagerBase;
@@ -98,11 +97,6 @@ class BridgelessDevSupportManager extends DevSupportManagerBase {
 
   private static ReactInstanceDevHelper createInstanceDevHelper(final ReactHostImpl reactHost) {
     return new ReactInstanceDevHelper() {
-      @Override
-      public void onReloadWithJSDebugger(JavaJSExecutor.Factory proxyExecutorFactory) {
-        // Not implemented
-      }
-
       @Override
       public void onJSBundleLoadedFromServer() {
         throw new IllegalStateException("Not implemented for bridgeless mode");


### PR DESCRIPTION
Summary:
## Context

**Remote JS Debugging removal**

In React Native 0.73, we have deprecated Remote JS Debugging (execution of JavaScript in a separate V8 process) and also removed the Dev Menu launcher (https://github.com/facebook/react-native/pull/36754).

This was motivated primarily by the broken state of this feature — in particular: incompatibility with the New Architecture. Secondly, as the React Native team continues to invest in improving debugging, we want to reduce the surface area of debugging modes that we support.

During this year, we reached out to our partners about the impact of removing this feature, and if there was interest in having separate community support for debugging JSC on Android (a limited use case affected by this change). Without strong interest, we concluded that dropping Remote JS Debugging support in core for React Native 0.74 makes sense. We are focusing future debugging efforts into providing a first-class experience for Hermes.

Existing alternatives:

- [Direct debugging for JSC (Safari, iOS only)](https://reactnative.dev/docs/0.71/debugging#safari-developer-tools).
- Direct debugging with Hermes: Flipper, [Chrome (old method)](https://reactnative.dev/docs/0.71/hermes#debugging-js-on-hermes-using-google-chromes-devtools), or via `react-native start --experimental-debugger` (intended future default).

## This diff

This removes remaining Remote JS Debugging code on Android.

Changelog: [Android][Breaking] Remove remote JS debugging capability (JSC projects)

Differential Revision: D50325682


