### PR TITLE
Fix ReactNativeHost to have default UIManagerProvider as null

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -132,7 +132,7 @@ public abstract class ReactNativeHost {
   }
 
   protected @Nullable UIManagerProvider getUIManagerProvider() {
-    return reactApplicationContext -> null;
+    return null;
   }
 
   /** Returns whether or not to treat it as normal if Activity is null. */


### PR DESCRIPTION
Summary: Fixing fallback to `getJSIModule()` by defaulting `getUIManagerProvider()` correctly to null

Reviewed By: christophpurrer

Differential Revision: D51500901


