### PR TITLE
Refactor DefaultReactNativeHost to use the new way of Fabric initialization

### DIFF
--- a/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
+++ b/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
@@ -21,14 +21,8 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactInstanceManagerBuilder;
 import com.facebook.react.ReactRootView;
-import com.facebook.react.bridge.JSIModulePackage;
-import com.facebook.react.bridge.JSIModuleProvider;
-import com.facebook.react.bridge.JSIModuleSpec;
-import com.facebook.react.bridge.JSIModuleType;
-import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.UIManager;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.PermissionAwareActivity;
@@ -37,8 +31,6 @@ import com.facebook.react.shell.MainReactPackage;
 import com.facebook.react.testing.idledetection.ReactBridgeIdleSignaler;
 import com.facebook.react.testing.idledetection.ReactIdleDetectionUtil;
 import com.facebook.react.uimanager.ViewManagerRegistry;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -244,44 +236,16 @@ public class ReactAppTestActivity extends FragmentActivity
         .setUseDeveloperSupport(useDevSupport)
         .setBridgeIdleDebugListener(mBridgeIdleSignaler)
         .setInitialLifecycleState(mLifecycleState)
-        .setJSIModulesPackage(
-            new JSIModulePackage() {
-              @Override
-              public List<JSIModuleSpec> getJSIModules(
-                  final ReactApplicationContext reactApplicationContext,
-                  final JavaScriptContextHolder jsContext) {
-                List<JSIModuleSpec> packages = new ArrayList<>();
-                packages.add(
-                    new JSIModuleSpec() {
-                      @Override
-                      public JSIModuleType getJSIModuleType() {
-                        return JSIModuleType.UIManager;
-                      }
+        .setUIManagerProvider(
+            (ReactApplicationContext reactApplicationContext) -> {
+              ViewManagerRegistry viewManagerRegistry =
+                  new ViewManagerRegistry(
+                      mReactInstanceManager.getOrCreateViewManagers(reactApplicationContext));
 
-                      @Override
-                      public JSIModuleProvider getJSIModuleProvider() {
-                        return new JSIModuleProvider() {
-                          @Override
-                          public UIManager get() {
-                            ViewManagerRegistry viewManagerRegistry =
-                                new ViewManagerRegistry(
-                                    mReactInstanceManager.getOrCreateViewManagers(
-                                        reactApplicationContext));
-
-                            FabricUIManagerFactory factory = spec.getFabricUIManagerFactory();
-                            return factory != null
-                                ? factory.getFabricUIManager(
-                                    reactApplicationContext, viewManagerRegistry)
-                                : null;
-                          }
-                        };
-                      }
-                    });
-                if (spec.getJSIModuleBuilder() != null) {
-                  packages.addAll(spec.getJSIModuleBuilder().build(reactApplicationContext));
-                }
-                return packages;
-              }
+              FabricUIManagerFactory factory = spec.getFabricUIManagerFactory();
+              return factory != null
+                  ? factory.getFabricUIManager(reactApplicationContext, viewManagerRegistry)
+                  : null;
             });
 
     final CountDownLatch latch = new CountDownLatch(1);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -71,6 +71,7 @@ import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.UIManager;
+import com.facebook.react.bridge.UIManagerProvider;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec;
@@ -186,6 +187,7 @@ public class ReactInstanceManager {
   private final MemoryPressureRouter mMemoryPressureRouter;
   private final @Nullable JSExceptionHandler mJSExceptionHandler;
   private final @Nullable JSIModulePackage mJSIModulePackage;
+  private final @Nullable UIManagerProvider mUIManagerProvider;
   private final @Nullable ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder;
   private List<ViewManager> mViewManagers;
   private boolean mUseFallbackBundle = true;
@@ -234,6 +236,7 @@ public class ReactInstanceManager {
       int minNumShakes,
       int minTimeLeftInFrameForNonBatchedOperationMs,
       @Nullable JSIModulePackage jsiModulePackage,
+      @Nullable UIManagerProvider uIManagerProvider,
       @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
       @Nullable ReactPackageTurboModuleManagerDelegate.Builder tmmDelegateBuilder,
       @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
@@ -294,6 +297,7 @@ public class ReactInstanceManager {
       mPackages.addAll(packages);
     }
     mJSIModulePackage = jsiModulePackage;
+    mUIManagerProvider = uIManagerProvider;
 
     // Instantiate ReactChoreographer in UI thread.
     ReactChoreographer.initialize(
@@ -1389,7 +1393,7 @@ public class ReactInstanceManager {
               catalystInstance.getJSCallInvokerHolder(),
               catalystInstance.getNativeMethodCallInvokerHolder());
 
-      catalystInstance.setTurboModuleManager(turboModuleManager);
+      catalystInstance.setTurboModuleRegistry(turboModuleManager);
 
       // Eagerly initialize TurboModules
       for (String moduleName : turboModuleManager.getEagerInitModuleNames()) {
@@ -1404,6 +1408,9 @@ public class ReactInstanceManager {
     }
     if (ReactFeatureFlags.enableFabricRenderer) {
       catalystInstance.getJSIModule(JSIModuleType.UIManager);
+      if (mUIManagerProvider != null) {
+        catalystInstance.setFabricUIManager(mUIManagerProvider.createUIManager(reactContext));
+      }
     }
     if (mBridgeIdleDebugListener != null) {
       catalystInstance.addBridgeIdleDebugListener(mBridgeIdleDebugListener);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.JSExceptionHandler;
 import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.NotThreadSafeBridgeIdleDebugListener;
+import com.facebook.react.bridge.UIManagerProvider;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.SurfaceDelegateFactory;
 import com.facebook.react.common.annotations.StableReactNativeAPI;
@@ -68,6 +69,7 @@ public class ReactInstanceManagerBuilder {
   private int mMinNumShakes = 1;
   private int mMinTimeLeftInFrameForNonBatchedOperationMs = -1;
   private @Nullable JSIModulePackage mJSIModulesPackage;
+  private @Nullable UIManagerProvider mUIManagerProvider;
   private @Nullable Map<String, RequestHandler> mCustomPackagerCommandHandlers;
   private @Nullable ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder;
   private @Nullable SurfaceDelegateFactory mSurfaceDelegateFactory;
@@ -87,6 +89,11 @@ public class ReactInstanceManagerBuilder {
   public ReactInstanceManagerBuilder setJavaScriptExecutorFactory(
       @Nullable JavaScriptExecutorFactory javaScriptExecutorFactory) {
     mJavaScriptExecutorFactory = javaScriptExecutorFactory;
+    return this;
+  }
+
+  public ReactInstanceManagerBuilder setUIManagerProvider(UIManagerProvider uIManagerProvider) {
+    mUIManagerProvider = uIManagerProvider;
     return this;
   }
 
@@ -355,6 +362,7 @@ public class ReactInstanceManagerBuilder {
         mMinNumShakes,
         mMinTimeLeftInFrameForNonBatchedOperationMs,
         mJSIModulesPackage,
+        mUIManagerProvider,
         mCustomPackagerCommandHandlers,
         mTMMDelegateBuilder,
         mSurfaceDelegateFactory,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
+import com.facebook.react.bridge.UIManagerProvider;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.SurfaceDelegate;
 import com.facebook.react.common.SurfaceDelegateFactory;
@@ -85,6 +86,7 @@ public abstract class ReactNativeHost {
             .setRedBoxHandler(getRedBoxHandler())
             .setJavaScriptExecutorFactory(getJavaScriptExecutorFactory())
             .setJSIModulesPackage(getJSIModulePackage())
+            .setUIManagerProvider(getUIManagerProvider())
             .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
             .setReactPackageTurboModuleManagerDelegateBuilder(
                 getReactPackageTurboModuleManagerDelegateBuilder())
@@ -127,6 +129,10 @@ public abstract class ReactNativeHost {
 
   protected @Nullable JSIModulePackage getJSIModulePackage() {
     return null;
+  }
+
+  protected @Nullable UIManagerProvider getUIManagerProvider() {
+    return reactApplicationContext -> null;
   }
 
   /** Returns whether or not to treat it as normal if Activity is null. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -14,12 +14,8 @@ import com.facebook.react.ReactHost
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
-import com.facebook.react.bridge.JSIModulePackage
-import com.facebook.react.bridge.JSIModuleProvider
-import com.facebook.react.bridge.JSIModuleSpec
-import com.facebook.react.bridge.JSIModuleType
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerProvider
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.fabric.FabricUIManagerProviderImpl
 import com.facebook.react.fabric.ReactNativeConfig
@@ -46,30 +42,20 @@ protected constructor(
         null
       }
 
-  override fun getJSIModulePackage(): JSIModulePackage? =
+  override fun getUIManagerProvider(): UIManagerProvider? =
       if (isNewArchEnabled) {
-        JSIModulePackage { reactApplicationContext: ReactApplicationContext, _ ->
-          listOf(
-              object : JSIModuleSpec<UIManager> {
-                override fun getJSIModuleType(): JSIModuleType = JSIModuleType.UIManager
+        UIManagerProvider { reactApplicationContext: ReactApplicationContext ->
+          val componentFactory = ComponentFactory()
 
-                override fun getJSIModuleProvider(): JSIModuleProvider<UIManager> {
-                  val componentFactory = ComponentFactory()
+          DefaultComponentsRegistry.register(componentFactory)
 
-                  DefaultComponentsRegistry.register(componentFactory)
+          val reactInstanceManager: ReactInstanceManager = getReactInstanceManager()
 
-                  val reactInstanceManager: ReactInstanceManager = getReactInstanceManager()
-
-                  val viewManagers =
-                      reactInstanceManager.getOrCreateViewManagers(reactApplicationContext)
-                  val viewManagerRegistry = ViewManagerRegistry(viewManagers)
-                  return FabricUIManagerProviderImpl(
-                      reactApplicationContext,
-                      componentFactory,
-                      ReactNativeConfig.DEFAULT_CONFIG,
-                      viewManagerRegistry)
-                }
-              })
+          val viewManagers = reactInstanceManager.getOrCreateViewManagers(reactApplicationContext)
+          val viewManagerRegistry = ViewManagerRegistry(viewManagers)
+          FabricUIManagerProviderImpl(
+                  componentFactory, ReactNativeConfig.DEFAULT_CONFIG, viewManagerRegistry)
+              .createUIManager(reactApplicationContext)
         }
       } else {
         null


### PR DESCRIPTION
Summary:
Refactoring `DefaultReactNativeHost` to use the new way of Fabric initialization through `FabricUIManagerProviderImpl`

Changelog:
[Internal] internal

Differential Revision: D50926872


