### PR TITLE
Exclude JSI headers when using hermes-engine prebuilt

### DIFF
--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -46,9 +46,15 @@ Pod::Spec.new do |s|
   s.dependency "glog"
 
   s.source_files  = "**/*.{cpp,h}"
-  s.exclude_files = [
+  files_to_exclude = [
                       "jsi/jsilib-posix.cpp",
                       "jsi/jsilib-windows.cpp",
                       "**/test/*"
-                    ]
+                     ]
+  if js_engine == :hermes
+    # JSI is a part of hermes-engine. Including them also in react-native will violate the One Definition Rulle.
+    files_to_exclude += [ "jsi/jsi.cpp" ]
+    s.dependency "hermes-engine"
+  end
+  s.exclude_files = files_to_exclude
 end

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |spec|
 
     spec.subspec 'Pre-built' do |ss|
       ss.preserve_paths = ["destroot/bin/*"].concat(["**/*.{h,c,cpp}"])
-      ss.source_files = "destroot/include/**/*.h"
+      ss.source_files = "destroot/include/hermes/**/*.h"
       ss.header_mappings_dir = "destroot/include"
       ss.ios.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
       ss.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"


### PR DESCRIPTION
Summary:
After D48152876 we consume JSI from `ReactCommon/jsi`, and ignore JSI that is distributed with `hermes-engine`.
This diff removes `include/jsi` from `source_files` of `hermes-engine` so we don't get two sets of JSI headers - one from `ReactCommon`, and the other one from `hermes-engine`.

Changelog: [iOS][Fixed] - Exclude JSI headers when using hermes-engine prebuilt.

Differential Revision: D51347562


