### PR TITLE
chore: remove duplicated pod 'Yoga' in RNTester

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -55,7 +55,6 @@ def pods(target_name, options = {})
 
   # Additional Pods which aren't included in the default Podfile
   pod 'React-RCTPushNotification', :path => "#{@prefix_path}/Libraries/PushNotificationIOS"
-  pod 'Yoga', :path => "#{@prefix_path}/ReactCommon/yoga", :modular_headers => true
   # Additional Pods which are classed as unstable
 
   # RNTester native modules and components


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR removes duplicated `pod 'Yoga'` as it is already declared in `use_react_native`.
 
## Changelog:

[INTERNAL] [REMOVED] - duplicated pod 'Yoga' in RNTester

## Test Plan:

CI Green
