### PR TITLE
RNTester-ios / RCTAppDelegate > correctly check for USE_HERMES Flag

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -27,7 +27,7 @@
 #import <React/RCTSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
 #import <ReactCommon/RCTContextContainerHandling.h>
-#if USE_HERMES
+#if RCT_USE_HERMES
 #import <ReactCommon/RCTHermesInstance.h>
 #else
 #import <ReactCommon/RCTJscInstance.h>
@@ -305,7 +305,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (std::shared_ptr<facebook::react::JSEngineInstance>)createJSEngineInstance
 {
-#if USE_HERMES
+#if RCT_USE_HERMES
   return std::make_shared<facebook::react::RCTHermesInstance>(_reactNativeConfig, nullptr);
 #else
   return std::make_shared<facebook::react::RCTJscInstance>();


### PR DESCRIPTION
Summary:
Changelog: [iOS][Fixed] RNTester-ios / RCTAppDelegate > correctly check for USE_HERMES Flag

On iOS we check for ENV flags if Hermes should be used:
- https://github.com/facebook/react-native/blob/b4d4aef057ebf90176287f22d72b4b3b8b280c9a/packages/react-native/React-Core.podspec#L24
- https://github.com/facebook/react-native/blob/b4d4aef057ebf90176287f22d72b4b3b8b280c9a/packages/react-native/React/React-RCTFabric.podspec#L90

and add necessary C++ packages based on that flag.

In code we do check for those imports
https://github.com/facebook/react-native/blob/b4d4aef057ebf90176287f22d72b4b3b8b280c9a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h#L16-L27

and decided if we should use Hermes or not.

However the .mm check is faulty and does not check for the `RCT_USE_HERMES` flag set in code.

Differential Revision: D51483740


