### PR TITLE
Extract ImageSize type from NativeImageLoader interface (re-submit)

### DIFF
--- a/packages/react-native/Libraries/Image/NativeImageLoaderAndroid.js
+++ b/packages/react-native/Libraries/Image/NativeImageLoaderAndroid.js
@@ -12,24 +12,17 @@ import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
+export type ImageSize = {
+  width: number,
+  height: number,
+  ...
+};
+
 export interface Spec extends TurboModule {
   +abortRequest: (requestId: number) => void;
   +getConstants: () => {||};
-  +getSize: (uri: string) => Promise<
-    $ReadOnly<{
-      width: number,
-      height: number,
-      ...
-    }>,
-  >;
-  +getSizeWithHeaders: (
-    uri: string,
-    headers: Object,
-  ) => Promise<{
-    width: number,
-    height: number,
-    ...
-  }>;
+  +getSize: (uri: string) => Promise<ImageSize>;
+  +getSizeWithHeaders: (uri: string, headers: Object) => Promise<ImageSize>;
   +prefetchImage: (uri: string, requestId: number) => Promise<boolean>;
   +queryCache: (uris: Array<string>) => Promise<Object>;
 }


### PR DESCRIPTION
Summary:
# Changelog:
[Internal]-

The change is equivalent in terms of API, however this makes it work nicer with C++ codegen and easier to use with a pure C++ implementation of the native module.

Differential Revision: D51493466


