### PR TITLE
Delete LazyReactPackage.getReactModuleInfoProviderViaReflection

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -25,11 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-/**
- * React package supporting lazy creation of native modules.
- *
- * <p>TODO(t11394819): Make this default and deprecate ReactPackage
- */
+/** React package supporting lazy creation of native modules. */
+@Deprecated(since = "This class is deprecated, please use BaseReactPackage instead.")
 public abstract class LazyReactPackage implements ReactPackage {
 
   @Deprecated

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -29,12 +29,6 @@ import java.util.Map;
 @Deprecated(since = "This class is deprecated, please use BaseReactPackage instead.")
 public abstract class LazyReactPackage implements ReactPackage {
 
-  @Deprecated
-  public static ReactModuleInfoProvider getReactModuleInfoProviderViaReflection(
-      LazyReactPackage lazyReactPackage) {
-    return Collections::emptyMap;
-  }
-
   /**
    * We return an iterable
    *


### PR DESCRIPTION
Summary:
LazyReactPackage.getReactModuleInfoProviderViaReflection was deprecated in 0.72, I'm just deleting it.
There are no usages internally or externally

changelog: [Android][Breaking] Delete deprecated method LazyReactPackage.getReactModuleInfoProviderViaReflection

Reviewed By: arushikesarwani94

Differential Revision: D50338302


