### PR TITLE
Update pkg/repo names in deprecation messages

### DIFF
--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -285,7 +285,7 @@ module.exports = {
       'pushNotificationIOS-moved',
       'PushNotificationIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/push-notification-ios' instead of 'react-native'. " +
-        'See https://github.com/react-native-push-notification-ios/push-notification-ios',
+        'See https://github.com/react-native-push-notification/ios',
     );
     return require('./Libraries/PushNotificationIOS/PushNotificationIOS');
   },
@@ -429,7 +429,8 @@ if (__DEV__) {
       invariant(
         false,
         'ART has been removed from React Native. ' +
-          "It can now be installed and imported from '@react-native-community/art' instead of 'react-native'. " +
+          "Please upgrade to use either 'react-native-svg' or a similar package. " +
+          "If you cannot upgrade to a different library, please install the deprecated '@react-native-community/art' package. " +
           'See https://github.com/react-native-art/art',
       );
     },
@@ -509,7 +510,7 @@ if (__DEV__) {
       invariant(
         false,
         'CameraRoll has been removed from React Native. ' +
-          "It can now be installed and imported from '@react-native-community/cameraroll' instead of 'react-native'. " +
+          "It can now be installed and imported from '@react-native-camera-roll/camera-roll' instead of 'react-native'. " +
           'See https://github.com/react-native-cameraroll/react-native-cameraroll',
       );
     },
@@ -622,7 +623,7 @@ if (__DEV__) {
       invariant(
         false,
         'SegmentedControlIOS has been removed from React Native. ' +
-          "It can now be installed and imported from '@react-native-community/segmented-checkbox' instead of 'react-native'." +
+          "It can now be installed and imported from '@react-native-segmented-control/segmented-control' instead of 'react-native'." +
           'See https://github.com/react-native-segmented-control/segmented-control',
       );
     },
@@ -700,7 +701,7 @@ if (__DEV__) {
       invariant(
         false,
         'MaskedViewIOS has been removed from React Native. ' +
-          "It can now be installed and imported from '@react-native-community/react-native-masked-view' instead of 'react-native'. " +
+          "It can now be installed and imported from '@react-native-masked-view/masked-view' instead of 'react-native'. " +
           'See https://github.com/react-native-masked-view/masked-view',
       );
     },
@@ -730,7 +731,7 @@ if (__DEV__) {
       invariant(
         false,
         'ImagePickerIOS has been removed from React Native. ' +
-          "Please upgrade to use either '@react-native-community/react-native-image-picker' or 'expo-image-picker'. " +
+          "Please upgrade to use either 'react-native-image-picker' or 'expo-image-picker'. " +
           "If you cannot upgrade to a different library, please install the deprecated '@react-native-community/image-picker-ios' package. " +
           'See https://github.com/rnc-archive/react-native-image-picker-ios',
       );


### PR DESCRIPTION
## Summary:

Several deprecation warning messages related to components that were removed from `react-native` were outdated.
Some repositories have been moved, some packages were renamed/re-published under new names. A couple **never existed** (`@react-native-community/segmented-checkbox` and `@react-native-community/react-native-image-picker`).

This updates all messages to include links to the latest repositories and references to npm packages.

Because `@react-native-community/art` is deprecated I've also slightly amended the message with the suggestion from its [repo readme](https://github.com/react-native-art/art#deprecated---this-package-is-deprecated-if-you-need-a-similar-package-please-consider-using-react-native-svg).

## Changelog:

[GENERAL] [FIXED] - Update pkg/repo names in deprecation messages

## Test Plan:

No code change, just documentation/text.