### PR TITLE
Make Yoga trunk builds "0.0.0"

### DIFF
--- a/packages/react-native/ReactCommon/yoga/Yoga.podspec
+++ b/packages/react-native/ReactCommon/yoga/Yoga.podspec
@@ -16,7 +16,7 @@ end
 
 Pod::Spec.new do |spec|
   spec.name = 'Yoga'
-  spec.version = '1.14.0'
+  spec.version = '0.0.0'
   spec.license =  { :type => 'MIT' }
   spec.homepage = 'https://yogalayout.dev'
   spec.documentation_url = 'https://yogalayout.dev/docs/'


### PR DESCRIPTION
Summary:
Right now Yoga's main branch says it's 2.0.0, and RN's dirsync says its 1.14.0, but the code is really closer to what will be Yoga 3.0.0.

This changes trunk builds to "0.0.0" for clarity, which will be assigned a real version number the first time publishing a new Yoga branch.

This is separately a good practice to prevent the chance of accidental publishes causing damage.

Differential Revision: D51236778


