### PR TITLE
Remove dangling reference to preload.bzl file

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -15,6 +15,3 @@
 
 [alias]
   rntester = //packages/rn-tester/android/app:app
-
-[buildfile]
-  includes = //tools/build_defs/oss/preload.bzl


### PR DESCRIPTION
Summary:
# Changelog:
[Internal]-

The actual file was removed in https://github.com/facebook/react-native/pull/36900, but the reference still remains, confusing different tools.

Differential Revision: D51559281


