### PR TITLE
Fix logging of error in MainReactPackage.getReactModuleInfoProvider()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@Deprecated(
+    since =
+        "CompositeReactPackageTurboModuleManagerDelegate is deprecated and will be deleted in the future. Please use ReactPackage interface or BaseReactPackage instead.")
 @DoNotStrip
 public class CompositeReactPackageTurboModuleManagerDelegate
     extends ReactPackageTurboModuleManagerDelegate {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -36,7 +36,8 @@ import javax.inject.Provider;
     nativeModules = {
       JSCHeapCapture.class,
     })
-public class DebugCorePackage extends TurboReactPackage implements ViewManagerOnDemandReactPackage {
+/* package */
+class DebugCorePackage extends TurboReactPackage implements ViewManagerOnDemandReactPackage {
   private @Nullable Map<String, ModuleSpec> mViewManagers;
 
   public DebugCorePackage() {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -303,10 +303,12 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
       return () -> reactModuleInfoMap;
     } catch (InstantiationException e) {
       throw new RuntimeException(
-          "No ReactModuleInfoProvider for CoreModulesPackage$$ReactModuleInfoProvider", e);
+          "No ReactModuleInfoProvider for com.facebook.react.shell.MainReactPackage$$ReactModuleInfoProvider",
+          e);
     } catch (IllegalAccessException e) {
       throw new RuntimeException(
-          "No ReactModuleInfoProvider for CoreModulesPackage$$ReactModuleInfoProvider", e);
+          "No ReactModuleInfoProvider for com.facebook.react.shell.MainReactPackage$$ReactModuleInfoProvider",
+          e);
     }
   }
 }


### PR DESCRIPTION
Summary:
This was probably caused by a copy paste, I'm fixing the log message to describe the proper class.

bypass-github-export-checks

changelog: [internal] internal

Reviewed By: RSNara

Differential Revision: D50338296


