### PR TITLE
[iOS] Fixes Dev menu pop up multiple times when Tap command `D` continuously

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -211,11 +211,15 @@ RCT_EXPORT_MODULE()
 
 - (void)toggle
 {
+  if (_actionSheet.isBeingPresented || _actionSheet.beingDismissed) {
+    return;
+  }
   if (_actionSheet) {
     [_actionSheet dismissViewControllerAnimated:YES
-                                     completion:^(void){
+                                     completion:^(void) {
+                                       self->_actionSheet = nil;
                                      }];
-    _actionSheet = nil;
+
   } else {
     [self show];
   }


### PR DESCRIPTION
## Summary:

Fixes Dev menu pop up multiple times when Tap command `D` continuously, demo like below:
https://github.com/facebook/react-native/assets/5061845/b4c2b38d-ece6-4d4e-a823-23eaa7cad001



## Changelog:


[IOS] [FIXED] - Fixes Dev menu pop up multiple times when Tap command `D` continuously


## Test Plan:

Press `D` continuously, the menu pop up and dismiss correctly.
