### PR TITLE
mark init as designated initializer for RCTNetworking

### DIFF
--- a/packages/react-native/Libraries/Network/RCTNetworking.h
+++ b/packages/react-native/Libraries/Network/RCTNetworking.h
@@ -28,6 +28,8 @@
 
 @interface RCTNetworking : RCTEventEmitter
 
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
 /**
  * Allows RCTNetworking instances to be initialized with handlers.
  * The handlers will be requested via the bridge's moduleForName method when required.

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -170,7 +170,7 @@ RCT_EXPORT_MODULE()
 - (instancetype)initWithHandlersProvider:
     (NSArray<id<RCTURLRequestHandler>> * (^)(RCTModuleRegistry *moduleRegistry))getHandlers
 {
-  if (self = [super initWithDisabledObservation]) {
+  if (self = [self init]) {
     _handlersProvider = getHandlers;
   }
   return self;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

let's add compile time safety so that `RCTNetworking` will always be initialized via `initWithDisabledObservation`.

Differential Revision: D50764524


