### PR TITLE
Add and use MC killswitch for enabling paint time reporting in Event Timing API

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -157,6 +157,9 @@ Scheduler::Scheduler(
       reactNativeConfig_->getBool(
           "react_fabric:enable_granular_shadow_tree_state_reconciliation");
 
+  CoreFeatures::enableReportEventPaintTime = reactNativeConfig_->getBool(
+      "rn_responsiveness_performance:enable_paint_time_reporting");
+
   if (animationDelegate != nullptr) {
     animationDelegate->setComponentDescriptorRegistry(
         componentDescriptorRegistry_);


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

Wires a switch for enabling the corresponding feature in Event Timing API.

Reviewed By: rubennorte

Differential Revision: D51341239


