### PR TITLE
fix: Update explanation for `inactive` `AppState`

### DIFF
--- a/packages/react-native/Libraries/AppState/AppState.d.ts
+++ b/packages/react-native/Libraries/AppState/AppState.d.ts
@@ -24,7 +24,7 @@ import {NativeEventSubscription} from '../EventEmitter/RCTNativeAppEventEmitter'
  * App States
  *      active - The app is running in the foreground
  *      background - The app is running in the background. The user is either in another app or on the home screen
- *      inactive [iOS] - This is a transition state that happens when the app launches, is asking for permissions or when a call or SMS message is received.
+ *      inactive [iOS] - This is a transition state that happens when the app launches, is asking for permissions, the control- or notification-center is opened or when a call is incoming
  *      unknown [iOS] - Initial value until the current app state is determined
  *      extension [iOS] - The app is running as an app extension
  *


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The documentation for the `"inactive"` AppState is not entirely correct. This PR updates the explanation to explain better when the `"inactive"` AppState is reached, as in most apps the relevant gesture is when the notification or control-center is pulled down.

For example, you might decide whether you want your Camera or Video to keep running/playing when the user drags down the Notification-/Control-center or not, and this is the state for that.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [CHANGED] - Update explanation for `inactive` `AppState`

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:


It's just type documentation.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
