### PR TITLE
Fix comments on Flipper build failure condition & syntax error

### DIFF
--- a/packages/react-native/template/ios/Podfile
+++ b/packages/react-native/template/ios/Podfile
@@ -8,14 +8,16 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-# If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.
-# because `react-native-flipper` depends on (FlipperKit,...) that will be excluded
+# If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is not set.
+# This is because `react-native-flipper` depends on (FlipperKit,...) which is excluded from the build.
 #
 # To fix this you can also exclude `react-native-flipper` using a `react-native.config.js`
 # ```js
 # module.exports = {
 #   dependencies: {
 #     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
+#   },
+# };
 # ```
 flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
 


### PR DESCRIPTION
## Summary:

This commit addresses two main points:

1. It updates the comments to clarify the conditions under which the iOS build will fail when using ```react-native-flipper```. The comment build failure condition has been changed from when NO_FLIPPER=1 is set to when ```NO_FLIPPER=1``` is **not** set. This change helps to accurately reflect the accompanying code.

2. A syntax error in the react-native.config.js code snippet has been fixed by adding a missing closing ``}``

## Changelog:

Fix comments on Flipper build failure condition & syntax error

Pick one each for the category and type tags:

[GENERAL] [FIXED] - comments on Flipper build failure condition & minor syntax error

## Test Plan:

“Changes limited to comments only