### PR TITLE
Refactor LazyTurboModuleManagerDelegate to avoid holding references to TurboModules

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyTurboModuleManagerDelegate.java
@@ -12,9 +12,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModule;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * This abstract class provides a simple Lazy implementation of TurboModuleManagerDelegate. Main
@@ -30,7 +28,6 @@ public abstract class LazyTurboModuleManagerDelegate
 
   private final List<ReactPackage> mPackages;
   private final ReactApplicationContext mReactContext;
-  private final Map<String, TurboModule> mModules = new HashMap<>();
 
   public LazyTurboModuleManagerDelegate(
       ReactApplicationContext reactApplicationContext, List<ReactPackage> packages) {
@@ -42,44 +39,38 @@ public abstract class LazyTurboModuleManagerDelegate
   @Override
   @Nullable
   public TurboModule getModule(String moduleName) {
-    TurboModule nativeModule = mModules.get(moduleName);
-    if (nativeModule == null) {
-      /**
-       * Returns first TurboModule from found with the name received as a parameter. There's no
-       * warning or error if there are more than one TurboModule registered with the same name in
-       * different packages. This method relies on the order of insertion of ReactPackage into
-       * mPackages. Usually the size of mPackages is very small (2 or 3 packages in the majority of
-       * the cases)
-       */
-      for (ReactPackage reactPackage : mPackages) {
-        if (reactPackage instanceof TurboReactPackage) {
-          TurboReactPackage turboPkg = (TurboReactPackage) reactPackage;
-          try {
-            nativeModule = (TurboModule) turboPkg.getModule(moduleName, mReactContext);
-          } catch (IllegalArgumentException ex) {
-            /*
-             TurboReactPackages can throw an IllegalArgumentException when a module isn't found. If
-             this happens, it's safe to ignore the exception because a later TurboReactPackage could
-             provide the module.
-            */
-          }
+    /*
+     * Returns first TurboModule found with the name received as a parameter. There's no
+     * warning or error if there are more than one TurboModule registered with the same name in
+     * different packages. This method relies on the order of insertion of ReactPackage into
+     * mPackages. Usually the size of mPackages is very small (2 or 3 packages in the majority of
+     * the cases)
+     */
+    for (ReactPackage reactPackage : mPackages) {
+      if (reactPackage instanceof TurboReactPackage) {
+        TurboReactPackage turboPkg = (TurboReactPackage) reactPackage;
+        try {
+          TurboModule nativeModule = (TurboModule) turboPkg.getModule(moduleName, mReactContext);
           if (nativeModule != null) {
-            mModules.put(moduleName, nativeModule);
-            nativeModule.initialize();
             return nativeModule;
           }
-        } else {
-          throw new IllegalArgumentException(
-              "ReactPackage must be an instance of TurboReactPackage");
+        } catch (IllegalArgumentException ex) {
+          /*
+           TurboReactPackages can throw an IllegalArgumentException when a module isn't found. If
+           this happens, it's safe to ignore the exception because a later TurboReactPackage could
+           provide the module.
+          */
         }
+      } else {
+        throw new IllegalArgumentException("ReactPackage must be an instance of TurboReactPackage");
       }
     }
-    return nativeModule;
+    return null;
   }
 
   @Override
   public boolean unstable_isModuleRegistered(String moduleName) {
-    return getModule(moduleName) != null;
+    throw new UnsupportedOperationException("unstable_isModuleRegistered is not supported");
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
@@ -20,6 +20,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.RuntimeExecutor;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.internal.turbomodule.core.interfaces.CallInvokerHolder;
 import com.facebook.react.internal.turbomodule.core.interfaces.NativeMethodCallInvokerHolder;
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModule;
@@ -195,7 +196,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
      * This API is invoked from global.__turboModuleProxy.
      * Only call getModule if the native module is a turbo module.
      */
-    if (!isTurboModule(moduleName)) {
+    if (!ReactFeatureFlags.enableTurboModuleStableAPI && !isTurboModule(moduleName)) {
       return null;
     }
 
@@ -218,7 +219,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
      * This API is invoked from global.__turboModuleProxy.
      * Only call getModule if the native module is a turbo module.
      */
-    if (!isTurboModule(moduleName)) {
+    if (!ReactFeatureFlags.enableTurboModuleStableAPI && !isTurboModule(moduleName)) {
       return null;
     }
 
@@ -249,7 +250,9 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
                 + "\", but TurboModuleManager was tearing down. Returning null. Was legacy: "
                 + isLegacyModule(moduleName)
                 + ". Was turbo: "
-                + isTurboModule(moduleName)
+                + (ReactFeatureFlags.enableTurboModuleStableAPI
+                    ? "[TurboModuleStableAPI enabled for " + moduleName + "]"
+                    : isTurboModule(moduleName))
                 + ".");
         return null;
       }
@@ -333,7 +336,9 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
                 + "\". Was legacy: "
                 + isLegacyModule(moduleName)
                 + ". Was turbo: "
-                + isTurboModule(moduleName)
+                + (ReactFeatureFlags.enableTurboModuleStableAPI
+                    ? "[TurboModuleStableAPI enabled for " + moduleName + "]"
+                    : isTurboModule(moduleName))
                 + ".");
       }
 


### PR DESCRIPTION
Summary:
The goal of this refactor is to ensure that LazyTurboModuleManagerDelegate doesn't hold references to TurboModules.

EveryTime that LazyTurboModuleManagerDelegate.getModule is called, it will create a new TurboModule. This 'should' be fine because the references to already created TurboModules are held on
TurboModuleManager.mModuleHolders.

As part of this diff I'm also throwing an exception when the method LazyTurboModuleManagerDelegate.unstable_isModuleRegistered is called. This should be fine because I ensured that
"LazyTurboModuleManagerDelegate.unstable_isModuleRegistered' is not called for this experiment.

changelog: [internal] internal

Reviewed By: RSNara

Differential Revision: D50610163


