### PR TITLE
Replace usages of deprecated class TurboReactPackage

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackage.java
@@ -62,13 +62,13 @@ public class CompositeReactPackage implements ViewManagerOnDemandReactPackage, R
        *
        * <p>TODO: T45627020
        */
-      if (reactPackage instanceof TurboReactPackage) {
-        TurboReactPackage turboReactPackage = (TurboReactPackage) reactPackage;
-        ReactModuleInfoProvider moduleInfoProvider = turboReactPackage.getReactModuleInfoProvider();
+      if (reactPackage instanceof BaseReactPackage) {
+        BaseReactPackage baseReactPackage = (BaseReactPackage) reactPackage;
+        ReactModuleInfoProvider moduleInfoProvider = baseReactPackage.getReactModuleInfoProvider();
         Map<String, ReactModuleInfo> moduleInfos = moduleInfoProvider.getReactModuleInfos();
 
         for (final String moduleName : moduleInfos.keySet()) {
-          moduleMap.put(moduleName, turboReactPackage.getModule(moduleName, reactContext));
+          moduleMap.put(moduleName, baseReactPackage.getModule(moduleName, reactContext));
         }
 
         continue;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyTurboModuleManagerDelegate.java
@@ -47,10 +47,11 @@ public abstract class LazyTurboModuleManagerDelegate
      * the cases)
      */
     for (ReactPackage reactPackage : mPackages) {
-      if (reactPackage instanceof TurboReactPackage) {
-        TurboReactPackage turboPkg = (TurboReactPackage) reactPackage;
+      if (reactPackage instanceof BaseReactPackage) {
+        BaseReactPackage baseReactPackage = (BaseReactPackage) reactPackage;
         try {
-          TurboModule nativeModule = (TurboModule) turboPkg.getModule(moduleName, mReactContext);
+          TurboModule nativeModule =
+              (TurboModule) baseReactPackage.getModule(moduleName, mReactContext);
           if (nativeModule != null) {
             return nativeModule;
           }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.java
@@ -34,9 +34,9 @@ public class NativeModuleRegistryBuilder {
     if (reactPackage instanceof LazyReactPackage) {
       moduleHolders =
           ((LazyReactPackage) reactPackage).getNativeModuleIterator(mReactApplicationContext);
-    } else if (reactPackage instanceof TurboReactPackage) {
+    } else if (reactPackage instanceof BaseReactPackage) {
       moduleHolders =
-          ((TurboReactPackage) reactPackage).getNativeModuleIterator(mReactApplicationContext);
+          ((BaseReactPackage) reactPackage).getNativeModuleIterator(mReactApplicationContext);
     } else {
       moduleHolders =
           ReactPackageHelper.getNativeModuleIterator(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -54,13 +54,13 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
     super();
     final ReactApplicationContext applicationContext = reactApplicationContext;
     for (ReactPackage reactPackage : packages) {
-      if (reactPackage instanceof TurboReactPackage) {
-        final TurboReactPackage turboPkg = (TurboReactPackage) reactPackage;
+      if (reactPackage instanceof BaseReactPackage) {
+        final BaseReactPackage baseReactPackage = (BaseReactPackage) reactPackage;
         final ModuleProvider moduleProvider =
-            moduleName -> turboPkg.getModule(moduleName, applicationContext);
+            moduleName -> baseReactPackage.getModule(moduleName, applicationContext);
         mModuleProviders.add(moduleProvider);
         mPackageModuleInfos.put(
-            moduleProvider, turboPkg.getReactModuleInfoProvider().getReactModuleInfos());
+            moduleProvider, baseReactPackage.getReactModuleInfoProvider().getReactModuleInfos());
         continue;
       }
 


### PR DESCRIPTION
Summary:
As part of https://github.com/facebook/react-native/pull/40775 we marked TurboReactPackage as DeprecatedInNewArchitecture introducing the new class BaseReactPackage.
In this diff I'm replacing usages of TurboReactPackage by BaseReactPackage to make sure new usages of BaseReactPackage work as expected.

changelog: [internal] internal

Reviewed By: arushikesarwani94

Differential Revision: D50611382


