### PR TITLE
Clean up eventTarget retaining logic in the pointer event processor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -97,7 +97,8 @@ void UIManagerBinding::dispatchEvent(
     const EventPayload& eventPayload) const {
   SystraceSection s("UIManagerBinding::dispatchEvent", "type", type);
 
-  if (eventPayload.getType() == EventPayloadType::PointerEvent) {
+  if (eventTarget != nullptr &&
+      eventPayload.getType() == EventPayloadType::PointerEvent) {
     auto pointerEvent = static_cast<const PointerEvent&>(eventPayload);
     auto dispatchCallback = [this](
                                 jsi::Runtime& runtime,
@@ -105,8 +106,10 @@ void UIManagerBinding::dispatchEvent(
                                 const std::string& type,
                                 ReactEventPriority priority,
                                 const EventPayload& eventPayload) {
+      eventTarget->retain(runtime);
       this->dispatchEventToJS(
           runtime, eventTarget, type, priority, eventPayload);
+      eventTarget->release(runtime);
     };
     pointerEventsProcessor_.interceptPointerEvent(
         runtime,


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Clean up eventTarget retaining logic in the pointer event processor

This refactors calls to EventTarget::retain/release to occur in the actual methods that require the event target to be retained instead of expecting the caller to manage that which should be more maintainable.

Differential Revision: D51279974


