### PR TITLE
[RN][CI] Prevent test windows to pull in node 20

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -619,7 +619,7 @@ jobs:
       - run:
           name: Install Node JS
           # Note: Version set separately for non-Windows builds, see above.
-          command: choco install nodejs-lts
+          command: choco install nodejs --version=18.18.0 --allow-downgrade 
 
       # Setup Dependencies
       - run:


### PR DESCRIPTION
## Summary:
Since yesterday, Chocolatey is pulling in Node 20 rather than Node 18 for tests.
It ends up that mock-fs is not working with Node 20, so, for the time being, we are going to keep 18.

## Changelog:
[Internal] - Use node 18 instead of 20 for Test Windows

## Test Plan:
CircleCI is green
