### PR TITLE
feat(iOS) make build-hermes-xcode.sh more extensible for out of tree platforms

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -10,6 +10,26 @@ release_version="$1"; shift
 hermesc_path="$1"; shift
 jsi_path="$1"; shift
 
+# Based on platform name returns the framework copy destination. Used later by `vendored_frameworks` in Podspec. 
+# Fallbacks to "ios" if platform is not recognized.
+function get_platform_copy_destination {
+    if [[ $1 == "macosx" ]]; then
+      echo "macosx"
+      return
+    fi
+    
+    echo "ios"
+}
+
+function get_deployment_target {
+    if [[ $1 == "macosx" ]]; then
+      echo ${MACOSX_DEPLOYMENT_TARGET}
+      return
+    fi
+    
+    echo ${IPHONEOS_DEPLOYMENT_TARGET}
+}
+
 enable_debugger="false"
 if [[ "$CONFIGURATION" == "Debug" ]]; then
   enable_debugger="true"
@@ -24,10 +44,7 @@ else
   cmake_build_type="MinSizeRel"
 fi
 
-deployment_target=${IPHONEOS_DEPLOYMENT_TARGET}
-if [ -z "$deployment_target" ]; then
-  deployment_target=${MACOSX_DEPLOYMENT_TARGET}
-fi
+deployment_target=$(get_deployment_target $PLATFORM_NAME)
 
 xcode_15_flags=""
 xcode_major_version=$(xcodebuild -version | grep -oE '[0-9]*' | head -n 1)
@@ -69,6 +86,8 @@ echo "Build Apple framework"
 
 echo "Copy Apple framework to destroot/Library/Frameworks"
 
+platform_copy_destination=$(get_platform_copy_destination $PLATFORM_NAME)
+
 cp -pfR \
   "${PODS_ROOT}/hermes-engine/build/${PLATFORM_NAME}/API/hermes/hermes.framework" \
-  "${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/ios"
+  "${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/${platform_copy_destination}"

--- a/packages/react-native/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh
@@ -19,11 +19,13 @@ pushd destroot/Library/Frameworks > /dev/null || exit 1
 
 echo '' > dummy.c
 
-mkdir -p macosx/hermes.framework
-clang dummy.c -dynamiclib -o macosx/hermes.framework/hermes
+platforms=( "macosx" "ios" ) # Add other platforms here if needed
 
-mkdir -p ios/hermes.framework
-clang dummy.c -dynamiclib -o ios/hermes.framework/hermes
+for platform in "${platforms[@]}" 
+do 
+    mkdir -p "${platform}/hermes.framework"
+    clang dummy.c -dynamiclib -o "${platform}/hermes.framework/hermes"
+done
 
 rm dummy.c
 


### PR DESCRIPTION
## Summary:

This PR aims to make scripts building hermes locally more extensible for out-of-tree platforms. It will make it easier for forks like visionOS to add additional `elif` statements.

As a side benefit this PR fixes Hermes builds for MacOS 😄 (I've checked that it now builds correctly)

## Changelog:

[IOS] [ADDED] - make build-hermes-xcode.sh more extensible for out-of-tree platforms

## Test Plan:

Run the local Hermes build by running `USE_HERMES=1 bundle exec pod install` and check if it runs smoothly. Also, a CI check should be sufficient.
