### PR TITLE
Reenable console.log in tests

### DIFF
--- a/packages/react-native/jest/local-setup.js
+++ b/packages/react-native/jest/local-setup.js
@@ -17,11 +17,6 @@ require('./setup');
 const consoleError = console.error;
 const consoleWarn = console.warn;
 
-// Blackhole verbose console output
-console.debug = jest.fn();
-console.info = jest.fn();
-console.log = jest.fn();
-
 console.error = (...args) => {
   consoleError(...args);
   throw new Error('console.error() was called (see error above)');


### PR DESCRIPTION
Summary:
D41564032 made `console.log` (as well as `debug` and `info`) a noop in tests within the React Native repo. Here we allow them through while still throwing errors on `console.error` and `console.warn`.

Changelog: [Internal]

Differential Revision: D51002264


