### PR TITLE
Wire up configuration to use microtasks in RuntimeScheduler, Hermes and React

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
@@ -9,13 +9,17 @@ package com.facebook.react.runtime.hermes
 
 import com.facebook.jni.HybridData
 import com.facebook.jni.annotations.DoNotStrip
+import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.runtime.JSEngineInstance
 import com.facebook.soloader.SoLoader
 
-class HermesInstance : JSEngineInstance(initHybrid()!!) {
+class HermesInstance constructor(reactNativeConfig: ReactNativeConfig?) :
+    JSEngineInstance(initHybrid(reactNativeConfig as Any?)) {
+
+  constructor() : this(null)
 
   companion object {
-    @JvmStatic @DoNotStrip protected external fun initHybrid(): HybridData?
+    @JvmStatic @DoNotStrip protected external fun initHybrid(reactNativeConfig: Any?): HybridData
 
     init {
       SoLoader.loadLibrary("hermesinstancejni")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
@@ -8,12 +8,18 @@
 #include "JHermesInstance.h"
 
 #include <fbjni/fbjni.h>
+#include <react/fabric/ReactNativeConfigHolder.h>
 
 namespace facebook::react {
 
 jni::local_ref<JHermesInstance::jhybriddata> JHermesInstance::initHybrid(
-    jni::alias_ref<jhybridobject>) {
-  return makeCxxInstance();
+    jni::alias_ref<jclass> /* unused */,
+    jni::alias_ref<jobject> reactNativeConfig) {
+  std::shared_ptr<const ReactNativeConfig> config = reactNativeConfig != nullptr
+      ? std::make_shared<const ReactNativeConfigHolder>(reactNativeConfig)
+      : nullptr;
+
+  return makeCxxInstance(config);
 }
 
 void JHermesInstance::registerNatives() {
@@ -24,8 +30,8 @@ void JHermesInstance::registerNatives() {
 
 std::unique_ptr<jsi::Runtime> JHermesInstance::createJSRuntime(
     std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
-  // TODO T105438175 Pass ReactNativeConfig to init Hermes with MobileConfig
-  return HermesInstance::createJSRuntime(nullptr, nullptr, msgQueueThread);
+  return HermesInstance::createJSRuntime(
+      reactNativeConfig_, nullptr, msgQueueThread);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
@@ -8,12 +8,12 @@
 #pragma once
 
 #include <memory>
-#include <string>
 
 #include <cxxreact/MessageQueueThread.h>
 #include <fbjni/fbjni.h>
 #include <jni.h>
 #include <jsi/jsi.h>
+#include <react/config/ReactNativeConfig.h>
 #include <react/runtime/JSEngineInstance.h>
 #include <react/runtime/hermes/HermesInstance.h>
 #include "../../jni/JJSEngineInstance.h"
@@ -26,9 +26,14 @@ class JHermesInstance
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/runtime/hermes/HermesInstance;";
 
-  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject>);
+  static jni::local_ref<jhybriddata> initHybrid(
+      jni::alias_ref<jclass> /* unused */,
+      jni::alias_ref<jobject> reactNativeConfig);
 
   static void registerNatives();
+
+  JHermesInstance(std::shared_ptr<const ReactNativeConfig> reactNativeConfig)
+      : reactNativeConfig_(reactNativeConfig){};
 
   std::unique_ptr<jsi::Runtime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;
@@ -37,6 +42,8 @@ class JHermesInstance
 
  private:
   friend HybridBase;
+
+  std::shared_ptr<const ReactNativeConfig> reactNativeConfig_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -26,4 +26,5 @@ target_link_libraries(react_render_runtimescheduler
         react_debug
         react_render_core
         react_render_debug
+        react_utils
         runtimeexecutor)

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -54,6 +54,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-runtimeexecutor"
   s.dependency "React-callinvoker"
+  s.dependency "React-cxxreact"
   s.dependency "React-debug"
   s.dependency "React-rendererdebug"
   s.dependency "React-utils"

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -152,13 +152,20 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   void scheduleTask(std::shared_ptr<Task> task);
 
   /**
-   * Follows all the steps necessary to execute the given task (in the future,
-   * this will include executing microtasks, flushing rendering work, etc.)
+   * Follows all the steps necessary to execute the given task.
+   * Depending on feature flags, this could also execute its microtasks.
+   * In the future, this will include other steps in the Web event loop, like
+   * updating the UI in native, executing resize observer callbacks, etc.
    */
   void executeTask(
       jsi::Runtime& runtime,
       const std::shared_ptr<Task>& task,
       RuntimeSchedulerTimePoint currentTime);
+
+  void executeMacrotask(
+      jsi::Runtime& runtime,
+      std::shared_ptr<Task> task,
+      bool didUserCallbackTimeout) const;
 
   /*
    * Returns a time point representing the current point in time. May be called

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -9,6 +9,7 @@
 #include <hermes/hermes.h>
 #include <jsi/jsi.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#include <react/utils/CoreFeatures.h>
 #include <memory>
 #include <semaphore>
 
@@ -24,7 +25,18 @@ class RuntimeSchedulerTest : public testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
     hostFunctionCallCount_ = 0;
-    runtime_ = facebook::hermes::makeHermesRuntime();
+
+    auto useModernRuntimeScheduler = GetParam();
+
+    CoreFeatures::enableMicrotasks = useModernRuntimeScheduler;
+
+    // Configuration that enables microtasks
+    ::hermes::vm::RuntimeConfig::Builder runtimeConfigBuilder =
+        ::hermes::vm::RuntimeConfig::Builder().withMicrotaskQueue(
+            useModernRuntimeScheduler);
+
+    runtime_ =
+        facebook::hermes::makeHermesRuntime(runtimeConfigBuilder.build());
     stubErrorUtils_ = StubErrorUtils::createAndInstallIfNeeded(*runtime_);
     stubQueue_ = std::make_unique<StubQueue>();
 
@@ -41,8 +53,6 @@ class RuntimeSchedulerTest : public testing::TestWithParam<bool> {
     auto stubNow = [this]() -> RuntimeSchedulerTimePoint {
       return stubClock_->getNow();
     };
-
-    auto useModernRuntimeScheduler = GetParam();
 
     runtimeScheduler_ = std::make_unique<RuntimeScheduler>(
         runtimeExecutor, useModernRuntimeScheduler, stubNow);
@@ -111,6 +121,54 @@ TEST_P(RuntimeSchedulerTest, scheduleSingleTask) {
   stubQueue_->tick();
 
   EXPECT_TRUE(didRunTask);
+  EXPECT_EQ(stubQueue_->size(), 0);
+}
+
+TEST_P(RuntimeSchedulerTest, scheduleSingleTaskWithMicrotasks) {
+  // Only for modern runtime scheduler
+  if (!GetParam()) {
+    return;
+  }
+
+  bool didRunTask = false;
+  bool didRunMicrotask = false;
+
+  auto callback = createHostFunctionFromLambda([&](bool /* unused */) {
+    didRunTask = true;
+
+    auto microtaskCallback = jsi::Function::createFromHostFunction(
+        *runtime_,
+        jsi::PropNameID::forUtf8(*runtime_, ""),
+        3,
+        [&](jsi::Runtime& /*unused*/,
+            const jsi::Value& /*unused*/,
+            const jsi::Value* arguments,
+            size_t /*unused*/) -> jsi::Value {
+          didRunMicrotask = true;
+          return jsi::Value::undefined();
+        });
+
+    // Hermes doesn't expose a C++ API to schedule microtasks, so we just access
+    // the API that it exposes to JS.
+    auto global = runtime_->global();
+    auto enqueueJobFn = global.getPropertyAsObject(*runtime_, "HermesInternal")
+                            .getPropertyAsFunction(*runtime_, "enqueueJob");
+
+    enqueueJobFn.call(*runtime_, std::move(microtaskCallback));
+
+    return jsi::Value::undefined();
+  });
+
+  runtimeScheduler_->scheduleTask(
+      SchedulerPriority::NormalPriority, std::move(callback));
+
+  EXPECT_FALSE(didRunTask);
+  EXPECT_EQ(stubQueue_->size(), 1);
+
+  stubQueue_->tick();
+
+  EXPECT_TRUE(didRunTask);
+  EXPECT_TRUE(didRunMicrotask);
   EXPECT_EQ(stubQueue_->size(), 0);
 }
 
@@ -521,7 +579,8 @@ TEST_P(RuntimeSchedulerTest, normalTaskYieldsToSynchronousAccess) {
 
   EXPECT_EQ(syncTaskExecutionCount, 1);
   EXPECT_TRUE(runtimeScheduler_->getShouldYield());
-  // The previous task is still in the queue (although it was executed already).
+  // The previous task is still in the queue (although it was executed
+  // already).
   EXPECT_EQ(stubQueue_->size(), 1);
 
   // Just empty the queue
@@ -597,8 +656,8 @@ TEST_P(RuntimeSchedulerTest, immediateTaskYieldsToSynchronousAccess) {
 
   EXPECT_EQ(syncTaskExecutionCount, 1);
   EXPECT_TRUE(runtimeScheduler_->getShouldYield());
-  // The previous task is still in the queue (although it was executed already),
-  // so the sync task scheduled the work loop to process it.
+  // The previous task is still in the queue (although it was executed
+  // already), so the sync task scheduled the work loop to process it.
   EXPECT_EQ(stubQueue_->size(), 1);
 
   // Just empty the queue
@@ -708,7 +767,7 @@ TEST_P(RuntimeSchedulerTest, sameThreadTaskCreatesImmediatePriorityTask) {
           runtimeScheduler_->scheduleTask(
               SchedulerPriority::ImmediatePriority, std::move(callback));
 
-          runtimeScheduler_->callExpiredTasks(runtime);
+          EXPECT_FALSE(didRunSubsequentTask);
         });
   });
 
@@ -724,7 +783,15 @@ TEST_P(RuntimeSchedulerTest, sameThreadTaskCreatesImmediatePriorityTask) {
   t1.join();
 
   EXPECT_TRUE(didRunSynchronousTask);
+  EXPECT_FALSE(didRunSubsequentTask);
+
+  EXPECT_EQ(stubQueue_->size(), 1);
+
+  stubQueue_->tick();
+
   EXPECT_TRUE(didRunSubsequentTask);
+
+  EXPECT_EQ(stubQueue_->size(), 0);
 }
 
 TEST_P(RuntimeSchedulerTest, sameThreadTaskCreatesLowPriorityTask) {
@@ -745,11 +812,6 @@ TEST_P(RuntimeSchedulerTest, sameThreadTaskCreatesLowPriorityTask) {
 
           runtimeScheduler_->scheduleTask(
               SchedulerPriority::LowPriority, std::move(callback));
-
-          // Only for legacy runtime scheduler
-          if (!GetParam()) {
-            runtimeScheduler_->callExpiredTasks(runtime);
-          }
 
           EXPECT_FALSE(didRunSubsequentTask);
         });
@@ -844,7 +906,8 @@ TEST_P(RuntimeSchedulerTest, modernTwoThreadsRequestAccessToTheRuntime) {
           // Notify that the second task can be scheduled.
           signalTask1ToScheduleTask2.release();
 
-          // Wait for the second task to be scheduled before finishing this task
+          // Wait for the second task to be scheduled before finishing this
+          // task
           signalTask2ToResumeTask1.acquire();
 
           didRunSynchronousTask1 = true;
@@ -860,8 +923,8 @@ TEST_P(RuntimeSchedulerTest, modernTwoThreadsRequestAccessToTheRuntime) {
 
     // Notify the first task that it can resume execution.
     // As we can't do this after the task this from thread has been scheduled
-    // (because it's synchronous), we can just do a short wait instead in a new
-    // thread.
+    // (because it's synchronous), we can just do a short wait instead in a
+    // new thread.
     std::thread t3([&signalTask2ToResumeTask1]() {
       std::chrono::duration<int, std::milli> timespan(50);
       std::this_thread::sleep_for(timespan);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -139,6 +139,14 @@ Scheduler::Scheduler(
   reduceDeleteCreateMutationLayoutAnimation_ = true;
 #endif
 
+#ifdef ANDROID
+  CoreFeatures::enableMicrotasks =
+      reactNativeConfig_->getBool("react_fabric:enable_microtasks_android");
+#else
+  CoreFeatures::enableMicrotasks =
+      reactNativeConfig_->getBool("react_fabric:enable_microtasks_ios");
+#endif
+
   CoreFeatures::blockPaintForUseLayoutEffect = reactNativeConfig_->getBool(
       "react_fabric:block_paint_for_use_layout_effect");
 

--- a/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
@@ -34,4 +34,5 @@ target_link_libraries(
         fb
         jsi
         jsireact
+        react_utils
 )

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-jserrorhandler"
   s.dependency "React-runtimescheduler"
+  s.dependency "React-utils"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-nativeconfig"
   s.dependency "React-jsitracing"
+  s.dependency "React-utils"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -148,7 +148,8 @@ void TimerManager::callTimer(uint32_t timerID) {
 void TimerManager::attachGlobals(jsi::Runtime& runtime) {
   // Install host functions for timers.
   // TODO (T45786383): Add missing timer functions from JSTimers
-  // TODL (T96212789): Skip immediate APIs when JSVM microtask queue is used.
+  // TODO (T96212789): Remove when JSVM microtask queue is used everywhere in
+  // bridgeless mode. This is being overwritten in JS in that case.
   runtime.global().setProperty(
       runtime,
       "setImmediate",

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -105,6 +105,17 @@ std::unique_ptr<jsi::Runtime> HermesInstance::createJSRuntime(
   auto heapSizeMB = heapSizeConfig > 0
       ? static_cast<::hermes::vm::gcheapsize_t>(heapSizeConfig)
       : 3072;
+
+#ifdef ANDROID
+  bool enableMicrotasks = reactNativeConfig
+      ? reactNativeConfig->getBool("react_fabric:enable_microtasks_android")
+      : false;
+#else
+  bool enableMicrotasks = reactNativeConfig
+      ? reactNativeConfig->getBool("react_fabric:enable_microtasks_ios")
+      : false;
+#endif
+
   ::hermes::vm::RuntimeConfig::Builder runtimeConfigBuilder =
       ::hermes::vm::RuntimeConfig::Builder()
           .withGCConfig(::hermes::vm::GCConfig::Builder()
@@ -119,6 +130,7 @@ std::unique_ptr<jsi::Runtime> HermesInstance::createJSRuntime(
                             .build())
           .withES6Proxy(false)
           .withEnableSampleProfiling(true)
+          .withMicrotaskQueue(enableMicrotasks)
           .withVMExperimentFlags(vmExperimentFlags);
 
   if (cm) {

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
@@ -22,5 +22,6 @@ bool CoreFeatures::enableGranularShadowTreeStateReconciliation = false;
 bool CoreFeatures::enableDefaultAsyncBatchedPriority = false;
 bool CoreFeatures::enableClonelessStateProgression = false;
 bool CoreFeatures::excludeYogaFromRawProps = false;
+bool CoreFeatures::enableMicrotasks = false;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
@@ -63,6 +63,10 @@ class CoreFeatures {
 
   // When enabled, rawProps in Props will not include Yoga specific props.
   static bool excludeYogaFromRawProps;
+
+  // Enables the use of microtasks in Hermes (scheduling) and RuntimeScheduler
+  // (execution).
+  static bool enableMicrotasks;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
This propagates to enable the use of microtasks in the React reconciler, Runtime Scheduler and Hermes.

Changelog: [internal]

Differential Revision: D50177355


