### PR TITLE
Remove `YGNodeMarkDirtyAndPropagateToDescendants`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
@@ -41,7 +41,6 @@ public class YogaNative {
   static native void jni_YGNodeRemoveChildJNI(long nativePointer, long childPointer);
   static native void jni_YGNodeCalculateLayoutJNI(long nativePointer, float width, float height, long[] nativePointers, YogaNodeJNIBase[] nodes);
   static native void jni_YGNodeMarkDirtyJNI(long nativePointer);
-  static native void jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI(long nativePointer);
   static native boolean jni_YGNodeIsDirtyJNI(long nativePointer);
   static native void jni_YGNodeCopyStyleJNI(long dstNativePointer, long srcNativePointer);
   static native int jni_YGNodeStyleGetDirectionJNI(long nativePointer);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -231,10 +231,6 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
     YogaNative.jni_YGNodeMarkDirtyJNI(mNativePointer);
   }
 
-  public void dirtyAllDescendants() {
-    YogaNative.jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI(mNativePointer);
-  }
-
   public boolean isDirty() {
     return YogaNative.jni_YGNodeIsDirtyJNI(mNativePointer);
   }

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -385,13 +385,6 @@ jni_YGNodeMarkDirtyJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   YGNodeMarkDirty(_jlong2YGNodeRef(nativePointer));
 }
 
-static void jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer) {
-  YGNodeMarkDirtyAndPropagateToDescendants(_jlong2YGNodeRef(nativePointer));
-}
-
 static jboolean
 jni_YGNodeIsDirtyJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   return (jboolean)YGNodeIsDirty(_jlong2YGNodeRef(nativePointer));
@@ -776,9 +769,6 @@ static JNINativeMethod methods[] = {
      "(JFF[J[Lcom/facebook/yoga/YogaNodeJNIBase;)V",
      (void*)jni_YGNodeCalculateLayoutJNI},
     {"jni_YGNodeMarkDirtyJNI", "(J)V", (void*)jni_YGNodeMarkDirtyJNI},
-    {"jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI",
-     "(J)V",
-     (void*)jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI},
     {"jni_YGNodeIsDirtyJNI", "(J)Z", (void*)jni_YGNodeIsDirtyJNI},
     {"jni_YGNodeCopyStyleJNI", "(JJ)V", (void*)jni_YGNodeCopyStyleJNI},
     {"jni_YGNodeStyleGetDirectionJNI",

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -92,10 +92,6 @@ bool YGNodeIsDirty(YGNodeConstRef node) {
   return resolveRef(node)->isDirty();
 }
 
-void YGNodeMarkDirtyAndPropagateToDescendants(const YGNodeRef node) {
-  return resolveRef(node)->markDirtyAndPropagateDownwards();
-}
-
 YGNodeRef YGNodeNewWithConfig(const YGConfigConstRef config) {
   auto* node = new yoga::Node{resolveRef(config)};
   yoga::assertFatal(

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -94,12 +94,6 @@ YG_EXPORT void YGNodeCalculateLayout(
 // this dirty marking manually.
 YG_EXPORT void YGNodeMarkDirty(YGNodeRef node);
 
-// Marks the current node and all its descendants as dirty.
-//
-// Intended to be used for Yoga benchmarks. Don't use in production, as calling
-// `YGCalculateLayout` will cause the recalculation of each and every node.
-YG_EXPORT void YGNodeMarkDirtyAndPropagateToDescendants(YGNodeRef node);
-
 YG_EXPORT void YGNodePrint(YGNodeConstRef node, YGPrintOptions options);
 
 YG_EXPORT bool YGFloatIsUndefined(float value);

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -640,13 +640,6 @@ void Node::markDirtyAndPropagate() {
   }
 }
 
-void Node::markDirtyAndPropagateDownwards() {
-  isDirty_ = true;
-  for_each(children_.begin(), children_.end(), [](Node* childNode) {
-    childNode->markDirtyAndPropagateDownwards();
-  });
-}
-
 float Node::resolveFlexGrow() const {
   // Root nodes flexGrow should always be 0
   if (owner_ == nullptr) {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -341,7 +341,6 @@ class YG_EXPORT Node : public ::YGNode {
       const float mainSize,
       const float crossSize,
       const float ownerWidth);
-  void markDirtyAndPropagateDownwards();
 
   // Other methods
   YGValue getFlexStartMarginValue(FlexDirection axis) const;


### PR DESCRIPTION
Summary: This should not be part of Yoga's API. If benchmarks want to do this, they still can (though I don't know the ones we have for it are super valuable).

Differential Revision: D50963933


