### PR TITLE
Migrate ReactInstanceEventListener to kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceEventListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceEventListener.kt
@@ -5,19 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react;
+package com.facebook.react
 
-import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContext
 
-/**
- * New Listener interface for react instance events. {@Link
- * ReactInstanceManager.ReactInstanceEventListener will be deprecated.}
- */
-public interface ReactInstanceEventListener {
-
+/** Interface to subscribe for react instance events */
+interface ReactInstanceEventListener {
   /**
    * Called when the react context is initialized (all modules registered). Always called on the UI
    * thread.
    */
-  void onReactContextInitialized(ReactContext context);
+  fun onReactContextInitialized(context: ReactContext)
 }


### PR DESCRIPTION
Summary:
Migrate ReactInstanceEventListener to kotlin

changelog: [internal] internal

Reviewed By: christophpurrer

Differential Revision: D50338295


