### PR TITLE
Clear mLastQueriedSurfaceMountingManager on stopSurface

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -143,8 +143,11 @@ public class MountingManager {
 
       surfaceMountingManager.stopSurface();
 
-      if (surfaceMountingManager == mMostRecentSurfaceMountingManager) {
+      if (mMostRecentSurfaceMountingManager == surfaceMountingManager) {
         mMostRecentSurfaceMountingManager = null;
+      }
+      if (mLastQueriedSurfaceMountingManager == surfaceMountingManager) {
+        mLastQueriedSurfaceMountingManager = null;
       }
     } else {
       ReactSoftExceptionLogger.logSoftException(


### PR DESCRIPTION
Summary:
Causing a small leak while we wait for the surface to be fully destroyed.

Changelog: [Internal]

Reviewed By: fabriziocucci

Differential Revision: D51499256


