### PR TITLE
Fix Binding JNI type

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -161,7 +161,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     FabricSoLoader.staticInit();
   }
 
-  @Nullable private Binding mBinding;
+  @Nullable private BindingImpl mBinding;
   @NonNull private final ReactApplicationContext mReactApplicationContext;
   @NonNull private final MountingManager mMountingManager;
   @NonNull private final EventDispatcher mEventDispatcher;
@@ -834,7 +834,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     }
   }
 
-  public void setBinding(Binding binding) {
+  public void setBinding(BindingImpl binding) {
     mBinding = binding;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -161,7 +161,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     FabricSoLoader.staticInit();
   }
 
-  @Nullable private BindingImpl mBinding;
+  @Nullable private Binding mBinding;
   @NonNull private final ReactApplicationContext mReactApplicationContext;
   @NonNull private final MountingManager mMountingManager;
   @NonNull private final EventDispatcher mEventDispatcher;
@@ -834,7 +834,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     }
   }
 
-  public void setBinding(BindingImpl binding) {
+  public void setBinding(Binding binding) {
     mBinding = binding;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -34,6 +34,11 @@ class ReactNativeConfig;
 class Scheduler;
 class SurfaceHandlerBinding;
 
+struct JBinding : public jni::JavaClass<JBinding> {
+    constexpr static auto kJavaDescriptor =
+            "Lcom/facebook/react/fabric/Binding;";
+};
+
 class Binding : public jni::HybridClass<Binding>,
                 public SchedulerDelegate,
                 public LayoutAnimationStatusDelegate {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -39,7 +39,7 @@ struct JBinding : public jni::JavaClass<JBinding> {
             "Lcom/facebook/react/fabric/Binding;";
 };
 
-class Binding : public jni::HybridClass<Binding>,
+class Binding : public jni::HybridClass<Binding, JBinding>,
                 public SchedulerDelegate,
                 public LayoutAnimationStatusDelegate {
  public:

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JFabricUIManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JFabricUIManager.cpp
@@ -13,8 +13,8 @@ namespace facebook::react {
 
 Binding* JFabricUIManager::getBinding() {
   static const auto bindingField =
-      javaClassStatic()->getField<Binding::javaobject>("mBinding");
+      javaClassStatic()->getField<JBinding::javaobject>("mBinding");
 
-  return getFieldValue(bindingField)->cthis();
+  return jni::static_ref_cast<Binding::javaobject>(getFieldValue(bindingField))->cthis();
 }
 } // namespace facebook::react


### PR DESCRIPTION
## Summary:

New implementation:
This PR adds cast from interface Binding to BindingImpl class.

Previous implementation: 
The changes made in this PR make the `mBinding` field of `FabricUIManager` visible for JNI. 

Without these changes, calling the method `JFabricUIManager::getBinding()` would result in an error.

<img width="400" alt="Screenshot 2023-11-27 at 13 55 44" src="https://github.com/facebook/react-native/assets/36106620/04418291-8ce8-4bae-b16c-29a5c9f2ee52">

In the `react-native-reanimated` library, we utilize `JFabricUIManager::getBinding()`, and we have noticed this issue since version 0.73. This isn't perfect solution, but I'm not certain which change in RN or FBJNI is the source of the problem. If there are any alternative solutions worth considering, I am open to discussing them.

Usage of `getBinding()` in Reanimated:
https://github.com/software-mansion/react-native-reanimated/blob/main/android/src/main/cpp/NativeProxy.cpp#L57

## Changelog:

[ANDROID] [FIXED] - Fix type for unrecognisable field mBinding

## Test Plan:

Just call `JFabricUIManager::getBinding` method (https://github.com/facebook/react-native/blob/v0.73.0-rc.5/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JFabricUIManager.cpp#L14)

or run app with repro:
https://github.com/piaskowyk/missing-mBinding-repro
after the app lunch you will receive error from above screenshot.

Co-author: @tomekzaw 
