### PR TITLE
Fix platform sensitivity in inspector-proxy tests

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -23,6 +23,10 @@ import {
   withServerForEachTest,
 } from './ServerUtils';
 import {createHash} from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+const fsPromise = fs.promises;
 
 // WebSocket is unreliable when using fake timers.
 jest.useRealTimers();
@@ -331,6 +335,13 @@ describe.each(['HTTP', 'HTTPS'])(
       });
 
       test('reads source from disk', async () => {
+        // Should be just 'foo\n', but the newline can get mangled by the OS
+        // and/or SCM, so let's read the source of truth from disk.
+        const fileRealContents = await fsPromise.readFile(
+          path.join(__dirname, '__fixtures__', 'mock-source-file.txt'),
+          'utf8',
+        );
+
         const {device, debugger_} = await createAndConnectTarget(
           serverRef,
           autoCleanup.signal,
@@ -351,7 +362,7 @@ describe.each(['HTTP', 'HTTPS'])(
               endLine: 0,
               startColumn: 0,
               endColumn: 0,
-              hash: createHash('sha256').update('foo\n').digest('hex'),
+              hash: createHash('sha256').update(fileRealContents).digest('hex'),
             },
           });
           const response = await debugger_.sendAndGetResponse({
@@ -362,7 +373,7 @@ describe.each(['HTTP', 'HTTPS'])(
             },
           });
           expect(response.result).toEqual(
-            expect.objectContaining({scriptSource: 'foo\n'}),
+            expect.objectContaining({scriptSource: fileRealContents}),
           );
           // The device does not receive the getScriptSource request, since it
           // is handled by the proxy.


### PR DESCRIPTION
Summary:
TSIA - should fix the [Windows test failure](https://app.circleci.com/pipelines/github/facebook/react-native/36174/workflows/055cabb6-cb41-4741-812a-59b06fc7c9b5/jobs/1200335/parallel-runs/0/steps/0-115?fbclid=IwAR38F8tE-831Rpe5J_KeFOmA5DARLWWYIAiLIgkXOLdEfMmSeaVOIGgPq5U) we saw on CircleCI.

Changelog: [Internal]

Differential Revision: D51254843


