### PR TITLE
Handle all incoming Inspector messages on main thread, downgrade some errors to logs

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -210,16 +210,10 @@ public class DevServerHelper {
       FLog.w(ReactConstants.TAG, "Inspector connection already open, nooping.");
       return;
     }
-    new AsyncTask<Void, Void, Void>() {
-      @Override
-      protected Void doInBackground(Void... params) {
-        mInspectorPackagerConnection =
-            new InspectorPackagerConnection(
-                getInspectorDeviceUrl(), mPackageName, mBundlerStatusProvider);
-        mInspectorPackagerConnection.connect();
-        return null;
-      }
-    }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    mInspectorPackagerConnection =
+        new InspectorPackagerConnection(
+            getInspectorDeviceUrl(), mPackageName, mBundlerStatusProvider);
+    mInspectorPackagerConnection.connect();
   }
 
   public void disableDebugger() {
@@ -229,16 +223,10 @@ public class DevServerHelper {
   }
 
   public void closeInspectorConnection() {
-    new AsyncTask<Void, Void, Void>() {
-      @Override
-      protected Void doInBackground(Void... params) {
-        if (mInspectorPackagerConnection != null) {
-          mInspectorPackagerConnection.closeQuietly();
-          mInspectorPackagerConnection = null;
-        }
-        return null;
-      }
-    }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    if (mInspectorPackagerConnection != null) {
+      mInspectorPackagerConnection.closeQuietly();
+      mInspectorPackagerConnection = null;
+    }
   }
 
   public String getWebsocketProxyURL() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -942,6 +942,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
   @Override
   public void startInspector() {
+    UiThreadUtil.assertOnUiThread();
     if (mIsDevSupportEnabled) {
       mDevServerHelper.openInspectorConnection();
     }
@@ -949,6 +950,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
   @Override
   public void stopInspector() {
+    UiThreadUtil.assertOnUiThread();
     mDevServerHelper.closeInspectorConnection();
   }
 
@@ -1045,9 +1047,12 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
             @Override
             public void onPackagerReloadCommand() {
-              // Disable debugger to resume the JsVM & avoid thread locks while reloading
-              mDevServerHelper.disableDebugger();
-              UiThreadUtil.runOnUiThread(() -> handleReloadJS());
+              UiThreadUtil.runOnUiThread(
+                  () -> {
+                    // Disable debugger to resume the JsVM & avoid thread locks while reloading
+                    mDevServerHelper.disableDebugger();
+                    handleReloadJS();
+                  });
             }
 
             @Override


### PR DESCRIPTION
Summary:
Changelog: [Internal]

* Updates `InspectorPackagerConnection.java`, `DevServerHelper.java` and `DevSupportManagerBase.java` to perform all connection management and message dispatching for the inspector socket on the main thread. This is in support of a new CDP implementation in React Native that will strictly assume it's called on the main thread (thus avoiding the need for explicit locking in many places).
* Downgrades JSON parsing errors and duplicate connection errors from exceptions to logs, matching the [iOS implementation](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m).

Reviewed By: javache

Differential Revision: D51346658


