### PR TITLE
Call `reactSetFrame` on affected layouts bottom-up

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -615,9 +615,9 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
 
     __block NSUInteger completionsCalled = 0;
 
-    NSInteger index = 0;
-    for (NSNumber *reactTag in reactTags) {
-      RCTFrameData frameData = frameDataArray[index++];
+    for (NSInteger index = count - 1; index >= 0; index--) {
+      NSNumber *reactTag = reactTags[index];
+      RCTFrameData frameData = frameDataArray[index];
 
       UIView *view = viewRegistry[reactTag];
       CGRect frame = frameData.frame;


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/41545

RN lays out the descendants of a root view using Yoga, then recurses to make a list of ShadowNodes which have new layout updates.

iOS Paper uses that list directly for ordering of calling `reactSetFrame` which informs UIViews of their dimensions.

As part of aligning Paper to Fabric's model of top-down onLayout events, https://github.com/facebook/react-native/commit/31680559b4e8b882614b1c11837f90aa38639790 changed the ordering of the list from being pseudo-random, to always top-down.

After the change, we can deterministically see a case of infinite recursion where:
1. We set the frame of the rootview
2. This triggers `safeAreaInsetsDidChange` of `RCTSafeAreaView`, which doesn't have a frame yet
3. `RCTSafeAreaView` triggers sync relayout of root view

Assigning frames bottom up (and is also what Android Paper does) ensures we lay out the RootView last, which avoids the issue, while keeping a deterministic order.

Changelog:
[iOS][Fixed] - Call `reactSetFrame` on affected layouts bottom-up

Differential Revision: D51534209


