### PR TITLE
Add tests for HTTPS-specific behaviour

### DIFF
--- a/flow-typed/npm/selfsigned_v2.x.x.js
+++ b/flow-typed/npm/selfsigned_v2.x.x.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+declare module 'selfsigned' {
+  declare interface SelfsignedOptions {
+    /**
+     * The number of days before expiration
+     *
+     * @default 365 */
+    days?: number;
+
+    /**
+     * The date before which the certificate should not be valid
+     *
+     * @default now */
+    notBeforeDate?: Date;
+
+    /**
+     * the size for the private key in bits
+     * @default 1024
+     */
+    keySize?: number;
+    /**
+     * additional extensions for the certificate
+     */
+    extensions?: mixed[];
+    /**
+     * The signature algorithm sha256 or sha1
+     * @default "sha1"
+     */
+    algorithm?: string;
+    /**
+     * include PKCS#7 as part of the output
+     * @default false
+     */
+    pkcs7?: boolean;
+    /**
+     * generate client cert signed by the original key
+     * @default false
+     */
+    clientCertificate?: boolean;
+    /**
+     * client certificate's common name
+     * @default "John Doe jdoe123"
+     */
+    clientCertificateCN?: string;
+    /**
+     * the size for the client private key in bits
+     * @default 1024
+     */
+    clientCertificateKeySize?: number;
+  }
+
+  declare interface GenerateResult {
+    private: string;
+    public: string;
+    cert: string;
+    fingerprint: string;
+  }
+
+  declare export function generate(
+    attrs?: pki$CertificateField[],
+    opts?: SelfsignedOptions,
+  ): GenerateResult;
+
+  declare export function generate(
+    attrs?: pki$CertificateField[],
+    opts?: SelfsignedOptions,
+    /** Optional callback, if not provided the generation is synchronous */
+    done?: (err: void | Error, result: GenerateResult) => mixed,
+  ): void;
+
+  // definitions from node-forge's `pki` and `asn1` namespaces
+  declare interface pki$CertificateFieldOptions {
+    name?: string | void;
+    type?: string | void;
+    shortName?: string | void;
+  }
+
+  declare enum asn1$Class {
+    UNIVERSAL = 0x00,
+    APPLICATION = 0x40,
+    CONTEXT_SPECIFIC = 0x80,
+    PRIVATE = 0xc0,
+  }
+
+  declare interface pki$CertificateField extends pki$CertificateFieldOptions {
+    valueConstructed?: boolean | void;
+    valueTagClass?: asn1$Class | void;
+    value?: mixed[] | string | void;
+    extensions?: mixed[] | void;
+  }
+}

--- a/flow-typed/npm/undici_v5.x.x.js
+++ b/flow-typed/npm/undici_v5.x.x.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+// Very incomplete types for the undici package.
+
+declare interface undici$Agent$Options {
+  connect?: tls$connectOptions;
+}
+
+declare module 'undici' {
+  declare export class Dispatcher extends events$EventEmitter {
+    constructor(): void;
+  }
+
+  declare export class Agent extends Dispatcher {
+    constructor(opts?: undici$Agent$Options): void;
+  }
+}

--- a/flow-typed/npm/wait-for-expect_v3.x.x.js
+++ b/flow-typed/npm/wait-for-expect_v3.x.x.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+declare module 'wait-for-expect' {
+  declare export default ((
+    expectation: () => void | Promise<void>,
+    timeout?: number,
+    interval?: number,
+  ) => Promise<void>) & {
+    defaults: {
+      timeout: number,
+      interval: number,
+    },
+  };
+}

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -35,5 +35,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "devDependencies": {
+    "wait-for-expect": "^3.0.2"
   }
 }

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -30,6 +30,7 @@
     "debug": "^2.2.0",
     "node-fetch": "^2.2.0",
     "open": "^7.0.3",
+    "selfsigned": "^2.4.1",
     "serve-static": "^1.13.1",
     "temp-dir": "^2.0.0"
   },
@@ -37,6 +38,7 @@
     "node": ">=18"
   },
   "devDependencies": {
+    "undici": "^5.27.2",
     "wait-for-expect": "^3.0.2"
   }
 }

--- a/packages/dev-middleware/src/__tests__/FetchUtils.js
+++ b/packages/dev-middleware/src/__tests__/FetchUtils.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+export async function fetchJson(url: string): Promise<mixed> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/packages/dev-middleware/src/__tests__/FetchUtils.js
+++ b/packages/dev-middleware/src/__tests__/FetchUtils.js
@@ -9,7 +9,9 @@
  * @oncall react_native
  */
 
-export async function fetchJson(url: string): Promise<mixed> {
+import type {JSONSerializable} from '../inspector-proxy/types';
+
+export async function fetchJson(url: string): Promise<JSONSerializable> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} ${response.statusText}`);

--- a/packages/dev-middleware/src/__tests__/FetchUtils.js
+++ b/packages/dev-middleware/src/__tests__/FetchUtils.js
@@ -11,8 +11,33 @@
 
 import type {JSONSerializable} from '../inspector-proxy/types';
 
-export async function fetchJson(url: string): Promise<JSONSerializable> {
-  const response = await fetch(url);
+import {Agent} from 'undici';
+
+/**
+ * A version of `fetch` that is usable with the HTTPS server created in
+ * ServerUtils (which uses a self-signed certificate).
+ */
+export async function fetchLocal(
+  url: string,
+  options?: Parameters<typeof fetch>[1] & {dispatcher?: mixed},
+): ReturnType<typeof fetch> {
+  return await fetch(url, {
+    ...options,
+    // Node's native `fetch` comes from undici and supports the same options,
+    // including `dispatcher` which we use to make it accept self-signed
+    // certificates.
+    dispatcher:
+      options?.dispatcher ??
+      new Agent({
+        connect: {
+          rejectUnauthorized: false,
+        },
+      }),
+  });
+}
+
+export async function fetchJson<T: JSONSerializable>(url: string): Promise<T> {
+  const response = await fetchLocal(url);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} ${response.statusText}`);
   }

--- a/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
@@ -19,7 +19,10 @@ export class DebuggerAgent {
   _readyPromise: Promise<void>;
 
   constructor(url: string, signal?: AbortSignal) {
-    const ws = new WebSocket(url);
+    const ws = new WebSocket(url, {
+      // The mock server uses a self-signed certificate.
+      rejectUnauthorized: false,
+    });
     this._ws = ws;
     ws.on('message', data => {
       this.__handle(JSON.parse(data.toString()));

--- a/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {JSONSerializable} from '../inspector-proxy/types';
+
+import nullthrows from 'nullthrows';
+import WebSocket from 'ws';
+
+export class DebuggerAgent {
+  _ws: ?WebSocket;
+  _readyPromise: Promise<void>;
+
+  constructor(url: string, signal?: AbortSignal) {
+    const ws = new WebSocket(url);
+    this._ws = ws;
+    ws.on('message', data => {
+      this.__handle(JSON.parse(data.toString()));
+    });
+    if (signal != null) {
+      signal.addEventListener('abort', () => {
+        this.close();
+      });
+    }
+    this._readyPromise = new Promise<void>((resolve, reject) => {
+      ws.once('open', () => {
+        resolve();
+      });
+      ws.once('error', error => {
+        reject(error);
+      });
+    });
+  }
+
+  __handle(message: JSONSerializable): void {}
+
+  send(message: JSONSerializable) {
+    if (!this._ws) {
+      return;
+    }
+    this._ws.send(JSON.stringify(message));
+  }
+
+  ready(): Promise<void> {
+    return this._readyPromise;
+  }
+
+  close() {
+    if (!this._ws) {
+      return;
+    }
+    try {
+      this._ws.terminate();
+    } catch {}
+    this._ws = null;
+  }
+
+  // $FlowIgnore[unsafe-getters-setters]
+  get socket(): WebSocket {
+    return nullthrows(this._ws);
+  }
+}
+
+export class DebuggerMock extends DebuggerAgent {
+  // Empty handlers
+  +handle: JestMockFn<[message: JSONSerializable], void> = jest.fn();
+
+  __handle(message: JSONSerializable): void {
+    this.handle(message);
+  }
+}
+
+export async function createDebuggerMock(
+  url: string,
+  signal: AbortSignal,
+): Promise<DebuggerMock> {
+  const debuggerMock = new DebuggerMock(url, signal);
+  await debuggerMock.ready();
+  return debuggerMock;
+}

--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -92,6 +92,10 @@ export class DeviceMock extends DeviceAgent {
     | void,
   > = jest.fn();
   +wrappedEvent: JestMockFn<[message: WrappedEvent], void> = jest.fn();
+  +wrappedEventParsed: JestMockFn<
+    [payload: {...WrappedEvent['payload'], wrappedEvent: JSONSerializable}],
+    void,
+  > = jest.fn();
 
   __handle(message: MessageToDevice): void {
     switch (message.event) {
@@ -107,6 +111,10 @@ export class DeviceMock extends DeviceAgent {
         break;
       case 'wrappedEvent':
         this.wrappedEvent(message);
+        this.wrappedEventParsed({
+          ...message.payload,
+          wrappedEvent: JSON.parse(message.payload.wrappedEvent),
+        });
         break;
       default:
         (message: empty);

--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -27,7 +27,10 @@ export class DeviceAgent {
   _readyPromise: Promise<void>;
 
   constructor(url: string, signal?: AbortSignal) {
-    const ws = new WebSocket(url);
+    const ws = new WebSocket(url, {
+      // The mock server uses a self-signed certificate.
+      rejectUnauthorized: false,
+    });
     this._ws = ws;
     ws.on('message', data => {
       this.__handle(JSON.parse(data.toString()));

--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {
+  ConnectRequest,
+  DisconnectRequest,
+  GetPagesRequest,
+  GetPagesResponse,
+  MessageFromDevice,
+  MessageToDevice,
+  WrappedEvent,
+} from '../inspector-proxy/types';
+
+import WebSocket from 'ws';
+
+export class DeviceAgent {
+  _ws: ?WebSocket;
+  _readyPromise: Promise<void>;
+
+  constructor(url: string, signal?: AbortSignal) {
+    const ws = new WebSocket(url);
+    this._ws = ws;
+    ws.on('message', data => {
+      this.__handle(JSON.parse(data.toString()));
+    });
+    if (signal != null) {
+      signal.addEventListener('abort', () => {
+        this.close();
+      });
+    }
+    this._readyPromise = new Promise<void>((resolve, reject) => {
+      ws.once('open', () => {
+        resolve();
+      });
+      ws.once('error', error => {
+        reject(error);
+      });
+    });
+  }
+
+  __handle(message: MessageToDevice): void {}
+
+  send(message: MessageFromDevice) {
+    if (!this._ws) {
+      return;
+    }
+    this._ws.send(JSON.stringify(message));
+  }
+
+  ready(): Promise<void> {
+    return this._readyPromise;
+  }
+
+  close() {
+    if (!this._ws) {
+      return;
+    }
+    try {
+      this._ws.terminate();
+    } catch {}
+    this._ws = null;
+  }
+}
+
+export class DeviceMock extends DeviceAgent {
+  // Empty handlers
+  +connect: JestMockFn<[message: ConnectRequest], void> = jest.fn();
+  +disconnect: JestMockFn<[message: DisconnectRequest], void> = jest.fn();
+  +getPages: JestMockFn<
+    [message: GetPagesRequest],
+    | GetPagesResponse['payload']
+    | Promise<GetPagesResponse['payload'] | void>
+    | void,
+  > = jest.fn();
+  +wrappedEvent: JestMockFn<[message: WrappedEvent], void> = jest.fn();
+
+  __handle(message: MessageToDevice): void {
+    switch (message.event) {
+      case 'connect':
+        this.connect(message);
+        break;
+      case 'disconnect':
+        this.disconnect(message);
+        break;
+      case 'getPages':
+        const result = this.getPages(message);
+        this._sendPayloadIfNonNull('getPages', result);
+        break;
+      case 'wrappedEvent':
+        this.wrappedEvent(message);
+        break;
+      default:
+        (message: empty);
+        throw new Error(`Unhandled event ${message.event}`);
+    }
+  }
+
+  _sendPayloadIfNonNull<Event: MessageFromDevice['event']>(
+    event: Event,
+    maybePayload:
+      | MessageFromDevice['payload']
+      | Promise<MessageFromDevice['payload'] | void>
+      | void,
+  ) {
+    if (maybePayload == null) {
+      return;
+    }
+    if (maybePayload instanceof Promise) {
+      // eslint-disable-next-line no-void
+      void maybePayload.then(payload => {
+        if (!payload) {
+          return;
+        }
+        // $FlowFixMe[incompatible-call] TODO(moti) Figure out the right way to type maybePayload generically
+        this.send({event, payload});
+      });
+      return;
+    }
+    // $FlowFixMe[incompatible-call] TODO(moti) Figure out the right way to type maybePayload generically
+    this.send({event, payload: maybePayload});
+  }
+}
+
+export async function createDeviceMock(
+  url: string,
+  signal: AbortSignal,
+): Promise<DeviceMock> {
+  const device = new DeviceMock(url, signal);
+  await device.ready();
+  return device;
+}

--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -14,6 +14,7 @@ import type {
   DisconnectRequest,
   GetPagesRequest,
   GetPagesResponse,
+  JSONSerializable,
   MessageFromDevice,
   MessageToDevice,
   WrappedEvent,
@@ -67,6 +68,16 @@ export class DeviceAgent {
       this._ws.terminate();
     } catch {}
     this._ws = null;
+  }
+
+  sendWrappedEvent(pageId: string, event: JSONSerializable) {
+    this.send({
+      event: 'wrappedEvent',
+      payload: {
+        pageId,
+        wrappedEvent: JSON.stringify(event),
+      },
+    });
   }
 }
 

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -73,14 +73,11 @@ describe('inspector proxy CDP transport', () => {
 
         await until(() => expect(device1.wrappedEvent).toBeCalled());
 
-        expect(device1.wrappedEvent).toBeCalledWith({
-          event: 'wrappedEvent',
-          payload: {
-            pageId: 'page1',
-            wrappedEvent: JSON.stringify({
-              method: 'Runtime.enable',
-              id: 0,
-            }),
+        expect(device1.wrappedEventParsed).toBeCalledWith({
+          pageId: 'page1',
+          wrappedEvent: {
+            method: 'Runtime.enable',
+            id: 0,
           },
         });
 

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {PageDescription} from '../inspector-proxy/types';
+
+import {fetchJson} from './FetchUtils';
+import {createDebuggerMock} from './InspectorDebuggerUtils';
+import {createDeviceMock} from './InspectorDeviceUtils';
+import {withAbortSignalForEachTest} from './ResourceUtils';
+import {withServerForEachTest} from './ServerUtils';
+import until from 'wait-for-expect';
+
+// WebSocket is unreliable when using fake timers.
+jest.useRealTimers();
+
+jest.setTimeout(10000);
+
+describe('inspector proxy CDP transport', () => {
+  const serverRef = withServerForEachTest({
+    logger: undefined,
+    projectRoot: '',
+  });
+  const autoCleanup = withAbortSignalForEachTest();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('connection/disconnection and message from debugger to device', async () => {
+    const device1 = await createDeviceMock(
+      `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+      autoCleanup.signal,
+    );
+    try {
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      let pageList: Array<PageDescription> = [];
+      await until(async () => {
+        pageList = (await fetchJson(
+          `${serverRef.serverBaseUrl}/json`,
+          // $FlowIgnore[unclear-type]
+        ): any);
+        expect(pageList).toHaveLength(1);
+      });
+      const [{webSocketDebuggerUrl}] = pageList;
+      expect(webSocketDebuggerUrl).toBeDefined();
+
+      const debugger_ = await createDebuggerMock(
+        webSocketDebuggerUrl,
+        autoCleanup.signal,
+      );
+      try {
+        await until(() => expect(device1.connect).toBeCalled());
+
+        debugger_.send({
+          method: 'Runtime.enable',
+          id: 0,
+        });
+
+        await until(() => expect(device1.wrappedEvent).toBeCalled());
+
+        expect(device1.wrappedEvent).toBeCalledWith({
+          event: 'wrappedEvent',
+          payload: {
+            pageId: 'page1',
+            wrappedEvent: JSON.stringify({
+              method: 'Runtime.enable',
+              id: 0,
+            }),
+          },
+        });
+
+        debugger_.close();
+
+        await until(() => expect(device1.disconnect).toBeCalled());
+      } finally {
+        debugger_.close();
+      }
+    } finally {
+      device1.close();
+    }
+  });
+
+  test('message and disconnection from device to debugger', async () => {
+    const device1 = await createDeviceMock(
+      `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+      autoCleanup.signal,
+    );
+    try {
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      let pageList: Array<PageDescription> = [];
+      await until(async () => {
+        pageList = (await fetchJson(
+          `${serverRef.serverBaseUrl}/json`,
+          // $FlowIgnore[unclear-type]
+        ): any);
+        expect(pageList).toHaveLength(1);
+      });
+      const [{webSocketDebuggerUrl}] = pageList;
+      expect(webSocketDebuggerUrl).toBeDefined();
+
+      const debugger_ = await createDebuggerMock(
+        webSocketDebuggerUrl,
+        autoCleanup.signal,
+      );
+      let debuggerSocketClosed = false;
+      debugger_.socket.once('close', () => {
+        debuggerSocketClosed = true;
+      });
+      try {
+        await until(() => expect(device1.connect).toBeCalled());
+
+        device1.sendWrappedEvent('page1', {
+          id: 0,
+        });
+
+        await until(() => expect(debugger_.handle).toBeCalledWith({id: 0}));
+
+        device1.close();
+
+        await until(() => expect(debuggerSocketClosed).toBe(true));
+      } finally {
+        debugger_.close();
+      }
+    } finally {
+      device1.close();
+    }
+  });
+});

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -23,126 +23,130 @@ jest.useRealTimers();
 
 jest.setTimeout(10000);
 
-describe('inspector proxy CDP transport', () => {
-  const serverRef = withServerForEachTest({
-    logger: undefined,
-    projectRoot: '',
-  });
-  const autoCleanup = withAbortSignalForEachTest();
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+describe.each(['HTTP', 'HTTPS'])(
+  'inspector proxy CDP transport over %s',
+  protocol => {
+    const serverRef = withServerForEachTest({
+      logger: undefined,
+      projectRoot: '',
+      secure: protocol === 'HTTPS',
+    });
+    const autoCleanup = withAbortSignalForEachTest();
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
 
-  test('connection/disconnection and message from debugger to device', async () => {
-    const device1 = await createDeviceMock(
-      `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
-      autoCleanup.signal,
-    );
-    try {
-      device1.getPages.mockImplementation(() => [
-        {
-          app: 'bar-app',
-          id: 'page1',
-          title: 'bar-title',
-          vm: 'bar-vm',
-        },
-      ]);
-
-      let pageList: Array<PageDescription> = [];
-      await until(async () => {
-        pageList = (await fetchJson(
-          `${serverRef.serverBaseUrl}/json`,
-          // $FlowIgnore[unclear-type]
-        ): any);
-        expect(pageList).toHaveLength(1);
-      });
-      const [{webSocketDebuggerUrl}] = pageList;
-      expect(webSocketDebuggerUrl).toBeDefined();
-
-      const debugger_ = await createDebuggerMock(
-        webSocketDebuggerUrl,
+    test('connection/disconnection and message from debugger to device', async () => {
+      const device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
         autoCleanup.signal,
       );
       try {
-        await until(() => expect(device1.connect).toBeCalled());
+        device1.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          },
+        ]);
 
-        debugger_.send({
-          method: 'Runtime.enable',
-          id: 0,
+        let pageList: Array<PageDescription> = [];
+        await until(async () => {
+          pageList = (await fetchJson(
+            `${serverRef.serverBaseUrl}/json`,
+            // $FlowIgnore[unclear-type]
+          ): any);
+          expect(pageList).toHaveLength(1);
         });
+        const [{webSocketDebuggerUrl}] = pageList;
+        expect(webSocketDebuggerUrl).toBeDefined();
 
-        await until(() => expect(device1.wrappedEvent).toBeCalled());
+        const debugger_ = await createDebuggerMock(
+          webSocketDebuggerUrl,
+          autoCleanup.signal,
+        );
+        try {
+          await until(() => expect(device1.connect).toBeCalled());
 
-        expect(device1.wrappedEventParsed).toBeCalledWith({
-          pageId: 'page1',
-          wrappedEvent: {
+          debugger_.send({
             method: 'Runtime.enable',
             id: 0,
-          },
-        });
+          });
 
-        debugger_.close();
+          await until(() => expect(device1.wrappedEvent).toBeCalled());
 
-        await until(() => expect(device1.disconnect).toBeCalled());
+          expect(device1.wrappedEventParsed).toBeCalledWith({
+            pageId: 'page1',
+            wrappedEvent: {
+              method: 'Runtime.enable',
+              id: 0,
+            },
+          });
+
+          debugger_.close();
+
+          await until(() => expect(device1.disconnect).toBeCalled());
+        } finally {
+          debugger_.close();
+        }
       } finally {
-        debugger_.close();
+        device1.close();
       }
-    } finally {
-      device1.close();
-    }
-  });
+    });
 
-  test('message and disconnection from device to debugger', async () => {
-    const device1 = await createDeviceMock(
-      `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
-      autoCleanup.signal,
-    );
-    try {
-      device1.getPages.mockImplementation(() => [
-        {
-          app: 'bar-app',
-          id: 'page1',
-          title: 'bar-title',
-          vm: 'bar-vm',
-        },
-      ]);
-
-      let pageList: Array<PageDescription> = [];
-      await until(async () => {
-        pageList = (await fetchJson(
-          `${serverRef.serverBaseUrl}/json`,
-          // $FlowIgnore[unclear-type]
-        ): any);
-        expect(pageList).toHaveLength(1);
-      });
-      const [{webSocketDebuggerUrl}] = pageList;
-      expect(webSocketDebuggerUrl).toBeDefined();
-
-      const debugger_ = await createDebuggerMock(
-        webSocketDebuggerUrl,
+    test('message and disconnection from device to debugger', async () => {
+      const device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
         autoCleanup.signal,
       );
-      let debuggerSocketClosed = false;
-      debugger_.socket.once('close', () => {
-        debuggerSocketClosed = true;
-      });
       try {
-        await until(() => expect(device1.connect).toBeCalled());
+        device1.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          },
+        ]);
 
-        device1.sendWrappedEvent('page1', {
-          id: 0,
+        let pageList: Array<PageDescription> = [];
+        await until(async () => {
+          pageList = (await fetchJson(
+            `${serverRef.serverBaseUrl}/json`,
+            // $FlowIgnore[unclear-type]
+          ): any);
+          expect(pageList).toHaveLength(1);
         });
+        const [{webSocketDebuggerUrl}] = pageList;
+        expect(webSocketDebuggerUrl).toBeDefined();
 
-        await until(() => expect(debugger_.handle).toBeCalledWith({id: 0}));
+        const debugger_ = await createDebuggerMock(
+          webSocketDebuggerUrl,
+          autoCleanup.signal,
+        );
+        let debuggerSocketClosed = false;
+        debugger_.socket.once('close', () => {
+          debuggerSocketClosed = true;
+        });
+        try {
+          await until(() => expect(device1.connect).toBeCalled());
 
-        device1.close();
+          device1.sendWrappedEvent('page1', {
+            id: 0,
+          });
 
-        await until(() => expect(debuggerSocketClosed).toBe(true));
+          await until(() => expect(debugger_.handle).toBeCalledWith({id: 0}));
+
+          device1.close();
+
+          await until(() => expect(debuggerSocketClosed).toBe(true));
+        } finally {
+          debugger_.close();
+        }
       } finally {
-        debugger_.close();
+        device1.close();
       }
-    } finally {
-      device1.close();
-    }
-  });
-});
+    });
+  },
+);

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {fetchJson} from './FetchUtils';
+import {createDeviceMock} from './InspectorDeviceUtils';
+import {withAbortSignalForEachTest} from './ResourceUtils';
+import {withServerForEachTest} from './ServerUtils';
+
+// Must be greater than or equal to PAGES_POLLING_INTERVAL in `InspectorProxy.js`.
+const PAGES_POLLING_DELAY = 1000;
+
+jest.useFakeTimers();
+
+describe('inspector proxy HTTP API', () => {
+  const serverRef = withServerForEachTest({
+    logger: undefined,
+    projectRoot: '',
+  });
+  const autoCleanup = withAbortSignalForEachTest();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('/json/version endpoint', () => {
+    test('returns version', async () => {
+      const json = await fetchJson(`${serverRef.serverBaseUrl}/json/version`);
+      expect(json).toMatchSnapshot();
+    });
+  });
+
+  describe.each(['/json', '/json/list'])('%s endpoint', endpoint => {
+    test('empty on start', async () => {
+      const json = await fetchJson(`${serverRef.serverBaseUrl}${endpoint}`);
+      expect(json).toEqual([]);
+    });
+
+    test('updates page details through polling', async () => {
+      const device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      try {
+        device1.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          },
+        ]);
+
+        jest.advanceTimersByTime(PAGES_POLLING_DELAY);
+
+        const jsonBefore = await fetchJson(
+          `${serverRef.serverBaseUrl}${endpoint}`,
+        );
+
+        device1.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1-updated',
+            title: 'bar-title-updated',
+            vm: 'bar-vm-updated',
+          },
+        ]);
+
+        jest.advanceTimersByTime(PAGES_POLLING_DELAY);
+
+        const jsonAfter = await fetchJson(
+          `${serverRef.serverBaseUrl}${endpoint}`,
+        );
+
+        expect(jsonBefore).toEqual([
+          expect.objectContaining({
+            id: 'device1-page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          }),
+        ]);
+
+        expect(jsonAfter).toEqual([
+          expect.objectContaining({
+            id: 'device1-page1-updated',
+            title: 'bar-title-updated',
+            vm: 'bar-vm-updated',
+          }),
+        ]);
+      } finally {
+        device1.close();
+      }
+    });
+
+    test('returns to empty on device disconnect', async () => {
+      const device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      try {
+        device1.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          },
+        ]);
+
+        jest.advanceTimersByTime(PAGES_POLLING_DELAY);
+
+        const jsonBefore = await fetchJson(
+          `${serverRef.serverBaseUrl}${endpoint}`,
+        );
+
+        device1.close();
+
+        const jsonAfter = await fetchJson(
+          `${serverRef.serverBaseUrl}${endpoint}`,
+        );
+
+        expect(jsonBefore).toEqual([
+          expect.objectContaining({
+            id: 'device1-page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          }),
+        ]);
+
+        expect(jsonAfter).toEqual([]);
+      } finally {
+        device1.close();
+      }
+    });
+
+    test('reports pages from two connected devices', async () => {
+      const device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      const device2 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device2&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      device2.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      // Ensure polling has happened a few times
+      jest.advanceTimersByTime(10 * PAGES_POLLING_DELAY);
+
+      try {
+        const json = await fetchJson(`${serverRef.serverBaseUrl}${endpoint}`);
+        expect(json).toEqual([
+          {
+            description: 'bar-app',
+            deviceName: 'foo',
+            devtoolsFrontendUrl: expect.any(String),
+            faviconUrl: 'https://reactjs.org/favicon.ico',
+            id: 'device1-page1',
+            reactNative: {
+              logicalDeviceId: 'device1',
+            },
+            title: 'bar-title',
+            type: 'node',
+            vm: 'bar-vm',
+            webSocketDebuggerUrl: expect.any(String),
+          },
+          {
+            description: 'bar-app',
+            deviceName: 'foo',
+            devtoolsFrontendUrl: expect.any(String),
+            faviconUrl: 'https://reactjs.org/favicon.ico',
+            id: 'device2-page1',
+            reactNative: {
+              logicalDeviceId: 'device2',
+            },
+            title: 'bar-title',
+            type: 'node',
+            vm: 'bar-vm',
+            webSocketDebuggerUrl: expect.any(String),
+          },
+        ]);
+      } finally {
+        device1.close();
+        device2.close();
+      }
+    });
+  });
+});

--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {fetchJson} from './FetchUtils';
+import {createDebuggerMock} from './InspectorDebuggerUtils';
+import {createDeviceMock} from './InspectorDeviceUtils';
+import {withAbortSignalForEachTest} from './ResourceUtils';
+import {withServerForEachTest} from './ServerUtils';
+import invariant from 'invariant';
+import until from 'wait-for-expect';
+
+// WebSocket is unreliable when using fake timers.
+jest.useRealTimers();
+
+jest.setTimeout(10000);
+
+describe('inspector proxy React Native reloads', () => {
+  const serverRef = withServerForEachTest({
+    logger: undefined,
+    projectRoot: '',
+  });
+  const autoCleanup = withAbortSignalForEachTest();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('routing messages from the debugger to the latest React Native page', async () => {
+    let device1, debugger_;
+    try {
+      /***
+       * Connect a device with one React Native page.
+       */
+      device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar',
+          id: 'originalPage-initial',
+          // NOTE: 'React' is a magic string used to detect React Native pages.
+          title: 'React Native (mock)',
+          vm: 'vm',
+        },
+      ]);
+      let pageList;
+      await until(async () => {
+        pageList = (await fetchJson(
+          `${serverRef.serverBaseUrl}/json`,
+          // $FlowIgnore[unclear-type]
+        ): any);
+        expect(pageList.length).toBeGreaterThan(0);
+      });
+      invariant(pageList != null, '');
+
+      /***
+       * The proxy reports *two* pages.
+       */
+      const syntheticPage = pageList.find(
+        ({title}) =>
+          // NOTE: Magic string used for the synthetic page that has a stable ID
+          title === 'React Native Experimental (Improved Chrome Reloads)',
+      );
+      const originalPage = pageList.find(
+        ({title}) => title === 'React Native (mock)',
+      );
+      expect(syntheticPage).not.toBeUndefined();
+      expect(originalPage).not.toBeUndefined();
+      expect(originalPage.id).toContain('originalPage-initial');
+      expect(syntheticPage.id).not.toEqual(originalPage.id);
+
+      // Connect to the synthetic page
+      debugger_ = await createDebuggerMock(
+        syntheticPage.webSocketDebuggerUrl,
+        autoCleanup.signal,
+      );
+
+      debugger_.send({
+        method: 'Console.enable',
+        id: 0,
+      });
+
+      await until(() =>
+        expect(device1.wrappedEventParsed).toBeCalledWith({
+          pageId: 'originalPage-initial',
+          wrappedEvent: {
+            method: 'Console.enable',
+            id: 0,
+          },
+        }),
+      );
+
+      /**
+       * Replace our original page with a new one.
+       */
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar',
+          id: 'originalPage-updated',
+          // NOTE: 'React' is a magic string used to detect React Native pages.
+          title: 'React Native (mock)',
+          vm: 'vm',
+        },
+      ]);
+      await until(async () => {
+        pageList = (await fetchJson(
+          `${serverRef.serverBaseUrl}/json`,
+          // $FlowIgnore[unclear-type]
+        ): any);
+        expect(pageList).toContainEqual(
+          expect.objectContaining({
+            id: expect.stringContaining('originalPage-updated'),
+          }),
+        );
+      });
+
+      /**
+       * We can reuse our existing debugger connection to the synthetic page.
+       * Messages will be routed to the updated page.
+       */
+      debugger_.send({
+        method: 'Console.disable',
+        id: 1,
+      });
+
+      await until(() =>
+        expect(device1.wrappedEventParsed).toBeCalledWith({
+          pageId: 'originalPage-updated',
+          wrappedEvent: {
+            method: 'Console.disable',
+            id: 1,
+          },
+        }),
+      );
+    } finally {
+      device1?.close();
+      debugger_?.close();
+    }
+  });
+
+  test('routing messages from the latest React Native page to the debugger', async () => {
+    let device1, debugger_;
+    try {
+      /***
+       * Connect a device with one React Native page.
+       */
+      device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar',
+          id: 'originalPage-initial',
+          // NOTE: 'React' is a magic string used to detect React Native pages.
+          title: 'React Native (mock)',
+          vm: 'vm',
+        },
+      ]);
+      let pageList;
+      await until(async () => {
+        pageList = (await fetchJson(
+          `${serverRef.serverBaseUrl}/json`,
+          // $FlowIgnore[unclear-type]
+        ): any);
+        expect(pageList.length).toBeGreaterThan(0);
+      });
+      invariant(pageList != null, '');
+
+      /***
+       * The proxy reports *two* pages.
+       */
+      const syntheticPage = pageList.find(
+        ({title}) =>
+          // NOTE: Magic string used for the synthetic page that has a stable ID
+          title === 'React Native Experimental (Improved Chrome Reloads)',
+      );
+      const originalPage = pageList.find(
+        ({title}) => title === 'React Native (mock)',
+      );
+      expect(syntheticPage).not.toBeUndefined();
+      expect(originalPage).not.toBeUndefined();
+      expect(originalPage.id).toContain('originalPage-initial');
+      expect(syntheticPage.id).not.toEqual(originalPage.id);
+
+      // Connect to the synthetic page
+      debugger_ = await createDebuggerMock(
+        syntheticPage.webSocketDebuggerUrl,
+        autoCleanup.signal,
+      );
+
+      device1.sendWrappedEvent('originalPage-initial', {
+        error: 'Mock error',
+      });
+
+      await until(() =>
+        expect(debugger_.handle).toBeCalledWith({
+          error: 'Mock error',
+        }),
+      );
+
+      /**
+       * Replace our original page with a new one.
+       */
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar',
+          id: 'originalPage-updated',
+          // NOTE: 'React' is a magic string used to detect React Native pages.
+          title: 'React Native (mock)',
+          vm: 'vm',
+        },
+      ]);
+      await until(async () => {
+        pageList = (await fetchJson(
+          `${serverRef.serverBaseUrl}/json`,
+          // $FlowIgnore[unclear-type]
+        ): any);
+        expect(pageList).toContainEqual(
+          expect.objectContaining({
+            id: expect.stringContaining('originalPage-updated'),
+          }),
+        );
+      });
+
+      /**
+       * We can reuse our existing debugger connection to the synthetic page.
+       * Messages from the updated page will be routed to the debugger.
+       */
+      device1.sendWrappedEvent('originalPage-initial', {
+        error: 'Another mock error',
+      });
+
+      await until(() =>
+        expect(debugger_.handle).toBeCalledWith({
+          error: 'Another mock error',
+        }),
+      );
+    } finally {
+      device1?.close();
+      debugger_?.close();
+    }
+  });
+});

--- a/packages/dev-middleware/src/__tests__/ResourceUtils.js
+++ b/packages/dev-middleware/src/__tests__/ResourceUtils.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+export function withAbortSignalForEachTest(): $ReadOnly<{signal: AbortSignal}> {
+  const ref: {signal: AbortSignal} = {
+    // $FlowIgnore[unsafe-getters-setters]
+    get signal() {
+      throw new Error(
+        'The return value of withAbortSignalForEachTest is lazily initialized and can only be accessed in tests.',
+      );
+    },
+  };
+  let controller;
+  beforeEach(() => {
+    controller = new AbortController();
+    Object.defineProperty(ref, 'signal', {
+      value: controller.signal,
+    });
+  });
+  afterEach(() => {
+    controller.abort();
+  });
+  return ref;
+}

--- a/packages/dev-middleware/src/__tests__/ServerUtils.js
+++ b/packages/dev-middleware/src/__tests__/ServerUtils.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {createDevMiddleware} from '../';
+import connect from 'connect';
+import http from 'http';
+import url from 'url';
+
+type CreateDevMiddlewareOptions = Parameters<typeof createDevMiddleware>[0];
+type CreateServerOptions = Omit<CreateDevMiddlewareOptions, 'serverBaseUrl'>;
+
+export function withServerForEachTest(options: CreateServerOptions): $ReadOnly<{
+  serverBaseUrl: string,
+  serverBaseWsUrl: string,
+}> {
+  const ref: {serverBaseUrl: string, serverBaseWsUrl: string} = {
+    // $FlowIgnore[unsafe-getters-setters]
+    get serverBaseUrl() {
+      throw new Error(
+        'The return value of withServerForEachTest is lazily initialized and can only be accessed in tests.',
+      );
+    },
+    // $FlowIgnore[unsafe-getters-setters]
+    get serverBaseWsUrl() {
+      throw new Error(
+        'The return value of withServerForEachTest is lazily initialized and can only be accessed in tests.',
+      );
+    },
+  };
+  let server: http$Server;
+  beforeEach(async () => {
+    server = await createServer(options);
+    const serverBaseUrl = baseUrlForServer(server, 'http');
+    const serverBaseWsUrl = baseUrlForServer(server, 'ws');
+    Object.defineProperty(ref, 'serverBaseUrl', {value: serverBaseUrl});
+    Object.defineProperty(ref, 'serverBaseWsUrl', {value: serverBaseWsUrl});
+  });
+  afterEach(done => {
+    server.close(() => done());
+  });
+  return ref;
+}
+
+export async function createServer(
+  options: CreateServerOptions,
+): Promise<http$Server> {
+  const app = connect();
+  const httpServer = http.createServer(app);
+
+  return new Promise((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(() => {
+      const {middleware, websocketEndpoints} = createDevMiddleware({
+        ...options,
+        serverBaseUrl: baseUrlForServer(httpServer, 'http'),
+      });
+      app.use(middleware);
+      httpServer.on('upgrade', (request, socket, head) => {
+        const {pathname} = url.parse(request.url);
+        if (pathname != null && websocketEndpoints[pathname]) {
+          websocketEndpoints[pathname].handleUpgrade(
+            request,
+            socket,
+            head,
+            ws => {
+              websocketEndpoints[pathname].emit('connection', ws, request);
+            },
+          );
+        } else {
+          socket.destroy();
+        }
+      });
+      resolve(httpServer);
+    });
+  });
+}
+
+export function baseUrlForServer(server: http$Server, scheme: string): string {
+  const address = server.address();
+  // Assumption: `server` is local and listening on `localhost`.
+  return `${scheme}://localhost:${address.port}`;
+}

--- a/packages/dev-middleware/src/__tests__/__snapshots__/InspectorProxyHttpApi-test.js.snap
+++ b/packages/dev-middleware/src/__tests__/__snapshots__/InspectorProxyHttpApi-test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inspector proxy HTTP API /json/version endpoint returns version 1`] = `
+Object {
+  "Browser": "Mobile JavaScript",
+  "Protocol-Version": "1.1",
+}
+`;

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -138,5 +138,5 @@ export type JSONSerializable =
   | number
   | string
   | null
-  | Array<JSONSerializable>
-  | {[string]: JSONSerializable};
+  | $ReadOnlyArray<JSONSerializable>
+  | {+[string]: JSONSerializable};

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -132,3 +132,11 @@ export type ErrorResponse = $ReadOnly<{
 export type DebuggerRequest =
   | SetBreakpointByUrlRequest
   | GetScriptSourceRequest;
+
+export type JSONSerializable =
+  | boolean
+  | number
+  | string
+  | null
+  | Array<JSONSerializable>
+  | {[string]: JSONSerializable};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9319,6 +9319,11 @@ vlq@^1.0.0:
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
   integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
 
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 walker@^1.0.7, walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,6 +1366,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@fastify/busboy@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.0.0.tgz#f22824caff3ae506b18207bad4126dbc6ccdb6b8"
+  integrity sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==
+
 "@firebase/analytics-compat@0.1.13":
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.1.13.tgz#61e1d6f9e4d033c3ed9943d91530eb3e0f382f92"
@@ -2744,6 +2749,13 @@
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
+
+"@types/node-forge@^1.3.0":
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-1.3.8.tgz#044ad98354ff309a031a55a40ad122f3be1ac2bb"
+  integrity sha512-vGXshY9vim9CJjrpcS5raqSjEfKlJcWy2HNdgUasR66fAnVEYarrf1ULV4nfvpC1nZq/moA9qyqBcu83x+Jlrg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^18.0.0":
   version "18.16.14"
@@ -7417,6 +7429,11 @@ node-fetch@2.6.7, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-forge@^1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -8474,6 +8491,14 @@ selenium-webdriver@4.1.2:
     tmp "^0.2.1"
     ws ">=7.4.6"
 
+selfsigned@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.4.1.tgz#560d90565442a3ed35b674034cec4e95dceb4ae0"
+  integrity sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==
+  dependencies:
+    "@types/node-forge" "^1.3.0"
+    node-forge "^1"
+
 "semver@2 >=2.2.1 || 3.x || 4 || 5 || 7", semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
@@ -9197,6 +9222,13 @@ unbzip2-stream@1.4.3:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
+
+undici@^5.27.2:
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.27.2.tgz#a270c563aea5b46cc0df2550523638c95c5d4411"
+  integrity sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Summary:
* Extends `dev-middleware`'s test utilities to enable testing against an HTTPS server with a self-signed cert.
* Runs the CDP transport integration tests (D51002261) using both HTTP and HTTPS.
* Adds a test to explicitly cover the `ws=...` / `wss=...` variation in `devtoolsFrontendUrl` first introduced in D49158227.

Differential Revision: D51006835

