### PR TITLE
RNTester: add the ability to open a specific example from incoming URL

### DIFF
--- a/packages/rn-tester/js/utils/RNTesterNavigationReducer.js
+++ b/packages/rn-tester/js/utils/RNTesterNavigationReducer.js
@@ -18,6 +18,7 @@ export const RNTesterNavigationActionsType = {
   BACK_BUTTON_PRESS: 'BACK_BUTTON_PRESS',
   MODULE_CARD_PRESS: 'MODULE_CARD_PRESS',
   EXAMPLE_CARD_PRESS: 'EXAMPLE_CARD_PRESS',
+  EXAMPLE_OPEN_URL_REQUEST: 'EXAMPLE_OPEN_URL_REQUEST',
 };
 
 const getUpdatedRecentlyUsed = ({
@@ -98,6 +99,14 @@ export const RNTesterNavigationReducer = (
           state.activeModuleExampleKey != null ? state.activeModuleKey : null,
         activeModuleTitle:
           state.activeModuleExampleKey != null ? state.activeModuleTitle : null,
+      };
+
+    case RNTesterNavigationActionsType.EXAMPLE_OPEN_URL_REQUEST:
+      return {
+        ...state,
+        activeModuleKey: key,
+        activeModuleTitle: title,
+        activeModuleExampleKey: null,
       };
 
     default:


### PR DESCRIPTION
Summary:
This allows opening an example within RNTester without tapping the module card. If the app receives an openURL request with the format `rntester://example/<key>`, open that example (if exists) directly. Such URL request may come from various sources (e.g. custom test run, etc).

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D51543385


