### PR TITLE
Prevent intersectionRatio from being higher than 1 in IntersectionObserverEntry

### DIFF
--- a/packages/react-native/Libraries/DOM/Nodes/ReactNativeElement.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReactNativeElement.js
@@ -90,7 +90,7 @@ export default class ReactNativeElement
           offsetParentInstanceHandle,
         );
         // $FlowExpectedError[incompatible-type] The value returned by `getOffset` is always an instance handle for `ReadOnlyElement`.
-        const offsetParentElement: ReadOnlyElement = offsetParent;
+        const offsetParentElement: ReadOnlyElement | null = offsetParent;
         return offsetParentElement;
       }
     }

--- a/packages/react-native/Libraries/DOM/Nodes/ReadOnlyNode.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReadOnlyNode.js
@@ -134,7 +134,9 @@ export default class ReadOnlyNode {
       return null;
     }
 
-    return getPublicInstanceFromInternalInstanceHandle(parentInstanceHandle);
+    return (
+      getPublicInstanceFromInternalInstanceHandle(parentInstanceHandle) ?? null
+    );
   }
 
   get previousSibling(): ReadOnlyNode | null {
@@ -322,9 +324,11 @@ export function getChildNodes(
   const childNodeInstanceHandles = nullthrows(
     getFabricUIManager(),
   ).getChildNodes(shadowNode);
-  return childNodeInstanceHandles.map(instanceHandle =>
-    getPublicInstanceFromInternalInstanceHandle(instanceHandle),
-  );
+  return childNodeInstanceHandles
+    .map(instanceHandle =>
+      getPublicInstanceFromInternalInstanceHandle(instanceHandle),
+    )
+    .filter(Boolean);
 }
 
 function getNodeSiblingsAndPosition(
@@ -348,7 +352,7 @@ function getNodeSiblingsAndPosition(
 
 export function getPublicInstanceFromInternalInstanceHandle(
   instanceHandle: InternalInstanceHandle,
-): ReadOnlyNode {
+): ?ReadOnlyNode {
   const mixedPublicInstance =
     ReactFabric.getPublicInstanceFromInternalInstanceHandle(instanceHandle);
   // $FlowExpectedError[incompatible-return] React defines public instances as "mixed" because it can't access the definition from React Native.

--- a/packages/react-native/Libraries/IntersectionObserver/IntersectionObserverEntry.js
+++ b/packages/react-native/Libraries/IntersectionObserver/IntersectionObserverEntry.js
@@ -11,11 +11,9 @@
 // flowlint unsafe-getters-setters:off
 
 import type ReactNativeElement from '../DOM/Nodes/ReactNativeElement';
-import type {InternalInstanceHandle} from '../Renderer/shims/ReactNativeTypes';
 import type {NativeIntersectionObserverEntry} from './NativeIntersectionObserver';
 
 import DOMRectReadOnly from '../DOM/Geometry/DOMRectReadOnly';
-import {getPublicInstanceFromInternalInstanceHandle} from '../DOM/Nodes/ReadOnlyNode';
 
 /**
  * The [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry)
@@ -29,9 +27,17 @@ export default class IntersectionObserverEntry {
   // We lazily compute all the properties from the raw entry provided by the
   // native module, so we avoid unnecessary work.
   _nativeEntry: NativeIntersectionObserverEntry;
+  // There are cases where this cannot be safely derived from the instance
+  // handle in the native entry (when the target is detached), so we need to
+  // keep a reference to it directly.
+  _target: ReactNativeElement;
 
-  constructor(nativeEntry: NativeIntersectionObserverEntry) {
+  constructor(
+    nativeEntry: NativeIntersectionObserverEntry,
+    target: ReactNativeElement,
+  ) {
     this._nativeEntry = nativeEntry;
+    this._target = target;
   }
 
   /**
@@ -113,15 +119,7 @@ export default class IntersectionObserverEntry {
    * The `ReactNativeElement` whose intersection with the root changed.
    */
   get target(): ReactNativeElement {
-    const targetInstanceHandle: InternalInstanceHandle =
-      // $FlowExpectedError[incompatible-type] native modules don't support using InternalInstanceHandle as a type
-      this._nativeEntry.targetInstanceHandle;
-
-    const targetElement =
-      getPublicInstanceFromInternalInstanceHandle(targetInstanceHandle);
-
-    // $FlowExpectedError[incompatible-cast] we know targetElement is a ReactNativeElement, not just a ReadOnlyNode
-    return (targetElement: ReactNativeElement);
+    return this._target;
   }
 
   /**
@@ -135,6 +133,7 @@ export default class IntersectionObserverEntry {
 
 export function createIntersectionObserverEntry(
   entry: NativeIntersectionObserverEntry,
+  target: ReactNativeElement,
 ): IntersectionObserverEntry {
-  return new IntersectionObserverEntry(entry);
+  return new IntersectionObserverEntry(entry, target);
 }

--- a/packages/react-native/Libraries/IntersectionObserver/IntersectionObserverEntry.js
+++ b/packages/react-native/Libraries/IntersectionObserver/IntersectionObserverEntry.js
@@ -66,10 +66,12 @@ export default class IntersectionObserverEntry {
       return 0;
     }
 
-    return (
+    const ratio =
       (intersectionRect.width * intersectionRect.height) /
-      (boundingClientRect.width * boundingClientRect.height)
-    );
+      (boundingClientRect.width * boundingClientRect.height);
+
+    // Prevent rounding errors from making this value greater than 1.
+    return Math.min(ratio, 1);
   }
 
   /**

--- a/packages/react-native/Libraries/IntersectionObserver/__mocks__/NativeIntersectionObserver.js
+++ b/packages/react-native/Libraries/IntersectionObserver/__mocks__/NativeIntersectionObserver.js
@@ -96,6 +96,16 @@ const NativeIntersectionObserverMock = {
       'unexpected duplicate call to unobserve',
     );
     observations.splice(observationIndex, 1);
+
+    pendingRecords = pendingRecords.filter(
+      record =>
+        record.intersectionObserverId !== intersectionObserverId ||
+        record.targetInstanceHandle !==
+          FabricUIManagerMock.__getInstanceHandleFromNode(
+            // $FlowExpectedError[incompatible-call]
+            targetShadowNode,
+          ),
+    );
   },
   connect: (notifyIntersectionObserversCallback: () => void): void => {
     invariant(callback == null, 'unexpected call to connect');

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,7 @@
  * @noformat
  * @flow strict
  * @nolint
- * @generated SignedSource<<652b117c94307244bcf5e4af18928903>>
+ * @generated SignedSource<<1836a1b6639552dce12199ef2c85f63d>>
  */
 
 import type {ElementRef, ElementType, Element, AbstractComponent} from 'react';
@@ -247,7 +247,7 @@ export type ReactFabricType = {
   ): ?Node,
   getPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle: InternalInstanceHandle,
-  ): PublicInstance | PublicTextInstance,
+  ): PublicInstance | PublicTextInstance | null,
   ...
 };
 


### PR DESCRIPTION
Summary:
This was possible before due to precision problems with `double` (we were seeing values like 1.000000002). This is an easy way to prevent that problem.

Changelog: [internal]

Differential Revision: D51230183


