### PR TITLE
[RN][CI]Update node installation on debian (0.73)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,16 @@ jobs:
           command: |
             apt update
             apt install -y wget git curl jq
-            curl -sL https://deb.nodesource.com/setup_18.x | bash -
+
+            apt-get update
+            apt-get install -y ca-certificates curl gnupg
+            mkdir -p /etc/apt/keyrings
+            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+            NODE_MAJOR=18
+            echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+            apt-get update
+
             apt install -y nodejs
             npm install --global yarn
       - checkout

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -621,7 +621,7 @@ jobs:
       - run:
           name: Install Node JS
           # Note: Version set separately for non-Windows builds, see above.
-          command: choco install nodejs-lts
+          command: choco install nodejs --version=18.18.0 --allow-downgrade
 
       # Setup Dependencies
       - run:
@@ -681,7 +681,16 @@ jobs:
             apt update
 
             apt install -y wget git curl jq
-            curl -sL https://deb.nodesource.com/setup_18.x | bash -
+
+            apt-get update
+            apt-get install -y ca-certificates curl gnupg
+            mkdir -p /etc/apt/keyrings
+            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+            NODE_MAJOR=18
+            echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+            apt-get update
+
             apt install -y nodejs
             npm install --global yarn
       - checkout


### PR DESCRIPTION
## Summary:
Instruction to install node on Debiam machine [has changed](https://github.com/nodesource/distributions#new-update-%EF%B8%8F) and the previous script cannot be used anymore.
This change updates it.

## Changelog:
[Internal] - Fix CI

## Test Plan:
CircleCI is green
