### PR TITLE
Enable lint/sort-imports everywhere

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,13 @@ module.exports = {
       },
     },
     {
+      files: ['*.js', '*.js.flow'],
+      excludedFiles: ['packages/react-native/template/**/*'],
+      rules: {
+        'lint/sort-imports': 1,
+      },
+    },
+    {
       files: ['package.json'],
       parser: 'jsonc-eslint-parser',
     },
@@ -60,7 +67,6 @@ module.exports = {
         'lint/no-haste-imports': 2,
         'lint/no-react-native-imports': 2,
         'lint/require-extends-error': 2,
-        'lint/sort-imports': 1,
       },
     },
     {


### PR DESCRIPTION
Summary:
Enables the `sort-imports` lint rule introduced in D39907799 in ~all files, rather than just in `react-native/Libraries`.

We exclude only `packages/react-native/template`, in order to (1) minimise noise for projects that are tracking updates to the template, (2) avoid the possibility of something breaking if the `react-native` import isn't at the top of `template/index.js`, (3) avoid leaking a reference to `lint/sort-imports` to the template (which doesn't ship with this rule) via an ESLint suppression comment.

Changelog: [Internal]

Differential Revision: D51025811


