### PR TITLE
RCTDeprecation BUCK integration

### DIFF
--- a/packages/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h
+++ b/packages/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef RCT_DEPRECATED_DECLARATIONS
+#define RCT_DEPRECATED_DECLARATIONS 0
+#endif
+
+#if RCT_DEPRECATED_DECLARATIONS
+#define RCT_DEPRECATED __attribute__((deprecated))
+#else
+#define RCT_DEPRECATED
+#endif

--- a/packages/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation/README.md
+++ b/packages/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation/README.md
@@ -1,0 +1,1 @@
+RCTDeprecation contains C macros to identify deprecated APIs at build-time.

--- a/packages/react-native/ReactApple/Libraries/RCTFoundation/README.md
+++ b/packages/react-native/ReactApple/Libraries/RCTFoundation/README.md
@@ -1,0 +1,12 @@
+# RCTFoundation
+
+RCTFoundation is a collection of lightweight utility libraries.
+
+Rules for RCTFoundation libraries:
+- They must only depend on other RCTFoundation libraries.
+- Headers cannot contain C++.
+- They have modular set to true in BUCK.
+- They have complete_nullability set to true.
+- They have enabled Clang compiler warnings.
+- They have documentation.
+- They have unit tests.

--- a/packages/react-native/ReactApple/README.md
+++ b/packages/react-native/ReactApple/README.md
@@ -1,0 +1,5 @@
+# ReactApple
+
+ReactApple contains code to ship React Native apps to Apple devices. The dominant language is Objective-C.
+
+New libraries built with Apple frameworks or intended to ship to Apple devices should live in this directory.


### PR DESCRIPTION
Summary:
Changelog: [Internal]

BUCK boilerplate to integrate the first RCTFoundation library. decided to split this up so we can reference it easily in the future when adding new libs

Differential Revision: D51101009


