### PR TITLE
Revert "RNTester-ios / RCTAppDelegate > correctly check for USE_HERMES Flag"

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -23,7 +23,7 @@
 #import <React/RCTSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
 #import <ReactCommon/RCTContextContainerHandling.h>
-#if RCT_USE_HERMES
+#if USE_HERMES
 #import <ReactCommon/RCTHermesInstance.h>
 #else
 #import <ReactCommon/RCTJscInstance.h>
@@ -291,7 +291,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 - (std::shared_ptr<facebook::react::JSEngineInstance>)createJSEngineInstance
 {
-#if RCT_USE_HERMES
+#if USE_HERMES
   return std::make_shared<facebook::react::RCTHermesInstance>(_reactNativeConfig, nullptr);
 #else
   return std::make_shared<facebook::react::RCTJscInstance>();


### PR DESCRIPTION
## Summary:
In the codebase, we never set the `RCT_USE_HERMES` flag.

When we [install the pods](https://github.com/facebook/react-native/blob/b4d4aef057ebf90176287f22d72b4b3b8b280c9a/packages/react-native/scripts/react_native_pods.rb#L76), we use the `USE_HERMES` flag and we [set `USE_HERMES`](https://github.com/facebook/react-native/blob/b4d4aef057ebf90176287f22d72b4b3b8b280c9a/packages/react-native/scripts/cocoapods/utils.rb#L69) as a build setting. So, the `RCT_USE_HERMES` flag will always be not set for the OSS.

<img width="512" alt="Screenshot 2023-11-23 at 12 18 08" src="https://github.com/facebook/react-native/assets/11162307/29a6418b-ecaa-456c-bf77-2655e3395b51">

## Changelog:
[iOS][Fixed] - Use the right `USE_HERMES` flag

## Test Plan:
Revert Hammer