### PR TITLE
Create JSRuntime interface

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
@@ -28,7 +28,7 @@ void JHermesInstance::registerNatives() {
   });
 }
 
-std::unique_ptr<jsi::Runtime> JHermesInstance::createJSRuntime(
+std::unique_ptr<JSRuntime> JHermesInstance::createJSRuntime(
     std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
   return HermesInstance::createJSRuntime(
       reactNativeConfig_, nullptr, msgQueueThread);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
@@ -35,7 +35,7 @@ class JHermesInstance
   JHermesInstance(std::shared_ptr<const ReactNativeConfig> reactNativeConfig)
       : reactNativeConfig_(reactNativeConfig){};
 
-  std::unique_ptr<jsi::Runtime> createJSRuntime(
+  std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;
 
   ~JHermesInstance() {}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jsc/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jsc/jni/OnLoad.cpp
@@ -30,9 +30,9 @@ class JSCInstance : public jni::HybridClass<JSCInstance, JJSRuntimeFactory> {
     });
   }
 
-  std::unique_ptr<jsi::Runtime> createJSRuntime(
+  std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
-    return jsc::makeJSCRuntime();
+    return std::make_unique<JSIRuntimeHolder>(jsc::makeJSCRuntime());
   }
 
  private:

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JSRuntimeFactory.h"
+
+namespace facebook::react {
+jsi::Runtime& JSIRuntimeHolder::getRuntime() noexcept {
+  return *runtime_;
+}
+
+JSIRuntimeHolder::JSIRuntimeHolder(std::unique_ptr<jsi::Runtime> runtime)
+    : runtime_(std::move(runtime)) {
+  assert(runtime_ != nullptr);
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
@@ -14,14 +14,37 @@
 namespace facebook::react {
 
 /**
+ * An interface that represents an instance of a JS VM
+ */
+class JSRuntime {
+ public:
+  virtual jsi::Runtime& getRuntime() noexcept = 0;
+
+  virtual ~JSRuntime() = default;
+};
+
+/**
  * Interface for a class that creates instances of a JS VM
  */
 class JSRuntimeFactory {
  public:
-  virtual std::unique_ptr<jsi::Runtime> createJSRuntime(
+  virtual std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept = 0;
 
   virtual ~JSRuntimeFactory() = default;
+};
+
+/**
+ * Utility class for creating a JSRuntime from a uniquely owned jsi::Runtime.
+ */
+class JSIRuntimeHolder : public JSRuntime {
+ public:
+  jsi::Runtime& getRuntime() noexcept override;
+
+  explicit JSIRuntimeHolder(std::unique_ptr<jsi::Runtime> runtime);
+
+ private:
+  std::unique_ptr<jsi::Runtime> runtime_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsitracing"
   s.dependency "React-utils"
   s.dependency "React-jsi"
+  s.dependency "React-RuntimeCore"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -14,6 +14,7 @@
 #include <jsireact/JSIExecutor.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/runtime/BufferedRuntimeExecutor.h>
+#include <react/runtime/JSRuntimeFactory.h>
 #include <react/runtime/TimerManager.h>
 
 namespace facebook::react {
@@ -29,7 +30,7 @@ class ReactInstance final {
   using BindingsInstallFunc = std::function<void(jsi::Runtime& runtime)>;
 
   ReactInstance(
-      std::unique_ptr<jsi::Runtime> runtime,
+      std::unique_ptr<JSRuntime> runtime,
       std::shared_ptr<MessageQueueThread> jsMessageQueueThread,
       std::shared_ptr<TimerManager> timerManager,
       JsErrorHandler::JsErrorHandlingFunc JsErrorHandlingFunc,
@@ -64,7 +65,7 @@ class ReactInstance final {
   void handleMemoryPressureJs(int pressureLevel);
 
  private:
-  std::shared_ptr<jsi::Runtime> runtime_;
+  std::shared_ptr<JSRuntime> runtime_;
   std::shared_ptr<MessageQueueThread> jsMessageQueueThread_;
   std::shared_ptr<BufferedRuntimeExecutor> bufferedRuntimeExecutor_;
   std::shared_ptr<TimerManager> timerManager_;

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(bridgelesshermes
         hermes_inspector_modern
         jsi
         hermes_executor_common
+        bridgeless
 )
 
 if(${CMAKE_BUILD_TYPE} MATCHES Debug)

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -89,7 +89,7 @@ class DecoratedRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
 
 #endif
 
-std::unique_ptr<jsi::Runtime> HermesInstance::createJSRuntime(
+std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
     std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
     std::shared_ptr<::hermes::vm::CrashManager> cm,
     std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
@@ -144,10 +144,10 @@ std::unique_ptr<jsi::Runtime> HermesInstance::createJSRuntime(
   std::unique_ptr<DecoratedRuntime> decoratedRuntime =
       std::make_unique<DecoratedRuntime>(
           std::move(hermesRuntime), msgQueueThread);
-  return decoratedRuntime;
+  return std::make_unique<JSIRuntimeHolder>(std::move(decoratedRuntime));
 #endif
 
-  return hermesRuntime;
+  return std::make_unique<JSIRuntimeHolder>(std::move(hermesRuntime));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
@@ -11,12 +11,13 @@
 #include <hermes/hermes.h>
 #include <jsi/jsi.h>
 #include <react/config/ReactNativeConfig.h>
+#include <react/runtime/JSRuntimeFactory.h>
 
 namespace facebook::react {
 
 class HermesInstance {
  public:
-  static std::unique_ptr<jsi::Runtime> createJSRuntime(
+  static std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
       std::shared_ptr<::hermes::vm::CrashManager> cm,
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
@@ -26,7 +26,7 @@ class RCTHermesInstance : public JSRuntimeFactory {
       std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
       CrashManagerProvider crashManagerProvider);
 
-  std::unique_ptr<jsi::Runtime> createJSRuntime(
+  std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept override;
 
   ~RCTHermesInstance(){};

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.mm
@@ -20,7 +20,7 @@ RCTHermesInstance::RCTHermesInstance(
 {
 }
 
-std::unique_ptr<jsi::Runtime> RCTHermesInstance::createJSRuntime(
+std::unique_ptr<JSRuntime> RCTHermesInstance::createJSRuntime(
     std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
 {
   return _hermesInstance->createJSRuntime(

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.h
@@ -16,7 +16,7 @@ class RCTJscInstance : public JSRuntimeFactory {
  public:
   RCTJscInstance();
 
-  std::unique_ptr<jsi::Runtime> createJSRuntime(
+  std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept override;
 
   ~RCTJscInstance(){};

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJscInstance.mm
@@ -13,10 +13,9 @@ namespace react {
 
 RCTJscInstance::RCTJscInstance() {}
 
-std::unique_ptr<jsi::Runtime> RCTJscInstance::createJSRuntime(
-    std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
+std::unique_ptr<JSRuntime> RCTJscInstance::createJSRuntime(std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
 {
-  return jsc::makeJSCRuntime();
+  return std::make_unique<JSIRuntimeHolder>(jsc::makeJSCRuntime());
 }
 
 } // namespace react

--- a/packages/react-native/ReactCommon/react/runtime/tests/cxx/ReactInstanceTest.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/tests/cxx/ReactInstanceTest.cpp
@@ -116,8 +116,9 @@ class ReactInstanceTest : public ::testing::Test {
   ReactInstanceTest() {}
 
   void SetUp() override {
-    auto runtime = hermes::makeHermesRuntime();
-    runtime_ = runtime.get();
+    auto runtime =
+        std::make_unique<JSIRuntimeHolder>(hermes::makeHermesRuntime());
+    runtime_ = &runtime->getRuntime();
     messageQueueThread_ = std::make_shared<MockMessageQueueThread>();
     auto mockRegistry = std::make_unique<MockTimerRegistry>();
     mockRegistry_ = mockRegistry.get();


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Introduces the `JSRuntime` interface as a straightforward wrapper around `jsi::Runtime`, and refactors `ReactInstance` to hold a `JSRuntime` instead of a `jsi::Runtime`. In an upcoming diff we'll add debugging-related methods to `JSRuntime` and specialise their implementations for Hermes.

NOTE: `JSRuntime` is somewhat analogous to `JSExecutor` in the Bridge architecture.

Differential Revision: D51447934

