### PR TITLE
Refactor generate-artifacts-executor.js: delete configFilename and configKey arguments

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -16,7 +16,6 @@ const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const codegenConfigKey = 'codegenConfig';
 const reactNativeDependencyName = 'react-native';
 const rootPath = path.join(__dirname, '../../..');
 
@@ -85,7 +84,7 @@ describe('extractLibrariesFromJSON', () => {
   it('throws if in react-native and no dependencies found', () => {
     let configFile = {};
     expect(() => {
-      underTest._extractLibrariesFromJSON(configFile, codegenConfigKey);
+      underTest._extractLibrariesFromJSON(configFile);
     }).toThrow();
   });
 
@@ -93,7 +92,6 @@ describe('extractLibrariesFromJSON', () => {
     let configFile = {};
     let libraries = underTest._extractLibrariesFromJSON(
       configFile,
-      codegenConfigKey,
       'some-node-module',
       'node_modules/some',
     );
@@ -104,7 +102,6 @@ describe('extractLibrariesFromJSON', () => {
     let configFile = fixtures.noLibrariesConfigFile;
     let libraries = underTest._extractLibrariesFromJSON(
       configFile,
-      codegenConfigKey,
       'my-app',
       '.',
     );
@@ -123,7 +120,6 @@ describe('extractLibrariesFromJSON', () => {
     const configFile = {codegenConfig: {libraries: []}};
     let libraries = underTest._extractLibrariesFromJSON(
       configFile,
-      codegenConfigKey,
       reactNativeDependencyName,
       rootPath,
     );
@@ -134,7 +130,6 @@ describe('extractLibrariesFromJSON', () => {
     const configFile = fixtures.singleLibraryCodegenConfig;
     let libraries = underTest._extractLibrariesFromJSON(
       configFile,
-      codegenConfigKey,
       reactNativeDependencyName,
       rootPath,
     );
@@ -155,7 +150,6 @@ describe('extractLibrariesFromJSON', () => {
     const myDependencyPath = path.join(__dirname, myDependency);
     let libraries = underTest._extractLibrariesFromJSON(
       configFile,
-      codegenConfigKey,
       myDependency,
       myDependencyPath,
     );

--- a/packages/react-native/scripts/generate-codegen-artifacts.js
+++ b/packages/react-native/scripts/generate-codegen-artifacts.js
@@ -21,17 +21,6 @@ const argv = yargs
     alias: 'outputPath',
     description: 'Path where generated artifacts will be output to',
   })
-  .option('f', {
-    alias: 'configFilename',
-    default: 'package.json',
-    description: 'The file that contains the codegen configuration.',
-  })
-  .option('k', {
-    alias: 'configKey',
-    default: 'codegenConfig',
-    description:
-      'The key that contains the codegen configuration in the config file.',
-  })
   .option('c', {
     alias: 'configFileDir',
     default: '',
@@ -46,19 +35,9 @@ const argv = yargs
   .usage('Usage: $0 -p [path to app]')
   .demandOption(['p']).argv;
 
-const CODEGEN_CONFIG_FILENAME = argv.f;
-const CODEGEN_CONFIG_FILE_DIR = argv.c;
-const CODEGEN_CONFIG_KEY = argv.k;
-const NODE = argv.n;
-
-const appRoot = argv.path;
-const outputPath = argv.outputPath;
-
 executor.execute(
-  appRoot,
-  outputPath,
-  NODE,
-  CODEGEN_CONFIG_FILENAME,
-  CODEGEN_CONFIG_KEY,
-  CODEGEN_CONFIG_FILE_DIR,
+  argv.path,
+  argv.outputPath,
+  argv.nodeBinary,
+  argv.configFileDir,
 );


### PR DESCRIPTION
Summary:
This diff removes `configFilename` and `configKey` arguments from iOS codegen CLI. Now we always expect them to be `package.json` and `codegenConfig` respectively.

## Motivation

The existing implementation expects every library to have its codegen config in a file with `configFilename` name. `configFilename` is passed as a single CLI argument and applied to every app dependency. I.e. if `configFilename = codegen.config.json` then we expect to find this file in *every* third-party library. That is weird expectation. This customisation option is unsound. Same with `configKey`. It is much simpler to just stick with convention that `configFilename = "package.json"` and `configKey = "codegenConfig"`.

Changelog: [General][Breaking] - Delete `configFilename` and `configKey` arguments from iOS codegen CLI. Now we always expect them to be `package.json` and `codegenConfig` respectively.

Differential Revision: D51256486


