### PR TITLE
[RN][Testing] Make integration tests work in the New Architecture

### DIFF
--- a/packages/rn-tester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTesterIntegrationTests.xcscheme
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTesterIntegrationTests.xcscheme
@@ -65,6 +65,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
## Summary:
Working on #39719 with @Saadnajmi we realized that running the IntegrationTests with the New Architecture turned on resulted in a crash due to `out-of-scope stack memory`. I need to research 
more about this problem, but enabling the Address Sanitizer in Xcode fixed the tests. 

## Changelog:
[Internal] - Make IntegrationTests on iOS work with the New Architecture

## Test Plan:
Tested locally
