### PR TITLE
Use CircleCI's ruby orb

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -31,38 +31,12 @@ commands:
       - restore_cache:
           key: *rbenv_cache_key
       - run:
-          name: Bundle Install
-          command: |
-            # Check if rbenv is installed. CircleCI is migrating to rbenv so we may not need to always install it.
-
-            if [[ -z "$(command -v rbenv)" ]]; then
-              brew install rbenv ruby-build
-              # Load and init rbenv
-              (rbenv init 2> /dev/null) || true
-              echo '' >>  ~/.bash_profile
-              echo 'eval "$(rbenv init - bash)"' >> ~/.bash_profile
-              source ~/.bash_profile
-            else
-              echo "rbenv found; Skipping installation"
-            fi
-
-            brew reinstall libyaml
-            gem install psych -- --with-libyaml-dir=$(brew --prefix libyaml)
-            export RUBY_CONFIGURE_OPTS=--with-libyaml-dir=$(brew --prefix libyaml)
-
-            # Install the right version of ruby
-            if [[ -z "$(rbenv versions | grep << parameters.ruby_version >>)" ]]; then
-              # ensure that `ruby-build` can see all the available versions of Ruby
-              # some PRs received machines in a weird state, this should make the pipelines
-              # more robust.
-              brew update && brew upgrade ruby-build
-              rbenv install << parameters.ruby_version >>
-            fi
-
-            # Set ruby dependencies
-            rbenv global << parameters.ruby_version >>
-            gem install bundler
-            bundle check || bundle install --path vendor/bundle --clean
+          name: Ruby Orb Dependencies
+          command: brew install gnupg
+      - ruby/install:
+          version: "<< parameters.ruby_version >>"
+      - ruby/install-deps:
+          clean-bundle: true
       - save_cache:
           key: *rbenv_cache_key
           paths:

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -7,6 +7,7 @@ version: 2.1
 orbs:
   win: circleci/windows@2.4.0
   android: circleci/android@2.3.0
+  ruby: circleci/ruby@2.1.0
 
 # -------------------------
 #        REFERENCES


### PR DESCRIPTION
## Summary:
Move to CircleCI managing the installation of Ruby.

## Changelog:
[Internal] - Use Orb instead of manual rbenv ruby installation

## Test Plan: CircleCI

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->
