### PR TITLE
Mark Mapbuffer classes and interfaces as Stable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -92,7 +92,10 @@ public abstract class BaseJavaModule implements NativeModule {
     onCatalystInstanceDestroy();
   }
 
-  /** Subclasses can use this method to access catalyst context passed as a constructor. */
+  /**
+   * Subclasses can use this method to access {@link ReactApplicationContext} passed as a
+   * constructor.
+   */
   protected final ReactApplicationContext getReactApplicationContext() {
     return Assertions.assertNotNull(
         mReactApplicationContext,
@@ -100,10 +103,11 @@ public abstract class BaseJavaModule implements NativeModule {
   }
 
   /**
-   * Subclasses can use this method to access catalyst context passed as a constructor. Use this
-   * version to check that the underlying CatalystInstance is active before returning, and
-   * automatically have SoftExceptions or debug information logged for you. Consider using this
-   * whenever calling ReactApplicationContext methods that require the Catalyst instance be alive.
+   * Subclasses can use this method to access {@link ReactApplicationContext} passed as a
+   * constructor. Use this version to check that the underlying React Instance is active before
+   * returning, and automatically have SoftExceptions or debug information logged for you. Consider
+   * using this whenever calling ReactApplicationContext methods that require the React instance be
+   * alive.
    *
    * <p>This can return null at any time, but especially during teardown methods it's
    * possible/likely.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBuffer.kt
@@ -7,6 +7,8 @@
 
 package com.facebook.react.common.mapbuffer
 
+import com.facebook.react.common.annotations.StableReactNativeAPI
+
 /**
  * MapBuffer is an optimized sparse array format for transferring props-like data between C++ and
  * JNI. It is designed to:
@@ -23,6 +25,7 @@ package com.facebook.react.common.mapbuffer
  * - O(log(N)) random key access for native buffers due to selected structure. Faster access can be
  *   achieved by retrieving [MapBuffer.Entry] with [entryAt] on known offsets.
  */
+@StableReactNativeAPI
 interface MapBuffer : Iterable<MapBuffer.Entry> {
   companion object {
     /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBufferSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/MapBufferSoLoader.kt
@@ -9,9 +9,11 @@ package com.facebook.react.common.mapbuffer
 
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarkerConstants
+import com.facebook.react.common.annotations.StableReactNativeAPI
 import com.facebook.soloader.SoLoader
 import com.facebook.systrace.Systrace
 
+@StableReactNativeAPI
 object MapBufferSoLoader {
   @Volatile private var didInit = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
@@ -9,6 +9,7 @@ package com.facebook.react.common.mapbuffer
 
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.common.annotations.StableReactNativeAPI
 import com.facebook.react.common.mapbuffer.MapBuffer.Companion.KEY_RANGE
 import java.lang.StringBuilder
 import java.nio.ByteBuffer
@@ -21,6 +22,7 @@ import javax.annotation.concurrent.NotThreadSafe
  *
  * See [MapBuffer] documentation for more details
  */
+@StableReactNativeAPI
 @NotThreadSafe
 @DoNotStrip
 class ReadableMapBuffer : MapBuffer {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/WritableMapBuffer.kt
@@ -9,6 +9,7 @@ package com.facebook.react.common.mapbuffer
 
 import android.util.SparseArray
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.common.annotations.StableReactNativeAPI
 import com.facebook.react.common.mapbuffer.MapBuffer.Companion.KEY_RANGE
 import com.facebook.react.common.mapbuffer.MapBuffer.DataType
 import javax.annotation.concurrent.NotThreadSafe
@@ -19,6 +20,7 @@ import javax.annotation.concurrent.NotThreadSafe
  *
  * See [MapBuffer] for more details
  */
+@StableReactNativeAPI
 @NotThreadSafe
 @DoNotStrip
 class WritableMapBuffer : MapBuffer {


### PR DESCRIPTION
Summary:
Mark Mapbuffer classes and interfaces as Stable

bypass-github-export-checks

changelog: [internal] internal

Reviewed By: luluwu2032

Differential Revision: D50294829


