### PR TITLE
Mark LazyReactPackage as Deprecated in the new architecture of React Native

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -25,11 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-/**
- * React package supporting lazy creation of native modules.
- *
- * <p>TODO(t11394819): Make this default and deprecate ReactPackage
- */
+/** React package supporting lazy creation of native modules. */
+@Deprecated(since = "This class is deprecated, please use BaseReactPackage instead.")
 public abstract class LazyReactPackage implements ReactPackage {
 
   @Deprecated


### PR DESCRIPTION
Summary:
LazyReactPackage is beig replaced by TurboReactPackage / BaseReactPackage, that's why I'm docummenting LazyReactPackage as Deprecated

changelog: [internal] internal

Reviewed By: arushikesarwani94

Differential Revision: D50338301


