### PR TITLE
remove warning to tell user to set requiresMainQueueSetup

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.mm
@@ -14,11 +14,6 @@
 
 RCT_EXPORT_MODULE()
 
-+ (BOOL)requiresMainQueueSetup
-{
-  return NO;
-}
-
 - (UIView *)view
 {
   return [[RCTInputAccessoryView alloc] initWithBridge:self.bridge];

--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -77,20 +77,6 @@ int32_t getUniqueId()
         !_instance && [_moduleClass instanceMethodForSelector:@selector(init)] != objectInitMethod;
 
     _requiresMainQueueSetup = _hasConstantsToExport || hasCustomInit;
-    if (_requiresMainQueueSetup) {
-      const char *methodName = "";
-      if (_hasConstantsToExport) {
-        methodName = "constantsToExport";
-      } else if (hasCustomInit) {
-        methodName = "init";
-      }
-      RCTLogWarn(
-          @"Module %@ requires main queue setup since it overrides `%s` but doesn't implement "
-           "`requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules "
-           "on a background thread unless explicitly opted-out of.",
-          _moduleClass,
-          methodName);
-    }
   }
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -879,19 +879,7 @@ static Class getFallbackClassFromName(const char *name)
    */
   const BOOL hasCustomInit = [moduleClass instanceMethodForSelector:@selector(init)] != objectInitMethod;
 
-  BOOL requiresMainQueueSetup = hasConstantsToExport || hasCustomInit;
-  if (requiresMainQueueSetup) {
-    RCTLogWarn(
-        @"Module %@ requires main queue setup since it overrides `%s` but doesn't implement "
-         "`requiresMainQueueSetup`. In a future release React Native will default to initializing all NativeModules "
-         "on a background thread unless explicitly opted-out of.",
-        moduleClass,
-        hasConstantsToExport ? "constantsToExport"
-            : hasCustomInit  ? "init"
-                             : "");
-  }
-
-  return requiresMainQueueSetup;
+  return hasConstantsToExport || hasCustomInit;
 }
 
 - (void)installJSBindings:(facebook::jsi::Runtime &)runtime


### PR DESCRIPTION
Summary:
Changelog: [Internal]

i believe this warning is outdated, i don't think having a custom initializer or exporting constants means that your module needs to be setup on main.

Reviewed By: cipolleschi

Differential Revision: D50919152


