### PR TITLE
fix speech input in onChange callback  multiline input

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -416,6 +416,11 @@ export interface TextInputAndroidProps {
   verticalAlign?: 'auto' | 'top' | 'bottom' | 'middle' | undefined;
 }
 
+export interface SpeechTextWithTime {
+  currentTime: number;
+  currentText: string;
+}
+
 /**
  * @see TextInputProps.onFocus
  */

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -416,11 +416,6 @@ export interface TextInputAndroidProps {
   verticalAlign?: 'auto' | 'top' | 'bottom' | 'middle' | undefined;
 }
 
-export interface SpeechTextWithTime {
-  currentTime: number;
-  currentText: string;
-}
-
 /**
  * @see TextInputProps.onFocus
  */

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1127,7 +1127,7 @@ function InternalTextInput(props: Props): React.Node {
 
   const inputRef = useRef<null | React.ElementRef<HostComponent<mixed>>>(null);
   const prevSpeechTextWithTimeRef = useRef<
-  React.MutableRefObject<SpeechTextWithTime>,
+    React.MutableRefObject<SpeechTextWithTime>,
   >({currentTime: 0, currentText: ''});
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1305,14 +1305,15 @@ function InternalTextInput(props: Props): React.Node {
       const DELAY_BETWEEN_ON_CHANGE = 100;
       const currentTime = new Date().getTime();
 
-      const isCurrentTextEmpty = currentText === "￼";
-      const timeDifferenceBetweenIteration = currentTime - prevSpeechTextWithTimeRef.current?.currentTime;
-      const isChangeBelowThreshold = timeDifferenceBetweenIteration < DELAY_BETWEEN_ON_CHANGE;
+      const isCurrentTextEmpty = currentText === '￼';
+      const timeDifferenceBetweenIteration =
+        currentTime - prevSpeechTextWithTimeRef.current?.currentTime;
+      const isChangeBelowThreshold =
+        timeDifferenceBetweenIteration < DELAY_BETWEEN_ON_CHANGE;
       const isPrevTextFilled =
         prevSpeechTextWithTimeRef.current?.currentText.length > 1;
-      const isSpeechToTextPotentialEmptyOnChange = isChangeBelowThreshold &&
-        isPrevTextFilled &&
-        isCurrentTextEmpty;
+      const isSpeechToTextPotentialEmptyOnChange =
+        isChangeBelowThreshold && isPrevTextFilled && isCurrentTextEmpty;
 
       if (isSpeechToTextPotentialEmptyOnChange) {
         return;

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -453,17 +453,6 @@ type AndroidProps = $ReadOnly<{|
   underlineColorAndroid?: ?ColorValue,
 |}>;
 
-export type SpeechTextWithTime = {
-  /**
-   * Current time in iteration _onChange.
-   */
-  currentTime: number,
-  /**
-   * Current text in iteration  _onChange.
-   */
-  currentText: string,
-};
-
 export type Props = $ReadOnly<{|
   ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
   ...IOSProps,
@@ -1126,9 +1115,10 @@ function InternalTextInput(props: Props): React.Node {
   } = props;
 
   const inputRef = useRef<null | React.ElementRef<HostComponent<mixed>>>(null);
-  const prevSpeechTextWithTimeRef = useRef<
-    React.MutableRefObject<SpeechTextWithTime>,
-  >({currentTime: 0, currentText: ''});
+  const prevSpeechTextWithTimeRef = useRef<{|
+    currentText: string,
+    currentTime: number,
+  |}>({currentTime: 0, currentText: ''});
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const selection: ?Selection =


### PR DESCRIPTION
### Summary:
simple fix for https://github.com/facebook/react-native/issues/38747, to stop clear text by failing haptics module

### Changelog:
[INTERNAL] [FIXED] - speech input shouldn’t clear text in multiple text input by closed record audio

### Bug: 
problem is when the user onPress on a keyboard to stop speech audio, text is immediately cleared.

there is console.log onChange func from react-native textInput, where they are get native.text in callback

LOG {"currentText": ""}
LOG {"currentText": ""}
LOG {"currentText": " 123"}
LOG {"currentText": " 1234"}
LOG {"currentText": " 12345"}
LOG {"currentText": " 123456"}
LOG {"currentText": " 1234567"}
LOG {"currentText": " 12345678"}
LOG {"currentText": " 12345678"}
LOG {"currentText": " 12345678"}
LOG {"currentText": " 123456789 "}
LOG {"currentText": " "}
LOG {"currentText": " "}
LOG {"currentText": " 123456789"}

### Test Plan:
CI should pass