### PR TITLE
Fix AppDelegate not passing props in bridgeless and rename getBundleURL

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -139,7 +139,7 @@
 - (BOOL)bridgelessEnabled;
 
 /// Return the bundle URL for the main bundle.
-- (NSURL *)getBundleURL;
+- (NSURL *)bundleURL;
 
 #endif
 

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -88,7 +88,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   RCTAppSetupPrepareApp(application, enableTM);
 
   UIView *rootView;
-
   if (enableBridgeless) {
 #if RCT_NEW_ARCH_ENABLED
     // Enable native view config interop only if both bridgeless mode and Fabric is enabled.
@@ -101,8 +100,8 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
     [self createReactHost];
     [self unstable_registerLegacyComponents];
     [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;
-    RCTFabricSurface *surface = [_reactHost createSurfaceWithModuleName:self.moduleName
-                                                      initialProperties:launchOptions];
+    NSDictionary *initProps = [self prepareInitialProps];
+    RCTFabricSurface *surface = [_reactHost createSurfaceWithModuleName:self.moduleName initialProperties:initProps];
 
     RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView = [[RCTSurfaceHostingProxyRootView alloc]
         initWithSurface:surface
@@ -284,14 +283,14 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 - (void)createReactHost
 {
   __weak __typeof(self) weakSelf = self;
-  _reactHost = [[RCTHost alloc] initWithBundleURL:[self getBundleURL]
+  _reactHost = [[RCTHost alloc] initWithBundleURL:[self bundleURL]
                                      hostDelegate:nil
                        turboModuleManagerDelegate:self
                                  jsEngineProvider:^std::shared_ptr<facebook::react::JSEngineInstance>() {
                                    return [weakSelf createJSEngineInstance];
                                  }];
   [_reactHost setBundleURLProvider:^NSURL *() {
-    return [weakSelf getBundleURL];
+    return [weakSelf bundleURL];
   }];
   [_reactHost setContextContainerHandler:self];
   [_reactHost start];
@@ -311,9 +310,9 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
 }
 
-- (NSURL *)getBundleURL
+- (NSURL *)bundleURL
 {
-  [NSException raise:@"RCTAppDelegate::getBundleURL not implemented"
+  [NSException raise:@"RCTAppDelegate::bundleURL not implemented"
               format:@"Subclasses must implement a valid getBundleURL method"];
   return nullptr;
 }

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -127,7 +127,7 @@ NSString *kBundlePath = @"js/RNTesterApp.ios";
 }
 #endif
 
-- (NSURL *)getBundleURL
+- (NSURL *)bundleURL
 {
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:kBundlePath];
 }


### PR DESCRIPTION
Summary:
* `initialProperties` should be based on `prepareInitialProps`, not `launchOptions` (which don't seem to have an equivalent in bridgeless)
* `getBundleURL` is not idiomatic Objective-C (eg https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html), so rename to `bundleURL`

Changelog: [Internal]

Differential Revision: D50595790


