### PR TITLE
add feature flag to disable Choreographer callbacks in Paper infra

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -174,4 +174,12 @@ public class ReactFeatureFlags {
    * in JS will be rejected (The JS error will include native stack)
    */
   public static boolean rejectTurboModulePromiseOnNativeError = true;
+
+  /*
+   * When the app is completely migrated to Fabric, set this flag to true to
+   * disable parts of Paper infrastructre that are not needed anymore but consume
+   * memory and CPU. Specifically, UIViewOperationQueue and EventDispatcherImpl will no
+   * longer work as they won't subscribe to ReactChoregrapher for updates.
+   */
+  public static boolean enableFabricRendererExclusively = false;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.RetryableMountingLayerException;
 import com.facebook.react.bridge.SoftAssertions;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.uimanager.debug.NotThreadSafeViewHierarchyUpdateDebugListener;
 import com.facebook.systrace.Systrace;
@@ -962,8 +963,10 @@ public class UIViewOperationQueue {
 
   /* package */ void resumeFrameCallback() {
     mIsDispatchUIFrameCallbackEnqueued = true;
-    ReactChoreographer.getInstance()
-        .postFrameCallback(ReactChoreographer.CallbackType.DISPATCH_UI, mDispatchUIFrameCallback);
+    if (!ReactFeatureFlags.enableFabricRendererExclusively) {
+      ReactChoreographer.getInstance()
+          .postFrameCallback(ReactChoreographer.CallbackType.DISPATCH_UI, mDispatchUIFrameCallback);
+    }
   }
 
   /* package */ void pauseFrameCallback() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.systrace.Systrace;
@@ -315,8 +316,11 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
     }
 
     private void post() {
-      ReactChoreographer.getInstance()
-          .postFrameCallback(ReactChoreographer.CallbackType.TIMERS_EVENTS, mCurrentFrameCallback);
+      if (!ReactFeatureFlags.enableFabricRendererExclusively) {
+        ReactChoreographer.getInstance()
+            .postFrameCallback(
+                ReactChoreographer.CallbackType.TIMERS_EVENTS, mCurrentFrameCallback);
+      }
     }
 
     public void maybePostFromNonUI() {


### PR DESCRIPTION
Summary:
changelog: [internal]

For constrained environments, we want to lower cpu usage of RN when the app is idle. `UIViewOperationQueue` and `EventDispatcherImpl` are not used in Fabric and therefore they do not need to run on each frame.

Reviewed By: javache

Differential Revision: D50741161


