### PR TITLE
Use a stable device+app ID to register with the inspector proxy

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -149,6 +149,9 @@ export default class InspectorProxy implements InspectorProxyQueries {
       webSocketDebuggerUrl,
       vm: page.vm,
       deviceName: device.getName(),
+      reactNative: {
+        logicalDeviceId: deviceId,
+      },
     };
   }
 

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -79,6 +79,10 @@ export type PageDescription = {
   devtoolsFrontendUrl: string,
   type: string,
   webSocketDebuggerUrl: string,
+  // Metadata specific to React Native
+  reactNative: {
+    logicalDeviceId: string,
+  },
   ...
 };
 export type JsonPagesListResponse = Array<PageDescription>;

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -57,7 +57,7 @@ export default function openDebuggerMiddleware({
       (experiments.enableOpenDebuggerRedirect && req.method === 'GET')
     ) {
       const {query} = url.parse(req.url, true);
-      const {appId} = query;
+      const {appId, device}: {appId?: string, device?: string, ...} = query;
 
       const targets = inspectorProxy.getPageDescriptions().filter(
         // Only use targets with better reloading support
@@ -69,12 +69,19 @@ export default function openDebuggerMiddleware({
       const launchType: 'launch' | 'redirect' =
         req.method === 'POST' ? 'launch' : 'redirect';
 
-      if (typeof appId === 'string') {
+      if (typeof appId === 'string' || typeof device === 'string') {
         logger?.info(
           (launchType === 'launch' ? 'Launching' : 'Redirecting to') +
             ' JS debugger (experimental)...',
         );
-        target = targets.find(_target => _target.description === appId);
+        if (typeof device === 'string') {
+          target = targets.find(
+            _target => _target.reactNative.logicalDeviceId === device,
+          );
+        }
+        if (!target && typeof appId === 'string') {
+          target = targets.find(_target => _target.description === appId);
+        }
       } else {
         logger?.info(
           (launchType === 'launch' ? 'Launching' : 'Redirecting to') +
@@ -101,9 +108,13 @@ export default function openDebuggerMiddleware({
       try {
         switch (launchType) {
           case 'launch':
-            await debuggerInstances.get(appId)?.kill();
+            const frontendInstanceId =
+              device != null
+                ? 'device:' + device
+                : 'app:' + (appId ?? '<null>');
+            await debuggerInstances.get(frontendInstanceId)?.kill();
             debuggerInstances.set(
-              appId,
+              frontendInstanceId,
               await browserLauncher.launchDebuggerAppWindow(
                 getDevToolsFrontendUrl(
                   target.webSocketDebuggerUrl,
@@ -130,7 +141,8 @@ export default function openDebuggerMiddleware({
           type: 'launch_debugger_frontend',
           launchType,
           status: 'success',
-          appId,
+          appId: appId ?? null,
+          deviceId: device ?? null,
         });
         return;
       } catch (e) {

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -36,7 +36,7 @@ export type ReportableEvent =
       type: 'launch_debugger_frontend',
       launchType: 'launch' | 'redirect',
       ...
-        | SuccessResult<{appId: string}>
+        | SuccessResult<{appId: string | null, deviceId: string | null}>
         | ErrorResult<mixed>
         | CodedErrorResult<'NO_APPS_FOUND'>,
     }

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -15,6 +15,8 @@
 #import <React/RCTDefines.h>
 #import <React/RCTInspectorPackagerConnection.h>
 
+#import <CommonCrypto/CommonCrypto.h>
+
 static NSString *const kDebuggerMsgDisable = @"{ \"id\":1,\"method\":\"Debugger.disable\" }";
 
 static NSString *getServerHost(NSURL *bundleURL)
@@ -40,16 +42,65 @@ static NSString *getServerHost(NSURL *bundleURL)
   return [NSString stringWithFormat:@"%@:%@", host, port];
 }
 
+static NSString *getSHA256(NSString *string)
+{
+  const char *str = string.UTF8String;
+  unsigned char result[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(str, (CC_LONG)strlen(str), result);
+
+  return [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+                                    result[0],
+                                    result[1],
+                                    result[2],
+                                    result[3],
+                                    result[4],
+                                    result[5],
+                                    result[6],
+                                    result[7],
+                                    result[8],
+                                    result[9],
+                                    result[10],
+                                    result[11],
+                                    result[12],
+                                    result[13],
+                                    result[14],
+                                    result[15],
+                                    result[16],
+                                    result[17],
+                                    result[18],
+                                    result[19]];
+}
+
+// Returns an opaque ID which is stable for the current combination of device and app, stable across installs,
+// and unique across devices.
+static NSString *getInspectorDeviceId()
+{
+  // A bundle ID uniquely identifies a single app throughout the system. [Source: Apple docs]
+  NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
+
+  // An alphanumeric string that uniquely identifies a device to the app's vendor. [Source: Apple docs]
+  NSString *identifierForVendor = [[UIDevice currentDevice] identifierForVendor].UUIDString;
+
+  NSString *rawDeviceId = [NSString stringWithFormat:@"apple-%@-%@", identifierForVendor, bundleId];
+
+  return getSHA256(rawDeviceId);
+}
+
 static NSURL *getInspectorDeviceUrl(NSURL *bundleURL)
 {
   NSString *escapedDeviceName = [[[UIDevice currentDevice] name]
       stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
   NSString *escapedAppName = [[[NSBundle mainBundle] bundleIdentifier]
       stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
-  return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/inspector/device?name=%@&app=%@",
+
+  NSString *escapedInspectorDeviceId = [getInspectorDeviceId()
+      stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
+
+  return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/inspector/device?name=%@&app=%@&device=%@",
                                                          getServerHost(bundleURL),
                                                          escapedDeviceName,
-                                                         escapedAppName]];
+                                                         escapedAppName,
+                                                         escapedInspectorDeviceId]];
 }
 
 @implementation RCTInspectorDevServerHelper
@@ -70,8 +121,13 @@ static void sendEventToAllConnections(NSString *event)
   NSString *appId = [[[NSBundle mainBundle] bundleIdentifier]
       stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
 
-  NSURL *url = [NSURL
-      URLWithString:[NSString stringWithFormat:@"http://%@/open-debugger?appId=%@", getServerHost(bundleURL), appId]];
+  NSString *escapedInspectorDeviceId = [getInspectorDeviceId()
+      stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
+
+  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/open-debugger?appId=%@&device=%@",
+                                                               getServerHost(bundleURL),
+                                                               appId,
+                                                               escapedInspectorDeviceId]];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
   [request setHTTPMethod:@"POST"];
 


### PR DESCRIPTION
Summary:
Building on byCedric's approach in https://github.com/facebook/metro/pull/991, and on D49954920, this diff passes stable, unique *logical device IDs* to the debugger connection infrastructure from Android and iOS.

See D49954920 for the precise stability and uniqueness requirements that these IDs meet.

Changelog:

[Changed][General] - Automatically reconnect to an existing debugger session on relaunching the app

Reviewed By: huntie

Differential Revision: D49954919

