### PR TITLE
RNTester iOS: require arm64 device capabilities

### DIFF
--- a/packages/react-native/template/ios/HelloWorld/Info.plist
+++ b/packages/react-native/template/ios/HelloWorld/Info.plist
@@ -38,7 +38,7 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -50,7 +50,7 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
Summary:
We have since targeted iOS min SDK 13.4, it's time to move to `arm64`.

Reference: https://developer.apple.com/documentation/bundleresources/information_property_list/uirequireddevicecapabilities?language=objc

Changelog: [iOS][Fixed] Move UIRequiredDeviceCapabilities for RNTester to arm64

Differential Revision: D51461103


