### PR TITLE
Fix windows 4018 and 4244 compiler warnings

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -69,7 +69,7 @@ const RawValue* RawPropsParser::at(
   do {
     rawProps.keyIndexCursor_++;
 
-    if (UNLIKELY(rawProps.keyIndexCursor_ >= keys_.size())) {
+    if (UNLIKELY(static_cast<size_t>(rawProps.keyIndexCursor_) >= keys_.size())) {
 #ifdef REACT_NATIVE_DEBUG
       if (resetLoop) {
         LOG(ERROR)

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -33,7 +33,7 @@ const RawValue* RawPropsParser::at(
     // 4950 lookups and equality checks on initialization of the parser, which
     // happens exactly once per component.
     size_t size = keys_.size();
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
       if (keys_[i] == key) {
         return nullptr;
       }

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -243,7 +243,7 @@ void ShadowNode::replaceChild(
   auto& children = const_cast<ShadowNode::ListOfShared&>(*children_);
   auto size = children.size();
 
-  if (suggestedIndex != -1 && suggestedIndex < size) {
+  if (suggestedIndex != -1 && static_cast<size_t>(suggestedIndex) < size) {
     // If provided `suggestedIndex` is accurate,
     // replacing in place using the index.
     if (children.at(suggestedIndex).get() == &oldChild) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Windows had to remove some previously suppressed compiler warnings and fork `ShadowNode.cpp` and `RawPropsParser.cpp` (See: https://github.com/microsoft/react-native-windows/issues/12300) to fix them. This PR adds the right data types and static casts to get rid of the compiler warnings.

## Changelog:

[GENERAL] [FIXED] - Fix windows 4018 and 4244 compiler warnings

## Test Plan:

tested in RNW Repository
