### PR TITLE
Use defaultSharedProps in ComponentView init

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
@@ -41,7 +41,7 @@ static UIActivityIndicatorViewStyle convertActivityIndicatorViewStyle(const Acti
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const ActivityIndicatorViewProps>();
+    const auto &defaultProps = ActivityIndicatorViewShadowNode::defaultSharedProps();
     _props = defaultProps;
 
     _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithFrame:self.bounds];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/DebuggingOverlay/RCTDebuggingOverlayComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/DebuggingOverlay/RCTDebuggingOverlayComponentView.mm
@@ -27,9 +27,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const DebuggingOverlayProps>();
-    _props = defaultProps;
-
+    _props = DebuggingOverlayShadowNode::defaultSharedProps();
     _overlay = [[RCTDebuggingOverlay alloc] initWithFrame:self.bounds];
 
     self.contentView = _overlay;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -28,7 +28,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const ImageProps>();
+    const auto &defaultProps = ImageShadowNode::defaultSharedProps();
     _props = defaultProps;
 
     _imageView = [RCTUIImageViewAnimated new];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -50,8 +50,7 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const InputAccessoryProps>();
-    _props = defaultProps;
+    _props = InputAccessoryShadowNode::defaultSharedProps();
     _contentView = [RCTInputAccessoryContentView new];
     _touchHandler = [RCTSurfaceTouchHandler new];
     [_touchHandler attachToView:_contentView];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -31,8 +31,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const LegacyViewManagerInteropViewProps>();
-    _props = defaultProps;
+    _props = LegacyViewManagerInteropShadowNode::defaultSharedProps();
     _viewsToBeMounted = [NSMutableArray new];
     _viewsToBeUnmounted = [NSMutableArray new];
     _hasInvokedForwardingWarning = NO;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -110,8 +110,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const ModalHostViewProps>();
-    _props = defaultProps;
+    _props = ModalHostViewShadowNode::defaultSharedProps();
     _shouldAnimatePresentation = YES;
 
     _isPresented = NO;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.mm
@@ -18,8 +18,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RootProps>();
-    _props = defaultProps;
+    _props = RootShadowNode::defaultSharedProps();
   }
 
   return self;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
@@ -22,8 +22,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const SafeAreaViewProps>();
-    _props = defaultProps;
+    _props = SafeAreaViewShadowNode::defaultSharedProps();
   }
 
   return self;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -36,8 +36,7 @@ using namespace facebook::react;
     // The pull-to-refresh view is not a subview of this view.
     self.hidden = YES;
 
-    static const auto defaultProps = std::make_shared<const PullToRefreshViewProps>();
-    _props = defaultProps;
+    _props = PullToRefreshViewShadowNode::defaultSharedProps();
 
     _refreshControl = [UIRefreshControl new];
     [_refreshControl addTarget:self

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -118,8 +118,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const ScrollViewProps>();
-    _props = defaultProps;
+    _props = ScrollViewShadowNode::defaultSharedProps();
 
     _scrollView = [[RCTEnhancedScrollView alloc] initWithFrame:self.bounds];
     _scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -29,8 +29,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const SwitchProps>();
-    _props = defaultProps;
+    _props = SwitchShadowNode::defaultSharedProps();
 
     _switchView = [[UISwitch alloc] initWithFrame:self.bounds];
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -40,8 +40,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const ParagraphProps>();
-    _props = defaultProps;
+    _props = ParagraphShadowNode::defaultSharedProps();
 
     self.opaque = NO;
     self.contentMode = UIViewContentModeRedraw;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -62,11 +62,10 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const TextInputProps>();
+    const auto &defaultProps = TextInputShadowNode::defaultSharedProps();
     _props = defaultProps;
-    auto &props = *defaultProps;
 
-    _backedTextInputView = props.traits.multiline ? [RCTUITextView new] : [RCTUITextField new];
+    _backedTextInputView = defaultProps->traits.multiline ? [RCTUITextView new] : [RCTUITextField new];
     _backedTextInputView.textInputDelegate = self;
     _ignoreNextTextInputCall = NO;
     _comingFromJS = NO;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
@@ -20,8 +20,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const UnimplementedNativeViewProps>();
-    _props = defaultProps;
+    _props = UnimplementedNativeViewShadowNode::defaultSharedProps();
 
     CGRect bounds = self.bounds;
     _label = [[UILabel alloc] initWithFrame:bounds];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
@@ -27,8 +27,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const UnimplementedViewProps>();
-    _props = defaultProps;
+    _props = UnimplementedViewShadowNode::defaultSharedProps();
 
     _label = [[UILabel alloc] initWithFrame:self.bounds];
     _label.backgroundColor = [UIColor colorWithRed:1.0 green:0.0 blue:0.0 alpha:0.3];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -46,8 +46,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const ViewProps>();
-    _props = defaultProps;
+    _props = ViewShadowNode::defaultSharedProps();
     _reactSubviews = [NSMutableArray new];
     self.multipleTouchEnabled = YES;
   }

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -85,7 +85,7 @@ class ConcreteShadowNode : public BaseShadowNodeT {
         rawProps);
   }
 
-  static SharedConcreteProps defaultSharedProps() {
+  static const SharedConcreteProps& defaultSharedProps() {
     static const SharedConcreteProps defaultSharedProps =
         std::make_shared<const PropsT>();
     return defaultSharedProps;


### PR DESCRIPTION
Summary:
`static` fields require additional code to ensure the field is only ever initialized once. We already have a static "default props" field in the shadow node, so let's reuse that as much as possible.

Changelog: [Internal]

Differential Revision: D51547638

