### PR TITLE
Fix running iOS timers when the proximity sensor is engaged

### DIFF
--- a/packages/react-native/React/CoreModules/RCTTiming.mm
+++ b/packages/react-native/React/CoreModules/RCTTiming.mm
@@ -129,7 +129,8 @@ RCT_EXPORT_MODULE()
   _timers = [NSMutableDictionary new];
   _inBackground = NO;
   RCTExecuteOnMainQueue(^{
-    if (!self->_inBackground && [RCTSharedApplication() applicationState] == UIApplicationStateBackground) {
+    if (!self->_inBackground && ([RCTSharedApplication() applicationState] == UIApplicationStateBackground
+        || [UIDevice currentDevice].proximityState)) {
       [self appDidMoveToBackground];
     }
   });
@@ -151,6 +152,11 @@ RCT_EXPORT_MODULE()
                                                  name:name
                                                object:nil];
   }
+
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(proximityChanged)
+                                               name:UIDeviceProximityStateDidChangeNotification
+                                             object:nil];
 }
 
 - (void)dealloc
@@ -185,6 +191,16 @@ RCT_EXPORT_MODULE()
 {
   _inBackground = NO;
   [self startTimers];
+}
+
+- (void)proximityChanged
+{
+  BOOL isClose = [UIDevice currentDevice].proximityState;
+  if (isClose) {
+    [self appDidMoveToBackground];
+  } else {
+    [self appDidMoveToForeground];
+  }
 }
 
 - (void)stopTimers


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When the proximity sensor is engaged and it detects "close", the screen is disabled so timers stop working. Treat the close proximity status as if the app went into the background so CADisplayLink based timers are not used.

## Changelog:

[iOS] [Fixed] - Fix running timers when the proximity sensor detects close

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
