### PR TITLE
Rollout RCTValidateCanSendEventInRCTEventEmitter

### DIFF
--- a/packages/react-native/React/Base/RCTConstants.h
+++ b/packages/react-native/React/Base/RCTConstants.h
@@ -50,12 +50,6 @@ RCT_EXTERN BOOL RCTGetDispatchW3CPointerEvents(void);
 RCT_EXTERN void RCTSetDispatchW3CPointerEvents(BOOL value);
 
 /*
- * Validate RCTEventEmitter
- */
-RCT_EXTERN BOOL RCTGetValidateCanSendEventInRCTEventEmitter(void);
-RCT_EXTERN void RCTSetValidateCanSendEventInRCTEventEmitter(BOOL value);
-
-/*
  * Memory Pressure Unloading Level
  */
 RCT_EXTERN int RCTGetMemoryPressureUnloadLevel(void);

--- a/packages/react-native/React/Base/RCTConstants.m
+++ b/packages/react-native/React/Base/RCTConstants.m
@@ -37,21 +37,6 @@ void RCTSetDispatchW3CPointerEvents(BOOL value)
 }
 
 /*
- * Validate RCTEventEmitter. For experimentation only.
- */
-static BOOL RCTValidateCanSendEventInRCTEventEmitter = NO;
-
-BOOL RCTGetValidateCanSendEventInRCTEventEmitter(void)
-{
-  return RCTValidateCanSendEventInRCTEventEmitter;
-}
-
-void RCTSetValidateCanSendEventInRCTEventEmitter(BOOL value)
-{
-  RCTValidateCanSendEventInRCTEventEmitter = value;
-}
-
-/*
  * Memory Pressure Unloading Level for experimentation only.
  * Default is 15, which is TRIM_MEMORY_RUNNING_CRITICAL.
  */

--- a/packages/react-native/React/CoreModules/RCTAppState.mm
+++ b/packages/react-native/React/CoreModules/RCTAppState.mm
@@ -107,9 +107,7 @@ RCT_EXPORT_MODULE()
 
 - (void)handleMemoryWarning
 {
-  if ([self canSendEvents_DEPRECATED]) {
-    [self sendEventWithName:@"memoryWarning" body:nil];
-  }
+  [self sendEventWithName:@"memoryWarning" body:nil];
 }
 
 - (void)handleAppStateDidChange:(NSNotification *)notification
@@ -126,9 +124,7 @@ RCT_EXPORT_MODULE()
 
   if (![newState isEqualToString:_lastKnownState]) {
     _lastKnownState = newState;
-    if ([self canSendEvents_DEPRECATED]) {
-      [self sendEventWithName:@"appStateDidChange" body:@{@"app_state" : _lastKnownState}];
-    }
+    [self sendEventWithName:@"appStateDidChange" body:@{@"app_state" : _lastKnownState}];
   }
 }
 

--- a/packages/react-native/React/Modules/RCTEventEmitter.h
+++ b/packages/react-native/React/Modules/RCTEventEmitter.h
@@ -32,8 +32,6 @@
  */
 - (void)sendEventWithName:(NSString *)name body:(id)body;
 
-- (BOOL)canSendEvents_DEPRECATED;
-
 /**
  * These methods will be called when the first observer is added and when the
  * last observer is removed (or when dealloc is called), respectively. These

--- a/packages/react-native/React/Modules/RCTEventEmitter.m
+++ b/packages/react-native/React/Modules/RCTEventEmitter.m
@@ -71,18 +71,6 @@
   }
 }
 
-/* TODO: (T118587955) Remove canSendEvents_DEPRECATED and validate RCTEventEmitter does not fail
- * RCTAssert in _callableJSModules when the React Native instance is invalidated.
- */
-- (BOOL)canSendEvents_DEPRECATED
-{
-  bool canSendEvents = _callableJSModules != nil;
-  if (!canSendEvents && RCTGetValidateCanSendEventInRCTEventEmitter()) {
-    RCTLogError(@"Trying to send event when _callableJSModules is nil.");
-  }
-  return canSendEvents;
-}
-
 - (void)startObserving
 {
   // Does nothing


### PR DESCRIPTION
Summary:
Replaces a previous soft error with an RCTAssert.

Changelog: [Internal]

Reviewed By: RSNara

Differential Revision: D50641816


