### PR TITLE
Include @babel/plugin-proposal-object-rest-spread for Hermes targets

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -112,15 +112,17 @@ const getPreset = (src, options) => {
       {useBuiltIns: true},
     ]);
   }
-  if (!isHermes && (isNull || hasClass || src.indexOf('...') !== -1)) {
-    extraPlugins.push(
-      [require('@babel/plugin-transform-spread')],
-      [
-        require('@babel/plugin-proposal-object-rest-spread'),
-        // Assume no dependence on getters or evaluation order. See https://github.com/babel/babel/pull/11520
-        {loose: true, useBuiltIns: true},
-      ],
-    );
+  if (isNull || hasClass || src.indexOf('...') !== -1) {
+    if (!isHermes) {
+      extraPlugins.push([require('@babel/plugin-transform-spread')]);
+    }
+    // Include this transform for Hermes until destructured
+    // rest params are supported: (...{bar}) => bar
+    extraPlugins.push([
+      require('@babel/plugin-proposal-object-rest-spread'),
+      // Assume no dependence on getters or evaluation order. See https://github.com/babel/babel/pull/11520
+      {loose: true, useBuiltIns: true},
+    ]);
   }
   if (isNull || src.indexOf('async') !== -1) {
     extraPlugins.push([


### PR DESCRIPTION
Differential Revision: D51416723

Enable babel object-rest-spread transform for hermes targets to support the following syntax:
```
function foo({...{bar}}){return bar};
```

