### PR TITLE
Stub nativeFabricUIManager for jest tests

### DIFF
--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -27,6 +27,12 @@ Object.defineProperties(global, {
     value: id => clearTimeout(id),
     writable: true,
   },
+  nativeFabricUIManager: {
+    configurable: true,
+    enumerable: true,
+    value: {},
+    writable: true,
+  },
   performance: {
     configurable: true,
     enumerable: true,


### PR DESCRIPTION
Summary:
When FabricRenderer is used during jests it will currently error out since `nativeFabricUIManager` is nog a configured global.

Changelog: [Internal]

Differential Revision: D51198314


