### PR TITLE
Let containing blocks layout their absolute descendants, not parents

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -488,11 +488,16 @@ void Node::setLayoutDimension(float LengthValue, Dimension dimension) {
 }
 
 // If both left and right are defined, then use left. Otherwise return +left or
-// -right depending on which is defined.
+// -right depending on which is defined. Ignore statically positioned nodes as
+// insets do not apply to them.
 float Node::relativePosition(
     FlexDirection axis,
     Direction direction,
     float axisSize) const {
+  if (style_.positionType() == PositionType::Static &&
+      !hasErrata(Errata::PositionStaticBehavesLikeRelative)) {
+    return 0;
+  }
   if (isInlineStartPositionDefined(axis, direction)) {
     return getInlineStartPosition(axis, direction, axisSize);
   }
@@ -514,8 +519,7 @@ void Node::setPosition(
   const FlexDirection crossAxis =
       yoga::resolveCrossDirection(mainAxis, directionRespectingRoot);
 
-  // Here we should check for `PositionType::Static` and in this case zero inset
-  // properties (left, right, top, bottom, begin, end).
+  // In the case of position static these are just 0. See:
   // https://www.w3.org/TR/css-position-3/#valdef-position-static
   const float relativePositionMain =
       relativePosition(mainAxis, directionRespectingRoot, mainSize);


### PR DESCRIPTION
Summary:
The way we plan on implementing `position: static` is by changing how we lay out absolutely positioned nodes. Instead of letting their direct parent lay them out we are going to let their containing block handle it. This is useful because by the time the containing block gets to this step it will already know its size, which is needed to ensure that absolute nodes can get the right value with percentage units. Additionally, it means that we can "translate" the position of the absolute nodes to be relative to their parent fairly easily, instead of some second pass that would not be possible with a different design.

This change just gets the core pieces of this process going. It makes it so that containing blocks will layout out absolute descendants that they contain. We also pass in the containing block size to the owner size args for `layoutAbsoluteChild`. This new path will only happen if we have the errata turned off. If there is no positioned ancestor for a given node we just assume the root is. This is not exactly how it works on the web - there is a notion of an initial containing block - but we are not implementing that as of right now.

Differential Revision: D51182593


