### PR TITLE
feat(iOS): remove usages of UIScreen mainScreen for Trait collections

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -302,14 +302,14 @@ static CGFloat screenScale;
 void RCTComputeScreenScale(void)
 {
   dispatch_once(&onceTokenScreenScale, ^{
-    screenScale = [UIScreen mainScreen].scale;
+    screenScale = [UITraitCollection currentTraitCollection].displayScale;
   });
 }
 
 CGFloat RCTScreenScale(void)
 {
   RCTUnsafeExecuteOnMainQueueOnceSync(&onceTokenScreenScale, ^{
-    screenScale = [UIScreen mainScreen].scale;
+    screenScale = [UITraitCollection currentTraitCollection].displayScale;
   });
 
   return screenScale;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -252,7 +252,7 @@ using namespace facebook::react;
   // `shouldRasterize`
   if (oldViewProps.shouldRasterize != newViewProps.shouldRasterize) {
     self.layer.shouldRasterize = newViewProps.shouldRasterize;
-    self.layer.rasterizationScale = newViewProps.shouldRasterize ? [UITraitCollection currentTraitCollection].displayScale : 1.0;
+    self.layer.rasterizationScale = newViewProps.shouldRasterize ? self.traitCollection.displayScale : 1.0;
   }
 
   // `pointerEvents`

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -252,7 +252,7 @@ using namespace facebook::react;
   // `shouldRasterize`
   if (oldViewProps.shouldRasterize != newViewProps.shouldRasterize) {
     self.layer.shouldRasterize = newViewProps.shouldRasterize;
-    self.layer.rasterizationScale = newViewProps.shouldRasterize ? [UIScreen mainScreen].scale : 1.0;
+    self.layer.rasterizationScale = newViewProps.shouldRasterize ? [UITraitCollection currentTraitCollection].displayScale : 1.0;
   }
 
   // `pointerEvents`

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -213,7 +213,7 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 {
   view.layer.shouldRasterize = json ? [RCTConvert BOOL:json] : defaultView.layer.shouldRasterize;
   view.layer.rasterizationScale =
-      view.layer.shouldRasterize ? [UIScreen mainScreen].scale : defaultView.layer.rasterizationScale;
+      view.layer.shouldRasterize ? [UITraitCollection currentTraitCollection].displayScale : defaultView.layer.rasterizationScale;
 }
 
 RCT_REMAP_VIEW_PROPERTY(transform, reactTransform, CATransform3D)

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -213,7 +213,7 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 {
   view.layer.shouldRasterize = json ? [RCTConvert BOOL:json] : defaultView.layer.shouldRasterize;
   view.layer.rasterizationScale =
-      view.layer.shouldRasterize ? [UITraitCollection currentTraitCollection].displayScale : defaultView.layer.rasterizationScale;
+      view.layer.shouldRasterize ? view.traitCollection.displayScale : defaultView.layer.rasterizationScale;
 }
 
 RCT_REMAP_VIEW_PROPERTY(transform, reactTransform, CATransform3D)

--- a/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Compare.m
+++ b/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Compare.m
@@ -42,7 +42,7 @@
       CGImageGetColorSpace(image.CGImage),
       (CGBitmapInfo)kCGImageAlphaPremultipliedLast);
 
-  CGFloat scaleFactor = [UIScreen mainScreen].scale;
+  CGFloat scaleFactor = [UITraitCollection currentTraitCollection].displayScale;
   CGContextScaleCTM(referenceImageContext, scaleFactor, scaleFactor);
   CGContextScaleCTM(imageContext, scaleFactor, scaleFactor);
 


### PR DESCRIPTION
## Summary:

The goal of this PR is to migrate from deprecated `[UIScreen mainScreen]` and get the `displayScale` from currentTraitCollection. Both of those return the same values. 

## Changelog:

[IOS] [CHANGED] - retrieve screen scale from trait collection instead of UIScreen mainScreen

## Test Plan:

Go to Dimensions example and check that everything works as expected

### Before

<img src="https://github.com/facebook/react-native/assets/52801365/53141e67-63e2-4c3b-818e-6a232aae8a5b" height="500" />

### After

<img src="https://github.com/facebook/react-native/assets/52801365/33728fce-0298-459c-b63e-a0b8ea34bde1" height="500" />


