### PR TITLE
Adding FabricUIManager() getter & setter and setter for TurboModuleRegistry

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
@@ -10,9 +10,11 @@ package com.facebook.react.bridge;
 import androidx.annotation.Nullable;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.internal.turbomodule.core.interfaces.CallInvokerHolder;
 import com.facebook.react.internal.turbomodule.core.interfaces.NativeMethodCallInvokerHolder;
+import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry;
 import java.util.Collection;
 import java.util.List;
 
@@ -134,4 +136,19 @@ public interface CatalystInstance
    * hasNativeModule, and getNativeModules can also return TurboModules.
    */
   void setTurboModuleManager(JSIModule getter);
+
+  @DeprecatedInNewArchitecture(
+      message =
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+  void setTurboModuleRegistry(TurboModuleRegistry turboModuleRegistry);
+
+  @DeprecatedInNewArchitecture(
+      message =
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+  void setFabricUIManager(UIManager fabricUIManager);
+
+  @DeprecatedInNewArchitecture(
+      message =
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+  UIManager getFabricUIManager();
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -103,7 +103,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
   private @Nullable String mSourceURL;
 
   private JavaScriptContextHolder mJavaScriptContextHolder;
-  private volatile @Nullable TurboModuleRegistry mTurboModuleRegistry = null;
+  private @Nullable TurboModuleRegistry mTurboModuleRegistry;
+  private @Nullable UIManager mFabricUIManager;
 
   // C++ parts
   private final HybridData mHybridData;
@@ -351,6 +352,9 @@ public class CatalystInstanceImpl implements CatalystInstance {
         () -> {
           mNativeModuleRegistry.notifyJSInstanceDestroy();
           mJSIModuleRegistry.notifyJSInstanceDestroy();
+          if (mFabricUIManager != null) {
+            mFabricUIManager.invalidate();
+          }
           boolean wasIdle = (mPendingJSCalls.getAndSet(0) == 0);
           if (!mBridgeIdleListeners.isEmpty()) {
             for (NotThreadSafeBridgeIdleDebugListener listener : mBridgeIdleListeners) {
@@ -568,6 +572,21 @@ public class CatalystInstanceImpl implements CatalystInstance {
 
   public void setTurboModuleManager(JSIModule module) {
     mTurboModuleRegistry = (TurboModuleRegistry) module;
+  }
+
+  @Override
+  public void setTurboModuleRegistry(TurboModuleRegistry turboModuleRegistry) {
+    mTurboModuleRegistry = turboModuleRegistry;
+  }
+
+  @Override
+  public void setFabricUIManager(UIManager fabricUIManager) {
+    mFabricUIManager = fabricUIManager;
+  }
+
+  @Override
+  public UIManager getFabricUIManager() {
+    return mFabricUIManager;
   }
 
   private void decrementPendingJSCalls() {


### PR DESCRIPTION
Summary:
Adding  `setTurboModuleRegistry(TurboModuleRegistry turboModuleRegistry)`, `setFabricUIManager(UIManager fabricUIManager)`, `getFabricUIManager()` new APIs

Changelog:
[General][Added] Introduce APIs for FabricUIManager

Differential Revision: D50832557


