### PR TITLE
Back out "RNTester-ios / RCTAppDelegate > correctly check for USE_HERMES Flag"

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -26,7 +26,7 @@
 #import <React/RCTSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
 #import <ReactCommon/RCTContextContainerHandling.h>
-#if RCT_USE_HERMES
+#if USE_HERMES
 #import <ReactCommon/RCTHermesInstance.h>
 #else
 #import <ReactCommon/RCTJscInstance.h>
@@ -292,7 +292,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (std::shared_ptr<facebook::react::JSRuntimeFactory>)createJSRuntimeFactory
 {
-#if RCT_USE_HERMES
+#if USE_HERMES
   return std::make_shared<facebook::react::RCTHermesInstance>(_reactNativeConfig, nullptr);
 #else
   return std::make_shared<facebook::react::RCTJscInstance>();


### PR DESCRIPTION
Summary:
In the codebase, we never set the RCT_USE_HERMES flag.

When we install the pods, we use the USE_HERMES flag and we set USE_HERMES as a build setting. So, the RCT_USE_HERMES flag will always be not set for the OSS.

https://pxl.cl/3RRxr

## Changelog:
[iOS][Fixed] - use the right USE_HERMES flag

## Facebook:
This change was incorrect as in OSS we never set the RCT_USE_HERMES flag, while we actually set the USE_HERMES one.

I will align the BUCK RNTester setup in the next diff of the stackog:

Reviewed By: dmytrorykun

Differential Revision: D51547810


