### PR TITLE
Temporarily back out ImageLoaderModule type extraction

### DIFF
--- a/packages/react-native/Libraries/Image/NativeImageLoaderAndroid.js
+++ b/packages/react-native/Libraries/Image/NativeImageLoaderAndroid.js
@@ -12,16 +12,24 @@ import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-export type ImageSize = {|
-  width: number,
-  height: number,
-|};
-
 export interface Spec extends TurboModule {
   +abortRequest: (requestId: number) => void;
   +getConstants: () => {||};
-  +getSize: (uri: string) => Promise<ImageSize>;
-  +getSizeWithHeaders: (uri: string, headers: Object) => Promise<ImageSize>;
+  +getSize: (uri: string) => Promise<
+    $ReadOnly<{
+      width: number,
+      height: number,
+      ...
+    }>,
+  >;
+  +getSizeWithHeaders: (
+    uri: string,
+    headers: Object,
+  ) => Promise<{
+    width: number,
+    height: number,
+    ...
+  }>;
   +prefetchImage: (uri: string, requestId: number) => Promise<boolean>;
   +queryCache: (uris: Array<string>) => Promise<Object>;
 }


### PR DESCRIPTION
Summary:
# Changelog:
[Internal]-

Pending figuring out why it might break backwards compatibility (which it shouldn't, in practice).

Reviewed By: GijsWeterings

Differential Revision: D51447646


