### PR TITLE
Refactor generate-artifacts-executor.js: give library lookup functions more accurate names

### DIFF
--- a/packages/react-native/scripts/generate-codegen-artifacts.js
+++ b/packages/react-native/scripts/generate-codegen-artifacts.js
@@ -15,11 +15,11 @@ const yargs = require('yargs');
 const argv = yargs
   .option('p', {
     alias: 'path',
-    description: 'Path to React Native application',
+    description: 'Path to the React Native project root.',
   })
   .option('o', {
     alias: 'outputPath',
-    description: 'Path where generated artifacts will be output to',
+    description: 'Path where generated artifacts will be output to.',
   })
   .usage('Usage: $0 -p [path to app]')
   .demandOption(['p']).argv;


### PR DESCRIPTION
Summary:
This diff gives some functions and variables more accurate names:
1. `appRoot` -> `projectRoot`
2. `handleThirdPartyLibraries` -> `findExternalLibraries`
3. `handleLibrariesFromReactNativeConfig` -> `findLibrariesFromReactNativeConfig`
4. `handleInAppLibraries` -> `findProjectRootLibraries`

It also removes `isAppRootValid` check that checks that `appRoot != null`, it is redundant since `appRoot`(now `projectRoot`) is required by the CLI.

	Changelog: [Internal]

Differential Revision: D51309027

