### PR TITLE
Fix concurrentRoot warning in bridgeless for Logbox

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -237,6 +237,6 @@ public class ReactActivityDelegate {
    * @return true if Fabric is enabled for this Activity, false otherwise.
    */
   protected boolean isFabricEnabled() {
-    return false;
+    return ReactFeatureFlags.enableFabricRenderer;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -72,12 +72,12 @@ public class ReactDelegate {
       @Nullable String appKey,
       @Nullable Bundle launchOptions,
       boolean fabricEnabled) {
+    mFabricEnabled = fabricEnabled;
     mActivity = activity;
     mMainComponentName = appKey;
     mLaunchOptions = composeLaunchOptions(launchOptions);
     mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
     mReactNativeHost = reactNativeHost;
-    mFabricEnabled = fabricEnabled;
   }
 
   public void onHostResume() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -332,8 +332,11 @@ public class ReactInstanceManager {
         Activity currentActivity = getCurrentActivity();
         if (currentActivity != null) {
           ReactRootView rootView = new ReactRootView(currentActivity);
-          rootView.setIsFabric(ReactFeatureFlags.enableFabricRenderer);
-          rootView.startReactApplication(ReactInstanceManager.this, appKey, null);
+          boolean isFabric = ReactFeatureFlags.enableFabricRenderer;
+          rootView.setIsFabric(isFabric);
+          Bundle launchOptions = new Bundle();
+          launchOptions.putBoolean("concurrentRoot", isFabric);
+          rootView.startReactApplication(ReactInstanceManager.this, appKey, launchOptions);
           return rootView;
         }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessDevSupportManager.java
@@ -9,6 +9,7 @@ package com.facebook.react.runtime;
 
 import android.app.Activity;
 import android.content.Context;
+import android.os.Bundle;
 import android.view.View;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JSBundleLoader;
@@ -134,9 +135,11 @@ class BridgelessDevSupportManager extends DevSupportManagerBase {
       public View createRootView(String appKey) {
         Activity currentActivity = getCurrentActivity();
         if (currentActivity != null && !reactHost.isSurfaceWithModuleNameAttached(appKey)) {
-          ReactSurfaceImpl reactSurface =
-              ReactSurfaceImpl.createWithView(currentActivity, appKey, null);
+          Bundle launchOptions = new Bundle();
+          launchOptions.putBoolean("concurrentRoot", true);
 
+          ReactSurfaceImpl reactSurface =
+              ReactSurfaceImpl.createWithView(currentActivity, appKey, launchOptions);
           reactSurface.attach(reactHost);
           reactSurface.start();
 


### PR DESCRIPTION
Summary:
When creating the react root for Logbox, we do not pass the concurrentRoot option leading to a warning because it is using Fabric.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D50558855


