### PR TITLE
Refactor generate-artifacts-executor.js: various cleanups

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -120,7 +120,6 @@ describe('extractLibrariesFromJSON', () => {
     );
     expect(libraries.length).toBe(1);
     expect(libraries[0]).toEqual({
-      library: 'my-app',
       config: {
         name: 'AppModules',
         type: 'all',
@@ -155,7 +154,6 @@ describe('extractLibrariesFromJSON', () => {
     );
     expect(libraries.length).toBe(1);
     expect(libraries[0]).toEqual({
-      library: reactNativeDependencyName,
       config: {
         name: 'react-native',
         type: 'all',
@@ -179,7 +177,6 @@ describe('extractLibrariesFromJSON', () => {
     );
     expect(libraries.length).toBe(3);
     expect(libraries[0]).toEqual({
-      library: myDependency,
       config: {
         name: 'react-native',
         type: 'all',
@@ -188,7 +185,6 @@ describe('extractLibrariesFromJSON', () => {
       libraryPath: myDependencyPath,
     });
     expect(libraries[1]).toEqual({
-      library: myDependency,
       config: {
         name: 'my-component',
         type: 'components',
@@ -197,7 +193,6 @@ describe('extractLibrariesFromJSON', () => {
       libraryPath: myDependencyPath,
     });
     expect(libraries[2]).toEqual({
-      library: myDependency,
       config: {
         name: 'my-module',
         type: 'module',
@@ -272,12 +267,10 @@ describe('findCodegenEnabledLibraries', () => {
 
     expect(libraries).toEqual([
       {
-        library: 'react-native',
         config: {},
         libraryPath: baseCodegenConfigFileDir,
       },
       {
-        library: 'react-native-foo',
         config: {name: 'RNFooSpec', type: 'modules', jsSrcsDir: 'src'},
         libraryPath: path.join(projectDir, 'library-foo'),
       },

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -105,13 +105,10 @@ function extractLibrariesFromConfigurationArray(
   configFile,
   codegenConfigKey,
   libraries,
-  dependency,
   dependencyPath,
 ) {
-  console.log(`[Codegen] Found ${dependency}`);
   configFile[codegenConfigKey].libraries.forEach(config => {
     const libraryConfig = {
-      library: dependency,
       config,
       libraryPath: dependencyPath,
     };
@@ -142,11 +139,10 @@ function extractLibrariesFromJSON(
     return;
   }
 
+  console.log(`[Codegen] Found ${dependency}`);
   if (configFile[codegenConfigKey].libraries == null) {
-    console.log(`[Codegen] Found ${dependency}`);
     var config = configFile[codegenConfigKey];
     libraries.push({
-      library: dependency,
       config,
       libraryPath: dependencyPath,
     });
@@ -156,13 +152,12 @@ function extractLibrariesFromJSON(
       configFile,
       codegenConfigKey,
       libraries,
-      dependency,
       dependencyPath,
     );
   }
 }
 
-function handleReactNativeCodeLibraries(
+function handleReactNativeCoreLibraries(
   libraries,
   codegenConfigFilename,
   codegenConfigKey,
@@ -397,7 +392,7 @@ function generateNativeCodegenFiles(
   });
 }
 
-function createComponentProvider(schemaPaths, node, iosOutputDir) {
+function createComponentProvider(schemaPaths, node) {
   console.log('\n\n>>>>> Creating component provider');
   // Save the list of spec paths to a temp file.
   const schemaListTmpPath = `${os.tmpdir()}/rn-tmp-schema-list.json`;
@@ -440,7 +435,7 @@ function findCodegenEnabledLibraries(
   const dependencies = {...pkgJson.dependencies, ...pkgJson.devDependencies};
   const libraries = [];
 
-  handleReactNativeCodeLibraries(
+  handleReactNativeCoreLibraries(
     libraries,
     codegenConfigFilename,
     codegenConfigKey,
@@ -554,7 +549,7 @@ function execute(
       schemaPaths,
     );
 
-    createComponentProvider(schemaPaths, node, iosOutputDir);
+    createComponentProvider(schemaPaths, node);
     cleanupEmptyFilesAndFolders(iosOutputDir);
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
Summary:
This diff makes some minor cleanups in `generate-artifacts-executor.js`. Specifically:
1. remove unused argument `iosOutputDir`
2. remove unused `libraryConfig.library` property
3. Fix typo in `handleReactNativeCo`**r**`eLibraries` function name

Changelog: [Internal]

Differential Revision: D51115394


