### PR TITLE
Do not filter out Image.source prop when sending it C++ on New Architecture on Android

### DIFF
--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -90,6 +90,11 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           borderTopLeftRadius: true,
           resizeMethod: true,
           src: true,
+          // NOTE: New Architecture expects this to be called `source`,
+          // regardless of the platform, therefore propagate it as well.
+          // For the backwards compatibility reasons, we keep both `src`
+          // and `source`, which will be identical at this stage.
+          source: true,
           borderRadius: true,
           headers: true,
           shouldNotifyLoadEvents: true,


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

This fixes a subtle problem whereas an update to `Image.source` (or `Image.src`) prop on JS side may not end up getting propagated to the C++ side, with New Architecture.

As the result, this can lead to some weird corner cases, whereas e.g. layout doesn't update after the image's size changes.

Differential Revision: D51479305


