### PR TITLE
fix: add `rn-tester/Pods` to jest excluded directories

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,7 @@ module.exports = {
     '<rootDir>/packages/react-native/sdks',
     '<rootDir>/packages/react-native/Libraries/Renderer',
     '<rootDir>/packages/rn-tester/e2e',
+    '<rootDir>/packages/rn-tester/Pods',
   ],
   transformIgnorePatterns: ['node_modules/(?!@react-native/)'],
   haste: {


### PR DESCRIPTION
## Summary:

This PR adds `rn-tester/Pods` to excluded directory in `jest.config.js`. When running tests locally (in the root dir) jest was picking up tests from `hermes`. 

Before: 

![CleanShot 2023-11-24 at 11 15 28@2x](https://github.com/facebook/react-native/assets/52801365/bb24ce77-4393-48bd-af69-47b956274a21)

After: 

![CleanShot 2023-11-24 at 11 15 59@2x](https://github.com/facebook/react-native/assets/52801365/715464c5-6701-4c52-9ad4-9a284cc88d77)

## Changelog:

[INTERNAL] [ADDED] - add `rn-tester/Pods` to excluded Jest directories

## Test Plan:

CI Green
