### PR TITLE
fix (iOS): Center aligning inline images in texts #41231

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
@@ -199,7 +199,7 @@
                               [attributedText addAttribute:NSFontAttributeName value:font range:range];
                             } else if (range.location + range.length < attributedText.length) {
                               UIFont *font = [attributedText attribute:NSFontAttributeName atIndex:range.location + range.length effectiveRange:NULL];
-                                [attributedText addAttribute:NSFontAttributeName value:font range:range];
+                              [attributedText addAttribute:NSFontAttributeName value:font range:range];
                             }
                           }];
 

--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
@@ -193,6 +193,14 @@
                             attachment.bounds = (CGRect){CGPointZero, fittingSize};
                             attachment.image = placeholderImage;
                             [attributedText addAttribute:NSAttachmentAttributeName value:attachment range:range];
+
+                            if (range.location > 0) {
+                              UIFont *font = [attributedText attribute:NSFontAttributeName atIndex:range.location - 1 effectiveRange:NULL];
+                              [attributedText addAttribute:NSFontAttributeName value:font range:range];
+                            } else if (range.location + range.length < attributedText.length) {
+                              UIFont *font = [attributedText attribute:NSFontAttributeName atIndex:range.location + range.length effectiveRange:NULL];
+                                [attributedText addAttribute:NSFontAttributeName value:font range:range];
+                            }
                           }];
 
   [attributedText endEditing];
@@ -286,11 +294,12 @@
                 CGSize attachmentSize = attachment.bounds.size;
 
                 UIFont *font = [textStorage attribute:NSFontAttributeName atIndex:range.location effectiveRange:nil];
+                float lineHeight = font.pointSize;
 
                 CGRect frame = {
                     {RCTRoundPixelValue(glyphRect.origin.x),
                      RCTRoundPixelValue(
-                         glyphRect.origin.y + glyphRect.size.height - attachmentSize.height + font.descender)},
+                         glyphRect.origin.y + glyphRect.size.height - lineHeight + (font.ascender + font.descender - attachmentSize.height) / 2)},
                     {RCTRoundPixelValue(attachmentSize.width), RCTRoundPixelValue(attachmentSize.height)}};
 
                 NSRange truncatedGlyphRange =

--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
@@ -294,12 +294,11 @@
                 CGSize attachmentSize = attachment.bounds.size;
 
                 UIFont *font = [textStorage attribute:NSFontAttributeName atIndex:range.location effectiveRange:nil];
-                float lineHeight = font.pointSize;
 
                 CGRect frame = {
                     {RCTRoundPixelValue(glyphRect.origin.x),
                      RCTRoundPixelValue(
-                         glyphRect.origin.y + glyphRect.size.height - lineHeight + (font.ascender + font.descender - attachmentSize.height) / 2)},
+                         glyphRect.origin.y + glyphRect.size.height - font.pointSize + (font.ascender + font.descender - attachmentSize.height) / 2)},
                     {RCTRoundPixelValue(attachmentSize.width), RCTRoundPixelValue(attachmentSize.height)}};
 
                 NSRange truncatedGlyphRange =


### PR DESCRIPTION
## Summary:
Inline is on the critical path of rich text, for example, (a center aligned lozenge as shown bellow)
<img width="566" alt="Screenshot 2023-10-30 at 22 13 17" src="https://github.com/facebook/react-native/assets/149237137/285960f4-bb79-40f7-8917-9749f673a0d0">
, where alignment is at its essence. This PR is to provide a by default centered inline and to foster smoother developer experience (a bit).

## Problem
On Android, inline images are aligned with center of the text which is good, while on iOS, they are aligned by line bottom.

On the consumer side, this discrepancy causes extra platform specific code to further layout of inline graphics (and custom views) in rich text field, which is fixed in this PR.

<img width="569" alt="Screenshot 2023-10-30 at 10 08 04" src="https://github.com/facebook/react-native/assets/149237137/efaa01de-1c60-45e8-b377-82f04e410a42">

## Changelog:

[IOS] [FIXED] - Mis-aligned inline images in texts across platforms

## Test Plan:

1. adding an image in the middle of a paragraph
1.2. placing the image to the beginning of the paragraph
1.3. placing the image to the paragraph end
1.4. changing image sizes
1.5. changing image padding and margin
2. adding a view in paragraph
2.2. changing view sizes
2.3. changing view padding and margin
3. changing font sizes
4. changing text padding and margin
5. changing text lineHeight
6. changing textAlign

**Test result:** (Please feel free suggest more test cases)
https://docs.google.com/spreadsheets/d/11fgvvw-yQqtJ-jtFPfY-yC5TD51FjoxwUj1lLXjx7Vc/edit?usp=sharing