### PR TITLE
setup test to use custom queue for RCTImageStoreManager operations instead of module queue

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageStoreManager.h
+++ b/packages/react-native/Libraries/Image/RCTImageStoreManager.h
@@ -11,6 +11,8 @@
 #import <React/RCTBridgeProxy.h>
 #import <React/RCTURLRequestHandler.h>
 
+RCT_EXTERN void RCTEnableImageStoreManagerStorageQueue(BOOL enabled);
+
 @interface RCTImageStoreManager : NSObject <RCTURLRequestHandler>
 
 /**


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in my quest to get rid of all synthesized `methodQueue`s, we have `RCTImageStoreManager` which uses this throughout. in this diff, i add a config that uses a queue that is managed by the module itself instead of the one generated by the infra.

Reviewed By: cipolleschi

Differential Revision: D50585904


