### PR TITLE
Revert import order change in dangerfile.js

### DIFF
--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -9,12 +9,16 @@
 
 'use strict';
 
-const {validate: validateChangelog} =
-  require('@rnx-kit/rn-changelog-generator').default;
-const eslint = require('@seadub/danger-plugin-eslint');
+/* eslint-disable lint/sort-imports */
+// The 'danger' package seems to have some side effects that make it unsafe
+// to reorder.
+
 const {danger, fail, /*message,*/ warn} = require('danger');
 const includes = require('lodash.includes');
+const eslint = require('@seadub/danger-plugin-eslint');
 const fetch = require('node-fetch');
+const {validate: validateChangelog} =
+  require('@rnx-kit/rn-changelog-generator').default;
 
 const isFromPhabricator =
   danger.github.pr.body &&


### PR DESCRIPTION
Summary:
Changelog: [Internal]

D51025812 broke Danger runs in the React Native repo, so let's revert the changes to `dangerfile.js`.

Differential Revision: D51075476


