### PR TITLE
Update generate-artifacts-executor.js

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -372,7 +372,7 @@ function generateCode(iosOutputDir, library, tmpDir, node, pathToSchema) {
   const outputDir =
     CORE_LIBRARIES_WITH_OUTPUT_FOLDER[library.config.name] ?? iosOutputDir;
   fs.mkdirSync(outputDir, {recursive: true});
-  execSync(`cp -R ${tmpOutputDir}/* "${outputDir}"`);
+  fs.cpSync(tmpOutputDir, outputDir, {recursive: true});
   console.log(`[Codegen] Generated artifacts: ${iosOutputDir}`);
 }
 


### PR DESCRIPTION
cp is not known in windows, use cross platform fs function instead

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I am under windows (exceptionally) and one of your script failed because CP is not a valid command under windows.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL] [FIXED] Windows script support fix
## Test Plan:

No unit test sorry
