### PR TITLE
[RN][CI] Add Hermes Xcode integration test to GH Actions

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,0 +1,41 @@
+name: ios-tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  test_ios_rntester-Hermes:
+    runs-on: macos-latest-large
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - name: Yarn Install
+        run: yarn install
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: '3.2'
+      - name: Cache cocoapods
+        uses: actions/cache@v3
+        with:
+          path: packages/rn-tester/Pods
+          key: ${{ runner.os }}-RNTesterPods-${{ hashFiles('packages/rn-tester/Podfile.lock') }}-${{ hashFiles('packages/rn-tester/Podfile') }}
+      - name: Pod Install
+        run: |
+          cd packages/rn-tester
+          bundle install
+          bundle exec pod install
+      - name: Install XCBeautify
+        run: brew install xcbeautify
+      - name: Build iOS
+        run: ./scripts/objc-test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ package-lock.json
 /packages/react-native/template/vendor
 .ruby-version
 /**/.ruby-version
+vendor/
 
 # iOS / CocoaPods
 /packages/react-native/template/ios/build/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 6.1.7.3)
+  activesupport (>= 6.1.7.3, < 7.1.0)
   cocoapods (~> 1.12)
 
 RUBY VERSION

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -1,5 +1,7 @@
-# Gemfile
 source 'https://rubygems.org'
+
+# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
+ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.12'
 gem 'rexml'


### PR DESCRIPTION
## Summary:
After disabling the E2E tests, we lost a test that was verifying that Hermes works well with the latest version of React Native for iOS
This change introduce this test back in GH actions

## Changelog:
[Internal] Add tests for Hermes-Xcode integration to GH Actions

## Test Plan:
CI is green 🤞
