### PR TITLE
[RN][CI] Move test_windows under test_JS

### DIFF
--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -115,4 +115,3 @@
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
-      - test_windows

--- a/.circleci/configurations/test_workflows/testAndroid.yml
+++ b/.circleci/configurations/test_workflows/testAndroid.yml
@@ -55,4 +55,3 @@
               architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]
               flavor: ["Debug", "Release"]
-      - test_windows

--- a/.circleci/configurations/test_workflows/testJS.yml
+++ b/.circleci/configurations/test_workflows/testJS.yml
@@ -10,3 +10,4 @@
       - test_js:
           name: test_js_prev_lts
           executor: nodeprevlts
+      - test_windows


### PR DESCRIPTION
## Summary:

CircleCI was broken since Friday because a change broke JS tests on Windows only.
The test_windows job didn't run on those changes because they were JS changes only, therefore won't affect the build of React Native on Windows.

The `test_windows` was listed among the various `test_android` jobs, but it is not actually building React Native android on windows machines.
Instead, the test_windows jobs is actually only running JS tests on a windows machines. Therefore, it makes more sense to have this test under the test_js group.

## Changelog:
[Internal] - Move the test_windows job under the testJS configuration

## Test Plan:
CircleCI is green. 
test_windows run together with the JS tests
