### PR TITLE
Remove web performance logging from GlobalPerformanceLogger

### DIFF
--- a/packages/react-native/Libraries/Utilities/createPerformanceLogger.js
+++ b/packages/react-native/Libraries/Utilities/createPerformanceLogger.js
@@ -22,10 +22,6 @@ const _cookies: {[key: string]: number, ...} = {};
 
 const PRINT_TO_CONSOLE: false = false; // Type as false to prevent accidentally committing `true`;
 
-// This is the prefix for optional logging points/timespans as marks/measures via Performance API,
-// used to separate these internally from other marks/measures
-const WEB_PERFORMANCE_PREFIX = 'web_perf_';
-
 export const getCurrentTimestamp: () => number =
   global.nativeQPLTimestamp ?? (() => global.performance.now());
 
@@ -35,41 +31,6 @@ class PerformanceLogger implements IPerformanceLogger {
   _points: {[key: string]: ?number} = {};
   _pointExtras: {[key: string]: ?Extras, ...} = {};
   _closed: boolean = false;
-  _isLoggingForWebPerformance: boolean = false;
-
-  // When `isLoggingForWebPerformance` is true, the data will be additionally logged via
-  // Performance.mark/measure API, if available.
-  constructor(isLoggingForWebPerformance?: boolean) {
-    this._isLoggingForWebPerformance = isLoggingForWebPerformance === true;
-  }
-
-  // NOTE: The Performance.mark/measure calls are wrapped here to ensure that
-  // we are safe from the cases when the global 'peformance' object is still not yet defined.
-  // It is only necessary in this file because of potential race conditions in the initialization
-  // order between 'createPerformanceLogger' and 'setUpPerformance'.
-  //
-  // In most of the other cases this kind of check for `performance` being defined
-  // wouldn't be necessary.
-  _performanceMark(key: string, startTime: number) {
-    if (this._isLoggingForWebPerformance) {
-      global.performance?.mark?.(key, {
-        startTime,
-      });
-    }
-  }
-
-  _performanceMeasure(
-    key: string,
-    start: number | string,
-    end: number | string,
-  ) {
-    if (this._isLoggingForWebPerformance) {
-      global.performance?.measure?.(key, {
-        start,
-        end,
-      });
-    }
-  }
 
   addTimespan(
     key: string,
@@ -101,12 +62,6 @@ class PerformanceLogger implements IPerformanceLogger {
       startExtras,
       endExtras,
     };
-
-    this._performanceMeasure(
-      `${WEB_PERFORMANCE_PREFIX}_${key}`,
-      startTime,
-      endTime,
-    );
   }
 
   append(performanceLogger: IPerformanceLogger) {
@@ -221,8 +176,6 @@ class PerformanceLogger implements IPerformanceLogger {
     if (extras) {
       this._pointExtras[key] = extras;
     }
-
-    this._performanceMark(`${WEB_PERFORMANCE_PREFIX}_${key}`, timestamp);
   }
 
   removeExtra(key: string): ?ExtraValue {
@@ -284,11 +237,6 @@ class PerformanceLogger implements IPerformanceLogger {
     if (PRINT_TO_CONSOLE) {
       infoLog('PerformanceLogger.js', 'start: ' + key);
     }
-
-    this._performanceMark(
-      `${WEB_PERFORMANCE_PREFIX}_timespan_start_${key}`,
-      timestamp,
-    );
   }
 
   stopTimespan(
@@ -334,12 +282,6 @@ class PerformanceLogger implements IPerformanceLogger {
       Systrace.endAsyncEvent(key, _cookies[key]);
       delete _cookies[key];
     }
-
-    this._performanceMeasure(
-      `${WEB_PERFORMANCE_PREFIX}_${key}`,
-      `${WEB_PERFORMANCE_PREFIX}_timespan_start_${key}`,
-      timestamp,
-    );
   }
 }
 
@@ -352,8 +294,6 @@ export type {Extras, ExtraValue, IPerformanceLogger, Timespan};
  * various performance data such as timespans, points and extras.
  * The loggers need to have minimal overhead since they're used in production.
  */
-export default function createPerformanceLogger(
-  isLoggingForWebPerformance?: boolean,
-): IPerformanceLogger {
-  return new PerformanceLogger(isLoggingForWebPerformance);
+export default function createPerformanceLogger(): IPerformanceLogger {
+  return new PerformanceLogger();
 }


### PR DESCRIPTION
Summary:
## Changelog:

It makes sense to keep Web Performance logging mechanism separate from the GlobalPerformanceLogger, removing.

Reviewed By: rubennorte

Differential Revision: D50930312


