### PR TITLE
Cleanup fabricEnabled callsites

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -399,7 +399,6 @@ class CodegenUtilsTests < Test::Unit::TestCase
                 "arguments"=> ["~/app/ios/../node_modules/react-native/scripts/generate-codegen-artifacts.js",
                     "-p", "~/app",
                     "-o", Pod::Config.instance.installation_root,
-                    "-e", "false",
                     "-c", ""]
             }
         ])

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -325,7 +325,6 @@ class CodegenUtils
           "#{relative_installation_root}/#{react_native_path}/scripts/generate-codegen-artifacts.js",
           "-p", "#{app_path}",
           "-o", Pod::Config.instance.installation_root,
-          "-e", "#{fabric_enabled}",
           "-c", "#{config_file_dir}",
         ])
       Pod::UI.puts out;

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -511,7 +511,6 @@ function cleanupEmptyFilesAndFolders(filepath) {
  * @parameter codegenConfigFilename: the file that contains the codeGen configuration. The default is `package.json`.
  * @parameter codegenConfigKey: the key in the codegenConfigFile that controls the codegen.
  * @parameter baseCodegenConfigFileDir: the directory of the codeGenConfigFile.
- * @parameter fabricEnabled: whether fabric is enabled or not.
  * @throws If it can't find a config file for react-native.
  * @throws If it can't find a CodeGen configuration in the file.
  * @throws If it can't find a cli for the CodeGen.

--- a/packages/react-native/scripts/generate-codegen-artifacts.js
+++ b/packages/react-native/scripts/generate-codegen-artifacts.js
@@ -32,12 +32,6 @@ const argv = yargs
     description:
       'The key that contains the codegen configuration in the config file.',
   })
-  .option('e', {
-    alias: 'fabricEnabled',
-    default: true,
-    description: 'A flag to control whether to generate fabric components.',
-    boolean: 'e',
-  })
   .option('c', {
     alias: 'configFileDir',
     default: '',
@@ -55,7 +49,6 @@ const argv = yargs
 const CODEGEN_CONFIG_FILENAME = argv.f;
 const CODEGEN_CONFIG_FILE_DIR = argv.c;
 const CODEGEN_CONFIG_KEY = argv.k;
-const CODEGEN_FABRIC_ENABLED = argv.e;
 const NODE = argv.n;
 
 const appRoot = argv.path;
@@ -68,5 +61,4 @@ executor.execute(
   CODEGEN_CONFIG_FILENAME,
   CODEGEN_CONFIG_KEY,
   CODEGEN_CONFIG_FILE_DIR,
-  CODEGEN_FABRIC_ENABLED,
 );

--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -96,7 +96,7 @@ generateCodegenArtifactsFromSchema () {
 generateArtifacts () {
     describe "Generating codegen artifacts"
     pushd "$RCT_SCRIPT_RN_DIR" >/dev/null || exit 1
-        "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$TEMP_OUTPUT_DIR" --fabricEnabled "$RCT_SCRIPT_FABRIC_ENABLED" --configFileDir "$RCT_SCRIPT_CONFIG_FILE_DIR" --nodeBinary "$NODE_BINARY"
+        "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$TEMP_OUTPUT_DIR" --configFileDir "$RCT_SCRIPT_CONFIG_FILE_DIR" --nodeBinary "$NODE_BINARY"
     popd >/dev/null || exit 1
 }
 


### PR DESCRIPTION
Summary:
Followup after [#41500](https://github.com/facebook/react-native/pull/41500) to cleanup some callsites that does not need the flag anymore.

## Changelog
[Internal] - Callsite cleanup

Differential Revision: D51465124


