### PR TITLE
Eliminate static const UndefinedColor from SharedColor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -25,9 +25,7 @@ namespace facebook::react {
  */
 class SharedColor {
  public:
-  static const Color UndefinedColor = HostPlatformColor::UndefinedColor;
-
-  SharedColor() : color_(UndefinedColor) {}
+  SharedColor() : color_(HostPlatformColor::UndefinedColor) {}
 
   SharedColor(Color color) : color_(color) {}
 
@@ -44,7 +42,7 @@ class SharedColor {
   }
 
   operator bool() const {
-    return color_ != UndefinedColor;
+    return color_ != HostPlatformColor::UndefinedColor;
   }
 
  private:


### PR DESCRIPTION
Summary:
Initializing UndefinedColor on iOS and Android is trivial because the platform color is an int32_t. On platforms where the HostPlatformColor header defines a color as a struct (e.g., Windows) it is less trivial to compose a constexpr for the undefined color representation to initialize this static const value with.

As it turns out, UndefinedColor is only used for operator bool in SharedColor, so it's reasonably safe to remove this "public" API (also good to limit the surface of SharedColor).

## Changelog:
[Internal]

Differential Revision: D51073395


