### PR TITLE
Fix type in BlobCollector.h/cpp

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/reactnativeblob/BlobCollector.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/reactnativeblob/BlobCollector.cpp
@@ -33,7 +33,7 @@ BlobCollector::~BlobCollector() {
 }
 
 void BlobCollector::nativeInstall(
-    jni::alias_ref<jhybridobject> jThis,
+    jni::alias_ref<jclass>,
     jni::alias_ref<jobject> blobModule,
     jlong jsContextNativePointer) {
   auto& runtime = *((jsi::Runtime*)jsContextNativePointer);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/reactnativeblob/BlobCollector.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/reactnativeblob/BlobCollector.h
@@ -16,7 +16,7 @@ class BlobCollector : public jni::HybridClass<BlobCollector>,
                       public jsi::HostObject {
  public:
   BlobCollector(
-      jni::global_ref<jobject> blobManager,
+      jni::global_ref<jobject> blobModule,
       const std::string& blobId);
   ~BlobCollector();
 
@@ -24,7 +24,7 @@ class BlobCollector : public jni::HybridClass<BlobCollector>,
       "Lcom/facebook/react/modules/blob/BlobCollector;";
 
   static void nativeInstall(
-      jni::alias_ref<jhybridobject> jThis,
+      jni::alias_ref<jclass>,
       jni::alias_ref<jobject> blobModule,
       jlong jsContextNativePointer);
 


### PR DESCRIPTION
When working on JSI module, `BlobCollector`'s `nativeInstall` is a good example. But the first type should be `jni::alias_ref<jclass>` according to https://github.com/facebookincubator/fbjni/blob/main/docs/quickref.md#basic-method-usage-java-to-c-and-c-to-java

## Summary:

Fix type in BlobCollector.h/cpp

## Changelog:

[ANDROID] [FIXED] - Fix type in BlobCollector.h/cpp

## Test Plan:

None