### PR TITLE
NIT FabricUIManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -404,12 +404,11 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     }
   }
 
-  // This is called on the JS thread (see CatalystInstanceImpl).
   @Override
   @AnyThread
   @ThreadConfined(ANY)
   public void invalidate() {
-    FLog.i(TAG, "FabricUIManager.onCatalystInstanceDestroy");
+    FLog.i(TAG, "FabricUIManager.invalidate");
 
     if (mDevToolsReactPerfLogger != null) {
       mDevToolsReactPerfLogger.removeDevToolsReactPerfLoggerListener(FABRIC_PERF_LOGGER);


### PR DESCRIPTION
Summary:
The comment in FabricUIManager about `invalidate()` being called from JS thread is not relevant.

Even in Bridgeless it's also called from Background Thread: https://www.internalfb.com/code/fbsource/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java?lines=1383

Similarly the tag rename was missed in the rename onCatalystInstanceDestroy -> invalidate.

Changelog:
[Internal] internal

Differential Revision: D50996760


