### PR TITLE
Catalyst: stop Catalyst crashing when remote debugging.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -329,11 +329,13 @@ jni::alias_ref<CallInvokerHolder::javaobject>
 CatalystInstanceImpl::getJSCallInvokerHolder() {
   if (!jsCallInvokerHolder_) {
     auto runtimeScheduler = getRuntimeScheduler();
-    auto runtimeSchedulerCallInvoker =
-        std::make_shared<RuntimeSchedulerCallInvoker>(
-            runtimeScheduler->cthis()->get());
-    jsCallInvokerHolder_ = jni::make_global(
-        CallInvokerHolder::newObjectCxxArgs(runtimeSchedulerCallInvoker));
+    if (runtimeScheduler) {
+      auto runtimeSchedulerCallInvoker =
+          std::make_shared<RuntimeSchedulerCallInvoker>(
+              runtimeScheduler->cthis()->get());
+      jsCallInvokerHolder_ = jni::make_global(
+          CallInvokerHolder::newObjectCxxArgs(runtimeSchedulerCallInvoker));
+    }
   }
   return jsCallInvokerHolder_;
 }


### PR DESCRIPTION
Summary:
Remote debugging is a deprecated feature, but still supported in 0.73. With remote debugging it's possible
for the runtime scheduler to return a nullptr. There might also be a race condition initializing our Java
Modules in this case and invoking them. Tracking that on T168653145.

Differential Revision: D51263253


