### PR TITLE
[RN][CI]Update node installation on debian (0.71) 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1151,7 +1151,15 @@ jobs:
           command: |
             apt update
             apt install -y wget git curl
-            curl -sL https://deb.nodesource.com/setup_16.x | bash -
+
+            apt-get update
+            apt-get install -y ca-certificates curl gnupg
+            mkdir -p /etc/apt/keyrings
+            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+            NODE_MAJOR=16
+            echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+            apt-get update
+
             apt install -y nodejs
             npm install --global yarn
       - checkout


### PR DESCRIPTION
## Summary:
Instruction to install node on Debiam machine [has changed](https://github.com/nodesource/distributions#new-update-%EF%B8%8F) and the previous script cannot be used anymore.
This change updates it.

## Changelog:
[Internal] - Fix CI

## Test Plan:
CircleCI is green
