### PR TITLE
Remove alias props for `inset`, `insetInline`, `insetBlock`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -391,15 +391,6 @@ void YogaLayoutableShadowNode::updateYogaProps() {
   yoga::Style result{baseStyle};
 
   // Aliases with precedence
-  if (!props.inset.isUndefined()) {
-    result.position()[YGEdgeAll] = props.inset;
-  }
-  if (!props.insetBlock.isUndefined()) {
-    result.position()[YGEdgeVertical] = props.insetBlock;
-  }
-  if (!props.insetInline.isUndefined()) {
-    result.position()[YGEdgeHorizontal] = props.insetInline;
-  }
   if (!props.insetInlineEnd.isUndefined()) {
     result.position()[YGEdgeEnd] = props.insetInlineEnd;
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -227,7 +227,12 @@ static inline T const getFieldValue(
   REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(position, YGEdgeRight, "right");   \
   REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(position, YGEdgeBottom, "bottom"); \
   REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(position, YGEdgeStart, "start");   \
-  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(position, YGEdgeEnd, "end");
+  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(position, YGEdgeEnd, "end");       \
+  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(                                   \
+      position, YGEdgeHorizontal, "insetInline");                         \
+  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(                                   \
+      position, YGEdgeVertical, "insetBlock");                            \
+  REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(position, YGEdgeAll, "inset");
 
 void YogaStylableProps::setProp(
     const PropsParserContext& context,
@@ -267,11 +272,8 @@ void YogaStylableProps::setProp(
     REBUILD_FIELD_YG_EDGES(border, "border", "Width");
 
     // Aliases
-    RAW_SET_PROP_SWITCH_CASE(inset, "inset");
-    RAW_SET_PROP_SWITCH_CASE(insetBlock, "insetBlock");
     RAW_SET_PROP_SWITCH_CASE(insetBlockEnd, "insetBlockEnd");
     RAW_SET_PROP_SWITCH_CASE(insetBlockStart, "insetBlockStart");
-    RAW_SET_PROP_SWITCH_CASE(insetInline, "insetInline");
     RAW_SET_PROP_SWITCH_CASE(insetInlineEnd, "insetInlineEnd");
     RAW_SET_PROP_SWITCH_CASE(insetInlineStart, "insetInlineStart");
     RAW_SET_PROP_SWITCH_CASE(marginInline, "marginInline");
@@ -387,18 +389,6 @@ void YogaStylableProps::convertRawPropAliases(
     const PropsParserContext& context,
     const YogaStylableProps& sourceProps,
     const RawProps& rawProps) {
-  inset = convertRawProp(
-      context,
-      rawProps,
-      "inset",
-      sourceProps.inset,
-      CompactValue::ofUndefined());
-  insetBlock = convertRawProp(
-      context,
-      rawProps,
-      "insetBlock",
-      sourceProps.insetBlock,
-      CompactValue::ofUndefined());
   insetBlockEnd = convertRawProp(
       context,
       rawProps,
@@ -410,12 +400,6 @@ void YogaStylableProps::convertRawPropAliases(
       rawProps,
       "insetBlockStart",
       sourceProps.insetBlockStart,
-      CompactValue::ofUndefined());
-  insetInline = convertRawProp(
-      context,
-      rawProps,
-      "insetInline",
-      sourceProps.insetInline,
       CompactValue::ofUndefined());
   insetInlineEnd = convertRawProp(
       context,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
@@ -41,10 +41,8 @@ class YogaStylableProps : public Props {
 
   // Duplicates of existing properties with different names, taking
   // precedence. E.g. "marginBlock" instead of "marginVertical"
-  CompactValue inset;
-  CompactValue insetInline;
-  CompactValue insetInlineEnd;
   CompactValue insetInlineStart;
+  CompactValue insetInlineEnd;
 
   CompactValue marginInline;
   CompactValue marginInlineStart;
@@ -59,9 +57,8 @@ class YogaStylableProps : public Props {
   // BlockEnd/BlockStart map to top/bottom (no writing mode), but we preserve
   // Yoga's precedence and prefer specific edges (e.g. top) to ones which are
   // flow relative (e.g. blockStart).
-  CompactValue insetBlock;
-  CompactValue insetBlockEnd;
   CompactValue insetBlockStart;
+  CompactValue insetBlockEnd;
 
   CompactValue marginBlockStart;
   CompactValue marginBlockEnd;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -143,6 +143,24 @@ static inline yoga::Style::Edges convertRawProp(
       "end",
       sourceValue[YGEdgeEnd],
       defaultValue[YGEdgeEnd]);
+  result[YGEdgeHorizontal] = convertRawProp(
+      context,
+      rawProps,
+      "insetInline",
+      sourceValue[YGEdgeHorizontal],
+      defaultValue[YGEdgeHorizontal]);
+  result[YGEdgeVertical] = convertRawProp(
+      context,
+      rawProps,
+      "insetBlock",
+      sourceValue[YGEdgeVertical],
+      defaultValue[YGEdgeVertical]);
+  result[YGEdgeAll] = convertRawProp(
+      context,
+      rawProps,
+      "inset",
+      sourceValue[YGEdgeAll],
+      defaultValue[YGEdgeAll]);
   return result;
 }
 


### PR DESCRIPTION
Summary:
We never use the position edges for Yoga style. We should not keep extra props, and instead just parse directly into the Yoga style.

Previously included in D50998164

Reviewed By: joevilches

Differential Revision: D51508217


