### PR TITLE
Fix RNTester not showing Redbox when Metro is not connected

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -638,6 +638,9 @@ public class ReactHostImpl implements ReactHost {
     final String method = "handleHostException(message = \"" + e.getMessage() + "\")";
     log(method);
 
+    if (DEV) {
+      mDevSupportManager.handleException(e);
+    }
     destroy(method, e);
     mReactHostDelegate.handleInstanceException(e);
   }


### PR DESCRIPTION
Summary:
In dev mode, display a Redbox for the first fatal error during RN initialization. So if the first fatal error is Metro not connected that will be displayed via Redbox.

Changelog:
[Android][Changed] - Fix RNTester not showing Redbox when Metro is not connected

Reviewed By: cortinico

Differential Revision: D50600631


