### PR TITLE
Fix ios pod post_install logic for detecting if fabric is enabled

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -236,7 +236,7 @@ def react_native_post_install(
 
   ReactNativePodsUtils.apply_mac_catalyst_patches(installer) if mac_catalyst_enabled
 
-  fabric_enabled = ReactNativePodsUtils.has_pod(installer, 'React-Fabric')
+  fabric_enabled = ENV['RCT_FABRIC_ENABLED'] == '1'
   hermes_enabled = ReactNativePodsUtils.has_pod(installer, "React-hermes")
 
   if hermes_enabled


### PR DESCRIPTION
## Summary:

There is a problem in the way that we check if Fabric is enabled inside `react_native_post_install`.

https://github.com/facebook/react-native/blob/899e7cdb55197fc17a96a93af4f8bcc7519553c2/packages/react-native/scripts/react_native_pods.rb#L239

We're determining if fabric is enabled by checking if the `React-Fabric pod `is present, but since we always call `setup_fabric!(:react_native_path => prefix)`  (https://github.com/facebook/react-native/pull/39057) inside `use_react_native` the `React-Fabric` pod is always present causing the `-DRN_FABRIC_ENABLED` flag to always be added to `project.pbxproj` even if the new arch is disabled.

## Changelog:

[IOS] [FIXED] - Fix ios pod post_install logic for detecting if fabric is enabled

## Test Plan:

Run `use_react_native!(fabric => false)` should not add the `-DRN_FABRIC_ENABLED` flag to `project.pbxproj`
