### PR TITLE
Adding getFabricUIManager() APIs to ReactContext

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -26,6 +26,7 @@ import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -552,6 +553,25 @@ public class ReactContext extends ContextWrapper {
           "Unable to retrieve a JSIModule if CatalystInstance is not active.");
     }
     return mCatalystInstance.getJSIModule(moduleType);
+  }
+
+  @DeprecatedInNewArchitecture(
+      message =
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+  /**
+   * Get the UIManager for Fabric from the CatalystInstance.
+   *
+   * @return The UIManager when CatalystInstance is active.
+   */
+  public @Nullable UIManager getFabricUIManager() {
+    if (!hasActiveReactInstance()) {
+      throw new IllegalStateException(
+          "Unable to retrieve a UIManager if CatalystInstance is not active.");
+    }
+    UIManager uiManager = mCatalystInstance.getFabricUIManager();
+    return uiManager != null
+        ? uiManager
+        : (UIManager) mCatalystInstance.getJSIModule(JSIModuleType.UIManager);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -21,6 +21,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
+import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -82,6 +83,11 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
     throw new UnsupportedOperationException(
         "getJSIModule is not implemented for bridgeless mode. Trying to get module: "
             + moduleType.name());
+  }
+
+  @Override
+  public @Nullable UIManager getFabricUIManager() {
+    return mReactHost.getUIManager();
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.JSIModuleType;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UIManager;
 
 /**
  * Wraps {@link ReactContext} with the base {@link Context} passed into the constructor. It provides
@@ -115,5 +116,13 @@ public class ThemedReactContext extends ReactContext {
       return mReactApplicationContext.getJSIModule(moduleType);
     }
     return super.getJSIModule(moduleType);
+  }
+
+  @Override
+  public UIManager getFabricUIManager() {
+    if (isBridgeless()) {
+      return mReactApplicationContext.getFabricUIManager();
+    }
+    return super.getFabricUIManager();
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
@@ -17,7 +17,6 @@ import android.widget.EditText;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
 import com.facebook.react.bridge.CatalystInstance;
-import com.facebook.react.bridge.JSIModuleType;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
@@ -53,7 +52,7 @@ public class UIManagerHelper {
       @UIManagerType int uiManagerType,
       boolean returnNullIfCatalystIsInactive) {
     if (context.isBridgeless()) {
-      @Nullable UIManager uiManager = (UIManager) context.getJSIModule(JSIModuleType.UIManager);
+      @Nullable UIManager uiManager = context.getFabricUIManager();
       if (uiManager == null) {
         ReactSoftExceptionLogger.logSoftException(
             TAG,
@@ -85,7 +84,7 @@ public class UIManagerHelper {
     CatalystInstance catalystInstance = context.getCatalystInstance();
     try {
       return uiManagerType == FABRIC
-          ? (UIManager) catalystInstance.getJSIModule(JSIModuleType.UIManager)
+          ? context.getFabricUIManager()
           : catalystInstance.getNativeModule(UIManagerModule.class);
     } catch (IllegalArgumentException ex) {
       // TODO T67518514 Clean this up once we migrate everything over to bridgeless mode

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
@@ -83,6 +83,7 @@ class NativeAnimatedNodeTraversalTest {
     whenever(catalystInstanceMock.getJSIModule(any(JSIModuleType::class.java))).thenAnswer {
       uiManagerMock
     }
+    whenever(reactApplicationContextMock.getFabricUIManager()).thenAnswer { uiManagerMock }
     whenever(catalystInstanceMock.getNativeModule(UIManagerModule::class.java)).thenAnswer {
       uiManagerMock
     }


### PR DESCRIPTION
Summary:
Adding APIs for `getFabricUIManager()` to ReactContext and it's subclasses. This will replace the `getJSIModule()` post JSI module deletion.

Changelog:
[Internal] internal

Differential Revision: D50926218


