### PR TITLE
include pdf in the list of supported image source types

### DIFF
--- a/packages/react-native/Libraries/Image/Image.d.ts
+++ b/packages/react-native/Libraries/Image/Image.d.ts
@@ -221,7 +221,7 @@ export interface ImagePropsBase
    * The native side will then choose the best uri to display based on the measured size of the image container.
    * A cache property can be added to control how networked request interacts with the local cache.
    *
-   * The currently supported formats are png, jpg, jpeg, bmp, gif, webp (Android only), psd (iOS only).
+   * The currently supported formats are png, jpg, jpeg, bmp, gif, webp (Android only), psd and pdf (iOS only).
    */
   source?: ImageSourcePropType | undefined;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

PDFs are supported by iOS as well (have been using them for years), so figured it can be mentioned in the types as well.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:


[GENERAL] [ADDED] - Updated documentation comment for Image `source` prop to include pdf as supported.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
