### PR TITLE
Add support for resolving custom platform variant

### DIFF
--- a/packages/community-cli-plugin/src/utils/__tests__/metroPlatformResolver-test.js
+++ b/packages/community-cli-plugin/src/utils/__tests__/metroPlatformResolver-test.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {CustomResolutionContext} from 'metro-resolver/src/types';
+
+import {reactNativePlatformResolver} from '../metroPlatformResolver';
+
+jest.dontMock('../metroPlatformResolver');
+
+describe('reactNativePlatformResolver', () => {
+  let resolveRequest = jest.fn();
+  let metroContextMock: Partial<{...CustomResolutionContext}> = {
+    customResolverOptions: {},
+    resolveRequest,
+  };
+  beforeEach(() => {
+    resolveRequest.mockReset();
+  });
+
+  test('forwards non react-native module', () => {
+    reactNativePlatformResolver({visionos: 'react-native-visionos'})(
+      // $FlowFixMe[incompatible-call]
+      metroContextMock,
+      'module-name',
+      'ios',
+    );
+
+    expect(resolveRequest).toHaveBeenCalledWith(
+      metroContextMock,
+      'module-name',
+      'ios',
+    );
+  });
+
+  test('rewrites react-native module to out-of-tree platform "macos"', () => {
+    reactNativePlatformResolver({macos: 'react-native-macos'})(
+      // $FlowFixMe[incompatible-call]
+      metroContextMock,
+      'react-native',
+      'macos',
+    );
+
+    expect(resolveRequest).toHaveBeenCalledWith(
+      metroContextMock,
+      'react-native-macos',
+      'macos',
+    );
+  });
+
+  test('rewrites internal react-native/Libraries/Utilities/Platform path to out-of-tree platform "macos"', () => {
+    reactNativePlatformResolver({macos: 'react-native-macos'})(
+      // $FlowFixMe[incompatible-call]
+      metroContextMock,
+      'react-native/Libraries/Utilities/Platform',
+      'macos',
+    );
+
+    expect(resolveRequest).toHaveBeenCalledWith(
+      metroContextMock,
+      'react-native-macos/Libraries/Utilities/Platform',
+      'macos',
+    );
+  });
+
+  test('rewrites react-native module to out-of-tree variant "visionos" based on "ios" platform', () => {
+    const metroContextMockWithVariant: Partial<{...CustomResolutionContext}> = {
+      ...metroContextMock,
+      customResolverOptions: {variant: 'visionos'},
+    };
+    reactNativePlatformResolver({visionos: 'react-native-visionos'})(
+      // $FlowFixMe[incompatible-call]
+      metroContextMockWithVariant,
+      'react-native',
+      'ios',
+    );
+
+    expect(resolveRequest).toHaveBeenCalledWith(
+      metroContextMockWithVariant,
+      'react-native-visionos',
+      'ios',
+    );
+  });
+
+  test('rewrites internal react-native/Libraries/Utilities/Platform path to out-of-tree variant "visionos" based on "ios" platform', () => {
+    const metroContextMockWithVariant: Partial<{...CustomResolutionContext}> = {
+      ...metroContextMock,
+      customResolverOptions: {variant: 'visionos'},
+    };
+    reactNativePlatformResolver({visionos: 'react-native-visionos'})(
+      // $FlowFixMe[incompatible-call]
+      metroContextMockWithVariant,
+      'react-native/Libraries/Utilities/Platform',
+      'ios',
+    );
+
+    expect(resolveRequest).toHaveBeenCalledWith(
+      metroContextMockWithVariant,
+      'react-native-visionos/Libraries/Utilities/Platform',
+      'ios',
+    );
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

For out-of-tree platforms that share most of the code with some base platform (like visionOS is based on iOS) the current `Platform` abstraction doesn't fit nicely. Making "visionos" a distinct platform would mean we couldn't leverage from all the community code hidden behind `Platform.OS === "ios"` checks.

Building on top of existing Metro infrastructure (namely [`customResolverOptions`](https://metrobundler.dev/docs/resolution/#customresolveroptions-string-mixed)), we'd like to propose a concept of a "Platform variant". Variant serves two purposes:
1. This PR: allows OOT platforms to properly resolve calls to `react-native` module, while not making them a de-facto platform. Would apply to `react-native-visionos` proxying `react-native` -> `react-native-visionos`. 
   
   It would also help the `react-native-tvos` platform as well to avoid [remapping in package.json: `"react-native": "npm:react-native-tvos@latest",`](https://github.com/react-native-tvos/react-native-tvos#react-native-tvos).
3. Future proposal: allows extending custom out-of-tree platform resolver to resolve: 
   `File.{platform}.{variant}.js` -> `File.{platform}.js` -> `File.js`

This change originates from visionOS fork: https://github.com/callstack/react-native-visionos/pull/32

## Changelog:

[GENERAL] [ADDED] - Add support for resolving custom platform variant

## Test Plan:

Added a unit test for `metroPlatformResolver` to illustrate the change
