### PR TITLE
[iOS] Fix Fabric componentregistrynative spec not work

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -115,7 +115,7 @@ Pod::Spec.new do |s|
   s.subspec "componentregistry" do |ss|
     ss.dependency             folly_dep_name, folly_version
     ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/componentregistry/**/*.{m,mm,cpp,h}"
+    ss.source_files         = "react/renderer/componentregistry/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/renderer/componentregistry"
   end
 


### PR DESCRIPTION
## Summary:

`componentregistry`'s `source_files` of spec contains the `componentregistrynative`'s `source_files`, it caused `componentregistrynative` spec not work.
![image](https://github.com/facebook/react-native/assets/5061845/9d8706d3-d5a4-4637-8cf4-db095264cda5)

cc. @sammy-SC 

## Changelog:

[IOS] [FIXED] -  Fix Fabric componentregistrynative spec not work

## Test Plan:

None.
