### PR TITLE
Optional prop for RNTesterApp to provide custom test lists

### DIFF
--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -8,6 +8,8 @@
  * @flow
  */
 
+import type {RNTesterModuleInfo} from './types/RNTesterTypes';
+
 import RNTesterModuleContainer from './components/RNTesterModuleContainer';
 import RNTesterModuleList from './components/RNTesterModuleList';
 import RNTesterNavBar, {navBarHeight} from './components/RNTesterNavbar';
@@ -28,7 +30,14 @@ import {BackHandler, StyleSheet, View, useColorScheme} from 'react-native';
 
 // RNTester App currently uses in memory storage for storing navigation state
 
-const RNTesterApp = (): React.Node => {
+const RNTesterApp = ({
+  testList,
+}: {
+  testList?: {
+    components?: Array<RNTesterModuleInfo>,
+    apis?: Array<RNTesterModuleInfo>,
+  },
+}): React.Node => {
   const [state, dispatch] = React.useReducer(
     RNTesterNavigationReducer,
     initialNavigationState,
@@ -44,8 +53,8 @@ const RNTesterApp = (): React.Node => {
   } = state;
 
   const examplesList = React.useMemo(
-    () => getExamplesListWithRecentlyUsed({recentlyUsed}),
-    [recentlyUsed],
+    () => getExamplesListWithRecentlyUsed({recentlyUsed, testList}),
+    [recentlyUsed, testList],
   );
 
   const handleBackPress = React.useCallback(() => {

--- a/packages/rn-tester/js/utils/testerStateUtils.js
+++ b/packages/rn-tester/js/utils/testerStateUtils.js
@@ -48,15 +48,21 @@ const filterEmptySections = (examplesList: ExamplesList): any => {
 
 export const getExamplesListWithRecentlyUsed = ({
   recentlyUsed,
+  testList,
 }: {
   recentlyUsed: ComponentList,
+  testList?: {
+    components?: Array<RNTesterModuleInfo>,
+    apis?: Array<RNTesterModuleInfo>,
+  },
 }): ExamplesList | null => {
   // Return early if state has not been initialized from storage
   if (!recentlyUsed) {
     return null;
   }
 
-  const components = RNTesterList.Components.map(
+  const componentList = testList?.components ?? RNTesterList.Components;
+  const components = componentList.map(
     (componentExample): RNTesterModuleInfo => ({
       ...componentExample,
       exampleType: Screens.COMPONENTS,
@@ -69,7 +75,8 @@ export const getExamplesListWithRecentlyUsed = ({
     )
     .filter(Boolean);
 
-  const apis = RNTesterList.APIs.map((apiExample): RNTesterModuleInfo => ({
+  const apisList = testList?.apis ?? RNTesterList.APIs;
+  const apis = apisList.map((apiExample): RNTesterModuleInfo => ({
     ...apiExample,
     exampleType: Screens.APIS,
   }));


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] -

This allows to optionally provide a custom list of component/api test clauses into `RNTesterApp`.

Differential Revision: D51429407


