### PR TITLE
Extract NativeMethod out of NativeModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -92,7 +92,10 @@ public abstract class BaseJavaModule implements NativeModule {
     onCatalystInstanceDestroy();
   }
 
-  /** Subclasses can use this method to access catalyst context passed as a constructor. */
+  /**
+   * Subclasses can use this method to access {@link ReactApplicationContext} passed as a
+   * constructor.
+   */
   protected final ReactApplicationContext getReactApplicationContext() {
     return Assertions.assertNotNull(
         mReactApplicationContext,
@@ -100,10 +103,11 @@ public abstract class BaseJavaModule implements NativeModule {
   }
 
   /**
-   * Subclasses can use this method to access catalyst context passed as a constructor. Use this
-   * version to check that the underlying CatalystInstance is active before returning, and
-   * automatically have SoftExceptions or debug information logged for you. Consider using this
-   * whenever calling ReactApplicationContext methods that require the Catalyst instance be alive.
+   * Subclasses can use this method to access {@link ReactApplicationContext} passed as a
+   * constructor. Use this version to check that the underlying React Instance is active before
+   * returning, and automatically have SoftExceptions or debug information logged for you. Consider
+   * using this whenever calling ReactApplicationContext methods that require the React instance be
+   * alive.
    *
    * <p>This can return null at any time, but especially during teardown methods it's
    * possible/likely.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
@@ -18,7 +18,7 @@ import com.facebook.systrace.SystraceMessage;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-class JavaMethodWrapper implements NativeModule.NativeMethod {
+class JavaMethodWrapper implements JavaModuleWrapper.NativeMethod {
 
   private abstract static class ArgumentExtractor<T> {
     public int getJSArgumentsNeeded() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -30,6 +30,13 @@ import java.util.Map;
  */
 @DoNotStrip
 class JavaModuleWrapper {
+
+  interface NativeMethod {
+    void invoke(JSInstance jsInstance, ReadableArray parameters);
+
+    String getType();
+  }
+
   @DoNotStrip
   public static class MethodDescriptor {
     @DoNotStrip Method method;
@@ -40,7 +47,7 @@ class JavaModuleWrapper {
 
   private final JSInstance mJSInstance;
   private final ModuleHolder mModuleHolder;
-  private final ArrayList<NativeModule.NativeMethod> mMethods;
+  private final ArrayList<NativeMethod> mMethods;
   private final ArrayList<MethodDescriptor> mDescs;
 
   public JavaModuleWrapper(JSInstance jsInstance, ModuleHolder moduleHolder) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -23,13 +23,6 @@ import javax.annotation.Nonnull;
 @DoNotStrip
 public interface NativeModule {
 
-  @DeprecatedInNewArchitecture
-  interface NativeMethod {
-    void invoke(JSInstance jsInstance, ReadableArray parameters);
-
-    String getType();
-  }
-
   /**
    * @return the name of this module. This will be the name used to {@code require()} this module
    *     from javascript.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
@@ -7,6 +7,8 @@
 
 package com.facebook.react.common.mapbuffer
 
+import com.facebook.react.common.annotations.StableReactNativeAPI
+
 /**
  * MapBuffer is an optimized sparse array format for transferring props-like data between C++ and
  * JNI. It is designed to:
@@ -23,6 +25,7 @@ package com.facebook.react.common.mapbuffer
  * - O(log(N)) random key access for native buffers due to selected structure. Faster access can be
  *   achieved by retrieving [MapBuffer.Entry] with [entryAt] on known offsets.
  */
+@StableReactNativeAPI
 interface MapBuffer : Iterable<MapBuffer.Entry> {
   companion object {
     /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBufferSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBufferSoLoader.kt
@@ -9,9 +9,11 @@ package com.facebook.react.common.mapbuffer
 
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarkerConstants
+import com.facebook.react.common.annotations.StableReactNativeAPI
 import com.facebook.soloader.SoLoader
 import com.facebook.systrace.Systrace
 
+@StableReactNativeAPI
 object MapBufferSoLoader {
   @Volatile private var didInit = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
@@ -9,6 +9,7 @@ package com.facebook.react.common.mapbuffer
 
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.common.annotations.StableReactNativeAPI
 import com.facebook.react.common.mapbuffer.MapBuffer.Companion.KEY_RANGE
 import java.lang.StringBuilder
 import java.nio.ByteBuffer
@@ -21,6 +22,7 @@ import javax.annotation.concurrent.NotThreadSafe
  *
  * See [MapBuffer] documentation for more details
  */
+@StableReactNativeAPI
 @NotThreadSafe
 @DoNotStrip
 class ReadableMapBuffer : MapBuffer {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
@@ -9,6 +9,7 @@ package com.facebook.react.common.mapbuffer
 
 import android.util.SparseArray
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.common.annotations.StableReactNativeAPI
 import com.facebook.react.common.mapbuffer.MapBuffer.Companion.KEY_RANGE
 import com.facebook.react.common.mapbuffer.MapBuffer.DataType
 import javax.annotation.concurrent.NotThreadSafe
@@ -19,6 +20,7 @@ import javax.annotation.concurrent.NotThreadSafe
  *
  * See [MapBuffer] for more details
  */
+@StableReactNativeAPI
 @NotThreadSafe
 @DoNotStrip
 class WritableMapBuffer : MapBuffer {


### PR DESCRIPTION
Summary:
The goal of this diff is to move NativeMethod out of NativeModule, in this case I'm moving it to JavaModuleWrapper.
We could also do a bigger refactor and just remove it, but since the usages of NativeMethod are not part of public API and these classes will dissapear in the new architecture, I opted for reducing risk a do a minor refactor.
Why I'm doing this: because I'm migrating NativeModule to kotlin and don't want to expose NativeMethod in the kotlin public API

This is not a breakage of compatibility because NativeMethod has package visibility.


bypass-github-export-checks

changelog: [internal] internal

Reviewed By: luluwu2032

Differential Revision: D50294833


