### PR TITLE
use c++20 likely and unlikely

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -7,7 +7,6 @@
 
 #include "RawPropsParser.h"
 
-#include <folly/Likely.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/core/RawProps.h>
 
@@ -21,7 +20,7 @@ namespace facebook::react {
 const RawValue* RawPropsParser::at(
     const RawProps& rawProps,
     const RawPropsKey& key) const noexcept {
-  if (UNLIKELY(!ready_)) {
+  if (!ready_) [[unlikely]] {
     // Check against the same key being inserted more than once.
     // This happens commonly with nested Props structs, where the higher-level
     // struct may access all fields, and then the nested Props struct may
@@ -69,8 +68,8 @@ const RawValue* RawPropsParser::at(
   do {
     rawProps.keyIndexCursor_++;
 
-    if (UNLIKELY(
-            static_cast<size_t>(rawProps.keyIndexCursor_) >= keys_.size())) {
+    if (static_cast<size_t>(rawProps.keyIndexCursor_) >= keys_.size())
+        [[unlikely]] {
 #ifdef REACT_NATIVE_DEBUG
       if (resetLoop) {
         LOG(ERROR)
@@ -82,7 +81,7 @@ const RawValue* RawPropsParser::at(
 #endif
       rawProps.keyIndexCursor_ = 0;
     }
-  } while (UNLIKELY(key != keys_[rawProps.keyIndexCursor_]));
+  } while (key != keys_[rawProps.keyIndexCursor_]);
 
   auto valueIndex = rawProps.keyIndexToValueIndex_[rawProps.keyIndexCursor_];
   return valueIndex == kRawPropsValueIndexEmpty ? nullptr

--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -9,7 +9,6 @@
 
 #include <optional>
 
-#include <folly/Likely.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawProps.h>
 #include <react/renderer/core/RawPropsKey.h>
@@ -117,13 +116,13 @@ T convertRawProp(
     const char* namePrefix = nullptr,
     const char* nameSuffix = nullptr) {
   const auto* rawValue = rawProps.at(name, namePrefix, nameSuffix);
-  if (LIKELY(rawValue == nullptr)) {
+  if (rawValue == nullptr) [[likely]] {
     return sourceValue;
   }
 
   // Special case: `null` always means "the prop was removed, use default
   // value".
-  if (UNLIKELY(!rawValue->hasValue())) {
+  if (!rawValue->hasValue()) [[unlikely]] {
     return defaultValue;
   }
 


### PR DESCRIPTION
Summary:
changelog: [internal]

RN now builds with C++ 20 and we can move away from folly::Likely.

More about [[likely]] and [[unlikely]] https://en.cppreference.com/w/cpp/language/attributes/likely

Differential Revision: D50540008


