### PR TITLE
Making setFabricEnabled Flag optional for ReactFragments

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -181,7 +181,7 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     public Builder() {
       mComponentName = null;
       mLaunchOptions = null;
-      mFabricEnabled = null;
+      mFabricEnabled = false;
     }
 
     /**


### PR DESCRIPTION
## Summary:

Making setFabricEnabled Flag optional for ReactFragments

## Changelog:
[ANDROID][CHANGED] - Continuation of PR: 36263

## Test Plan:

Kotlin Code Snippet to test:
```
supportFragmentManager
  .beginTransaction()
  .add(android.R.id.content,
     ReactFragment.Builder()
       .setComponentName("componentName")
       .setFabricEnabled(true)
       .build())
  .commit()
```
