### PR TITLE
Add CDP transport tests

### DIFF
--- a/flow-typed/npm/wait-for-expect_v3.x.x.js
+++ b/flow-typed/npm/wait-for-expect_v3.x.x.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+declare module 'wait-for-expect' {
+  declare export default ((
+    expectation: () => void | Promise<void>,
+    timeout?: number,
+    interval?: number,
+  ) => Promise<void>) & {
+    defaults: {
+      timeout: number,
+      interval: number,
+    },
+  };
+}

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -35,5 +35,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "devDependencies": {
+    "wait-for-expect": "^3.0.2"
   }
 }

--- a/packages/dev-middleware/src/__tests__/FetchUtils.js
+++ b/packages/dev-middleware/src/__tests__/FetchUtils.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+export async function fetchJson(url: string): Promise<mixed> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/packages/dev-middleware/src/__tests__/FetchUtils.js
+++ b/packages/dev-middleware/src/__tests__/FetchUtils.js
@@ -9,7 +9,9 @@
  * @oncall react_native
  */
 
-export async function fetchJson(url: string): Promise<mixed> {
+import type {JSONSerializable} from '../inspector-proxy/types';
+
+export async function fetchJson(url: string): Promise<JSONSerializable> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} ${response.statusText}`);

--- a/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {JSONSerializable} from '../inspector-proxy/types';
+
+import nullthrows from 'nullthrows';
+import WebSocket from 'ws';
+
+export class DebuggerAgent {
+  _ws: ?WebSocket;
+  _readyPromise: Promise<void>;
+
+  constructor(url: string, signal?: AbortSignal) {
+    const ws = new WebSocket(url);
+    this._ws = ws;
+    ws.on('message', data => {
+      this.__handle(JSON.parse(data.toString()));
+    });
+    if (signal != null) {
+      signal.addEventListener('abort', () => {
+        this.close();
+      });
+    }
+    this._readyPromise = new Promise<void>((resolve, reject) => {
+      ws.once('open', () => {
+        resolve();
+      });
+      ws.once('error', error => {
+        reject(error);
+      });
+    });
+  }
+
+  __handle(message: JSONSerializable): void {}
+
+  send(message: JSONSerializable) {
+    if (!this._ws) {
+      return;
+    }
+    this._ws.send(JSON.stringify(message));
+  }
+
+  ready(): Promise<void> {
+    return this._readyPromise;
+  }
+
+  close() {
+    if (!this._ws) {
+      return;
+    }
+    try {
+      this._ws.terminate();
+    } catch {}
+    this._ws = null;
+  }
+
+  // $FlowIgnore[unsafe-getters-setters]
+  get socket(): WebSocket {
+    return nullthrows(this._ws);
+  }
+}
+
+export class DebuggerMock extends DebuggerAgent {
+  // Empty handlers
+  +handle: JestMockFn<[message: JSONSerializable], void> = jest.fn();
+
+  __handle(message: JSONSerializable): void {
+    this.handle(message);
+  }
+}
+
+export async function createDebuggerMock(
+  url: string,
+  signal: AbortSignal,
+): Promise<DebuggerMock> {
+  const debuggerMock = new DebuggerMock(url, signal);
+  await debuggerMock.ready();
+  return debuggerMock;
+}

--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {
+  ConnectRequest,
+  DisconnectRequest,
+  GetPagesRequest,
+  GetPagesResponse,
+  MessageFromDevice,
+  MessageToDevice,
+  WrappedEvent,
+} from '../inspector-proxy/types';
+
+import WebSocket from 'ws';
+
+export class DeviceAgent {
+  _ws: ?WebSocket;
+  _readyPromise: Promise<void>;
+
+  constructor(url: string, signal?: AbortSignal) {
+    const ws = new WebSocket(url);
+    this._ws = ws;
+    ws.on('message', data => {
+      this.__handle(JSON.parse(data.toString()));
+    });
+    if (signal != null) {
+      signal.addEventListener('abort', () => {
+        this.close();
+      });
+    }
+    this._readyPromise = new Promise<void>((resolve, reject) => {
+      ws.once('open', () => {
+        resolve();
+      });
+      ws.once('error', error => {
+        reject(error);
+      });
+    });
+  }
+
+  __handle(message: MessageToDevice): void {}
+
+  send(message: MessageFromDevice) {
+    if (!this._ws) {
+      return;
+    }
+    this._ws.send(JSON.stringify(message));
+  }
+
+  ready(): Promise<void> {
+    return this._readyPromise;
+  }
+
+  close() {
+    if (!this._ws) {
+      return;
+    }
+    try {
+      this._ws.terminate();
+    } catch {}
+    this._ws = null;
+  }
+}
+
+export class DeviceMock extends DeviceAgent {
+  // Empty handlers
+  +connect: JestMockFn<[message: ConnectRequest], void> = jest.fn();
+  +disconnect: JestMockFn<[message: DisconnectRequest], void> = jest.fn();
+  +getPages: JestMockFn<
+    [message: GetPagesRequest],
+    | GetPagesResponse['payload']
+    | Promise<GetPagesResponse['payload'] | void>
+    | void,
+  > = jest.fn();
+  +wrappedEvent: JestMockFn<[message: WrappedEvent], void> = jest.fn();
+
+  __handle(message: MessageToDevice): void {
+    switch (message.event) {
+      case 'connect':
+        this.connect(message);
+        break;
+      case 'disconnect':
+        this.disconnect(message);
+        break;
+      case 'getPages':
+        const result = this.getPages(message);
+        this._sendPayloadIfNonNull('getPages', result);
+        break;
+      case 'wrappedEvent':
+        this.wrappedEvent(message);
+        break;
+      default:
+        (message: empty);
+        throw new Error(`Unhandled event ${message.event}`);
+    }
+  }
+
+  _sendPayloadIfNonNull<Event: MessageFromDevice['event']>(
+    event: Event,
+    maybePayload:
+      | MessageFromDevice['payload']
+      | Promise<MessageFromDevice['payload'] | void>
+      | void,
+  ) {
+    if (maybePayload == null) {
+      return;
+    }
+    if (maybePayload instanceof Promise) {
+      // eslint-disable-next-line no-void
+      void maybePayload.then(payload => {
+        if (!payload) {
+          return;
+        }
+        // $FlowFixMe[incompatible-call] TODO(moti) Figure out the right way to type maybePayload generically
+        this.send({event, payload});
+      });
+      return;
+    }
+    // $FlowFixMe[incompatible-call] TODO(moti) Figure out the right way to type maybePayload generically
+    this.send({event, payload: maybePayload});
+  }
+}
+
+export async function createDeviceMock(
+  url: string,
+  signal: AbortSignal,
+): Promise<DeviceMock> {
+  const device = new DeviceMock(url, signal);
+  await device.ready();
+  return device;
+}

--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -14,6 +14,7 @@ import type {
   DisconnectRequest,
   GetPagesRequest,
   GetPagesResponse,
+  JSONSerializable,
   MessageFromDevice,
   MessageToDevice,
   WrappedEvent,
@@ -67,6 +68,16 @@ export class DeviceAgent {
       this._ws.terminate();
     } catch {}
     this._ws = null;
+  }
+
+  sendWrappedEvent(pageId: string, event: JSONSerializable) {
+    this.send({
+      event: 'wrappedEvent',
+      payload: {
+        pageId,
+        wrappedEvent: JSON.stringify(event),
+      },
+    });
   }
 }
 

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {PageDescription} from '../inspector-proxy/types';
+
+import {fetchJson} from './FetchUtils';
+import {createDebuggerMock} from './InspectorDebuggerUtils';
+import {createDeviceMock} from './InspectorDeviceUtils';
+import {withAbortSignalForEachTest} from './ResourceUtils';
+import {withServerForEachTest} from './ServerUtils';
+import until from 'wait-for-expect';
+
+// WebSocket is unreliable when using fake timers.
+jest.useRealTimers();
+
+jest.setTimeout(10000);
+
+describe('inspector proxy CDP transport', () => {
+  const serverRef = withServerForEachTest({
+    logger: undefined,
+    projectRoot: '',
+  });
+  const autoCleanup = withAbortSignalForEachTest();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('connection/disconnection and message from debugger to device', async () => {
+    const device1 = await createDeviceMock(
+      `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+      autoCleanup.signal,
+    );
+    try {
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      let pageList: Array<PageDescription> = [];
+      await until(async () => {
+        pageList = (await fetchJson(
+          `${serverRef.serverBaseUrl}/json`,
+          // $FlowIgnore[unclear-type]
+        ): any);
+        expect(pageList).toHaveLength(1);
+      });
+      const [{webSocketDebuggerUrl}] = pageList;
+      expect(webSocketDebuggerUrl).toBeDefined();
+
+      const debugger_ = await createDebuggerMock(
+        webSocketDebuggerUrl,
+        autoCleanup.signal,
+      );
+      try {
+        await until(() => expect(device1.connect).toBeCalled());
+
+        debugger_.send({
+          method: 'Runtime.enable',
+          id: 0,
+        });
+
+        await until(() => expect(device1.wrappedEvent).toBeCalled());
+
+        expect(device1.wrappedEvent).toBeCalledWith({
+          event: 'wrappedEvent',
+          payload: {
+            pageId: 'page1',
+            wrappedEvent: JSON.stringify({
+              method: 'Runtime.enable',
+              id: 0,
+            }),
+          },
+        });
+
+        debugger_.close();
+
+        await until(() => expect(device1.disconnect).toBeCalled());
+      } finally {
+        debugger_.close();
+      }
+    } finally {
+      device1.close();
+    }
+  });
+
+  test('message and disconnection from device to debugger', async () => {
+    const device1 = await createDeviceMock(
+      `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+      autoCleanup.signal,
+    );
+    try {
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      let pageList: Array<PageDescription> = [];
+      await until(async () => {
+        pageList = (await fetchJson(
+          `${serverRef.serverBaseUrl}/json`,
+          // $FlowIgnore[unclear-type]
+        ): any);
+        expect(pageList).toHaveLength(1);
+      });
+      const [{webSocketDebuggerUrl}] = pageList;
+      expect(webSocketDebuggerUrl).toBeDefined();
+
+      const debugger_ = await createDebuggerMock(
+        webSocketDebuggerUrl,
+        autoCleanup.signal,
+      );
+      let debuggerSocketClosed = false;
+      debugger_.socket.once('close', () => {
+        debuggerSocketClosed = true;
+      });
+      try {
+        await until(() => expect(device1.connect).toBeCalled());
+
+        device1.sendWrappedEvent('page1', {
+          id: 0,
+        });
+
+        await until(() => expect(debugger_.handle).toBeCalledWith({id: 0}));
+
+        device1.close();
+
+        await until(() => expect(debuggerSocketClosed).toBe(true));
+      } finally {
+        debugger_.close();
+      }
+    } finally {
+      device1.close();
+    }
+  });
+});

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {fetchJson} from './FetchUtils';
+import {createDeviceMock} from './InspectorDeviceUtils';
+import {withAbortSignalForEachTest} from './ResourceUtils';
+import {withServerForEachTest} from './ServerUtils';
+
+// Must be greater than or equal to PAGES_POLLING_INTERVAL in `InspectorProxy.js`.
+const PAGES_POLLING_DELAY = 1000;
+
+jest.useFakeTimers();
+
+describe('inspector proxy HTTP API', () => {
+  const serverRef = withServerForEachTest({
+    logger: undefined,
+    projectRoot: '',
+  });
+  const autoCleanup = withAbortSignalForEachTest();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('/json/version endpoint', () => {
+    test('returns version', async () => {
+      const json = await fetchJson(`${serverRef.serverBaseUrl}/json/version`);
+      expect(json).toMatchSnapshot();
+    });
+  });
+
+  describe.each(['/json', '/json/list'])('%s endpoint', endpoint => {
+    test('empty on start', async () => {
+      const json = await fetchJson(`${serverRef.serverBaseUrl}${endpoint}`);
+      expect(json).toEqual([]);
+    });
+
+    test('updates page details through polling', async () => {
+      const device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      try {
+        device1.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          },
+        ]);
+
+        jest.advanceTimersByTime(PAGES_POLLING_DELAY);
+
+        const jsonBefore = await fetchJson(
+          `${serverRef.serverBaseUrl}${endpoint}`,
+        );
+
+        device1.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1-updated',
+            title: 'bar-title-updated',
+            vm: 'bar-vm-updated',
+          },
+        ]);
+
+        jest.advanceTimersByTime(PAGES_POLLING_DELAY);
+
+        const jsonAfter = await fetchJson(
+          `${serverRef.serverBaseUrl}${endpoint}`,
+        );
+
+        expect(jsonBefore).toEqual([
+          expect.objectContaining({
+            id: 'device1-page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          }),
+        ]);
+
+        expect(jsonAfter).toEqual([
+          expect.objectContaining({
+            id: 'device1-page1-updated',
+            title: 'bar-title-updated',
+            vm: 'bar-vm-updated',
+          }),
+        ]);
+      } finally {
+        device1.close();
+      }
+    });
+
+    test('returns to empty on device disconnect', async () => {
+      const device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      try {
+        device1.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          },
+        ]);
+
+        jest.advanceTimersByTime(PAGES_POLLING_DELAY);
+
+        const jsonBefore = await fetchJson(
+          `${serverRef.serverBaseUrl}${endpoint}`,
+        );
+
+        device1.close();
+
+        const jsonAfter = await fetchJson(
+          `${serverRef.serverBaseUrl}${endpoint}`,
+        );
+
+        expect(jsonBefore).toEqual([
+          expect.objectContaining({
+            id: 'device1-page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          }),
+        ]);
+
+        expect(jsonAfter).toEqual([]);
+      } finally {
+        device1.close();
+      }
+    });
+
+    test('reports pages from two connected devices', async () => {
+      const device1 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+
+      device1.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      const device2 = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device2&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      device2.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      // Ensure polling has happened a few times
+      jest.advanceTimersByTime(10 * PAGES_POLLING_DELAY);
+
+      try {
+        const json = await fetchJson(`${serverRef.serverBaseUrl}${endpoint}`);
+        expect(json).toEqual([
+          {
+            description: 'bar-app',
+            deviceName: 'foo',
+            devtoolsFrontendUrl: expect.any(String),
+            faviconUrl: 'https://reactjs.org/favicon.ico',
+            id: 'device1-page1',
+            reactNative: {
+              logicalDeviceId: 'device1',
+            },
+            title: 'bar-title',
+            type: 'node',
+            vm: 'bar-vm',
+            webSocketDebuggerUrl: expect.any(String),
+          },
+          {
+            description: 'bar-app',
+            deviceName: 'foo',
+            devtoolsFrontendUrl: expect.any(String),
+            faviconUrl: 'https://reactjs.org/favicon.ico',
+            id: 'device2-page1',
+            reactNative: {
+              logicalDeviceId: 'device2',
+            },
+            title: 'bar-title',
+            type: 'node',
+            vm: 'bar-vm',
+            webSocketDebuggerUrl: expect.any(String),
+          },
+        ]);
+      } finally {
+        device1.close();
+        device2.close();
+      }
+    });
+  });
+});

--- a/packages/dev-middleware/src/__tests__/ResourceUtils.js
+++ b/packages/dev-middleware/src/__tests__/ResourceUtils.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+export function withAbortSignalForEachTest(): $ReadOnly<{signal: AbortSignal}> {
+  const ref: {signal: AbortSignal} = {
+    // $FlowIgnore[unsafe-getters-setters]
+    get signal() {
+      throw new Error(
+        'The return value of withAbortSignalForEachTest is lazily initialized and can only be accessed in tests.',
+      );
+    },
+  };
+  let controller;
+  beforeEach(() => {
+    controller = new AbortController();
+    Object.defineProperty(ref, 'signal', {
+      value: controller.signal,
+    });
+  });
+  afterEach(() => {
+    controller.abort();
+  });
+  return ref;
+}

--- a/packages/dev-middleware/src/__tests__/ServerUtils.js
+++ b/packages/dev-middleware/src/__tests__/ServerUtils.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {createDevMiddleware} from '../';
+import connect from 'connect';
+import http from 'http';
+import url from 'url';
+
+type CreateDevMiddlewareOptions = Parameters<typeof createDevMiddleware>[0];
+type CreateServerOptions = Omit<CreateDevMiddlewareOptions, 'serverBaseUrl'>;
+
+export function withServerForEachTest(options: CreateServerOptions): $ReadOnly<{
+  serverBaseUrl: string,
+  serverBaseWsUrl: string,
+}> {
+  const ref: {serverBaseUrl: string, serverBaseWsUrl: string} = {
+    // $FlowIgnore[unsafe-getters-setters]
+    get serverBaseUrl() {
+      throw new Error(
+        'The return value of withServerForEachTest is lazily initialized and can only be accessed in tests.',
+      );
+    },
+    // $FlowIgnore[unsafe-getters-setters]
+    get serverBaseWsUrl() {
+      throw new Error(
+        'The return value of withServerForEachTest is lazily initialized and can only be accessed in tests.',
+      );
+    },
+  };
+  let server: http$Server;
+  beforeEach(async () => {
+    server = await createServer(options);
+    const serverBaseUrl = baseUrlForServer(server, 'http');
+    const serverBaseWsUrl = baseUrlForServer(server, 'ws');
+    Object.defineProperty(ref, 'serverBaseUrl', {value: serverBaseUrl});
+    Object.defineProperty(ref, 'serverBaseWsUrl', {value: serverBaseWsUrl});
+  });
+  afterEach(done => {
+    server.close(() => done());
+  });
+  return ref;
+}
+
+export async function createServer(
+  options: CreateServerOptions,
+): Promise<http$Server> {
+  const app = connect();
+  const httpServer = http.createServer(app);
+
+  return new Promise((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(() => {
+      const {middleware, websocketEndpoints} = createDevMiddleware({
+        ...options,
+        serverBaseUrl: baseUrlForServer(httpServer, 'http'),
+      });
+      app.use(middleware);
+      httpServer.on('upgrade', (request, socket, head) => {
+        const {pathname} = url.parse(request.url);
+        if (pathname != null && websocketEndpoints[pathname]) {
+          websocketEndpoints[pathname].handleUpgrade(
+            request,
+            socket,
+            head,
+            ws => {
+              websocketEndpoints[pathname].emit('connection', ws, request);
+            },
+          );
+        } else {
+          socket.destroy();
+        }
+      });
+      resolve(httpServer);
+    });
+  });
+}
+
+export function baseUrlForServer(server: http$Server, scheme: string): string {
+  const address = server.address();
+  // Assumption: `server` is local and listening on `localhost`.
+  return `${scheme}://localhost:${address.port}`;
+}

--- a/packages/dev-middleware/src/__tests__/__snapshots__/InspectorProxyHttpApi-test.js.snap
+++ b/packages/dev-middleware/src/__tests__/__snapshots__/InspectorProxyHttpApi-test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inspector proxy HTTP API /json/version endpoint returns version 1`] = `
+Object {
+  "Browser": "Mobile JavaScript",
+  "Protocol-Version": "1.1",
+}
+`;

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -132,3 +132,11 @@ export type ErrorResponse = $ReadOnly<{
 export type DebuggerRequest =
   | SetBreakpointByUrlRequest
   | GetScriptSourceRequest;
+
+export type JSONSerializable =
+  | boolean
+  | number
+  | string
+  | null
+  | Array<JSONSerializable>
+  | {[string]: JSONSerializable};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9319,6 +9319,11 @@ vlq@^1.0.0:
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
   integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
 
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 walker@^1.0.7, walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds basic tests for two-way communication between a debugger (frontend) and a target (backend) using CDP over `inspector-proxy`.

Differential Revision: D51002261

