### PR TITLE
Remove composite border comparisons

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -39,6 +39,15 @@ ViewShadowNode::ViewShadowNode(
 void ViewShadowNode::initialize() noexcept {
   auto& viewProps = static_cast<const ViewProps&>(*props_);
 
+  auto hasBorder = [&]() {
+    for (auto edge : yoga::ordinals<yoga::Edge>()) {
+      if (viewProps.yogaStyle.border()[yoga::unscopedEnum(edge)].isDefined()) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   bool formsStackingContext = !viewProps.collapsable ||
       viewProps.pointerEvents == PointerEventsMode::None ||
       !viewProps.nativeId.empty() || viewProps.accessible ||
@@ -55,8 +64,7 @@ void ViewShadowNode::initialize() noexcept {
       HostPlatformViewTraitsInitializer::formsStackingContext(viewProps);
 
   bool formsView = formsStackingContext ||
-      isColorMeaningful(viewProps.backgroundColor) ||
-      !(viewProps.yogaStyle.border() == yoga::Style::Edges{}) ||
+      isColorMeaningful(viewProps.backgroundColor) || hasBorder() ||
       !viewProps.testId.empty() ||
       HostPlatformViewTraitsInitializer::formsView(viewProps);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/YogaStylablePropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/YogaStylablePropsMapBuffer.cpp
@@ -13,22 +13,30 @@
 
 namespace facebook::react {
 
-MapBuffer convertBorderWidths(const yoga::Style::Edges& border) {
+MapBuffer convertBorderWidths(const yoga::Style& style) {
   MapBufferBuilder builder(7);
   putOptionalFloat(
-      builder, EDGE_TOP, optionalFloatFromYogaValue(border[YGEdgeTop]));
+      builder, EDGE_TOP, optionalFloatFromYogaValue(style.border()[YGEdgeTop]));
   putOptionalFloat(
-      builder, EDGE_RIGHT, optionalFloatFromYogaValue(border[YGEdgeRight]));
+      builder,
+      EDGE_RIGHT,
+      optionalFloatFromYogaValue(style.border()[YGEdgeRight]));
   putOptionalFloat(
-      builder, EDGE_BOTTOM, optionalFloatFromYogaValue(border[YGEdgeBottom]));
+      builder,
+      EDGE_BOTTOM,
+      optionalFloatFromYogaValue(style.border()[YGEdgeBottom]));
   putOptionalFloat(
-      builder, EDGE_LEFT, optionalFloatFromYogaValue(border[YGEdgeLeft]));
+      builder,
+      EDGE_LEFT,
+      optionalFloatFromYogaValue(style.border()[YGEdgeLeft]));
   putOptionalFloat(
-      builder, EDGE_START, optionalFloatFromYogaValue(border[YGEdgeStart]));
+      builder,
+      EDGE_START,
+      optionalFloatFromYogaValue(style.border()[YGEdgeStart]));
   putOptionalFloat(
-      builder, EDGE_END, optionalFloatFromYogaValue(border[YGEdgeEnd]));
+      builder, EDGE_END, optionalFloatFromYogaValue(style.border()[YGEdgeEnd]));
   putOptionalFloat(
-      builder, EDGE_ALL, optionalFloatFromYogaValue(border[YGEdgeAll]));
+      builder, EDGE_ALL, optionalFloatFromYogaValue(style.border()[YGEdgeAll]));
   return builder.build();
 }
 
@@ -54,9 +62,17 @@ void YogaStylableProps::propsDiffMapBuffer(
     const auto& oldStyle = oldProps.yogaStyle;
     const auto& newStyle = newProps.yogaStyle;
 
-    if (!(oldStyle.border() == newStyle.border())) {
-      builder.putMapBuffer(
-          YG_BORDER_WIDTH, convertBorderWidths(newStyle.border()));
+    bool areBordersEqual = true;
+    for (auto edge : yoga::ordinals<yoga::Edge>()) {
+      if (oldStyle.border()[yoga::unscopedEnum(edge)] !=
+          newStyle.border()[yoga::unscopedEnum(edge)]) {
+        areBordersEqual = false;
+        break;
+      }
+    }
+
+    if (!areBordersEqual) {
+      builder.putMapBuffer(YG_BORDER_WIDTH, convertBorderWidths(newStyle));
     }
 
     if (oldStyle.overflow() != newStyle.overflow()) {

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/YogaEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/YogaEnums.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <type_traits>
 
 namespace facebook::yoga {
@@ -14,13 +15,52 @@ namespace facebook::yoga {
 template <typename EnumT>
 constexpr inline int32_t ordinalCount();
 
+/**
+ * Count of bits needed to represent every ordinal
+ */
 template <typename EnumT>
 constexpr inline int32_t bitCount();
 
-// Polyfill of C++ 23 to_underlying()
-// https://en.cppreference.com/w/cpp/utility/to_underlying
+/**
+ * Polyfill of C++ 23 to_underlying()
+ * https://en.cppreference.com/w/cpp/utility/to_underlying
+ */
 constexpr auto to_underlying(auto e) noexcept {
   return static_cast<std::underlying_type_t<decltype(e)>>(e);
+}
+
+/**
+ * Convenience function to iterate through every value in a Yoga enum as part of
+ * a range-based for loop.
+ */
+template <typename EnumT>
+auto ordinals() {
+  struct Iterator {
+    EnumT e{};
+
+    EnumT operator*() const {
+      return e;
+    }
+
+    Iterator& operator++() {
+      e = static_cast<EnumT>(to_underlying(e) + 1);
+      return *this;
+    }
+
+    bool operator==(const Iterator& other) const = default;
+    bool operator!=(const Iterator& other) const = default;
+  };
+
+  struct Range {
+    Iterator begin() const {
+      return Iterator{};
+    }
+    Iterator end() const {
+      return Iterator{static_cast<EnumT>(ordinalCount<EnumT>())};
+    }
+  };
+
+  return Range{};
 }
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -19,6 +19,7 @@
 #include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Display.h>
+#include <yoga/enums/Edge.h>
 #include <yoga/enums/FlexDirection.h>
 #include <yoga/enums/Gutter.h>
 #include <yoga/enums/Justify.h>


### PR DESCRIPTION
Summary:
Removes cases where we rely on comparing composite of Yoga edges, since we are removing that internal API (public API is already one at a time). Extracted from D50998164, with more sound facility for looping through edges.

Changelog: [Internal]

Differential Revision: D51478403


