### PR TITLE
fix: remove unused exclude in podspec

### DIFF
--- a/packages/react-native/ReactCommon/logger/React-logger.podspec
+++ b/packages/react-native/ReactCommon/logger/React-logger.podspec
@@ -31,7 +31,6 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
-  s.exclude_files          = "SampleCxxModule.*"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "" }
   s.header_dir             = "logger"


### PR DESCRIPTION
## Summary:

Remove unused `s.exclude_files` since `React-logger.podspec` doesn't include `SampleCxxModule.*`

## Changelog:

[INTERNAL] [FIXED] - remove unused exclude in podspec

## Test Plan:

None