### PR TITLE
Remove unnecessary unstable_useRuntimeSchedulerAlways Feature Flag

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1358,14 +1358,12 @@ public class ReactInstanceManager {
 
     reactContext.initializeWithInstance(catalystInstance);
 
-    if (ReactFeatureFlags.unstable_useRuntimeSchedulerAlways) {
-      // On Old Architecture, we need to initialize the Native Runtime Scheduler so that
-      // the `nativeRuntimeScheduler` object is registered on JS.
-      // On New Architecture, this is normally triggered by instantiate a TurboModuleManager.
-      // Here we invoke getRuntimeScheduler() to trigger the creation of it regardless of the
-      // architecture so it will always be there.
-      catalystInstance.getRuntimeScheduler();
-    }
+    // On Old Architecture, we need to initialize the Native Runtime Scheduler so that
+    // the `nativeRuntimeScheduler` object is registered on JS.
+    // On New Architecture, this is normally triggered by instantiate a TurboModuleManager.
+    // Here we invoke getRuntimeScheduler() to trigger the creation of it regardless of the
+    // architecture so it will always be there.
+    catalystInstance.getRuntimeScheduler();
 
     if (ReactFeatureFlags.useTurboModules && mTMMDelegateBuilder != null) {
       TurboModuleManagerDelegate tmmDelegate =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -57,13 +57,6 @@ public class ReactFeatureFlags {
   public static volatile boolean unstable_useFabricInterop = false;
 
   /**
-   * Should this application always use the Native RuntimeScheduler? If yes, we'll be instantiating
-   * it over all the architectures (both Old and New). This is intentionally set to true as we want
-   * to use it more as a kill-switch to turn off this feature to potentially debug issues.
-   */
-  public static volatile boolean unstable_useRuntimeSchedulerAlways = true;
-
-  /**
    * Feature flag to enable the new bridgeless architecture. Note: Enabling this will force enable
    * the following flags: `useTurboModules` & `enableFabricRenderer`.
    */


### PR DESCRIPTION
Summary:
This feature flag was just a killswitch for OSS. As we don't need it anymore, I'm removing it.
I've also discussed with Expo so they remove any usages of this in their codebase.

Changelog:
[Internal] [Changed] - Remove unnecessary unstable_useRuntimeSchedulerAlways Feature Flag

Differential Revision: D50554334


