### PR TITLE
Simplify C++ TM struct generation

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -324,7 +324,7 @@ struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
 #pragma mark - NativeEnumTurboModuleBaseStateType
 
 template <typename P0>
-struct NativeEnumTurboModuleBaseStateType {
+struct [[deprecated(\\"Use NativeEnumTurboModuleStateType instead.\\")]] NativeEnumTurboModuleBaseStateType {
   P0 state;
   bool operator==(const NativeEnumTurboModuleBaseStateType &other) const {
     return state == other.state;
@@ -332,7 +332,7 @@ struct NativeEnumTurboModuleBaseStateType {
 };
 
 template <typename P0>
-struct NativeEnumTurboModuleBaseStateTypeBridging {
+struct [[deprecated(\\"Use NativeEnumTurboModuleStateTypeBridging instead.\\")]] NativeEnumTurboModuleBaseStateTypeBridging {
   static NativeEnumTurboModuleBaseStateType<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -363,7 +363,7 @@ struct NativeEnumTurboModuleBaseStateTypeBridging {
 #pragma mark - NativeEnumTurboModuleBaseStateTypeWithEnums
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct NativeEnumTurboModuleBaseStateTypeWithEnums {
+struct [[deprecated(\\"Use NativeEnumTurboModuleStateTypeWithEnums instead.\\")]] NativeEnumTurboModuleBaseStateTypeWithEnums {
   P0 state;
   P1 regular;
   P2 str;
@@ -375,7 +375,7 @@ struct NativeEnumTurboModuleBaseStateTypeWithEnums {
 };
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct NativeEnumTurboModuleBaseStateTypeWithEnumsBridging {
+struct [[deprecated(\\"Use NativeEnumTurboModuleStateTypeWithEnumsBridging instead.\\")]] NativeEnumTurboModuleBaseStateTypeWithEnumsBridging {
   static NativeEnumTurboModuleBaseStateTypeWithEnums<P0, P1, P2, P3, P4> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -414,6 +414,115 @@ struct NativeEnumTurboModuleBaseStateTypeWithEnumsBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const NativeEnumTurboModuleBaseStateTypeWithEnums<P0, P1, P2, P3, P4> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
+    result.setProperty(rt, \\"regular\\", bridging::toJs(rt, value.regular, jsInvoker));
+    result.setProperty(rt, \\"str\\", bridging::toJs(rt, value.str, jsInvoker));
+    result.setProperty(rt, \\"num\\", bridging::toJs(rt, value.num, jsInvoker));
+    result.setProperty(rt, \\"fraction\\", bridging::toJs(rt, value.fraction, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - NativeEnumTurboModuleStateType
+
+template <typename P0>
+struct NativeEnumTurboModuleStateType {
+  P0 state;
+  bool operator==(const NativeEnumTurboModuleStateType &other) const {
+    return state == other.state;
+  }
+};
+
+template <typename T>
+struct NativeEnumTurboModuleStateTypeBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.state)>(rt, value.getProperty(rt, \\"state\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String stateToJs(jsi::Runtime &rt, decltype(types.state) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
+    return result;
+  }
+};
+
+
+
+#pragma mark - NativeEnumTurboModuleStateTypeWithEnums
+
+template <typename P0, typename P1, typename P2, typename P3, typename P4>
+struct NativeEnumTurboModuleStateTypeWithEnums {
+  P0 state;
+  P1 regular;
+  P2 str;
+  P3 num;
+  P4 fraction;
+  bool operator==(const NativeEnumTurboModuleStateTypeWithEnums &other) const {
+    return state == other.state && regular == other.regular && str == other.str && num == other.num && fraction == other.fraction;
+  }
+};
+
+template <typename T>
+struct NativeEnumTurboModuleStateTypeWithEnumsBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.state)>(rt, value.getProperty(rt, \\"state\\"), jsInvoker),
+      bridging::fromJs<decltype(types.regular)>(rt, value.getProperty(rt, \\"regular\\"), jsInvoker),
+      bridging::fromJs<decltype(types.str)>(rt, value.getProperty(rt, \\"str\\"), jsInvoker),
+      bridging::fromJs<decltype(types.num)>(rt, value.getProperty(rt, \\"num\\"), jsInvoker),
+      bridging::fromJs<decltype(types.fraction)>(rt, value.getProperty(rt, \\"fraction\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String stateToJs(jsi::Runtime &rt, decltype(types.state) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String regularToJs(jsi::Runtime &rt, decltype(types.regular) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String strToJs(jsi::Runtime &rt, decltype(types.str) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static int numToJs(jsi::Runtime &rt, decltype(types.num) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static double fractionToJs(jsi::Runtime &rt, decltype(types.fraction) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
@@ -794,7 +903,7 @@ private:
 #pragma mark - NativePartialAnnotationTurboModuleBaseSomeObj
 
 template <typename P0, typename P1>
-struct NativePartialAnnotationTurboModuleBaseSomeObj {
+struct [[deprecated(\\"Use NativePartialAnnotationTurboModuleSomeObj instead.\\")]] NativePartialAnnotationTurboModuleBaseSomeObj {
   P0 a;
   P1 b;
   bool operator==(const NativePartialAnnotationTurboModuleBaseSomeObj &other) const {
@@ -803,7 +912,7 @@ struct NativePartialAnnotationTurboModuleBaseSomeObj {
 };
 
 template <typename P0, typename P1>
-struct NativePartialAnnotationTurboModuleBaseSomeObjBridging {
+struct [[deprecated(\\"Use NativePartialAnnotationTurboModuleSomeObjBridging instead.\\")]] NativePartialAnnotationTurboModuleBaseSomeObjBridging {
   static NativePartialAnnotationTurboModuleBaseSomeObj<P0, P1> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -827,6 +936,55 @@ struct NativePartialAnnotationTurboModuleBaseSomeObjBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const NativePartialAnnotationTurboModuleBaseSomeObj<P0, P1> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"a\\", bridging::toJs(rt, value.a, jsInvoker));
+    if (value.b) {
+      result.setProperty(rt, \\"b\\", bridging::toJs(rt, value.b.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - NativePartialAnnotationTurboModuleSomeObj
+
+template <typename P0, typename P1>
+struct NativePartialAnnotationTurboModuleSomeObj {
+  P0 a;
+  P1 b;
+  bool operator==(const NativePartialAnnotationTurboModuleSomeObj &other) const {
+    return a == other.a && b == other.b;
+  }
+};
+
+template <typename T>
+struct NativePartialAnnotationTurboModuleSomeObjBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.a)>(rt, value.getProperty(rt, \\"a\\"), jsInvoker),
+      bridging::fromJs<decltype(types.b)>(rt, value.getProperty(rt, \\"b\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String aToJs(jsi::Runtime &rt, decltype(types.a) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static bool bToJs(jsi::Runtime &rt, decltype(types.b) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"a\\", bridging::toJs(rt, value.a, jsInvoker));
@@ -969,7 +1127,7 @@ private:
 #pragma mark - SampleTurboModuleBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleAnimal instead.\\")]] SampleTurboModuleBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleBaseAnimal &other) const {
     return name == other.name;
@@ -977,7 +1135,7 @@ struct SampleTurboModuleBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleAnimalBridging instead.\\")]] SampleTurboModuleBaseAnimalBridging {
   static SampleTurboModuleBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -996,6 +1154,46 @@ struct SampleTurboModuleBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleAnimal
+
+template <typename P0>
+struct SampleTurboModuleAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
@@ -1161,7 +1359,7 @@ private:
 #pragma mark - SampleTurboModuleArraysBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleArraysBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleArraysAnimal instead.\\")]] SampleTurboModuleArraysBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleArraysBaseAnimal &other) const {
     return name == other.name;
@@ -1169,7 +1367,7 @@ struct SampleTurboModuleArraysBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleArraysBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleArraysAnimalBridging instead.\\")]] SampleTurboModuleArraysBaseAnimalBridging {
   static SampleTurboModuleArraysBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -1188,6 +1386,46 @@ struct SampleTurboModuleArraysBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleArraysBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleArraysAnimal
+
+template <typename P0>
+struct SampleTurboModuleArraysAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleArraysAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleArraysAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
@@ -1353,7 +1591,7 @@ private:
 #pragma mark - SampleTurboModuleNullableBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleNullableBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleNullableAnimal instead.\\")]] SampleTurboModuleNullableBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleNullableBaseAnimal &other) const {
     return name == other.name;
@@ -1361,7 +1599,7 @@ struct SampleTurboModuleNullableBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleNullableBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleNullableAnimalBridging instead.\\")]] SampleTurboModuleNullableBaseAnimalBridging {
   static SampleTurboModuleNullableBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -1380,6 +1618,46 @@ struct SampleTurboModuleNullableBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleNullableBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleNullableAnimal
+
+template <typename P0>
+struct SampleTurboModuleNullableAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleNullableAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleNullableAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static std::optional<jsi::String> nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
@@ -1545,7 +1823,7 @@ private:
 #pragma mark - SampleTurboModuleNullableAndOptionalBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleNullableAndOptionalBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleNullableAndOptionalAnimal instead.\\")]] SampleTurboModuleNullableAndOptionalBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleNullableAndOptionalBaseAnimal &other) const {
     return name == other.name;
@@ -1553,7 +1831,7 @@ struct SampleTurboModuleNullableAndOptionalBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleNullableAndOptionalBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleNullableAndOptionalAnimalBridging instead.\\")]] SampleTurboModuleNullableAndOptionalBaseAnimalBridging {
   static SampleTurboModuleNullableAndOptionalBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -1572,6 +1850,48 @@ struct SampleTurboModuleNullableAndOptionalBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleNullableAndOptionalBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.name) {
+      result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleNullableAndOptionalAnimal
+
+template <typename P0>
+struct SampleTurboModuleNullableAndOptionalAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleNullableAndOptionalAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleNullableAndOptionalAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static std::optional<jsi::String> nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     if (value.name) {
@@ -1739,7 +2059,7 @@ private:
 #pragma mark - SampleTurboModuleOptionalBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleOptionalBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleOptionalAnimal instead.\\")]] SampleTurboModuleOptionalBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleOptionalBaseAnimal &other) const {
     return name == other.name;
@@ -1747,7 +2067,7 @@ struct SampleTurboModuleOptionalBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleOptionalBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleOptionalAnimalBridging instead.\\")]] SampleTurboModuleOptionalBaseAnimalBridging {
   static SampleTurboModuleOptionalBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -1766,6 +2086,48 @@ struct SampleTurboModuleOptionalBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleOptionalBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.name) {
+      result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleOptionalAnimal
+
+template <typename P0>
+struct SampleTurboModuleOptionalAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleOptionalAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleOptionalAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     if (value.name) {
@@ -2312,7 +2674,7 @@ struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
 #pragma mark - NativeEnumTurboModuleBaseStateType
 
 template <typename P0>
-struct NativeEnumTurboModuleBaseStateType {
+struct [[deprecated(\\"Use NativeEnumTurboModuleStateType instead.\\")]] NativeEnumTurboModuleBaseStateType {
   P0 state;
   bool operator==(const NativeEnumTurboModuleBaseStateType &other) const {
     return state == other.state;
@@ -2320,7 +2682,7 @@ struct NativeEnumTurboModuleBaseStateType {
 };
 
 template <typename P0>
-struct NativeEnumTurboModuleBaseStateTypeBridging {
+struct [[deprecated(\\"Use NativeEnumTurboModuleStateTypeBridging instead.\\")]] NativeEnumTurboModuleBaseStateTypeBridging {
   static NativeEnumTurboModuleBaseStateType<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -2351,7 +2713,7 @@ struct NativeEnumTurboModuleBaseStateTypeBridging {
 #pragma mark - NativeEnumTurboModuleBaseStateTypeWithEnums
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct NativeEnumTurboModuleBaseStateTypeWithEnums {
+struct [[deprecated(\\"Use NativeEnumTurboModuleStateTypeWithEnums instead.\\")]] NativeEnumTurboModuleBaseStateTypeWithEnums {
   P0 state;
   P1 regular;
   P2 str;
@@ -2363,7 +2725,7 @@ struct NativeEnumTurboModuleBaseStateTypeWithEnums {
 };
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct NativeEnumTurboModuleBaseStateTypeWithEnumsBridging {
+struct [[deprecated(\\"Use NativeEnumTurboModuleStateTypeWithEnumsBridging instead.\\")]] NativeEnumTurboModuleBaseStateTypeWithEnumsBridging {
   static NativeEnumTurboModuleBaseStateTypeWithEnums<P0, P1, P2, P3, P4> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -2402,6 +2764,115 @@ struct NativeEnumTurboModuleBaseStateTypeWithEnumsBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const NativeEnumTurboModuleBaseStateTypeWithEnums<P0, P1, P2, P3, P4> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
+    result.setProperty(rt, \\"regular\\", bridging::toJs(rt, value.regular, jsInvoker));
+    result.setProperty(rt, \\"str\\", bridging::toJs(rt, value.str, jsInvoker));
+    result.setProperty(rt, \\"num\\", bridging::toJs(rt, value.num, jsInvoker));
+    result.setProperty(rt, \\"fraction\\", bridging::toJs(rt, value.fraction, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - NativeEnumTurboModuleStateType
+
+template <typename P0>
+struct NativeEnumTurboModuleStateType {
+  P0 state;
+  bool operator==(const NativeEnumTurboModuleStateType &other) const {
+    return state == other.state;
+  }
+};
+
+template <typename T>
+struct NativeEnumTurboModuleStateTypeBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.state)>(rt, value.getProperty(rt, \\"state\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String stateToJs(jsi::Runtime &rt, decltype(types.state) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
+    return result;
+  }
+};
+
+
+
+#pragma mark - NativeEnumTurboModuleStateTypeWithEnums
+
+template <typename P0, typename P1, typename P2, typename P3, typename P4>
+struct NativeEnumTurboModuleStateTypeWithEnums {
+  P0 state;
+  P1 regular;
+  P2 str;
+  P3 num;
+  P4 fraction;
+  bool operator==(const NativeEnumTurboModuleStateTypeWithEnums &other) const {
+    return state == other.state && regular == other.regular && str == other.str && num == other.num && fraction == other.fraction;
+  }
+};
+
+template <typename T>
+struct NativeEnumTurboModuleStateTypeWithEnumsBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.state)>(rt, value.getProperty(rt, \\"state\\"), jsInvoker),
+      bridging::fromJs<decltype(types.regular)>(rt, value.getProperty(rt, \\"regular\\"), jsInvoker),
+      bridging::fromJs<decltype(types.str)>(rt, value.getProperty(rt, \\"str\\"), jsInvoker),
+      bridging::fromJs<decltype(types.num)>(rt, value.getProperty(rt, \\"num\\"), jsInvoker),
+      bridging::fromJs<decltype(types.fraction)>(rt, value.getProperty(rt, \\"fraction\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String stateToJs(jsi::Runtime &rt, decltype(types.state) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String regularToJs(jsi::Runtime &rt, decltype(types.regular) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String strToJs(jsi::Runtime &rt, decltype(types.str) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static int numToJs(jsi::Runtime &rt, decltype(types.num) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static double fractionToJs(jsi::Runtime &rt, decltype(types.fraction) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"state\\", bridging::toJs(rt, value.state, jsInvoker));
@@ -2782,7 +3253,7 @@ private:
 #pragma mark - NativePartialAnnotationTurboModuleBaseSomeObj
 
 template <typename P0, typename P1>
-struct NativePartialAnnotationTurboModuleBaseSomeObj {
+struct [[deprecated(\\"Use NativePartialAnnotationTurboModuleSomeObj instead.\\")]] NativePartialAnnotationTurboModuleBaseSomeObj {
   P0 a;
   P1 b;
   bool operator==(const NativePartialAnnotationTurboModuleBaseSomeObj &other) const {
@@ -2791,7 +3262,7 @@ struct NativePartialAnnotationTurboModuleBaseSomeObj {
 };
 
 template <typename P0, typename P1>
-struct NativePartialAnnotationTurboModuleBaseSomeObjBridging {
+struct [[deprecated(\\"Use NativePartialAnnotationTurboModuleSomeObjBridging instead.\\")]] NativePartialAnnotationTurboModuleBaseSomeObjBridging {
   static NativePartialAnnotationTurboModuleBaseSomeObj<P0, P1> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -2815,6 +3286,55 @@ struct NativePartialAnnotationTurboModuleBaseSomeObjBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const NativePartialAnnotationTurboModuleBaseSomeObj<P0, P1> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"a\\", bridging::toJs(rt, value.a, jsInvoker));
+    if (value.b) {
+      result.setProperty(rt, \\"b\\", bridging::toJs(rt, value.b.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - NativePartialAnnotationTurboModuleSomeObj
+
+template <typename P0, typename P1>
+struct NativePartialAnnotationTurboModuleSomeObj {
+  P0 a;
+  P1 b;
+  bool operator==(const NativePartialAnnotationTurboModuleSomeObj &other) const {
+    return a == other.a && b == other.b;
+  }
+};
+
+template <typename T>
+struct NativePartialAnnotationTurboModuleSomeObjBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.a)>(rt, value.getProperty(rt, \\"a\\"), jsInvoker),
+      bridging::fromJs<decltype(types.b)>(rt, value.getProperty(rt, \\"b\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String aToJs(jsi::Runtime &rt, decltype(types.a) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static bool bToJs(jsi::Runtime &rt, decltype(types.b) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"a\\", bridging::toJs(rt, value.a, jsInvoker));
@@ -2957,7 +3477,7 @@ private:
 #pragma mark - SampleTurboModuleBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleAnimal instead.\\")]] SampleTurboModuleBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleBaseAnimal &other) const {
     return name == other.name;
@@ -2965,7 +3485,7 @@ struct SampleTurboModuleBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleAnimalBridging instead.\\")]] SampleTurboModuleBaseAnimalBridging {
   static SampleTurboModuleBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -2984,6 +3504,46 @@ struct SampleTurboModuleBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleAnimal
+
+template <typename P0>
+struct SampleTurboModuleAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
@@ -3149,7 +3709,7 @@ private:
 #pragma mark - SampleTurboModuleArraysBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleArraysBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleArraysAnimal instead.\\")]] SampleTurboModuleArraysBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleArraysBaseAnimal &other) const {
     return name == other.name;
@@ -3157,7 +3717,7 @@ struct SampleTurboModuleArraysBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleArraysBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleArraysAnimalBridging instead.\\")]] SampleTurboModuleArraysBaseAnimalBridging {
   static SampleTurboModuleArraysBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -3176,6 +3736,46 @@ struct SampleTurboModuleArraysBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleArraysBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleArraysAnimal
+
+template <typename P0>
+struct SampleTurboModuleArraysAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleArraysAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleArraysAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
@@ -3341,7 +3941,7 @@ private:
 #pragma mark - SampleTurboModuleNullableBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleNullableBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleNullableAnimal instead.\\")]] SampleTurboModuleNullableBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleNullableBaseAnimal &other) const {
     return name == other.name;
@@ -3349,7 +3949,7 @@ struct SampleTurboModuleNullableBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleNullableBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleNullableAnimalBridging instead.\\")]] SampleTurboModuleNullableBaseAnimalBridging {
   static SampleTurboModuleNullableBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -3368,6 +3968,46 @@ struct SampleTurboModuleNullableBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleNullableBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleNullableAnimal
+
+template <typename P0>
+struct SampleTurboModuleNullableAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleNullableAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleNullableAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static std::optional<jsi::String> nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
@@ -3533,7 +4173,7 @@ private:
 #pragma mark - SampleTurboModuleNullableAndOptionalBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleNullableAndOptionalBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleNullableAndOptionalAnimal instead.\\")]] SampleTurboModuleNullableAndOptionalBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleNullableAndOptionalBaseAnimal &other) const {
     return name == other.name;
@@ -3541,7 +4181,7 @@ struct SampleTurboModuleNullableAndOptionalBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleNullableAndOptionalBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleNullableAndOptionalAnimalBridging instead.\\")]] SampleTurboModuleNullableAndOptionalBaseAnimalBridging {
   static SampleTurboModuleNullableAndOptionalBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -3560,6 +4200,48 @@ struct SampleTurboModuleNullableAndOptionalBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleNullableAndOptionalBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.name) {
+      result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleNullableAndOptionalAnimal
+
+template <typename P0>
+struct SampleTurboModuleNullableAndOptionalAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleNullableAndOptionalAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleNullableAndOptionalAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static std::optional<jsi::String> nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     if (value.name) {
@@ -3727,7 +4409,7 @@ private:
 #pragma mark - SampleTurboModuleOptionalBaseAnimal
 
 template <typename P0>
-struct SampleTurboModuleOptionalBaseAnimal {
+struct [[deprecated(\\"Use SampleTurboModuleOptionalAnimal instead.\\")]] SampleTurboModuleOptionalBaseAnimal {
   P0 name;
   bool operator==(const SampleTurboModuleOptionalBaseAnimal &other) const {
     return name == other.name;
@@ -3735,7 +4417,7 @@ struct SampleTurboModuleOptionalBaseAnimal {
 };
 
 template <typename P0>
-struct SampleTurboModuleOptionalBaseAnimalBridging {
+struct [[deprecated(\\"Use SampleTurboModuleOptionalAnimalBridging instead.\\")]] SampleTurboModuleOptionalBaseAnimalBridging {
   static SampleTurboModuleOptionalBaseAnimal<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -3754,6 +4436,48 @@ struct SampleTurboModuleOptionalBaseAnimalBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleOptionalBaseAnimal<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.name) {
+      result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleOptionalAnimal
+
+template <typename P0>
+struct SampleTurboModuleOptionalAnimal {
+  P0 name;
+  bool operator==(const SampleTurboModuleOptionalAnimal &other) const {
+    return name == other.name;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleOptionalAnimalBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     if (value.name) {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -232,33 +232,36 @@ function createStructsString(
       enumMap,
     );
 
-  return Object.keys(aliasMap)
-    .map(alias => {
-      const value = aliasMap[alias];
-      if (value.properties.length === 0) {
-        return '';
-      }
-      const structName = `${moduleName}Base${alias}`;
-      const templateParameterWithTypename = value.properties
-        .map((v, i) => `typename P${i}`)
-        .join(', ');
-      const templateParameter = value.properties
-        .map((v, i) => 'P' + i)
-        .join(', ');
-      const debugParameterConversion = value.properties
-        .map(
-          (v, i) => `  static ${getCppType(v)} ${
-            v.name
-          }ToJs(jsi::Runtime &rt, P${i} value) {
+  // TODO: T171006733 [Begin] Remove deprecated Cxx TMs structs after a new release.
+  return (
+    Object.keys(aliasMap)
+      .map(alias => {
+        const value = aliasMap[alias];
+        if (value.properties.length === 0) {
+          return '';
+        }
+        const structName = `${moduleName}Base${alias}`;
+        const structNameNew = `${moduleName}${alias}`;
+        const templateParameterWithTypename = value.properties
+          .map((v, i) => `typename P${i}`)
+          .join(', ');
+        const templateParameter = value.properties
+          .map((v, i) => 'P' + i)
+          .join(', ');
+        const debugParameterConversion = value.properties
+          .map(
+            (v, i) => `  static ${getCppType(v)} ${
+              v.name
+            }ToJs(jsi::Runtime &rt, P${i} value) {
     return bridging::toJs(rt, value);
   }`,
-        )
-        .join('\n\n');
-      return `
+          )
+          .join('\n\n');
+        return `
 #pragma mark - ${structName}
 
 template <${templateParameterWithTypename}>
-struct ${structName} {
+struct [[deprecated("Use ${structNameNew} instead.")]] ${structName} {
 ${value.properties.map((v, i) => '  P' + i + ' ' + v.name).join(';\n')};
   bool operator==(const ${structName} &other) const {
     return ${value.properties
@@ -268,7 +271,7 @@ ${value.properties.map((v, i) => '  P' + i + ' ' + v.name).join(';\n')};
 };
 
 template <${templateParameterWithTypename}>
-struct ${structName}Bridging {
+struct [[deprecated("Use ${structNameNew}Bridging instead.")]] ${structName}Bridging {
   static ${structName}<${templateParameter}> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -308,8 +311,87 @@ ${value.properties
 };
 
 `;
-    })
-    .join('\n');
+      })
+      .join('\n') +
+    // TODO: T171006733 [End] Remove deprecated Cxx TMs structs after a new release.
+    Object.keys(aliasMap)
+      .map(alias => {
+        const value = aliasMap[alias];
+        if (value.properties.length === 0) {
+          return '';
+        }
+        const structName = `${moduleName}${alias}`;
+        const templateParameterWithTypename = value.properties
+          .map((v, i) => `typename P${i}`)
+          .join(', ');
+        const debugParameterConversion = value.properties
+          .map(
+            (v, i) => `  static ${getCppType(v)} ${
+              v.name
+            }ToJs(jsi::Runtime &rt, decltype(types.${v.name}) value) {
+    return bridging::toJs(rt, value);
+  }`,
+          )
+          .join('\n\n');
+        return `
+#pragma mark - ${structName}
+
+template <${templateParameterWithTypename}>
+struct ${structName} {
+${value.properties.map((v, i) => '  P' + i + ' ' + v.name).join(';\n')};
+  bool operator==(const ${structName} &other) const {
+    return ${value.properties
+      .map(v => `${v.name} == other.${v.name}`)
+      .join(' && ')};
+  }
+};
+
+template <typename T>
+struct ${structName}Bridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+${value.properties
+  .map(
+    (v, i) =>
+      `      bridging::fromJs<decltype(types.${v.name})>(rt, value.getProperty(rt, "${v.name}"), jsInvoker)`,
+  )
+  .join(',\n')}};
+    return result;
+  }
+
+#ifdef DEBUG
+${debugParameterConversion}
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+${value.properties
+  .map((v, i) => {
+    if (v.optional) {
+      return `    if (value.${v.name}) {
+      result.setProperty(rt, "${v.name}", bridging::toJs(rt, value.${v.name}.value(), jsInvoker));
+    }`;
+    } else {
+      return `    result.setProperty(rt, "${v.name}", bridging::toJs(rt, value.${v.name}, jsInvoker));`;
+    }
+  })
+  .join('\n')}
+    return result;
+  }
+};
+
+`;
+      })
+      .join('\n')
+  );
 }
 
 type NativeEnumMemberValueType = 'std::string' | 'int32_t' | 'float';

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -300,7 +300,7 @@ struct Bridging<SampleTurboModuleCxxStringEnum> {
 #pragma mark - SampleTurboModuleCxxBaseObjectAlias
 
 template <typename P0>
-struct SampleTurboModuleCxxBaseObjectAlias {
+struct [[deprecated(\\"Use SampleTurboModuleCxxObjectAlias instead.\\")]] SampleTurboModuleCxxBaseObjectAlias {
   P0 x;
   bool operator==(const SampleTurboModuleCxxBaseObjectAlias &other) const {
     return x == other.x;
@@ -308,7 +308,7 @@ struct SampleTurboModuleCxxBaseObjectAlias {
 };
 
 template <typename P0>
-struct SampleTurboModuleCxxBaseObjectAliasBridging {
+struct [[deprecated(\\"Use SampleTurboModuleCxxObjectAliasBridging instead.\\")]] SampleTurboModuleCxxBaseObjectAliasBridging {
   static SampleTurboModuleCxxBaseObjectAlias<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -327,6 +327,46 @@ struct SampleTurboModuleCxxBaseObjectAliasBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const SampleTurboModuleCxxBaseObjectAlias<P0> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"x\\", bridging::toJs(rt, value.x, jsInvoker));
+    return result;
+  }
+};
+
+
+#pragma mark - SampleTurboModuleCxxObjectAlias
+
+template <typename P0>
+struct SampleTurboModuleCxxObjectAlias {
+  P0 x;
+  bool operator==(const SampleTurboModuleCxxObjectAlias &other) const {
+    return x == other.x;
+  }
+};
+
+template <typename T>
+struct SampleTurboModuleCxxObjectAliasBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.x)>(rt, value.getProperty(rt, \\"x\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static double xToJs(jsi::Runtime &rt, decltype(types.x) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"x\\", bridging::toJs(rt, value.x, jsInvoker));
@@ -509,7 +549,7 @@ namespace react {
 #pragma mark - AliasTurboModuleBaseOptions
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct AliasTurboModuleBaseOptions {
+struct [[deprecated(\\"Use AliasTurboModuleOptions instead.\\")]] AliasTurboModuleBaseOptions {
   P0 offset;
   P1 size;
   P2 displaySize;
@@ -521,7 +561,7 @@ struct AliasTurboModuleBaseOptions {
 };
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct AliasTurboModuleBaseOptionsBridging {
+struct [[deprecated(\\"Use AliasTurboModuleOptionsBridging instead.\\")]] AliasTurboModuleBaseOptionsBridging {
   static AliasTurboModuleBaseOptions<P0, P1, P2, P3, P4> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -560,6 +600,80 @@ struct AliasTurboModuleBaseOptionsBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const AliasTurboModuleBaseOptions<P0, P1, P2, P3, P4> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"offset\\", bridging::toJs(rt, value.offset, jsInvoker));
+    result.setProperty(rt, \\"size\\", bridging::toJs(rt, value.size, jsInvoker));
+    if (value.displaySize) {
+      result.setProperty(rt, \\"displaySize\\", bridging::toJs(rt, value.displaySize.value(), jsInvoker));
+    }
+    if (value.resizeMode) {
+      result.setProperty(rt, \\"resizeMode\\", bridging::toJs(rt, value.resizeMode.value(), jsInvoker));
+    }
+    if (value.allowExternalStorage) {
+      result.setProperty(rt, \\"allowExternalStorage\\", bridging::toJs(rt, value.allowExternalStorage.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - AliasTurboModuleOptions
+
+template <typename P0, typename P1, typename P2, typename P3, typename P4>
+struct AliasTurboModuleOptions {
+  P0 offset;
+  P1 size;
+  P2 displaySize;
+  P3 resizeMode;
+  P4 allowExternalStorage;
+  bool operator==(const AliasTurboModuleOptions &other) const {
+    return offset == other.offset && size == other.size && displaySize == other.displaySize && resizeMode == other.resizeMode && allowExternalStorage == other.allowExternalStorage;
+  }
+};
+
+template <typename T>
+struct AliasTurboModuleOptionsBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.offset)>(rt, value.getProperty(rt, \\"offset\\"), jsInvoker),
+      bridging::fromJs<decltype(types.size)>(rt, value.getProperty(rt, \\"size\\"), jsInvoker),
+      bridging::fromJs<decltype(types.displaySize)>(rt, value.getProperty(rt, \\"displaySize\\"), jsInvoker),
+      bridging::fromJs<decltype(types.resizeMode)>(rt, value.getProperty(rt, \\"resizeMode\\"), jsInvoker),
+      bridging::fromJs<decltype(types.allowExternalStorage)>(rt, value.getProperty(rt, \\"allowExternalStorage\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::Object offsetToJs(jsi::Runtime &rt, decltype(types.offset) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::Object sizeToJs(jsi::Runtime &rt, decltype(types.size) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::Object displaySizeToJs(jsi::Runtime &rt, decltype(types.displaySize) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String resizeModeToJs(jsi::Runtime &rt, decltype(types.resizeMode) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static bool allowExternalStorageToJs(jsi::Runtime &rt, decltype(types.allowExternalStorage) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"offset\\", bridging::toJs(rt, value.offset, jsInvoker));
@@ -661,7 +775,7 @@ namespace react {
 #pragma mark - CameraRollManagerBasePhotoIdentifierImage
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
-struct CameraRollManagerBasePhotoIdentifierImage {
+struct [[deprecated(\\"Use CameraRollManagerPhotoIdentifierImage instead.\\")]] CameraRollManagerBasePhotoIdentifierImage {
   P0 uri;
   P1 playableDuration;
   P2 width;
@@ -674,7 +788,7 @@ struct CameraRollManagerBasePhotoIdentifierImage {
 };
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
-struct CameraRollManagerBasePhotoIdentifierImageBridging {
+struct [[deprecated(\\"Use CameraRollManagerPhotoIdentifierImageBridging instead.\\")]] CameraRollManagerBasePhotoIdentifierImageBridging {
   static CameraRollManagerBasePhotoIdentifierImage<P0, P1, P2, P3, P4, P5> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -737,7 +851,7 @@ struct CameraRollManagerBasePhotoIdentifierImageBridging {
 #pragma mark - CameraRollManagerBasePhotoIdentifier
 
 template <typename P0>
-struct CameraRollManagerBasePhotoIdentifier {
+struct [[deprecated(\\"Use CameraRollManagerPhotoIdentifier instead.\\")]] CameraRollManagerBasePhotoIdentifier {
   P0 node;
   bool operator==(const CameraRollManagerBasePhotoIdentifier &other) const {
     return node == other.node;
@@ -745,7 +859,7 @@ struct CameraRollManagerBasePhotoIdentifier {
 };
 
 template <typename P0>
-struct CameraRollManagerBasePhotoIdentifierBridging {
+struct [[deprecated(\\"Use CameraRollManagerPhotoIdentifierBridging instead.\\")]] CameraRollManagerBasePhotoIdentifierBridging {
   static CameraRollManagerBasePhotoIdentifier<P0> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -776,7 +890,7 @@ struct CameraRollManagerBasePhotoIdentifierBridging {
 #pragma mark - CameraRollManagerBasePhotoIdentifiersPage
 
 template <typename P0, typename P1>
-struct CameraRollManagerBasePhotoIdentifiersPage {
+struct [[deprecated(\\"Use CameraRollManagerPhotoIdentifiersPage instead.\\")]] CameraRollManagerBasePhotoIdentifiersPage {
   P0 edges;
   P1 page_info;
   bool operator==(const CameraRollManagerBasePhotoIdentifiersPage &other) const {
@@ -785,7 +899,7 @@ struct CameraRollManagerBasePhotoIdentifiersPage {
 };
 
 template <typename P0, typename P1>
-struct CameraRollManagerBasePhotoIdentifiersPageBridging {
+struct [[deprecated(\\"Use CameraRollManagerPhotoIdentifiersPageBridging instead.\\")]] CameraRollManagerBasePhotoIdentifiersPageBridging {
   static CameraRollManagerBasePhotoIdentifiersPage<P0, P1> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -822,7 +936,7 @@ struct CameraRollManagerBasePhotoIdentifiersPageBridging {
 #pragma mark - CameraRollManagerBaseGetPhotosParams
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
-struct CameraRollManagerBaseGetPhotosParams {
+struct [[deprecated(\\"Use CameraRollManagerGetPhotosParams instead.\\")]] CameraRollManagerBaseGetPhotosParams {
   P0 first;
   P1 after;
   P2 groupName;
@@ -836,7 +950,7 @@ struct CameraRollManagerBaseGetPhotosParams {
 };
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
-struct CameraRollManagerBaseGetPhotosParamsBridging {
+struct [[deprecated(\\"Use CameraRollManagerGetPhotosParamsBridging instead.\\")]] CameraRollManagerBaseGetPhotosParamsBridging {
   static CameraRollManagerBaseGetPhotosParams<P0, P1, P2, P3, P4, P5, P6> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -885,6 +999,267 @@ struct CameraRollManagerBaseGetPhotosParamsBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const CameraRollManagerBaseGetPhotosParams<P0, P1, P2, P3, P4, P5, P6> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"first\\", bridging::toJs(rt, value.first, jsInvoker));
+    if (value.after) {
+      result.setProperty(rt, \\"after\\", bridging::toJs(rt, value.after.value(), jsInvoker));
+    }
+    if (value.groupName) {
+      result.setProperty(rt, \\"groupName\\", bridging::toJs(rt, value.groupName.value(), jsInvoker));
+    }
+    if (value.groupTypes) {
+      result.setProperty(rt, \\"groupTypes\\", bridging::toJs(rt, value.groupTypes.value(), jsInvoker));
+    }
+    if (value.assetType) {
+      result.setProperty(rt, \\"assetType\\", bridging::toJs(rt, value.assetType.value(), jsInvoker));
+    }
+    if (value.maxSize) {
+      result.setProperty(rt, \\"maxSize\\", bridging::toJs(rt, value.maxSize.value(), jsInvoker));
+    }
+    if (value.mimeTypes) {
+      result.setProperty(rt, \\"mimeTypes\\", bridging::toJs(rt, value.mimeTypes.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - CameraRollManagerPhotoIdentifierImage
+
+template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
+struct CameraRollManagerPhotoIdentifierImage {
+  P0 uri;
+  P1 playableDuration;
+  P2 width;
+  P3 height;
+  P4 isStored;
+  P5 filename;
+  bool operator==(const CameraRollManagerPhotoIdentifierImage &other) const {
+    return uri == other.uri && playableDuration == other.playableDuration && width == other.width && height == other.height && isStored == other.isStored && filename == other.filename;
+  }
+};
+
+template <typename T>
+struct CameraRollManagerPhotoIdentifierImageBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.uri)>(rt, value.getProperty(rt, \\"uri\\"), jsInvoker),
+      bridging::fromJs<decltype(types.playableDuration)>(rt, value.getProperty(rt, \\"playableDuration\\"), jsInvoker),
+      bridging::fromJs<decltype(types.width)>(rt, value.getProperty(rt, \\"width\\"), jsInvoker),
+      bridging::fromJs<decltype(types.height)>(rt, value.getProperty(rt, \\"height\\"), jsInvoker),
+      bridging::fromJs<decltype(types.isStored)>(rt, value.getProperty(rt, \\"isStored\\"), jsInvoker),
+      bridging::fromJs<decltype(types.filename)>(rt, value.getProperty(rt, \\"filename\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String uriToJs(jsi::Runtime &rt, decltype(types.uri) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static double playableDurationToJs(jsi::Runtime &rt, decltype(types.playableDuration) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static double widthToJs(jsi::Runtime &rt, decltype(types.width) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static double heightToJs(jsi::Runtime &rt, decltype(types.height) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static bool isStoredToJs(jsi::Runtime &rt, decltype(types.isStored) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String filenameToJs(jsi::Runtime &rt, decltype(types.filename) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"uri\\", bridging::toJs(rt, value.uri, jsInvoker));
+    result.setProperty(rt, \\"playableDuration\\", bridging::toJs(rt, value.playableDuration, jsInvoker));
+    result.setProperty(rt, \\"width\\", bridging::toJs(rt, value.width, jsInvoker));
+    result.setProperty(rt, \\"height\\", bridging::toJs(rt, value.height, jsInvoker));
+    if (value.isStored) {
+      result.setProperty(rt, \\"isStored\\", bridging::toJs(rt, value.isStored.value(), jsInvoker));
+    }
+    result.setProperty(rt, \\"filename\\", bridging::toJs(rt, value.filename, jsInvoker));
+    return result;
+  }
+};
+
+
+
+#pragma mark - CameraRollManagerPhotoIdentifier
+
+template <typename P0>
+struct CameraRollManagerPhotoIdentifier {
+  P0 node;
+  bool operator==(const CameraRollManagerPhotoIdentifier &other) const {
+    return node == other.node;
+  }
+};
+
+template <typename T>
+struct CameraRollManagerPhotoIdentifierBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.node)>(rt, value.getProperty(rt, \\"node\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::Object nodeToJs(jsi::Runtime &rt, decltype(types.node) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"node\\", bridging::toJs(rt, value.node, jsInvoker));
+    return result;
+  }
+};
+
+
+
+#pragma mark - CameraRollManagerPhotoIdentifiersPage
+
+template <typename P0, typename P1>
+struct CameraRollManagerPhotoIdentifiersPage {
+  P0 edges;
+  P1 page_info;
+  bool operator==(const CameraRollManagerPhotoIdentifiersPage &other) const {
+    return edges == other.edges && page_info == other.page_info;
+  }
+};
+
+template <typename T>
+struct CameraRollManagerPhotoIdentifiersPageBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.edges)>(rt, value.getProperty(rt, \\"edges\\"), jsInvoker),
+      bridging::fromJs<decltype(types.page_info)>(rt, value.getProperty(rt, \\"page_info\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::Array edgesToJs(jsi::Runtime &rt, decltype(types.edges) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::Object page_infoToJs(jsi::Runtime &rt, decltype(types.page_info) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"edges\\", bridging::toJs(rt, value.edges, jsInvoker));
+    result.setProperty(rt, \\"page_info\\", bridging::toJs(rt, value.page_info, jsInvoker));
+    return result;
+  }
+};
+
+
+
+#pragma mark - CameraRollManagerGetPhotosParams
+
+template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
+struct CameraRollManagerGetPhotosParams {
+  P0 first;
+  P1 after;
+  P2 groupName;
+  P3 groupTypes;
+  P4 assetType;
+  P5 maxSize;
+  P6 mimeTypes;
+  bool operator==(const CameraRollManagerGetPhotosParams &other) const {
+    return first == other.first && after == other.after && groupName == other.groupName && groupTypes == other.groupTypes && assetType == other.assetType && maxSize == other.maxSize && mimeTypes == other.mimeTypes;
+  }
+};
+
+template <typename T>
+struct CameraRollManagerGetPhotosParamsBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.first)>(rt, value.getProperty(rt, \\"first\\"), jsInvoker),
+      bridging::fromJs<decltype(types.after)>(rt, value.getProperty(rt, \\"after\\"), jsInvoker),
+      bridging::fromJs<decltype(types.groupName)>(rt, value.getProperty(rt, \\"groupName\\"), jsInvoker),
+      bridging::fromJs<decltype(types.groupTypes)>(rt, value.getProperty(rt, \\"groupTypes\\"), jsInvoker),
+      bridging::fromJs<decltype(types.assetType)>(rt, value.getProperty(rt, \\"assetType\\"), jsInvoker),
+      bridging::fromJs<decltype(types.maxSize)>(rt, value.getProperty(rt, \\"maxSize\\"), jsInvoker),
+      bridging::fromJs<decltype(types.mimeTypes)>(rt, value.getProperty(rt, \\"mimeTypes\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static double firstToJs(jsi::Runtime &rt, decltype(types.first) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String afterToJs(jsi::Runtime &rt, decltype(types.after) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String groupNameToJs(jsi::Runtime &rt, decltype(types.groupName) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String groupTypesToJs(jsi::Runtime &rt, decltype(types.groupTypes) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String assetTypeToJs(jsi::Runtime &rt, decltype(types.assetType) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static double maxSizeToJs(jsi::Runtime &rt, decltype(types.maxSize) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::Array mimeTypesToJs(jsi::Runtime &rt, decltype(types.mimeTypes) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"first\\", bridging::toJs(rt, value.first, jsInvoker));
@@ -987,7 +1362,7 @@ private:
 #pragma mark - ExceptionsManagerBaseStackFrame
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct ExceptionsManagerBaseStackFrame {
+struct [[deprecated(\\"Use ExceptionsManagerStackFrame instead.\\")]] ExceptionsManagerBaseStackFrame {
   P0 column;
   P1 file;
   P2 lineNumber;
@@ -999,7 +1374,7 @@ struct ExceptionsManagerBaseStackFrame {
 };
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct ExceptionsManagerBaseStackFrameBridging {
+struct [[deprecated(\\"Use ExceptionsManagerStackFrameBridging instead.\\")]] ExceptionsManagerBaseStackFrameBridging {
   static ExceptionsManagerBaseStackFrame<P0, P1, P2, P3, P4> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -1060,7 +1435,7 @@ struct ExceptionsManagerBaseStackFrameBridging {
 #pragma mark - ExceptionsManagerBaseExceptionData
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
-struct ExceptionsManagerBaseExceptionData {
+struct [[deprecated(\\"Use ExceptionsManagerExceptionData instead.\\")]] ExceptionsManagerBaseExceptionData {
   P0 message;
   P1 originalMessage;
   P2 name;
@@ -1075,7 +1450,7 @@ struct ExceptionsManagerBaseExceptionData {
 };
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
-struct ExceptionsManagerBaseExceptionDataBridging {
+struct [[deprecated(\\"Use ExceptionsManagerExceptionDataBridging instead.\\")]] ExceptionsManagerBaseExceptionDataBridging {
   static ExceptionsManagerBaseExceptionData<P0, P1, P2, P3, P4, P5, P6, P7> fromJs(
       jsi::Runtime &rt,
       const jsi::Object &value,
@@ -1129,6 +1504,172 @@ struct ExceptionsManagerBaseExceptionDataBridging {
   static jsi::Object toJs(
       jsi::Runtime &rt,
       const ExceptionsManagerBaseExceptionData<P0, P1, P2, P3, P4, P5, P6, P7> &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    result.setProperty(rt, \\"message\\", bridging::toJs(rt, value.message, jsInvoker));
+    result.setProperty(rt, \\"originalMessage\\", bridging::toJs(rt, value.originalMessage, jsInvoker));
+    result.setProperty(rt, \\"name\\", bridging::toJs(rt, value.name, jsInvoker));
+    result.setProperty(rt, \\"componentStack\\", bridging::toJs(rt, value.componentStack, jsInvoker));
+    result.setProperty(rt, \\"stack\\", bridging::toJs(rt, value.stack, jsInvoker));
+    result.setProperty(rt, \\"id\\", bridging::toJs(rt, value.id, jsInvoker));
+    result.setProperty(rt, \\"isFatal\\", bridging::toJs(rt, value.isFatal, jsInvoker));
+    if (value.extraData) {
+      result.setProperty(rt, \\"extraData\\", bridging::toJs(rt, value.extraData.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+#pragma mark - ExceptionsManagerStackFrame
+
+template <typename P0, typename P1, typename P2, typename P3, typename P4>
+struct ExceptionsManagerStackFrame {
+  P0 column;
+  P1 file;
+  P2 lineNumber;
+  P3 methodName;
+  P4 collapse;
+  bool operator==(const ExceptionsManagerStackFrame &other) const {
+    return column == other.column && file == other.file && lineNumber == other.lineNumber && methodName == other.methodName && collapse == other.collapse;
+  }
+};
+
+template <typename T>
+struct ExceptionsManagerStackFrameBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.column)>(rt, value.getProperty(rt, \\"column\\"), jsInvoker),
+      bridging::fromJs<decltype(types.file)>(rt, value.getProperty(rt, \\"file\\"), jsInvoker),
+      bridging::fromJs<decltype(types.lineNumber)>(rt, value.getProperty(rt, \\"lineNumber\\"), jsInvoker),
+      bridging::fromJs<decltype(types.methodName)>(rt, value.getProperty(rt, \\"methodName\\"), jsInvoker),
+      bridging::fromJs<decltype(types.collapse)>(rt, value.getProperty(rt, \\"collapse\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static double columnToJs(jsi::Runtime &rt, decltype(types.column) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String fileToJs(jsi::Runtime &rt, decltype(types.file) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static double lineNumberToJs(jsi::Runtime &rt, decltype(types.lineNumber) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String methodNameToJs(jsi::Runtime &rt, decltype(types.methodName) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static bool collapseToJs(jsi::Runtime &rt, decltype(types.collapse) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    auto result = facebook::jsi::Object(rt);
+    if (value.column) {
+      result.setProperty(rt, \\"column\\", bridging::toJs(rt, value.column.value(), jsInvoker));
+    }
+    result.setProperty(rt, \\"file\\", bridging::toJs(rt, value.file, jsInvoker));
+    if (value.lineNumber) {
+      result.setProperty(rt, \\"lineNumber\\", bridging::toJs(rt, value.lineNumber.value(), jsInvoker));
+    }
+    result.setProperty(rt, \\"methodName\\", bridging::toJs(rt, value.methodName, jsInvoker));
+    if (value.collapse) {
+      result.setProperty(rt, \\"collapse\\", bridging::toJs(rt, value.collapse.value(), jsInvoker));
+    }
+    return result;
+  }
+};
+
+
+
+#pragma mark - ExceptionsManagerExceptionData
+
+template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
+struct ExceptionsManagerExceptionData {
+  P0 message;
+  P1 originalMessage;
+  P2 name;
+  P3 componentStack;
+  P4 stack;
+  P5 id;
+  P6 isFatal;
+  P7 extraData;
+  bool operator==(const ExceptionsManagerExceptionData &other) const {
+    return message == other.message && originalMessage == other.originalMessage && name == other.name && componentStack == other.componentStack && stack == other.stack && id == other.id && isFatal == other.isFatal && extraData == other.extraData;
+  }
+};
+
+template <typename T>
+struct ExceptionsManagerExceptionDataBridging {
+  static T types;
+
+  static T fromJs(
+      jsi::Runtime &rt,
+      const jsi::Object &value,
+      const std::shared_ptr<CallInvoker> &jsInvoker) {
+    T result{
+      bridging::fromJs<decltype(types.message)>(rt, value.getProperty(rt, \\"message\\"), jsInvoker),
+      bridging::fromJs<decltype(types.originalMessage)>(rt, value.getProperty(rt, \\"originalMessage\\"), jsInvoker),
+      bridging::fromJs<decltype(types.name)>(rt, value.getProperty(rt, \\"name\\"), jsInvoker),
+      bridging::fromJs<decltype(types.componentStack)>(rt, value.getProperty(rt, \\"componentStack\\"), jsInvoker),
+      bridging::fromJs<decltype(types.stack)>(rt, value.getProperty(rt, \\"stack\\"), jsInvoker),
+      bridging::fromJs<decltype(types.id)>(rt, value.getProperty(rt, \\"id\\"), jsInvoker),
+      bridging::fromJs<decltype(types.isFatal)>(rt, value.getProperty(rt, \\"isFatal\\"), jsInvoker),
+      bridging::fromJs<decltype(types.extraData)>(rt, value.getProperty(rt, \\"extraData\\"), jsInvoker)};
+    return result;
+  }
+
+#ifdef DEBUG
+  static jsi::String messageToJs(jsi::Runtime &rt, decltype(types.message) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String originalMessageToJs(jsi::Runtime &rt, decltype(types.originalMessage) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String nameToJs(jsi::Runtime &rt, decltype(types.name) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::String componentStackToJs(jsi::Runtime &rt, decltype(types.componentStack) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::Array stackToJs(jsi::Runtime &rt, decltype(types.stack) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static double idToJs(jsi::Runtime &rt, decltype(types.id) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static bool isFatalToJs(jsi::Runtime &rt, decltype(types.isFatal) value) {
+    return bridging::toJs(rt, value);
+  }
+
+  static jsi::Object extraDataToJs(jsi::Runtime &rt, decltype(types.extraData) value) {
+    return bridging::toJs(rt, value);
+  }
+#endif
+
+  static jsi::Object toJs(
+      jsi::Runtime &rt,
+      const T &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     auto result = facebook::jsi::Object(rt);
     result.setProperty(rt, \\"message\\", bridging::toJs(rt, value.message, jsInvoker));

--- a/packages/react-native/Libraries/IntersectionObserver/NativeIntersectionObserver.h
+++ b/packages/react-native/Libraries/IntersectionObserver/NativeIntersectionObserver.h
@@ -20,7 +20,7 @@ using NativeIntersectionObserverIntersectionObserverId = int32_t;
 using RectAsTuple = std::tuple<Float, Float, Float, Float>;
 
 using NativeIntersectionObserverObserveOptions =
-    NativeIntersectionObserverCxxBaseNativeIntersectionObserverObserveOptions<
+    NativeIntersectionObserverCxxNativeIntersectionObserverObserveOptions<
         // intersectionObserverId
         NativeIntersectionObserverIntersectionObserverId,
         // targetShadowNode
@@ -30,16 +30,11 @@ using NativeIntersectionObserverObserveOptions =
 
 template <>
 struct Bridging<NativeIntersectionObserverObserveOptions>
-    : NativeIntersectionObserverCxxBaseNativeIntersectionObserverObserveOptionsBridging<
-          // intersectionObserverId
-          NativeIntersectionObserverIntersectionObserverId,
-          // targetShadowNode
-          jsi::Object,
-          // thresholds
-          std::vector<Float>> {};
+    : NativeIntersectionObserverCxxNativeIntersectionObserverObserveOptionsBridging<
+          NativeIntersectionObserverObserveOptions> {};
 
 using NativeIntersectionObserverEntry =
-    NativeIntersectionObserverCxxBaseNativeIntersectionObserverEntry<
+    NativeIntersectionObserverCxxNativeIntersectionObserverEntry<
         // intersectionObserverId
         NativeIntersectionObserverIntersectionObserverId,
         // targetInstanceHandle
@@ -57,21 +52,8 @@ using NativeIntersectionObserverEntry =
 
 template <>
 struct Bridging<NativeIntersectionObserverEntry>
-    : NativeIntersectionObserverCxxBaseNativeIntersectionObserverEntryBridging<
-          // intersectionObserverId
-          NativeIntersectionObserverIntersectionObserverId,
-          // targetInstanceHandle
-          jsi::Value,
-          // targetRect
-          RectAsTuple,
-          // rootRect
-          RectAsTuple,
-          // intersectionRect
-          std::optional<RectAsTuple>,
-          // isIntersectingAboveThresholds
-          bool,
-          // time
-          double> {};
+    : NativeIntersectionObserverCxxNativeIntersectionObserverEntryBridging<
+          NativeIntersectionObserverEntry> {};
 
 class NativeIntersectionObserver
     : public NativeIntersectionObserverCxxSpec<NativeIntersectionObserver>,

--- a/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.h
+++ b/packages/react-native/Libraries/MutationObserver/NativeMutationObserver.h
@@ -17,7 +17,7 @@
 namespace facebook::react {
 
 using NativeMutationObserverObserveOptions =
-    NativeMutationObserverCxxBaseNativeMutationObserverObserveOptions<
+    NativeMutationObserverCxxNativeMutationObserverObserveOptions<
         // mutationObserverId
         MutationObserverId,
         // targetShadowNode
@@ -27,15 +27,10 @@ using NativeMutationObserverObserveOptions =
 
 template <>
 struct Bridging<NativeMutationObserverObserveOptions>
-    : NativeMutationObserverCxxBaseNativeMutationObserverObserveOptionsBridging<
-          // mutationObserverId
-          MutationObserverId,
-          // targetShadowNode
-          jsi::Object,
-          // subtree
-          bool> {};
+    : NativeMutationObserverCxxNativeMutationObserverObserveOptionsBridging<
+          NativeMutationObserverObserveOptions> {};
 
-using NativeMutationRecord = NativeMutationObserverCxxBaseNativeMutationRecord<
+using NativeMutationRecord = NativeMutationObserverCxxNativeMutationRecord<
     // mutationObserverId
     MutationObserverId,
     // target
@@ -47,15 +42,8 @@ using NativeMutationRecord = NativeMutationObserverCxxBaseNativeMutationRecord<
 
 template <>
 struct Bridging<NativeMutationRecord>
-    : NativeMutationObserverCxxBaseNativeMutationRecordBridging<
-          // mutationObserverId
-          MutationObserverId,
-          // target
-          jsi::Value,
-          // addedNodes
-          std::vector<jsi::Value>,
-          // removedNodes
-          std::vector<jsi::Value>> {};
+    : NativeMutationObserverCxxNativeMutationRecordBridging<
+          NativeMutationRecord> {};
 
 class NativeMutationObserver
     : public NativeMutationObserverCxxSpec<NativeMutationObserver>,

--- a/packages/react-native/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -20,7 +20,7 @@ class PerformanceEntryReporter;
 
 using RawPerformanceEntryType = int32_t;
 
-using RawPerformanceEntry = NativePerformanceObserverCxxBaseRawPerformanceEntry<
+using RawPerformanceEntry = NativePerformanceObserverCxxRawPerformanceEntry<
     std::string,
     RawPerformanceEntryType,
     double,
@@ -32,25 +32,18 @@ using RawPerformanceEntry = NativePerformanceObserverCxxBaseRawPerformanceEntry<
 
 template <>
 struct Bridging<RawPerformanceEntry>
-    : NativePerformanceObserverCxxBaseRawPerformanceEntryBridging<
-          std::string,
-          RawPerformanceEntryType,
-          double,
-          double,
-          std::optional<double>,
-          std::optional<double>,
-          std::optional<uint32_t>> {};
+    : NativePerformanceObserverCxxRawPerformanceEntryBridging<
+          RawPerformanceEntry> {};
 
 using GetPendingEntriesResult =
-    NativePerformanceObserverCxxBaseGetPendingEntriesResult<
+    NativePerformanceObserverCxxGetPendingEntriesResult<
         std::vector<RawPerformanceEntry>,
         uint32_t>;
 
 template <>
 struct Bridging<GetPendingEntriesResult>
-    : NativePerformanceObserverCxxBaseGetPendingEntriesResultBridging<
-          std::vector<RawPerformanceEntry>,
-          uint32_t> {};
+    : NativePerformanceObserverCxxGetPendingEntriesResultBridging<
+          GetPendingEntriesResult> {};
 
 #pragma mark - implementation
 

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -24,35 +24,27 @@ namespace facebook::react {
 
 #pragma mark - Structs
 using ConstantsStruct =
-    NativeCxxModuleExampleCxxBaseConstantsStruct<bool, int32_t, std::string>;
+    NativeCxxModuleExampleCxxConstantsStruct<bool, int32_t, std::string>;
 
 template <>
 struct Bridging<ConstantsStruct>
-    : NativeCxxModuleExampleCxxBaseConstantsStructBridging<
-          bool,
-          int32_t,
-          std::string> {};
+    : NativeCxxModuleExampleCxxConstantsStructBridging<ConstantsStruct> {};
 
-using ObjectStruct = NativeCxxModuleExampleCxxBaseObjectStruct<
+using ObjectStruct = NativeCxxModuleExampleCxxObjectStruct<
     int32_t,
     std::string,
     std::optional<std::string>>;
 
 template <>
 struct Bridging<ObjectStruct>
-    : NativeCxxModuleExampleCxxBaseObjectStructBridging<
-          int32_t,
-          std::string,
-          std::optional<std::string>> {};
+    : NativeCxxModuleExampleCxxObjectStructBridging<ObjectStruct> {};
 
 using ValueStruct =
-    NativeCxxModuleExampleCxxBaseValueStruct<double, std::string, ObjectStruct>;
+    NativeCxxModuleExampleCxxValueStruct<double, std::string, ObjectStruct>;
 
 template <>
-struct Bridging<ValueStruct> : NativeCxxModuleExampleCxxBaseValueStructBridging<
-                                   double,
-                                   std::string,
-                                   ObjectStruct> {};
+struct Bridging<ValueStruct>
+    : NativeCxxModuleExampleCxxValueStructBridging<ValueStruct> {};
 
 #pragma mark - enums
 enum CustomEnumInt { A = 23, B = 42 };


### PR DESCRIPTION
Summary:
Right now, when defining concrete structs and Bridging headers for Cxx TMs we need to define their member types twice:
```
using ConstantsStruct =
    NativeCxxModuleExampleCxxBaseConstantsStruct<bool, int32_t, std::string>;

template <>
struct Bridging<ConstantsStruct>
    : NativeCxxModuleExampleCxxBaseConstantsStructBridging<
          bool,
          int32_t,
          std::string> {};
```
Now we only need to define those once
```
using ConstantsStruct =
    NativeCxxModuleExampleCxxConstantsStruct<bool, int32_t, std::string>;

template <>
struct Bridging<ConstantsStruct>
    : NativeCxxModuleExampleCxxConstantsStructBridging<ConstantsStruct> {};
```

This change keeps the existing base types untouched - but they will be removed in the next RN version.

Changelog: [Internal]

Differential Revision: D51571453


