### PR TITLE
migrate RCTActionSheetManager to handle synchronous void method execution

### DIFF
--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -46,11 +46,6 @@ RCT_EXPORT_MODULE()
 
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
 
-- (dispatch_queue_t)methodQueue
-{
-  return dispatch_get_main_queue();
-}
-
 - (void)presentViewController:(UIViewController *)alertController
        onParentViewController:(UIViewController *)parentViewController
                 anchorViewTag:(NSNumber *)anchorViewTag
@@ -99,100 +94,102 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
     NSNumber *destructiveButtonIndex = @-1;
     destructiveButtonIndices = @[ destructiveButtonIndex ];
   }
-
-  UIViewController *controller = RCTPresentedViewController();
   NSNumber *anchor = [RCTConvert NSNumber:options.anchor() ? @(*options.anchor()) : nil];
   UIColor *tintColor = [RCTConvert UIColor:options.tintColor() ? @(*options.tintColor()) : nil];
   UIColor *cancelButtonTintColor =
       [RCTConvert UIColor:options.cancelButtonTintColor() ? @(*options.cancelButtonTintColor()) : nil];
-
-  if (controller == nil) {
-    RCTLogError(
-        @"Tried to display action sheet but there is no application window. options: %@", @{
-          @"title" : title,
-          @"message" : message,
-          @"options" : buttons,
-          @"cancelButtonIndex" : @(cancelButtonIndex),
-          @"destructiveButtonIndices" : destructiveButtonIndices,
-          @"anchor" : anchor,
-          @"tintColor" : tintColor,
-          @"cancelButtonTintColor" : cancelButtonTintColor,
-          @"disabledButtonIndices" : disabledButtonIndices,
-        });
-    return;
-  }
-
-  /*
-   * The `anchor` option takes a view to set as the anchor for the share
-   * popup to point to, on iPads running iOS 8. If it is not passed, it
-   * defaults to centering the share popup on screen without any arrows.
-   */
-  NSNumber *anchorViewTag = anchor;
-
-  UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
-                                                                           message:message
-                                                                    preferredStyle:UIAlertControllerStyleActionSheet];
-
-  NSInteger index = 0;
-  bool isCancelButtonIndex = false;
-  // The handler for a button might get called more than once when tapping outside
-  // the action sheet on iPad. RCTResponseSenderBlock can only be called once so
-  // keep track of callback invocation here.
-  __block bool callbackInvoked = false;
-  for (NSString *option in buttons) {
-    UIAlertActionStyle style = UIAlertActionStyleDefault;
-    if ([destructiveButtonIndices containsObject:@(index)]) {
-      style = UIAlertActionStyleDestructive;
-    } else if (index == cancelButtonIndex) {
-      style = UIAlertActionStyleCancel;
-      isCancelButtonIndex = true;
-    }
-
-    NSInteger localIndex = index;
-    UIAlertAction *actionButton = [UIAlertAction actionWithTitle:option
-                                                           style:style
-                                                         handler:^(__unused UIAlertAction *action) {
-                                                           if (!callbackInvoked) {
-                                                             callbackInvoked = true;
-                                                             [self->_alertControllers removeObject:alertController];
-                                                             callback(@[ @(localIndex) ]);
-                                                           }
-                                                         }];
-    if (isCancelButtonIndex) {
-      [actionButton setValue:cancelButtonTintColor forKey:@"titleTextColor"];
-    }
-    [alertController addAction:actionButton];
-
-    index++;
-  }
-
-  if (disabledButtonIndices) {
-    for (NSNumber *disabledButtonIndex in disabledButtonIndices) {
-      if ([disabledButtonIndex integerValue] < buttons.count) {
-        [alertController.actions[[disabledButtonIndex integerValue]] setEnabled:false];
-      } else {
-        RCTLogError(
-            @"Index %@ from `disabledButtonIndices` is out of bounds. Maximum index value is %@.",
-            @([disabledButtonIndex integerValue]),
-            @(buttons.count - 1));
-        return;
-      }
-    }
-  }
-
-  alertController.view.tintColor = tintColor;
   NSString *userInterfaceStyle = [RCTConvert NSString:options.userInterfaceStyle()];
 
-  if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
-    alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
-  } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
-    alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-  } else if ([userInterfaceStyle isEqualToString:@"light"]) {
-    alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
-  }
+  UIViewController *controller = RCTPresentedViewController();
 
-  [_alertControllers addObject:alertController];
-  [self presentViewController:alertController onParentViewController:controller anchorViewTag:anchorViewTag];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (controller == nil) {
+      RCTLogError(
+          @"Tried to display action sheet but there is no application window. options: %@", @{
+            @"title" : title,
+            @"message" : message,
+            @"options" : buttons,
+            @"cancelButtonIndex" : @(cancelButtonIndex),
+            @"destructiveButtonIndices" : destructiveButtonIndices,
+            @"anchor" : anchor,
+            @"tintColor" : tintColor,
+            @"cancelButtonTintColor" : cancelButtonTintColor,
+            @"disabledButtonIndices" : disabledButtonIndices,
+          });
+      return;
+    }
+
+    /*
+     * The `anchor` option takes a view to set as the anchor for the share
+     * popup to point to, on iPads running iOS 8. If it is not passed, it
+     * defaults to centering the share popup on screen without any arrows.
+     */
+    NSNumber *anchorViewTag = anchor;
+
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
+                                                                             message:message
+                                                                      preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSInteger index = 0;
+    bool isCancelButtonIndex = false;
+    // The handler for a button might get called more than once when tapping outside
+    // the action sheet on iPad. RCTResponseSenderBlock can only be called once so
+    // keep track of callback invocation here.
+    __block bool callbackInvoked = false;
+    for (NSString *option in buttons) {
+      UIAlertActionStyle style = UIAlertActionStyleDefault;
+      if ([destructiveButtonIndices containsObject:@(index)]) {
+        style = UIAlertActionStyleDestructive;
+      } else if (index == cancelButtonIndex) {
+        style = UIAlertActionStyleCancel;
+        isCancelButtonIndex = true;
+      }
+
+      NSInteger localIndex = index;
+      UIAlertAction *actionButton = [UIAlertAction actionWithTitle:option
+                                                             style:style
+                                                           handler:^(__unused UIAlertAction *action) {
+                                                             if (!callbackInvoked) {
+                                                               callbackInvoked = true;
+                                                               [self->_alertControllers removeObject:alertController];
+                                                               callback(@[ @(localIndex) ]);
+                                                             }
+                                                           }];
+      if (isCancelButtonIndex) {
+        [actionButton setValue:cancelButtonTintColor forKey:@"titleTextColor"];
+      }
+      [alertController addAction:actionButton];
+
+      index++;
+    }
+
+    if (disabledButtonIndices) {
+      for (NSNumber *disabledButtonIndex in disabledButtonIndices) {
+        if ([disabledButtonIndex integerValue] < buttons.count) {
+          [alertController.actions[[disabledButtonIndex integerValue]] setEnabled:false];
+        } else {
+          RCTLogError(
+              @"Index %@ from `disabledButtonIndices` is out of bounds. Maximum index value is %@.",
+              @([disabledButtonIndex integerValue]),
+              @(buttons.count - 1));
+          return;
+        }
+      }
+    }
+
+    alertController.view.tintColor = tintColor;
+
+    if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
+      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+    } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
+      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    } else if ([userInterfaceStyle isEqualToString:@"light"]) {
+      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+    }
+
+    [self->_alertControllers addObject:alertController];
+    [self presentViewController:alertController onParentViewController:controller anchorViewTag:anchorViewTag];
+  });
 }
 
 RCT_EXPORT_METHOD(dismissActionSheet)
@@ -201,9 +198,11 @@ RCT_EXPORT_METHOD(dismissActionSheet)
     RCTLogWarn(@"Unable to dismiss action sheet");
   }
 
-  id _alertController = [_alertControllers lastObject];
-  [_alertController dismissViewControllerAnimated:YES completion:nil];
-  [_alertControllers removeLastObject];
+  UIAlertController *alertController = [_alertControllers lastObject];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [alertController dismissViewControllerAnimated:YES completion:nil];
+    [self->_alertControllers removeLastObject];
+  });
 }
 
 RCT_EXPORT_METHOD(showShareActionSheetWithOptions
@@ -218,68 +217,69 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions
 
   NSMutableArray<id> *items = [NSMutableArray array];
   NSString *message = options.message();
-  if (message) {
-    [items addObject:message];
-  }
   NSURL *URL = [RCTConvert NSURL:options.url()];
-  if (URL) {
-    if ([URL.scheme.lowercaseString isEqualToString:@"data"]) {
-      NSError *error;
-      NSData *data = [NSData dataWithContentsOfURL:URL options:(NSDataReadingOptions)0 error:&error];
-      if (!data) {
-        failureCallback(@[ RCTJSErrorFromNSError(error) ]);
-        return;
-      }
-      [items addObject:data];
-    } else {
-      [items addObject:URL];
-    }
-  }
-  if (items.count == 0) {
-    RCTLogError(@"No `url` or `message` to share");
-    return;
-  }
-
-  UIActivityViewController *shareController = [[UIActivityViewController alloc] initWithActivityItems:items
-                                                                                applicationActivities:nil];
-
   NSString *subject = options.subject();
-  if (subject) {
-    [shareController setValue:subject forKey:@"subject"];
-  }
-
   NSArray *excludedActivityTypes =
       RCTConvertOptionalVecToArray(options.excludedActivityTypes(), ^id(NSString *element) {
         return element;
       });
-  if (excludedActivityTypes) {
-    shareController.excludedActivityTypes = excludedActivityTypes;
-  }
-
-  UIViewController *controller = RCTPresentedViewController();
-  shareController.completionWithItemsHandler =
-      ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
-        if (activityError) {
-          failureCallback(@[ RCTJSErrorFromNSError(activityError) ]);
-        } else if (completed || activityType == nil) {
-          successCallback(@[ @(completed), RCTNullIfNil(activityType) ]);
-        }
-      };
-
-  NSNumber *anchorViewTag = [RCTConvert NSNumber:options.anchor() ? @(*options.anchor()) : nil];
-  shareController.view.tintColor = [RCTConvert UIColor:options.tintColor() ? @(*options.tintColor()) : nil];
-
   NSString *userInterfaceStyle = [RCTConvert NSString:options.userInterfaceStyle()];
+  NSNumber *anchorViewTag = [RCTConvert NSNumber:options.anchor() ? @(*options.anchor()) : nil];
+  UIColor *tintColor = [RCTConvert UIColor:options.tintColor() ? @(*options.tintColor()) : nil];
 
-  if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
-    shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
-  } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
-    shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-  } else if ([userInterfaceStyle isEqualToString:@"light"]) {
-    shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
-  }
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (message) {
+      [items addObject:message];
+    }
+    if (URL) {
+      if ([URL.scheme.lowercaseString isEqualToString:@"data"]) {
+        NSError *error;
+        NSData *data = [NSData dataWithContentsOfURL:URL options:(NSDataReadingOptions)0 error:&error];
+        if (!data) {
+          failureCallback(@[ RCTJSErrorFromNSError(error) ]);
+          return;
+        }
+        [items addObject:data];
+      } else {
+        [items addObject:URL];
+      }
+    }
+    if (items.count == 0) {
+      RCTLogError(@"No `url` or `message` to share");
+      return;
+    }
 
-  [self presentViewController:shareController onParentViewController:controller anchorViewTag:anchorViewTag];
+    UIActivityViewController *shareController = [[UIActivityViewController alloc] initWithActivityItems:items
+                                                                                  applicationActivities:nil];
+    if (subject) {
+      [shareController setValue:subject forKey:@"subject"];
+    }
+    if (excludedActivityTypes) {
+      shareController.excludedActivityTypes = excludedActivityTypes;
+    }
+
+    UIViewController *controller = RCTPresentedViewController();
+    shareController.completionWithItemsHandler =
+        ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
+          if (activityError) {
+            failureCallback(@[ RCTJSErrorFromNSError(activityError) ]);
+          } else if (completed || activityType == nil) {
+            successCallback(@[ @(completed), RCTNullIfNil(activityType) ]);
+          }
+        };
+
+    shareController.view.tintColor = tintColor;
+
+    if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
+      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+    } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
+      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    } else if ([userInterfaceStyle isEqualToString:@"light"]) {
+      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+    }
+
+    [self presentViewController:shareController onParentViewController:controller anchorViewTag:anchorViewTag];
+  });
 }
 
 - (std::shared_ptr<TurboModule>)getTurboModule:(const ObjCTurboModule::InitParams &)params


### PR DESCRIPTION
Summary:
in the future, all void native module methods will execute synchronously.

currently, many modules override the methodQueue selector to return the main queue so their async methods will be executed on the main thread by our infra. now that void methods are executing synchronously, this override will be ignored, thus causing unpredictable behavior for those methods that do depend on being run on main thread to behave correctly.

the migration in this stack will prevent bugs caused by this behavioral change by explicitly dispatching execution onto the main thread.

Reviewed By: mdvacca

Differential Revision: D50635827


