### PR TITLE
feat(iOS): migrate deprecated UIMenuController to UIEditMenuInteraction

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -16,13 +16,11 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-#ifdef __IPHONE_16_0
 @interface RCTTextView () <UIEditMenuInteractionDelegate>
 
 @property (nonatomic, nullable) UIEditMenuInteraction *editMenuInteraction API_AVAILABLE(ios(16.0));
 
 @end
-#endif
 
 @implementation RCTTextView {
   CAShapeLayer *_highlightLayer;

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -249,21 +249,21 @@
       if (_editMenuInteraction) {
           [_editMenuInteraction presentEditMenuWithConfiguration:config];
       }
-  } else {
-      // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
-      UIMenuController *menuController = [UIMenuController sharedMenuController];
-
-      if (menuController.isMenuVisible) {
-        return;
-      }
-
-      if (!self.isFirstResponder) {
-        [self becomeFirstResponder];
-      }
-
-      [menuController setTargetRect:self.bounds inView:self];
-      [menuController setMenuVisible:YES animated:YES];
+      return;
   }
+  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
+  UIMenuController *menuController = [UIMenuController sharedMenuController];
+
+  if (menuController.isMenuVisible) {
+    return;
+  }
+
+  if (!self.isFirstResponder) {
+    [self becomeFirstResponder];
+  }
+
+  [menuController setTargetRect:self.bounds inView:self];
+  [menuController setMenuVisible:YES animated:YES];
 #endif
 }
 

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -16,6 +16,14 @@
 
 #import <QuartzCore/QuartzCore.h>
 
+#ifdef __IPHONE_16_0
+@interface RCTTextView () <UIEditMenuInteractionDelegate>
+
+@property (nonatomic, nullable) UIEditMenuInteraction *editMenuInteraction API_AVAILABLE(ios(16.0));
+
+@end
+#endif
+
 @implementation RCTTextView {
   CAShapeLayer *_highlightLayer;
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
@@ -213,31 +221,49 @@
 {
   _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                               action:@selector(handleLongPress:)];
+  if (@available(iOS 16.0, *)) {
+      _editMenuInteraction = [[UIEditMenuInteraction alloc] initWithDelegate:self];
+      [self addInteraction:_editMenuInteraction];
+  }
+    
   [self addGestureRecognizer:_longPressGestureRecognizer];
 }
 
 - (void)disableContextMenu
 {
   [self removeGestureRecognizer:_longPressGestureRecognizer];
+    
+  if (@available(iOS 16.0, *)) {
+    [self removeInteraction:_editMenuInteraction];
+    _editMenuInteraction = nil;
+  }
   _longPressGestureRecognizer = nil;
 }
 
 - (void)handleLongPress:(UILongPressGestureRecognizer *)gesture
 {
-  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
 #if !TARGET_OS_UIKITFORMAC
-  UIMenuController *menuController = [UIMenuController sharedMenuController];
+  if (@available(iOS 16.0, *)) {
+      CGPoint location = [gesture locationInView:self];
+      UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
+      if (_editMenuInteraction) {
+          [_editMenuInteraction presentEditMenuWithConfiguration:config];
+      }
+  } else {
+      // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
+      UIMenuController *menuController = [UIMenuController sharedMenuController];
 
-  if (menuController.isMenuVisible) {
-    return;
+      if (menuController.isMenuVisible) {
+        return;
+      }
+
+      if (!self.isFirstResponder) {
+        [self becomeFirstResponder];
+      }
+
+      [menuController setTargetRect:self.bounds inView:self];
+      [menuController setMenuVisible:YES animated:YES];
   }
-
-  if (!self.isFirstResponder) {
-    [self becomeFirstResponder];
-  }
-
-  [menuController setTargetRect:self.bounds inView:self];
-  [menuController setMenuVisible:YES animated:YES];
 #endif
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -246,21 +246,21 @@ using namespace facebook::react;
       if (_editMenuInteraction) {
           [_editMenuInteraction presentEditMenuWithConfiguration:config];
       }
-  } else {
-      // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
-      UIMenuController *menuController = [UIMenuController sharedMenuController];
-
-      if (menuController.isMenuVisible) {
-        return;
-      }
-
-      if (!self.isFirstResponder) {
-        [self becomeFirstResponder];
-      }
-
-      [menuController setTargetRect:self.bounds inView:self];
-      [menuController setMenuVisible:YES animated:YES];
+      return;
   }
+  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
+  UIMenuController *menuController = [UIMenuController sharedMenuController];
+
+  if (menuController.isMenuVisible) {
+    return;
+  }
+
+  if (!self.isFirstResponder) {
+    [self becomeFirstResponder];
+  }
+
+  [menuController setTargetRect:self.bounds inView:self];
+  [menuController setMenuVisible:YES animated:YES];
 #endif
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -24,13 +24,11 @@
 
 using namespace facebook::react;
 
-#ifdef __IPHONE_16_0
 @interface RCTParagraphComponentView () <UIEditMenuInteractionDelegate>
 
 @property (nonatomic, nullable) UIEditMenuInteraction *editMenuInteraction API_AVAILABLE(ios(16.0));
 
 @end
-#endif
 
 @implementation RCTParagraphComponentView {
   ParagraphShadowNode::ConcreteState::Shared _state;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -24,6 +24,14 @@
 
 using namespace facebook::react;
 
+#ifdef __IPHONE_16_0
+@interface RCTParagraphComponentView () <UIEditMenuInteractionDelegate>
+
+@property (nonatomic, nullable) UIEditMenuInteraction *editMenuInteraction API_AVAILABLE(ios(16.0));
+
+@end
+#endif
+
 @implementation RCTParagraphComponentView {
   ParagraphShadowNode::ConcreteState::Shared _state;
   ParagraphAttributes _paragraphAttributes;
@@ -211,31 +219,48 @@ using namespace facebook::react;
 {
   _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                               action:@selector(handleLongPress:)];
+    
+  if (@available(iOS 16.0, *)) {
+    _editMenuInteraction = [[UIEditMenuInteraction alloc] initWithDelegate:self];
+    [self addInteraction:_editMenuInteraction];
+  }
   [self addGestureRecognizer:_longPressGestureRecognizer];
 }
 
 - (void)disableContextMenu
 {
   [self removeGestureRecognizer:_longPressGestureRecognizer];
+  if (@available(iOS 16.0, *)) {
+      [self removeInteraction:_editMenuInteraction];
+      _editMenuInteraction = nil;
+  }
   _longPressGestureRecognizer = nil;
 }
 
 - (void)handleLongPress:(UILongPressGestureRecognizer *)gesture
 {
-  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
 #if !TARGET_OS_UIKITFORMAC
-  UIMenuController *menuController = [UIMenuController sharedMenuController];
+  if (@available(iOS 16.0, *)) {
+      CGPoint location = [gesture locationInView:self];
+      UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
+      if (_editMenuInteraction) {
+          [_editMenuInteraction presentEditMenuWithConfiguration:config];
+      }
+  } else {
+      // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
+      UIMenuController *menuController = [UIMenuController sharedMenuController];
 
-  if (menuController.isMenuVisible) {
-    return;
+      if (menuController.isMenuVisible) {
+        return;
+      }
+
+      if (!self.isFirstResponder) {
+        [self becomeFirstResponder];
+      }
+
+      [menuController setTargetRect:self.bounds inView:self];
+      [menuController setMenuVisible:YES animated:YES];
   }
-
-  if (!self.isFirstResponder) {
-    [self becomeFirstResponder];
-  }
-
-  [menuController setTargetRect:self.bounds inView:self];
-  [menuController setMenuVisible:YES animated:YES];
 #endif
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The goal of this PR is to migrate deprecated `UIMenuController` to `UIEditMenuInteraction`. `UIMenuController` has been deprecated in iOS 16 and for that reason it's not available for VisionOS. 

## Recording

https://github.com/facebook/react-native/assets/52801365/fed994be-d444-462a-9ed0-39b50531425d


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [CHANGED] - Migrate RCTTextView to UIEditMenuInteraction
## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Launch RNTester and check for "Selectable Text" example and check that it works for iOS 16/17.
