### PR TITLE
Expose EventEmitter::dispatchEvent APIs for all platforms

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -58,13 +58,6 @@ class EventEmitter {
 
   const SharedEventTarget& getEventTarget() const;
 
- protected:
-#ifdef ANDROID
-  // We need this temporarily due to lack of Java-counterparts for particular
-  // subclasses.
- public:
-#endif
-
   /*
    * Initiates an event delivery process.
    * Is used by particular subclasses only.


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

This API was already accessible on the Android platform, now other platforms (C++) would benefit from having it available as well.

Arguably, it's perfectly fine to have it as public class members - based on empiric experience with the use case we have had.

Differential Revision: D51031340


