### PR TITLE
Restore InspectorProxy tests - fix Windows by Babel-ignoring `node_modules` consistently

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -40,8 +40,7 @@ beforeAll(() => {
   jest.resetModules();
 });
 
-// TODO T169943794
-xdescribe.each(['HTTP', 'HTTPS'])(
+describe.each(['HTTP', 'HTTPS'])(
   'inspector proxy CDP rewriting hacks over %s',
   protocol => {
     const serverRef = withServerForEachTest({

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -23,8 +23,7 @@ jest.useRealTimers();
 
 jest.setTimeout(10000);
 
-// TODO T169943794
-xdescribe.each(['HTTP', 'HTTPS'])(
+describe.each(['HTTP', 'HTTPS'])(
   'inspector proxy CDP transport over %s',
   protocol => {
     const serverRef = withServerForEachTest({

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -24,8 +24,7 @@ const PAGES_POLLING_DELAY = 1000;
 
 jest.useFakeTimers();
 
-// TODO T169943794
-xdescribe('inspector proxy HTTP API', () => {
+describe('inspector proxy HTTP API', () => {
   const serverRef = withServerForEachTest({
     logger: undefined,
     projectRoot: '',

--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -23,8 +23,7 @@ jest.useRealTimers();
 
 jest.setTimeout(10000);
 
-// TODO T169943794
-xdescribe('inspector proxy React Native reloads', () => {
+describe('inspector proxy React Native reloads', () => {
   const serverRef = withServerForEachTest({
     logger: undefined,
     projectRoot: '',

--- a/scripts/build/babel-register.js
+++ b/scripts/build/babel-register.js
@@ -50,7 +50,7 @@ function registerPackage(packageName /*: string */) {
   const registerConfig = {
     ...getBabelConfig(packageName),
     root: packageDir,
-    ignore: [/\/node_modules\//],
+    ignore: [/[/\\]node_modules[/\\]/],
   };
 
   require('@babel/register')(registerConfig);


### PR DESCRIPTION
Summary:
CI failures in Windows JS tests recently (https://github.com/facebook/react-native/pull/41463) were caused by the triggering of Babel registration during tests, due to an import of `packages/dev-middleware` (index), breaking subsequent transformation of other tests.

## Root cause
Example of a problematic import:
https://github.com/facebook/react-native/blob/a5d8ea4579c630af1e4e0fe1d99ad9dc0915df86/packages/dev-middleware/src/__tests__/ServerUtils.js#L15

..which triggers a Babel registration:
https://github.com/facebook/react-native/blob/a5d8ea4579c630af1e4e0fe1d99ad9dc0915df86/packages/dev-middleware/src/index.js#L16-L18

That registration behaves differently on Windows due to the `ignore: [/\/node_modules\/\]`, which doesn't match against Windows path separators - Babel matches against system separators.

In particular, this changed whether `node_modules/flow-parser` was transformed when loading the RN Babel transformer. Transforming this file causes a `console.warn` from Babel due to its size:
> [BABEL] Note: The code generator has deoptimised the styling of /Users/robhogan/workspace/react-native/node_modules/flow-parser/flow_parser.js as it exceeds the max of 500KB.

This throws due to our setup:
https://github.com/facebook/react-native/blob/a5d8ea4579c630af1e4e0fe1d99ad9dc0915df86/packages/react-native/jest/local-setup.js#L27

This all manifests as the first test following a Babel registration (within the same Jest worker) that requires the RN Babel transformer throwing during script transformation.

## This change
This is the minimally disruptive change that makes Babel registration behaviour consistent between Windows and other platforms. The more durable solution here would be *not* to rely on any Babel registration for Jest, which has its own `ScriptTransformer` mechanism for running code from source. Given the fragile way our internal+OSS Babel set up hangs together that's a higher-risk change, so I'll follow up separately.

Changelog: [Internal]