### PR TITLE
Revert ReactInstanceManager this::invokeDefaultOnBackPressed lambda

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -276,7 +276,12 @@ public class ReactInstanceManager {
       mPackages.add(
           new CoreModulesPackage(
               this,
-              this::invokeDefaultOnBackPressed,
+              new DefaultHardwareBackBtnHandler() {
+                @Override
+                public void invokeDefaultOnBackPressed() {
+                  ReactInstanceManager.this.invokeDefaultOnBackPressed();
+                }
+              },
               lazyViewManagersEnabled,
               minTimeLeftInFrameForNonBatchedOperationMs));
       if (mUseDeveloperSupport) {


### PR DESCRIPTION
Summary:
We got reports of the Twilight Android app crashing whenever the user presses the OS back button. Crash logs here: P860542895

Upon investigating, this issue happens only on the twilight_release build, not the twilight_debug or twilight-android build. Thus, we believe the issue is related to Proguard's optimization of the app since twilight_release is the only build of the app that gets the full Proguard optimization.

Changing ReactInstanceManager's function from lambda back to its original (it was converted to a lambda here: D45062457) fixes this issue, likely because Proguard was having trouble optimizing it correctly.

It's not 100% clear to me why this issue appeared on v238 as the [mobile bisect](https://m.intern.facebook.com/mobil.../bisect/detail_new/...) shows this issue started beteween Oct 12 7:28AM and 8:22AM but D45062457 was landed in April. One hypothesis I have is that [Proguard had a version update on Oct 12](https://github.com/Guardsquare/proguard/commit/f04ef27f668ad9da51e1bbcb18bc8d0da8577645) which may have contributed.

changelog: [internal] internal

Differential Revision: D50520227


