### PR TITLE
Ignore .windows.js and .macos.js in root .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,10 @@
 ; Ignore "BUCK" generated dirs
 <PROJECT_ROOT>/\.buckd/
 
+; Ignore other platform suffixes
+.*\.macos\.js$
+.*\.windows\.js$
+
 .*/node_modules/resolve/test/resolver/malformed_package_json/package\.json$
 
 ; Checked-in build output


### PR DESCRIPTION
Summary:
Long term, we'll want to flow check React Native desktop code, but in the near term, we can side step flow issues entirely by denylisting the desktop forked files in .flowconfig [ignore]. In fact, we don't do any flow checks on react-native desktop today 😬.

For the most part, the .macos.js and .windows.js forked files will be trivial changes to existing modules from react-native-github, and they will be kept in sync in an automated way, so there's an argument that the value of flow checks on these files is pretty limited.

However, at least until flow supports sub-directory multi-platform extensions and interface type hierarchies, we'll need to have entirely separate .flowconfigs for mobile and desktop (as desktop adds APIs to react-native mobile for things like keyboard input and navigation on arbitrary views).

These desktop .flowconfigs will come in a later diff.

## Changelog

[General][Internal]

Reviewed By: shwanton

Differential Revision: D50426512


