### PR TITLE
Clean up legacy use of native modules to access ReactNativeConfig

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
@@ -11,7 +11,6 @@ import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.ReactPackage
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.JSBundleLoader
-import com.facebook.react.bridge.NativeModule
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.runtime.BindingsInstaller
@@ -50,7 +49,7 @@ class DefaultReactHostDelegate(
     override val turboModuleManagerDelegateBuilder: ReactPackageTurboModuleManagerDelegate.Builder
 ) : ReactHostDelegate {
 
-  override fun getReactNativeConfig(moduleProvider: (String) -> NativeModule?) = reactNativeConfig
+  override fun getReactNativeConfig() = reactNativeConfig
 
   override fun handleInstanceException(error: Exception) = exceptionHandler(error)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostDelegate.kt
@@ -11,7 +11,6 @@ import com.facebook.infer.annotation.ThreadSafe
 import com.facebook.react.ReactPackage
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.JSBundleLoader
-import com.facebook.react.bridge.NativeModule
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
 
@@ -63,7 +62,7 @@ interface ReactHostDelegate {
    * [moduleProvider] is a function that returns the Native Module with the name received as a
    * parameter.
    */
-  fun getReactNativeConfig(moduleProvider: (String) -> NativeModule?): ReactNativeConfig
+  fun getReactNativeConfig(): ReactNativeConfig
 
   @UnstableReactNativeAPI
   class ReactHostDelegateBase(
@@ -78,7 +77,7 @@ interface ReactHostDelegate {
       private val exceptionHandler: (error: Exception) -> Unit = {}
   ) : ReactHostDelegate {
 
-    override fun getReactNativeConfig(moduleProvider: (String) -> NativeModule?) = reactNativeConfig
+    override fun getReactNativeConfig() = reactNativeConfig
 
     override fun handleInstanceException(error: Exception) = exceptionHandler(error)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -74,7 +74,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
-import kotlin.jvm.functions.Function1;
 
 /**
  * An experimental replacement for {@link com.facebook.react.ReactInstanceManager} responsible for
@@ -280,9 +279,7 @@ final class ReactInstance {
     mFabricUIManager =
         new FabricUIManager(mBridgelessReactContext, viewManagerRegistry, eventBeatManager);
 
-    ReactNativeConfig config =
-        mDelegate.getReactNativeConfig(
-            (Function1<String, NativeModule>) name -> mTurboModuleManager.getModule(name));
+    ReactNativeConfig config = mDelegate.getReactNativeConfig();
 
     // Misc initialization that needs to be done before Fabric init
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(mBridgelessReactContext);


### PR DESCRIPTION
Summary:
This removes a legacy behavior in React Native to use the native module for MobileConfig to create `ReactNativeConfig`. It now uses the same implementation that the native module uses so we don't depend on TurboModule infra and we can instantiate `ReactNativeConfig` before that infra is ready.

Changelog: [internal]

Reviewed By: christophpurrer

Differential Revision: D51268579


