### PR TITLE
chore: update info about `fabric_enabled` in RNTester README 

### DIFF
--- a/packages/rn-tester/README.md
+++ b/packages/rn-tester/README.md
@@ -13,7 +13,7 @@ yarn install
 
 ### Running on iOS
 
-If you are testing non-fabric component, modify [the fabric_enabled flag in RNTester's Podfile](https://github.com/facebook/react-native/blob/main/packages/rn-tester/Podfile#L24).
+If you are testing non-fabric component, modify [the fabric_enabled flag in RNTester's Podfile](https://github.com/facebook/react-native/blob/main/packages/rn-tester/Podfile#L38).
 
 ```ruby
 fabric_enabled = false

--- a/packages/rn-tester/README.md
+++ b/packages/rn-tester/README.md
@@ -13,7 +13,7 @@ yarn install
 
 ### Running on iOS
 
-If you are testing non-fabric component, modify [the fabric_enabled flag in RNTester's Podfile](https://github.com/facebook/react-native/blob/main/packages/rn-tester/Podfile#L38).
+If you are testing non-fabric component, search for and modify the `fabric_enabled` flag in [RNTester's Podfile](https://github.com/facebook/react-native/blob/main/packages/rn-tester/Podfile).
 
 ```ruby
 fabric_enabled = false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This is a small fix to update line number pointing to `fabric_enabled` line number

## Changelog

[Internal] [Fixed] - Update line number in RNTester README

## Test Plan

Not needed