### PR TITLE
"yogalayout.com" to "yogalayout.dev"

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -626,7 +626,7 @@ type ____LayoutStyle_Internal = $ReadOnly<{
   /** `direction` specifies the directional flow of the user interface.
    *  The default is `inherit`, except for root node which will have
    *  value based on the current locale.
-   *  See https://yogalayout.com/docs/layout-direction
+   *  See https://yogalayout.dev/docs/layout-direction
    *  for more details.
    *  @platform ios
    */

--- a/packages/react-native/ReactCommon/yoga/Yoga.podspec
+++ b/packages/react-native/ReactCommon/yoga/Yoga.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |spec|
   spec.name = 'Yoga'
   spec.version = '1.14.0'
   spec.license =  { :type => 'MIT' }
-  spec.homepage = 'https://yogalayout.com'
-  spec.documentation_url = 'https://yogalayout.com/docs/'
+  spec.homepage = 'https://yogalayout.dev'
+  spec.documentation_url = 'https://yogalayout.dev/docs/'
 
   spec.summary = 'Yoga is a cross-platform layout engine which implements Flexbox.'
   spec.description = 'Yoga is a cross-platform layout engine enabling maximum collaboration within your team by implementing an API many designers are familiar with, and opening it up to developers across different platforms.'


### PR DESCRIPTION
Summary:
https://yogalayout.com now redirects to https://yogalayout.dev

This replaces references to "yogalayout.com" with "yogalayout.dev", the same website, with a new domain. This includes:
1. Code comments
2. Yoga website config (publish action CNAME, Docusaurus config)
3. Documentation URLs in Yoga packages

Changelog:
[General][Fixed] - "yogalayout.com" to "yogalayout.dev"

Differential Revision: D51229587


