### PR TITLE
Replace Jest runner with Wdio runner E2E

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -134,11 +134,10 @@ jobs:
       - setup_ruby:
           ruby_version: << parameters.ruby_version >>
       - run:
-          name: Install appium
-          command: npm install appium@2.0.0 -g
-      - run:
-          name: Install appium drivers
-          command: appium driver install xcuitest@5.6.0
+          name: Copy packages
+          command: |
+            cd packages/rn-tester-e2e/scripts
+            copy-packages.sh
       - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
@@ -196,11 +195,10 @@ jobs:
           restore-gradle-cache-prefix: v1a
           post-emulator-launch-assemble-command: ""
       - run:
-          name: Install appium
-          command: npm install appium@2.0.0 -g
-      - run:
-          name: Install appium drivers
-          command: appium driver install uiautomator2@2.29.0
+          name: Copy packages
+          command: |
+            cd packages/rn-tester-e2e/scripts
+            copy-packages.sh
       - run:
           name: Start Metro
           command: |

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -138,7 +138,7 @@ jobs:
           command: |
             cd packages/rn-tester-e2e/scripts
             chmod +x copy-packages.sh
-            copy-packages.sh
+            ./copy-packages.sh
       - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
@@ -200,7 +200,7 @@ jobs:
           command: |
             cd packages/rn-tester-e2e/scripts
             chmod +x copy-packages.sh
-            copy-packages.sh
+            ./copy-packages.sh
       - run:
           name: Start Metro
           command: |

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -137,6 +137,7 @@ jobs:
           name: Copy packages
           command: |
             cd packages/rn-tester-e2e/scripts
+            chmod +x copy-packages.sh
             copy-packages.sh
       - run:
           name: Boot iOS Simulator
@@ -198,6 +199,7 @@ jobs:
           name: Copy packages
           command: |
             cd packages/rn-tester-e2e/scripts
+            chmod +x copy-packages.sh
             copy-packages.sh
       - run:
           name: Start Metro

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -171,6 +171,8 @@ jobs:
                   (yarn test-e2e-ios 2>&1 | tee /tmp/test_log) || true
             - store_artifacts:
                 path: /tmp/test_log
+            - store_artifacts:
+                path: ~/react-native/packages/rn-tester-e2e/reports
 
   # -------------------------
   #     JOBS: Android E2E Tests
@@ -220,6 +222,8 @@ jobs:
             (yarn test-e2e-android 2>&1 | tee /tmp/test_log) || true
       - store_artifacts:
           path: /tmp/test_log
+      - store_artifacts:
+          path:  ~/react-native/packages/rn-tester-e2e/reports
 
   # -------------------------
   #    JOBS: Build Android

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -134,6 +134,12 @@ jobs:
       - setup_ruby:
           ruby_version: << parameters.ruby_version >>
       - run:
+          name: Install appium
+          command: npm install appium@2.0.0 -g
+      - run:
+          name: Install appium drivers
+          command: appium driver install xcuitest@5.6.0
+      - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
       - with_xcodebuild_cache:
@@ -185,6 +191,12 @@ jobs:
           no-window: true
           restore-gradle-cache-prefix: v1a
           post-emulator-launch-assemble-command: ""
+      - run:
+          name: Install appium
+          command: npm install appium@2.0.0 -g
+      - run:
+          name: Install appium drivers
+          command: appium driver install uiautomator2@2.29.0
       - run:
           name: Start Metro
           command: |

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -140,6 +140,10 @@ jobs:
           name: Install appium drivers
           command: appium driver install xcuitest@5.6.0
       - run:
+          name: Start Appium server
+          command: appium --base-path /
+          background: true
+      - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
       - with_xcodebuild_cache:

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -173,6 +173,8 @@ jobs:
                 path: /tmp/test_log
             - store_artifacts:
                 path: ~/react-native/packages/rn-tester-e2e/reports
+            - store_artifacts:
+                path: ~/react-native/packages/rn-tester-e2e/reports/errorShots
 
   # -------------------------
   #     JOBS: Android E2E Tests
@@ -224,6 +226,8 @@ jobs:
           path: /tmp/test_log
       - store_artifacts:
           path:  ~/react-native/packages/rn-tester-e2e/reports
+      - store_artifacts:
+          path: ~/react-native/packages/rn-tester-e2e/reports/errorShots
 
   # -------------------------
   #    JOBS: Build Android

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -134,12 +134,6 @@ jobs:
       - setup_ruby:
           ruby_version: << parameters.ruby_version >>
       - run:
-          name: Install appium
-          command: npm install appium@2.0.0 -g
-      - run:
-          name: Install appium drivers
-          command: appium driver install xcuitest@5.6.0
-      - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
       - with_xcodebuild_cache:
@@ -193,12 +187,6 @@ jobs:
           no-window: true
           restore-gradle-cache-prefix: v1a
           post-emulator-launch-assemble-command: ""
-      - run:
-          name: Install appium
-          command: npm install appium@2.0.0 -g
-      - run:
-          name: Install appium drivers
-          command: appium driver install uiautomator2@2.29.0
       - run:
           name: Start Metro
           command: |

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -140,10 +140,6 @@ jobs:
           name: Install appium drivers
           command: appium driver install xcuitest@5.6.0
       - run:
-          name: Start Appium server
-          command: appium --base-path /
-          background: true
-      - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
       - with_xcodebuild_cache:

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -140,8 +140,11 @@ jobs:
           name: Install appium drivers
           command: appium driver install xcuitest@5.6.0
       - run:
-          name: Boot iOS Simulator
-          command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
+          name: Boot iOS Simulator and Collect Logs
+          command: |
+            source scripts/.tests.env
+            xcrun simctl boot "$IOS_DEVICE" || true
+            xcrun simctl spawn "$IOS_DEVICE" log stream --level=error > /tmp/ios-simulator-logs &
       - with_xcodebuild_cache:
           steps:
             - run:
@@ -171,6 +174,8 @@ jobs:
                   (yarn test-e2e-ios 2>&1 | tee /tmp/test_log) || true
             - store_artifacts:
                 path: /tmp/test_log
+            - store_artifacts:
+                path: /tmp/ios-simulator-logs
             - store_artifacts:
                 path: ~/react-native/packages/rn-tester-e2e/reports
             - store_artifacts:

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -140,11 +140,8 @@ jobs:
           name: Install appium drivers
           command: appium driver install xcuitest@5.6.0
       - run:
-          name: Boot iOS Simulator and Collect Logs
-          command: |
-            source scripts/.tests.env
-            xcrun simctl boot "$IOS_DEVICE" || true
-            xcrun simctl spawn "$IOS_DEVICE" log stream --level=error > /tmp/ios-simulator-logs &
+          name: Boot iOS Simulator
+          command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
       - with_xcodebuild_cache:
           steps:
             - run:
@@ -174,8 +171,6 @@ jobs:
                   (yarn test-e2e-ios 2>&1 | tee /tmp/test_log) || true
             - store_artifacts:
                 path: /tmp/test_log
-            - store_artifacts:
-                path: /tmp/ios-simulator-logs
             - store_artifacts:
                 path: ~/react-native/packages/rn-tester-e2e/reports
             - store_artifacts:

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -182,7 +182,7 @@ jobs:
   test_e2e_android:
     executor:
       name: android/android-machine
-      tag: 2023.07.1
+      tag: default
     steps:
       - checkout_code_with_cache
       - run_yarn

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -134,6 +134,12 @@ jobs:
       - setup_ruby:
           ruby_version: << parameters.ruby_version >>
       - run:
+          name: Install appium
+          command: npm install appium@2.0.0 -g
+      - run:
+          name: Install appium drivers
+          command: appium driver install xcuitest@5.6.0
+      - run:
           name: Boot iOS Simulator
           command: source scripts/.tests.env && xcrun simctl boot "$IOS_DEVICE" || true
       - with_xcodebuild_cache:
@@ -187,6 +193,12 @@ jobs:
           no-window: true
           restore-gradle-cache-prefix: v1a
           post-emulator-launch-assemble-command: ""
+      - run:
+          name: Install appium
+          command: npm install appium@2.0.0 -g
+      - run:
+          name: Install appium drivers
+          command: appium driver install uiautomator2@2.29.0
       - run:
           name: Start Metro
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ vendor/
 .metro-health-check*
 
 # E2E files
+/packages/rn-tester-e2e/reports
 /packages/rn-tester-e2e/apps/*.apk
 /packages/rn-tester-e2e/apps/*.app
 

--- a/packages/rn-tester-e2e/package.json
+++ b/packages/rn-tester-e2e/package.json
@@ -27,8 +27,8 @@
     "@wdio/local-runner": "^7.32.0",
     "@wdio/mocha-framework": "^7.32.0",
     "@wdio/spec-reporter": "^7.32.0",
-    "appium": "^2.0.0",
-    "appium-uiautomator2-driver": "^2.29.0",
-    "appium-xcuitest-driver": "^5.6.0"
+    "appium": "2.0.0",
+    "appium-uiautomator2-driver": "2.29.0",
+    "appium-xcuitest-driver": "5.6.0"
   }
 }

--- a/packages/rn-tester-e2e/package.json
+++ b/packages/rn-tester-e2e/package.json
@@ -25,7 +25,7 @@
     "@wdio/spec-reporter": "8.8.7",
     "appium": "2.0.0",
     "appium-uiautomator2-driver": "^2.29.0",
-    "appium-xcuitest-driver": "^5.6.0",
+    "appium-xcuitest-driver": "5.6.0",
     "eslint": "^8.23.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.2"

--- a/packages/rn-tester-e2e/package.json
+++ b/packages/rn-tester-e2e/package.json
@@ -6,29 +6,28 @@
   "description": "React Native E2E tester app.",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/rn-tester-e2e",
   "repository": {
-  "type": "git",
-  "url": "git@github.com:facebook/react-native.git",
-  "directory": "packages/rn-tester-e2e"
+    "type": "git",
+    "url": "git@github.com:facebook/react-native.git",
+    "directory": "packages/rn-tester-e2e"
   },
   "scripts": {
     "test-e2e-ios": "npx wdio wdio.conf.ios.js",
     "test-e2e-android": "npx wdio wdio.conf.android.js"
   },
   "devDependencies": {
-    "eslint": "^8.23.1",
-    "webdriverio": "^7.32.0",
     "@babel/core": "^7.20.0",
-    "@babel/preset-env": "^7.20.0",
     "@babel/plugin-transform-flow-strip-types": "^7.20.0",
-    "@babel/register": "^7.20.0",
-    "@types/mocha": "^10.0.3",
-    "@wdio/appium-service": "^7.32.0",
-    "@wdio/cli": "^7.32.0",
-    "@wdio/local-runner": "^7.32.0",
-    "@wdio/mocha-framework": "^7.32.0",
-    "@wdio/spec-reporter": "^7.32.0",
+    "@babel/preset-env": "^7.20.0",
+    "@wdio/appium-service": "^8.10.5",
+    "@wdio/cli": "^8.10.5",
+    "@wdio/local-runner": "^8.10.5",
+    "@wdio/mocha-framework": "8.10.4",
+    "@wdio/spec-reporter": "8.8.7",
     "appium": "2.0.0",
-    "appium-uiautomator2-driver": "2.29.0",
-    "appium-xcuitest-driver": "5.6.0"
+    "appium-uiautomator2-driver": "^2.29.0",
+    "appium-xcuitest-driver": "^5.6.0",
+    "eslint": "^8.23.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.2"
   }
 }

--- a/packages/rn-tester-e2e/package.json
+++ b/packages/rn-tester-e2e/package.json
@@ -24,7 +24,7 @@
     "@wdio/mocha-framework": "8.10.4",
     "@wdio/spec-reporter": "8.8.7",
     "appium": "2.0.0",
-    "appium-uiautomator2-driver": "^2.29.0",
+    "appium-uiautomator2-driver": "2.29.0",
     "appium-xcuitest-driver": "5.6.0",
     "eslint": "^8.23.1",
     "ts-node": "^10.9.1",

--- a/packages/rn-tester-e2e/scripts/copy-packages.sh
+++ b/packages/rn-tester-e2e/scripts/copy-packages.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+SOURCE_DIR=../../../node_modules
+DEST_DIR=../node_modules
+
+# List of package directories to copy
+PACKAGES=("appium" "appium-uiautomator2-driver" "appium-xcuitest-driver" "@wdio")
+
+# Copy each package directory
+for PACKAGE in "${PACKAGES[@]}"; do
+    echo "Copying $PACKAGE..."
+    cp -R "$SOURCE_DIR/$PACKAGE" "$DEST_DIR"
+done
+
+echo "Copying completed."

--- a/packages/rn-tester-e2e/tests/helpers/utils.js
+++ b/packages/rn-tester-e2e/tests/helpers/utils.js
@@ -40,7 +40,7 @@ class Utils {
     let {width, height} = await driver.getWindowSize();
     let elementIsFound;
     try {
-      elementIsFound = await $(locator).isDisplayed();
+      elementIsFound = await $(locator).isClickable();
       while (!(await elementIsFound)) {
         driver.touchPerform([
           {

--- a/packages/rn-tester-e2e/tests/helpers/utils.js
+++ b/packages/rn-tester-e2e/tests/helpers/utils.js
@@ -16,7 +16,7 @@ type PlatformsReference = {
 class Utils {
   async checkElementExistence(
     locator: string,
-    timeout: number = browser.waitforTimeout,
+    timeout: number = browser.config.waitforTimeout,
   ): Promise<boolean> {
     await $(locator).waitForDisplayed({timeout: timeout});
     return $(locator).isDisplayed();

--- a/packages/rn-tester-e2e/tests/helpers/utils.js
+++ b/packages/rn-tester-e2e/tests/helpers/utils.js
@@ -14,8 +14,8 @@ type PlatformsReference = {
 };
 
 class Utils {
-  async checkElementExistence(locator: string): Promise<boolean> {
-    await $(locator).waitForDisplayed();
+  async checkElementExistence(locator: string, timeout: number = browser.waitforTimeout): Promise<boolean> {
+    await $(locator).waitForDisplayed({timeout: timeout});
     return $(locator).isDisplayed();
   }
 

--- a/packages/rn-tester-e2e/tests/helpers/utils.js
+++ b/packages/rn-tester-e2e/tests/helpers/utils.js
@@ -30,8 +30,7 @@ class Utils {
   }
 
   platformSelect(platforms: PlatformsReference): string {
-    // if something goes wrong, we fallback to ios. But it should never happent, the process will fail way earlier.
-    return platforms[process?.env?.E2E_DEVICE || 'ios'];
+    return platforms[browser.capabilities.platformName.toLowerCase()];
   }
 
   async scrollToElement(locator: string): Promise<void> {

--- a/packages/rn-tester-e2e/tests/helpers/utils.js
+++ b/packages/rn-tester-e2e/tests/helpers/utils.js
@@ -29,6 +29,11 @@ class Utils {
     return $(locator).getText();
   }
 
+  async setElementText(locator: string, text: string): Promise<void> {
+    await $(locator).waitForDisplayed();
+    return $(locator).setValue(text);
+  }
+
   platformSelect(platforms: PlatformsReference): string {
     return platforms[browser.capabilities.platformName.toLowerCase()];
   }

--- a/packages/rn-tester-e2e/tests/helpers/utils.js
+++ b/packages/rn-tester-e2e/tests/helpers/utils.js
@@ -14,7 +14,10 @@ type PlatformsReference = {
 };
 
 class Utils {
-  async checkElementExistence(locator: string, timeout: number = browser.waitforTimeout): Promise<boolean> {
+  async checkElementExistence(
+    locator: string,
+    timeout: number = browser.waitforTimeout,
+  ): Promise<boolean> {
     await $(locator).waitForDisplayed({timeout: timeout});
     return $(locator).isDisplayed();
   }

--- a/packages/rn-tester-e2e/tests/helpers/utils.js
+++ b/packages/rn-tester-e2e/tests/helpers/utils.js
@@ -14,11 +14,8 @@ type PlatformsReference = {
 };
 
 class Utils {
-  async checkElementExistence(
-    locator: string,
-    timeout: number = browser.config.waitforTimeout,
-  ): Promise<boolean> {
-    await $(locator).waitForDisplayed({timeout: timeout});
+  async checkElementExistence(locator: string): Promise<boolean> {
+    await $(locator).waitForDisplayed();
     return $(locator).isDisplayed();
   }
 
@@ -67,7 +64,7 @@ class Utils {
             action: 'release',
           },
         ]);
-        elementIsFound = await $(locator).isDisplayed();
+        elementIsFound = await $(locator).isClickable();
       }
     } catch (err) {
       console.log('Element is not found');

--- a/packages/rn-tester-e2e/tests/screens/components.screen.js
+++ b/packages/rn-tester-e2e/tests/screens/components.screen.js
@@ -30,6 +30,7 @@ const refreshControlComponentLabel =
   'RefreshControl Adds pull-to-refresh support to a scrollview.';
 const scrollViewSimpleExampleComponentLabel =
   'ScrollViewSimpleExample Component that enables scrolling through child components.';
+const searchInputLabel = 'Search...';
 
 type ComponentsScreenType = {
   componentScreenHeaderElement: string,
@@ -43,6 +44,7 @@ type ComponentsScreenType = {
   pressableComponentLabelElement: string,
   refreshControlComponentLabelElement: string,
   scrollViewSimpleExampleComponentLabelElement: string,
+  searchInputLabelElement: string,
   checkButtonComponentIsDisplayed: () => Promise<boolean>,
   checkActivityIndicatorComponentIsDisplayed: () => Promise<boolean>,
   checkKeyboardAvoidingViewComponentIsDisplayed: () => Promise<boolean>,
@@ -63,6 +65,7 @@ type ComponentsScreenType = {
   clickPressableComponent: () => Promise<void>,
   clickRefreshControlComponent: () => Promise<void>,
   clickScrollViewSimpleExampleComponent: () => Promise<void>,
+  setValueToSearch: () => Promise<void>
 };
 
 export const ComponentsScreen: ComponentsScreenType = {
@@ -110,6 +113,10 @@ export const ComponentsScreen: ComponentsScreenType = {
   scrollViewSimpleExampleComponentLabelElement: Utils.platformSelect({
     ios: iOSLabel(scrollViewSimpleExampleComponentLabel),
     android: `~${scrollViewSimpleExampleComponentLabel}`,
+  }),
+  searchInputLabelElement: Utils.platformSelect({
+    ios: iOSLabel(searchInputLabel),
+    android: `~${searchInputLabel}`,
   }),
   // Methods to interact with top level elements in the list
   checkComponentScreenHeaderIsDisplayed: async function (
@@ -233,4 +240,10 @@ export const ComponentsScreen: ComponentsScreenType = {
   ): Promise<void> {
     await Utils.clickElement(this.scrollViewSimpleExampleComponentLabelElement);
   },
+  setValueToSearch: async function (
+    this: ComponentsScreenType,
+    searchInput: string
+  ): Promise<void> {
+    await Utils.setElementText(this.searchInputLabelElement, searchInput)
+  }
 };

--- a/packages/rn-tester-e2e/tests/screens/components.screen.js
+++ b/packages/rn-tester-e2e/tests/screens/components.screen.js
@@ -115,7 +115,10 @@ export const ComponentsScreen: ComponentsScreenType = {
   checkComponentScreenHeaderIsDisplayed: async function (
     this: ComponentsScreenType,
   ): Promise<boolean> {
-    return await Utils.checkElementExistence(this.componentScreenHeaderElement, 60000);
+    return await Utils.checkElementExistence(
+      this.componentScreenHeaderElement,
+      60000,
+    );
   },
   checkButtonComponentIsDisplayed: async function (
     this: ComponentsScreenType,

--- a/packages/rn-tester-e2e/tests/screens/components.screen.js
+++ b/packages/rn-tester-e2e/tests/screens/components.screen.js
@@ -115,7 +115,7 @@ export const ComponentsScreen: ComponentsScreenType = {
   checkComponentScreenHeaderIsDisplayed: async function (
     this: ComponentsScreenType,
   ): Promise<boolean> {
-    return await Utils.checkElementExistence(this.componentScreenHeaderElement);
+    return await Utils.checkElementExistence(this.componentScreenHeaderElement, 60000);
   },
   checkButtonComponentIsDisplayed: async function (
     this: ComponentsScreenType,

--- a/packages/rn-tester-e2e/tests/screens/components.screen.js
+++ b/packages/rn-tester-e2e/tests/screens/components.screen.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import {UtilsSingleton as Utils, iOSLabel} from '../helpers/utils';
+import {UtilsSingleton as Utils, iOSLabel, androidWidget} from '../helpers/utils';
 
 // root level screen in RNTester: Components
 
@@ -116,7 +116,7 @@ export const ComponentsScreen: ComponentsScreenType = {
   }),
   searchInputLabelElement: Utils.platformSelect({
     ios: iOSLabel(searchInputLabel),
-    android: `~${searchInputLabel}`,
+    android: androidWidget('EditText', 'text', searchInputLabel),
   }),
   // Methods to interact with top level elements in the list
   checkComponentScreenHeaderIsDisplayed: async function (

--- a/packages/rn-tester-e2e/tests/screens/components.screen.js
+++ b/packages/rn-tester-e2e/tests/screens/components.screen.js
@@ -115,10 +115,7 @@ export const ComponentsScreen: ComponentsScreenType = {
   checkComponentScreenHeaderIsDisplayed: async function (
     this: ComponentsScreenType,
   ): Promise<boolean> {
-    return await Utils.checkElementExistence(
-      this.componentScreenHeaderElement,
-      60000,
-    );
+    return await Utils.checkElementExistence(this.componentScreenHeaderElement);
   },
   checkButtonComponentIsDisplayed: async function (
     this: ComponentsScreenType,

--- a/packages/rn-tester-e2e/tests/screens/components.screen.js
+++ b/packages/rn-tester-e2e/tests/screens/components.screen.js
@@ -8,7 +8,11 @@
  * @format
  */
 
-import {UtilsSingleton as Utils, iOSLabel, androidWidget} from '../helpers/utils';
+import {
+  UtilsSingleton as Utils,
+  iOSLabel,
+  androidWidget,
+} from '../helpers/utils';
 
 // root level screen in RNTester: Components
 
@@ -65,7 +69,7 @@ type ComponentsScreenType = {
   clickPressableComponent: () => Promise<void>,
   clickRefreshControlComponent: () => Promise<void>,
   clickScrollViewSimpleExampleComponent: () => Promise<void>,
-  setValueToSearch: () => Promise<void>
+  setValueToSearch: () => Promise<void>,
 };
 
 export const ComponentsScreen: ComponentsScreenType = {
@@ -242,8 +246,8 @@ export const ComponentsScreen: ComponentsScreenType = {
   },
   setValueToSearch: async function (
     this: ComponentsScreenType,
-    searchInput: string
+    searchInput: string,
   ): Promise<void> {
-    await Utils.setElementText(this.searchInputLabelElement, searchInput)
-  }
+    await Utils.setElementText(this.searchInputLabelElement, searchInput);
+  },
 };

--- a/packages/rn-tester-e2e/tests/screens/components.screen.js
+++ b/packages/rn-tester-e2e/tests/screens/components.screen.js
@@ -12,6 +12,7 @@ import {UtilsSingleton as Utils, iOSLabel} from '../helpers/utils';
 
 // root level screen in RNTester: Components
 
+const componentScreenHeader = 'Components';
 const buttonComponentLabel = 'Button Simple React Native button component.';
 const activityIndicatorComponentLabel =
   'ActivityIndicator Animated loading indicators.';
@@ -31,6 +32,7 @@ const scrollViewSimpleExampleComponentLabel =
   'ScrollViewSimpleExample Component that enables scrolling through child components.';
 
 type ComponentsScreenType = {
+  componentScreenHeaderElement: string,
   buttonComponentLabelElement: string,
   activityIndicatorComponentLabelElement: string,
   keyboardAvoidingViewComponentLabelElement: string,
@@ -65,6 +67,10 @@ type ComponentsScreenType = {
 
 export const ComponentsScreen: ComponentsScreenType = {
   // Reference in the top level Component list
+  componentScreenHeaderElement: Utils.platformSelect({
+    ios: iOSLabel(componentScreenHeader),
+    android: `~${componentScreenHeader}`,
+  }),
   buttonComponentLabelElement: Utils.platformSelect({
     ios: iOSLabel(buttonComponentLabel),
     android: `~${buttonComponentLabel}`,
@@ -106,6 +112,11 @@ export const ComponentsScreen: ComponentsScreenType = {
     android: `~${scrollViewSimpleExampleComponentLabel}`,
   }),
   // Methods to interact with top level elements in the list
+  checkComponentScreenHeaderIsDisplayed: async function (
+    this: ComponentsScreenType,
+  ): Promise<boolean> {
+    return await Utils.checkElementExistence(this.componentScreenHeaderElement);
+  },
   checkButtonComponentIsDisplayed: async function (
     this: ComponentsScreenType,
   ): Promise<boolean> {

--- a/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
@@ -14,11 +14,17 @@ const {
 } = require('../../../screens/components/activityIndicatorComponent.screen.js');
 
 describe('Test is checking default activity indicator component', function () {
-  it('Should view properly Indicator Component', async function () {
-    expect(
-      await ComponentsScreen.checkActivityIndicatorComponentIsDisplayed(),
-    ).toBeTruthy();
-  });
+  before(async function (capabilities, specs) {
+    //Added it for make sure that metro bundler is completed
+    await ComponentsScreen.checkComponentScreenHeaderIsDisplayed({
+      timeout: 100000,
+    });
+  }),
+    it('Should view properly Indicator Component', async function () {
+      expect(
+        await ComponentsScreen.checkActivityIndicatorComponentIsDisplayed(),
+      ).toBeTruthy();
+    });
 
   it('Click Activity Indicator', async function () {
     await ComponentsScreen.clickActivityIndicatorComponent();

--- a/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
@@ -13,23 +13,23 @@ const {
   ActivityIndicatorComponentScreen,
 } = require('../../../screens/components/activityIndicatorComponent.screen.js');
 
-describe('Test is checking default activity indicator component', function () {
+describe('Testing Default Activity Indicator Functionality', function () {
   before(async function (capabilities, specs) {
     //Added it for make sure that metro bundler is completed
     await ComponentsScreen.checkComponentScreenHeaderIsDisplayed();
   });
 
-  it('Should view properly Indicator Component', async function () {
+  it('Should ensure the Activity Indicator component is displayed', async () => {
     expect(
       await ComponentsScreen.checkActivityIndicatorComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Click Activity Indicator', async function () {
+  it('Should click on the Activity Indicator component', async () => {
     await ComponentsScreen.clickActivityIndicatorComponent();
   });
 
-  it('Should view properly default progress bar', async function () {
+  it('Should check that the default Activity Indicator is visible', async () => {
     expect(
       await ActivityIndicatorComponentScreen.checkDefaultActivityIndicatorIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
@@ -25,11 +25,8 @@ describe('Testing Default Activity Indicator Functionality', function () {
     ).toBeTruthy();
   });
 
-  it('Should click on the Activity Indicator component', async () => {
+  it('Should open Activity Indicator component screen and check if displayed', async () => {
     await ComponentsScreen.clickActivityIndicatorComponent();
-  });
-
-  it('Should check that the default Activity Indicator is visible', async () => {
     expect(
       await ActivityIndicatorComponentScreen.checkDefaultActivityIndicatorIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
@@ -16,15 +16,14 @@ const {
 describe('Test is checking default activity indicator component', function () {
   before(async function (capabilities, specs) {
     //Added it for make sure that metro bundler is completed
-    await ComponentsScreen.checkComponentScreenHeaderIsDisplayed({
-      timeout: 100000,
-    });
-  }),
-    it('Should view properly Indicator Component', async function () {
-      expect(
-        await ComponentsScreen.checkActivityIndicatorComponentIsDisplayed(),
-      ).toBeTruthy();
-    });
+    await ComponentsScreen.checkComponentScreenHeaderIsDisplayed();
+  });
+
+  it('Should view properly Indicator Component', async function () {
+    expect(
+      await ComponentsScreen.checkActivityIndicatorComponentIsDisplayed(),
+    ).toBeTruthy();
+  });
 
   it('Click Activity Indicator', async function () {
     await ComponentsScreen.clickActivityIndicatorComponent();

--- a/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/activityIndicatior/defaultProgressBar.test.js
@@ -8,27 +8,25 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   ActivityIndicatorComponentScreen,
- } = require('../../../screens/components/activityIndicatorComponent.screen.js');
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  ActivityIndicatorComponentScreen,
+} = require('../../../screens/components/activityIndicatorComponent.screen.js');
 
 describe('Test is checking default activity indicator component', function () {
-  
-  it('Should view properly Indicator Component', async function() {
+  it('Should view properly Indicator Component', async function () {
     expect(
       await ComponentsScreen.checkActivityIndicatorComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Click Activity Indicator', async function() {
+  it('Click Activity Indicator', async function () {
     await ComponentsScreen.clickActivityIndicatorComponent();
   });
 
-  it('Should view properly default progress bar', async function() {
+  it('Should view properly default progress bar', async function () {
     expect(
       await ActivityIndicatorComponentScreen.checkDefaultActivityIndicatorIsDisplayed(),
     ).toBeTruthy();
   });
-
 });

--- a/packages/rn-tester-e2e/tests/specs/components/button/cancelButton.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/button/cancelButton.test.js
@@ -8,24 +8,23 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   ButtonComponentScreen,
- } = require('../../../screens/components/buttonComponent.screen.js');
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  ButtonComponentScreen,
+} = require('../../../screens/components/buttonComponent.screen.js');
 
 const cancelText = 'Your application has been cancelled!';
 
-describe('Test is checking cancel button', function() {
-    it('Should view properly submit cancel text', async function() {
-        expect(
-        await ComponentsScreen.checkButtonComponentIsDisplayed(),
-        ).toBeTruthy();
-        await ComponentsScreen.clickButtonComponent();
-        await ButtonComponentScreen.clickCancelApplication();
-        expect(await ButtonComponentScreen.getCancelAlertText()).toContain(
-        cancelText,
-        );
-        await ButtonComponentScreen.clickOkButton();
-    });
+describe('Test is checking cancel button', function () {
+  it('Should view properly submit cancel text', async function () {
+    expect(
+      await ComponentsScreen.checkButtonComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickButtonComponent();
+    await ButtonComponentScreen.clickCancelApplication();
+    expect(await ButtonComponentScreen.getCancelAlertText()).toContain(
+      cancelText,
+    );
+    await ButtonComponentScreen.clickOkButton();
   });
-  
+});

--- a/packages/rn-tester-e2e/tests/specs/components/button/cancelButton.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/button/cancelButton.test.js
@@ -22,21 +22,15 @@ describe('Testing Cancel Button Functionality', function () {
     ).toBeTruthy();
   });
 
-  it('Should click on the Button component', async function () {
+  it('Should open component and click on Cancel Button then check alert text', async function () {
     await ComponentsScreen.clickButtonComponent();
-  });
-
-  it('Should click the Cancel Application button', async function () {
     await ButtonComponentScreen.clickCancelApplication();
-  });
-
-  it('Should view properly submit cancel text', async function () {
     expect(await ButtonComponentScreen.getCancelAlertText()).toContain(
       cancelText,
     );
   });
 
-  it('Should click the OK button', async function () {
+  it('Should click the OK button and check if is closed', async function () {
     await ButtonComponentScreen.clickOkButton();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/button/cancelButton.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/button/cancelButton.test.js
@@ -15,16 +15,28 @@ const {
 
 const cancelText = 'Your application has been cancelled!';
 
-describe('Test is checking cancel button', function () {
-  it('Should view properly submit cancel text', async function () {
+describe('Testing Cancel Button Functionality', function () {
+  it('Should ensure the Button component is displayed', async function () {
     expect(
       await ComponentsScreen.checkButtonComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the Button component', async function () {
     await ComponentsScreen.clickButtonComponent();
+  });
+
+  it('Should click the Cancel Application button', async function () {
     await ButtonComponentScreen.clickCancelApplication();
+  });
+
+  it('Should view properly submit cancel text', async function () {
     expect(await ButtonComponentScreen.getCancelAlertText()).toContain(
       cancelText,
     );
+  });
+
+  it('Should click the OK button', async function () {
     await ButtonComponentScreen.clickOkButton();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/button/submitButton.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/button/submitButton.test.js
@@ -22,15 +22,9 @@ describe('Testing Submit Button functionality ', function () {
     ).toBeTruthy();
   });
 
-  it('Should click on the Button component', async function () {
+  it('Should open component and click on Submit Button then check alert text', async function () {
     await ComponentsScreen.clickButtonComponent();
-  });
-
-  it('Should click the Submit Application button', async function () {
     await ButtonComponentScreen.clickSubmitApplication();
-  });
-
-  it('Should verify that the submit alert text is displayed', async function () {
     expect(await ButtonComponentScreen.getSubmitAlertText()).toContain(
       submitText,
     );

--- a/packages/rn-tester-e2e/tests/specs/components/button/submitButton.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/button/submitButton.test.js
@@ -15,16 +15,28 @@ const {
 
 const submitText = 'Your application has been submitted!';
 
-describe('Test is checking submit button', function () {
-  it('Should view properly submit alert text', async function () {
+describe('Testing Submit Button functionality ', function () {
+  it('Should ensure the Button component is displayed', async function () {
     expect(
       await ComponentsScreen.checkButtonComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the Button component', async function () {
     await ComponentsScreen.clickButtonComponent();
+  });
+
+  it('Should click the Submit Application button', async function () {
     await ButtonComponentScreen.clickSubmitApplication();
+  });
+
+  it('Should verify that the submit alert text is displayed', async function () {
     expect(await ButtonComponentScreen.getSubmitAlertText()).toContain(
       submitText,
     );
+  });
+
+  it('Should click the OK button in the alert', async function () {
     await ButtonComponentScreen.clickOkButton();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/button/submitButton.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/button/submitButton.test.js
@@ -8,15 +8,15 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   ButtonComponentScreen,
- } = require('../../../screens/components/buttonComponent.screen.js');
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  ButtonComponentScreen,
+} = require('../../../screens/components/buttonComponent.screen.js');
 
 const submitText = 'Your application has been submitted!';
 
-describe('Test is checking submit button', function() {
-  it('Should view properly submit alert text', async function(){
+describe('Test is checking submit button', function () {
+  it('Should view properly submit alert text', async function () {
     expect(
       await ComponentsScreen.checkButtonComponentIsDisplayed(),
     ).toBeTruthy();
@@ -28,6 +28,3 @@ describe('Test is checking submit button', function() {
     await ButtonComponentScreen.clickOkButton();
   });
 });
-
-
-

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/basic.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/basic.test.js
@@ -20,21 +20,15 @@ describe('Testing Basic Flat List Functionality', function () {
     ).toBeTruthy();
   });
 
-  it('Click on FlatList component', async function () {
+  it('Open on FlatList component and check if displayed correctly', async function () {
     await ComponentsScreen.clickFlatListComponent();
-  });
-
-  it('Should view properly the FlatList Content Inset Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Click on FlatList Content Inset button', async function () {
+  it('Click on FlatList Content Inset button and check if displayed correctly', async function () {
     await FlatListComponentScreen.clickFlatListContentInsetButton();
-  });
-
-  it('Should view properly the collapse button', async function () {
     expect(
       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/basic.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/basic.test.js
@@ -13,18 +13,36 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking basic flat list', function () {
-  it('Should view properly search bar of basic flat list', async function () {
+describe('Testing Basic Flat List Functionality', function () {
+  it('Should view properly the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Click on FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should view properly the FlatList Content Inset Screen', async function () {
     expect(
-      await FlatListComponentScreen.checkFlatListBasicScreenIsDisplayed(),
+      await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
     ).toBeTruthy();
-    await FlatListComponentScreen.clickFlatListBasicButton();
+  });
+
+  it('Click on FlatList Content Inset button', async function () {
+    await FlatListComponentScreen.clickFlatListContentInsetButton();
+  });
+
+  it('Should view properly the collapse button', async function () {
     expect(
-      await FlatListComponentScreen.checkSearchBarIsDisplayed(),
+      await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
+    ).toBeTruthy();
+  });
+
+  it('Should view properly the Content Inset menu', async function () {
+    expect(
+      await FlatListComponentScreen.checkContentInsetMenuIsDisplayed(),
     ).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/basic.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/basic.test.js
@@ -8,23 +8,23 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking basic flat list', function() {
-   it('Should view properly search bar of basic flat list', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     expect(
-       await FlatListComponentScreen.checkFlatListBasicScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListBasicButton();
-     expect(
-       await FlatListComponentScreen.checkSearchBarIsDisplayed(),
-     ).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking basic flat list', function () {
+  it('Should view properly search bar of basic flat list', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListBasicScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListBasicButton();
+    expect(
+      await FlatListComponentScreen.checkSearchBarIsDisplayed(),
+    ).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/contentInset.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/contentInset.test.js
@@ -13,19 +13,34 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking content inset flat list', function () {
-  it('Should view properly the menu element', async function () {
+describe('Testing Content Inset Flat List Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should display the FlatList Content Inset Screen after clicking FlatList component', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click the FlatList Content Inset button', async function () {
     await FlatListComponentScreen.clickFlatListContentInsetButton();
+  });
+
+  it('Should display the collapse button after clicking FlatList Content Inset button', async function () {
     expect(
       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should display the Content Inset menu after clicking FlatList Content Inset button', async function () {
     expect(
       await FlatListComponentScreen.checkContentInsetMenuIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/contentInset.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/contentInset.test.js
@@ -8,26 +8,26 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking content inset flat list', function() {
-   it('Should view properly the menu element', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     expect(
-       await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListContentInsetButton();
-     expect(
-       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
-     ).toBeTruthy();
-     expect(
-       await FlatListComponentScreen.checkContentInsetMenuIsDisplayed(),
-     ).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking content inset flat list', function () {
+  it('Should view properly the menu element', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListContentInsetButton();
+    expect(
+      await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
+    ).toBeTruthy();
+    expect(
+      await FlatListComponentScreen.checkContentInsetMenuIsDisplayed(),
+    ).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/contentInset.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/contentInset.test.js
@@ -20,27 +20,18 @@ describe('Testing Content Inset Flat List Functionality', function () {
     ).toBeTruthy();
   });
 
-  it('Should click on FlatList component', async function () {
+  it('Should click on FlatList component and check if displayed', async function () {
     await ComponentsScreen.clickFlatListComponent();
-  });
-
-  it('Should display the FlatList Content Inset Screen after clicking FlatList component', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click the FlatList Content Inset button', async function () {
+  it('Should click the FlatList Content Inset button and check if component is displayed correctly', async function () {
     await FlatListComponentScreen.clickFlatListContentInsetButton();
-  });
-
-  it('Should display the collapse button after clicking FlatList Content Inset button', async function () {
     expect(
       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
     ).toBeTruthy();
-  });
-
-  it('Should display the Content Inset menu after clicking FlatList Content Inset button', async function () {
     expect(
       await FlatListComponentScreen.checkContentInsetMenuIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/flatListWithSeparators.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/flatListWithSeparators.test.js
@@ -20,25 +20,16 @@ describe('Testing Flat List with Separators Functionality', function () {
     ).toBeTruthy();
   });
 
-  it('Should click on FlatList component', async function () {
+  it('Should click on FlatList component and search for component', async function () {
     await ComponentsScreen.clickFlatListComponent();
-  });
-
-  it('Should scroll until nested element is displayed', async function () {
-    await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
-  });
-
-  it('Should display the FlatList with Separators Screen after scrolling', async function () {
+    await ComponentsScreen.setValueToSearch('FlatList with Separators');
     expect(
       await FlatListComponentScreen.checkFlatListWithSeparatorsScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click the FlatList with Separators button', async function () {
+  it('Should open the FlatList with Separators and check if button is correctly displyed', async function () {
     await FlatListComponentScreen.clickFlatListWithSeparatorsButton();
-  });
-
-  it('Should display the separator after clicking the FlatList with Separators button', async function () {
     expect(
       await FlatListComponentScreen.checkSeparatorIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/flatListWithSeparators.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/flatListWithSeparators.test.js
@@ -8,24 +8,24 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking FlatList with Separators component', function() {
-   it('Should view properly the separator element', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
-     expect(
-       await FlatListComponentScreen.checkFlatListWithSeparatorsScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListWithSeparatorsButton();
-     expect(
-       await FlatListComponentScreen.checkSeparatorIsDisplayed(),
-     ).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking FlatList with Separators component', function () {
+  it('Should view properly the separator element', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+    expect(
+      await FlatListComponentScreen.checkFlatListWithSeparatorsScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListWithSeparatorsButton();
+    expect(
+      await FlatListComponentScreen.checkSeparatorIsDisplayed(),
+    ).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/flatListWithSeparators.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/flatListWithSeparators.test.js
@@ -13,17 +13,32 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking FlatList with Separators component', function () {
-  it('Should view properly the separator element', async function () {
+describe('Testing Flat List with Separators Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should scroll until nested element is displayed', async function () {
     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+  });
+
+  it('Should display the FlatList with Separators Screen after scrolling', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListWithSeparatorsScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click the FlatList with Separators button', async function () {
     await FlatListComponentScreen.clickFlatListWithSeparatorsButton();
+  });
+
+  it('Should display the separator after clicking the FlatList with Separators button', async function () {
     expect(
       await FlatListComponentScreen.checkSeparatorIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/flatListWithSeparators.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/flatListWithSeparators.test.js
@@ -20,7 +20,7 @@ describe('Testing Flat List with Separators Functionality', function () {
     ).toBeTruthy();
   });
 
-  it('Should click on FlatList component and search for component', async function () {
+  it('Should open FlatList component and search for FlatList with Separators', async function () {
     await ComponentsScreen.clickFlatListComponent();
     await ComponentsScreen.setValueToSearch('FlatList with Separators');
     expect(

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/invertedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/invertedFlatList.test.js
@@ -13,19 +13,40 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking inverted flat list', function () {
-  it('Should view properly the menu element', async function () {
+describe('Testing Inverted Flat List Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should scroll until onViewableItemsChanged is displayed', async function () {
     await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
+  });
+
+  it('Should display the FlatList Inverted Screen after scrolling', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListInvertedScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click the FlatList Inverted button', async function () {
     await FlatListComponentScreen.clickFlatListInvertedButton();
+  });
+
+  it('Should display the pizza item after clicking the FlatList Inverted button', async function () {
     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
+  });
+
+  it('Should allow toggling the True button', async function () {
     await FlatListComponentScreen.clickToggleTrueButton();
+  });
+
+  it('Should still display the pizza item after toggling the True button', async function () {
     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/invertedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/invertedFlatList.test.js
@@ -14,39 +14,27 @@ const {
 } = require('../../../screens/components/flatListComponent.screen.js');
 
 describe('Testing Inverted Flat List Functionality', function () {
-  it('Should display the FlatList component', async function () {
+  it('Should display the FlatList component then click on it', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
-  });
-
-  it('Should click on FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
   });
 
   it('Should scroll until onViewableItemsChanged is displayed', async function () {
     await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
-  });
-
-  it('Should display the FlatList Inverted Screen after scrolling', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListInvertedScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click the FlatList Inverted button', async function () {
+  it('Should click the FlatList Inverted button and check if pizza item is displayed', async function () {
     await FlatListComponentScreen.clickFlatListInvertedButton();
-  });
-
-  it('Should display the pizza item after clicking the FlatList Inverted button', async function () {
     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
   });
 
-  it('Should allow toggling the True button', async function () {
+  it('Should toggld the True button then check if pizza item is displayed', async function () {
     await FlatListComponentScreen.clickToggleTrueButton();
-  });
-
-  it('Should still display the pizza item after toggling the True button', async function () {
     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/invertedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/invertedFlatList.test.js
@@ -8,24 +8,24 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking inverted flat list', function() {
-   it('Should view properly the menu element', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
-     expect(
-       await FlatListComponentScreen.checkFlatListInvertedScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListInvertedButton();
-     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
-     await FlatListComponentScreen.clickToggleTrueButton();
-     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking inverted flat list', function () {
+  it('Should view properly the menu element', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
+    expect(
+      await FlatListComponentScreen.checkFlatListInvertedScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListInvertedButton();
+    expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
+    await FlatListComponentScreen.clickToggleTrueButton();
+    expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/invertedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/invertedFlatList.test.js
@@ -19,10 +19,13 @@ describe('Testing Inverted Flat List Functionality', function () {
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
     await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
+    ).toBeTruthy();
   });
 
-  it('Should scroll until onViewableItemsChanged is displayed', async function () {
-    await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
+  it('Should search for onViewableItemsChanged and check if displayed', async function () {
+    await ComponentsScreen.setValueToSearch('Inverted');
     expect(
       await FlatListComponentScreen.checkFlatListInvertedScreenIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/multicolumn.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/multicolumn.test.js
@@ -14,31 +14,22 @@ const {
 } = require('../../../screens/components/flatListComponent.screen.js');
 
 describe('Testing MultiColumn Functionality', function () {
-  it('Should display the FlatList component', async function () {
+  it('Should display the FlatList component and open it', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
-  });
-
-  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
   });
 
   it('Should scroll until the nested element is displayed', async function () {
     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
-  });
-
-  it('Should display the FlatList MultiColumn Screen after scrolling', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListMultiColumnScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click the FlatList MultiColumn button', async function () {
+  it('Should open the FlatList MultiColumn button and check if list header is displayed', async function () {
     await FlatListComponentScreen.clickFlatListMultiColumnButton();
-  });
-
-  it('Should display the list header after clicking the FlatList MultiColumn button', async function () {
     expect(
       await FlatListComponentScreen.checkListHeaderIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/multicolumn.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/multicolumn.test.js
@@ -13,17 +13,32 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking multicolumn component', function () {
-  it('Should view properly the list header element', async function () {
+describe('Testing MultiColumn Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should scroll until the nested element is displayed', async function () {
     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+  });
+
+  it('Should display the FlatList MultiColumn Screen after scrolling', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListMultiColumnScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click the FlatList MultiColumn button', async function () {
     await FlatListComponentScreen.clickFlatListMultiColumnButton();
+  });
+
+  it('Should display the list header after clicking the FlatList MultiColumn button', async function () {
     expect(
       await FlatListComponentScreen.checkListHeaderIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/multicolumn.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/multicolumn.test.js
@@ -19,10 +19,13 @@ describe('Testing MultiColumn Functionality', function () {
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
     await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
+    ).toBeTruthy();
   });
 
-  it('Should scroll until the nested element is displayed', async function () {
-    await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+  it('Should search for nested and check if element is displayed', async function () {
+    await ComponentsScreen.setValueToSearch('MultiColumn');
     expect(
       await FlatListComponentScreen.checkFlatListMultiColumnScreenIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/multicolumn.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/multicolumn.test.js
@@ -8,24 +8,24 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking multicolumn component', function() {
-   it('Should view properly the list header element', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
-     expect(
-       await FlatListComponentScreen.checkFlatListMultiColumnScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListMultiColumnButton();
-     expect(
-       await FlatListComponentScreen.checkListHeaderIsDisplayed(),
-     ).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking multicolumn component', function () {
+  it('Should view properly the list header element', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+    expect(
+      await FlatListComponentScreen.checkFlatListMultiColumnScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListMultiColumnButton();
+    expect(
+      await FlatListComponentScreen.checkListHeaderIsDisplayed(),
+    ).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/nested.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/nested.test.js
@@ -13,17 +13,32 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking nested component', function () {
-  it('Should view properly the nested header element', async function () {
+describe('Testing Nested Flat List Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should scroll until the nested element is displayed', async function () {
     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+  });
+
+  it('Should display the FlatList Nested Screen after scrolling', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListNestedScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click the FlatList Nested button', async function () {
     await FlatListComponentScreen.clickFlatListNestedButton();
+  });
+
+  it('Should display the nested header after clicking the FlatList Nested button', async function () {
     expect(
       await FlatListComponentScreen.checkNestedHeaderIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/nested.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/nested.test.js
@@ -8,13 +8,13 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking nested component', function() {
-  it('Should view properly the nested header element', async function() {
+describe('Test is checking nested component', function () {
+  it('Should view properly the nested header element', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/nested.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/nested.test.js
@@ -14,31 +14,22 @@ const {
 } = require('../../../screens/components/flatListComponent.screen.js');
 
 describe('Testing Nested Flat List Functionality', function () {
-  it('Should display the FlatList component', async function () {
+  it('Should display the FlatList component and open it', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
-  });
-
-  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
   });
 
   it('Should scroll until the nested element is displayed', async function () {
     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
-  });
-
-  it('Should display the FlatList Nested Screen after scrolling', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListNestedScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click the FlatList Nested button', async function () {
+  it('Should click the FlatList Nested button and check if header is displayed', async function () {
     await FlatListComponentScreen.clickFlatListNestedButton();
-  });
-
-  it('Should display the nested header after clicking the FlatList Nested button', async function () {
     expect(
       await FlatListComponentScreen.checkNestedHeaderIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/nested.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/nested.test.js
@@ -19,10 +19,13 @@ describe('Testing Nested Flat List Functionality', function () {
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
     await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
+    ).toBeTruthy();
   });
 
-  it('Should scroll until the nested element is displayed', async function () {
-    await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+  it('Should search for nested and check if element is displayed', async function () {
+    await ComponentsScreen.setValueToSearch('Nested');
     expect(
       await FlatListComponentScreen.checkFlatListNestedScreenIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onEndReachedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onEndReachedFlatList.test.js
@@ -13,20 +13,38 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking onEndReached flat list', function () {
-  it('Should view properly the last element', async function () {
+describe('Testing onEndReached Flat List Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should display the FlatList OnEndReached Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListOnEndReachedScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the OnEndReached button', async function () {
     await FlatListComponentScreen.clickFlatListOnEndButton();
+  });
+
+  it('Should display the collapse button after clicking on the OnEndReached button', async function () {
     expect(
       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the OnStartTest button', async function () {
     await FlatListComponentScreen.clickFlatListOnStartTestButton();
+  });
+
+  it('Should display the ice cream after clicking on the OnStartTest button', async function () {
     expect(
       await FlatListComponentScreen.checkIceCreamIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onEndReachedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onEndReachedFlatList.test.js
@@ -8,27 +8,27 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking onEndReached flat list', function() {
-   it('Should view properly the last element', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     expect(
-       await FlatListComponentScreen.checkFlatListOnEndReachedScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListOnEndButton();
-     expect(
-       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListOnStartTestButton();
-     expect(
-       await FlatListComponentScreen.checkIceCreamIsDisplayed(),
-     ).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking onEndReached flat list', function () {
+  it('Should view properly the last element', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListOnEndReachedScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListOnEndButton();
+    expect(
+      await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListOnStartTestButton();
+    expect(
+      await FlatListComponentScreen.checkIceCreamIsDisplayed(),
+    ).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onEndReachedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onEndReachedFlatList.test.js
@@ -20,31 +20,22 @@ describe('Testing onEndReached Flat List Functionality', function () {
     ).toBeTruthy();
   });
 
-  it('Should click on the FlatList component', async function () {
+  it('Should click on the FlatList component then check if FlatList OnEndReached button is displayed', async function () {
     await ComponentsScreen.clickFlatListComponent();
-  });
-
-  it('Should display the FlatList OnEndReached Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListOnEndReachedScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the OnEndReached button', async function () {
+  it('Should click on the OnEndReached button then check if component screen is displayed', async function () {
     await FlatListComponentScreen.clickFlatListOnEndButton();
-  });
-
-  it('Should display the collapse button after clicking on the OnEndReached button', async function () {
     expect(
       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the OnStartTest button', async function () {
+  it('Should click on the OnStartTest button and check if ice cream is displayed after click', async function () {
     await FlatListComponentScreen.clickFlatListOnStartTestButton();
-  });
-
-  it('Should display the ice cream after clicking on the OnStartTest button', async function () {
     expect(
       await FlatListComponentScreen.checkIceCreamIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onStartReachedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onStartReachedFlatList.test.js
@@ -20,31 +20,22 @@ describe('Testing onStartReached Flat List Functionality', function () {
     ).toBeTruthy();
   });
 
-  it('Should click on the FlatList component', async function () {
+  it('Should click on the FlatList component and check if OnStartReached button is displayed', async function () {
     await ComponentsScreen.clickFlatListComponent();
-  });
-
-  it('Should display the FlatList OnStartReached Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListOnStartReachedScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the OnStartReached button', async function () {
+  it('Should click on the OnStartReached and check if OnStartReached screen is visible', async function () {
     await FlatListComponentScreen.clickFlatListOnStartButton();
-  });
-
-  it('Should display the collapse button after clicking on the OnStartReached button', async function () {
     expect(
       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the OnStartTest button', async function () {
+  it('Should click on the OnStartTest button and check if pizza is displayed after click', async function () {
     await FlatListComponentScreen.clickFlatListOnStartTestButton();
-  });
-
-  it('Should display the pizza after clicking on the OnStartTest button', async function () {
     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onStartReachedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onStartReachedFlatList.test.js
@@ -8,25 +8,25 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking onStartReached flat list', function() {
-   it('Should view properly first element', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     expect(
-       await FlatListComponentScreen.checkFlatListOnStartReachedScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListOnStartButton();
-     expect(
-       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListOnStartTestButton();
-     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking onStartReached flat list', function () {
+  it('Should view properly first element', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListOnStartReachedScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListOnStartButton();
+    expect(
+      await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListOnStartTestButton();
+    expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onStartReachedFlatList.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onStartReachedFlatList.test.js
@@ -13,20 +13,38 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking onStartReached flat list', function () {
-  it('Should view properly first element', async function () {
+describe('Testing onStartReached Flat List Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should display the FlatList OnStartReached Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListOnStartReachedScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the OnStartReached button', async function () {
     await FlatListComponentScreen.clickFlatListOnStartButton();
+  });
+
+  it('Should display the collapse button after clicking on the OnStartReached button', async function () {
     expect(
       await FlatListComponentScreen.checkCollapseButtonIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the OnStartTest button', async function () {
     await FlatListComponentScreen.clickFlatListOnStartTestButton();
+  });
+
+  it('Should display the pizza after clicking on the OnStartTest button', async function () {
     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onViewableItemsChanges.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onViewableItemsChanges.test.js
@@ -13,17 +13,32 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking onViewableItemsChanges component', function () {
-  it('Should view properly the pizza element', async function () {
+describe('Testing onViewableItemsChanges Flat List Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should scroll until onViewableItemsChanged is displayed', async function () {
     await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
+  });
+
+  it('Should display the FlatList onViewableItemsChanged Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListOnViewableItemsChangedScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click onViewableItemsChanged button', async function () {
     await FlatListComponentScreen.clickFlatListOnViewableItemsChangedButton();
+  });
+
+  it('Should display the pizza after clicking onViewableItemsChanged button', async function () {
     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onViewableItemsChanges.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onViewableItemsChanges.test.js
@@ -19,10 +19,13 @@ describe('Testing onViewableItemsChanges Flat List Functionality', function () {
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
     await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
+    ).toBeTruthy();
   });
 
-  it('Should scroll until onViewableItemsChanged component button is displayed', async function () {
-    await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
+  it('Should search for onViewableItemsChanged and check if button is displayed', async function () {
+    await ComponentsScreen.setValueToSearch('onViewableItemsChanged');
     expect(
       await FlatListComponentScreen.checkFlatListOnViewableItemsChangedScreenIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onViewableItemsChanges.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onViewableItemsChanges.test.js
@@ -14,31 +14,22 @@ const {
 } = require('../../../screens/components/flatListComponent.screen.js');
 
 describe('Testing onViewableItemsChanges Flat List Functionality', function () {
-  it('Should display the FlatList component', async function () {
+  it('Should display the FlatList component then click on it', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
-  });
-
-  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
   });
 
-  it('Should scroll until onViewableItemsChanged is displayed', async function () {
+  it('Should scroll until onViewableItemsChanged component button is displayed', async function () {
     await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
-  });
-
-  it('Should display the FlatList onViewableItemsChanged Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListOnViewableItemsChangedScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click onViewableItemsChanged button', async function () {
+  it('Should click onViewableItemsChanged button and check if pizza is displayed after click', async function () {
     await FlatListComponentScreen.clickFlatListOnViewableItemsChangedButton();
-  });
-
-  it('Should display the pizza after clicking onViewableItemsChanged button', async function () {
     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/onViewableItemsChanges.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/onViewableItemsChanges.test.js
@@ -8,22 +8,22 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking onViewableItemsChanges component', function() {
-   it('Should view properly the pizza element', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
-     expect(
-       await FlatListComponentScreen.checkFlatListOnViewableItemsChangedScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListOnViewableItemsChangedButton();
-     expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking onViewableItemsChanges component', function () {
+  it('Should view properly the pizza element', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    await FlatListComponentScreen.scrollUntilOnViewableItemsChangedIsDisplayed();
+    expect(
+      await FlatListComponentScreen.checkFlatListOnViewableItemsChangedScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListOnViewableItemsChangedButton();
+    expect(await FlatListComponentScreen.checkPizzaIsDisplayed()).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/stickyHeaders.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/stickyHeaders.test.js
@@ -13,17 +13,32 @@ const {
   FlatListComponentScreen,
 } = require('../../../screens/components/flatListComponent.screen.js');
 
-describe('Test is checking sticky headers component', function () {
-  it('Should view properly the sticky pizza element', async function () {
+describe('Testing Sticky Headers Flat List Functionality', function () {
+  it('Should display the FlatList component', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
+  });
+
+  it('Should scroll until the Nested element is displayed', async function () {
     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+  });
+
+  it('Should display the FlatList Sticky Headers Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListStickyHeadersScreenIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click the Sticky Headers button', async function () {
     await FlatListComponentScreen.clickFlatListStickyHeadersButton();
+  });
+
+  it('Should display the sticky pizza after clicking the Sticky Headers button', async function () {
     expect(
       await FlatListComponentScreen.checkStickyPizzaIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/stickyHeaders.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/stickyHeaders.test.js
@@ -8,24 +8,24 @@
  * @format
  */
 
- const {ComponentsScreen} = require('../../../screens/components.screen.js');
- const {
-   FlatListComponentScreen,
- } = require('../../../screens/components/flatListComponent.screen.js');
- 
- describe('Test is checking sticky headers component', function()  {
-   it('Should view properly the sticky pizza element', async function() {
-     expect(
-       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
-     ).toBeTruthy();
-     await ComponentsScreen.clickFlatListComponent();
-     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
-     expect(
-       await FlatListComponentScreen.checkFlatListStickyHeadersScreenIsDisplayed(),
-     ).toBeTruthy();
-     await FlatListComponentScreen.clickFlatListStickyHeadersButton();
-     expect(
-       await FlatListComponentScreen.checkStickyPizzaIsDisplayed(),
-     ).toBeTruthy();
-   });
- });
+const {ComponentsScreen} = require('../../../screens/components.screen.js');
+const {
+  FlatListComponentScreen,
+} = require('../../../screens/components/flatListComponent.screen.js');
+
+describe('Test is checking sticky headers component', function () {
+  it('Should view properly the sticky pizza element', async function () {
+    expect(
+      await ComponentsScreen.checkFlatListComponentIsDisplayed(),
+    ).toBeTruthy();
+    await ComponentsScreen.clickFlatListComponent();
+    await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+    expect(
+      await FlatListComponentScreen.checkFlatListStickyHeadersScreenIsDisplayed(),
+    ).toBeTruthy();
+    await FlatListComponentScreen.clickFlatListStickyHeadersButton();
+    expect(
+      await FlatListComponentScreen.checkStickyPizzaIsDisplayed(),
+    ).toBeTruthy();
+  });
+});

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/stickyHeaders.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/stickyHeaders.test.js
@@ -14,31 +14,22 @@ const {
 } = require('../../../screens/components/flatListComponent.screen.js');
 
 describe('Testing Sticky Headers Flat List Functionality', function () {
-  it('Should display the FlatList component', async function () {
+  it('Should check if FlatList component si displayed then click on it', async function () {
     expect(
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
-  });
-
-  it('Should click on the FlatList component', async function () {
     await ComponentsScreen.clickFlatListComponent();
   });
 
-  it('Should scroll until the Nested element is displayed', async function () {
+  it('Should scroll until the Nested component button is displayed', async function () {
     await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
-  });
-
-  it('Should display the FlatList Sticky Headers Screen', async function () {
     expect(
       await FlatListComponentScreen.checkFlatListStickyHeadersScreenIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click the Sticky Headers button', async function () {
+  it('Should click the Sticky Headers button and check if sticky pizza is displayed after click', async function () {
     await FlatListComponentScreen.clickFlatListStickyHeadersButton();
-  });
-
-  it('Should display the sticky pizza after clicking the Sticky Headers button', async function () {
     expect(
       await FlatListComponentScreen.checkStickyPizzaIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/flatList/stickyHeaders.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/flatList/stickyHeaders.test.js
@@ -19,10 +19,13 @@ describe('Testing Sticky Headers Flat List Functionality', function () {
       await ComponentsScreen.checkFlatListComponentIsDisplayed(),
     ).toBeTruthy();
     await ComponentsScreen.clickFlatListComponent();
+    expect(
+      await FlatListComponentScreen.checkFlatListContentInsetScreenIsDisplayed(),
+    ).toBeTruthy();
   });
 
-  it('Should scroll until the Nested component button is displayed', async function () {
-    await FlatListComponentScreen.scrollUntilNestedIsDisplayed();
+  it('Should search for Nested component and check if button is displayed', async function () {
+    await ComponentsScreen.setValueToSearch('Sticky Headers');
     expect(
       await FlatListComponentScreen.checkFlatListStickyHeadersScreenIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/jsResponderHandlerComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/jsResponderHandlerComponentScreen.test.js
@@ -16,8 +16,8 @@ const {
 // fixed variables
 const roweZeroText = 'I am row 0';
 
-describe('Test is checking row zero JSResponderHandler component', function() {
-  it('Should view properly row zero element', async function() {
+describe('Test is checking row zero JSResponderHandler component', function () {
+  it('Should view properly row zero element', async function () {
     await JSResponderHandlerComponentScreen.scrollUntilJSResponderHandlerComponentIsDisplayed();
     expect(
       await ComponentsScreen.checkJSResponderHandlerComponentIsDisplayed(),

--- a/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/jsResponderHandlerComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/jsResponderHandlerComponentScreen.test.js
@@ -17,12 +17,21 @@ const {
 const roweZeroText = 'I am row 0';
 
 describe('Test is checking row zero JSResponderHandler component', function () {
-  it('Should view properly row zero element', async function () {
+  it('Should scroll to JSResponderHandler component', async function () {
     await JSResponderHandlerComponentScreen.scrollUntilJSResponderHandlerComponentIsDisplayed();
+  });
+
+  it('Should check visiblity of component element', async function () {
     expect(
       await ComponentsScreen.checkJSResponderHandlerComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on component element', async function () {
     await ComponentsScreen.clickJSResponderHandlerComponent();
+  });
+
+  it('Should view properly row zero element', async function () {
     expect(
       await JSResponderHandlerComponentScreen.checkRowZeroLabelIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/rowZero.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/rowZero.test.js
@@ -17,24 +17,21 @@ const {
 const roweZeroText = 'I am row 0';
 
 describe('Testing row zero of JSResponderHandler Functionality Testis checking row zero JSResponderHandler component', function () {
-  it('Should scroll to JSResponderHandler component', async function () {
+  it('Should scroll to JSResponderHandler component and check component visibility', async function () {
     await JSResponderHandlerComponentScreen.scrollUntilJSResponderHandlerComponentIsDisplayed();
-  });
-
-  it('Should check visiblity of component element', async function () {
     expect(
       await ComponentsScreen.checkJSResponderHandlerComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on component element', async function () {
+  it('Should click on component element and check visibility of row zero element', async function () {
     await ComponentsScreen.clickJSResponderHandlerComponent();
-  });
-
-  it('Should view properly row zero element', async function () {
     expect(
       await JSResponderHandlerComponentScreen.checkRowZeroLabelIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should check text of row zero element text', async function () {
     expect(await JSResponderHandlerComponentScreen.getRowZeroText()).toContain(
       roweZeroText,
     );

--- a/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/rowZero.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/rowZero.test.js
@@ -16,7 +16,7 @@ const {
 // fixed variables
 const roweZeroText = 'I am row 0';
 
-describe('Test is checking row zero JSResponderHandler component', function () {
+describe('Testing row zero of JSResponderHandler Functionality Testis checking row zero JSResponderHandler component', function () {
   it('Should scroll to JSResponderHandler component', async function () {
     await JSResponderHandlerComponentScreen.scrollUntilJSResponderHandlerComponentIsDisplayed();
   });

--- a/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/rowZero.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/jsResponderHandler/rowZero.test.js
@@ -17,8 +17,8 @@ const {
 const roweZeroText = 'I am row 0';
 
 describe('Testing row zero of JSResponderHandler Functionality Testis checking row zero JSResponderHandler component', function () {
-  it('Should scroll to JSResponderHandler component and check component visibility', async function () {
-    await JSResponderHandlerComponentScreen.scrollUntilJSResponderHandlerComponentIsDisplayed();
+  it('Should search for JSResponderHandler component and check component visibility', async function () {
+    await ComponentsScreen.setValueToSearch('JSResponderHandler');
     expect(
       await ComponentsScreen.checkJSResponderHandlerComponentIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/keyboardAvoidingView/differentBehaviors.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/keyboardAvoidingView/differentBehaviors.test.js
@@ -44,5 +44,4 @@ describe('Testing Keyboard Avoiding View with different behaviors Functionality'
       await KeyboardAvoidingViewComponentScreen.getRegisterAlertText(),
     ).toContain(registerText);
   });
-  
 });

--- a/packages/rn-tester-e2e/tests/specs/components/keyboardAvoidingView/differentBehaviors.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/keyboardAvoidingView/differentBehaviors.test.js
@@ -16,24 +16,48 @@ const {
 // fixed variables
 const registerText = 'Successfully Registered!';
 
-describe('Test is checking keyboardAvoidingView component', function () {
-  it('Should view properly successfully registered text', async function () {
+describe('Testing Keyboard Avoiding View with different behaviors Functionality', function () {
+  it('Should scroll until the KeyboardAvoidingView component is displayed', async function () {
     await KeyboardAvoidingViewComponentScreen.scrollUntilKeyboardAvoidingViewComponentIsDisplayed();
+  });
+
+  it('Should display the KeyboardAvoidingView component', async function () {
     expect(
       await ComponentsScreen.checkKeyboardAvoidingViewComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the KeyboardAvoidingView component', async function () {
     await ComponentsScreen.clickKeyboardAvoidingViewComponent();
+  });
+
+  it('Should display the button to open different behaviors example', async function () {
     expect(
       await KeyboardAvoidingViewComponentScreen.checkBtnDifferentBehaviorsOpenExampleIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click to open different behaviors example', async function () {
     await KeyboardAvoidingViewComponentScreen.clickDifferentBehaviorsOpenExampleButton();
+  });
+
+  it('Should display the register button in the example', async function () {
     expect(
       await KeyboardAvoidingViewComponentScreen.checkBtnRegisterIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click the register button', async function () {
     await KeyboardAvoidingViewComponentScreen.clickRegisterButton();
+  });
+
+  it('Should display the successfully registered text', async function () {
     expect(
       await KeyboardAvoidingViewComponentScreen.getRegisterAlertText(),
     ).toContain(registerText);
+  });
+
+  it('Should click the OK button', async function () {
     await KeyboardAvoidingViewComponentScreen.clickOkButton();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/keyboardAvoidingView/differentBehaviors.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/keyboardAvoidingView/differentBehaviors.test.js
@@ -17,47 +17,32 @@ const {
 const registerText = 'Successfully Registered!';
 
 describe('Testing Keyboard Avoiding View with different behaviors Functionality', function () {
-  it('Should scroll until the KeyboardAvoidingView component is displayed', async function () {
-    await KeyboardAvoidingViewComponentScreen.scrollUntilKeyboardAvoidingViewComponentIsDisplayed();
-  });
-
-  it('Should display the KeyboardAvoidingView component', async function () {
+  it('Should search for the KeyboardAvoidingView component and check if displayed', async function () {
+    await ComponentsScreen.setValueToSearch('KeyboardAvoidingView');
     expect(
       await ComponentsScreen.checkKeyboardAvoidingViewComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the KeyboardAvoidingView component', async function () {
+  it('Should click on KeyboardAvoidingView component and check if displayed', async function () {
     await ComponentsScreen.clickKeyboardAvoidingViewComponent();
-  });
-
-  it('Should display the button to open different behaviors example', async function () {
     expect(
       await KeyboardAvoidingViewComponentScreen.checkBtnDifferentBehaviorsOpenExampleIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click to open different behaviors example', async function () {
+  it('Should click to open different behaviors example and check if button is correctly displyed', async function () {
     await KeyboardAvoidingViewComponentScreen.clickDifferentBehaviorsOpenExampleButton();
-  });
-
-  it('Should display the register button in the example', async function () {
     expect(
       await KeyboardAvoidingViewComponentScreen.checkBtnRegisterIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click the register button', async function () {
+  it('Should click the register button and check if displayed correctly', async function () {
     await KeyboardAvoidingViewComponentScreen.clickRegisterButton();
-  });
-
-  it('Should display the successfully registered text', async function () {
     expect(
       await KeyboardAvoidingViewComponentScreen.getRegisterAlertText(),
     ).toContain(registerText);
   });
-
-  it('Should click the OK button', async function () {
-    await KeyboardAvoidingViewComponentScreen.clickOkButton();
-  });
+  
 });

--- a/packages/rn-tester-e2e/tests/specs/components/keyboardAvoidingView/keyboardAvoidingViewComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/keyboardAvoidingView/keyboardAvoidingViewComponentScreen.test.js
@@ -16,8 +16,8 @@ const {
 // fixed variables
 const registerText = 'Successfully Registered!';
 
-describe('Test is checking keyboardAvoidingView component', function() {
-  it('Should view properly successfully registered text', async function() {
+describe('Test is checking keyboardAvoidingView component', function () {
+  it('Should view properly successfully registered text', async function () {
     await KeyboardAvoidingViewComponentScreen.scrollUntilKeyboardAvoidingViewComponentIsDisplayed();
     expect(
       await ComponentsScreen.checkKeyboardAvoidingViewComponentIsDisplayed(),

--- a/packages/rn-tester-e2e/tests/specs/components/modal/modalComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/modal/modalComponentScreen.test.js
@@ -13,8 +13,8 @@ const {
   ModalComponentScreen,
 } = require('../../../screens/components/modalComponent.screen.js');
 
-describe('Test is checking modal component', function() {
-  it('Should view show modal element', async function() {
+describe('Test is checking modal component', function () {
+  it('Should view show modal element', async function () {
     await ModalComponentScreen.scrollUntilModalComponentIsDisplayed();
     expect(
       await ComponentsScreen.checkModalComponentIsDisplayed(),

--- a/packages/rn-tester-e2e/tests/specs/components/modal/presentationShowModal.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/modal/presentationShowModal.test.js
@@ -14,39 +14,27 @@ const {
 } = require('../../../screens/components/modalComponent.screen.js');
 
 describe('Testing Show Modal button of Modal Presentation Functionality', function () {
-  it('Should scroll until the Modal component is displayed', async function () {
+  it('Should scroll until the Modal component check if it is displayed', async function () {
     await ModalComponentScreen.scrollUntilModalComponentIsDisplayed();
-  });
-
-  it('Should check that the Modal component is displayed', async function () {
     expect(
       await ComponentsScreen.checkModalComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the Modal component', async function () {
+  it('Should click on the Modal component and check if Show Modal button is displayed', async function () {
     await ComponentsScreen.clickModalComponent();
-  });
-
-  it('Should check that the Show Modal button is displayed', async function () {
     expect(await ModalComponentScreen.checkShowModalIsDisplayed()).toBeTruthy();
   });
 
-  it('Should click on the Show Modal button', async function () {
+  it('Should click on the Show Modal button and check that the modal with the animation type is displayed', async function () {
     await ModalComponentScreen.clickShowModalButton();
-  });
-
-  it('Should check that the Modal with the animation type is displayed', async function () {
     expect(
       await ModalComponentScreen.checkModalAnimationTypeIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the Close button within the Modal', async function () {
+  it('Should click on the Close button within the Modal and check if closed correctly', async function () {
     await ModalComponentScreen.clickCloseButton();
-  });
-
-  it('Should verify the Show Modal is still displayed after closing the Modal', async function () {
     expect(await ModalComponentScreen.checkShowModalIsDisplayed()).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/modal/presentationShowModal.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/modal/presentationShowModal.test.js
@@ -15,7 +15,7 @@ const {
 
 describe('Testing Show Modal button of Modal Presentation Functionality', function () {
   it('Should scroll until the Modal component check if it is displayed', async function () {
-    await ModalComponentScreen.scrollUntilModalComponentIsDisplayed();
+    await ComponentsScreen.setValueToSearch('Modal');
     expect(
       await ComponentsScreen.checkModalComponentIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/modal/presentationShowModal.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/modal/presentationShowModal.test.js
@@ -13,19 +13,40 @@ const {
   ModalComponentScreen,
 } = require('../../../screens/components/modalComponent.screen.js');
 
-describe('Test is checking modal component', function () {
-  it('Should view show modal element', async function () {
+describe('Testing Show Modal button of Modal Presentation Functionality', function () {
+  it('Should scroll until the Modal component is displayed', async function () {
     await ModalComponentScreen.scrollUntilModalComponentIsDisplayed();
+  });
+
+  it('Should check that the Modal component is displayed', async function () {
     expect(
       await ComponentsScreen.checkModalComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the Modal component', async function () {
     await ComponentsScreen.clickModalComponent();
+  });
+
+  it('Should check that the Show Modal button is displayed', async function () {
     expect(await ModalComponentScreen.checkShowModalIsDisplayed()).toBeTruthy();
+  });
+
+  it('Should click on the Show Modal button', async function () {
     await ModalComponentScreen.clickShowModalButton();
+  });
+
+  it('Should check that the Modal with the animation type is displayed', async function () {
     expect(
       await ModalComponentScreen.checkModalAnimationTypeIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the Close button within the Modal', async function () {
     await ModalComponentScreen.clickCloseButton();
+  });
+
+  it('Should verify the Show Modal is still displayed after closing the Modal', async function () {
     expect(await ModalComponentScreen.checkShowModalIsDisplayed()).toBeTruthy();
   });
 });

--- a/packages/rn-tester-e2e/tests/specs/components/newApp/newAppComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/newApp/newAppComponentScreen.test.js
@@ -13,8 +13,8 @@ const {
   NewAppComponentScreen,
 } = require('../../../screens/components/newAppComponent.screen.js');
 
-describe('Test is checking new app screen component', function() {
-  it('Should view new app header element', async function() {
+describe('Test is checking new app screen component', function () {
+  it('Should view new app header element', async function () {
     await NewAppComponentScreen.scrollUntilNewAppHeaderComponentIsDisplayed();
     expect(
       await ComponentsScreen.checkNewAppScreenComponentIsDisplayed(),

--- a/packages/rn-tester-e2e/tests/specs/components/newApp/newAppScreenHeader.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/newApp/newAppScreenHeader.test.js
@@ -14,8 +14,8 @@ const {
 } = require('../../../screens/components/newAppComponent.screen.js');
 
 describe('Testing New App Screen Header Visibility', function () {
-  it('Should scroll until the New App Header component and check displayed', async function () {
-    await NewAppComponentScreen.scrollUntilNewAppHeaderComponentIsDisplayed();
+  it('Should search for New App Header component and check if displayed', async function () {
+    await ComponentsScreen.setValueToSearch('New App Screen');
     expect(
       await ComponentsScreen.checkNewAppScreenComponentIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/newApp/newAppScreenHeader.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/newApp/newAppScreenHeader.test.js
@@ -14,21 +14,15 @@ const {
 } = require('../../../screens/components/newAppComponent.screen.js');
 
 describe('Testing New App Screen Header Visibility', function () {
-  it('Should scroll until the New App Header component is displayed', async function () {
+  it('Should scroll until the New App Header component and check displayed', async function () {
     await NewAppComponentScreen.scrollUntilNewAppHeaderComponentIsDisplayed();
-  });
-
-  it('Should check that the New App Screen component is displayed', async function () {
     expect(
       await ComponentsScreen.checkNewAppScreenComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the New App Screen component', async function () {
+  it('Should open the New App Screen component and verify if displayed correctly', async function () {
     await ComponentsScreen.clickNewAppScreenComponent();
-  });
-
-  it('Should verify that the New App Header is displayed', async function () {
     expect(
       await NewAppComponentScreen.checkNewAppHeaderIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/newApp/newAppScreenHeader.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/newApp/newAppScreenHeader.test.js
@@ -13,13 +13,22 @@ const {
   NewAppComponentScreen,
 } = require('../../../screens/components/newAppComponent.screen.js');
 
-describe('Test is checking new app screen component', function () {
-  it('Should view new app header element', async function () {
+describe('Testing New App Screen Header Visibility', function () {
+  it('Should scroll until the New App Header component is displayed', async function () {
     await NewAppComponentScreen.scrollUntilNewAppHeaderComponentIsDisplayed();
+  });
+
+  it('Should check that the New App Screen component is displayed', async function () {
     expect(
       await ComponentsScreen.checkNewAppScreenComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the New App Screen component', async function () {
     await ComponentsScreen.clickNewAppScreenComponent();
+  });
+
+  it('Should verify that the New App Header is displayed', async function () {
     expect(
       await NewAppComponentScreen.checkNewAppHeaderIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/pressable/changeContent.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/pressable/changeContent.test.js
@@ -19,29 +19,20 @@ const onPressText = 'onPress';
 describe('Testing Press Me button of Change conent based on Press Functionality', function () {
   it('Should scroll until the Pressable component is displayed', async function () {
     await PressableComponentScreen.scrollUntilPressableComponentIsDisplayed();
-  });
-
-  it('Should ensure the Pressable component is visible', async function () {
     expect(
       await ComponentsScreen.checkPressableComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the Pressable component', async function () {
+  it('Should open the Pressable component and heck if header is displayed', async function () {
     await ComponentsScreen.clickPressableComponent();
-  });
-
-  it('Should display the Press Me header', async function () {
     expect(
       await PressableComponentScreen.checkPressMeHeaderIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click the Press Me button', async function () {
+  it('Should click the Press Me button and check if onPress text is displayed', async function () {
     await PressableComponentScreen.clickPressMeButton();
-  });
-
-  it('Should check if onPress text is displayed', async function () {
     expect(
       await PressableComponentScreen.checkOnPressIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/pressable/changeContent.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/pressable/changeContent.test.js
@@ -16,20 +16,38 @@ const {
 // fixed variables
 const onPressText = 'onPress';
 
-describe('Test is checking pressable component', function () {
-  it('Should view onPress text', async function () {
+describe('Testing Press Me button of Change conent based on Press Functionality', function () {
+  it('Should scroll until the Pressable component is displayed', async function () {
     await PressableComponentScreen.scrollUntilPressableComponentIsDisplayed();
+  });
+
+  it('Should ensure the Pressable component is visible', async function () {
     expect(
       await ComponentsScreen.checkPressableComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the Pressable component', async function () {
     await ComponentsScreen.clickPressableComponent();
+  });
+
+  it('Should display the Press Me header', async function () {
     expect(
       await PressableComponentScreen.checkPressMeHeaderIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click the Press Me button', async function () {
     await PressableComponentScreen.clickPressMeButton();
+  });
+
+  it('Should check if onPress text is displayed', async function () {
     expect(
       await PressableComponentScreen.checkOnPressIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should verify the onPress text content', async function () {
     expect(await PressableComponentScreen.getOnPressText()).toContain(
       onPressText,
     );

--- a/packages/rn-tester-e2e/tests/specs/components/pressable/changeContent.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/pressable/changeContent.test.js
@@ -17,8 +17,8 @@ const {
 const onPressText = 'onPress';
 
 describe('Testing Press Me button of Change conent based on Press Functionality', function () {
-  it('Should scroll until the Pressable component is displayed', async function () {
-    await PressableComponentScreen.scrollUntilPressableComponentIsDisplayed();
+  it('Should search for Pressable component and check if is displayed', async function () {
+    await ComponentsScreen.setValueToSearch('Pressable');
     expect(
       await ComponentsScreen.checkPressableComponentIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/pressable/pressableComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/pressable/pressableComponentScreen.test.js
@@ -16,8 +16,8 @@ const {
 // fixed variables
 const onPressText = 'onPress';
 
-describe('Test is checking pressable component', function() {
-  it('Should view onPress text', async function() {
+describe('Test is checking pressable component', function () {
+  it('Should view onPress text', async function () {
     await PressableComponentScreen.scrollUntilPressableComponentIsDisplayed();
     expect(
       await ComponentsScreen.checkPressableComponentIsDisplayed(),

--- a/packages/rn-tester-e2e/tests/specs/components/refreshControl/refreshControlComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/refreshControl/refreshControlComponentScreen.test.js
@@ -16,19 +16,13 @@ const {
 describe('Testing if any Initial Row is visible', function () {
   it('Should scroll until the Refresh Control component is displayed', async function () {
     await RefreshControlComponentScreen.scrollUntilRefreshControlComponentIsDisplayed();
-  });
-
-  it('Should verify that the Refresh Control component is visible', async function () {
     expect(
       await ComponentsScreen.checkRefreshControlComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the Refresh Control component', async function () {
+  it('Should click on the Refresh Control component and check if initial row is displayed', async function () {
     await ComponentsScreen.clickRefreshControlComponent();
-  });
-
-  it('Should check that the initial row is displayed', async function () {
     expect(
       await RefreshControlComponentScreen.checkInitialRowIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/refreshControl/refreshControlComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/refreshControl/refreshControlComponentScreen.test.js
@@ -14,8 +14,8 @@ const {
 } = require('../../../screens/components/refreshControlComponent.screen.js');
 
 describe('Testing if any Initial Row is visible', function () {
-  it('Should scroll until the Refresh Control component is displayed', async function () {
-    await RefreshControlComponentScreen.scrollUntilRefreshControlComponentIsDisplayed();
+  it('Should search for the Refresh Control component and check if displayed', async function () {
+    await ComponentsScreen.setValueToSearch('RefreshControl');
     expect(
       await ComponentsScreen.checkRefreshControlComponentIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/refreshControl/refreshControlComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/refreshControl/refreshControlComponentScreen.test.js
@@ -13,8 +13,8 @@ const {
   RefreshControlComponentScreen,
 } = require('../../../screens/components/refreshControlComponent.screen.js');
 
-describe('Test is checking RefreshControl component', function() {
-  it('Should view initial row element', async function() {
+describe('Test is checking RefreshControl component', function () {
+  it('Should view initial row element', async function () {
     await RefreshControlComponentScreen.scrollUntilRefreshControlComponentIsDisplayed();
     expect(
       await ComponentsScreen.checkRefreshControlComponentIsDisplayed(),

--- a/packages/rn-tester-e2e/tests/specs/components/refreshControl/refreshControlComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/refreshControl/refreshControlComponentScreen.test.js
@@ -13,13 +13,22 @@ const {
   RefreshControlComponentScreen,
 } = require('../../../screens/components/refreshControlComponent.screen.js');
 
-describe('Test is checking RefreshControl component', function () {
-  it('Should view initial row element', async function () {
+describe('Testing if any Initial Row is visible', function () {
+  it('Should scroll until the Refresh Control component is displayed', async function () {
     await RefreshControlComponentScreen.scrollUntilRefreshControlComponentIsDisplayed();
+  });
+
+  it('Should verify that the Refresh Control component is visible', async function () {
     expect(
       await ComponentsScreen.checkRefreshControlComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the Refresh Control component', async function () {
     await ComponentsScreen.clickRefreshControlComponent();
+  });
+
+  it('Should check that the initial row is displayed', async function () {
     expect(
       await RefreshControlComponentScreen.checkInitialRowIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/scrollViewSimpleExample/scrollViewItem.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/scrollViewSimpleExample/scrollViewItem.test.js
@@ -16,19 +16,13 @@ const {
 describe('Testing first item visibility of ScrollViewSimpleExample Component', function () {
   it('Should scroll until the Scroll View Simple Example component is displayed', async function () {
     await ScrollViewSimpleExampleComponentScreen.scrollUntilScrollViewSimpleExampleComponentIsDisplayed();
-  });
-
-  it('Should check that the Scroll View Simple Example component is visible', async function () {
     expect(
       await ComponentsScreen.checkScrollViewSimpleExampleComponentIsDisplayed(),
     ).toBeTruthy();
   });
 
-  it('Should click on the Scroll View Simple Example component', async function () {
+  it('Should click on the Scroll View Simple Example component and verify if displayed', async function () {
     await ComponentsScreen.clickScrollViewSimpleExampleComponent();
-  });
-
-  it('Should verify that the Scroll View items are displayed', async function () {
     expect(
       await ScrollViewSimpleExampleComponentScreen.checkScrollViewItemsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/scrollViewSimpleExample/scrollViewItem.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/scrollViewSimpleExample/scrollViewItem.test.js
@@ -14,8 +14,8 @@ const {
 } = require('../../../screens/components/scrollViewSimpleExampleComponent.screen.js');
 
 describe('Testing first item visibility of ScrollViewSimpleExample Component', function () {
-  it('Should scroll until the Scroll View Simple Example component is displayed', async function () {
-    await ScrollViewSimpleExampleComponentScreen.scrollUntilScrollViewSimpleExampleComponentIsDisplayed();
+  it('Should search for the Scroll View Simple Example component and check if displayed', async function () {
+    await ComponentsScreen.setValueToSearch('ScrollViewSimpleExample');
     expect(
       await ComponentsScreen.checkScrollViewSimpleExampleComponentIsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/scrollViewSimpleExample/scrollViewItem.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/scrollViewSimpleExample/scrollViewItem.test.js
@@ -13,13 +13,22 @@ const {
   ScrollViewSimpleExampleComponentScreen,
 } = require('../../../screens/components/scrollViewSimpleExampleComponent.screen.js');
 
-describe('Test is checking ScrollVIewSimpleExample component', function () {
-  it('Should view scroll view item element', async function () {
+describe('Testing first item visibility of ScrollViewSimpleExample Component', function () {
+  it('Should scroll until the Scroll View Simple Example component is displayed', async function () {
     await ScrollViewSimpleExampleComponentScreen.scrollUntilScrollViewSimpleExampleComponentIsDisplayed();
+  });
+
+  it('Should check that the Scroll View Simple Example component is visible', async function () {
     expect(
       await ComponentsScreen.checkScrollViewSimpleExampleComponentIsDisplayed(),
     ).toBeTruthy();
+  });
+
+  it('Should click on the Scroll View Simple Example component', async function () {
     await ComponentsScreen.clickScrollViewSimpleExampleComponent();
+  });
+
+  it('Should verify that the Scroll View items are displayed', async function () {
     expect(
       await ScrollViewSimpleExampleComponentScreen.checkScrollViewItemsDisplayed(),
     ).toBeTruthy();

--- a/packages/rn-tester-e2e/tests/specs/components/scrollViewSimpleExample/scrollViewSimpleExampleComponentScreen.test.js
+++ b/packages/rn-tester-e2e/tests/specs/components/scrollViewSimpleExample/scrollViewSimpleExampleComponentScreen.test.js
@@ -13,8 +13,8 @@ const {
   ScrollViewSimpleExampleComponentScreen,
 } = require('../../../screens/components/scrollViewSimpleExampleComponent.screen.js');
 
-describe('Test is checking ScrollVIewSimpleExample component', function() {
-  it('Should view scroll view item element', async function() {
+describe('Test is checking ScrollVIewSimpleExample component', function () {
+  it('Should view scroll view item element', async function () {
     await ScrollViewSimpleExampleComponentScreen.scrollUntilScrollViewSimpleExampleComponentIsDisplayed();
     expect(
       await ComponentsScreen.checkScrollViewSimpleExampleComponentIsDisplayed(),

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -38,9 +38,10 @@ exports.config = {
     [
       'appium',
       {
+        command: 'appium',
         args: {
-          address: 'localhost',
           port: 4723,
+          address: '127.0.0.1',
         },
         logPath: './reports',
       },

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -29,7 +29,7 @@ exports.config = {
     },
   ],
   logLevel: 'debug',
-  bail: 0,
+  bail: 10, //reduce time of failed builds
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -32,7 +32,7 @@ exports.config = {
   bail: 3, //reduce time of failed builds
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
-  connectionRetryCount: 3,
+  connectionRetryCount: 2,
   specFileRetries: 2,
   services: [
     [
@@ -51,8 +51,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 80000,
-    require: ['@babel/register'],
+    timeout: 80000
   },
 
   beforeSession: async function (config, capabilities, specs) {

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -29,7 +29,7 @@ exports.config = {
     },
   ],
   logLevel: 'debug',
-  bail: 10, //reduce time of failed builds
+  bail: 3, //reduce time of failed builds
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -27,15 +27,10 @@ exports.config = {
       'appium:newCommandTimeout': 240,
     },
   ],
-
   logLevel: 'debug',
-
   bail: 0,
-
   waitforTimeout: 10000,
-
   connectionRetryTimeout: 120000,
-
   connectionRetryCount: 3,
   specFileRetries: 2,
   services: [
@@ -50,9 +45,10 @@ exports.config = {
       },
     ],
   ],
-  framework: 'mocha',
   reporters: ['spec'],
+  framework: 'mocha',
   mochaOpts: {
+    bail: true,
     ui: 'bdd',
     timeout: 40000,
     require: ['@babel/register'],
@@ -67,7 +63,7 @@ exports.config = {
     context,
     {error, result, duration, passed, retries},
   ) {
-    if (!passed || error !== undefined) {
+    if (!passed) {
       const fileName = encodeURIComponent(
         await test.title.replace(/\s+/g, '-'),
       );

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -9,6 +9,7 @@
  */
 
 const path = require('path');
+const fs = require('fs');
 
 exports.config = {
   runner: 'local',

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -24,14 +24,14 @@ exports.config = {
       'appium:deviceName': 'Android Emulator',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.apk'),
       'appium:automationName': 'UiAutomator2',
-      'appium:newCommandTimeout': 240,
+      'appium:newCommandTimeout': 120,
       'appium:fullReset': false
     },
   ],
   logLevel: 'debug',
   bail: 3, //reduce time of failed builds
   waitforTimeout: 30000,
-  connectionRetryTimeout: 120000,
+  connectionRetryTimeout: 30000,
   connectionRetryCount: 3,
   specFileRetries: 3,
   services: [
@@ -51,7 +51,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 80000
+    timeout: 50000
   },
 
   beforeSession: async function (config, capabilities, specs) {

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -25,7 +25,7 @@ exports.config = {
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.apk'),
       'appium:automationName': 'UiAutomator2',
       'appium:newCommandTimeout': 120,
-      'appium:fullReset': false
+      'appium:fullReset': false,
     },
   ],
   logLevel: 'debug',
@@ -51,7 +51,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 70000
+    timeout: 70000,
   },
 
   beforeSession: async function (config, capabilities, specs) {

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -25,6 +25,7 @@ exports.config = {
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.apk'),
       'appium:automationName': 'UiAutomator2',
       'appium:newCommandTimeout': 240,
+      'appium:fullReset': false
     },
   ],
   logLevel: 'debug',

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -67,7 +67,7 @@ exports.config = {
     context,
     {error, result, duration, passed, retries},
   ) {
-    if (!passed) {
+    if (!passed || error !== undefined) {
       const fileName = encodeURIComponent(
         await test.title.replace(/\s+/g, '-'),
       );

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -30,10 +30,10 @@ exports.config = {
   ],
   logLevel: 'debug',
   bail: 3, //reduce time of failed builds
-  waitforTimeout: 10000,
+  waitforTimeout: 30000,
   connectionRetryTimeout: 120000,
-  connectionRetryCount: 2,
-  specFileRetries: 2,
+  connectionRetryCount: 3,
+  specFileRetries: 3,
   services: [
     [
       'appium',

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -68,7 +68,7 @@ exports.config = {
         await test.title.replace(/\s+/g, '-'),
       );
       const filePath = './reports/errorShots/' + fileName + '.png';
-      await driver.takeScreenshot(filePath);
+      await browser.saveScreenshot(filePath);
     }
   },
 };

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -54,7 +54,7 @@ exports.config = {
   reporters: ['spec'],
   mochaOpts: {
     ui: 'bdd',
-    timeout: 60000,
+    timeout: 120000,
     require: ['@babel/register'],
   },
 

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -32,7 +32,7 @@ exports.config = {
 
   bail: 0,
 
-  waitforTimeout: 20000,
+  waitforTimeout: 10000,
 
   connectionRetryTimeout: 120000,
 
@@ -54,7 +54,7 @@ exports.config = {
   reporters: ['spec'],
   mochaOpts: {
     ui: 'bdd',
-    timeout: 120000,
+    timeout: 40000,
     require: ['@babel/register'],
   },
 

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -37,7 +37,6 @@ exports.config = {
     [
       'appium',
       {
-        command: 'appium',  
         args: {
           address: 'localhost',
           port: 4723,

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -37,6 +37,7 @@ exports.config = {
     [
       'appium',
       {
+        command: 'appium',  
         args: {
           address: 'localhost',
           port: 4723,

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -50,7 +50,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 40000,
+    timeout: 80000,
     require: ['@babel/register'],
   },
 

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -11,64 +11,67 @@
 const path = require('path');
 
 exports.config = {
-    runner: 'local',
-    path: '/',
-    specs: [
-        './tests/specs/components/**/*.test.js'
-    ],
-    exclude: [
-    ],
-    maxInstances: 1,
-    capabilities: [{ 
-        platformName: 'Android',
-        'appium:platformVersion': '14.0',
-        'appium:deviceName': 'Android Emulator',
-        'appium:app': path.join(process.cwd(), '/apps/rn-tester.apk'),
-        'appium:automationName': 'UiAutomator2',
-        'appium:newCommandTimeout': 240,
-    }],
-
-
-    logLevel: 'debug',
-
-    bail: 0,
-
-    waitforTimeout: 20000,
-
-    connectionRetryTimeout: 120000,
-
-    connectionRetryCount: 3,
-    specFileRetries: 2,
-    services: [
-        [
-        'appium',
-        {
-            args: {
-            address: 'localhost',
-            port: 4723
-            },
-            logPath: './reports',
-        }
-        ]
-    ],
-    framework: 'mocha',
-    reporters: ['spec'],
-    mochaOpts: {
-        ui: 'bdd',
-        timeout: 60000,
-        require: ['@babel/register']
+  runner: 'local',
+  path: '/',
+  specs: ['./tests/specs/components/**/*.test.js'],
+  exclude: [],
+  maxInstances: 1,
+  capabilities: [
+    {
+      platformName: 'Android',
+      'appium:platformVersion': '14.0',
+      'appium:deviceName': 'Android Emulator',
+      'appium:app': path.join(process.cwd(), '/apps/rn-tester.apk'),
+      'appium:automationName': 'UiAutomator2',
+      'appium:newCommandTimeout': 240,
     },
+  ],
 
-    beforeSession: async function (config, capabilities, specs) {
-        await fs.mkdirSync('./reports/errorShots', { recursive: true });
+  logLevel: 'debug',
+
+  bail: 0,
+
+  waitforTimeout: 20000,
+
+  connectionRetryTimeout: 120000,
+
+  connectionRetryCount: 3,
+  specFileRetries: 2,
+  services: [
+    [
+      'appium',
+      {
+        args: {
+          address: 'localhost',
+          port: 4723,
+        },
+        logPath: './reports',
       },
-  
-    afterTest: async function(test, context, { error, result, duration, passed, retries }) {
-        if (!passed) {
-            const fileName = encodeURIComponent(await test.title.replace(/\s+/g, '-'));
-            const filePath = './reports/errorShots/' + fileName + '.png';
-            await driver.takeScreenshot(filePath);
-        }
-    },
+    ],
+  ],
+  framework: 'mocha',
+  reporters: ['spec'],
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+    require: ['@babel/register'],
+  },
 
+  beforeSession: async function (config, capabilities, specs) {
+    await fs.mkdirSync('./reports/errorShots', {recursive: true});
+  },
+
+  afterTest: async function (
+    test,
+    context,
+    {error, result, duration, passed, retries},
+  ) {
+    if (!passed) {
+      const fileName = encodeURIComponent(
+        await test.title.replace(/\s+/g, '-'),
+      );
+      const filePath = './reports/errorShots/' + fileName + '.png';
+      await driver.takeScreenshot(filePath);
+    }
+  },
 };

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -31,7 +31,7 @@ exports.config = {
   logLevel: 'debug',
   bail: 3, //reduce time of failed builds
   waitforTimeout: 30000,
-  connectionRetryTimeout: 30000,
+  connectionRetryTimeout: 50000,
   connectionRetryCount: 3,
   specFileRetries: 3,
   services: [

--- a/packages/rn-tester-e2e/wdio.conf.android.js
+++ b/packages/rn-tester-e2e/wdio.conf.android.js
@@ -30,8 +30,8 @@ exports.config = {
   ],
   logLevel: 'debug',
   bail: 3, //reduce time of failed builds
-  waitforTimeout: 30000,
-  connectionRetryTimeout: 50000,
+  waitforTimeout: 50000,
+  connectionRetryTimeout: 70000,
   connectionRetryCount: 3,
   specFileRetries: 3,
   services: [
@@ -51,7 +51,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 50000
+    timeout: 70000
   },
 
   beforeSession: async function (config, capabilities, specs) {

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -25,7 +25,7 @@ exports.config = {
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
       'appium:newCommandTimeout': 120,
-      'appium:fullReset': false,
+      'appium:fullReset': false
     },
   ],
   logLevel: 'debug',
@@ -38,6 +38,7 @@ exports.config = {
     [
       'appium',
       {
+        address: '127.0.0.1',
         port: 4723,
         logPath: './reports',
       },

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -65,7 +65,7 @@ exports.config = {
     context,
     {error, result, duration, passed, retries},
   ) {
-    if (!passed || error) {
+    if (!passed || error !== undefined) {
       const fileName = encodeURIComponent(
         await test.title.replace(/\s+/g, '-'),
       );

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -24,12 +24,12 @@ exports.config = {
       'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
-      'appium:newCommandTimeout': 60,
+      'appium:newCommandTimeout': 120,
       'appium:fullReset': false
     },
   ],
   logLevel: 'debug',
-  bail: 10, //reduce time of failed builds
+  bail: 3, //reduce time of failed builds
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -24,7 +24,7 @@ exports.config = {
       'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
-      'appium:newCommandTimeout': 120,
+      'appium:newCommandTimeout': 240,
       'appium:fullReset': false
     },
   ],

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -32,7 +32,7 @@ exports.config = {
   bail: 3, //reduce time of failed builds
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
-  connectionRetryCount: 3,
+  connectionRetryCount: 2,
   specFileRetries: 2,
   services: [
     [
@@ -51,8 +51,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 120000,
-    require: ['@babel/register'],
+    timeout: 120000
   },
 
   beforeSession: async function (config, capabilities, specs) {

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -68,7 +68,7 @@ exports.config = {
         await test.title.replace(/\s+/g, '-'),
       );
       const filePath = './reports/errorShots/' + fileName + '.png';
-      await driver.saveScreenshot(filePath);
+      await browser.saveScreenshot(filePath);
     }
   },
 };

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -31,7 +31,7 @@ exports.config = {
   ],
   logLevel: 'info',
   bail: 0,
-  waitforTimeout: 10000,
+  waitforTimeout: 20000,
   connectionRetryTimeout: 120000,
 
   connectionRetryCount: 3,

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -20,7 +20,7 @@ exports.config = {
   capabilities: [
     {
       platformName: 'iOS',
-      'appium:platformVersion': '16.0',
+      'appium:platformVersion': '15.5',
       'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -14,12 +14,9 @@ const fs = require('fs');
 exports.config = {
   runner: 'local',
   path: '/',
-
   specs: ['./tests/specs/components/**/*.test.js'],
   exclude: [],
-
   maxInstances: 1,
-
   capabilities: [
     {
       platformName: 'iOS',
@@ -27,13 +24,13 @@ exports.config = {
       'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
+      'appium:newCommandTimeout': 60,
     },
   ],
-  logLevel: 'info',
+  logLevel: 'debug',
   bail: 0,
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
-
   connectionRetryCount: 3,
   specFileRetries: 2,
   services: [
@@ -51,6 +48,7 @@ exports.config = {
   reporters: ['spec'],
   framework: 'mocha',
   mochaOpts: {
+    bail: true,
     ui: 'bdd',
     timeout: 40000,
     require: ['@babel/register'],
@@ -65,7 +63,7 @@ exports.config = {
     context,
     {error, result, duration, passed, retries},
   ) {
-    if (!passed || error !== undefined) {
+    if (!passed) {
       const fileName = encodeURIComponent(
         await test.title.replace(/\s+/g, '-'),
       );

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -32,7 +32,7 @@ exports.config = {
   bail: 3, //reduce time of failed builds
   waitforTimeout: 30000,
   connectionRetryTimeout: 120000,
-  connectionRetryCount: 2,
+  connectionRetryCount: 3,
   specFileRetries: 3,
   services: [
     [

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -52,7 +52,7 @@ exports.config = {
   framework: 'mocha',
   mochaOpts: {
     ui: 'bdd',
-    timeout: 60000,
+    timeout: 120000,
     require: ['@babel/register'],
   },
 

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -39,8 +39,7 @@ exports.config = {
       'appium',
       {
         port: 4723,
-        logPath: './reports',
-        'session-override': true
+        logPath: './reports'
       },
     ],
   ],
@@ -68,5 +67,9 @@ exports.config = {
       const filePath = './reports/errorShots/' + fileName + '.png';
       await browser.saveScreenshot(filePath);
     }
+  },
+
+  afterSuite: async function (config, capabilities, specs) {
+    await browser.deleteSession()
   },
 };

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -30,10 +30,10 @@ exports.config = {
   ],
   logLevel: 'debug',
   bail: 3, //reduce time of failed builds
-  waitforTimeout: 10000,
+  waitforTimeout: 30000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 2,
-  specFileRetries: 2,
+  specFileRetries: 3,
   services: [
     [
       'appium',

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -20,7 +20,7 @@ exports.config = {
   capabilities: [
     {
       platformName: 'iOS',
-      'appium:platformVersion': '15.5',
+      'appium:platformVersion': '16.4',
       'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
@@ -29,7 +29,7 @@ exports.config = {
     },
   ],
   logLevel: 'debug',
-  bail: 0,
+  bail: 10, //reduce time of failed builds
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -25,6 +25,7 @@ exports.config = {
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
       'appium:newCommandTimeout': 60,
+      'appium:fullReset': false
     },
   ],
   logLevel: 'debug',

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -17,7 +17,6 @@ exports.config = {
   specs: ['./tests/specs/components/**/*.test.js'],
   exclude: [],
   maxInstances: 1,
-  port: 4723,
   capabilities: [
     {
       platformName: 'iOS',
@@ -39,7 +38,9 @@ exports.config = {
     [
       'appium',
       {
+        port: 4723,
         logPath: './reports',
+        'session-override': true
       },
     ],
   ],
@@ -48,7 +49,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 120000
+    timeout: 80000
   },
 
   beforeSession: async function (config, capabilities, specs) {

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -24,14 +24,14 @@ exports.config = {
       'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
-      'appium:newCommandTimeout': 240,
+      'appium:newCommandTimeout': 120,
       'appium:fullReset': false
     },
   ],
   logLevel: 'debug',
   bail: 3, //reduce time of failed builds
   waitforTimeout: 30000,
-  connectionRetryTimeout: 120000,
+  connectionRetryTimeout: 30000,
   connectionRetryCount: 3,
   specFileRetries: 3,
   services: [
@@ -48,7 +48,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 80000
+    timeout: 50000
   },
 
   beforeSession: async function (config, capabilities, specs) {

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -51,7 +51,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 80000,
+    timeout: 120000,
     require: ['@babel/register'],
   },
 

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -65,7 +65,7 @@ exports.config = {
     context,
     {error, result, duration, passed, retries},
   ) {
-    if (!passed) {
+    if (!passed || error) {
       const fileName = encodeURIComponent(
         await test.title.replace(/\s+/g, '-'),
       );

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -37,7 +37,6 @@ exports.config = {
     [
       'appium',
       {
-        command: 'appium',  
         args: {
           address: 'localhost',
           port: 4723,

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -37,6 +37,7 @@ exports.config = {
     [
       'appium',
       {
+        command: 'appium',  
         args: {
           address: 'localhost',
           port: 4723,

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -25,7 +25,7 @@ exports.config = {
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
       'appium:newCommandTimeout': 120,
-      'appium:fullReset': false
+      'appium:fullReset': false,
     },
   ],
   logLevel: 'debug',
@@ -39,7 +39,7 @@ exports.config = {
       'appium',
       {
         port: 4723,
-        logPath: './reports'
+        logPath: './reports',
       },
     ],
   ],
@@ -48,7 +48,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 50000
+    timeout: 50000,
   },
 
   beforeSession: async function (config, capabilities, specs) {
@@ -67,5 +67,5 @@ exports.config = {
       const filePath = './reports/errorShots/' + fileName + '.png';
       await browser.saveScreenshot(filePath);
     }
-  }
+  },
 };

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -17,11 +17,12 @@ exports.config = {
   specs: ['./tests/specs/components/**/*.test.js'],
   exclude: [],
   maxInstances: 1,
+  port: 4723,
   capabilities: [
     {
       platformName: 'iOS',
-      'appium:platformVersion': '16.4',
-      'appium:deviceName': 'iPhone 14',
+      'appium:platformVersion': '17.0',
+      'appium:deviceName': 'iPhone 15',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
       'appium:newCommandTimeout': 240,
@@ -38,10 +39,6 @@ exports.config = {
     [
       'appium',
       {
-        args: {
-          address: 'localhost',
-          port: 4723,
-        },
         logPath: './reports',
       },
     ],

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -21,8 +21,8 @@ exports.config = {
   capabilities: [
     {
       platformName: 'iOS',
-      'appium:platformVersion': '17.0',
-      'appium:deviceName': 'iPhone 15',
+      'appium:platformVersion': '16.4',
+      'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
       'appium:newCommandTimeout': 240,

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -20,7 +20,7 @@ exports.config = {
   capabilities: [
     {
       platformName: 'iOS',
-      'appium:platformVersion': '16.4',
+      'appium:platformVersion': '16.0',
       'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -67,9 +67,5 @@ exports.config = {
       const filePath = './reports/errorShots/' + fileName + '.png';
       await browser.saveScreenshot(filePath);
     }
-  },
-
-  afterSuite: async function (config, capabilities, specs) {
-    await browser.deleteSession()
-  },
+  }
 };

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -50,7 +50,7 @@ exports.config = {
   mochaOpts: {
     bail: true,
     ui: 'bdd',
-    timeout: 40000,
+    timeout: 80000,
     require: ['@babel/register'],
   },
 

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -9,64 +9,68 @@
  */
 
 const path = require('path');
-const fs = require('fs')
+const fs = require('fs');
 
 exports.config = {
-    runner: 'local',
-    path: '/',
-    
-    specs: [
-        './tests/specs/components/**/*.test.js'
-    ],
-    exclude: [
-    ],
-    
-    maxInstances: 1,
-    
-    capabilities: [{ 
+  runner: 'local',
+  path: '/',
+
+  specs: ['./tests/specs/components/**/*.test.js'],
+  exclude: [],
+
+  maxInstances: 1,
+
+  capabilities: [
+    {
       platformName: 'iOS',
       'appium:platformVersion': '17.0',
       'appium:deviceName': 'iPhone 15',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
-    }],
-    logLevel: 'info',
-    bail: 0,
-    waitforTimeout: 10000,
-    connectionRetryTimeout: 120000,
-    
-    connectionRetryCount: 3,
-    specFileRetries: 2,
-    services: [
-        [
-          'appium',
-          {
-            args: {
-              address: 'localhost',
-              port: 4723
-            },
-            logPath: './reports',
-          }
-        ]
-      ],
-    reporters: ['spec'],
-    framework: 'mocha',
-    mochaOpts: {
-        ui: 'bdd',
-        timeout: 60000,
-        require: ['@babel/register']
     },
+  ],
+  logLevel: 'info',
+  bail: 0,
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 120000,
 
-    beforeSession: async function (config, capabilities, specs) {
-      await fs.mkdirSync('./reports/errorShots', { recursive: true });
-    },
+  connectionRetryCount: 3,
+  specFileRetries: 2,
+  services: [
+    [
+      'appium',
+      {
+        args: {
+          address: 'localhost',
+          port: 4723,
+        },
+        logPath: './reports',
+      },
+    ],
+  ],
+  reporters: ['spec'],
+  framework: 'mocha',
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+    require: ['@babel/register'],
+  },
 
-    afterTest: async function(test, context, { error, result, duration, passed, retries }) {
-      if (!passed) {
-        const fileName = encodeURIComponent(await test.title.replace(/\s+/g, '-'));
-        const filePath = './reports/errorShots/' + fileName + '.png';
-        await driver.saveScreenshot(filePath);
-      }
-    },
+  beforeSession: async function (config, capabilities, specs) {
+    await fs.mkdirSync('./reports/errorShots', {recursive: true});
+  },
 
+  afterTest: async function (
+    test,
+    context,
+    {error, result, duration, passed, retries},
+  ) {
+    if (!passed) {
+      const fileName = encodeURIComponent(
+        await test.title.replace(/\s+/g, '-'),
+      );
+      const filePath = './reports/errorShots/' + fileName + '.png';
+      await driver.saveScreenshot(filePath);
+    }
+  },
 };

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -23,8 +23,8 @@ exports.config = {
   capabilities: [
     {
       platformName: 'iOS',
-      'appium:platformVersion': '17.0',
-      'appium:deviceName': 'iPhone 15',
+      'appium:platformVersion': '16.4',
+      'appium:deviceName': 'iPhone 14',
       'appium:automationName': 'XCUITest',
       'appium:app': path.join(process.cwd(), '/apps/rn-tester.app'),
     },

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -31,7 +31,7 @@ exports.config = {
   ],
   logLevel: 'info',
   bail: 0,
-  waitforTimeout: 20000,
+  waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
 
   connectionRetryCount: 3,
@@ -52,7 +52,7 @@ exports.config = {
   framework: 'mocha',
   mochaOpts: {
     ui: 'bdd',
-    timeout: 120000,
+    timeout: 40000,
     require: ['@babel/register'],
   },
 

--- a/packages/rn-tester-e2e/wdio.conf.ios.js
+++ b/packages/rn-tester-e2e/wdio.conf.ios.js
@@ -31,7 +31,7 @@ exports.config = {
   logLevel: 'debug',
   bail: 3, //reduce time of failed builds
   waitforTimeout: 30000,
-  connectionRetryTimeout: 30000,
+  connectionRetryTimeout: 50000,
   connectionRetryCount: 3,
   specFileRetries: 3,
   services: [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Due to the high flakiness of e2e tests, we suggested changing the Jest runner to Wdio runner, which should help us reduce the flakiness and increase the usefulness of the tests through better logs.

## Changelog:
- Changed test runner from Jest to Wdio with Mocha assertion library. Because of using Mocha, I changed the Jest `test` block to Mochas `it` and changed the arrow functions to regular functions (in Mocha, the arrow function is discouraged from using https://mochajs.org/#arrow-functions)
- All tests are moved to component folders(naming convention of folders and tests to be decided)
- Moved steps to separate `it` for better visibility on results
- As a temporal solution, I've created separate conf files for ios and Android
- Added `spec` reporter. After we decide about result storing, we can change to, eg. Allure
- Appium is added to services, which means that we don't start the appium server by a terminal, and Appium logs are displayed in a terminal while tests are running
- Updated CircleCI jobs
 


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
