### PR TITLE
Fix android layout event lossy conversion

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.java
@@ -65,10 +65,10 @@ public class OnLayoutEvent extends Event<OnLayoutEvent> {
   @Override
   protected WritableMap getEventData() {
     WritableMap layout = Arguments.createMap();
-    layout.putDouble("x", PixelUtil.toDIPFromPixel(mX));
-    layout.putDouble("y", PixelUtil.toDIPFromPixel(mY));
-    layout.putDouble("width", PixelUtil.toDIPFromPixel(mWidth));
-    layout.putDouble("height", PixelUtil.toDIPFromPixel(mHeight));
+    layout.putDouble("x", PixelUtil.toDIPFromPixel((double) mX));
+    layout.putDouble("y", PixelUtil.toDIPFromPixel((double) mY));
+    layout.putDouble("width", PixelUtil.toDIPFromPixel((double) mWidth));
+    layout.putDouble("height", PixelUtil.toDIPFromPixel((double) mHeight));
 
     WritableMap event = Arguments.createMap();
     event.putMap("layout", layout);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.java
@@ -51,6 +51,11 @@ public class PixelUtil {
     return value / DisplayMetricsHolder.getWindowDisplayMetrics().density;
   }
 
+  /** Convert from PX to DP */
+  public static double toDIPFromPixel(double value) {
+    return value / Double.valueOf(DisplayMetricsHolder.getWindowDisplayMetrics().density);
+  }
+
   /** @return {@link float} that represents the density of the display metrics for device screen. */
   public static float getDisplayMetricDensity() {
     return DisplayMetricsHolder.getWindowDisplayMetrics().density;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ContentSizeChangeEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ContentSizeChangeEvent.java
@@ -43,8 +43,8 @@ public class ContentSizeChangeEvent extends Event<ContentSizeChangeEvent> {
   @Override
   protected WritableMap getEventData() {
     WritableMap data = Arguments.createMap();
-    data.putDouble("width", PixelUtil.toDIPFromPixel(mWidth));
-    data.putDouble("height", PixelUtil.toDIPFromPixel(mHeight));
+    data.putDouble("width", PixelUtil.toDIPFromPixel((double) mWidth));
+    data.putDouble("height", PixelUtil.toDIPFromPixel((double) mHeight));
     return data;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ScrollEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ScrollEvent.java
@@ -152,16 +152,16 @@ public class ScrollEvent extends Event<ScrollEvent> {
     contentInset.putDouble("right", 0);
 
     WritableMap contentOffset = Arguments.createMap();
-    contentOffset.putDouble("x", PixelUtil.toDIPFromPixel(mScrollX));
-    contentOffset.putDouble("y", PixelUtil.toDIPFromPixel(mScrollY));
+    contentOffset.putDouble("x", PixelUtil.toDIPFromPixel((double) mScrollX));
+    contentOffset.putDouble("y", PixelUtil.toDIPFromPixel((double) mScrollY));
 
     WritableMap contentSize = Arguments.createMap();
-    contentSize.putDouble("width", PixelUtil.toDIPFromPixel(mContentWidth));
-    contentSize.putDouble("height", PixelUtil.toDIPFromPixel(mContentHeight));
+    contentSize.putDouble("width", PixelUtil.toDIPFromPixel((double) mContentWidth));
+    contentSize.putDouble("height", PixelUtil.toDIPFromPixel((double) mContentHeight));
 
     WritableMap layoutMeasurement = Arguments.createMap();
-    layoutMeasurement.putDouble("width", PixelUtil.toDIPFromPixel(mScrollViewWidth));
-    layoutMeasurement.putDouble("height", PixelUtil.toDIPFromPixel(mScrollViewHeight));
+    layoutMeasurement.putDouble("width", PixelUtil.toDIPFromPixel((double) mScrollViewWidth));
+    layoutMeasurement.putDouble("height", PixelUtil.toDIPFromPixel((double) mScrollViewHeight));
 
     WritableMap velocity = Arguments.createMap();
     velocity.putDouble("x", mXVelocity);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix https://github.com/facebook/react-native/issues/32814 and https://github.com/facebook/react-native/issues/26906

I've tried `PixelRatio.roundToNearestPixel()`, which also returns a float number that has lost precision

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [BREAKING] - Fix android layout event lossy conversion

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

The test should verify that `originWidth == width` returns `true`


```javascript
const ratio = PixelRatio.get();
const originWidth = PixelRatio.roundToNearestPixel(301);
console.log('PixelRatio.get()', ratio)
const printEventWidth = (eventName, width) => {
  console.log(eventName, originWidth, width, originWidth == width);
};
return (
  <ScrollView
    style={{ width: originWidth, height: '100%' }}
    onLayout={({ nativeEvent: { layout: { width }}}) => {
      printEventWidth('onLayout', width);
    }}
    onScroll={({ nativeEvent: { layoutMeasurement: { width }}}) => {
      printEventWidth('onScroll', width);
    }}
    onContentSizeChange={(width) => {
      printEventWidth('onContentSizeChange', width);
    }}
  >
    <View style={{ width: '100%', height: 2000 }}></View>
  </ScrollView>
);
```



##### Before
```plain
// PixelRatio.get() 2.75
// onContentSizeChange 301.09090909090907 301.0909118652344 false
// onLayout 301.09090909090907 301.0909118652344 false
// onScroll 301.09090909090907 301.0909118652344 false
```

##### After
```plain
// PixelRatio.get() 2.75
// onContentSizeChange 301.09090909090907 301.09090909090907 true
// onLayout 301.09090909090907 301.09090909090907 true
// onScroll 301.09090909090907 301.09090909090907 true
```

