### PR TITLE
Fix Ruby installation

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -46,11 +46,14 @@ commands:
               echo "rbenv found; Skipping installation"
             fi
 
-            echo "Xcode version $(xcodebuild -version)"
+            xcode=$(xcodebuild -version | cut -d' ' -f2 | head -n 1)
+            # For some reason, the Xcode 14.1 machnine is already properly configured.
+            if [[ $xcode != '14.1' ]]; then
+              brew reinstall libyaml
+              gem install psych -- --with-libyaml-dir=$(brew --prefix libyaml)
+              export RUBY_CONFIGURE_OPTS=--with-libyaml-dir=$(brew --prefix libyaml)
+            fi
 
-            brew reinstall libyaml
-            gem install psych -- --with-libyaml-dir=$(brew --prefix libyaml)
-            export RUBY_CONFIGURE_OPTS=--with-libyaml-dir=$(brew --prefix libyaml)
 
             # Install the right version of ruby
             if [[ -z "$(rbenv versions | grep << parameters.ruby_version >>)" ]]; then

--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -46,6 +46,8 @@ commands:
               echo "rbenv found; Skipping installation"
             fi
 
+            echo "Xcode version $(xcodebuild -version)"
+
             brew reinstall libyaml
             gem install psych -- --with-libyaml-dir=$(brew --prefix libyaml)
             export RUBY_CONFIGURE_OPTS=--with-libyaml-dir=$(brew --prefix libyaml)


### PR DESCRIPTION
## Summary:
Starting from Monday, Ruby jobs using Xcode 14.1 started failing on PRs but not on main.
While CircleCI is investigating why this is happening, we found a way to make sure that we can install Ruby even when the cache misses.

## Changelog:
[Internal] - Make sure we can install ruby 3.2.0 when rbenv cache misses.

## Test Plan:
CircleCI is green
