### PR TITLE
put PR#41194 behind gating

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -61,6 +61,9 @@ void RCTEnableTurboModuleSyncVoidMethods(BOOL enabled);
 BOOL RCTTurboModuleSharedQueueEnabled(void);
 void RCTEnableTurboModuleSharedQueue(BOOL enabled);
 
+BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void);
+void RCTUIManagerSetDispatchAccessibilityManagerInitOntoMain(BOOL enabled);
+
 typedef enum {
   kRCTBridgeProxyLoggingLevelNone,
   kRCTBridgeProxyLoggingLevelWarning,

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -162,6 +162,17 @@ void RCTEnableTurboModuleSharedQueue(BOOL enabled)
   gTurboModuleEnableSharedQueue = enabled;
 }
 
+BOOL kDispatchAccessibilityManagerInitOntoMain = NO;
+BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void)
+{
+  return kDispatchAccessibilityManagerInitOntoMain;
+}
+
+void RCTUIManagerSetDispatchAccessibilityManagerInitOntoMain(BOOL enabled)
+{
+  kDispatchAccessibilityManagerInitOntoMain = enabled;
+}
+
 @interface RCTBridge () <RCTReloadListener>
 @end
 

--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -181,7 +181,10 @@ RCT_EXPORT_MODULE()
   }
 
   // This dispatch_async avoids a deadlock while configuring native modules
-  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
+  dispatch_queue_t accessibilityManagerInitQueue = RCTUIManagerDispatchAccessibilityManagerInitOntoMain()
+      ? dispatch_get_main_queue()
+      : dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0);
+  dispatch_async(accessibilityManagerInitQueue, ^{
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didReceiveNewContentSizeMultiplier)
                                                  name:@"RCTAccessibilityManagerDidUpdateMultiplierNotification"


### PR DESCRIPTION
Summary:
Changelog: [Internal]

PR#41194 (https://github.com/facebook/react-native/pull/41194) introduces a new callsite to `RCTUnsafeExecuteOnMainQueueSync` in the module init path, which increases risk for deadlock. let's gate it

Differential Revision: D51274859


