### PR TITLE
Migrate to @rnx-kit/chromium-edge-launcher for Windows fix

### DIFF
--- a/flow-typed/npm/@rnx-kit/chromium-edge-launcher_v1.x.x.js
+++ b/flow-typed/npm/@rnx-kit/chromium-edge-launcher_v1.x.x.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-declare module 'chromium-edge-launcher' {
+declare module '@rnx-kit/chromium-edge-launcher' {
   import typeof fs from 'fs';
   import typeof childProcess from 'child_process';
   import type {ChildProcess} from 'child_process';

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@isaacs/ttlcache": "^1.4.1",
     "@react-native/debugger-frontend": "^0.74.0",
+    "@rnx-kit/chromium-edge-launcher": "^1.0.0",
     "chrome-launcher": "^0.15.2",
-    "chromium-edge-launcher": "^1.0.0",
     "connect": "^3.6.5",
     "debug": "^2.2.0",
     "node-fetch": "^2.2.0",

--- a/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
@@ -15,8 +15,8 @@ import {promises as fs} from 'fs';
 import path from 'path';
 import osTempDir from 'temp-dir';
 
+const {Launcher: EdgeLauncher} = require('@rnx-kit/chromium-edge-launcher');
 const ChromeLauncher = require('chrome-launcher');
-const {Launcher: EdgeLauncher} = require('chromium-edge-launcher');
 
 /**
  * Default `BrowserLauncher` implementation which opens URLs on the host

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,6 +2542,18 @@
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.73.2.tgz#cc8e48fbae2bbfff53e12f209369e8d2e4cf34ec"
   integrity sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w==
 
+"@rnx-kit/chromium-edge-launcher@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz#c0df8ea00a902c7a417cd9655aab06de398b939c"
+  integrity sha512-lzD84av1ZQhYUS+jsGqJiCMaJO2dn9u+RTT9n9q6D3SaKVwWqv+7AoRKqBu19bkwyE+iFRl1ymr40QS90jVFYg==
+  dependencies:
+    "@types/node" "^18.0.0"
+    escape-string-regexp "^4.0.0"
+    is-wsl "^2.2.0"
+    lighthouse-logger "^1.0.0"
+    mkdirp "^1.0.4"
+    rimraf "^3.0.2"
+
 "@rnx-kit/rn-changelog-generator@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@rnx-kit/rn-changelog-generator/-/rn-changelog-generator-0.4.0.tgz#637d87bcf8de6e87599930ed88d9375010277660"
@@ -3839,18 +3851,6 @@ chrome-launcher@^0.15.0, chrome-launcher@^0.15.2:
     escape-string-regexp "^4.0.0"
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
-
-chromium-edge-launcher@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz#0443083074715a13c669530b35df7bfea33b1509"
-  integrity sha512-pgtgjNKZ7i5U++1g1PWv75umkHvhVTDOQIZ+sjeUX9483S7Y6MUvO0lrd7ShGlQlFHMN4SwKTCq/X8hWrbv2KA==
-  dependencies:
-    "@types/node" "*"
-    escape-string-regexp "^4.0.0"
-    is-wsl "^2.2.0"
-    lighthouse-logger "^1.0.0"
-    mkdirp "^1.0.4"
-    rimraf "^3.0.2"
 
 ci-info@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Summary: @acoates-ms graciously published the Windows Edge launcher fix from https://github.com/cezaraugusto/chromium-edge-launcher/pull/1 as a new package (https://github.com/microsoft/rnx-kit/pull/2796), so let's pull that into `dev-middleware`.

Changelog: [Internal] - Fix experimental debugger launch flow with Edge on Windows

Differential Revision: D51086297


