### PR TITLE
Terminate on logic error in createNode HostFunction

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -230,23 +230,27 @@ jsi::Value UIManagerBinding::get(
             const jsi::Value& /*thisValue*/,
             const jsi::Value* arguments,
             size_t count) -> jsi::Value {
-          validateArgumentCount(runtime, methodName, paramCount, count);
+          try {
+            validateArgumentCount(runtime, methodName, paramCount, count);
 
-          auto instanceHandle =
-              instanceHandleFromValue(runtime, arguments[4], arguments[0]);
-          if (!instanceHandle) {
-            react_native_assert(false);
-            return jsi::Value::undefined();
+            auto instanceHandle =
+                instanceHandleFromValue(runtime, arguments[4], arguments[0]);
+            if (!instanceHandle) {
+              react_native_assert(false);
+              return jsi::Value::undefined();
+            }
+
+            return valueFromShadowNode(
+                runtime,
+                uiManager->createNode(
+                    tagFromValue(arguments[0]),
+                    stringFromValue(runtime, arguments[1]),
+                    surfaceIdFromValue(runtime, arguments[2]),
+                    RawProps(runtime, arguments[3]),
+                    std::move(instanceHandle)));
+          } catch (const std::logic_error& ex) {
+            LOG(FATAL) << "logic_error in createNode: " << ex.what();
           }
-
-          return valueFromShadowNode(
-              runtime,
-              uiManager->createNode(
-                  tagFromValue(arguments[0]),
-                  stringFromValue(runtime, arguments[1]),
-                  surfaceIdFromValue(runtime, arguments[2]),
-                  RawProps(runtime, arguments[3]),
-                  std::move(instanceHandle)));
         });
   }
 


### PR DESCRIPTION
Summary:
Sometimes `createNode` calls into is throwing `std::out_of_range_error` or `std::length_error` in response to both vector and string operations.

Instead of propagating `std::logic_error`, which indicates a defect in native code, terminate, so we can get an actionable native stack trace.

`createNode` and `cloneNode` also both ocasionally see `bad_alloc`, but this is not usually an instance of a defect at the allocation-site, and throwing would be more graceful.

Changelog:
[Internal]

Differential Revision: D51463600


