### PR TITLE
Apply Babel arrow transform only when needed

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -84,11 +84,8 @@ const getPreset = (src, options) => {
     extraPlugins.push([require('@babel/plugin-transform-classes')]);
   }
 
-  // TODO(gaearon): put this back into '=>' indexOf bailout
-  // and patch react-refresh to not depend on this transform.
-  extraPlugins.push([require('@babel/plugin-transform-arrow-functions')]);
-
   if (!isHermes) {
+    extraPlugins.push([require('@babel/plugin-transform-arrow-functions')]);
     extraPlugins.push([require('@babel/plugin-transform-computed-properties')]);
     extraPlugins.push([require('@babel/plugin-transform-parameters')]);
     extraPlugins.push([

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -84,8 +84,10 @@ const getPreset = (src, options) => {
     extraPlugins.push([require('@babel/plugin-transform-classes')]);
   }
 
-  if (!isHermes) {
+  if (!isHermes && (isNull || src.indexOf('=>') !== -1)) {
     extraPlugins.push([require('@babel/plugin-transform-arrow-functions')]);
+  }
+  if (!isHermes) {
     extraPlugins.push([require('@babel/plugin-transform-computed-properties')]);
     extraPlugins.push([require('@babel/plugin-transform-parameters')]);
     extraPlugins.push([


### PR DESCRIPTION
## Summary

Hermes supports arrows. I assume the only reason the transform wasn't dropped is due to the scary TODO.

Originally, the arrow transform was conditional like this:

```js
  if (isNull || src.indexOf('=>') !== -1) {
    extraPlugins.push(es2015ArrowFunctions);
  }
```

I made it unconditional in https://github.com/facebook/metro/commit/beb3d1ab5dc46a856e0810f3c0787f8885c8f654 (D15947985) to work around an issue where React Refresh Babel plugin emitted arrow functions. However, I fixed that plugin to _not_ emit arrow functions a long time ago in https://github.com/facebook/react/pull/15956. So this TODO is effectively solved, and has been, for ages.

In this commit, we:

- Skip the transform for Hermes altogether
- For non-Hermes, revert to the old conditional behavior

Possible alternatives:

- We could skip it for Hermes but apply unconditionally otherwise (a bit simpler)
- Or, if all target non-Hermes runtimes already support it natively, we could completely remove it

## Changelog:

[GENERAL] [CHANGED] - Apply Babel arrow transform only for non-Hermes

## Test Plan

Run fbsource tests (that's for you, not for me :)

