### PR TITLE
Configure Java toolchains per project

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -71,7 +71,6 @@ class ReactPlugin : Plugin<Project> {
       configureBuildConfigFieldsForApp(project, extension)
       configureDevPorts(project)
       configureBackwardCompatibilityReactMap(project)
-      configureJavaToolChains(project)
 
       project.extensions.getByType(AndroidComponentsExtension::class.java).apply {
         onVariants(selector().all()) { variant ->
@@ -87,6 +86,9 @@ class ReactPlugin : Plugin<Project> {
     project.pluginManager.withPlugin("com.android.library") {
       configureCodegen(project, extension, rootExtension, isLibrary = true)
     }
+
+    // Library and App Configurations
+    configureJavaToolChains(project)
   }
 
   private fun checkJvmVersion(project: Project) {

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -17,36 +17,30 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
 
 internal object JdkConfiguratorUtils {
   /**
-   * Function that takes care of configuring the JDK toolchain for all the projects projects. As we
-   * do decide the JDK version based on the AGP version that RNGP brings over, here we can safely
+   * Function that takes care of configuring the JDK toolchain for the project. As we do
+   * decide the JDK version based on the AGP version that RNGP brings over, here we can safely
    * configure the toolchain to 17.
    */
-  fun configureJavaToolChains(input: Project) {
+  fun configureJavaToolChains(project: Project) {
     // Check at the app level if react.internal.disableJavaVersionAlignment is set.
-    if (input.hasProperty(INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT)) {
+    if (project.hasProperty(INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT)) {
       return
     }
-    input.rootProject.allprojects { project ->
-      // Allows every single module to set react.internal.disableJavaVersionAlignment also.
-      if (project.hasProperty(INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT)) {
-        return@allprojects
-      }
-      val action =
-          Action<AppliedPlugin> {
-            project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext
-              ->
-              ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_17
-              ext.compileOptions.targetCompatibility = JavaVersion.VERSION_17
-            }
+    val action =
+        Action<AppliedPlugin> {
+          project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext
+            ->
+            ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_17
+            ext.compileOptions.targetCompatibility = JavaVersion.VERSION_17
           }
-      project.pluginManager.withPlugin("com.android.application", action)
-      project.pluginManager.withPlugin("com.android.library", action)
-      project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
-        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
-      }
-      project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
-      }
+        }
+    project.pluginManager.withPlugin("com.android.application", action)
+    project.pluginManager.withPlugin("com.android.library", action)
+    project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+      project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
+    }
+    project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+      project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

A follow-up fix on #40560

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The fix introduced by #40757 worked under the false assumption that `:app` gets evaluated before any other library. However, some libraries, such as [@amplitude/analytics-react-native](https://www.npmjs.com/package/@amplitude/analytics-react-native) (whose project name is `:amplitude_analytics-react-native`), might be evaluated before `:app` and miss the `configureJavaToolChains()` process.

This PR changes `configureJavaToolChains()` into a per-project implementation, and invokes the function during both library and app configurations. This can ensure that all projects get their Java toolchains configured promptly.

## Changelog:

[ANDROID] [FIXED] - Configure Java toolchains per project

## Test Plan:

Test with [@amplitude/analytics-react-native](https://www.npmjs.com/package/@amplitude/analytics-react-native) and ensure that the android app builds **in new arch**.

- Before: https://github.com/UNIDY2002/repro-rn-73-java-new-arch/actions/runs/6745744156/job/18338149263
- After: https://github.com/UNIDY2002/repro-rn-73-java-new-arch/actions/runs/6745838309/job/18338439143
