### PR TITLE
Weak SurfaceHandler Link to ShadowTree

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -132,8 +132,12 @@ void Binding::startSurface(
 
   surfaceHandler.start();
 
-  surfaceHandler.getMountingCoordinator()->setMountingOverrideDelegate(
-      animationDriver_);
+  auto mountingCoordinator = surfaceHandler.getMountingCoordinator();
+  if (!mountingCoordinator) {
+    return;
+  }
+
+  mountingCoordinator->setMountingOverrideDelegate(animationDriver_);
 
   {
     SystraceSection s2("FabricUIManagerBinding::startSurface::surfaceId::lock");

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -30,8 +30,6 @@ using ShadowTreeCommitTransaction = std::function<RootShadowNode::Unshared(
  */
 class ShadowTree final {
  public:
-  using Unique = std::unique_ptr<ShadowTree>;
-
   /*
    * Represents a result of a `commit` operation.
    */

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.cpp
@@ -16,13 +16,14 @@ ShadowTreeRegistry::~ShadowTreeRegistry() {
       registry_.empty() && "Deallocation of non-empty `ShadowTreeRegistry`.");
 }
 
-void ShadowTreeRegistry::add(std::unique_ptr<ShadowTree>&& shadowTree) const {
+void ShadowTreeRegistry::add(std::shared_ptr<ShadowTree> shadowTree) const {
   std::unique_lock lock(mutex_);
 
-  registry_.emplace(shadowTree->getSurfaceId(), std::move(shadowTree));
+  auto surfaceId = shadowTree->getSurfaceId();
+  registry_.emplace(surfaceId, std::move(shadowTree));
 }
 
-std::unique_ptr<ShadowTree> ShadowTreeRegistry::remove(
+std::shared_ptr<ShadowTree> ShadowTreeRegistry::remove(
     SurfaceId surfaceId) const {
   std::unique_lock lock(mutex_);
 
@@ -31,7 +32,7 @@ std::unique_ptr<ShadowTree> ShadowTreeRegistry::remove(
     return {};
   }
 
-  auto shadowTree = std::unique_ptr<ShadowTree>(iterator->second.release());
+  auto shadowTree = iterator->second;
   registry_.erase(iterator);
   return shadowTree;
 }

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
@@ -28,7 +28,7 @@ class ShadowTreeRegistry final {
    * The ownership of the instance is also transferred to the registry.
    * Can be called from any thread.
    */
-  void add(std::unique_ptr<ShadowTree>&& shadowTree) const;
+  void add(std::shared_ptr<ShadowTree> shadowTree) const;
 
   /*
    * Removes a `ShadowTree` instance with given `surfaceId` from the registry
@@ -37,7 +37,7 @@ class ShadowTreeRegistry final {
    * Returns `nullptr` if a `ShadowTree` with given `surfaceId` was not found.
    * Can be called from any thread.
    */
-  std::unique_ptr<ShadowTree> remove(SurfaceId surfaceId) const;
+  std::shared_ptr<ShadowTree> remove(SurfaceId surfaceId) const;
 
   /*
    * Finds a `ShadowTree` instance with a given `surfaceId` in the registry and
@@ -62,7 +62,7 @@ class ShadowTreeRegistry final {
 
  private:
   mutable std::shared_mutex mutex_;
-  mutable std::unordered_map<SurfaceId, std::unique_ptr<ShadowTree>>
+  mutable std::unordered_map<SurfaceId, std::shared_ptr<ShadowTree>>
       registry_; // Protected by `mutex_`.
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
@@ -189,7 +189,7 @@ class SurfaceHandler {
   struct Link {
     Status status{Status::Unregistered};
     const UIManager* uiManager{};
-    const ShadowTree* shadowTree{};
+    std::weak_ptr<const ShadowTree> shadowTree;
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -192,7 +192,7 @@ void UIManager::setIsJSResponder(
 }
 
 void UIManager::startSurface(
-    ShadowTree::Unique&& shadowTree,
+    std::shared_ptr<ShadowTree> shadowTree,
     const std::string& moduleName,
     const folly::dynamic& props,
     DisplayMode displayMode) const {
@@ -221,7 +221,7 @@ void UIManager::setSurfaceProps(
   });
 }
 
-ShadowTree::Unique UIManager::stopSurface(SurfaceId surfaceId) const {
+std::shared_ptr<ShadowTree> UIManager::stopSurface(SurfaceId surfaceId) const {
   SystraceSection s("UIManager::stopSurface");
 
   // Stop any ongoing animations.

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -106,7 +106,7 @@ class UIManager final : public ShadowTreeDelegate {
 #pragma mark - Surface Start & Stop
 
   void startSurface(
-      ShadowTree::Unique&& shadowTree,
+      std::shared_ptr<ShadowTree> shadowTree,
       const std::string& moduleName,
       const folly::dynamic& props,
       DisplayMode displayMode) const;
@@ -117,7 +117,7 @@ class UIManager final : public ShadowTreeDelegate {
       const folly::dynamic& props,
       DisplayMode displayMode) const;
 
-  ShadowTree::Unique stopSurface(SurfaceId surfaceId) const;
+  std::shared_ptr<ShadowTree> stopSurface(SurfaceId surfaceId) const;
 
 #pragma mark - ShadowTreeDelegate
 


### PR DESCRIPTION
Summary:
`SurfaceHandler` keeps a raw pointer to ShadowTree and UIManager. This is normally set to null when a surface is stopped, but it seems like there may be a race condition where the `ShadowTree` dies during surface start, and we call something which assumes the pointer is valid.

This converts the raw pointer to weak pointer, so we get nulled out automatically, and inserts a null-check in the case where we seem to be accessing invalid ShadowTree.

Changelog: [Internal]

Differential Revision: D51452801


