### PR TITLE
Delete node calls from generate-artifacts-executor.js

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
@@ -11,45 +11,9 @@
 
 'use strict';
 
-const combine = require('./combine-js-to-schema');
-const {filterJSFile, parseArgs} = require('./combine-utils');
-const fs = require('fs');
-const glob = require('glob');
-const path = require('path');
+const {combineSchemasInFileList} = require('./combine-js-to-schema');
+const {parseArgs} = require('./combine-utils');
 
 const {platform, outfile, fileList} = parseArgs(process.argv);
 
-const allFiles = [];
-fileList.forEach(file => {
-  if (fs.lstatSync(file).isDirectory()) {
-    const filePattern = path.sep === '\\' ? file.replace(/\\/g, '/') : file;
-    const dirFiles = glob
-      .sync(`${filePattern}/**/*.{js,ts,tsx}`, {
-        nodir: true,
-        // TODO: This will remove the need of slash substitution above for Windows,
-        // but it requires glob@v9+; with the package currenlty relying on
-        // glob@7.1.1; and flow-typed repo not having definitions for glob@9+.
-        // windowsPathsNoEscape: true,
-      })
-      .filter(element => filterJSFile(element, platform));
-    allFiles.push(...dirFiles);
-  } else if (filterJSFile(file)) {
-    allFiles.push(file);
-  }
-});
-
-const combined = combine(allFiles);
-
-// Warn users if there is no modules to process
-if (Object.keys(combined.modules).length === 0) {
-  console.error(
-    'No modules to process in combine-js-to-schema-cli. If this is unexpected, please check if you set up your NativeComponent correctly. See combine-js-to-schema.js for how codegen finds modules.',
-  );
-}
-const formattedSchema = JSON.stringify(combined, null, 2);
-
-if (outfile != null) {
-  fs.writeFileSync(outfile, formattedSchema);
-} else {
-  console.log(formattedSchema);
-}
+combineSchemasInFileList(fileList, platform, outfile);

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
@@ -13,7 +13,9 @@ import type {SchemaType} from '../../CodegenSchema.js';
 
 const {FlowParser} = require('../../parsers/flow/parser');
 const {TypeScriptParser} = require('../../parsers/typescript/parser');
+const {filterJSFile} = require('./combine-utils');
 const fs = require('fs');
+const glob = require('glob');
 const path = require('path');
 
 const flowParser = new FlowParser();
@@ -46,4 +48,44 @@ function combineSchemas(files: Array<string>): SchemaType {
   );
 }
 
-module.exports = combineSchemas;
+function expandDirectoriesIntoFiles(
+  fileList: Array<string>,
+  platform: ?string,
+): Array<string> {
+  return fileList
+    .flatMap(file => {
+      if (!fs.lstatSync(file).isDirectory()) {
+        return [file];
+      }
+      const filePattern = path.sep === '\\' ? file.replace(/\\/g, '/') : file;
+      return glob.sync(`${filePattern}/**/*.{js,ts,tsx}`, {
+        nodir: true,
+        // TODO: This will remove the need of slash substitution above for Windows,
+        // but it requires glob@v9+; with the package currenlty relying on
+        // glob@7.1.1; and flow-typed repo not having definitions for glob@9+.
+        // windowsPathsNoEscape: true,
+      });
+    })
+    .filter(element => filterJSFile(element, platform));
+}
+
+function combineSchemasInFileList(
+  fileList: Array<string>,
+  platform: ?string,
+  outfile: string,
+): void {
+  const expandedFileList = expandDirectoriesIntoFiles(fileList, platform);
+  const combined = combineSchemas(expandedFileList);
+  if (Object.keys(combined.modules).length === 0) {
+    console.error(
+      'No modules to process in combine-js-to-schema-cli. If this is unexpected, please check if you set up your NativeComponent correctly. See combine-js-to-schema.js for how codegen finds modules.',
+    );
+  }
+  const formattedSchema = JSON.stringify(combined, null, 2);
+  fs.writeFileSync(outfile, formattedSchema);
+}
+
+module.exports = {
+  combineSchemas,
+  combineSchemasInFileList,
+};

--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -12,73 +12,10 @@
 
 const fixtures = require('../__test_fixtures__/fixtures');
 const underTest = require('../generate-artifacts-executor');
-const child_process = require('child_process');
-const fs = require('fs');
 const path = require('path');
 
 const reactNativeDependencyName = 'react-native';
 const rootPath = path.join(__dirname, '../../..');
-
-describe('generateCode', () => {
-  afterEach(() => {
-    jest.resetModules();
-    jest.resetAllMocks();
-  });
-
-  beforeEach(() => {
-    // Silence logs from printDeprecationWarningIfNeeded. Ideally, we should have test assertions on these warnings.
-    jest.spyOn(console, 'log').mockImplementation();
-    jest.spyOn(console, 'debug').mockImplementation();
-  });
-
-  it('executeNodes with the right arguments', () => {
-    // Define variables and expected values
-    const iosOutputDir = 'app/ios/build/generated/ios';
-    const library = {config: {name: 'library', type: 'all'}};
-    const tmpDir = 'tmp';
-    const node = 'usr/bin/node';
-    const pathToSchema = 'app/build/schema.json';
-    const rnRoot = path.join(__dirname, '../..');
-    const libraryTypeArg = 'all';
-
-    const tmpOutputDir = path.join(tmpDir, 'out');
-
-    // mock used functions
-    jest.spyOn(fs, 'mkdirSync').mockImplementation();
-    jest.spyOn(child_process, 'execSync').mockImplementation();
-    jest.spyOn(child_process, 'execFileSync').mockImplementation();
-
-    underTest._generateCode(iosOutputDir, library, tmpDir, node, pathToSchema);
-
-    expect(child_process.execFileSync).toHaveBeenCalledTimes(1);
-    expect(child_process.execFileSync).toHaveBeenNthCalledWith(1, node, [
-      `${path.join(rnRoot, 'generate-specs-cli.js')}`,
-      '--platform',
-      'ios',
-      '--schemaPath',
-      pathToSchema,
-      '--outputDir',
-      tmpOutputDir,
-      '--libraryName',
-      library.config.name,
-      '--libraryType',
-      libraryTypeArg,
-    ]);
-    expect(child_process.execSync).toHaveBeenCalledTimes(1);
-    expect(child_process.execSync).toHaveBeenNthCalledWith(
-      1,
-      `cp -R ${tmpOutputDir}/* "${iosOutputDir}"`,
-    );
-
-    expect(fs.mkdirSync).toHaveBeenCalledTimes(2);
-    expect(fs.mkdirSync).toHaveBeenNthCalledWith(1, tmpOutputDir, {
-      recursive: true,
-    });
-    expect(fs.mkdirSync).toHaveBeenNthCalledWith(2, iosOutputDir, {
-      recursive: true,
-    });
-  });
-});
 
 describe('extractLibrariesFromJSON', () => {
   it('throws if in react-native and no dependencies found', () => {

--- a/packages/react-native/scripts/codegen/codegen-utils.js
+++ b/packages/react-native/scripts/codegen/codegen-utils.js
@@ -32,6 +32,20 @@ function getCodegen() {
   return RNCodegen;
 }
 
+function getCombineJSToSchema() {
+  let combineJSToSchema;
+  try {
+    combineJSToSchema = require('../../packages/react-native-codegen/lib/cli/combine/combine-js-to-schema.js');
+  } catch (e) {
+    combineJSToSchema = require('@react-native/codegen/lib/cli/combine/combine-js-to-schema.js');
+  }
+  if (!combineJSToSchema) {
+    throw 'combine-js-to-schema not found.';
+  }
+  return combineJSToSchema;
+}
+
 module.exports = {
   getCodegen: getCodegen,
+  getCombineJSToSchema: getCombineJSToSchema,
 };

--- a/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
+++ b/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
@@ -13,7 +13,6 @@ const utils = require('./codegen-utils');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
-const RNCodegen = utils.getCodegen();
 
 const GENERATORS = {
   all: {
@@ -94,7 +93,7 @@ function generateSpec(
   createFolderIfDefined(composePath('react/renderer/components/'));
   createFolderIfDefined(composePath('./'));
 
-  RNCodegen.generate(
+  utils.getCodegen().generate(
     {
       libraryName,
       schema,

--- a/packages/react-native/scripts/generate-codegen-artifacts.js
+++ b/packages/react-native/scripts/generate-codegen-artifacts.js
@@ -27,17 +27,7 @@ const argv = yargs
     description:
       'Path where codegen config files are located (e.g. node_modules dir).',
   })
-  .option('n', {
-    alias: 'nodeBinary',
-    default: 'node',
-    description: 'Path to the node executable.',
-  })
   .usage('Usage: $0 -p [path to app]')
   .demandOption(['p']).argv;
 
-executor.execute(
-  argv.path,
-  argv.outputPath,
-  argv.nodeBinary,
-  argv.configFileDir,
-);
+executor.execute(argv.path, argv.outputPath, argv.configFileDir);

--- a/packages/react-native/scripts/generate-provider-cli.js
+++ b/packages/react-native/scripts/generate-provider-cli.js
@@ -9,16 +9,7 @@
 
 'use strict';
 
-let RNCodegen;
-try {
-  RNCodegen = require('../packages/react-native-codegen/lib/generators/RNCodegen.js');
-} catch (e) {
-  RNCodegen = require('@react-native/codegen/lib/generators/RNCodegen.js');
-  if (!RNCodegen) {
-    throw 'RNCodegen not found.';
-  }
-}
-
+const utils = require('./codegen/codegen-utils');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const yargs = require('yargs');
@@ -81,7 +72,7 @@ function generateProvider(platform, schemaListPath, outputDirectory) {
     throw new Error(`Invalid platform type. ${platform}`);
   }
 
-  RNCodegen.generateFromSchemas(
+  utils.getCodegen().generateFromSchemas(
     {
       schemas,
       outputDirectory,

--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -96,7 +96,7 @@ generateCodegenArtifactsFromSchema () {
 generateArtifacts () {
     describe "Generating codegen artifacts"
     pushd "$RCT_SCRIPT_RN_DIR" >/dev/null || exit 1
-        "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$TEMP_OUTPUT_DIR" --configFileDir "$RCT_SCRIPT_CONFIG_FILE_DIR" --nodeBinary "$NODE_BINARY"
+        "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$TEMP_OUTPUT_DIR" --configFileDir "$RCT_SCRIPT_CONFIG_FILE_DIR"
     popd >/dev/null || exit 1
 }
 


### PR DESCRIPTION
Summary:
This diff deletes calls to `node` from `generate-artifacts-executor.js`, and replaces them with normal `requires` of JS sources.
This is a squashed version of (D51116291 ... D51158799).
The following sequence of changes has been made:
1. Require and directly invoke `generate-specs-cli-executor` instead of using `node`.
2. Use `codegen-util` to get `RNCodegen` in `generate-provider-cli.js`.
3. Use `RNCodegen` directly instead of using `node`.
4. Move all implementation code from `combine-js-to-schema-cli.js` to `combine-js-to-schema.js`.
5. Decouple building the codegen from getting the codegen CLI.
6. Use `combine-js-to-schema` directly instead of using `node`.
7. Delete unit test that was testing node invocation.
8. Delete `nodeBinary` argument form `generate-codegen-artifacts.js` and its callsites.

Changelog: [Internal]

Differential Revision: D51158845


