### PR TITLE
setup test to use custom queue for RCTNetworking operations instead of module queue

### DIFF
--- a/packages/react-native/Libraries/Blob/RCTBlobCollector.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobCollector.mm
@@ -21,7 +21,7 @@ RCTBlobCollector::~RCTBlobCollector()
 {
   RCTBlobManager *blobManager = blobManager_;
   NSString *blobId = [NSString stringWithUTF8String:blobId_.c_str()];
-  dispatch_async([blobManager_ methodQueue], ^{
+  dispatch_async([blobManager_ executionQueue], ^{
     [blobManager remove:blobId];
   });
 }

--- a/packages/react-native/Libraries/Blob/RCTBlobManager.h
+++ b/packages/react-native/Libraries/Blob/RCTBlobManager.h
@@ -10,6 +10,8 @@
 #import <React/RCTInitializing.h>
 #import <React/RCTURLRequestHandler.h>
 
+RCT_EXTERN void RCTEnableBlobManagerProcessingQueue(BOOL enabled);
+
 @interface RCTBlobManager : NSObject <RCTBridgeModule, RCTURLRequestHandler, RCTInitializing>
 
 - (NSString *)store:(NSData *)data;
@@ -25,5 +27,7 @@
 - (void)remove:(NSString *)blobId;
 
 - (void)createFromParts:(NSArray<NSDictionary<NSString *, id> *> *)parts withId:(NSString *)blobId;
+
+- (dispatch_queue_t)executionQueue;
 
 @end

--- a/packages/react-native/Libraries/Blob/RCTBlobManager.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobManager.mm
@@ -159,11 +159,11 @@ RCT_EXPORT_METHOD(addNetworkingHandler)
 
   // TODO(T63516227): Why can methodQueue be nil here?
   // We don't want to do anything when methodQueue is nil.
-  if (!networking.methodQueue) {
+  if (![networking requestQueue]) {
     return;
   }
 
-  dispatch_async(networking.methodQueue, ^{
+  dispatch_async([networking requestQueue], ^{
     [networking addRequestHandler:self];
     [networking addResponseHandler:self];
   });

--- a/packages/react-native/Libraries/Blob/RCTBlobManager.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobManager.mm
@@ -11,12 +11,23 @@
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <React/RCTConvert.h>
+#import <React/RCTMockDef.h>
 #import <React/RCTNetworking.h>
 #import <React/RCTUtils.h>
 #import <React/RCTWebSocketModule.h>
 
 #import "RCTBlobCollector.h"
 #import "RCTBlobPlugins.h"
+
+RCT_MOCK_DEF(RCTBlobManager, dispatch_async);
+#define dispatch_async RCT_MOCK_USE(RCTBlobManager, dispatch_async)
+
+static BOOL gBlobManagerProcessingQueueEnabled = NO;
+
+RCT_EXTERN void RCTEnableBlobManagerProcessingQueue(BOOL enabled)
+{
+  gBlobManagerProcessingQueueEnabled = enabled;
+}
 
 static NSString *const kBlobURIScheme = @"blob";
 
@@ -35,6 +46,7 @@ static NSString *const kBlobURIScheme = @"blob";
   std::mutex _blobsMutex;
 
   NSOperationQueue *_queue;
+  dispatch_queue_t _processingQueue;
 }
 
 RCT_EXPORT_MODULE(BlobModule)
@@ -47,6 +59,10 @@ RCT_EXPORT_MODULE(BlobModule)
 {
   std::lock_guard<std::mutex> lock(_blobsMutex);
   _blobs = [NSMutableDictionary new];
+
+  if (gBlobManagerProcessingQueueEnabled) {
+    _processingQueue = dispatch_queue_create("com.facebook.react.blobmanager.processing", DISPATCH_QUEUE_SERIAL);
+  }
 
   facebook::react::RCTBlobCollector::install(self);
 }
@@ -194,12 +210,22 @@ RCT_EXPORT_METHOD(createFromParts : (NSArray<NSDictionary<NSString *, id> *> *)p
       [NSException raise:@"Invalid type for blob" format:@"%@ is invalid", type];
     }
   }
-  [self store:data withId:blobId];
+
+  dispatch_async([self executionQueue], ^{
+    [self store:data withId:blobId];
+  });
 }
 
 RCT_EXPORT_METHOD(release : (NSString *)blobId)
 {
-  [self remove:blobId];
+  dispatch_async([self executionQueue], ^{
+    [self remove:blobId];
+  });
+}
+
+- (dispatch_queue_t)executionQueue
+{
+  return gBlobManagerProcessingQueueEnabled ? _processingQueue : _methodQueue;
 }
 
 #pragma mark - RCTURLRequestHandler methods

--- a/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm
+++ b/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(readAsText
                   : (RCTPromiseRejectBlock)reject)
 {
   RCTBlobManager *blobManager = [_moduleRegistry moduleForName:"BlobModule"];
-  dispatch_async(blobManager.methodQueue, ^{
+  dispatch_async([blobManager executionQueue], ^{
     NSData *data = [blobManager resolve:blob];
 
     if (data == nil) {
@@ -62,7 +62,7 @@ RCT_EXPORT_METHOD(readAsDataURL
                   : (RCTPromiseRejectBlock)reject)
 {
   RCTBlobManager *blobManager = [_moduleRegistry moduleForName:"BlobModule"];
-  dispatch_async(blobManager.methodQueue, ^{
+  dispatch_async([blobManager executionQueue], ^{
     NSData *data = [blobManager resolve:blob];
 
     if (data == nil) {

--- a/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -78,7 +78,8 @@ RCT_EXPORT_MODULE()
 
     NSOperationQueue *callbackQueue = [NSOperationQueue new];
     callbackQueue.maxConcurrentOperationCount = 1;
-    callbackQueue.underlyingQueue = [[_moduleRegistry moduleForName:"Networking"] methodQueue];
+    RCTNetworking *networking = [_moduleRegistry moduleForName:"Networking"];
+    callbackQueue.underlyingQueue = [networking requestQueue];
     NSURLSessionConfiguration *configuration;
     if (urlSessionConfigurationProvider) {
       configuration = urlSessionConfigurationProvider();

--- a/packages/react-native/Libraries/Network/RCTNetworking.h
+++ b/packages/react-native/Libraries/Network/RCTNetworking.h
@@ -10,6 +10,8 @@
 #import <React/RCTNetworkTask.h>
 #import <React/RCTURLRequestHandler.h>
 
+RCT_EXTERN void RCTEnableNetworkingRequestQueue(BOOL enabled);
+
 @protocol RCTNetworkingRequestHandler <NSObject>
 
 // @lint-ignore FBOBJCUNTYPEDCOLLECTION1
@@ -53,6 +55,8 @@
 - (void)removeRequestHandler:(id<RCTNetworkingRequestHandler>)handler;
 
 - (void)removeResponseHandler:(id<RCTNetworkingResponseHandler>)handler;
+
+- (dispatch_queue_t)requestQueue;
 
 @end
 

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -19,6 +19,13 @@
 
 #import "RCTNetworkPlugins.h"
 
+static BOOL gEnableNetworkingRequestQueue = NO;
+
+RCT_EXTERN void RCTEnableNetworkingRequestQueue(BOOL enabled)
+{
+  gEnableNetworkingRequestQueue = enabled;
+}
+
 typedef RCTURLRequestCancellationBlock (^RCTHTTPQueryResult)(NSError *error, NSDictionary<NSString *, id> *result);
 
 NSString *const RCTNetworkingPHUploadHackScheme = @"ph-upload";
@@ -151,6 +158,7 @@ static NSString *RCTGenerateFormBoundary()
   NSArray<id<RCTURLRequestHandler>> * (^_handlersProvider)(RCTModuleRegistry *);
   NSMutableArray<id<RCTNetworkingRequestHandler>> *_requestHandlers;
   NSMutableArray<id<RCTNetworkingResponseHandler>> *_responseHandlers;
+  dispatch_queue_t _requestQueue;
 }
 
 @synthesize methodQueue = _methodQueue;
@@ -162,15 +170,13 @@ RCT_EXPORT_MODULE()
   return YES;
 }
 
-- (instancetype)init
-{
-  return [super initWithDisabledObservation];
-}
-
 - (instancetype)initWithHandlersProvider:
     (NSArray<id<RCTURLRequestHandler>> * (^)(RCTModuleRegistry *moduleRegistry))getHandlers
 {
   if (self = [super initWithDisabledObservation]) {
+    if (gEnableNetworkingRequestQueue) {
+      _requestQueue = dispatch_queue_create("com.facebook.react.network.request", DISPATCH_QUEUE_SERIAL);
+    }
     _handlersProvider = getHandlers;
   }
   return self;
@@ -294,7 +300,7 @@ RCT_EXPORT_MODULE()
 - (RCTURLRequestCancellationBlock)buildRequest:(NSDictionary<NSString *, id> *)query
                                completionBlock:(void (^)(NSURLRequest *request))block
 {
-  RCTAssertThread(_methodQueue, @"buildRequest: must be called on method queue");
+  RCTAssertThread([self requestQueue], @"buildRequest: must be called on method queue");
 
   NSURL *URL = [RCTConvert NSURL:query[@"url"]]; // this is marked as nullable in JS, but should not be null
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
@@ -347,7 +353,7 @@ RCT_EXPORT_MODULE()
                                       forHTTPHeaderField:@"Content-Length"];
                                 }
 
-                                dispatch_async(self->_methodQueue, ^{
+                                dispatch_async([self requestQueue], ^{
                                   block(request);
                                 });
 
@@ -385,7 +391,7 @@ RCT_EXPORT_MODULE()
                    callback:(RCTURLRequestCancellationBlock (^)(NSError *error, NSDictionary<NSString *, id> *result))
                                 callback
 {
-  RCTAssertThread(_methodQueue, @"processDataForHTTPQuery: must be called on method queue");
+  RCTAssertThread([self requestQueue], @"processDataForHTTPQuery: must be called on method queue");
 
   if (!query) {
     return callback(nil, nil);
@@ -414,7 +420,7 @@ RCT_EXPORT_MODULE()
     RCTNetworkTask *task =
         [self networkTaskWithRequest:request
                      completionBlock:^(NSURLResponse *response, NSData *data, NSError *error) {
-                       dispatch_async(self->_methodQueue, ^{
+                       dispatch_async([self requestQueue], ^{
                          cancellationBlock = callback(
                              error, data ? @{@"body" : data, @"contentType" : RCTNullIfNil(response.MIMEType)} : nil);
                        });
@@ -514,7 +520,7 @@ RCT_EXPORT_MODULE()
         response:(NSURLResponse *)response
          forTask:(RCTNetworkTask *)task
 {
-  RCTAssertThread(_methodQueue, @"sendData: must be called on method queue");
+  RCTAssertThread([self requestQueue], @"sendData: must be called on method queue");
 
   id responseData = nil;
   for (id<RCTNetworkingResponseHandler> handler in _responseHandlers) {
@@ -552,7 +558,7 @@ RCT_EXPORT_MODULE()
     incrementalUpdates:(BOOL)incrementalUpdates
         responseSender:(RCTResponseSenderBlock)responseSender
 {
-  RCTAssertThread(_methodQueue, @"sendRequest: must be called on method queue");
+  RCTAssertThread([self requestQueue], @"sendRequest: must be called on method queue");
   __weak __typeof(self) weakSelf = self;
   __block RCTNetworkTask *task;
   RCTURLRequestProgressBlock uploadProgressBlock = ^(int64_t progress, int64_t total) {
@@ -689,7 +695,9 @@ RCT_EXPORT_MODULE()
     return nil;
   }
 
-  RCTNetworkTask *task = [[RCTNetworkTask alloc] initWithRequest:request handler:handler callbackQueue:_methodQueue];
+  RCTNetworkTask *task = [[RCTNetworkTask alloc] initWithRequest:request
+                                                         handler:handler
+                                                   callbackQueue:[self requestQueue]];
   task.completionBlock = completionBlock;
   return task;
 }
@@ -709,7 +717,7 @@ RCT_EXPORT_METHOD(sendRequest
   double timeout = query.timeout();
   bool withCredentials = query.withCredentials();
 
-  dispatch_async(_methodQueue, ^{
+  dispatch_async([self requestQueue], ^{
     NSDictionary *queryDict = @{
       @"method" : method,
       @"url" : url,
@@ -738,7 +746,7 @@ RCT_EXPORT_METHOD(sendRequest
 
 RCT_EXPORT_METHOD(abortRequest : (double)requestID)
 {
-  dispatch_async(_methodQueue, ^{
+  dispatch_async([self requestQueue], ^{
     [self->_tasksByRequestID[[NSNumber numberWithDouble:requestID]] cancel];
     [self->_tasksByRequestID removeObjectForKey:[NSNumber numberWithDouble:requestID]];
   });
@@ -746,7 +754,7 @@ RCT_EXPORT_METHOD(abortRequest : (double)requestID)
 
 RCT_EXPORT_METHOD(clearCookies : (RCTResponseSenderBlock)responseSender)
 {
-  dispatch_async(_methodQueue, ^{
+  dispatch_async([self requestQueue], ^{
     NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
     if (!storage.cookies.count) {
       responseSender(@[ @NO ]);
@@ -758,6 +766,11 @@ RCT_EXPORT_METHOD(clearCookies : (RCTResponseSenderBlock)responseSender)
     }
     responseSender(@[ @YES ]);
   });
+}
+
+- (dispatch_queue_t)requestQueue
+{
+  return gEnableNetworkingRequestQueue ? _requestQueue : _methodQueue;
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/rn-tester/RNTesterUnitTests/RCTBlobManagerTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTBlobManagerTests.m
@@ -8,6 +8,15 @@
 #import <XCTest/XCTest.h>
 
 #import <React/RCTBlobManager.h>
+#import <React/RCTMockDef.h>
+
+RCT_MOCK_REF(RCTBlobManager, dispatch_async);
+
+static void _mock_dispatch_async(dispatch_queue_t queue, dispatch_block_t block)
+{
+  XCTAssertNotNil(queue);
+  block();
+}
 
 @interface RCTBlobManagerTests : XCTestCase
 
@@ -23,8 +32,12 @@
 {
   [super setUp];
 
+  RCT_MOCK_SET(RCTBlobManager, dispatch_async, _mock_dispatch_async);
+
   _module = [RCTBlobManager new];
+  dispatch_queue_t methodQueue = dispatch_queue_create("test.queue", DISPATCH_QUEUE_SERIAL);
   [_module setValue:nil forKey:@"bridge"];
+  [_module setValue:methodQueue forKey:@"methodQueue"];
   [_module initialize];
   NSInteger size = 120;
   _data = [NSMutableData dataWithCapacity:size];
@@ -34,6 +47,13 @@
   }
   _blobId = [NSUUID UUID].UUIDString;
   [_module store:_data withId:_blobId];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+
+  RCT_MOCK_RESET(RCTBlobManager, dispatch_async);
 }
 
 - (void)testResolve
@@ -70,6 +90,39 @@
 
 - (void)testCreateFromParts
 {
+  NSDictionary<NSString *, id> *blobData = @{
+    @"blobId" : _blobId,
+    @"offset" : @0,
+    @"size" : @(_data.length),
+  };
+  NSDictionary<NSString *, id> *blob = @{
+    @"data" : blobData,
+    @"type" : @"blob",
+  };
+  NSString *stringData = @"i \u2665 dogs";
+  NSDictionary<NSString *, id> *string = @{
+    @"data" : stringData,
+    @"type" : @"string",
+  };
+  NSString *resultId = [NSUUID UUID].UUIDString;
+  NSArray<id> *parts = @[ blob, string ];
+
+  [_module createFromParts:parts withId:resultId];
+
+  NSMutableData *expectedData = [NSMutableData new];
+  [expectedData appendData:_data];
+  [expectedData appendData:[stringData dataUsingEncoding:NSUTF8StringEncoding]];
+
+  NSData *result = [_module resolve:resultId offset:0 size:expectedData.length];
+
+  XCTAssertTrue([expectedData isEqualToData:result]);
+}
+
+- (void)testCreateFromPartsProcessingQueue
+{
+  RCTEnableBlobManagerProcessingQueue(YES);
+  [self setUp];
+
   NSDictionary<NSString *, id> *blobData = @{
     @"blobId" : _blobId,
     @"offset" : @0,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in my quest to get rid of all synthesized methodQueues, we have RCTNetworking which uses it internally as well as exposes its underlying execution queue. in this diff, i add a config that replaces that queue with one that is managed by the module itself instead of the one generated by the infra.

this is the last one!

Reviewed By: cipolleschi

Differential Revision: D50588308


