### PR TITLE
[RN][iOS] Fix React-FabricImage dependencies

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -56,7 +56,6 @@ Pod::Spec.new do |s|
 
   s.dependency "RCT-Folly/Fabric"
   s.dependency "React-Core/Default"
-  s.dependency "React-RCTImage"
   s.dependency "glog"
 
   add_dependency(s, "React-Fabric")

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -585,6 +585,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
             'React-graphics': [],
             'React-rncore':  [],
             'React-Fabric': [],
+            'React-FabricImage': [],
             'React-utils': [],
             'React-debug': [],
             'React-rendererdebug': [],
@@ -604,6 +605,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         specs[:dependencies].merge!({
             'React-graphics': [],
             'React-Fabric': [],
+            'React-FabricImage': [],
             'React-utils': [],
             'React-debug': [],
             'React-rendererdebug': [],

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -144,6 +144,7 @@ class CodegenUtils
             'React-graphics': [],
             'React-rendererdebug': [],
             'React-Fabric': [],
+            'React-FabricImage': [],
             'React-debug': [],
             'React-utils': [],
           });


### PR DESCRIPTION
## Summary:
This is the porting of #41640 to 0.73

`react-native-svg` reported that the SVG library was not building on the latest RC of React Native because Codegen was not finding the proper files.

By inspecting an example app with SVG, we realized that React-Codegen was not depending on `React-FabricImage`, while having access to their headers.

We added the dependency, but them the build was failing due to a circular dependency because the `React-ImageManager` was dependeing on `React-RCTImage`.
This dependency is conceptually wrong (a piece of Core should not depend on Library which depends on Core... 😑) and I verified that by removing that dependency the framework continue to build.

## Changelog:
[Internal] - Fixed dependencies of Codegen on React-Image

## Test Plan
Tested on a local app + CircleCI