### PR TITLE
remove folly hash from codebase

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -11,7 +11,6 @@
 #include <limits>
 #include <optional>
 
-#include <folly/Hash.h>
 #include <react/renderer/attributedstring/primitives.h>
 #include <react/renderer/components/view/AccessibilityPrimitives.h>
 #include <react/renderer/core/LayoutPrimitives.h>
@@ -20,6 +19,7 @@
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Size.h>
+#include <react/utils/hash_combine.h>
 
 namespace facebook::react {
 
@@ -108,8 +108,7 @@ template <>
 struct hash<facebook::react::TextAttributes> {
   size_t operator()(
       const facebook::react::TextAttributes& textAttributes) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         textAttributes.foregroundColor,
         textAttributes.backgroundColor,
         textAttributes.opacity,

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -7,7 +7,6 @@
 
 #include "RawPropsParser.h"
 
-#include <folly/Hash.h>
 #include <folly/Likely.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/core/RawProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/Hash.h>
 #include <limits>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -178,8 +178,7 @@ inline size_t textAttributedStringHashLayoutWise(
   auto seed = size_t{0};
 
   for (const auto& fragment : attributedString.getFragments()) {
-    seed =
-        folly::hash::hash_combine(seed, textAttributesHashLayoutWise(fragment));
+    facebook::react::hash_combine(seed, textAttributesHashLayoutWise(fragment));
   }
 
   return seed;
@@ -208,8 +207,7 @@ namespace std {
 template <>
 struct hash<facebook::react::TextMeasureCacheKey> {
   size_t operator()(const facebook::react::TextMeasureCacheKey& key) const {
-    return folly::hash::hash_combine(
-        0,
+    return facebook::react::hash_combine(
         textAttributedStringHashLayoutWise(key.attributedString),
         key.paragraphAttributes,
         key.layoutConstraints.maximumSize.width);


### PR DESCRIPTION
Summary:
changelog: [internal]

RN moved away from using folly::hash. These are a few places missed during the migration.

Differential Revision: D50540176


