### PR TITLE
Implement "paint time" support in Event Timing API

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/EventLogger.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventLogger.h
@@ -32,12 +32,12 @@ class EventLogger {
    * Called when event starts getting dispatched (processed by the handlers, if
    * any)
    */
-  virtual void onEventDispatch(EventTag tag) = 0;
+  virtual void onEventProcessingStart(EventTag tag) = 0;
 
   /*
    * Called when event finishes being dispatched
    */
-  virtual void onEventEnd(EventTag tag) = 0;
+  virtual void onEventProcessingEnd(EventTag tag) = 0;
 };
 
 void setEventLogger(EventLogger* eventLogger);

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -55,7 +55,7 @@ void EventQueueProcessor::flushEvents(
 
     auto eventLogger = getEventLogger();
     if (eventLogger != nullptr) {
-      eventLogger->onEventDispatch(event.loggingTag);
+      eventLogger->onEventProcessingStart(event.loggingTag);
     }
 
     if (event.eventPayload == nullptr) {
@@ -77,7 +77,7 @@ void EventQueueProcessor::flushEvents(
     }
 
     if (eventLogger != nullptr) {
-      eventLogger->onEventEnd(event.loggingTag);
+      eventLogger->onEventProcessingEnd(event.loggingTag);
     }
 
     if (event.category == RawEvent::Category::ContinuousStart) {

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
@@ -23,5 +23,6 @@ bool CoreFeatures::enableDefaultAsyncBatchedPriority = false;
 bool CoreFeatures::enableClonelessStateProgression = false;
 bool CoreFeatures::excludeYogaFromRawProps = false;
 bool CoreFeatures::enableMicrotasks = false;
+bool CoreFeatures::enableReportEventPaintTime = false;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
@@ -67,6 +67,10 @@ class CoreFeatures {
   // Enables the use of microtasks in Hermes (scheduling) and RuntimeScheduler
   // (execution).
   static bool enableMicrotasks;
+
+  // Report paint time inside the Event Timing API implementation
+  // (PerformanceObserver).
+  static bool enableReportEventPaintTime;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

Uses mount hooks to report "paint time" via the Event Timing API - i.e. "duration" now corresponds not the the JS dispatch end point, but to the moment when the corresponding mount ("paint") happened on the native side.

This feature is disabled by default for now, but can be enabled via `NativePerformanceObserver.setIsReportingEventPaintTime(true);`.

Differential Revision: D51313902


