### PR TITLE
fix catalyst + use_frameworks build w/header change in React-RCTFabric.podspec

### DIFF
--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -72,7 +72,7 @@ Pod::Spec.new do |s|
     "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" + " " + folly_flags,
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20"
   }.merge!(ENV['USE_FRAMEWORKS'] != nil ? {
-    "PUBLIC_HEADERS_FOLDER_PATH" => "$(CONTENTS_FOLDER_PATH)/Headers/React"
+    "PUBLIC_HEADERS_FOLDER_PATH" => "RCTFabric.framework/Headers/React"
   }: {})
 
   s.dependency "React-Core", version


### PR DESCRIPTION

## Summary:

react-native 0.73 had a compile regression for macCatalyst builds with use_frameworks

There was some investigation on discord and with all credit to @cipolleschi for this header path fix, the build appears to work with this change

## Changelog:

[IOS] [FIXED] - Fixed catalyst build regression in use_frameworks context

## Test Plan:

I have a demonstration script that checks use_frameworks builds for ios debug, ios release and macCatalyst, it detected the problem and confirmed the fix: https://github.com/mikehardy/rnfbdemo/commits/rn73-catalyst