### PR TITLE
Update Element Inspector string to "Toggle"

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -283,8 +283,7 @@ RCT_EXPORT_MODULE()
 
   [items addObject:[RCTDevMenuItem
                        buttonItemWithTitleBlock:^NSString * {
-                         return devSettings.isElementInspectorShown ? @"Hide Element Inspector"
-                                                                    : @"Show Element Inspector";
+                         return @"Toggle Element Inspector";
                        }
                        handler:^{
                          [devSettings toggleElementInspector];

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -414,9 +414,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
         });
 
     options.put(
-        mDevSettings.isElementInspectorEnabled()
-            ? mApplicationContext.getString(R.string.catalyst_inspector_stop)
-            : mApplicationContext.getString(R.string.catalyst_inspector),
+        mApplicationContext.getString(R.string.catalyst_inspector_toggle),
         new DevOptionHandler() {
           @Override
           public void onOptionSelected() {

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -11,8 +11,7 @@
   <string name="catalyst_hot_reloading_stop" project="catalyst" translatable="false">Disable Fast Refresh</string>
   <string name="catalyst_hot_reloading_auto_disable" project="catalyst" translatable="false">Disabling Fast Refresh because it requires a development bundle.</string>
   <string name="catalyst_hot_reloading_auto_enable" project="catalyst" translatable="false">Switching to development bundle in order to enable Fast Refresh.</string>
-  <string name="catalyst_inspector" project="catalyst" translatable="false">Show Element Inspector</string>
-  <string name="catalyst_inspector_stop" project="catalyst" translatable="false">Hide Element Inspector</string>
+  <string name="catalyst_inspector_toggle" project="catalyst" translatable="false">Toggle Element Inspector</string>
   <string name="catalyst_perf_monitor" project="catalyst" translatable="false">Show Perf Monitor</string>
   <string name="catalyst_perf_monitor_stop" project="catalyst" translatable="false">Hide Perf Monitor</string>
   <string name="catalyst_settings" project="catalyst" translatable="false">Settings</string>


### PR DESCRIPTION
Summary:
Instead of having to select between Enable/Hide the Element Inspector String, let's just use "Toggle".

Changelog:
[Internal] [Changed] - Update Element Inspector string to "Toggle"

Differential Revision: D51503403


