### PR TITLE
[RN][CI] Disable unstable E2E tests

### DIFF
--- a/.circleci/configurations/test_workflows/testAndroid.yml
+++ b/.circleci/configurations/test_workflows/testAndroid.yml
@@ -46,7 +46,7 @@
       - test_android:
           requires:
             - build_android
-      - test_e2e_android
+      # - test_e2e_android
       - test_android_template:
           requires:
             - build_npm_package

--- a/.circleci/configurations/test_workflows/testE2E.yml
+++ b/.circleci/configurations/test_workflows/testE2E.yml
@@ -7,5 +7,4 @@
     jobs:
       - test_e2e_ios:
           ruby_version: "2.7.7"
-      # This is not stable
-      # - test_e2e_android
+      - test_e2e_android

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -43,8 +43,8 @@
             - build_hermesc_linux
             - build_hermes_macos
             - build_hermesc_windows
-      - test_e2e_ios:
-          ruby_version: "2.7.7"
+      # - test_e2e_ios:
+      #     ruby_version: "2.7.7"
       - test_ios_template:
           requires:
             - build_npm_package

--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -182,4 +182,4 @@ async function handleStatuses() {
   }
 }
 
-handleStatuses();
+// handleStatuses();

--- a/scripts/circleci/pipeline_selection.js
+++ b/scripts/circleci/pipeline_selection.js
@@ -54,10 +54,10 @@ const mapping = [
     name: 'RUN_ANDROID',
     filterFN: name => name.indexOf('ReactAndroid/') > -1,
   },
-  {
-    name: 'RUN_E2E',
-    filterFN: name => name.indexOf('rn-tester-e2e/') > -1,
-  },
+  // {
+  //   name: 'RUN_E2E',
+  //   filterFN: name => name.indexOf('rn-tester-e2e/') > -1,
+  // },
   {
     name: 'RUN_JS',
     filterFN: name => isJSChange(name),
@@ -154,7 +154,7 @@ async function _computeAndSavePipelineParameters(pipelineType, outputPath) {
     run_ios: pipelineType === 'RUN_IOS',
     run_android: pipelineType === 'RUN_ANDROID',
     run_js: pipelineType === 'RUN_JS',
-    run_e2e: pipelineType === 'RUN_E2E' || pipelineType === 'RUN_JS',
+    // run_e2e: pipelineType === 'RUN_E2E' || pipelineType === 'RUN_JS',
   };
 
   const stringifiedParams = JSON.stringify(params, null, 2);
@@ -180,8 +180,8 @@ function createConfigs(inputPath, outputPath, configFile) {
   const testConfigs = {
     run_ios: ['testIOS.yml'],
     run_android: ['testAndroid.yml'],
-    run_e2e: ['testE2E.yml'],
-    run_all: ['testE2E.yml', 'testJS.yml', 'testAll.yml'],
+    // run_e2e: ['testE2E.yml'],
+    run_all: [/*'testE2E.yml',*/ 'testJS.yml', 'testAll.yml'],
     run_js: ['testJS.yml'],
   };
 


### PR DESCRIPTION
## Summary:
E2E tests in OSS are expensive and flaky.
They already prevented some broken changes to land on main, but as of today:
- they are always green, so they are not bloking
- nobody is looking at the reporting job
- the reporting job takes a lot of time to run and prevent other useful signals to be available soon
- it is expensive

So we decide to disable them for the time being, while we iterate on those with Callstack and MSFT.

## Changelog:
[Internal] -  Disable E2E tests

## Test Plan:
CircleCI stays green
