### PR TITLE
Pass reactNativeConfig to HermesInstance when not using the native module version

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
@@ -9,13 +9,17 @@ package com.facebook.react.runtime.hermes
 
 import com.facebook.jni.HybridData
 import com.facebook.jni.annotations.DoNotStrip
+import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.runtime.JSEngineInstance
 import com.facebook.soloader.SoLoader
 
-class HermesInstance : JSEngineInstance(initHybrid()!!) {
+class HermesInstance constructor(reactNativeConfig: ReactNativeConfig?) :
+    JSEngineInstance(initHybrid(reactNativeConfig as Any?)) {
+
+  constructor() : this(null)
 
   companion object {
-    @JvmStatic @DoNotStrip protected external fun initHybrid(): HybridData?
+    @JvmStatic @DoNotStrip protected external fun initHybrid(reactNativeConfig: Any?): HybridData
 
     init {
       SoLoader.loadLibrary("hermesinstancejni")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
@@ -8,12 +8,18 @@
 #include "JHermesInstance.h"
 
 #include <fbjni/fbjni.h>
+#include <react/fabric/ReactNativeConfigHolder.h>
 
 namespace facebook::react {
 
 jni::local_ref<JHermesInstance::jhybriddata> JHermesInstance::initHybrid(
-    jni::alias_ref<jhybridobject>) {
-  return makeCxxInstance();
+    jni::alias_ref<jclass> /* unused */,
+    jni::alias_ref<jobject> reactNativeConfig) {
+  std::shared_ptr<const ReactNativeConfig> config = reactNativeConfig != nullptr
+      ? std::make_shared<const ReactNativeConfigHolder>(reactNativeConfig)
+      : nullptr;
+
+  return makeCxxInstance(config);
 }
 
 void JHermesInstance::registerNatives() {
@@ -24,8 +30,8 @@ void JHermesInstance::registerNatives() {
 
 std::unique_ptr<jsi::Runtime> JHermesInstance::createJSRuntime(
     std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
-  // TODO T105438175 Pass ReactNativeConfig to init Hermes with MobileConfig
-  return HermesInstance::createJSRuntime(nullptr, nullptr, msgQueueThread);
+  return HermesInstance::createJSRuntime(
+      reactNativeConfig_, nullptr, msgQueueThread);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
@@ -8,12 +8,12 @@
 #pragma once
 
 #include <memory>
-#include <string>
 
 #include <cxxreact/MessageQueueThread.h>
 #include <fbjni/fbjni.h>
 #include <jni.h>
 #include <jsi/jsi.h>
+#include <react/config/ReactNativeConfig.h>
 #include <react/runtime/JSEngineInstance.h>
 #include <react/runtime/hermes/HermesInstance.h>
 #include "../../jni/JJSEngineInstance.h"
@@ -26,9 +26,14 @@ class JHermesInstance
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/runtime/hermes/HermesInstance;";
 
-  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject>);
+  static jni::local_ref<jhybriddata> initHybrid(
+      jni::alias_ref<jclass> /* unused */,
+      jni::alias_ref<jobject> reactNativeConfig);
 
   static void registerNatives();
+
+  JHermesInstance(std::shared_ptr<const ReactNativeConfig> reactNativeConfig)
+      : reactNativeConfig_(reactNativeConfig){};
 
   std::unique_ptr<jsi::Runtime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;
@@ -37,6 +42,8 @@ class JHermesInstance
 
  private:
   friend HybridBase;
+
+  std::shared_ptr<const ReactNativeConfig> reactNativeConfig_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
We're testing a method to access `ReactNativeConfig` without a dependency on native modules, so we can access it before that infra is initialized in places like Hermes or RuntimeScheduler.

When we're in that variant, this passes the configuration to Hermes so we can use it to set flags in the runtime (like enabling microtasks in D50177355).

Changelog: [internal]

Differential Revision: D50450488

