### PR TITLE
Fix `build_codegen!` not finding `@react-native/codegen` in pnpm setups

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
@@ -68,7 +68,7 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pod::Executable.executed_commands.length, 0)
     end
 
-    def testCheckAndGenerateEmptyThirdPartyProvider_whenHeaderMissingAndCodegenMissing_raiseError()
+    def testCheckAndGenerateEmptyThirdPartyProvider_whenHeaderMissingAndCodegenMissing_dontBuildCodegen()
 
         # Arrange
         FileMock.mocked_existing_files([
@@ -76,7 +76,7 @@ class CodegenTests < Test::Unit::TestCase
         ])
 
         # Act
-        assert_raise {
+        assert_nothing_raised {
             checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, dir_manager: DirMock, file_manager: FileMock)
         }
 
@@ -84,20 +84,18 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
-            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header,
+            @base_path + "/" + @prefix + "/React/Fabric/tmpSchemaList.txt",
         ])
-        assert_equal(Pod::UI.collected_messages, [])
+        assert_equal(DirMock.exist_invocation_params, [
+            @base_path + "/"+ @prefix + "/../react-native-codegen",
+        ])
+        assert_equal(Pod::UI.collected_messages, [
+          "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider",
+        ])
         assert_equal($collected_commands, [])
-        assert_equal(FileMock.open_files.length, 0)
-        assert_equal(Pod::Executable.executed_commands, [
-          {
-            "arguments"=> [
-              "-p",
-              "require.resolve('@react-native/codegen/package.json', {paths: ['#{@base_path + "/"+ @prefix}']})"
-            ],
-            "command"=>"node"
-          }
-        ])
+        assert_equal(FileMock.open_files.length, 1)
+        assert_equal(Pod::Executable.executed_commands.length, 1)
     end
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenImplementationMissingAndCodegenrepoExists_dontBuildCodegen()
@@ -134,7 +132,7 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(FileMock.open_files_with_mode[@prefix + "/React/Fabric/tmpSchemaList.txt"], nil)
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
-        assert_equal(Pod::Executable.executed_commands[1], {
+        assert_equal(Pod::Executable.executed_commands[0], {
             "command" => "node",
             "arguments" => [
                 @base_path + "/" + @prefix + "/scripts/generate-provider-cli.js",
@@ -168,13 +166,13 @@ class CodegenTests < Test::Unit::TestCase
             codegen_cli_path + "/lib",
         ])
         assert_equal(Pod::UI.collected_messages, [
-            "[Codegen] building #{codegen_cli_path}.",
+            "[Codegen] building #{codegen_cli_path}",
             "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
         ])
         assert_equal($collected_commands, ["~/app/ios/../../../react-native-codegen/scripts/oss/build.sh"])
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
-        assert_equal(Pod::Executable.executed_commands[1], {
+        assert_equal(Pod::Executable.executed_commands[0], {
             "command" => "node",
             "arguments" => [
                 @base_path + "/" + @prefix + "/scripts/generate-provider-cli.js",
@@ -208,13 +206,15 @@ class CodegenTests < Test::Unit::TestCase
             @base_path + "/" + codegen_cli_path + "/lib",
         ])
         assert_equal(Pod::UI.collected_messages, [
-            "[Codegen] building #{@base_path + "/" + codegen_cli_path}.",
+            "[Codegen] building #{@base_path + "/" + codegen_cli_path}",
             "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
         ])
-        assert_equal($collected_commands, [@base_path + "/" + rn_path + "/../react-native-codegen/scripts/oss/build.sh"])
+        assert_equal($collected_commands, [
+          @base_path + "/" + rn_path + "/../react-native-codegen/scripts/oss/build.sh",
+        ])
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
-        assert_equal(Pod::Executable.executed_commands[1], {
+        assert_equal(Pod::Executable.executed_commands[0], {
             "command" => "node",
             "arguments" => [
                 @base_path + "/" + rn_path + "/scripts/generate-provider-cli.js",

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
@@ -86,15 +86,18 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(FileMock.exist_invocation_params, [
             @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header
         ])
-        assert_equal(DirMock.exist_invocation_params, [
-            @base_path + "/"+ @prefix + "/../react-native-codegen",
-            @base_path + "/"+ @prefix + "/../@react-native/codegen",
-            @base_path + "/"+ @prefix + "/node_modules/@react-native/codegen",
-        ])
         assert_equal(Pod::UI.collected_messages, [])
         assert_equal($collected_commands, [])
         assert_equal(FileMock.open_files.length, 0)
-        assert_equal(Pod::Executable.executed_commands.length, 0)
+        assert_equal(Pod::Executable.executed_commands, [
+          {
+            "arguments"=> [
+              "-p",
+              "require.resolve('@react-native/codegen/package.json', {paths: ['#{@base_path + "/"+ @prefix}']})"
+            ],
+            "command"=>"node"
+          }
+        ])
     end
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenImplementationMissingAndCodegenrepoExists_dontBuildCodegen()
@@ -131,7 +134,7 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(FileMock.open_files_with_mode[@prefix + "/React/Fabric/tmpSchemaList.txt"], nil)
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
-        assert_equal(Pod::Executable.executed_commands[0], {
+        assert_equal(Pod::Executable.executed_commands[1], {
             "command" => "node",
             "arguments" => [
                 @base_path + "/" + @prefix + "/scripts/generate-provider-cli.js",
@@ -146,7 +149,7 @@ class CodegenTests < Test::Unit::TestCase
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenBothMissing_buildCodegen()
         # Arrange
-        codegen_cli_path = @base_path + "/" + @prefix + "/../@react-native/codegen"
+        codegen_cli_path = @base_path + "/" + @prefix + "/../react-native-codegen"
         DirMock.mocked_existing_dirs([
             codegen_cli_path,
         ])
@@ -161,7 +164,6 @@ class CodegenTests < Test::Unit::TestCase
             @base_path + "/" + @prefix + "/React/Fabric/" + @tmp_schema_list_file
         ])
         assert_equal(DirMock.exist_invocation_params, [
-            @base_path + "/" + @prefix + "/../react-native-codegen",
             codegen_cli_path,
             codegen_cli_path + "/lib",
         ])
@@ -169,10 +171,10 @@ class CodegenTests < Test::Unit::TestCase
             "[Codegen] building #{codegen_cli_path}.",
             "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
         ])
-        assert_equal($collected_commands, ["~/app/ios/../../../@react-native/codegen/scripts/oss/build.sh"])
+        assert_equal($collected_commands, ["~/app/ios/../../../react-native-codegen/scripts/oss/build.sh"])
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
-        assert_equal(Pod::Executable.executed_commands[0], {
+        assert_equal(Pod::Executable.executed_commands[1], {
             "command" => "node",
             "arguments" => [
                 @base_path + "/" + @prefix + "/scripts/generate-provider-cli.js",
@@ -186,7 +188,7 @@ class CodegenTests < Test::Unit::TestCase
     def testCheckAndGenerateEmptyThirdPartyProvider_withAbsoluteReactNativePath_buildCodegen()
         # Arrange
         rn_path = 'packages/react-native'
-        codegen_cli_path = rn_path + "/../@react-native/codegen"
+        codegen_cli_path = rn_path + "/../react-native-codegen"
         DirMock.mocked_existing_dirs([
             @base_path + "/" + codegen_cli_path,
         ])
@@ -202,7 +204,6 @@ class CodegenTests < Test::Unit::TestCase
             @base_path + "/" + rn_path + "/React/Fabric/" + @tmp_schema_list_file
         ])
         assert_equal(DirMock.exist_invocation_params, [
-            @base_path + "/" + rn_path + "/../react-native-codegen",
             @base_path + "/" + codegen_cli_path,
             @base_path + "/" + codegen_cli_path + "/lib",
         ])
@@ -210,10 +211,10 @@ class CodegenTests < Test::Unit::TestCase
             "[Codegen] building #{@base_path + "/" + codegen_cli_path}.",
             "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
         ])
-        assert_equal($collected_commands, [@base_path + "/" + rn_path + "/../@react-native/codegen/scripts/oss/build.sh"])
+        assert_equal($collected_commands, [@base_path + "/" + rn_path + "/../react-native-codegen/scripts/oss/build.sh"])
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
-        assert_equal(Pod::Executable.executed_commands[0], {
+        assert_equal(Pod::Executable.executed_commands[1], {
             "command" => "node",
             "arguments" => [
                 @base_path + "/" + rn_path + "/scripts/generate-provider-cli.js",

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
@@ -89,6 +89,7 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(DirMock.exist_invocation_params, [
             @base_path + "/"+ @prefix + "/../react-native-codegen",
             @base_path + "/"+ @prefix + "/../@react-native/codegen",
+            @base_path + "/"+ @prefix + "/node_modules/@react-native/codegen",
         ])
         assert_equal(Pod::UI.collected_messages, [])
         assert_equal($collected_commands, [])

--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -11,16 +11,20 @@
 # - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
 # @throws an error if it could not find the codegen folder.
 def build_codegen!(react_native_path, relative_installation_root, dir_manager: Dir)
-    codegen_repo_path = "#{basePath(react_native_path, relative_installation_root)}/../react-native-codegen";
-    codegen_npm_path = "#{basePath(react_native_path, relative_installation_root)}/../@react-native/codegen";
+    react_native_relpath = "#{basePath(react_native_path, relative_installation_root)}"
+    codegen_repo_path = "#{react_native_relpath}/../react-native-codegen";
+    codegen_npm_path = "#{react_native_relpath}/../@react-native/codegen";
+    codegen_pnpm_path = "#{react_native_relpath}/node_modules/@react-native/codegen";
     codegen_cli_path = ""
 
     if dir_manager.exist?(codegen_repo_path)
       codegen_cli_path = codegen_repo_path
     elsif dir_manager.exist?(codegen_npm_path)
       codegen_cli_path = codegen_npm_path
+    elsif dir_manager.exist?(codegen_pnpm_path)
+      codegen_cli_path = codegen_pnpm_path
     else
-      raise "[codegen] Could not find react-native-codegen."
+      raise "[codegen] Could not find react-native-codegen"
     end
 
     if !dir_manager.exist?("#{codegen_cli_path}/lib")

--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -11,25 +11,11 @@
 # - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
 # @throws an error if it could not find the codegen folder.
 def build_codegen!(react_native_path, relative_installation_root, dir_manager: Dir)
-  react_native_relpath = "#{relative_installation_root}/#{react_native_path}"
-  codegen_json_path = Pod::Executable.execute_command('node', [
-    '-p',
-    "require.resolve('@react-native/codegen/package.json', {paths: ['#{react_native_relpath}']})"
-  ])
-  if codegen_json_path.is_a? String
-    codegen_json_path = codegen_json_path.strip
-    codegen_path = Pathname.new(codegen_json_path).parent.relative_path_from(Pathname.pwd)
-  else
-    # This should only happen under testing
-    codegen_path = "#{react_native_relpath}/../react-native-codegen"
-  end
+  codegen_repo_path = "#{basePath(react_native_path, relative_installation_root)}/../react-native-codegen"
+  return unless dir_manager.exist?(codegen_repo_path) && !dir_manager.exist?("#{codegen_repo_path}/lib")
 
-  raise "[Codegen] Could not find react-native-codegen" unless dir_manager.exist?(codegen_path)
-
-  if !dir_manager.exist?("#{codegen_path}/lib")
-    Pod::UI.puts "[Codegen] building #{codegen_path}."
-    system("#{codegen_path}/scripts/oss/build.sh")
-  end
+  Pod::UI.puts "[Codegen] building #{codegen_repo_path}"
+  system("#{codegen_repo_path}/scripts/oss/build.sh")
 end
 
 # It generates an empty `ThirdPartyProvider`, required by Fabric to load the components


### PR DESCRIPTION
## Summary:

`build_codegen!` currently assumes that `@react-native/codegen` gets installed next to `react-native`. In a pnpm setup, it's found under `/~/react-native/node_modules/@react-native/codegen` instead.

However, as @dmytrorykun pointed out, we don't actually need to build it outside of this repository.

## Changelog:

[GENERAL] [FIXED] - `@react-native/codegen` shouldn't be built unless it's in the repo — fixes `pod install` failures in pnpm setups

## Test Plan:

We have a patched version of `react-native` working in a pnpm setup here: https://github.com/microsoft/rnx-kit/pull/2811