### PR TITLE
Use CSS terminology for sizing rules

### DIFF
--- a/packages/react-native/React/Tests/Text/RCTParagraphComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Text/RCTParagraphComponentViewTests.mm
@@ -121,8 +121,8 @@ using namespace facebook::react;
             auto &props = *sharedProps;
             props.layoutConstraints = LayoutConstraints{{0, 0}, {500, 500}};
             auto &yogaStyle = props.yogaStyle;
-            yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
-            yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(200));
+            yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(200));
+            yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(200));
             return sharedProps;
           })
           .children({
@@ -134,10 +134,10 @@ using namespace facebook::react;
                     props.accessible = true;
                     auto &yogaStyle = props.yogaStyle;
                     yogaStyle.positionType() = yoga::PositionType::Absolute;
-                    yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::of<YGUnitPoint>(0));
-                    yogaStyle.setPosition(YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(0));
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(200));
+                    yogaStyle.setPosition(YGEdgeLeft, yoga::value::points(0));
+                    yogaStyle.setPosition(YGEdgeTop, yoga::value::points(0));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(200));
                     return sharedProps;
                   })
                   .children({
@@ -214,10 +214,10 @@ using namespace facebook::react;
                     props.accessible = true;
                     auto &yogaStyle = props.yogaStyle;
                     yogaStyle.positionType() = yoga::PositionType::Absolute;
-                    yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::of<YGUnitPoint>(0));
-                    yogaStyle.setPosition(YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(30));
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(50));
+                    yogaStyle.setPosition(YGEdgeLeft, yoga::value::points(0));
+                    yogaStyle.setPosition(YGEdgeTop, yoga::value::points(30));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(50));
                     return sharedProps;
                   })
                   .children({
@@ -258,10 +258,10 @@ using namespace facebook::react;
                     props.accessible = true;
                     auto &yogaStyle = props.yogaStyle;
                     yogaStyle.positionType() = yoga::PositionType::Absolute;
-                    yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::of<YGUnitPoint>(0));
-                    yogaStyle.setPosition(YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(90));
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(50));
+                    yogaStyle.setPosition(YGEdgeLeft, yoga::value::points(0));
+                    yogaStyle.setPosition(YGEdgeTop, yoga::value::points(90));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(50));
                     return sharedProps;
                   })
                   .children({
@@ -418,8 +418,8 @@ static ParagraphShadowNode::ConcreteState::Shared stateWithShadowNode(
                        auto &props = *sharedProps;
                        props.layoutConstraints = LayoutConstraints{{0, 0}, {500, 500}};
                        auto &yogaStyle = props.yogaStyle;
-                       yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
-                       yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(200));
+                       yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(200));
+                       yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(200));
                        return sharedProps;
                      })
                      .children({
@@ -432,10 +432,10 @@ static ParagraphShadowNode::ConcreteState::Shared stateWithShadowNode(
                                props.accessibilityTraits = AccessibilityTraits::Link;
                                auto &yogaStyle = props.yogaStyle;
                                yogaStyle.positionType() = yoga::PositionType::Absolute;
-                               yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::of<YGUnitPoint>(0));
-                               yogaStyle.setPosition(YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(0));
-                               yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
-                               yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(20));
+                               yogaStyle.setPosition(YGEdgeLeft, yoga::value::points(0));
+                               yogaStyle.setPosition(YGEdgeTop, yoga::value::points(90));
+                               yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(200));
+                               yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(20));
                                return sharedProps;
                              })
                              .children({

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -13,7 +13,6 @@
 
 #include <yoga/YGEnums.h>
 #include <yoga/YGValue.h>
-#include <yoga/style/CompactValue.h>
 
 #include <unordered_map>
 
@@ -106,27 +105,23 @@ class AndroidTextInputComponentDescriptor final
           !textInputProps.hasPaddingLeft &&
           !textInputProps.hasPaddingHorizontal) {
         changedPadding = true;
-        style.setPadding(
-            YGEdgeStart, yoga::CompactValue::of<YGUnitPoint>(theme.start));
+        style.setPadding(YGEdgeStart, yoga::value::points(theme.start));
       }
       if (!textInputProps.hasPadding && !textInputProps.hasPaddingEnd &&
           !textInputProps.hasPaddingRight &&
           !textInputProps.hasPaddingHorizontal) {
         changedPadding = true;
-        style.setPadding(
-            YGEdgeEnd, yoga::CompactValue::of<YGUnitPoint>(theme.end));
+        style.setPadding(YGEdgeEnd, yoga::value::points(theme.end));
       }
       if (!textInputProps.hasPadding && !textInputProps.hasPaddingTop &&
           !textInputProps.hasPaddingVertical) {
         changedPadding = true;
-        style.setPadding(
-            YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(theme.top));
+        style.setPadding(YGEdgeTop, yoga::value::points(theme.top));
       }
       if (!textInputProps.hasPadding && !textInputProps.hasPaddingBottom &&
           !textInputProps.hasPaddingVertical) {
         changedPadding = true;
-        style.setPadding(
-            YGEdgeBottom, yoga::CompactValue::of<YGUnitPoint>(theme.bottom));
+        style.setPadding(YGEdgeBottom, yoga::value::points(theme.bottom));
       }
 
       // If the TextInput initially does not have paddingLeft or paddingStart, a
@@ -137,12 +132,12 @@ class AndroidTextInputComponentDescriptor final
       if ((textInputProps.hasPadding || textInputProps.hasPaddingLeft ||
            textInputProps.hasPaddingHorizontal) &&
           !textInputProps.hasPaddingStart) {
-        style.setPadding(YGEdgeStart, yoga::CompactValue::ofUndefined());
+        style.setPadding(YGEdgeStart, yoga::value::undefined());
       }
       if ((textInputProps.hasPadding || textInputProps.hasPaddingRight ||
            textInputProps.hasPaddingHorizontal) &&
           !textInputProps.hasPaddingEnd) {
-        style.setPadding(YGEdgeEnd, yoga::CompactValue::ofUndefined());
+        style.setPadding(YGEdgeEnd, yoga::value::undefined());
       }
 
       // Note that this is expensive: on every adopt, we need to set the Yoga

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -529,12 +529,8 @@ void YogaLayoutableShadowNode::setSize(Size size) const {
   ensureUnsealed();
 
   auto style = yogaNode_.getStyle();
-  style.setDimension(
-      yoga::Dimension::Width,
-      yoga::CompactValue::ofMaybe<YGUnitPoint>(size.width));
-  style.setDimension(
-      yoga::Dimension::Height,
-      yoga::CompactValue::ofMaybe<YGUnitPoint>(size.height));
+  style.setDimension(yoga::Dimension::Width, yoga::value::points(size.width));
+  style.setDimension(yoga::Dimension::Height, yoga::value::points(size.height));
   yogaNode_.setStyle(style);
   yogaNode_.setDirty(true);
 }
@@ -544,23 +540,19 @@ void YogaLayoutableShadowNode::setPadding(RectangleEdges<Float> padding) const {
 
   auto style = yogaNode_.getStyle();
 
-  auto leftPadding = yoga::CompactValue::ofMaybe<YGUnitPoint>(padding.left);
-  auto topPadding = yoga::CompactValue::ofMaybe<YGUnitPoint>(padding.top);
-  auto rightPadding = yoga::CompactValue::ofMaybe<YGUnitPoint>(padding.right);
-  auto bottomPadding = yoga::CompactValue::ofMaybe<YGUnitPoint>(padding.bottom);
+  auto leftPadding = yoga::value::points(padding.left);
+  auto topPadding = yoga::value::points(padding.top);
+  auto rightPadding = yoga::value::points(padding.right);
+  auto bottomPadding = yoga::value::points(padding.bottom);
 
   if (leftPadding != style.padding(YGEdgeLeft) ||
       topPadding != style.padding(YGEdgeTop) ||
       rightPadding != style.padding(YGEdgeRight) ||
       bottomPadding != style.padding(YGEdgeBottom)) {
-    style.setPadding(
-        YGEdgeTop, yoga::CompactValue::ofMaybe<YGUnitPoint>(padding.top));
-    style.setPadding(
-        YGEdgeLeft, yoga::CompactValue::ofMaybe<YGUnitPoint>(padding.left));
-    style.setPadding(
-        YGEdgeRight, yoga::CompactValue::ofMaybe<YGUnitPoint>(padding.right));
-    style.setPadding(
-        YGEdgeBottom, yoga::CompactValue::ofMaybe<YGUnitPoint>(padding.bottom));
+    style.setPadding(YGEdgeTop, yoga::value::points(padding.top));
+    style.setPadding(YGEdgeLeft, yoga::value::points(padding.left));
+    style.setPadding(YGEdgeRight, yoga::value::points(padding.right));
+    style.setPadding(YGEdgeBottom, yoga::value::points(padding.bottom));
     yogaNode_.setStyle(style);
     yogaNode_.setDirty(true);
   }
@@ -630,20 +622,16 @@ void YogaLayoutableShadowNode::layoutTree(
   auto ownerHeight = yogaFloatFromFloat(maximumSize.height);
 
   yogaStyle.setMaxDimension(
-      yoga::Dimension::Width,
-      yoga::CompactValue::ofMaybe<YGUnitPoint>(maximumSize.width));
+      yoga::Dimension::Width, yoga::value::points(maximumSize.width));
 
   yogaStyle.setMaxDimension(
-      yoga::Dimension::Height,
-      yoga::CompactValue::ofMaybe<YGUnitPoint>(maximumSize.height));
+      yoga::Dimension::Height, yoga::value::points(maximumSize.height));
 
   yogaStyle.setMinDimension(
-      yoga::Dimension::Width,
-      yoga::CompactValue::ofMaybe<YGUnitPoint>(minimumSize.width));
+      yoga::Dimension::Width, yoga::value::points(minimumSize.width));
 
   yogaStyle.setMinDimension(
-      yoga::Dimension::Height,
-      yoga::CompactValue::ofMaybe<YGUnitPoint>(minimumSize.height));
+      yoga::Dimension::Height, yoga::value::points(minimumSize.height));
 
   auto direction =
       yogaDirectionFromLayoutDirection(layoutConstraints.layoutDirection);
@@ -887,32 +875,32 @@ void YogaLayoutableShadowNode::swapLeftAndRightInYogaStyleProps(
 
   if (yogaStyle.position(YGEdgeLeft).isDefined()) {
     yogaStyle.setPosition(YGEdgeStart, yogaStyle.position(YGEdgeLeft));
-    yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::ofUndefined());
+    yogaStyle.setPosition(YGEdgeLeft, yoga::value::undefined());
   }
 
   if (yogaStyle.position(YGEdgeRight).isDefined()) {
     yogaStyle.setPosition(YGEdgeEnd, yogaStyle.position(YGEdgeRight));
-    yogaStyle.setPosition(YGEdgeRight, yoga::CompactValue::ofUndefined());
+    yogaStyle.setPosition(YGEdgeRight, yoga::value::undefined());
   }
 
   if (yogaStyle.padding(YGEdgeLeft).isDefined()) {
     yogaStyle.setPadding(YGEdgeStart, yogaStyle.padding(YGEdgeLeft));
-    yogaStyle.setPadding(YGEdgeLeft, yoga::CompactValue::ofUndefined());
+    yogaStyle.setPadding(YGEdgeLeft, yoga::value::undefined());
   }
 
   if (yogaStyle.padding(YGEdgeRight).isDefined()) {
     yogaStyle.setPadding(YGEdgeEnd, yogaStyle.padding(YGEdgeRight));
-    yogaStyle.setPadding(YGEdgeRight, yoga::CompactValue::ofUndefined());
+    yogaStyle.setPadding(YGEdgeRight, yoga::value::undefined());
   }
 
   if (yogaStyle.margin(YGEdgeLeft).isDefined()) {
     yogaStyle.setMargin(YGEdgeStart, yogaStyle.margin(YGEdgeLeft));
-    yogaStyle.setMargin(YGEdgeLeft, yoga::CompactValue::ofUndefined());
+    yogaStyle.setMargin(YGEdgeLeft, yoga::value::undefined());
   }
 
   if (yogaStyle.margin(YGEdgeRight).isDefined()) {
     yogaStyle.setMargin(YGEdgeEnd, yogaStyle.margin(YGEdgeRight));
-    yogaStyle.setMargin(YGEdgeRight, yoga::CompactValue::ofUndefined());
+    yogaStyle.setMargin(YGEdgeRight, yoga::value::undefined());
   }
 
   shadowNode.yogaNode_.setStyle(yogaStyle);
@@ -967,12 +955,12 @@ void YogaLayoutableShadowNode::swapLeftAndRightInViewProps(
 
   if (props.yogaStyle.border(YGEdgeLeft).isDefined()) {
     props.yogaStyle.setBorder(YGEdgeStart, props.yogaStyle.border(YGEdgeLeft));
-    props.yogaStyle.setBorder(YGEdgeLeft, yoga::CompactValue::ofUndefined());
+    props.yogaStyle.setBorder(YGEdgeLeft, yoga::value::undefined());
   }
 
   if (props.yogaStyle.border(YGEdgeRight).isDefined()) {
     props.yogaStyle.setBorder(YGEdgeEnd, props.yogaStyle.border(YGEdgeRight));
-    props.yogaStyle.setBorder(YGEdgeRight, yoga::CompactValue::ofUndefined());
+    props.yogaStyle.setBorder(YGEdgeRight, yoga::value::undefined());
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -22,8 +22,6 @@
 namespace facebook::react {
 
 class YogaLayoutableShadowNode : public LayoutableShadowNode {
-  using CompactValue = facebook::yoga::CompactValue;
-
  public:
   using Shared = std::shared_ptr<const YogaLayoutableShadowNode>;
   using ListOfShared = std::vector<Shared>;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -417,98 +417,98 @@ void YogaStylableProps::convertRawPropAliases(
       rawProps,
       "insetBlockEnd",
       sourceProps.insetBlockEnd,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   insetBlockStart = convertRawProp(
       context,
       rawProps,
       "insetBlockStart",
       sourceProps.insetBlockStart,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   insetInlineEnd = convertRawProp(
       context,
       rawProps,
       "insetInlineEnd",
       sourceProps.insetInlineEnd,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   insetInlineStart = convertRawProp(
       context,
       rawProps,
       "insetInlineStart",
       sourceProps.insetInlineStart,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   marginInline = convertRawProp(
       context,
       rawProps,
       "marginInline",
       sourceProps.marginInline,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   marginInlineStart = convertRawProp(
       context,
       rawProps,
       "marginInlineStart",
       sourceProps.marginInlineStart,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   marginInlineEnd = convertRawProp(
       context,
       rawProps,
       "marginInlineEnd",
       sourceProps.marginInlineEnd,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   marginBlock = convertRawProp(
       context,
       rawProps,
       "marginBlock",
       sourceProps.marginBlock,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   marginBlockStart = convertRawProp(
       context,
       rawProps,
       "marginBlockStart",
       sourceProps.marginBlockStart,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   marginBlockEnd = convertRawProp(
       context,
       rawProps,
       "marginBlockEnd",
       sourceProps.marginBlockEnd,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
 
   paddingInline = convertRawProp(
       context,
       rawProps,
       "paddingInline",
       sourceProps.paddingInline,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   paddingInlineStart = convertRawProp(
       context,
       rawProps,
       "paddingInlineStart",
       sourceProps.paddingInlineStart,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   paddingInlineEnd = convertRawProp(
       context,
       rawProps,
       "paddingInlineEnd",
       sourceProps.paddingInlineEnd,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   paddingBlock = convertRawProp(
       context,
       rawProps,
       "paddingBlock",
       sourceProps.paddingBlock,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   paddingBlockStart = convertRawProp(
       context,
       rawProps,
       "paddingBlockStart",
       sourceProps.paddingBlockStart,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
   paddingBlockEnd = convertRawProp(
       context,
       rawProps,
       "paddingBlockEnd",
       sourceProps.paddingBlockEnd,
-      CompactValue::ofUndefined());
+      yoga::value::undefined());
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
@@ -16,8 +16,6 @@
 namespace facebook::react {
 
 class YogaStylableProps : public Props {
-  using CompactValue = facebook::yoga::CompactValue;
-
  public:
   YogaStylableProps() = default;
   YogaStylableProps(
@@ -41,30 +39,30 @@ class YogaStylableProps : public Props {
 
   // Duplicates of existing properties with different names, taking
   // precedence. E.g. "marginBlock" instead of "marginVertical"
-  CompactValue insetInlineStart;
-  CompactValue insetInlineEnd;
+  yoga::Style::Length insetInlineStart;
+  yoga::Style::Length insetInlineEnd;
 
-  CompactValue marginInline;
-  CompactValue marginInlineStart;
-  CompactValue marginInlineEnd;
-  CompactValue marginBlock;
+  yoga::Style::Length marginInline;
+  yoga::Style::Length marginInlineStart;
+  yoga::Style::Length marginInlineEnd;
+  yoga::Style::Length marginBlock;
 
-  CompactValue paddingInline;
-  CompactValue paddingInlineStart;
-  CompactValue paddingInlineEnd;
-  CompactValue paddingBlock;
+  yoga::Style::Length paddingInline;
+  yoga::Style::Length paddingInlineStart;
+  yoga::Style::Length paddingInlineEnd;
+  yoga::Style::Length paddingBlock;
 
   // BlockEnd/BlockStart map to top/bottom (no writing mode), but we preserve
   // Yoga's precedence and prefer specific edges (e.g. top) to ones which are
   // flow relative (e.g. blockStart).
-  CompactValue insetBlockStart;
-  CompactValue insetBlockEnd;
+  yoga::Style::Length insetBlockStart;
+  yoga::Style::Length insetBlockEnd;
 
-  CompactValue marginBlockStart;
-  CompactValue marginBlockEnd;
+  yoga::Style::Length marginBlockStart;
+  yoga::Style::Length marginBlockEnd;
 
-  CompactValue paddingBlockStart;
-  CompactValue paddingBlockEnd;
+  yoga::Style::Length paddingBlockStart;
+  yoga::Style::Length paddingBlockEnd;
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -395,9 +395,9 @@ inline void fromRawValue(
 inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
-    yoga::CompactValue& result) {
+    yoga::Style::Length& result) {
   if (value.hasType<Float>()) {
-    result = yoga::CompactValue::ofMaybe<YGUnitPoint>((float)value);
+    result = yoga::value::points((float)value);
     return;
   } else if (value.hasType<std::string>()) {
     const auto stringValue = (std::string)value;
@@ -409,13 +409,13 @@ inline void fromRawValue(
         auto tryValue = folly::tryTo<float>(
             std::string_view(stringValue).substr(0, stringValue.length() - 1));
         if (tryValue.hasValue()) {
-          result = YGValue{tryValue.value(), YGUnitPercent};
+          result = yoga::value::percent(tryValue.value());
           return;
         }
       } else {
         auto tryValue = folly::tryTo<float>(stringValue);
         if (tryValue.hasValue()) {
-          result = YGValue{tryValue.value(), YGUnitPoint};
+          result = yoga::value::points(tryValue.value());
           return;
         }
       }
@@ -428,7 +428,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     YGValue& result) {
-  yoga::CompactValue ygValue{};
+  yoga::Style::Length ygValue{};
   fromRawValue(context, value, ygValue);
   result = ygValue;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
@@ -77,8 +77,8 @@ class LayoutTest : public ::testing::Test {
             auto &props = *sharedProps;
             props.layoutConstraints = LayoutConstraints{{0,0}, {500, 500}};
             auto &yogaStyle = props.yogaStyle;
-            yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(200));
-            yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(200));
+            yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(200));
+            yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(200));
             return sharedProps;
           })
           .children({
@@ -90,8 +90,8 @@ class LayoutTest : public ::testing::Test {
                 auto &props = *sharedProps;
                 auto &yogaStyle = props.yogaStyle;
                 yogaStyle.positionType() = yoga::PositionType::Absolute;
-                yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(50));
-                yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(50));
+                yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(50));
+                yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(50));
                 return sharedProps;
               })
               .children({
@@ -103,10 +103,10 @@ class LayoutTest : public ::testing::Test {
                     auto &props = *sharedProps;
                     auto &yogaStyle = props.yogaStyle;
                     yogaStyle.positionType() = yoga::PositionType::Absolute;
-                    yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::of<YGUnitPoint>(10));
-                    yogaStyle.setPosition(YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(10));
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(30));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(90));
+                    yogaStyle.setPosition(YGEdgeLeft, yoga::value::points(10));
+                    yogaStyle.setPosition(YGEdgeTop, yoga::value::points(10));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(30));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(90));
 
                     if (testCase == TRANSFORM_SCALE) {
                       props.transform = props.transform * Transform::Scale(2, 2, 1);
@@ -136,10 +136,10 @@ class LayoutTest : public ::testing::Test {
                         }
 
                         yogaStyle.positionType() = yoga::PositionType::Absolute;
-                        yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::of<YGUnitPoint>(10));
-                        yogaStyle.setPosition(YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(10));
-                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(110));
-                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(20));
+                        yogaStyle.setPosition(YGEdgeLeft, yoga::value::points(10));
+                        yogaStyle.setPosition(YGEdgeTop, yoga::value::points(10));
+                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(110));
+                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(20));
                         return sharedProps;
                       })
                       .children({
@@ -151,10 +151,10 @@ class LayoutTest : public ::testing::Test {
                             auto &props = *sharedProps;
                             auto &yogaStyle = props.yogaStyle;
                             yogaStyle.positionType() = yoga::PositionType::Absolute;
-                            yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::of<YGUnitPoint>(70));
-                            yogaStyle.setPosition(YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(-50));
-                            yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(30));
-                            yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(60));
+                            yogaStyle.setPosition(YGEdgeLeft, yoga::value::points(70));
+                            yogaStyle.setPosition(YGEdgeTop, yoga::value::points(-50));
+                            yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(30));
+                            yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(60));
                             return sharedProps;
                           })
                       }),
@@ -166,10 +166,10 @@ class LayoutTest : public ::testing::Test {
                         auto &props = *sharedProps;
                         auto &yogaStyle = props.yogaStyle;
                         yogaStyle.positionType() = yoga::PositionType::Absolute;
-                        yogaStyle.setPosition(YGEdgeLeft, yoga::CompactValue::of<YGUnitPoint>(-60));
-                        yogaStyle.setPosition(YGEdgeTop, yoga::CompactValue::of<YGUnitPoint>(50));
-                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::CompactValue::of<YGUnitPoint>(70));
-                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::CompactValue::of<YGUnitPoint>(20));
+                        yogaStyle.setPosition(YGEdgeLeft, yoga::value::points(-60));
+                        yogaStyle.setPosition(YGEdgeTop, yoga::value::points(50));
+                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::value::points(70));
+                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::value::points(20));
                         return sharedProps;
                       })
                   })

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -251,8 +251,8 @@ TEST_F(StackingContextTest, mostPropsDoNotForceViewsToMaterialize) {
 
   mutateViewShadowNodeProps_(nodeAA_, [](ViewProps& props) {
     auto& yogaStyle = props.yogaStyle;
-    yogaStyle.setPadding(YGEdgeAll, yoga::CompactValue::of<YGUnitPoint>(42));
-    yogaStyle.setMargin(YGEdgeAll, yoga::CompactValue::of<YGUnitPoint>(42));
+    yogaStyle.setPadding(YGEdgeAll, yoga::value::points(42));
+    yogaStyle.setMargin(YGEdgeAll, yoga::value::points(42));
     yogaStyle.positionType() = yoga::PositionType::Absolute;
     props.shadowRadius = 42;
     props.shadowOffset = Size{42, 42};
@@ -262,7 +262,7 @@ TEST_F(StackingContextTest, mostPropsDoNotForceViewsToMaterialize) {
   mutateViewShadowNodeProps_(nodeBA_, [](ViewProps& props) {
     auto& yogaStyle = props.yogaStyle;
     props.zIndex = 42;
-    yogaStyle.setMargin(YGEdgeAll, yoga::CompactValue::of<YGUnitPoint>(42));
+    yogaStyle.setMargin(YGEdgeAll, yoga::value::points(42));
     props.shadowColor = clearColor();
     props.shadowOpacity = 0.42;
   });

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -351,13 +351,13 @@ bool YGNodeCanUseCachedMeasurement(
     float marginColumn,
     YGConfigRef config) {
   return yoga::canUseCachedMeasurement(
-      scopedEnum(widthMode),
+      sizingMode(scopedEnum(widthMode)),
       availableWidth,
-      scopedEnum(heightMode),
+      sizingMode(scopedEnum(heightMode)),
       availableHeight,
-      scopedEnum(lastWidthMode),
+      sizingMode(scopedEnum(lastWidthMode)),
       lastAvailableWidth,
-      scopedEnum(lastHeightMode),
+      sizingMode(scopedEnum(lastHeightMode)),
       lastAvailableHeight,
       lastComputedWidth,
       lastComputedHeight,

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -186,6 +186,19 @@ typedef struct YGSize {
 } YGSize;
 
 /**
+ * Returns the computed dimensions of the node, following the contraints of
+ * `widthMode` and `heightMode`:
+ *
+ * YGMeasureModeUndefined: The parent has not imposed any constraint on the
+ * child. It can be whatever size it wants.
+ *
+ * YGMeasureModeAtMost: The child can be as large as it wants up to the
+ * specified size.
+ *
+ * YGMeasureModeExactly: The parent has determined an exact size for the
+ * child. The child is going to be given those bounds regardless of how big it
+ * wants to be.
+ *
  * @returns the size of the leaf node, measured under the given contraints.
  */
 typedef YGSize (*YGMeasureFunc)(

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
@@ -26,22 +26,22 @@ void updateStyle(
   }
 }
 
-template <typename Ref, typename T>
-void updateStyle(YGNodeRef node, Ref (Style::*prop)(), T value) {
+template <typename Ref, typename ValueT>
+void updateStyle(YGNodeRef node, Ref (Style::*prop)(), ValueT value) {
   updateStyle(
       resolveRef(node),
       value,
-      [prop](Style& s, T x) { return (s.*prop)() != x; },
-      [prop](Style& s, T x) { (s.*prop)() = x; });
+      [prop](Style& s, ValueT x) { return (s.*prop)() != x; },
+      [prop](Style& s, ValueT x) { (s.*prop)() = x; });
 }
 
-template <auto GetterT, auto SetterT, typename IdxT>
-void updateIndexedStyleProp(YGNodeRef node, IdxT idx, CompactValue value) {
+template <auto GetterT, auto SetterT, typename IdxT, typename ValueT>
+void updateIndexedStyleProp(YGNodeRef node, IdxT idx, ValueT value) {
   updateStyle(
       resolveRef(node),
       value,
-      [idx](Style& s, CompactValue x) { return (s.*GetterT)(idx) != x; },
-      [idx](Style& s, CompactValue x) { (s.*SetterT)(idx, x); });
+      [idx](Style& s, ValueT x) { return (s.*GetterT)(idx) != x; },
+      [idx](Style& s, ValueT x) { (s.*SetterT)(idx, x); });
 }
 
 } // namespace
@@ -198,20 +198,19 @@ float YGNodeStyleGetFlexShrink(const YGNodeConstRef nodeRef) {
 }
 
 void YGNodeStyleSetFlexBasis(const YGNodeRef node, const float flexBasis) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(flexBasis);
-  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value);
+  updateStyle<MSVC_HINT(flexBasis)>(
+      node, &Style::flexBasis, value::points(flexBasis));
 }
 
 void YGNodeStyleSetFlexBasisPercent(
     const YGNodeRef node,
     const float flexBasisPercent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(flexBasisPercent);
-  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value);
+  updateStyle<MSVC_HINT(flexBasis)>(
+      node, &Style::flexBasis, value::percent(flexBasisPercent));
 }
 
 void YGNodeStyleSetFlexBasisAuto(const YGNodeRef node) {
-  updateStyle<MSVC_HINT(flexBasis)>(
-      node, &Style::flexBasis, CompactValue::ofAuto());
+  updateStyle<MSVC_HINT(flexBasis)>(node, &Style::flexBasis, value::ofAuto());
 }
 
 YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
@@ -223,15 +222,13 @@ YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetPosition(YGNodeRef node, YGEdge edge, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::position, &Style::setPosition>(
-      node, edge, value);
+      node, edge, value::points(points));
 }
 
 void YGNodeStyleSetPositionPercent(YGNodeRef node, YGEdge edge, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::position, &Style::setPosition>(
-      node, edge, value);
+      node, edge, value::percent(percent));
 }
 
 YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
@@ -239,18 +236,18 @@ YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
 }
 
 void YGNodeStyleSetMargin(YGNodeRef node, YGEdge edge, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
-  updateIndexedStyleProp<&Style::margin, &Style::setMargin>(node, edge, value);
+  updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
+      node, edge, value::points(points));
 }
 
 void YGNodeStyleSetMarginPercent(YGNodeRef node, YGEdge edge, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
-  updateIndexedStyleProp<&Style::margin, &Style::setMargin>(node, edge, value);
+  updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
+      node, edge, value::percent(percent));
 }
 
 void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
   updateIndexedStyleProp<&Style::margin, &Style::setMargin>(
-      node, edge, CompactValue::ofAuto());
+      node, edge, value::ofAuto());
 }
 
 YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
@@ -258,15 +255,13 @@ YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
 }
 
 void YGNodeStyleSetPadding(YGNodeRef node, YGEdge edge, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::padding, &Style::setPadding>(
-      node, edge, value);
+      node, edge, value::points(points));
 }
 
 void YGNodeStyleSetPaddingPercent(YGNodeRef node, YGEdge edge, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::padding, &Style::setPadding>(
-      node, edge, value);
+      node, edge, value::percent(percent));
 }
 
 YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
@@ -277,8 +272,8 @@ void YGNodeStyleSetBorder(
     const YGNodeRef node,
     const YGEdge edge,
     const float border) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(border);
-  updateIndexedStyleProp<&Style::border, &Style::setBorder>(node, edge, value);
+  updateIndexedStyleProp<&Style::border, &Style::setBorder>(
+      node, edge, value::points(border));
 }
 
 float YGNodeStyleGetBorder(const YGNodeConstRef node, const YGEdge edge) {
@@ -294,9 +289,8 @@ void YGNodeStyleSetGap(
     const YGNodeRef node,
     const YGGutter gutter,
     const float gapLength) {
-  auto length = CompactValue::ofMaybe<YGUnitPoint>(gapLength);
   updateIndexedStyleProp<&Style::gap, &Style::setGap>(
-      node, scopedEnum(gutter), length);
+      node, scopedEnum(gutter), value::points(gapLength));
 }
 
 float YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
@@ -319,20 +313,18 @@ float YGNodeStyleGetAspectRatio(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetWidth(YGNodeRef node, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::points(points));
 }
 
 void YGNodeStyleSetWidthPercent(YGNodeRef node, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::percent(percent));
 }
 
 void YGNodeStyleSetWidthAuto(YGNodeRef node) {
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, CompactValue::ofAuto());
+      node, Dimension::Width, value::ofAuto());
 }
 
 YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
@@ -340,20 +332,18 @@ YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetHeight(YGNodeRef node, float points) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(points);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::points(points));
 }
 
 void YGNodeStyleSetHeightPercent(YGNodeRef node, float percent) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(percent);
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::percent(percent));
 }
 
 void YGNodeStyleSetHeightAuto(YGNodeRef node) {
   updateIndexedStyleProp<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, CompactValue::ofAuto());
+      node, Dimension::Height, value::ofAuto());
 }
 
 YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
@@ -361,15 +351,13 @@ YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetMinWidth(const YGNodeRef node, const float minWidth) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(minWidth);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::points(minWidth));
 }
 
 void YGNodeStyleSetMinWidthPercent(const YGNodeRef node, const float minWidth) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(minWidth);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::percent(minWidth));
 }
 
 YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
@@ -377,17 +365,15 @@ YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetMinHeight(const YGNodeRef node, const float minHeight) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(minHeight);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::points(minHeight));
 }
 
 void YGNodeStyleSetMinHeightPercent(
     const YGNodeRef node,
     const float minHeight) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(minHeight);
   updateIndexedStyleProp<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::percent(minHeight));
 }
 
 YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
@@ -395,15 +381,13 @@ YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetMaxWidth(const YGNodeRef node, const float maxWidth) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(maxWidth);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::points(maxWidth));
 }
 
 void YGNodeStyleSetMaxWidthPercent(const YGNodeRef node, const float maxWidth) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(maxWidth);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Width, value);
+      node, Dimension::Width, value::percent(maxWidth));
 }
 
 YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
@@ -411,17 +395,15 @@ YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
 }
 
 void YGNodeStyleSetMaxHeight(const YGNodeRef node, const float maxHeight) {
-  auto value = CompactValue::ofMaybe<YGUnitPoint>(maxHeight);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::points(maxHeight));
 }
 
 void YGNodeStyleSetMaxHeightPercent(
     const YGNodeRef node,
     const float maxHeight) {
-  auto value = CompactValue::ofMaybe<YGUnitPercent>(maxHeight);
   updateIndexedStyleProp<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Height, value);
+      node, Dimension::Height, value::percent(maxHeight));
 }
 
 YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/Cache.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/Cache.h
@@ -7,19 +7,19 @@
 
 #pragma once
 
+#include <yoga/algorithm/SizingMode.h>
 #include <yoga/config/Config.h>
-#include <yoga/enums/MeasureMode.h>
 
 namespace facebook::yoga {
 
 bool canUseCachedMeasurement(
-    MeasureMode widthMode,
+    SizingMode widthMode,
     float availableWidth,
-    MeasureMode heightMode,
+    SizingMode heightMode,
     float availableHeight,
-    MeasureMode lastWidthMode,
+    SizingMode lastWidthMode,
     float lastAvailableWidth,
-    MeasureMode lastHeightMode,
+    SizingMode lastHeightMode,
     float lastAvailableHeight,
     float lastComputedWidth,
     float lastComputedHeight,

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/ResolveValue.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/ResolveValue.h
@@ -10,7 +10,7 @@
 #include <yoga/Yoga.h>
 
 #include <yoga/numeric/FloatOptional.h>
-#include <yoga/style/CompactValue.h>
+#include <yoga/style/Style.h>
 
 namespace facebook::yoga {
 
@@ -25,7 +25,7 @@ inline FloatOptional resolveValue(const YGValue value, const float ownerSize) {
   }
 }
 
-inline FloatOptional resolveValue(CompactValue value, float ownerSize) {
+inline FloatOptional resolveValue(Style::Length value, float ownerSize) {
   return resolveValue((YGValue)value, ownerSize);
 }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/SizingMode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/SizingMode.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/debug/AssertFatal.h>
+#include <yoga/enums/MeasureMode.h>
+
+namespace facebook::yoga {
+
+/**
+ * Corresponds to a CSS auto box sizes. Missing "min-content", as Yoga does not
+ * current support automatic minimum sizes.
+ * https://www.w3.org/TR/css-sizing-3/#auto-box-sizes
+ * https://www.w3.org/TR/css-flexbox-1/#min-size-auto
+ */
+enum class SizingMode {
+  /**
+   * The size a box would take if its outer size filled the available space in
+   * the given axis; in other words, the stretch fit into the available space,
+   * if that is definite. Undefined if the available space is indefinite.
+   */
+  StretchFit,
+
+  /**
+   * A box’s “ideal” size in a given axis when given infinite available space.
+   * Usually this is the smallest size the box could take in that axis while
+   * still fitting around its contents, i.e. minimizing unfilled space while
+   * avoiding overflow.
+   */
+  MaxContent,
+
+  /**
+   * If the available space in a given axis is definite, equal to
+   * clamp(min-content size, stretch-fit size, max-content size) (i.e.
+   * max(min-content size, min(max-content size, stretch-fit size))). When
+   * sizing under a min-content constraint, equal to the min-content size.
+   * Otherwise, equal to the max-content size in that axis.
+   */
+  FitContent,
+};
+
+inline MeasureMode measureMode(SizingMode mode) {
+  switch (mode) {
+    case SizingMode::StretchFit:
+      return MeasureMode::Exactly;
+    case SizingMode::MaxContent:
+      return MeasureMode::Undefined;
+    case SizingMode::FitContent:
+      return MeasureMode::AtMost;
+  }
+
+  fatalWithMessage("Invalid SizingMode");
+}
+
+inline SizingMode sizingMode(MeasureMode mode) {
+  switch (mode) {
+    case MeasureMode::Exactly:
+      return SizingMode::StretchFit;
+    case MeasureMode::Undefined:
+      return SizingMode::MaxContent;
+    case MeasureMode::AtMost:
+      return SizingMode::FitContent;
+  }
+
+  fatalWithMessage("Invalid MeasureMode");
+}
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.cpp
@@ -7,8 +7,10 @@
 
 #include <stdexcept>
 
+#include <yoga/config/Config.h>
 #include <yoga/debug/AssertFatal.h>
 #include <yoga/debug/Log.h>
+#include <yoga/node/Node.h>
 
 namespace facebook::yoga {
 

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.h
@@ -8,10 +8,11 @@
 #pragma once
 
 #include <yoga/Yoga.h>
-#include <yoga/config/Config.h>
-#include <yoga/node/Node.h>
 
 namespace facebook::yoga {
+
+class Node;
+class Config;
 
 [[noreturn]] void fatalWithMessage(const char* message);
 

--- a/packages/react-native/ReactCommon/yoga/yoga/node/CachedMeasurement.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/CachedMeasurement.h
@@ -11,7 +11,7 @@
 
 #include <yoga/Yoga.h>
 
-#include <yoga/enums/MeasureMode.h>
+#include <yoga/algorithm/SizingMode.h>
 #include <yoga/numeric/Comparison.h>
 
 namespace facebook::yoga {
@@ -19,15 +19,15 @@ namespace facebook::yoga {
 struct CachedMeasurement {
   float availableWidth{-1};
   float availableHeight{-1};
-  MeasureMode widthMeasureMode{MeasureMode::Undefined};
-  MeasureMode heightMeasureMode{MeasureMode::Undefined};
+  SizingMode widthSizingMode{SizingMode::MaxContent};
+  SizingMode heightSizingMode{SizingMode::MaxContent};
 
   float computedWidth{-1};
   float computedHeight{-1};
 
   bool operator==(CachedMeasurement measurement) const {
-    bool isEqual = widthMeasureMode == measurement.widthMeasureMode &&
-        heightMeasureMode == measurement.heightMeasureMode;
+    bool isEqual = widthSizingMode == measurement.widthSizingMode &&
+        heightSizingMode == measurement.heightSizingMode;
 
     if (!yoga::isUndefined(availableWidth) ||
         !yoga::isUndefined(measurement.availableWidth)) {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -58,7 +58,7 @@ void Node::print() {
 
 // TODO: Edge value resolution should be moved to `yoga::Style`
 template <auto Field>
-CompactValue Node::computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const {
+Style::Length Node::computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const {
   if ((style_.*Field)(rowEdge).isDefined()) {
     return (style_.*Field)(rowEdge);
   } else if ((style_.*Field)(edge).isDefined()) {
@@ -72,7 +72,7 @@ CompactValue Node::computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const {
 
 // TODO: Edge value resolution should be moved to `yoga::Style`
 template <auto Field>
-CompactValue Node::computeEdgeValueForColumn(YGEdge edge) const {
+Style::Length Node::computeEdgeValueForColumn(YGEdge edge) const {
   if ((style_.*Field)(edge).isDefined()) {
     return (style_.*Field)(edge);
   } else if ((style_.*Field)(YGEdgeVertical).isDefined()) {
@@ -497,8 +497,8 @@ void Node::setLayoutHadOverflow(bool hadOverflow) {
   layout_.setHadOverflow(hadOverflow);
 }
 
-void Node::setLayoutDimension(float dimensionValue, Dimension dimension) {
-  layout_.setDimension(dimension, dimensionValue);
+void Node::setLayoutDimension(float LengthValue, Dimension dimension) {
+  layout_.setDimension(dimension, LengthValue);
 }
 
 // If both left and right are defined, then use left. Otherwise return +left or

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -20,7 +20,6 @@
 #include <yoga/enums/MeasureMode.h>
 #include <yoga/enums/NodeType.h>
 #include <yoga/node/LayoutResults.h>
-#include <yoga/style/CompactValue.h>
 #include <yoga/style/Style.h>
 
 // Tag struct used to form the opaque YGNodeRef for the public C API
@@ -66,10 +65,10 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   template <auto Field>
-  CompactValue computeEdgeValueForColumn(YGEdge edge) const;
+  Style::Length computeEdgeValueForColumn(YGEdge edge) const;
 
   template <auto Field>
-  CompactValue computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const;
+  Style::Length computeEdgeValueForRow(YGEdge rowEdge, YGEdge edge) const;
 
   // DANGER DANGER DANGER!
   // If the node assigned to has children, we'd either have to deallocate
@@ -327,7 +326,7 @@ class YG_EXPORT Node : public ::YGNode {
       uint32_t computedFlexBasisGeneration);
   void setLayoutMeasuredDimension(float measuredDimension, Dimension dimension);
   void setLayoutHadOverflow(bool hadOverflow);
-  void setLayoutDimension(float dimensionValue, Dimension dimension);
+  void setLayoutDimension(float LengthValue, Dimension dimension);
   void setLayoutDirection(Direction direction);
   void setLayoutMargin(float margin, YGEdge edge);
   void setLayoutBorder(float border, YGEdge edge);

--- a/packages/react-native/ReactCommon/yoga/yoga/style/CompactValue.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/CompactValue.h
@@ -52,6 +52,10 @@ class YG_EXPORT CompactValue {
 
   template <YGUnit Unit>
   static CompactValue of(float value) noexcept {
+    if (yoga::isUndefined(value) || std::isinf(value)) {
+      return ofUndefined();
+    }
+
     if (value == 0.0f || (value < LOWER_BOUND && value > -LOWER_BOUND)) {
       constexpr auto zero =
           Unit == YGUnitPercent ? ZERO_BITS_PERCENT : ZERO_BITS_POINT;
@@ -69,16 +73,6 @@ class YG_EXPORT CompactValue {
     data -= BIAS;
     data |= unitBit;
     return {data};
-  }
-
-  template <YGUnit Unit>
-  static CompactValue ofMaybe(float value) noexcept {
-    return std::isnan(value) || std::isinf(value) ? ofUndefined()
-                                                  : of<Unit>(value);
-  }
-
-  static constexpr CompactValue ofZero() noexcept {
-    return CompactValue{ZERO_BITS_POINT};
   }
 
   static constexpr CompactValue ofUndefined() noexcept {
@@ -168,10 +162,6 @@ template <>
 CompactValue CompactValue::of<YGUnitUndefined>(float) noexcept = delete;
 template <>
 CompactValue CompactValue::of<YGUnitAuto>(float) noexcept = delete;
-template <>
-CompactValue CompactValue::ofMaybe<YGUnitUndefined>(float) noexcept = delete;
-template <>
-CompactValue CompactValue::ofMaybe<YGUnitAuto>(float) noexcept = delete;
 
 constexpr bool operator==(CompactValue a, CompactValue b) noexcept {
   return a.repr_ == b.repr_;

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -28,18 +28,29 @@
 #include <yoga/enums/Wrap.h>
 #include <yoga/numeric/FloatOptional.h>
 #include <yoga/style/CompactValue.h>
+#include <yoga/style/ValueFactories.h>
 
 namespace facebook::yoga {
 
 class YG_EXPORT Style {
-  template <typename Enum>
-  using Values = std::array<CompactValue, ordinalCount<Enum>()>;
-
-  using Dimensions = Values<Dimension>;
-  using Edges = Values<YGEdge>;
-  using Gutters = Values<Gutter>;
-
  public:
+  /**
+   * Style::Length represents a CSS Value which may be one of:
+   * 1. Undefined
+   * 2. A keyword (e.g. auto)
+   * 3. A CSS <length-percentage> value:
+   *    a. <length> value (e.g. 10px)
+   *    b. <percentage> value of a reference <length>
+   * 4. (soon) A math function which returns a <length-percentage> value
+   *
+   * References:
+   * 1. https://www.w3.org/TR/css-values-4/#lengths
+   * 2. https://www.w3.org/TR/css-values-4/#percentage-value
+   * 3. https://www.w3.org/TR/css-values-4/#mixed-percentages
+   * 4. https://www.w3.org/TR/css-values-4/#math
+   */
+  using Length = CompactValue;
+
   static constexpr float DefaultFlexGrow = 0.0f;
   static constexpr float DefaultFlexShrink = 0.0f;
   static constexpr float WebDefaultFlexShrink = 1.0f;
@@ -76,6 +87,10 @@ class YG_EXPORT Style {
   ~Style() = default;
 
  private:
+  using Dimensions = std::array<Style::Length, ordinalCount<Dimension>()>;
+  using Edges = std::array<Style::Length, ordinalCount<Edge>()>;
+  using Gutters = std::array<Style::Length, ordinalCount<Gutter>()>;
+
   static constexpr uint8_t directionOffset = 0;
   static constexpr uint8_t flexdirectionOffset =
       directionOffset + minimumBitCount<Direction>();
@@ -101,13 +116,13 @@ class YG_EXPORT Style {
   FloatOptional flex_ = {};
   FloatOptional flexGrow_ = {};
   FloatOptional flexShrink_ = {};
-  CompactValue flexBasis_ = CompactValue::ofAuto();
+  Style::Length flexBasis_ = value::ofAuto();
   Edges margin_ = {};
   Edges position_ = {};
   Edges padding_ = {};
   Edges border_ = {};
   Gutters gap_ = {};
-  Dimensions dimensions_{CompactValue::ofAuto(), CompactValue::ofAuto()};
+  Dimensions dimensions_{value::ofAuto(), value::ofAuto()};
   Dimensions minDimensions_ = {};
   Dimensions maxDimensions_ = {};
   // Yoga specific properties, not compatible with flexbox specification
@@ -205,66 +220,66 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  CompactValue flexBasis() const {
+  Style::Length flexBasis() const {
     return flexBasis_;
   }
-  Ref<CompactValue, &Style::flexBasis_> flexBasis() {
+  Ref<Style::Length, &Style::flexBasis_> flexBasis() {
     return {*this};
   }
 
-  CompactValue margin(YGEdge edge) const {
+  Style::Length margin(YGEdge edge) const {
     return margin_[edge];
   }
-  void setMargin(YGEdge edge, CompactValue value) {
+  void setMargin(YGEdge edge, Style::Length value) {
     margin_[edge] = value;
   }
 
-  CompactValue position(YGEdge edge) const {
+  Style::Length position(YGEdge edge) const {
     return position_[edge];
   }
-  void setPosition(YGEdge edge, CompactValue value) {
+  void setPosition(YGEdge edge, Style::Length value) {
     position_[edge] = value;
   }
 
-  CompactValue padding(YGEdge edge) const {
+  Style::Length padding(YGEdge edge) const {
     return padding_[edge];
   }
-  void setPadding(YGEdge edge, CompactValue value) {
+  void setPadding(YGEdge edge, Style::Length value) {
     padding_[edge] = value;
   }
 
-  CompactValue border(YGEdge edge) const {
+  Style::Length border(YGEdge edge) const {
     return border_[edge];
   }
-  void setBorder(YGEdge edge, CompactValue value) {
+  void setBorder(YGEdge edge, Style::Length value) {
     border_[edge] = value;
   }
 
-  CompactValue gap(Gutter gutter) const {
+  Style::Length gap(Gutter gutter) const {
     return gap_[yoga::to_underlying(gutter)];
   }
-  void setGap(Gutter gutter, CompactValue value) {
+  void setGap(Gutter gutter, Style::Length value) {
     gap_[yoga::to_underlying(gutter)] = value;
   }
 
-  CompactValue dimension(Dimension axis) const {
+  Style::Length dimension(Dimension axis) const {
     return dimensions_[yoga::to_underlying(axis)];
   }
-  void setDimension(Dimension axis, CompactValue value) {
+  void setDimension(Dimension axis, Style::Length value) {
     dimensions_[yoga::to_underlying(axis)] = value;
   }
 
-  CompactValue minDimension(Dimension axis) const {
+  Style::Length minDimension(Dimension axis) const {
     return minDimensions_[yoga::to_underlying(axis)];
   }
-  void setMinDimension(Dimension axis, CompactValue value) {
+  void setMinDimension(Dimension axis, Style::Length value) {
     minDimensions_[yoga::to_underlying(axis)] = value;
   }
 
-  CompactValue maxDimension(Dimension axis) const {
+  Style::Length maxDimension(Dimension axis) const {
     return maxDimensions_[yoga::to_underlying(axis)];
   }
-  void setMaxDimension(Dimension axis, CompactValue value) {
+  void setMaxDimension(Dimension axis, Style::Length value) {
     maxDimensions_[yoga::to_underlying(axis)] = value;
   }
 
@@ -276,7 +291,7 @@ class YG_EXPORT Style {
     return {*this};
   }
 
-  CompactValue resolveColumnGap() const {
+  Length resolveColumnGap() const {
     if (gap_[yoga::to_underlying(Gutter::Column)].isDefined()) {
       return gap_[yoga::to_underlying(Gutter::Column)];
     } else {
@@ -284,7 +299,7 @@ class YG_EXPORT Style {
     }
   }
 
-  CompactValue resolveRowGap() const {
+  Style::Length resolveRowGap() const {
     if (gap_[yoga::to_underlying(Gutter::Row)].isDefined()) {
       return gap_[yoga::to_underlying(Gutter::Row)];
     } else {

--- a/packages/react-native/ReactCommon/yoga/yoga/style/ValueFactories.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/ValueFactories.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <yoga/style/CompactValue.h>
+
+namespace facebook::yoga::value {
+
+/**
+ * Canonical unit (one YGUnitPoint)
+ */
+inline CompactValue points(float value) {
+  return CompactValue::of<YGUnitPoint>(value);
+}
+
+/**
+ * Percent of reference
+ */
+inline CompactValue percent(float value) {
+  return CompactValue::of<YGUnitPercent>(value);
+}
+
+/**
+ * "auto" keyword
+ */
+inline CompactValue ofAuto() {
+  return CompactValue::ofAuto();
+}
+
+/**
+ * Undefined
+ */
+inline CompactValue undefined() {
+  return CompactValue::ofUndefined();
+}
+
+} // namespace facebook::yoga::value


### PR DESCRIPTION
Summary:
Yoga passes `MeasureMode`/`YGMeasureMode` to express constraints in how a box should be measured, given definite or indefinite available space.

This is modeled after Android [MeasureSpec](https://developer.android.com/reference/android/view/View.MeasureSpec), with a table above `calculateLayoutImpl()` explaining the CSS terms they map to. This can be confusing when flipping between the spec, and code.

This switches internal usages to the CSS terms, but leaves around `YGMeasureMode` since it is the public API passed to measure functions.

Reviewed By: joevilches

Differential Revision: D51068417

