### PR TITLE
Add LTO to ReactCommon compiler flags

### DIFF
--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.header_dir             = "ReactCommon" # Use global header_dir for all subspecs for use_frameworks! compatibility
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
+  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + ' ' + '-flto'
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",
                                "USE_HEADERMAP" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",


### PR DESCRIPTION

## Summary:

Link Time Optimziation allows the compiler to optimize across source files, at link time, typically resulting in binary code that is overall smaller and faster. This allows for a more thorough analysis, cross-file inclining, deeper propagation of const folding, and many other benefits. If this works well, the next step would be to emit ReactCommon and other libraries as Static Libraries (`.a` files) so that even more of the end-to-end native code stack gets this uplift.

There shouldn't be any downside to using LTO on each library in isolation, but we should lean on mobile lab testing infra to tell us if there's some unforseeable impact at scale.

## Changelog:

[INTERNAL] [CHANGED] - Improve native code size and performance by enabling Link Time Optimization in ReactCommon podsepc.


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
