### PR TITLE
Rename JSEngineInstance -> JSRuntimeFactory

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -38,7 +38,7 @@
 #import <react/config/ReactNativeConfig.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
-#import <react/runtime/JSEngineInstance.h>
+#import <react/runtime/JSRuntimeFactory.h>
 
 static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
@@ -293,8 +293,8 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
   _reactHost = [[RCTHost alloc] initWithBundleURL:[self bundleURL]
                                      hostDelegate:nil
                        turboModuleManagerDelegate:self
-                                 jsEngineProvider:^std::shared_ptr<facebook::react::JSEngineInstance>() {
-                                   return [weakSelf createJSEngineInstance];
+                                 jsEngineProvider:^std::shared_ptr<facebook::react::JSRuntimeFactory>() {
+                                   return [weakSelf createJSRuntimeFactory];
                                  }];
   [_reactHost setBundleURLProvider:^NSURL *() {
     return [weakSelf bundleURL];
@@ -303,7 +303,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
   [_reactHost start];
 }
 
-- (std::shared_ptr<facebook::react::JSEngineInstance>)createJSEngineInstance
+- (std::shared_ptr<facebook::react::JSRuntimeFactory>)createJSRuntimeFactory
 {
 #if RCT_USE_HERMES
   return std::make_shared<facebook::react::RCTHermesInstance>(_reactNativeConfig, nullptr);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -54,13 +54,13 @@ object DefaultReactHost {
     if (reactHost == null) {
       val jsBundleLoader =
           JSBundleLoader.createAssetLoader(context, "assets://$jsBundleAssetPath", true)
-      val jsEngineInstance = if (isHermesEnabled) HermesInstance() else JSCInstance()
+      val jsRuntimeFactory = if (isHermesEnabled) HermesInstance() else JSCInstance()
       val defaultReactHostDelegate =
           DefaultReactHostDelegate(
               jsMainModulePath = jsMainModulePath,
               jsBundleLoader = jsBundleLoader,
               reactPackages = packageList,
-              jsEngineInstance = jsEngineInstance,
+              jsRuntimeFactory = jsRuntimeFactory,
               turboModuleManagerDelegateBuilder = DefaultTurboModuleManagerDelegate.Builder())
       val reactJsExceptionHandler = ReactJsExceptionHandler { _ -> }
       val componentFactory = ComponentFactory()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
@@ -14,7 +14,7 @@ import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.runtime.BindingsInstaller
-import com.facebook.react.runtime.JSEngineInstance
+import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.react.runtime.ReactHostDelegate
 import com.facebook.react.runtime.hermes.HermesInstance
 
@@ -28,7 +28,7 @@ import com.facebook.react.runtime.hermes.HermesInstance
  * @param jsBundleLoader Bundle loader to use when setting up JS environment. <p>Example:
  *   [JSBundleLoader.createFileLoader(application, bundleFile)]
  * @param reactPackages list of reactPackages to expose Native Modules and View Components to JS
- * @param jsEngineInstance Object that holds a native reference to the javascript engine
+ * @param jsRuntimeFactory Object that holds a native reference to the JS Runtime factory
  * @param bindingsInstaller Object that holds a native C++ references that allow host applications
  *   to install C++ objects into jsi::Runtime during the initialization of React Native
  * @param reactNativeConfig ReactNative Configuration that allows to customize the behavior of
@@ -42,7 +42,7 @@ class DefaultReactHostDelegate(
     override val jsMainModulePath: String,
     override val jsBundleLoader: JSBundleLoader,
     override val reactPackages: List<ReactPackage> = emptyList(),
-    override val jsEngineInstance: JSEngineInstance = HermesInstance(),
+    override val jsRuntimeFactory: JSRuntimeFactory = HermesInstance(),
     override val bindingsInstaller: BindingsInstaller = DefaultBindingsInstaller(),
     private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
     private val exceptionHandler: (Exception) -> Unit = {},

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSCInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSCInstance.java
@@ -13,7 +13,7 @@ import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.soloader.SoLoader;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public class JSCInstance extends JSEngineInstance {
+public class JSCInstance extends JSRuntimeFactory {
   static {
     SoLoader.loadLibrary("jscinstance");
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.java
@@ -13,14 +13,14 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.soloader.SoLoader;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public abstract class JSEngineInstance {
+public abstract class JSRuntimeFactory {
   static {
     SoLoader.loadLibrary("rninstance");
   }
 
   @DoNotStrip private final HybridData mHybridData;
 
-  protected JSEngineInstance(HybridData hybridData) {
+  protected JSRuntimeFactory(HybridData hybridData) {
     mHybridData = hybridData;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostDelegate.kt
@@ -38,7 +38,7 @@ interface ReactHostDelegate {
   val reactPackages: List<ReactPackage>
 
   /** Object that holds a native reference to the javascript engine */
-  val jsEngineInstance: JSEngineInstance
+  val jsRuntimeFactory: JSRuntimeFactory
 
   /**
    * Bundle loader to use when setting up JS environment. <p>Example:
@@ -68,7 +68,7 @@ interface ReactHostDelegate {
   class ReactHostDelegateBase(
       override val jsMainModulePath: String,
       override val jsBundleLoader: JSBundleLoader,
-      override val jsEngineInstance: JSEngineInstance,
+      override val jsRuntimeFactory: JSRuntimeFactory,
       override val turboModuleManagerDelegateBuilder:
           ReactPackageTurboModuleManagerDelegate.Builder,
       override val reactPackages: List<ReactPackage> = emptyList(),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -167,7 +167,7 @@ final class ReactInstance {
           }
         });
 
-    JSEngineInstance jsEngineInstance = mDelegate.getJsEngineInstance();
+    JSRuntimeFactory jsRuntimeFactory = mDelegate.getJsRuntimeFactory();
     BindingsInstaller bindingsInstaller = mDelegate.getBindingsInstaller();
     // Notify JS if profiling is enabled
     boolean isProfiling =
@@ -177,7 +177,7 @@ final class ReactInstance {
     boolean useModernRuntimeScheduler = ReactFeatureFlags.useModernRuntimeScheduler;
     mHybridData =
         initHybrid(
-            jsEngineInstance,
+            jsRuntimeFactory,
             jsMessageQueueThread,
             nativeModulesMessageQueueThread,
             mJavaTimerManager,
@@ -432,7 +432,7 @@ final class ReactInstance {
 
   @DoNotStrip
   private native HybridData initHybrid(
-      JSEngineInstance jsEngineInstance,
+      JSRuntimeFactory jsRuntimeFactory,
       MessageQueueThread jsMessageQueueThread,
       MessageQueueThread nativeModulesMessageQueueThread,
       JavaTimerManager timerManager,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
@@ -10,11 +10,11 @@ package com.facebook.react.runtime.hermes
 import com.facebook.jni.HybridData
 import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.fabric.ReactNativeConfig
-import com.facebook.react.runtime.JSEngineInstance
+import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.soloader.SoLoader
 
 class HermesInstance constructor(reactNativeConfig: ReactNativeConfig?) :
-    JSEngineInstance(initHybrid(reactNativeConfig as Any?)) {
+    JSRuntimeFactory(initHybrid(reactNativeConfig as Any?)) {
 
   constructor() : this(null)
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
@@ -14,14 +14,14 @@
 #include <jni.h>
 #include <jsi/jsi.h>
 #include <react/config/ReactNativeConfig.h>
-#include <react/runtime/JSEngineInstance.h>
+#include <react/runtime/JSRuntimeFactory.h>
 #include <react/runtime/hermes/HermesInstance.h>
-#include "../../jni/JJSEngineInstance.h"
+#include "../../jni/JJSRuntimeFactory.h"
 
 namespace facebook::react {
 
 class JHermesInstance
-    : public jni::HybridClass<JHermesInstance, JJSEngineInstance> {
+    : public jni::HybridClass<JHermesInstance, JJSRuntimeFactory> {
  public:
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/runtime/hermes/HermesInstance;";

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JJSRuntimeFactory.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JJSRuntimeFactory.h
@@ -9,15 +9,15 @@
 
 #include <fbjni/fbjni.h>
 #include <jni.h>
-#include <react/runtime/JSEngineInstance.h>
+#include <react/runtime/JSRuntimeFactory.h>
 
 namespace facebook::react {
 
-class JJSEngineInstance : public jni::HybridClass<JJSEngineInstance>,
-                          public JSEngineInstance {
+class JJSRuntimeFactory : public jni::HybridClass<JJSRuntimeFactory>,
+                          public JSRuntimeFactory {
  public:
   static auto constexpr kJavaDescriptor =
-      "Lcom/facebook/react/runtime/JSEngineInstance;";
+      "Lcom/facebook/react/runtime/JSRuntimeFactory;";
 
  private:
   friend HybridBase;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -29,7 +29,7 @@
 namespace facebook::react {
 
 JReactInstance::JReactInstance(
-    jni::alias_ref<JJSEngineInstance::javaobject> jsEngineInstance,
+    jni::alias_ref<JJSRuntimeFactory::javaobject> jsRuntimeFactory,
     jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
     jni::alias_ref<JavaMessageQueueThread::javaobject> nativeMessageQueueThread,
     jni::alias_ref<JJavaTimerManager::javaobject> javaTimerManager,
@@ -62,7 +62,7 @@ JReactInstance::JReactInstance(
   jBindingsInstaller_ = jni::make_global(jBindingsInstaller);
 
   instance_ = std::make_unique<ReactInstance>(
-      jsEngineInstance->cthis()->createJSRuntime(sharedJSMessageQueueThread),
+      jsRuntimeFactory->cthis()->createJSRuntime(sharedJSMessageQueueThread),
       sharedJSMessageQueueThread,
       timerManager,
       std::move(jsErrorHandlingFunc),
@@ -110,7 +110,7 @@ JReactInstance::JReactInstance(
 
 jni::local_ref<JReactInstance::jhybriddata> JReactInstance::initHybrid(
     jni::alias_ref<jhybridobject> /* unused */,
-    jni::alias_ref<JJSEngineInstance::javaobject> jsEngineInstance,
+    jni::alias_ref<JJSRuntimeFactory::javaobject> jsRuntimeFactory,
     jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
     jni::alias_ref<JavaMessageQueueThread::javaobject> nativeMessageQueueThread,
     jni::alias_ref<JJavaTimerManager::javaobject> javaTimerManager,
@@ -120,7 +120,7 @@ jni::local_ref<JReactInstance::jhybriddata> JReactInstance::initHybrid(
     bool isProfiling,
     bool useModernRuntimeScheduler) {
   return makeCxxInstance(
-      jsEngineInstance,
+      jsRuntimeFactory,
       jsMessageQueueThread,
       nativeMessageQueueThread,
       javaTimerManager,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.h
@@ -18,12 +18,12 @@
 #include <react/jni/JRuntimeScheduler.h>
 #include <react/jni/JSLoader.h>
 #include <react/jni/ReadableNativeMap.h>
-#include <react/runtime/JSEngineInstance.h>
+#include <react/runtime/JSRuntimeFactory.h>
 #include <react/runtime/PlatformTimerRegistry.h>
 #include <react/runtime/ReactInstance.h>
 
 #include "JBindingsInstaller.h"
-#include "JJSEngineInstance.h"
+#include "JJSRuntimeFactory.h"
 #include "JJSTimerExecutor.h"
 #include "JJavaTimerManager.h"
 #include "JReactExceptionManager.h"
@@ -37,7 +37,7 @@ class JReactInstance : public jni::HybridClass<JReactInstance> {
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jhybridobject>,
-      jni::alias_ref<JJSEngineInstance::javaobject> jsEngineInstance,
+      jni::alias_ref<JJSRuntimeFactory::javaobject> jsRuntimeFactory,
       jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
       jni::alias_ref<JavaMessageQueueThread::javaobject>
           nativeMessageQueueThread,
@@ -83,7 +83,7 @@ class JReactInstance : public jni::HybridClass<JReactInstance> {
   friend HybridBase;
 
   explicit JReactInstance(
-      jni::alias_ref<JJSEngineInstance::javaobject> jsEngineInstance,
+      jni::alias_ref<JJSRuntimeFactory::javaobject> jsRuntimeFactory,
       jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
       jni::alias_ref<JavaMessageQueueThread::javaobject>
           nativeMessageQueueThread,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jsc/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jsc/jni/OnLoad.cpp
@@ -10,12 +10,12 @@
 #include <jsc/JSCRuntime.h>
 #include <jsi/jsi.h>
 #include <react/jni/ReadableNativeMap.h>
-#include <react/runtime/JSEngineInstance.h>
-#include <react/runtime/jni/JJSEngineInstance.h>
+#include <react/runtime/JSRuntimeFactory.h>
+#include <react/runtime/jni/JJSRuntimeFactory.h>
 
 namespace facebook::react {
 
-class JSCInstance : public jni::HybridClass<JSCInstance, JJSEngineInstance> {
+class JSCInstance : public jni::HybridClass<JSCInstance, JJSRuntimeFactory> {
  public:
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/runtime/JSCInstance;";

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactHostDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactHostDelegateTest.kt
@@ -34,13 +34,13 @@ class ReactHostDelegateTest {
     val jsBundleLoader: JSBundleLoader = Mockito.mock(JSBundleLoader::class.java)
     val turboModuleManagerDelegateBuilderMock: ReactPackageTurboModuleManagerDelegate.Builder =
         Mockito.mock(ReactPackageTurboModuleManagerDelegate.Builder::class.java)
-    val hermesInstance: JSEngineInstance = Mockito.mock(HermesInstance::class.java)
+    val hermesInstance: JSRuntimeFactory = Mockito.mock(HermesInstance::class.java)
     val jsMainModulePathMocked = "mockedJSMainModulePath"
     val delegate =
         DefaultReactHostDelegate(
             jsMainModulePath = jsMainModulePathMocked,
             jsBundleLoader = jsBundleLoader,
-            jsEngineInstance = hermesInstance,
+            jsRuntimeFactory = hermesInstance,
             turboModuleManagerDelegateBuilder = turboModuleManagerDelegateBuilderMock)
 
     assertThat(delegate.jsMainModulePath).isEqualTo(jsMainModulePathMocked)

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
@@ -14,14 +14,14 @@
 namespace facebook::react {
 
 /**
- * Interface for a class that creates and owns an instance of a JS VM
+ * Interface for a class that creates instances of a JS VM
  */
-class JSEngineInstance {
+class JSRuntimeFactory {
  public:
   virtual std::unique_ptr<jsi::Runtime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept = 0;
 
-  virtual ~JSEngineInstance() = default;
+  virtual ~JSRuntimeFactory() = default;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTHostTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTHostTests.mm
@@ -56,7 +56,7 @@ static ShimRCTInstance *shimmedRCTInstance;
   _subject = [[RCTHost alloc] initWithBundleURL:OCMClassMock([NSURL class])
                                    hostDelegate:_mockHostDelegate
                      turboModuleManagerDelegate:OCMProtocolMock(@protocol(RCTTurboModuleManagerDelegate))
-                               jsEngineProvider:^std::shared_ptr<facebook::react::JSEngineInstance>() {
+                               jsEngineProvider:^std::shared_ptr<facebook::react::JSRuntimeFactory>() {
                                  return std::make_shared<facebook::react::RCTHermesInstance>();
                                }];
 }

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
@@ -10,7 +10,7 @@
 #import <cxxreact/MessageQueueThread.h>
 #import <hermes/Public/CrashManager.h>
 #import <jsi/jsi.h>
-#import <react/runtime/JSEngineInstance.h>
+#import <react/runtime/JSRuntimeFactory.h>
 #import <react/runtime/hermes/HermesInstance.h>
 
 namespace facebook {
@@ -19,7 +19,7 @@ using CrashManagerProvider =
     std::function<std::shared_ptr<::hermes::vm::CrashManager>()>;
 
 // ObjC++ wrapper for HermesInstance.cpp
-class RCTHermesInstance : public JSEngineInstance {
+class RCTHermesInstance : public JSRuntimeFactory {
  public:
   RCTHermesInstance();
   RCTHermesInstance(

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -9,7 +9,7 @@
 
 #import <React/RCTDefines.h>
 #import <react/renderer/core/ReactPrimitives.h>
-#import <react/runtime/JSEngineInstance.h>
+#import <react/runtime/JSRuntimeFactory.h>
 
 #import "RCTInstance.h"
 
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProvider)(void);
+typedef std::shared_ptr<facebook::react::JSRuntimeFactory> (^RCTHostJSEngineProvider)(void);
 
 @interface RCTHost : NSObject
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -147,7 +147,7 @@ using namespace facebook::react;
     [_instance invalidate];
   }
   _instance = [[RCTInstance alloc] initWithDelegate:self
-                                   jsEngineInstance:[self _provideJSEngine]
+                                   jsRuntimeFactory:[self _provideJSEngine]
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
@@ -214,7 +214,7 @@ using namespace facebook::react;
   }
 
   _instance = [[RCTInstance alloc] initWithDelegate:self
-                                   jsEngineInstance:[self _provideJSEngine]
+                                   jsRuntimeFactory:[self _provideJSEngine]
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
@@ -301,10 +301,10 @@ using namespace facebook::react;
   return surfaces;
 }
 
-- (std::shared_ptr<facebook::react::JSEngineInstance>)_provideJSEngine
+- (std::shared_ptr<facebook::react::JSRuntimeFactory>)_provideJSEngine
 {
   RCTAssert(_jsEngineProvider, @"_jsEngineProvider must be non-nil");
-  std::shared_ptr<facebook::react::JSEngineInstance> jsEngine = _jsEngineProvider();
+  std::shared_ptr<facebook::react::JSRuntimeFactory> jsEngine = _jsEngineProvider();
   RCTAssert(jsEngine != nullptr, @"_jsEngineProvider must return a nonnull pointer");
 
   return jsEngine;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
@@ -9,7 +9,7 @@
 
 #import <React/RCTDefines.h>
 #import <react/renderer/mapbuffer/MapBuffer.h>
-#import <react/runtime/JSEngineInstance.h>
+#import <react/runtime/JSRuntimeFactory.h>
 #import <react/runtime/ReactInstance.h>
 
 #import "RCTContextContainerHandling.h"
@@ -68,7 +68,7 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
 @interface RCTInstance : NSObject
 
 - (instancetype)initWithDelegate:(id<RCTInstanceDelegate>)delegate
-                jsEngineInstance:(std::shared_ptr<facebook::react::JSEngineInstance>)jsEngineInstance
+                jsRuntimeFactory:(std::shared_ptr<facebook::react::JSRuntimeFactory>)jsRuntimeFactory
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -67,7 +67,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
 @implementation RCTInstance {
   std::unique_ptr<ReactInstance> _reactInstance;
-  std::shared_ptr<JSEngineInstance> _jsEngineInstance;
+  std::shared_ptr<JSRuntimeFactory> _jsRuntimeFactory;
   __weak id<RCTTurboModuleManagerDelegate> _appTMMDelegate;
   __weak id<RCTInstanceDelegate> _delegate;
   RCTSurfacePresenter *_surfacePresenter;
@@ -86,7 +86,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 #pragma mark - Public
 
 - (instancetype)initWithDelegate:(id<RCTInstanceDelegate>)delegate
-                jsEngineInstance:(std::shared_ptr<facebook::react::JSEngineInstance>)jsEngineInstance
+                jsRuntimeFactory:(std::shared_ptr<facebook::react::JSRuntimeFactory>)jsRuntimeFactory
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
@@ -98,7 +98,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     [_performanceLogger markStartForTag:RCTPLReactInstanceInit];
 
     _delegate = delegate;
-    _jsEngineInstance = jsEngineInstance;
+    _jsRuntimeFactory = jsRuntimeFactory;
     _appTMMDelegate = tmmDelegate;
     _jsThreadManager = [RCTJSThreadManager new];
     _onInitialBundleLoad = onInitialBundleLoad;
@@ -149,7 +149,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
     // Clean up all the Resources
     self->_reactInstance = nullptr;
-    self->_jsEngineInstance = nullptr;
+    self->_jsRuntimeFactory = nullptr;
     self->_appTMMDelegate = nil;
     self->_delegate = nil;
     self->_displayLink = nil;
@@ -223,7 +223,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
   // Create the React Instance
   _reactInstance = std::make_unique<ReactInstance>(
-      _jsEngineInstance->createJSRuntime(_jsThreadManager.jsMessageThread),
+      _jsRuntimeFactory->createJSRuntime(_jsThreadManager.jsMessageThread),
       _jsThreadManager.jsMessageThread,
       timerManager,
       jsErrorHandlingFunc,

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.h
@@ -7,12 +7,12 @@
 
 #import <cxxreact/MessageQueueThread.h>
 #import <jsi/jsi.h>
-#import <react/runtime/JSEngineInstance.h>
+#import <react/runtime/JSRuntimeFactory.h>
 
 namespace facebook {
 namespace react {
 
-class RCTJscInstance : public JSEngineInstance {
+class RCTJscInstance : public JSRuntimeFactory {
  public:
   RCTJscInstance();
 

--- a/packages/react-native/ReactCommon/react/test_utils/ios/Shims/ShimRCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/test_utils/ios/Shims/ShimRCTInstance.mm
@@ -23,7 +23,7 @@ static __weak ShimRCTInstance *weakShim = nil;
         [RCTInstance class],
         [ShimRCTInstance class],
         @selector(initWithDelegate:
-                  jsEngineInstance:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry:));
+                  jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry:));
     RCTSwizzleInstanceSelector([RCTInstance class], [ShimRCTInstance class], @selector(invalidate));
     RCTSwizzleInstanceSelector(
         [RCTInstance class], [ShimRCTInstance class], @selector(callFunctionOnJSModule:method:args:));
@@ -38,7 +38,7 @@ static __weak ShimRCTInstance *weakShim = nil;
       [RCTInstance class],
       [ShimRCTInstance class],
       @selector(initWithDelegate:
-                jsEngineInstance:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry:));
+                jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry:));
   RCTSwizzleInstanceSelector([RCTInstance class], [ShimRCTInstance class], @selector(invalidate));
   RCTSwizzleInstanceSelector(
       [RCTInstance class], [ShimRCTInstance class], @selector(callFunctionOnJSModule:method:args:));
@@ -47,7 +47,7 @@ static __weak ShimRCTInstance *weakShim = nil;
 }
 
 - (instancetype)initWithDelegate:(id<RCTInstanceDelegate>)delegate
-                jsEngineInstance:(std::shared_ptr<facebook::react::JSEngineInstance>)jsEngineInstance
+                jsRuntimeFactory:(std::shared_ptr<facebook::react::JSRuntimeFactory>)jsRuntimeFactory
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad


### PR DESCRIPTION
Summary:
`JSEngineInstance` is a misnomer - this interface actually creates `jsi::Runtime`s and doesn't represent an "instance of a JS engine". This diff renames it to `JSRuntimeFactory`.

Changelog: [Internal]

Differential Revision: D51447882


