### PR TITLE
remove unnecessary requiresMainQueueSetup

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.mm
@@ -14,11 +14,6 @@
 
 RCT_EXPORT_MODULE()
 
-+ (BOOL)requiresMainQueueSetup
-{
-  return NO;
-}
-
 - (UIView *)view
 {
   return [[RCTInputAccessoryView alloc] initWithBridge:self.bridge];


### PR DESCRIPTION
Summary:
Changelog: [Internal]

modules will be setup on main queue for any the following criteria:
- override requiresMainQueueSetup and set it to yes
- have a method that starts with `init`
- have `constantsToExport` implemented

these methods return `NO` but don't fulfill the latter criteria, so we should just delete them

Reviewed By: cipolleschi

Differential Revision: D50919151


