### PR TITLE
feat(accessibility): add focus accessibility action support

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -76,6 +76,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
     sActionIdMap.put("decrement", AccessibilityActionCompat.ACTION_SCROLL_BACKWARD.getId());
     sActionIdMap.put("expand", AccessibilityActionCompat.ACTION_EXPAND.getId());
     sActionIdMap.put("collapse", AccessibilityActionCompat.ACTION_COLLAPSE.getId());
+    sActionIdMap.put("accessibilityFocus", AccessibilityActionCompat.ACTION_ACCESSIBILITY_FOCUS.getId());
   }
 
   private final View mView;
@@ -602,6 +603,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
       final AccessibilityRole accessibilityRole =
           (AccessibilityRole) host.getTag(R.id.accessibility_role);
       final ReadableMap accessibilityValue = (ReadableMap) host.getTag(R.id.accessibility_value);
+
       if (accessibilityRole == AccessibilityRole.ADJUSTABLE
           && (action == AccessibilityActionCompat.ACTION_SCROLL_FORWARD.getId()
               || action == AccessibilityActionCompat.ACTION_SCROLL_BACKWARD.getId())) {
@@ -610,6 +612,13 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
         }
         return super.performAccessibilityAction(host, action, args);
       }
+
+      // When checking the accessibility focus action, we don't want to intercept the native event
+      // otherwise it would intercept the change of focus
+      if (action == AccessibilityActionCompat.ACTION_ACCESSIBILITY_FOCUS.getId()) {
+        return super.performAccessibilityAction(host, action, args);
+      }
+
       return true;
     }
     return super.performAccessibilityAction(host, action, args);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I am working on an app that needs to check for accessibility focus events on TalkBack on Android.
There is no way right now to know when a view/text was focused with TalkBack.


## Changelog:

[ANDROID] [ADDED] - add accessibilityFocus action support

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

By adding

```patch
diff --git a/packages/rn-tester/js/components/RNTTitleBar.js b/packages/rn-tester/js/components/RNTTitleBar.js
index d6094056e75..68e35c547b4 100644
--- a/packages/rn-tester/js/components/RNTTitleBar.js
+++ b/packages/rn-tester/js/components/RNTTitleBar.js
@@ -73,7 +73,12 @@ const HeaderAndroid = ({
     <SafeAreaView>
       <View style={[styles.toolbar, {backgroundColor: theme.BackgroundColor}]}>
         <View style={styles.toolbarCenter}>
-          <Text style={[styles.title, {color: theme.LabelColor}]}>{title}</Text>
+          <Text
+            style={[styles.title, {color: theme.LabelColor}]}
+            accessibilityActions={[{ name: 'accessibilityFocus' }]}
+            accessible
+            onAccessibilityAction={(event) => { console.log('accessibility focus on title')}}
+          >{title}</Text>
           {documentationURL && (
             <RNTesterDocumentationURL documentationURL={documentationURL} />
           )}
```

and

```patch
diff --git a/packages/rn-tester/js/components/RNTPressableRow.js b/packages/rn-tester/js/components/RNTPressableRow.js
index 3db9460e152..62ffcbef4d4 100644
--- a/packages/rn-tester/js/components/RNTPressableRow.js
+++ b/packages/rn-tester/js/components/RNTPressableRow.js
@@ -53,6 +53,8 @@ export default function RNTPressableRow({
           ? {backgroundColor: theme.SecondarySystemFillColor}
           : {backgroundColor: theme.SecondaryGroupedBackgroundColor},
       ]}
+      accessibilityActions={[{name: 'accessibilityFocus'}]}
+      onAccessibilityAction={() => {console.log('accessibility focus on pressable')}}
       onPress={onPress}>
       <View style={styles.topRowStyle}>
         <RNTesterComponentTitle>{title}</RNTesterComponentTitle>
```

I get

https://github.com/facebook/react-native/assets/6313316/574d5fb1-60f7-4230-ad17-790bb70cc6f3

## TODO

- [ ] support iOS as well (I am waiting to be sure that this change is OK on Android)
- [ ] update the documentation
