### PR TITLE
Fix ReactInstanceManager for getting rid of getJSIModule()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1407,9 +1407,10 @@ public class ReactInstanceManager {
               reactContext, catalystInstance.getJavaScriptContextHolder()));
     }
     if (ReactFeatureFlags.enableFabricRenderer) {
-      catalystInstance.getJSIModule(JSIModuleType.UIManager);
       if (mUIManagerProvider != null) {
         catalystInstance.setFabricUIManager(mUIManagerProvider.createUIManager(reactContext));
+      } else {
+        catalystInstance.getJSIModule(JSIModuleType.UIManager);
       }
     }
     if (mBridgeIdleDebugListener != null) {


### PR DESCRIPTION
Summary: Fix ReactInstanceManager for getting rid of `getJSIModule()` in order to make Catalyst and RN-Tester work with the changes for Fabric initialization

Differential Revision: D51338036


