### PR TITLE
Fix AndroidTextInputProps Detection of Padding

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -13,13 +13,9 @@
 
 namespace facebook::react {
 
-static bool hasValue(
-    const RawProps& rawProps,
-    bool defaultValue,
-    const char* name,
-    const char* prefix,
-    const char* suffix) {
-  auto rawValue = rawProps.at(name, prefix, suffix);
+static bool
+hasValue(const RawProps& rawProps, bool defaultValue, const char* name) {
+  auto rawValue = rawProps.at(name, nullptr, nullptr);
 
   // No change to prop - use default
   if (rawValue == nullptr) {
@@ -217,47 +213,35 @@ AndroidTextInputProps::AndroidTextInputProps(
           convertRawProp(context, rawProps, sourceProps.paragraphAttributes, {})),
       // See AndroidTextInputComponentDescriptor for usage
       // TODO T63008435: can these, and this feature, be removed entirely?
-      hasPadding(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPadding : hasValue(rawProps, sourceProps.hasPadding, "", "padding", "")),
+      hasPadding(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPadding : hasValue(rawProps, sourceProps.hasPadding, "padding")),
       hasPaddingHorizontal(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingHorizontal : hasValue(
           rawProps,
           sourceProps.hasPaddingHorizontal,
-          "Horizontal",
-          "padding",
-          "")),
+          "paddingHorizontal")),
       hasPaddingVertical(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingVertical : hasValue(
           rawProps,
           sourceProps.hasPaddingVertical,
-          "Vertical",
-          "padding",
-          "")),
+          "paddingVertical")),
       hasPaddingLeft(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingLeft : hasValue(
           rawProps,
           sourceProps.hasPaddingLeft,
-          "Left",
-          "padding",
-          "")),
+          "paddingLeft")),
       hasPaddingTop(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingTop :
-          hasValue(rawProps, sourceProps.hasPaddingTop, "Top", "padding", "")),
+          hasValue(rawProps, sourceProps.hasPaddingTop, "paddingTop")),
       hasPaddingRight(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingRight : hasValue(
           rawProps,
           sourceProps.hasPaddingRight,
-          "Right",
-          "padding",
-          "")),
+          "paddingRight")),
       hasPaddingBottom(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingBottom : hasValue(
           rawProps,
           sourceProps.hasPaddingBottom,
-          "Bottom",
-          "padding",
-          "")),
+          "paddingBottom")),
       hasPaddingStart(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingStart : hasValue(
           rawProps,
           sourceProps.hasPaddingStart,
-          "Start",
-          "padding",
-          "")),
+          "paddingStart")),
       hasPaddingEnd(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingEnd :
-          hasValue(rawProps, sourceProps.hasPaddingEnd, "End", "padding", "")) {
+          hasValue(rawProps, sourceProps.hasPaddingEnd, "paddingEnd")) {
 }
 
 void AndroidTextInputProps::setProp(


### PR DESCRIPTION
Summary:
Code in `AndroidTextInputComponentDescriptor` will rewrite Yoga props for padding based on Android theme, if a value isn't supplied. It determines this by adding props in `AndroidTextInputProps` which reads Yoga RawProps to tell if they were set.

RawProps are keyed using separate prefix/name/suffix, instead of the combined string name of the prop. This means that searching for the name `paddingLeft`, would be different from reading one with a name of `padding` and a suffix of `Left`.

This updates the keying, based on the changes in D51510562.

We should refactor this in the future (D20109605, introducing this code, admitted as much). We already have a phase, for aliased props, where we transform input props into the Yoga style (they don't need to be 1:1). This doesn't depend on RawProps, extra props, or prop mutations.

Changelog:
[Android][Fixed] - Fix AndroidTextInputProps Detection of Padding

Differential Revision: D51566900


