### PR TITLE
Fix static view config not to filter out "onClick" events on Android

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -304,6 +304,7 @@ const validAttributesForEventProps = {
   onTouchCancel: true,
 
   // Pointer events
+  onClick: true,
   onPointerEnter: true,
   onPointerEnterCapture: true,
   onPointerLeave: true,


### PR DESCRIPTION
Summary:
# Changelog:

Even though `onClick` is used on Android (e.g. via Pressability), the fact of having the handler registered didn't get through to the C++ side on New Architecture, because of being filtered out via the corresponding static view config.

As the result, there was no way to know on C++ side whether the corresponding event handler is registered for the view or not. Dynamic updates to the prop also wouldn't correctly propagate to C++, which may be a problem if a view gets e.g. the handler dynamically added.

Differential Revision: D51551255


