### PR TITLE
Remove `yoga::Style::Edges` usage in `AndroidTextInputComponentDescriptor`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -40,7 +40,7 @@ class AndroidTextInputComponentDescriptor final
       const ShadowNodeFamily::Shared& family) const override {
     int surfaceId = family->getSurfaceId();
 
-    yoga::Style::Edges theme;
+    ThemePadding theme;
     // TODO: figure out RTL/start/end/left/right stuff here
     if (surfaceIdToThemePaddingMap_.find(surfaceId) !=
         surfaceIdToThemePaddingMap_.end()) {
@@ -59,11 +59,10 @@ class AndroidTextInputComponentDescriptor final
               fabricUIManager, surfaceId, defaultTextInputPaddingArray)) {
         jfloat* defaultTextInputPadding =
             env->GetFloatArrayElements(defaultTextInputPaddingArray, 0);
-        theme[YGEdgeStart] = (YGValue){defaultTextInputPadding[0], YGUnitPoint};
-        theme[YGEdgeEnd] = (YGValue){defaultTextInputPadding[1], YGUnitPoint};
-        theme[YGEdgeTop] = (YGValue){defaultTextInputPadding[2], YGUnitPoint};
-        theme[YGEdgeBottom] =
-            (YGValue){defaultTextInputPadding[3], YGUnitPoint};
+        theme.start = defaultTextInputPadding[0];
+        theme.end = defaultTextInputPadding[1];
+        theme.top = defaultTextInputPadding[2];
+        theme.bottom = defaultTextInputPadding[3];
         surfaceIdToThemePaddingMap_.emplace(std::make_pair(surfaceId, theme));
         env->ReleaseFloatArrayElements(
             defaultTextInputPaddingArray, defaultTextInputPadding, JNI_ABORT);
@@ -73,14 +72,7 @@ class AndroidTextInputComponentDescriptor final
 
     return std::make_shared<AndroidTextInputShadowNode::ConcreteState>(
         std::make_shared<const AndroidTextInputState>(AndroidTextInputState(
-            0,
-            {},
-            {},
-            {},
-            ((YGValue)theme[YGEdgeStart]).value,
-            ((YGValue)theme[YGEdgeEnd]).value,
-            ((YGValue)theme[YGEdgeTop]).value,
-            ((YGValue)theme[YGEdgeBottom]).value)),
+            0, {}, {}, {}, theme.start, theme.end, theme.top, theme.bottom)),
         family);
   }
 
@@ -99,7 +91,7 @@ class AndroidTextInputComponentDescriptor final
     int surfaceId = textInputShadowNode.getSurfaceId();
     if (surfaceIdToThemePaddingMap_.find(surfaceId) !=
         surfaceIdToThemePaddingMap_.end()) {
-      yoga::Style::Edges theme = surfaceIdToThemePaddingMap_[surfaceId];
+      const auto& theme = surfaceIdToThemePaddingMap_[surfaceId];
 
       auto& textInputProps = textInputShadowNode.getConcreteProps();
 
@@ -108,29 +100,33 @@ class AndroidTextInputComponentDescriptor final
       // TODO: T62959168 account for RTL and paddingLeft when setting default
       // paddingStart, and vice-versa with paddingRight/paddingEnd.
       // For now this assumes no RTL.
-      yoga::Style::Edges result = textInputProps.yogaStyle.padding();
+      auto& style = const_cast<yoga::Style&>(textInputProps.yogaStyle);
       bool changedPadding = false;
       if (!textInputProps.hasPadding && !textInputProps.hasPaddingStart &&
           !textInputProps.hasPaddingLeft &&
           !textInputProps.hasPaddingHorizontal) {
         changedPadding = true;
-        result[YGEdgeStart] = theme[YGEdgeStart];
+        style.padding()[YGEdgeStart] =
+            yoga::CompactValue::of<YGUnitPoint>(theme.start);
       }
       if (!textInputProps.hasPadding && !textInputProps.hasPaddingEnd &&
           !textInputProps.hasPaddingRight &&
           !textInputProps.hasPaddingHorizontal) {
         changedPadding = true;
-        result[YGEdgeEnd] = theme[YGEdgeEnd];
+        style.padding()[YGEdgeEnd] =
+            yoga::CompactValue::of<YGUnitPoint>(theme.end);
       }
       if (!textInputProps.hasPadding && !textInputProps.hasPaddingTop &&
           !textInputProps.hasPaddingVertical) {
         changedPadding = true;
-        result[YGEdgeTop] = theme[YGEdgeTop];
+        style.padding()[YGEdgeTop] =
+            yoga::CompactValue::of<YGUnitPoint>(theme.top);
       }
       if (!textInputProps.hasPadding && !textInputProps.hasPaddingBottom &&
           !textInputProps.hasPaddingVertical) {
         changedPadding = true;
-        result[YGEdgeBottom] = theme[YGEdgeBottom];
+        style.padding()[YGEdgeBottom] =
+            yoga::CompactValue::of<YGUnitPoint>(theme.bottom);
       }
 
       // If the TextInput initially does not have paddingLeft or paddingStart, a
@@ -141,21 +137,18 @@ class AndroidTextInputComponentDescriptor final
       if ((textInputProps.hasPadding || textInputProps.hasPaddingLeft ||
            textInputProps.hasPaddingHorizontal) &&
           !textInputProps.hasPaddingStart) {
-        result[YGEdgeStart] = YGValueUndefined;
+        style.padding()[YGEdgeStart] = yoga::CompactValue::ofUndefined();
       }
       if ((textInputProps.hasPadding || textInputProps.hasPaddingRight ||
            textInputProps.hasPaddingHorizontal) &&
           !textInputProps.hasPaddingEnd) {
-        result[YGEdgeEnd] = YGValueUndefined;
+        style.padding()[YGEdgeEnd] = yoga::CompactValue::ofUndefined();
       }
 
       // Note that this is expensive: on every adopt, we need to set the Yoga
       // props again, which normally only happens during prop parsing. Every
       // commit, state update, etc, will incur this cost.
       if (changedPadding) {
-        // Set new props on node
-        const_cast<AndroidTextInputProps&>(textInputProps).yogaStyle.padding() =
-            result;
         // Communicate new props to Yoga part of the node
         textInputShadowNode.updateYogaProps();
       }
@@ -168,13 +161,19 @@ class AndroidTextInputComponentDescriptor final
   }
 
  private:
+  struct ThemePadding {
+    float start{};
+    float end{};
+    float top{};
+    float bottom{};
+  };
+
   // TODO T68526882: Unify with Binding::UIManagerJavaDescriptor
   constexpr static auto UIManagerJavaDescriptor =
       "com/facebook/react/fabric/FabricUIManager";
 
   SharedTextLayoutManager textLayoutManager_;
-  mutable std::unordered_map<int, yoga::Style::Edges>
-      surfaceIdToThemePaddingMap_;
+  mutable std::unordered_map<int, ThemePadding> surfaceIdToThemePaddingMap_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -39,6 +39,15 @@ ViewShadowNode::ViewShadowNode(
 void ViewShadowNode::initialize() noexcept {
   auto& viewProps = static_cast<const ViewProps&>(*props_);
 
+  auto hasBorder = [&]() {
+    for (auto edge : yoga::ordinals<yoga::Edge>()) {
+      if (viewProps.yogaStyle.border()[yoga::unscopedEnum(edge)].isDefined()) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   bool formsStackingContext = !viewProps.collapsable ||
       viewProps.pointerEvents == PointerEventsMode::None ||
       !viewProps.nativeId.empty() || viewProps.accessible ||
@@ -55,8 +64,7 @@ void ViewShadowNode::initialize() noexcept {
       HostPlatformViewTraitsInitializer::formsStackingContext(viewProps);
 
   bool formsView = formsStackingContext ||
-      isColorMeaningful(viewProps.backgroundColor) ||
-      !(viewProps.yogaStyle.border() == yoga::Style::Edges{}) ||
+      isColorMeaningful(viewProps.backgroundColor) || hasBorder() ||
       !viewProps.testId.empty() ||
       HostPlatformViewTraitsInitializer::formsView(viewProps);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/YogaStylablePropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/YogaStylablePropsMapBuffer.cpp
@@ -13,22 +13,30 @@
 
 namespace facebook::react {
 
-MapBuffer convertBorderWidths(const yoga::Style::Edges& border) {
+MapBuffer convertBorderWidths(const yoga::Style& style) {
   MapBufferBuilder builder(7);
   putOptionalFloat(
-      builder, EDGE_TOP, optionalFloatFromYogaValue(border[YGEdgeTop]));
+      builder, EDGE_TOP, optionalFloatFromYogaValue(style.border()[YGEdgeTop]));
   putOptionalFloat(
-      builder, EDGE_RIGHT, optionalFloatFromYogaValue(border[YGEdgeRight]));
+      builder,
+      EDGE_RIGHT,
+      optionalFloatFromYogaValue(style.border()[YGEdgeRight]));
   putOptionalFloat(
-      builder, EDGE_BOTTOM, optionalFloatFromYogaValue(border[YGEdgeBottom]));
+      builder,
+      EDGE_BOTTOM,
+      optionalFloatFromYogaValue(style.border()[YGEdgeBottom]));
   putOptionalFloat(
-      builder, EDGE_LEFT, optionalFloatFromYogaValue(border[YGEdgeLeft]));
+      builder,
+      EDGE_LEFT,
+      optionalFloatFromYogaValue(style.border()[YGEdgeLeft]));
   putOptionalFloat(
-      builder, EDGE_START, optionalFloatFromYogaValue(border[YGEdgeStart]));
+      builder,
+      EDGE_START,
+      optionalFloatFromYogaValue(style.border()[YGEdgeStart]));
   putOptionalFloat(
-      builder, EDGE_END, optionalFloatFromYogaValue(border[YGEdgeEnd]));
+      builder, EDGE_END, optionalFloatFromYogaValue(style.border()[YGEdgeEnd]));
   putOptionalFloat(
-      builder, EDGE_ALL, optionalFloatFromYogaValue(border[YGEdgeAll]));
+      builder, EDGE_ALL, optionalFloatFromYogaValue(style.border()[YGEdgeAll]));
   return builder.build();
 }
 
@@ -54,9 +62,17 @@ void YogaStylableProps::propsDiffMapBuffer(
     const auto& oldStyle = oldProps.yogaStyle;
     const auto& newStyle = newProps.yogaStyle;
 
-    if (!(oldStyle.border() == newStyle.border())) {
-      builder.putMapBuffer(
-          YG_BORDER_WIDTH, convertBorderWidths(newStyle.border()));
+    bool areBordersEqual = true;
+    for (auto edge : yoga::ordinals<yoga::Edge>()) {
+      if (oldStyle.border()[yoga::unscopedEnum(edge)] !=
+          newStyle.border()[yoga::unscopedEnum(edge)]) {
+        areBordersEqual = false;
+        break;
+      }
+    }
+
+    if (!areBordersEqual) {
+      builder.putMapBuffer(YG_BORDER_WIDTH, convertBorderWidths(newStyle));
     }
 
     if (oldStyle.overflow() != newStyle.overflow()) {

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/YogaEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/YogaEnums.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <type_traits>
 
 namespace facebook::yoga {
@@ -14,13 +15,52 @@ namespace facebook::yoga {
 template <typename EnumT>
 constexpr inline int32_t ordinalCount();
 
+/**
+ * Count of bits needed to represent every ordinal
+ */
 template <typename EnumT>
 constexpr inline int32_t bitCount();
 
-// Polyfill of C++ 23 to_underlying()
-// https://en.cppreference.com/w/cpp/utility/to_underlying
+/**
+ * Polyfill of C++ 23 to_underlying()
+ * https://en.cppreference.com/w/cpp/utility/to_underlying
+ */
 constexpr auto to_underlying(auto e) noexcept {
   return static_cast<std::underlying_type_t<decltype(e)>>(e);
+}
+
+/**
+ * Convenience function to iterate through every value in a Yoga enum as part of
+ * a range-based for loop.
+ */
+template <typename EnumT>
+auto ordinals() {
+  struct Iterator {
+    EnumT e{};
+
+    EnumT operator*() const {
+      return e;
+    }
+
+    Iterator& operator++() {
+      e = static_cast<EnumT>(to_underlying(e) + 1);
+      return *this;
+    }
+
+    bool operator==(const Iterator& other) const = default;
+    bool operator!=(const Iterator& other) const = default;
+  };
+
+  struct Range {
+    Iterator begin() const {
+      return Iterator{};
+    }
+    Iterator end() const {
+      return Iterator{static_cast<EnumT>(ordinalCount<EnumT>())};
+    }
+  };
+
+  return Range{};
 }
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -19,6 +19,7 @@
 #include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
 #include <yoga/enums/Display.h>
+#include <yoga/enums/Edge.h>
 #include <yoga/enums/FlexDirection.h>
 #include <yoga/enums/Gutter.h>
 #include <yoga/enums/Justify.h>


### PR DESCRIPTION
Summary:
This code merges native, Android provided theme text input padding, with Yoga style. We are removing operations on all edges as aggregate, so this replaces that.

This was previously part of D50998164

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D51503493


