### PR TITLE
AGP to 8.1.4

### DIFF
--- a/packages/react-native-gradle-plugin/gradle/libs.versions.toml
+++ b/packages/react-native-gradle-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.1.1"
+agp = "8.1.4"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ targetSdk = "34"
 compileSdk = "34"
 buildTools = "34.0.0"
 # Dependencies versions
-agp = "8.1.2"
+agp = "8.1.4"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.6.1"
 androidx-autofill = "1.1.0"


### PR DESCRIPTION
Summary:
This bumps AGP to the latest bugfix version

Changelog:
[Internal] [Changed] - AGP to 8.1.4

Differential Revision: D51589071


