### PR TITLE
Enable Flow casting_syntax=both in fbsource

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -33,6 +33,7 @@ packages/react-native/flow/
 [options]
 experimental.global_find_ref=true
 enums=true
+casting_syntax=both
 
 emoji=true
 


### PR DESCRIPTION
Summary:
Enable Flow `casting_syntax=both` in fbsource, before the announcement so that when people see it they can check it out without rebasing.

Changelog: [Internal]

Differential Revision: D51097870


