### PR TITLE
FP Tolerance in iOS Paper SafeAreaView debouncing

### DIFF
--- a/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaView.m
+++ b/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaView.m
@@ -57,7 +57,12 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
 
 - (void)setSafeAreaInsets:(UIEdgeInsets)safeAreaInsets
 {
-  if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
+  // Relayout with different padding may result in a close but slightly different result, amplified by Yoga rounding to
+  // physical pixel grid. To avoid infinite relayout, allow one physical pixel of difference, along with small amount of
+  // extra tolerance for FP error.
+  CGFloat tolerance = 1.0 / RCTScreenScale() + 0.01;
+
+  if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, tolerance)) {
     return;
   }
 


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/41545

SafeAreaView works by adding padding in order to shift content out of the safe area. This may change the layout dimensions of the SafeAreaView, in turn effecting its safe area insets.

This can cause layout results to change, which in turn changes the inset value. Because of this, there is a tolerance, where safe area inset changes do not trigger a new update.

Yoga is instructed to round layout dimensions to the closest physical pixel, so a very small difference in layout may result being off by about a pixel. Right now the tolerance is exactly one physical pixel, and if there is FP error here, we may not pass the test, and start oscillating with different layout values.

After changing affected ShadowNode order to always be root-first, the first call to set the frame of the `SafeAreaView` happens when a non-zero-sized RootView is present, which I think may lead to a safe area inset update communicated that wasn't before? Or other cosmic butterflies. Layout rounds to one physical pixel in difference, and our tolerance is `0.00001` dips off (not helped that 1/3 screen scale cannot be represented as decimal, even without FP error).

This adds a small tolerance beyond just the pixel boundary, matching the logic in Fabric, which seems to resolve the issue.

Changelog:
[iOS][Fixed] - FP Tolerance in iOS Paper SafeAreaView debouncing

Reviewed By: philIip

Differential Revision: D51539091


