### PR TITLE
Remove vestigial reference to UIActionSheetDelegate

### DIFF
--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -20,7 +20,7 @@
 
 using namespace facebook::react;
 
-@interface RCTActionSheetManager () <UIActionSheetDelegate, NativeActionSheetManagerSpec>
+@interface RCTActionSheetManager () <NativeActionSheetManagerSpec>
 
 @property (nonatomic, strong) NSMutableArray<UIAlertController *> *alertControllers;
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

UIActionSheet was deprecated in iOS 8.3.

The RCTActionSheetManager class listed the UIActionSheetDelegate as an adopted protocol but none of the protocol methods were implemented.

Differential Revision: D50732844


