### PR TITLE
Deprecate CompositeReactPackageTurboModuleManagerDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@Deprecated(
+    since =
+        "CompositeReactPackageTurboModuleManagerDelegate is deprecated and will be deleted in the future. Please use ReactPackage interface or BaseReactPackage instead.")
 @DoNotStrip
 public class CompositeReactPackageTurboModuleManagerDelegate
     extends ReactPackageTurboModuleManagerDelegate {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -36,7 +36,8 @@ import javax.inject.Provider;
     nativeModules = {
       JSCHeapCapture.class,
     })
-public class DebugCorePackage extends TurboReactPackage implements ViewManagerOnDemandReactPackage {
+/* package */
+class DebugCorePackage extends TurboReactPackage implements ViewManagerOnDemandReactPackage {
   private @Nullable Map<String, ModuleSpec> mViewManagers;
 
   public DebugCorePackage() {}


### PR DESCRIPTION
Summary:
Deprecate CompositeReactPackageTurboModuleManagerDelegate

bypass-github-export-checks

changelog: [Android][Changed] Deprecate CompositeReactPackageTurboModuleManagerDelegate

Reviewed By: RSNara

Differential Revision: D50338303


