### PR TITLE
Refactor hover tracking logic to the shared C++ renderer

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -612,7 +612,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 {
   for (const auto &activePointer : activePointers) {
     PointerEvent pointerEvent = CreatePointerEventFromActivePointer(activePointer, eventType, _rootComponentView);
-    [self handleIncomingPointerEvent:pointerEvent onView:activePointer.componentView];
 
     SharedTouchEventEmitter eventEmitter = GetTouchEmitterFromView(
         activePointer.componentView,
@@ -630,19 +629,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
         }
         case RCTPointerEventTypeEnd: {
           eventEmitter->onPointerUp(pointerEvent);
-
           if (pointerEvent.isPrimary && pointerEvent.button == 0 && IsPointerWithinInitialTree(activePointer)) {
             eventEmitter->onClick(pointerEvent);
-          }
-
-          if (activePointer.shouldLeaveWhenReleased) {
-            [self handleIncomingPointerEvent:pointerEvent onView:nil];
           }
           break;
         }
         case RCTPointerEventTypeCancel: {
           eventEmitter->onPointerCancel(pointerEvent);
-          [self handleIncomingPointerEvent:pointerEvent onView:nil];
           break;
         }
       }
@@ -764,109 +757,15 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   PointerEvent event = CreatePointerEventFromIncompleteHoverData(
       pointerId, pointerType, clientLocation, screenLocation, offsetLocation, modifierFlags);
 
-  [self handleIncomingPointerEvent:event onView:targetView];
   SharedTouchEventEmitter eventEmitter = GetTouchEmitterFromView(targetView, offsetLocation);
   if (eventEmitter != nil) {
-    eventEmitter->onPointerMove(event);
-  }
-}
-
-#pragma mark - Shared pointer handlers
-
-/**
- * Private method which is used for tracking the location of pointer events to manage the entering/leaving events.
- * The primary idea is that a pointer's presence & movement is dicated by a variety of underlying events such as down,
- * move, and up — and they should all be treated the same when it comes to tracking the entering & leaving of pointers
- * to views. This method accomplishes that by receiving the pointer event, the target view (can be null in cases when
- * the event indicates that the pointer has left the screen entirely), and a block/callback where the underlying event
- * should be fired.
- */
-- (NSOrderedSet<RCTReactTaggedView *> *)handleIncomingPointerEvent:(PointerEvent)event
-                                                            onView:(nullable UIView *)targetView
-{
-  NSInteger pointerId = event.pointerId;
-  CGPoint clientLocation = CGPointMake(event.clientPoint.x, event.clientPoint.y);
-
-  NSOrderedSet<RCTReactTaggedView *> *currentlyHoveredViews =
-      [_currentlyHoveredViewsPerPointer objectForKey:@(pointerId)];
-  if (currentlyHoveredViews == nil) {
-    currentlyHoveredViews = [NSOrderedSet orderedSet];
-  }
-
-  RCTReactTaggedView *targetTaggedView = [RCTReactTaggedView wrap:targetView];
-  RCTReactTaggedView *prevTargetTaggedView = [currentlyHoveredViews firstObject];
-  UIView *prevTargetView = prevTargetTaggedView.view;
-
-  NSOrderedSet<RCTReactTaggedView *> *eventPathViews = GetTouchableViewsInPathToRoot(targetView);
-
-  // Out
-  if (prevTargetView != nil && prevTargetTaggedView.tag != targetTaggedView.tag) {
-    SharedTouchEventEmitter eventEmitter =
-        GetTouchEmitterFromView(prevTargetView, [_rootComponentView convertPoint:clientLocation toView:prevTargetView]);
-    if (eventEmitter != nil) {
-      eventEmitter->onPointerOut(event);
+    switch (recognizer.state) {
+      case UIGestureRecognizerStateEnded:
+        eventEmitter->onPointerLeave(event);
+      default:
+        eventEmitter->onPointerMove(event);
     }
   }
-
-  // Leaving
-
-  // pointerleave events need to be emitted from the deepest target to the root but
-  // we also need to efficiently keep track of if a view has a parent which is listening to the leave events,
-  // so we first iterate from the root to the target, collecting the views which need events fired for, of which
-  // we reverse iterate (now from target to root), actually emitting the events.
-  NSMutableOrderedSet<UIView *> *viewsToEmitLeaveEventsTo = [NSMutableOrderedSet orderedSet];
-
-  for (RCTReactTaggedView *taggedView in [currentlyHoveredViews reverseObjectEnumerator]) {
-    UIView *componentView = taggedView.view;
-
-    BOOL shouldEmitEvent = componentView != nil;
-
-    if (shouldEmitEvent && ![eventPathViews containsObject:taggedView]) {
-      [viewsToEmitLeaveEventsTo addObject:componentView];
-    }
-  }
-
-  for (UIView *componentView in [viewsToEmitLeaveEventsTo reverseObjectEnumerator]) {
-    SharedTouchEventEmitter eventEmitter =
-        GetTouchEmitterFromView(componentView, [_rootComponentView convertPoint:clientLocation toView:componentView]);
-    if (eventEmitter != nil) {
-      eventEmitter->onPointerLeave(event);
-    }
-  }
-
-  // Over
-  if (targetView != nil && prevTargetTaggedView.tag != targetTaggedView.tag) {
-    SharedTouchEventEmitter eventEmitter =
-        GetTouchEmitterFromView(targetView, [_rootComponentView convertPoint:clientLocation toView:targetView]);
-    if (eventEmitter != nil) {
-      eventEmitter->onPointerOver(event);
-    }
-  }
-
-  // Entering
-
-  // We only want to emit events to JS if there is a view that is currently listening to said event
-  // so we only send those event to the JS side if the element which has been entered is itself listening,
-  // or if one of its parents is listening in case those listeners care about the capturing phase. Adding the ability
-  // for native to distinguish between capturing listeners and not could be an optimization to further reduce the number
-  // of events we send to JS
-  for (RCTReactTaggedView *taggedView in [eventPathViews reverseObjectEnumerator]) {
-    UIView *componentView = taggedView.view;
-
-    BOOL shouldEmitEvent = componentView != nil;
-
-    if (shouldEmitEvent && ![currentlyHoveredViews containsObject:taggedView]) {
-      SharedTouchEventEmitter eventEmitter =
-          GetTouchEmitterFromView(componentView, [_rootComponentView convertPoint:clientLocation toView:componentView]);
-      if (eventEmitter != nil) {
-        eventEmitter->onPointerEnter(event);
-      }
-    }
-  }
-
-  [_currentlyHoveredViewsPerPointer setObject:eventPathViews forKey:@(pointerId)];
-
-  return eventPathViews;
 }
 
 @end

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -10,6 +10,7 @@
 #include <functional>
 
 #include <jsi/jsi.h>
+#include <react/renderer/uimanager/PointerHoverTracker.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/primitives.h>
 
@@ -25,6 +26,12 @@ struct PointerEventTarget {
 // metadata
 struct ActivePointer {
   PointerEvent event;
+
+  /*
+   * Informs the event system that when the touch is released it should be
+   * treated as the pointer leaving the screen entirely.
+   */
+  bool shouldLeaveWhenReleased{};
 };
 
 using DispatchEvent = std::function<void(
@@ -40,6 +47,8 @@ using CaptureTargetOverrideRegistry =
 
 using ActivePointerRegistry =
     std::unordered_map<PointerIdentifier, ActivePointer>;
+using PointerHoverTrackerRegistry =
+    std::unordered_map<PointerIdentifier, PointerHoverTracker::Unique>;
 
 class PointerEventsProcessor final {
  public:
@@ -79,6 +88,25 @@ class PointerEventsProcessor final {
 
   CaptureTargetOverrideRegistry pendingPointerCaptureTargetOverrides_;
   CaptureTargetOverrideRegistry activePointerCaptureTargetOverrides_;
+
+  /*
+   * Private method which is used for tracking the location of pointer events to
+   * manage the entering/leaving events. The primary idea is that a pointer's
+   * presence & movement is dicated by a variety of underlying events such as
+   * down, move, and up — and they should all be treated the same when it comes
+   * to tracking the entering & leaving of pointers to views. This method
+   * accomplishes that by receiving the pointer event, and the target view (can
+   * be null in cases when the event indicates that the pointer has left the
+   * screen entirely)
+   */
+  void handleIncomingPointerEventOnNode(
+      PointerEvent const& event,
+      ShadowNode::Shared const& targetNode,
+      jsi::Runtime& runtime,
+      DispatchEvent const& eventDispatcher,
+      UIManager const& uiManager);
+
+  PointerHoverTrackerRegistry previousHoverTrackersPerPointer_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PointerHoverTracker.h"
+
+#include <ranges>
+#include <utility>
+
+namespace facebook::react {
+
+using EventPath = PointerHoverTracker::EventPath;
+
+PointerHoverTracker::PointerHoverTracker(
+    ShadowNode::Shared target,
+    UIManager const& uiManager)
+    : isOldTracker_(false), target_(std::move(target)) {
+  if (target_ != nullptr) {
+    // Retrieve the root shadow node at this current revision so that we can
+    // leverage it to get the event path list at the moment the event occured
+    auto rootShadowNode = ShadowNode::Shared{};
+    auto& shadowTreeRegistry = uiManager.getShadowTreeRegistry();
+    shadowTreeRegistry.visit(
+        target_->getSurfaceId(),
+        [&rootShadowNode](ShadowTree const& shadowTree) {
+          rootShadowNode = shadowTree.getCurrentRevision().rootShadowNode;
+        });
+    this->root_ = rootShadowNode;
+  }
+}
+
+bool PointerHoverTracker::hasSameTarget(
+    PointerHoverTracker const& other) const {
+  if (target_ != nullptr && other.target_ != nullptr) {
+    return ShadowNode::sameFamily(*this->target_, *other.target_);
+  }
+  return false;
+}
+
+bool PointerHoverTracker::areAnyTargetsListeningToEvents(
+    std::initializer_list<ViewEvents::Offset> eventTypes,
+    UIManager const& uiManager) const {
+  auto eventPath = getEventPathTargets();
+
+  for (const auto& oldTarget : eventPath) {
+    auto newestTarget = uiManager.getNewestCloneOfShadowNode(oldTarget);
+    if (newestTarget &&
+        newestTarget->getTraits().check(ShadowNodeTraits::Trait::ViewKind)) {
+      auto eventFlags =
+          static_cast<const ViewProps&>(*newestTarget->getProps()).events;
+      for (const auto& eventType : eventTypes) {
+        if (eventFlags[eventType]) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+std::tuple<EventPath, EventPath> PointerHoverTracker::diffEventPath(
+    PointerHoverTracker const& other,
+    UIManager const& uiManager) const {
+  auto myEventPath = getEventPathTargets();
+  auto otherEventPath = other.getEventPathTargets();
+
+  // Starting from the root node, iterate through both event paths, comparing
+  // the nodes' families until a difference is found, and then just break out of
+  // the loop early. This will leave the iterators for each path at the point
+  // where the event paths diverge and can be subsequently used as the beginning
+  // iterator of a subrange, where the subrange on *this* tracker would
+  // represent the removed views, and the subrange on *other* tracker would
+  // represent the added views.
+  //
+  // NOTE: This works based on the assumption that nodes in react-native don't
+  // get "re-parented" so if there are any bugs reported due to extra
+  // leave->enter events, this solution may need to be revisited with a more
+  // robust diffing solution.
+  auto myIt = myEventPath.rbegin();
+  auto otherIt = otherEventPath.rbegin();
+  while (myIt != myEventPath.rend() && otherIt != otherEventPath.rend()) {
+    if (!ShadowNode::sameFamily(myIt->get(), otherIt->get())) {
+      break;
+    }
+    ++myIt;
+    ++otherIt;
+  }
+
+  auto removedViews =
+      std::ranges::subrange{myIt, myEventPath.rend()} |
+      std::views::transform(
+          [this, &uiManager](ShadowNode const& node) -> const ShadowNode* {
+            return this->getLatestNode(node, uiManager);
+          }) |
+      std::views::filter([](auto n) -> bool { return n != nullptr; }) |
+      std::views::transform([](auto n) -> ShadowNode const& { return *n; });
+  EventPath removed(removedViews.begin(), removedViews.end());
+
+  auto addedViews =
+      std::ranges::subrange{otherIt, otherEventPath.rend()} |
+      std::views::transform(
+          [&other, &uiManager](ShadowNode const& node) -> const ShadowNode* {
+            return other.getLatestNode(node, uiManager);
+          }) |
+      std::views::filter([](auto n) -> bool { return n != nullptr; }) |
+      std::views::transform([](auto n) -> ShadowNode const& { return *n; });
+  EventPath added(addedViews.begin(), addedViews.end());
+
+  return std::make_tuple(removed, added);
+}
+
+const ShadowNode* PointerHoverTracker::getTarget(
+    UIManager const& uiManager) const {
+  if (target_ == nullptr) {
+    return nullptr;
+  }
+  return getLatestNode(*target_, uiManager);
+}
+
+void PointerHoverTracker::markAsOld() {
+  isOldTracker_ = true;
+}
+
+const ShadowNode* PointerHoverTracker::getLatestNode(
+    ShadowNode const& node,
+    UIManager const& uiManager) const {
+  if (isOldTracker_) {
+    auto newestTarget = uiManager.getNewestCloneOfShadowNode(node);
+    return newestTarget.get();
+  }
+  return &node;
+}
+
+EventPath PointerHoverTracker::getEventPathTargets() const {
+  EventPath result{};
+  if (target_ == nullptr || root_ == nullptr) {
+    return result;
+  }
+
+  auto ancestors = target_->getFamily().getAncestors(*root_);
+
+  result.emplace_back(*target_);
+  for (auto& ancestor : std::ranges::reverse_view(ancestors)) {
+    result.emplace_back(ancestor.first);
+  }
+
+  return result;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+#include <initializer_list>
+#include <memory>
+
+#include <react/renderer/components/view/primitives.h>
+#include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/core/ShadowNode.h>
+#include <react/renderer/uimanager/UIManager.h>
+
+namespace facebook::react {
+
+class PointerHoverTracker {
+ public:
+  using Unique = std::unique_ptr<PointerHoverTracker>;
+  using EventPath = std::vector<std::reference_wrapper<const ShadowNode>>;
+
+  PointerHoverTracker(ShadowNode::Shared target, UIManager const& uiManager);
+
+  const ShadowNode* getTarget(UIManager const& uiManager) const;
+  bool hasSameTarget(PointerHoverTracker const& other) const;
+  bool areAnyTargetsListeningToEvents(
+      std::initializer_list<ViewEvents::Offset> eventTypes,
+      UIManager const& uiManager) const;
+
+  /**
+   * Performs a diff between the current and given trackers and returns a tuple
+   * containing [1]: the nodes that have been removed and [2]: the nodes that
+   * have been added. Note that the order of these lists are from parents ->
+   * children.
+   */
+  std::tuple<EventPath, EventPath> diffEventPath(
+      PointerHoverTracker const& other,
+      UIManager const& uiManager) const;
+
+  void markAsOld();
+
+ private:
+  /**
+   * Flag that lets the tracker know if it needs to fetch the latest version of
+   * the shadow node or not.
+   */
+  mutable bool isOldTracker_;
+
+  ShadowNode::Shared root_;
+  ShadowNode::Shared target_;
+
+  /**
+   * A thin wrapper around `UIManager::getNewestCloneOfShadowNode` that only
+   * actually gets the newest clone only if the tracker is marked as "old".
+   */
+  const ShadowNode* getLatestNode(
+      ShadowNode const& node,
+      UIManager const& uiManager) const;
+
+  /**
+   * Retrieves the list of shadow node references in the event's path starting
+   * from the target node to the root node.
+   */
+  EventPath getEventPathTargets() const;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -97,7 +97,8 @@ void UIManagerBinding::dispatchEvent(
     const EventPayload& eventPayload) const {
   SystraceSection s("UIManagerBinding::dispatchEvent", "type", type);
 
-  if (eventPayload.getType() == EventPayloadType::PointerEvent) {
+  if (eventTarget != nullptr &&
+      eventPayload.getType() == EventPayloadType::PointerEvent) {
     auto pointerEvent = static_cast<const PointerEvent&>(eventPayload);
     auto dispatchCallback = [this](
                                 jsi::Runtime& runtime,
@@ -105,8 +106,10 @@ void UIManagerBinding::dispatchEvent(
                                 const std::string& type,
                                 ReactEventPriority priority,
                                 const EventPayload& eventPayload) {
+      eventTarget->retain(runtime);
       this->dispatchEventToJS(
           runtime, eventTarget, type, priority, eventPayload);
+      eventTarget->release(runtime);
     };
     pointerEventsProcessor_.interceptPointerEvent(
         runtime,


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Refactor hover tracking logic to the shared c++ renderer

This diff refactors our hover tracking logic out of the platform (in this case only iOS, integrating Android is going to require extra work due to their pointer events being untyped) and puts it into the event intercepting infra in Fabric's C++ core. This is a big-ish diff so I'm going to try my best to use this summary to guide you through the changes.

To begin with — the changes inside `RCTSurfacePointerHandler.mm` are mostly about removing the existing hover tracking logic. The logic of the hover tracking is largely the same between the objective-c and c++ implementations with minor tweaks in order to be a better citizen when it comes to storing node references. One small "addition" to this file is explicitly firing a `pointerleave` event from the iOS layer when we detect that the pointer has left the app entirely because the C++ would otherwise not know when the pointer leaves the app. We don't need to include a special case for `pointerenter` because we can derive that in C++ from the first `pointermove` event that gets sent once the pointer re-enters the app's root view.

Next I think it makes most sense to continue onto the `PointerEventsProcessor.h/mm` which is the central class we're working in. One small change is adding a flag to the `ActivePointer` struct (`shouldLeaveWhenReleased`) which we will set during `ActivePointer` registration — setting to false if the pointer in question exists in the (also) newly added `previousHoverTrackersPerPointer_` registry. This logic is primarily used for knowing later when the pointer is released and whether we should emit the synthetic leave/out event on release. If the pointer existed in `previousHoverTrackersPerPointer_` **before** the `ActivePointer` registration that implies that the pointer is capable of hovering to some degree and we should **not** emit those leave/out events yet.

The real meat & potatoes of this diff is the `handleIncomingPointerEventOnNode` method which matches the `handleIncomingPointerEvent` method we removed from `RCTSurfacePointerHandler.mm`. This method derives the enter/leave/over/out pointer events by comparing the current event's target path (list of nodes from the root node to the target node of the event) to the previously recorded event target path. The representation of this event path is through the new `PointerHoverTracker` class which stores a pointer to just the root node and the target node as we can recreate the entire event path from these.

For over/out events all that matters is when the deepest-most target changes which is checked in `handleIncomingPointerEventOnNode` by leveraging `PointerHoverTracker`'s `hasSameTarget` method. For enter/leave events we need to fire discrete events for every node in the path which has either been removed or added, so the `diffEventPath` method was introduced on `PointerHoverTracker` to provide that.

Differential Revision: D51317492


