### PR TITLE
Introduce again com/facebook/react/turbomodule/core/interfaces/TurboModule.kt

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModule.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core.interfaces
+
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
+
+/**
+ * This interface was introduced for backward compatibility purposes. This interface will be
+ * deprecated as part of the deprecation and removal of ReactModuleInfoProvider in the near future.
+ *
+ * See description of https://github.com/facebook/react-native/pull/41412 for more context.
+ */
+@DeprecatedInNewArchitecture
+interface TurboModule : com.facebook.react.internal.turbomodule.core.interfaces.TurboModule {}


### PR DESCRIPTION
Summary:
The PR https://github.com/facebook/react-native/pull/39682
 moved all TurboModule classes into the folder com/facebook/react/internal/turbomodule/core/interfaces/TurboModule. The reasoning is TurboModule classes are internal implementation of RN and they shouldn't be part of the public API.

Later we realized that com.facebook.react.internal.turbomodule.core.interfaces.TurboModule interface is actually being used by OSS developers too implement the TurboReactPackage.getReactModuleInfoProvider() method:
https://reactnative.dev/docs/next/the-new-architecture/pillars-turbomodules#updating-the-calculatorpackagejava

In this diff I'm re-introducing the com.facebook.react.turbomodule.core.interfaces.TurboModule interface jus for backward compatibility.

Since the plan is to delete the TurboReactPackage.getReactModuleInfoProvider method in the next few months, the plan is:

- Iterate on the experiments to remove TurboReactPackage.getReactModuleInfoProvider method

- Once TurboReactPackage.getReactModuleInfoProvider method is ready to be deleted, there's no need to expose TurboModule interface anymore, so we will delete 'com.facebook.react.turbomodule.core.interfaces.TurboModule' and 'TurboReactPackage.getReactModuleInfoProvider' method
- com.facebook.react.internal.turbomodule.core.interfaces.TurboModule will still remain in the codebase, but this will be an internal API

changelog: [Android][Changed] Fix backward compatibility breakage

Reviewed By: fkgozali

Differential Revision: D51168413


