### PR TITLE
Use concurrentRoot in ReactDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -74,10 +74,10 @@ public class ReactDelegate {
       boolean fabricEnabled) {
     mActivity = activity;
     mMainComponentName = appKey;
+    mFabricEnabled = fabricEnabled;
     mLaunchOptions = composeLaunchOptions(launchOptions);
     mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
     mReactNativeHost = reactNativeHost;
-    mFabricEnabled = fabricEnabled;
   }
 
   public void onHostResume() {


### PR DESCRIPTION
Summary:
On Twilight Android, I was noticing that we were seeing this [console log](https://www.internalfb.com/code/fbsource/[b107d68204f4]/xplat/js/react-native-github/packages/react-native/Libraries/ReactNative/renderApplication.js?lines=88) added by javache recently: "Using Fabric without concurrent root is deprecated. Please enable concurrent root for this application."

Upon investigating I noticed that in ReactDelegate, we were calling composeLaunchOptions() before mFabricIsEnabled is set based on the parameter. This means that mFabricEnabled was always false even if we passed in true when composeLaunchOptions() was called, and therefore concurrentRoot is never enabled.

This change updates mFabricEnabled before calling composeLaunchOptions() so the concurrentRoot flag is set accordingly.

Differential Revision: D50562664


