### PR TITLE
fix(iOS): update template to cocoapods 1.14.2

### DIFF
--- a/packages/react-native/template/Gemfile
+++ b/packages/react-native/template/Gemfile
@@ -3,5 +3,4 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '~> 1.13'
-gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+gem 'cocoapods', '~> 1.14.2'


### PR DESCRIPTION
## Summary:

Activesupport issues are fixed in 1.14.x with different patches

Ref:
https://github.com/CocoaPods/CocoaPods/releases

## Changelog:

[IOS] [FIXED] - issues with cocoapods regarding activesupport


## Test Plan:

Run `bundler exec pod install`
