### PR TITLE
Do not attempt to query Maven Central if project has react.internal.mavenLocalRepo

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -36,6 +36,12 @@ internal object DependencyUtils {
         repositories.mavenCentral { repo ->
           // We don't want to fetch JSC from Maven Central as there are older versions there.
           repo.content { it.excludeModule("org.webkit", "android-jsc") }
+
+          // If the user provided a react.internal.mavenLocalRepo, do not attempt to load
+          // anything from Maven Central that is react related.
+          if (hasProperty(INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO)) {
+            repo.content { it.excludeGroup("com.facebook.react") }
+          }
         }
         // Android JSC is installed from npm
         mavenRepoFromURI(File(reactNativeDir, "../jsc-android/dist").toURI())


### PR DESCRIPTION
Summary:
This will make sure that if you specify a maven local folder with `react.internal.mavenLocalRepo`
you're not attempting to fetch artifacts from Maven Central.

Changelog:
[Internal] [Changed] - Do not attempt to query Maven Central if project has react.internal.mavenLocalRepo

Reviewed By: mdvacca

Differential Revision: D50600815


