### PR TITLE
adding missing getScrollableNode type

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -130,6 +130,8 @@ export class VirtualizedList<ItemT> extends React.Component<
 
   recordInteraction: () => void;
 
+  getScrollableNode: () => number | undefined;
+
   getScrollRef: () =>
     | React.ElementRef<typeof ScrollView>
     | React.ElementRef<typeof View>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

While working with `VirtualizedList` I found out that the library is missing a type for `getScrollableNode()` method. Added it to the `VirtualizedList.d.ts` file.

## Changelog:

[GENERAL] [ADDED] - Added missing `getScrollableNode()` type for VirtualizedLists component.

## Test Plan:
Used the `packages/rn-tester` app to test it out.