### PR TITLE
[iOS] Move ActionSheet UI operation to main thread

### DIFF
--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -100,9 +100,9 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
       [RCTConvert UIColor:options.cancelButtonTintColor() ? @(*options.cancelButtonTintColor()) : nil];
   NSString *userInterfaceStyle = [RCTConvert NSString:options.userInterfaceStyle()];
 
-  UIViewController *controller = RCTPresentedViewController();
-
   dispatch_async(dispatch_get_main_queue(), ^{
+    UIViewController *controller = RCTPresentedViewController();
+
     if (controller == nil) {
       RCTLogError(
           @"Tried to display action sheet but there is no application window. options: %@", @{


### PR DESCRIPTION
## Summary:
Fixes UI operation not on the main thread.
![image](https://github.com/facebook/react-native/assets/5061845/276f7e9c-dcf8-4ba1-af2d-c9fa990d41a1)

![image](https://github.com/facebook/react-native/assets/5061845/cfe85921-3cc9-4f32-b794-a6a8bc00ee1d)

## Changelog:

[IOS] [FIXED] - Move ActionSheet UI operation to main thread

## Test Plan:

None.
