### PR TITLE
Eliminate const qualifier from MutationRecord

### DIFF
--- a/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.cpp
+++ b/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.cpp
@@ -88,7 +88,7 @@ void NativeMutationObserver::connect(
 
   notifyMutationObservers_ = std::move(notifyMutationObservers);
 
-  auto onMutationsCallback = [&](std::vector<const MutationRecord>& records) {
+  auto onMutationsCallback = [&](std::vector<MutationRecord>& records) {
     return onMutations(records);
   };
 
@@ -125,8 +125,7 @@ NativeMutationObserver::getPublicInstancesFromShadowNodes(
   return publicInstances;
 }
 
-void NativeMutationObserver::onMutations(
-    std::vector<const MutationRecord>& records) {
+void NativeMutationObserver::onMutations(std::vector<MutationRecord>& records) {
   SystraceSection s("NativeMutationObserver::onMutations");
 
   for (const auto& record : records) {

--- a/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.h
+++ b/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.h
@@ -94,7 +94,7 @@ class NativeMutationObserver
   bool notifiedMutationObservers_{};
   std::function<void()> notifyMutationObservers_;
 
-  void onMutations(std::vector<const MutationRecord>& records);
+  void onMutations(std::vector<MutationRecord>& records);
   void notifyMutationObserversIfNecessary();
 
   std::vector<jsi::Value> getPublicInstancesFromShadowNodes(

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
@@ -77,7 +77,7 @@ static ShadowNode::Shared findNodeOfSameFamily(
 void MutationObserver::recordMutations(
     const RootShadowNode& oldRootShadowNode,
     const RootShadowNode& newRootShadowNode,
-    std::vector<const MutationRecord>& recordedMutations) const {
+    std::vector<MutationRecord>& recordedMutations) const {
   // This tracks the nodes that have already been processed by this observer,
   // so we avoid unnecessary work and duplicated entries.
   SetOfShadowNodePointers processedNodes;
@@ -110,7 +110,7 @@ void MutationObserver::recordMutationsInTarget(
     const RootShadowNode& oldRootShadowNode,
     const RootShadowNode& newRootShadowNode,
     bool observeSubtree,
-    std::vector<const MutationRecord>& recordedMutations,
+    std::vector<MutationRecord>& recordedMutations,
     SetOfShadowNodePointers& processedNodes) const {
   // If the node isnt't present in the old tree, it's either:
   // - A new node. In that case, the mutation happened in its parent, not in the
@@ -146,7 +146,7 @@ void MutationObserver::recordMutationsInSubtrees(
     const ShadowNode& oldNode,
     const ShadowNode& newNode,
     bool observeSubtree,
-    std::vector<const MutationRecord>& recordedMutations,
+    std::vector<MutationRecord>& recordedMutations,
     SetOfShadowNodePointers processedNodes) const {
   bool isSameNode = &oldNode == &newNode;
   // If the nodes are referentially equal, their children are also the same.

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
@@ -35,7 +35,7 @@ class MutationObserver {
   void recordMutations(
       const RootShadowNode& oldRootShadowNode,
       const RootShadowNode& newRootShadowNode,
-      std::vector<const MutationRecord>& recordedMutations) const;
+      std::vector<MutationRecord>& recordedMutations) const;
 
  private:
   MutationObserverId mutationObserverId_;
@@ -49,7 +49,7 @@ class MutationObserver {
       const RootShadowNode& oldRootShadowNode,
       const RootShadowNode& newRootShadowNode,
       bool observeSubtree,
-      std::vector<const MutationRecord>& recordedMutations,
+      std::vector<MutationRecord>& recordedMutations,
       SetOfShadowNodePointers& processedNodes) const;
 
   void recordMutationsInSubtrees(
@@ -57,7 +57,7 @@ class MutationObserver {
       const ShadowNode& oldNode,
       const ShadowNode& newNode,
       bool observeSubtree,
-      std::vector<const MutationRecord>& recordedMutations,
+      std::vector<MutationRecord>& recordedMutations,
       SetOfShadowNodePointers processedNodes) const;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
@@ -70,7 +70,7 @@ void MutationObserverManager::unobserve(
 
 void MutationObserverManager::connect(
     UIManager& uiManager,
-    std::function<void(std::vector<const MutationRecord>&)> onMutations) {
+    std::function<void(std::vector<MutationRecord>&)> onMutations) {
   SystraceSection s("MutationObserverManager::connect");
 
   // Fail-safe in case the caller doesn't guarantee consistency.
@@ -124,7 +124,7 @@ void MutationObserverManager::runMutationObservations(
     return;
   }
 
-  std::vector<const MutationRecord> mutationRecords;
+  std::vector<MutationRecord> mutationRecords;
 
   auto& observers = observersIt->second;
   for (const auto& [mutationObserverId, observer] : observers) {

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
@@ -31,7 +31,7 @@ class MutationObserverManager final : public UIManagerCommitHook {
 
   void connect(
       UIManager& uiManager,
-      std::function<void(std::vector<const MutationRecord>&)> onMutations);
+      std::function<void(std::vector<MutationRecord>&)> onMutations);
 
   void disconnect(UIManager& uiManager);
 
@@ -51,7 +51,7 @@ class MutationObserverManager final : public UIManagerCommitHook {
       std::unordered_map<MutationObserverId, MutationObserver>>
       observersBySurfaceId_;
 
-  std::function<void(std::vector<const MutationRecord>&)> onMutations_;
+  std::function<void(std::vector<MutationRecord>&)> onMutations_;
   bool commitHookRegistered_{};
 
   void runMutationObservations(


### PR DESCRIPTION
Summary:
"The C++ standard forbids containers of const elements because allocator<const T> is ill-formed."

We have a few other callsites for std::vector<const ...>, but the const values are always const pointers, which I guess are okay?

Suffice to say, this doesn't compile with Microsoft STL headers unless you remove const.

## Changelog

[Internal]

Differential Revision: D50563174


