### PR TITLE
Refactor generate-artifacts-executor.js: keep schema in memory instead of writing/reading from disk

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
@@ -11,9 +11,11 @@
 
 'use strict';
 
-const {combineSchemasInFileList} = require('./combine-js-to-schema');
+const {
+  combineSchemasInFileListAndWriteToFile,
+} = require('./combine-js-to-schema');
 const {parseArgs} = require('./combine-utils');
 
 const {platform, outfile, fileList} = parseArgs(process.argv);
 
-combineSchemasInFileList(fileList, platform, outfile);
+combineSchemasInFileListAndWriteToFile(fileList, platform, outfile);

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
@@ -72,8 +72,7 @@ function expandDirectoriesIntoFiles(
 function combineSchemasInFileList(
   fileList: Array<string>,
   platform: ?string,
-  outfile: string,
-): void {
+): SchemaType {
   const expandedFileList = expandDirectoriesIntoFiles(fileList, platform);
   const combined = combineSchemas(expandedFileList);
   if (Object.keys(combined.modules).length === 0) {
@@ -81,6 +80,15 @@ function combineSchemasInFileList(
       'No modules to process in combine-js-to-schema-cli. If this is unexpected, please check if you set up your NativeComponent correctly. See combine-js-to-schema.js for how codegen finds modules.',
     );
   }
+  return combined;
+}
+
+function combineSchemasInFileListAndWriteToFile(
+  fileList: Array<string>,
+  platform: ?string,
+  outfile: string,
+): void {
+  const combined = combineSchemasInFileList(fileList, platform);
   const formattedSchema = JSON.stringify(combined, null, 2);
   fs.writeFileSync(outfile, formattedSchema);
 }
@@ -88,4 +96,5 @@ function combineSchemasInFileList(
 module.exports = {
   combineSchemas,
   combineSchemasInFileList,
+  combineSchemasInFileListAndWriteToFile,
 };

--- a/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
+++ b/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
@@ -70,18 +70,15 @@ function validateLibraryType(libraryType) {
   }
 }
 
-function generateSpec(
+function generateSpecFromInMemorySchema(
   platform,
-  schemaPath,
+  schema,
   outputDirectory,
   libraryName,
   packageName,
   libraryType,
 ) {
   validateLibraryType(libraryType);
-
-  let schema = readAndParseSchema(schemaPath);
-
   createOutputDirectoryIfNeeded(outputDirectory, libraryName);
   function composePath(intermediate) {
     return path.join(outputDirectory, intermediate, libraryName);
@@ -121,6 +118,25 @@ function generateSpec(
   }
 }
 
+function generateSpec(
+  platform,
+  schemaPath,
+  outputDirectory,
+  libraryName,
+  packageName,
+  libraryType,
+) {
+  generateSpecFromInMemorySchema(
+    platform,
+    readAndParseSchema(schemaPath),
+    outputDirectory,
+    libraryName,
+    packageName,
+    libraryType,
+  );
+}
+
 module.exports = {
   execute: generateSpec,
+  generateSpecFromInMemorySchema: generateSpecFromInMemorySchema,
 };


### PR DESCRIPTION
Summary:
This diff removes inefficiency where we first write schema to disk in `combine-js-to-schema.js`, and then read it from disk in `generate-specs-cli-executor.js`. With this change we can just pass it as an argument.
Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D51161162


