### PR TITLE
Schedule a Choreographer callback only if there is ongoing animation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.uimanager.GuardedFrameCallback;
@@ -247,14 +248,13 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
                 return;
               }
 
-              // TODO: Would be great to avoid adding this callback in case there are no active
-              // animations and no outstanding tasks on the operations queue. Apparently frame
-              // callbacks can only be posted from the UI thread and therefore we cannot schedule
-              // them directly from other threads.
-              Assertions.assertNotNull(mReactChoreographer)
-                  .postFrameCallback(
-                      ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE,
-                      mAnimatedFrameCallback);
+              if (!ReactFeatureFlags.enableOnDemandReactChoreographer
+                  || nodesManager != null && nodesManager.hasActiveAnimations()) {
+                Assertions.assertNotNull(mReactChoreographer)
+                    .postFrameCallback(
+                        ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE,
+                        mAnimatedFrameCallback);
+              }
             } catch (Exception ex) {
               throw new RuntimeException(ex);
             }
@@ -1116,6 +1116,7 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
                       opsAndArgs.getInt(i++), opsAndArgs.getInt(i++));
                   break;
                 case OP_CODE_START_ANIMATING_NODE:
+                  enqueueFrameCallback();
                   animatedNodesManager.startAnimatingNode(
                       opsAndArgs.getInt(i++), opsAndArgs.getInt(i++), opsAndArgs.getMap(i++), null);
                   break;


### PR DESCRIPTION
Summary: From sammy-SC, we would like to minimize the number of times that React Native schedules Choreographer calls. For animations, we do not need choreographer running on every frame, it only needs to run on frames that have an animation active. This diff modifies the frame callbacks such that Choreographer calls are only enqueued if there is an ongoing animation.

Reviewed By: sammy-SC

Differential Revision: D50647971


