### PR TITLE
Fix ReactInstanceManager to initialize the UIManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1408,7 +1408,9 @@ public class ReactInstanceManager {
     }
     if (ReactFeatureFlags.enableFabricRenderer) {
       if (mUIManagerProvider != null) {
-        catalystInstance.setFabricUIManager(mUIManagerProvider.createUIManager(reactContext));
+        UIManager uiManager = mUIManagerProvider.createUIManager(reactContext);
+        uiManager.initialize();
+        catalystInstance.setFabricUIManager(uiManager);
       } else {
         catalystInstance.getJSIModule(JSIModuleType.UIManager);
       }


### PR DESCRIPTION
Summary: Adding `initialize()` to FabricUIManager just as was done by JSIModule

Without this change switching to UIManagerProvider would cause the UI to be Frozen and the events not correctly registered.

Reviewed By: javache

Differential Revision: D51456979


