### PR TITLE
Fix modulemap typo

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/module.modulemap
+++ b/packages/react-native/ReactCommon/yoga/yoga/module.modulemap
@@ -12,7 +12,7 @@ module yoga [system] {
         header "YGMacros.h"
         header "YGNode.h"
         header "YGNodeLayout.h"
-        header "YGNodeStye.h"
+        header "YGNodeStyle.h"
         header "YGPixelGrid.h"
         header "YGValue.h"
         header "Yoga.h"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1474

Fixes https://github.com/facebook/yoga/issues/1468

We build with Swift, but don't build something consuming Yoga module, and don't use modulemap and CocoaPods. This is a gap in validation we should figure out, but in the meantime, we should fix the typo.

Differential Revision: D51472493


