### PR TITLE
Update ios pod post_install logic for detecting if hermes is enabled

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -237,7 +237,7 @@ def react_native_post_install(
   ReactNativePodsUtils.apply_mac_catalyst_patches(installer) if mac_catalyst_enabled
 
   fabric_enabled = ENV['RCT_FABRIC_ENABLED'] == '1'
-  hermes_enabled = ReactNativePodsUtils.has_pod(installer, "React-hermes")
+  hermes_enabled = ENV['USE_HERMES'] == '1'
 
   if hermes_enabled
     ReactNativePodsUtils.set_gcc_preprocessor_definition_for_React_hermes(installer)


### PR DESCRIPTION
## Summary:

Follow up of https://github.com/facebook/react-native/pull/41284#issuecomment-1789516046

We should not rely on  checking if the `React-hermes` pod is present to determine if hermes is enabled

## Changelog:
 
[IOS] [CHANGED] - Update ios pod post_install logic for detecting if hermes is enabled

## Test Plan:

Run `use_react_native!(hermes => false)` should not add `USE_HERMES = true;` to `project.pbxproj`
