### PR TITLE
Revert "BlobManager: implement Blob from ArrayBuffer (#39276)"

### DIFF
--- a/packages/react-native/Libraries/Blob/Blob.js
+++ b/packages/react-native/Libraries/Blob/Blob.js
@@ -57,10 +57,7 @@ class Blob {
    * Currently we only support creating Blobs from other Blobs.
    * Reference: https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob
    */
-  constructor(
-    parts: Array<$ArrayBufferView | ArrayBuffer | Blob | string> = [],
-    options?: BlobOptions,
-  ) {
+  constructor(parts: Array<Blob | string> = [], options?: BlobOptions) {
     const BlobManager = require('./BlobManager');
     this.data = BlobManager.createFromParts(parts, options).data;
   }

--- a/packages/react-native/Libraries/Blob/BlobManager.js
+++ b/packages/react-native/Libraries/Blob/BlobManager.js
@@ -11,7 +11,6 @@
 import type {BlobCollector, BlobData, BlobOptions} from './BlobTypes';
 
 import NativeBlobModule from './NativeBlobModule';
-import {fromByteArray} from 'base64-js';
 import invariant from 'invariant';
 
 const Blob = require('./Blob');
@@ -60,20 +59,22 @@ class BlobManager {
    * Create blob from existing array of blobs.
    */
   static createFromParts(
-    parts: Array<$ArrayBufferView | ArrayBuffer | Blob | string>,
+    parts: Array<Blob | string>,
     options?: BlobOptions,
   ): Blob {
     invariant(NativeBlobModule, 'NativeBlobModule is available.');
 
     const blobId = uuidv4();
     const items = parts.map(part => {
-      if (part instanceof ArrayBuffer || ArrayBuffer.isView(part)) {
-        return {
-          // $FlowFixMe[incompatible-cast]
-          data: fromByteArray(new Uint8Array((part: ArrayBuffer))),
-          type: 'string',
-        };
-      } else if (part instanceof Blob) {
+      if (
+        part instanceof ArrayBuffer ||
+        (global.ArrayBufferView && part instanceof global.ArrayBufferView)
+      ) {
+        throw new Error(
+          "Creating blobs from 'ArrayBuffer' and 'ArrayBufferView' are not supported",
+        );
+      }
+      if (part instanceof Blob) {
         return {
           data: part.data,
           type: 'blob',

--- a/packages/react-native/Libraries/Blob/BlobManager.js
+++ b/packages/react-native/Libraries/Blob/BlobManager.js
@@ -66,10 +66,7 @@ class BlobManager {
 
     const blobId = uuidv4();
     const items = parts.map(part => {
-      if (
-        part instanceof ArrayBuffer ||
-        (global.ArrayBufferView && part instanceof global.ArrayBufferView)
-      ) {
+      if (part instanceof ArrayBuffer || ArrayBuffer.isView(part)) {
         throw new Error(
           "Creating blobs from 'ArrayBuffer' and 'ArrayBufferView' are not supported",
         );

--- a/packages/react-native/Libraries/Blob/File.js
+++ b/packages/react-native/Libraries/Blob/File.js
@@ -23,7 +23,7 @@ class File extends Blob {
    * Constructor for JS consumers.
    */
   constructor(
-    parts: Array<$ArrayBufferView | ArrayBuffer | Blob | string>,
+    parts: Array<Blob | string>,
     name: string,
     options?: BlobOptions,
   ) {

--- a/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
@@ -15,7 +15,6 @@ jest.setMock('../../BatchedBridge/NativeModules', {
 });
 
 const Blob = require('../Blob');
-const {fromByteArray} = require('base64-js');
 
 describe('Blob', function () {
   it('should create empty blob', () => {
@@ -27,7 +26,7 @@ describe('Blob', function () {
     expect(blob.type).toBe('');
   });
 
-  it('should create blob from ArrayBuffer, other blobs, strings', () => {
+  it('should create blob from other blobs and strings', () => {
     const blobA = new Blob();
     const blobB = new Blob();
     const textA = 'i \u2665 dogs';
@@ -44,20 +43,14 @@ describe('Blob', function () {
     blobA.data.size = 34540;
     blobB.data.size = 65452;
 
-    const buffer = new ArrayBuffer(4);
-
-    const blob = new Blob([blobA, blobB, textA, textB, textC, buffer]);
+    const blob = new Blob([blobA, blobB, textA, textB, textC]);
 
     expect(blob.size).toBe(
       blobA.size +
         blobB.size +
         global.Buffer.byteLength(textA, 'UTF-8') +
         global.Buffer.byteLength(textB, 'UTF-8') +
-        global.Buffer.byteLength(textC, 'UTF-8') +
-        global.Buffer.byteLength(
-          fromByteArray(new Uint8Array(buffer)),
-          'UTF-8',
-        ),
+        global.Buffer.byteLength(textC, 'UTF-8'),
     );
     expect(blob.type).toBe('');
   });


### PR DESCRIPTION
## Summary:

As per #41079, we're outputting ASCII encoded data URIs to `FileReader.readAsDataURL` due to lack of native `ArrayBuffer` support and unclear use of encoding to align with web. I'll revisit this at a later point with a better testing strategy once we have a good idea of how this should behave internally.

Aside from purely reverting #39276, I've kept the use of `ArrayBuffer.isView(part)` to the previous `part instanceof global.ArrayBufferView` since it is more correct.

## Changelog:

[INTERNAL] [REMOVED] - Revert Blob from ArrayBuffer

## Test Plan:

Run the following at the project root to selectively test changes:

`jest packages/react-native/Libraries/Blob`
