### PR TITLE
Always install all the pods

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -80,42 +80,33 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-NativeModulesApple")
   add_dependency(s, "React-runtimescheduler")
   add_dependency(s, "React-RCTFabric", :framework_name => "RCTFabric")
-
-  if is_new_arch_enabled
-    add_dependency(s, "React-RuntimeCore")
-    add_dependency(s, "React-RuntimeApple")
-    if use_hermes
-      s.dependency "React-RuntimeHermes"
-    end
-  end
+  add_dependency(s, "React-RuntimeCore")
+  add_dependency(s, "React-RuntimeApple")
+  add_dependency(s, "React-Fabric", :additional_framework_paths => ["react/renderer/components/view/platform/cxx"])
+  add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
+  add_dependency(s, "React-utils")
+  add_dependency(s, "React-debug")
+  add_dependency(s, "React-rendererdebug")
 
   if use_hermes
     s.dependency "React-hermes"
+    s.dependency "React-RuntimeHermes"
   else
     s.dependency "React-jsc"
   end
 
-  if is_new_arch_enabled
-    add_dependency(s, "React-Fabric", :additional_framework_paths => ["react/renderer/components/view/platform/cxx"])
-    add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
-    add_dependency(s, "React-utils")
-    add_dependency(s, "React-debug")
-    add_dependency(s, "React-rendererdebug")
+  rel_path_from_pods_root_to_app = Pathname.new(ENV['APP_PATH']).relative_path_from(Pod::Config.instance.installation_root)
+  rel_path_from_pods_to_app = Pathname.new(ENV['APP_PATH']).relative_path_from(File.join(Pod::Config.instance.installation_root, 'Pods'))
 
-    rel_path_from_pods_root_to_app = Pathname.new(ENV['APP_PATH']).relative_path_from(Pod::Config.instance.installation_root)
-    rel_path_from_pods_to_app = Pathname.new(ENV['APP_PATH']).relative_path_from(File.join(Pod::Config.instance.installation_root, 'Pods'))
-
-
-    s.script_phases = {
-      :name => "Generate Legacy Components Interop",
-      :script => "
+  s.script_phases = {
+    :name => "Generate Legacy Components Interop",
+    :script => "
 WITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"
 source $WITH_ENVIRONMENT
 ${NODE_BINARY} ${REACT_NATIVE_PATH}/scripts/codegen/generate-legacy-interop-components.js -p #{rel_path_from_pods_to_app} -o ${REACT_NATIVE_PATH}/Libraries/AppDelegate
-      ",
-      :execution_position => :before_compile,
-      :input_files => ["#{rel_path_from_pods_root_to_app}/react-native.config.js"],
-      :output_files => ["${REACT_NATIVE_PATH}/Libraries/AppDelegate/RCTLegacyInteropComponents.mm"],
-    }
-  end
+    ",
+    :execution_position => :before_compile,
+    :input_files => ["#{rel_path_from_pods_root_to_app}/react-native.config.js"],
+    :output_files => ["${REACT_NATIVE_PATH}/Libraries/AppDelegate/RCTLegacyInteropComponents.mm"],
+  }
 end

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -24,9 +24,8 @@ use_hermes =  ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
 is_fabric_enabled = is_new_arch_enabled || ENV["RCT_FABRIC_ENABLED"]
-fabric_flag = (is_fabric_enabled ? " -DRN_FABRIC_ENABLED" : "")
 hermes_flag = (use_hermes ? " -DUSE_HERMES" : "")
-other_cflags = "$(inherited)" + folly_flags + new_arch_enabled_flag + fabric_flag + hermes_flag
+other_cflags = "$(inherited)" + folly_flags + new_arch_enabled_flag + hermes_flag
 
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/../../ReactCommon",

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -58,7 +58,7 @@ Pod::Spec.new do |s|
   s.framework              = ["JavaScriptCore", "MobileCoreServices"]
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths,
-    "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" + " " + folly_flags,
+    "OTHER_CFLAGS" => "$(inherited) " + folly_flags,
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20"
   }.merge!(ENV['USE_FRAMEWORKS'] != nil ? {
     "PUBLIC_HEADERS_FOLDER_PATH" => "#{module_name}.framework/Headers/#{header_dir}"

--- a/packages/react-native/ReactCommon/jsc/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsc/CMakeLists.txt
@@ -30,10 +30,6 @@ target_link_libraries(jscruntime
         jsi
         glog)
 
-# TODO: Remove this flag when ready.
-# Android has this enabled by default, but the flag is still needed for iOS.
-target_compile_options(jscruntime PRIVATE -DRN_FABRIC_ENABLED)
-
 if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(jscruntime PRIVATE -DNDEBUG)
 endif()

--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -240,10 +240,7 @@ class JSCRuntime : public jsi::Runtime {
   static JSStringRef stringRef(const jsi::String& str);
   static JSStringRef stringRef(const jsi::PropNameID& sym);
   static JSObjectRef objectRef(const jsi::Object& obj);
-
-#ifdef RN_FABRIC_ENABLED
   static JSObjectRef objectRef(const jsi::WeakObject& obj);
-#endif
 
   // Factory methods for creating String/Object
   jsi::Symbol createSymbol(JSValueRef symbolRef) const;
@@ -1065,23 +1062,15 @@ jsi::Array JSCRuntime::getPropertyNames(const jsi::Object& obj) {
 }
 
 jsi::WeakObject JSCRuntime::createWeakObject(const jsi::Object& obj) {
-#ifdef RN_FABRIC_ENABLED
   // TODO: revisit this implementation
   JSObjectRef objRef = objectRef(obj);
   return make<jsi::WeakObject>(makeObjectValue(objRef));
-#else
-  throw std::logic_error("Not implemented");
-#endif
 }
 
 jsi::Value JSCRuntime::lockWeakObject(const jsi::WeakObject& obj) {
-#ifdef RN_FABRIC_ENABLED
   // TODO: revisit this implementation
   JSObjectRef objRef = objectRef(obj);
   return jsi::Value(createObject(objRef));
-#else
-  throw std::logic_error("Not implemented");
-#endif
 }
 
 jsi::Array JSCRuntime::createArray(size_t length) {
@@ -1527,12 +1516,10 @@ JSObjectRef JSCRuntime::objectRef(const jsi::Object& obj) {
   return static_cast<const JSCObjectValue*>(getPointerValue(obj))->obj_;
 }
 
-#ifdef RN_FABRIC_ENABLED
 JSObjectRef JSCRuntime::objectRef(const jsi::WeakObject& obj) {
   // TODO: revisit this implementation
   return static_cast<const JSCObjectValue*>(getPointerValue(obj))->obj_;
 }
-#endif
 
 void JSCRuntime::checkException(JSValueRef exc) {
   if (JSC_UNLIKELY(exc)) {

--- a/packages/react-native/ReactCommon/jsc/React-jsc.podspec
+++ b/packages/react-native/ReactCommon/jsc/React-jsc.podspec
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi", version
 
   s.subspec "Fabric" do |ss|
-    ss.pod_target_xcconfig  = { "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" }
+    ss.pod_target_xcconfig  = { "OTHER_CFLAGS" => "$(inherited)" }
   end
 end

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -93,25 +93,6 @@ class CodegenUtilsTests < Test::Unit::TestCase
     # ========================== #
     # Test - GetReactCodegenSpec #
     # ========================== #
-
-    def testGetReactCodegenSpec_whenFabricDisabledAndNoScriptPhases_generatesAPodspec
-        # Arrange
-        FileMock.files_to_read('package.json' => '{ "version": "99.98.97"}')
-
-        # Act
-        podspec = CodegenUtils.new().get_react_codegen_spec(
-            'package.json',
-            :fabric_enabled => false,
-            :hermes_enabled => true,
-            :script_phases => nil,
-            :file_manager => FileMock
-        )
-
-        # Assert
-        assert_equal(podspec, get_podspec_no_fabric_no_script())
-        assert_equal(Pod::UI.collected_messages, [])
-    end
-
     def testGetReactCodegenSpec_whenFabricEnabledAndScriptPhases_generatesAPodspec
         # Arrange
         FileMock.files_to_read('package.json' => '{ "version": "99.98.97"}')
@@ -119,7 +100,6 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Act
         podspec = CodegenUtils.new().get_react_codegen_spec(
             'package.json',
-            :fabric_enabled => true,
             :hermes_enabled => true,
             :script_phases => "echo Test Script Phase",
             :file_manager => FileMock
@@ -138,7 +118,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Act
         podspec = CodegenUtils.new().get_react_codegen_spec(
             'package.json',
-            :fabric_enabled => true,
+
             :hermes_enabled => true,
             :script_phases => nil,
             :file_manager => FileMock
@@ -380,11 +360,9 @@ class CodegenUtilsTests < Test::Unit::TestCase
             :app_path => app_path,
             :config_file_dir => "",
             :config_key => "codegenConfig",
-            :fabric_enabled => false,
             :react_native_path => "../node_modules/react-native"}
         ])
         assert_equal(codegen_utils_mock.get_react_codegen_spec_params,  [{
-            :fabric_enabled => false,
             :folly_version=>"2023.08.07.00",
             :package_json_file => "#{app_path}/ios/../node_modules/react-native/package.json",
             :script_phases => "echo TestScript"

--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/CodegenUtilsMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/CodegenUtilsMock.rb
@@ -58,7 +58,6 @@ class CodegenUtilsMock
     )
         @get_react_codegen_script_phases_params.push({
             app_path: app_path,
-            fabric_enabled: fabric_enabled,
             config_file_dir: config_file_dir,
             react_native_path: react_native_path,
             config_key: config_key
@@ -66,11 +65,10 @@ class CodegenUtilsMock
         return @react_codegen_script_phases
     end
 
-    def get_react_codegen_spec(package_json_file, folly_version: '2023.08.07.00', fabric_enabled: false, hermes_enabled: true, script_phases: nil)
+    def get_react_codegen_spec(package_json_file, folly_version: '2023.08.07.00', hermes_enabled: true, script_phases: nil)
         @get_react_codegen_spec_params.push({
             package_json_file: package_json_file,
             folly_version: folly_version,
-            fabric_enabled: fabric_enabled,
             script_phases: script_phases
         })
         return @react_codegen_spec

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -790,68 +790,6 @@ class UtilsTests < Test::Unit::TestCase
         end
     end
 
-    # ============================= #
-    # Test - Apply Flags For Fabric #
-    # ============================= #
-    def test_applyFlagsForFabric_whenFabricEnabled_addsTheFlag
-        # Arrange
-        first_target = prepare_target("FirstTarget")
-        second_target = prepare_target("SecondTarget")
-        third_target = prepare_target("ThirdTarget", "com.apple.product-type.bundle")
-        user_project_mock = UserProjectMock.new("a/path", [
-                prepare_config("Debug"),
-                prepare_config("Release"),
-            ],
-            :native_targets => [
-                first_target,
-                second_target
-            ]
-        )
-        pods_projects_mock = PodsProjectMock.new([third_target], {"hermes-engine" => {}})
-        installer = InstallerMock.new(pods_projects_mock, [
-            AggregatedProjectMock.new(user_project_mock)
-        ])
-
-        # Act
-        ReactNativePodsUtils.apply_flags_for_fabric(installer, fabric_enabled: true)
-
-        # Assert
-        user_project_mock.build_configurations.each do |config|
-            received_cflags = config.build_settings["OTHER_CFLAGS"]
-            expected_cflags = "$(inherited) -DRN_FABRIC_ENABLED"
-            assert_equal(received_cflags, expected_cflags)
-        end
-
-    end
-
-    def test_applyFlagsForFabric_whenFabricDisabled_doNothing
-        # Arrange
-        first_target = prepare_target("FirstTarget")
-        second_target = prepare_target("SecondTarget")
-        third_target = prepare_target("ThirdTarget", "com.apple.product-type.bundle")
-        user_project_mock = UserProjectMock.new("/a/path", [
-                prepare_config("Debug"),
-                prepare_config("Release"),
-            ],
-            :native_targets => [
-                first_target,
-                second_target
-            ]
-        )
-        pods_projects_mock = PodsProjectMock.new([third_target], {"hermes-engine" => {}})
-        installer = InstallerMock.new(pods_projects_mock, [
-            AggregatedProjectMock.new(user_project_mock)
-        ])
-
-        # Act
-        ReactNativePodsUtils.apply_flags_for_fabric(installer, fabric_enabled: false)
-
-        # Assert
-        user_project_mock.build_configurations.each do |config|
-            assert_equal(config.build_settings["OTHER_CFLAGS"], "$(inherited)")
-        end
-    end
-
     # ============================== #
     # Test - Apply ATS configuration #
     # ============================== #

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -66,11 +66,10 @@ class CodegenUtils
     #
     # Parameters
     # - package_json_file: the path to the `package.json`, required to extract the proper React Native version
-    # - fabric_enabled: whether fabric is enabled or not.
     # - hermes_enabled: whether hermes is enabled or not.
     # - script_phases: whether we want to add some build script phases or not.
     # - file_manager: a class that implements the `File` interface. Defaults to `File`, the Dependency can be injected for testing purposes.
-    def get_react_codegen_spec(package_json_file, folly_version: '2023.08.07.00', fabric_enabled: false, hermes_enabled: true, script_phases: nil, file_manager: File)
+    def get_react_codegen_spec(package_json_file, folly_version: '2023.08.07.00', hermes_enabled: true, script_phases: nil, file_manager: File)
         package = JSON.parse(file_manager.read(package_json_file))
         version = package['version']
         new_arch_disabled = ENV['RCT_NEW_ARCH_ENABLED'] != "1"
@@ -136,18 +135,13 @@ class CodegenUtils
             "React-NativeModulesApple": [],
             "glog": [],
             "DoubleConversion": [],
-          }
-        }
-
-        if fabric_enabled
-          spec[:'dependencies'].merge!({
             'React-graphics': [],
             'React-rendererdebug': [],
             'React-Fabric': [],
             'React-debug': [],
             'React-utils': [],
-          });
-        end
+          }
+        }
 
         if hermes_enabled
           spec[:'dependencies'].merge!({
@@ -313,7 +307,6 @@ class CodegenUtils
       react_codegen_spec = codegen_utils.get_react_codegen_spec(
         file_manager.join(relative_installation_root, react_native_path, "package.json"),
         :folly_version => folly_version,
-        :fabric_enabled => fabric_enabled,
         :hermes_enabled => hermes_enabled,
         :script_phases => script_phases
       )

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -147,15 +147,6 @@ class ReactNativePodsUtils
 
     end
 
-    def self.apply_flags_for_fabric(installer, fabric_enabled: false)
-        fabric_flag = "-DRN_FABRIC_ENABLED"
-        if fabric_enabled
-            self.add_compiler_flag_to_project(installer, fabric_flag)
-        else
-            self.remove_compiler_flag_from_project(installer, fabric_flag)
-        end
-    end
-
     private
 
     def self.add_build_settings_to_pod(installer, settings_name, settings_value, target_pod_name, configuration)

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -281,7 +281,6 @@ def react_native_post_install(
   ReactNativePodsUtils.update_search_paths(installer)
   ReactNativePodsUtils.set_use_hermes_build_setting(installer, hermes_enabled)
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
-  ReactNativePodsUtils.apply_flags_for_fabric(installer, fabric_enabled: fabric_enabled)
   ReactNativePodsUtils.apply_xcode_15_patch(installer)
   ReactNativePodsUtils.apply_ats_config(installer)
   ReactNativePodsUtils.updateOSDeploymentTarget(installer)

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -103,6 +103,8 @@ def use_react_native! (
 
   ReactNativePodsUtils.warn_if_not_on_arm64()
 
+  build_codegen!(prefix, relative_path_from_current)
+
   # The Pods which should be included in all projects
   pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
   pod 'RCTRequired', :path => "#{prefix}/Libraries/Required"
@@ -174,15 +176,7 @@ def use_react_native! (
   # If the New Arch is turned off, we will use the Old Renderer, though.
   # RNTester always installed Fabric, this change is required to make the template work.
   setup_fabric!(:react_native_path => prefix)
-
-  if !fabric_enabled
-    relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
-    build_codegen!(prefix, relative_installation_root)
-  end
-
-  if NewArchitectureHelper.new_arch_enabled
-    setup_bridgeless!(:react_native_path => prefix, :use_hermes => hermes_enabled)
-  end
+  setup_bridgeless!(:react_native_path => prefix, :use_hermes => hermes_enabled)
 
   pods_to_update = LocalPodspecPatch.pods_to_update(:react_native_path => prefix)
   if !pods_to_update.empty?

--- a/packages/react-native/scripts/react_native_pods_utils/__tests__/script_phases.snap.rb
+++ b/packages/react-native/scripts/react_native_pods_utils/__tests__/script_phases.snap.rb
@@ -13,7 +13,6 @@ def snap_get_script_phases_with_codegen_discovery_with_config_file_dir()
     export RCT_SCRIPT_APP_PATH=$RCT_SCRIPT_POD_INSTALLATION_ROOT/
     export RCT_SCRIPT_CONFIG_FILE_DIR=$RCT_SCRIPT_POD_INSTALLATION_ROOT/node_modules
     export RCT_SCRIPT_OUTPUT_DIR=$RCT_SCRIPT_POD_INSTALLATION_ROOT
-    export RCT_SCRIPT_FABRIC_ENABLED=true
     export RCT_SCRIPT_TYPE=withCodegenDiscovery
 
     SCRIPT_PHASES_SCRIPT="$RCT_SCRIPT_RN_DIR/scripts/react_native_pods_utils/script_phases.sh"
@@ -32,7 +31,6 @@ def snap_get_script_phases_with_codegen_discovery_without_config_file_dir()
     export RCT_SCRIPT_APP_PATH=$RCT_SCRIPT_POD_INSTALLATION_ROOT/
     export RCT_SCRIPT_CONFIG_FILE_DIR=
     export RCT_SCRIPT_OUTPUT_DIR=$RCT_SCRIPT_POD_INSTALLATION_ROOT
-    export RCT_SCRIPT_FABRIC_ENABLED=true
     export RCT_SCRIPT_TYPE=withCodegenDiscovery
 
     SCRIPT_PHASES_SCRIPT="$RCT_SCRIPT_RN_DIR/scripts/react_native_pods_utils/script_phases.sh"

--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.rb
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.rb
@@ -13,7 +13,6 @@ def get_script_phases_with_codegen_discovery(options)
         'RCT_SCRIPT_APP_PATH' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:relative_app_root]}",
         'RCT_SCRIPT_CONFIG_FILE_DIR' => "#{options[:relative_config_file_dir] != '' ? "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:relative_config_file_dir]}" : ''}",
         'RCT_SCRIPT_OUTPUT_DIR' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT",
-        'RCT_SCRIPT_FABRIC_ENABLED' => "#{options[:fabric_enabled]}",
         'RCT_SCRIPT_TYPE' => "withCodegenDiscovery",
     }
     return get_script_template(options[:react_native_path], export_vars)

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -933,10 +933,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DRN_FABRIC_ENABLED",
-				);
+				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -944,7 +941,6 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
-					"-DRN_FABRIC_ENABLED",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -1029,10 +1025,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DRN_FABRIC_ENABLED",
-				);
+				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -1040,7 +1033,6 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
-					"-DRN_FABRIC_ENABLED",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",


### PR DESCRIPTION
Summary:
This change always installs all the Pods for both architecture.
This unify the behavior between iOS and Android.

## Changelog:
[Internal] - Always install all the pods

## Facebook:
The inly four pods that are changed when flipping between the new and the old arch with RNTester are:
- MyNativeView
- NativeCxxModuleExample
- React-RCTAppDelegate
- ScreenshotManager
The only change there is the RCt_NEW_ARCH_ENABLED flag being set or not in those pods

Reviewed By: dmytrorykun

Differential Revision: D51494498


