### PR TITLE
Remove unused import from Pressable.js

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -30,7 +30,7 @@ import useAndroidRippleForView, {
   type RippleConfig,
 } from './useAndroidRippleForView';
 import * as React from 'react';
-import {useImperativeHandle, useMemo, useRef, useState} from 'react';
+import {useMemo, useRef, useState} from 'react';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
 


### PR DESCRIPTION
Summary:
All callsites for `useImperativeHandle` have been removed, so we can also remove the import from react.

## Changelog
[General][Internal]

Differential Revision: D50457268

