### PR TITLE
[RN-Tester] Fix assert cxx example crash the app when tap `Run all tests`

### DIFF
--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -55,7 +55,9 @@ type Examples =
   | 'rejectPromise'
   | 'voidFunc'
   | 'optionalArgs'
-  | 'emitDeviceEvent'
+  | 'emitDeviceEvent';
+
+type ErrorExamples =
   | 'voidFuncThrows'
   | 'getObjectThrows'
   | 'promiseThrows'
@@ -131,6 +133,10 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
       });
       NativeCxxModuleExample?.emitCustomDeviceEvent(CUSTOM_EVENT_TYPE);
     },
+  };
+
+  // $FlowFixMe[missing-local-annot]
+  _errorTests = {
     voidFuncThrows: () => {
       try {
         NativeCxxModuleExample?.voidFuncThrows();
@@ -231,7 +237,7 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
                 this._setResult(item, this._tests[item]()),
               )
             }>
-            <Text style={styles.buttonTextLarge}>Run all tests</Text>
+            <Text style={styles.buttonTextLarge}>Run function call tests</Text>
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => this.setState({testResults: {}})}
@@ -248,6 +254,24 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
               <TouchableOpacity
                 style={[styles.column, styles.button]}
                 onPress={e => this._setResult(item, this._tests[item]())}>
+                <Text style={styles.buttonText}>{item}</Text>
+              </TouchableOpacity>
+              <View style={[styles.column]}>{this._renderResult(item)}</View>
+            </View>
+          )}
+        />
+        <View style={styles.item}>
+          <Text style={styles.buttonTextLarge}>Report errors tests</Text>
+        </View>
+        <FlatList
+          // $FlowFixMe[incompatible-type-arg]
+          data={Object.keys(this._errorTests)}
+          keyExtractor={item => item}
+          renderItem={({item}: {item: ErrorExamples, ...}) => (
+            <View style={styles.item}>
+              <TouchableOpacity
+                style={[styles.column, styles.button]}
+                onPress={e => this._setResult(item, this._errorTests[item]())}>
                 <Text style={styles.buttonText}>{item}</Text>
               </TouchableOpacity>
               <View style={[styles.column]}>{this._renderResult(item)}</View>

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -208,7 +208,7 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
     }));
   }
 
-  _renderResult(name: Examples): React.Node {
+  _renderResult(name: Examples | ErrorExamples): React.Node {
     const result = this.state.testResults[name] || {};
     return (
       <View style={styles.result}>


### PR DESCRIPTION
## Summary:

When I tap the `Run all tests` button in CxxModuleExample, App crashed because our `assert` examples directoly. 
![image](https://github.com/facebook/react-native/assets/5061845/6d3fbbc1-9d41-419a-9074-898e839ee51a)
I moved the error report examples to individual section so `Run all tests` not crash.
![image](https://github.com/facebook/react-native/assets/5061845/4b781b40-0606-4d40-a752-1cd716073e33)


## Changelog:
[INTERNAL] [FIXED] - [RN-Tester] Fix assert cxx example crash the app when tap `Run all tests`

## Test Plan:

None.
