### PR TITLE
Refactor DefaultReactNativeHost to use the new way of Fabric initialization

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -14,12 +14,8 @@ import com.facebook.react.ReactHost
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
-import com.facebook.react.bridge.JSIModulePackage
-import com.facebook.react.bridge.JSIModuleProvider
-import com.facebook.react.bridge.JSIModuleSpec
-import com.facebook.react.bridge.JSIModuleType
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerProvider
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.fabric.FabricUIManagerProviderImpl
 import com.facebook.react.fabric.ReactNativeConfig
@@ -46,30 +42,20 @@ protected constructor(
         null
       }
 
-  override fun getJSIModulePackage(): JSIModulePackage? =
+  override fun getUIManagerProvider(): UIManagerProvider? =
       if (isNewArchEnabled) {
-        JSIModulePackage { reactApplicationContext: ReactApplicationContext, _ ->
-          listOf(
-              object : JSIModuleSpec<UIManager> {
-                override fun getJSIModuleType(): JSIModuleType = JSIModuleType.UIManager
+        UIManagerProvider { reactApplicationContext: ReactApplicationContext ->
+          val componentFactory = ComponentFactory()
 
-                override fun getJSIModuleProvider(): JSIModuleProvider<UIManager> {
-                  val componentFactory = ComponentFactory()
+          DefaultComponentsRegistry.register(componentFactory)
 
-                  DefaultComponentsRegistry.register(componentFactory)
+          val reactInstanceManager: ReactInstanceManager = getReactInstanceManager()
 
-                  val reactInstanceManager: ReactInstanceManager = getReactInstanceManager()
-
-                  val viewManagers =
-                      reactInstanceManager.getOrCreateViewManagers(reactApplicationContext)
-                  val viewManagerRegistry = ViewManagerRegistry(viewManagers)
-                  return FabricUIManagerProviderImpl(
-                      reactApplicationContext,
-                      componentFactory,
-                      ReactNativeConfig.DEFAULT_CONFIG,
-                      viewManagerRegistry)
-                }
-              })
+          val viewManagers = reactInstanceManager.getOrCreateViewManagers(reactApplicationContext)
+          val viewManagerRegistry = ViewManagerRegistry(viewManagers)
+          FabricUIManagerProviderImpl(
+                  componentFactory, ReactNativeConfig.DEFAULT_CONFIG, viewManagerRegistry)
+              .createUIManager(reactApplicationContext)
         }
       } else {
         null


### PR DESCRIPTION
Summary: Refactoring `DefaultReactNativeHost` to use the new way of Fabric initialization through `FabricUIManagerProviderImpl`

Differential Revision: D51224854

