### PR TITLE
Fix projects being broken on dependencies starting with `a..`

### DIFF
--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -26,6 +26,10 @@ gradlePlugin {
       id = "com.facebook.react"
       implementationClass = "com.facebook.react.ReactPlugin"
     }
+    create("reactrootproject") {
+      id = "com.facebook.react.rootproject"
+      implementationClass = "com.facebook.react.ReactRootProjectPlugin"
+    }
   }
 }
 

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactRootProjectPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactRootProjectPlugin.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Gradle plugin applied to the `android/build.gradle` file.
+ *
+ * This plugin allows to specify project wide configurations that can be applied to both apps and
+ * libraries before they're evaluated.
+ */
+class ReactRootProjectPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.subprojects {
+      // As the :app project (i.e. ReactPlugin) configures both namespaces and JVM toolchains
+      // for libraries, its evaluation must happen before the libraries' evaluation.
+      // Eventually the configuration of namespace/JVM toolchain can be moved inside this plugin.
+      if (it.path != ":app") {
+        it.evaluationDependsOn(":app")
+      }
+    }
+  }
+}

--- a/packages/react-native/template/android/build.gradle
+++ b/packages/react-native/template/android/build.gradle
@@ -1,5 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
@@ -19,3 +17,5 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     }
 }
+
+apply plugin: "com.facebook.react.rootproject"


### PR DESCRIPTION
Summary:
Currently, if you have a dependency that is alphabetically smaller than `app`, it's evaluation will happen before `app`.
This means that the namespace auto-discovery and the JVM toolchain configuration won't be working and the project will fail to buid.

This fixes it by introducing a root-project Gradle Plugin that takes care of enforcing the evaluation order on the `app` project.

Fixes #41620

Changelog:
[Android] [Fixed] - Fix projects being broken on dependencies starting with `a..`

Differential Revision: D51547294


