### PR TITLE
remove unused methodQueue from RCTHTTPRequestHandler

### DIFF
--- a/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -32,7 +32,6 @@ void RCTSetCustomNSURLSessionConfigurationProvider(NSURLSessionConfigurationProv
 }
 
 @synthesize moduleRegistry = _moduleRegistry;
-@synthesize methodQueue = _methodQueue;
 
 RCT_EXPORT_MODULE()
 


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking] You cannot call methodQueue on RCTHTTPRequestHandler

the `synthesize methodQueue` API is confusing, it looks like an API only for use within native module implementation, but it's actually needed to create a selector that corresponds to the property declared in the `RCTBridgeModule` public protocol.

no one is using the `methodQueue`  on `RCTHTTPRequestHandler`, so let's get rid of the public access to it.

Differential Revision: D50525900


