### PR TITLE
Add Systrace sections for async TurboModule calls on Android and iOS

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -6,9 +6,9 @@
  */
 
 #include <memory>
-#include <sstream>
 #include <string>
 
+#include <cxxreact/SystraceSection.h>
 #include <fbjni/fbjni.h>
 #include <glog/logging.h>
 #include <jsi/jsi.h>
@@ -739,6 +739,15 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
            moduleNameStr = name_,
            methodNameStr,
            id = getUniqueId()]() mutable {
+            SystraceSection s(
+                "JavaTurboModuleAsyncMethodInvocation",
+                "module",
+                moduleNameStr,
+                "method",
+                methodNameStr,
+                "returnType",
+                "void");
+
             auto instance = instance_.lockLocal();
             if (!instance) {
               return;
@@ -822,6 +831,15 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
            moduleNameStr = name_,
            methodNameStr,
            id = getUniqueId()]() mutable {
+            SystraceSection s(
+                "JavaTurboModuleAsyncMethodInvocation",
+                "module",
+                moduleNameStr,
+                "method",
+                methodNameStr,
+                "returnType",
+                "promise");
+
             auto instance = instance_.lockLocal();
             if (!instance) {
               return;


### PR DESCRIPTION
Summary:
We currently don't have visibility on what the native module thread is doing when it's busy (on Android). This adds Systrace blocks to at least know the native module and the method we're running there.

Changelog: [internal]

Reviewed By: ryancat

Differential Revision: D50645557


