### PR TITLE
fix: typo in build-ios-framework.sh

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -14,7 +14,7 @@ function get_architecture {
     elif [[ $1 == "catalyst" ]]; then
       echo "x86_64;arm64"
     else
-      echo "Error: unknown arkitecture passed $1"
+      echo "Error: unknown architecture passed $1"
       exit 1
     fi
 }


### PR DESCRIPTION
## Summary:

This PR fixes a small typo in `build-ios-framework.sh`

## Changelog:

[INTERNAL] [FIXED] - Typo in `build-ios-framework.sh`

## Test Plan:

Check if correct error message is printed out
