### PR TITLE
feat(iOS) remove deprecated [UIScreen mainScreen] references 

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -114,13 +114,14 @@ RCT_EXPORT_MODULE()
   dispatch_async(dispatch_get_main_queue(), ^{
     self->_showDate = [NSDate date];
     if (!self->_window && !RCTRunningInTestEnvironment()) {
-      CGSize screenSize = [UIScreen mainScreen].bounds.size;
 
       UIWindow *window = RCTSharedApplication().keyWindow;
+      CGFloat windowWidth = window.bounds.size.width;
+        
       self->_window =
-          [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, window.safeAreaInsets.top + 10)];
+          [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, windowWidth, window.safeAreaInsets.top + 10)];
       self->_label =
-          [[UILabel alloc] initWithFrame:CGRectMake(0, window.safeAreaInsets.top - 10, screenSize.width, 20)];
+          [[UILabel alloc] initWithFrame:CGRectMake(0, window.safeAreaInsets.top - 10, windowWidth, 20)];
       [self->_window addSubview:self->_label];
 
       self->_window.windowLevel = UIWindowLevelStatusBar + 1;

--- a/packages/rn-tester/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/packages/rn-tester/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -238,8 +238,10 @@ typedef NS_ENUM(NSInteger, FBTestSnapshotFileNameType) {
   if (0 < identifier.length) {
     fileName = [fileName stringByAppendingFormat:@"_%@", identifier];
   }
-  if ([[UIScreen mainScreen] scale] > 1.0) {
-    fileName = [fileName stringByAppendingFormat:@"@%.fx", [[UIScreen mainScreen] scale]];
+    
+  UITraitCollection *currentTraitCollection = [UITraitCollection currentTraitCollection];
+  if (currentTraitCollection.displayScale > 1.0) {
+    fileName = [fileName stringByAppendingFormat:@"@%.fx", currentTraitCollection.displayScale];
   }
   fileName = [fileName stringByAppendingPathExtension:@"png"];
   return fileName;


### PR DESCRIPTION
## Summary:

The goal for this PR is to further remove references for `[UIScreen mainScreen]` and migrate them to use trait collections. This helps out of tree platforms like visionOS (where the `UIScreen` is not available). 

## Changelog:

[INTERNAL] [CHANGED] - use currentTraitCollection for FBSnapshotTestController.m
[IOS] [CHANGED] - use key window width to assign the correct width for RCTDevLoadingView

## Test Plan:

– Check if tests passes 
- Check if `RCTDevLoadingView` shows up correctly. 

Screenshot: 
![CleanShot 2023-11-09 at 13 48 48@2x](https://github.com/facebook/react-native/assets/52801365/4c91399e-f70a-4e78-8288-bc7b8377c980)


