### PR TITLE
Fix Test Windows (0.73)

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -621,7 +621,7 @@ jobs:
       - run:
           name: Install Node JS
           # Note: Version set separately for non-Windows builds, see above.
-          command: choco install nodejs-lts
+          command: choco install nodejs --version=18.18.0 --allow-downgrade
 
       # Setup Dependencies
       - run:


### PR DESCRIPTION
## Summary
This PR fixes the `test_windows` in 0.73 after node has moved to 20 as LTS

## Changelog:
[Internal] - Fix test_windows by using the right Node

## Test Plan:
CircleCI is back to green.