### PR TITLE
add onCellLayout prop to VirtualizedList

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -287,6 +287,9 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
   onEndReachedThreshold?: number | null | undefined;
 
   onLayout?: ((event: LayoutChangeEvent) => void) | undefined;
+  onCellLayout?:
+    | ((event: LayoutChangeEvent, cellKey: string, cellIndex: number) => void)
+    | undefined;
 
   /**
    * If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1298,6 +1298,8 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     cellKey: string,
     cellIndex: number,
   ): void => {
+    this.props.onCellLayout &&
+      this.props.onCellLayout(e.nativeEvent, cellKey, cellIndex);
     const layoutHasChanged = this._listMetrics.notifyCellLayout({
       cellIndex,
       cellKey,

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -2271,6 +2271,35 @@ it('handles maintainVisibleContentPosition when anchor moves before minIndexForV
   expect(component).toMatchSnapshot();
 });
 
+it('calls onCellLayout with expected args', () => {
+  const onCellLayout = jest.fn();
+  const items = generateItems(10);
+  let component;
+  ReactTestRenderer.act(() => {
+    component = ReactTestRenderer.create(
+      <VirtualizedList
+        initialNumToRender={3}
+        maxToRenderPerBatch={1}
+        windowSize={1}
+        {...baseItemProps(items)}
+        onCellLayout={onCellLayout}
+      />,
+    );
+  });
+  simulateCellLayout(component, items, 5, {
+    width: 10,
+    height: 200,
+    x: 0,
+    y: 10,
+  });
+  expect(onCellLayout).toHaveBeenCalledTimes(1);
+  expect(onCellLayout).toHaveBeenCalledWith(
+    {layout: {height: 200, width: 10, x: 0, y: 10}, zoomScale: 1},
+    5,
+    5,
+  );
+});
+
 function generateItems(count, startKey = 0) {
   return Array(count)
     .fill()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Surfacing the values used by _onCellLayout to the outside world helps with stuff like creating custom sticky headers in `VirtualizedList`.

For my use case I was trying to create a custom sticky header(s) in `SectionList`, in addition to the `renderSectionHeader`.

You can achieve this without hooking into `_onCellLayout`, however is not as robust: calculating the 'cell layout' isn't trivial as you have to do stuff like getting the screenY position of the element, along with the position of the list on the screen, and this is constantly changing because the sections / rows are different heights depending on what filters / locations are selected, not to mention the list changes position on pull to refresh, which can interfere with the calculations.

Exposing `onCellLayout` makes creating custom sticky headers is trivial, as we now have the position of each row relative to the list. We can then just apply transformY as needed.

## Changelog:

Pick one each for the category and type tags:

[GENERAL] [ADDED] - Add onCellLayout prop to `VirtualizedList`

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [x] Added `calls onCellLayout with expected args` Jest test case