### PR TITLE
Add .gitattributes for LF line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Tests may require LF line endings
+* text=auto eol=lf

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -23,6 +23,10 @@ import {
   withServerForEachTest,
 } from './ServerUtils';
 import {createHash} from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+const fsPromise = fs.promises;
 
 // WebSocket is unreliable when using fake timers.
 jest.useRealTimers();
@@ -331,6 +335,13 @@ describe.each(['HTTP', 'HTTPS'])(
       });
 
       test('reads source from disk', async () => {
+        // Should be just 'foo\n', but the newline can get mangled by the OS
+        // and/or SCM, so let's read the source of truth from disk.
+        const fileRealContents = await fsPromise.readFile(
+          path.join(__dirname, '__fixtures__', 'mock-source-file.txt'),
+          'utf8',
+        );
+
         const {device, debugger_} = await createAndConnectTarget(
           serverRef,
           autoCleanup.signal,
@@ -351,7 +362,7 @@ describe.each(['HTTP', 'HTTPS'])(
               endLine: 0,
               startColumn: 0,
               endColumn: 0,
-              hash: createHash('sha256').update('foo\n').digest('hex'),
+              hash: createHash('sha256').update(fileRealContents).digest('hex'),
             },
           });
           const response = await debugger_.sendAndGetResponse({
@@ -362,7 +373,7 @@ describe.each(['HTTP', 'HTTPS'])(
             },
           });
           expect(response.result).toEqual(
-            expect.objectContaining({scriptSource: 'foo\n'}),
+            expect.objectContaining({scriptSource: fileRealContents}),
           );
           // The device does not receive the getScriptSource request, since it
           // is handled by the proxy.


### PR DESCRIPTION
Summary:
Similar to D42266712 in Metro and D35718095 in Relay - we've had issues with tests failing on Windows because of differing line endings (e.g. D51254843). With this change, we can assume LF line endings everywhere.

Changelog: [Internal]

Differential Revision: D51255346


