### PR TITLE
fix: fixed types props tabIndex in view

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
@@ -145,6 +145,17 @@ export interface ViewPropsAndroid {
    * Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
    */
   focusable?: boolean | undefined;
+
+  /**
+   * Indicates whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
+   * See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
+   * for more details.
+   *
+   * Supports the following values:
+   * -  0 (View is focusable)
+   * - -1 (View is not focusable)
+   */
+  tabIndex?: 0 | -1 | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary:

@zfrankdesign reported that in RN 0.72.6, they receive warnings that some new props listed in the documents are missing:
View tabIndex https://reactnative.dev/docs/view#tabindex-android. It seems the components accept these props but they were not typed.

## Changelog:

[GENERAL] [FIXED] - Missing typings for the props `tabIndex` for **View**


## Test Plan:

1. Instantiate a component of type View
   1.1. Should add the property tabIndex to the View component.
   1.2. Should not see a warning about the missing tabIndex property.