### PR TITLE
Make sure that third party libraries include Fabric code

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -19,10 +19,10 @@ end
 folly_flags = ' -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1'
 folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
 
-is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+is_new_arch_enabled = ENV["USE_NEW_ARCH"] == "1"
 use_hermes =  ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
-new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
+new_arch_enabled_flag = (is_new_arch_enabled ? " -DUSE_NEW_ARCH" : "")
 is_fabric_enabled = is_new_arch_enabled || ENV["RCT_FABRIC_ENABLED"]
 hermes_flag = (use_hermes ? " -DUSE_HERMES" : "")
 other_cflags = "$(inherited)" + folly_flags + new_arch_enabled_flag + hermes_flag

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -93,9 +93,10 @@ def use_react_native! (
   # Better to rely and enable this environment flag if the new architecture is turned on using flags.
   relative_path_from_current = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
   react_native_version = NewArchitectureHelper.extract_react_native_version(File.join(relative_path_from_current, path))
-  ENV['RCT_NEW_ARCH_ENABLED'] = NewArchitectureHelper.compute_new_arch_enabled(new_arch_enabled, react_native_version)
-
+  ENV['USE_NEW_ARCH'] = NewArchitectureHelper.compute_new_arch_enabled(new_arch_enabled, react_native_version)
   fabric_enabled = fabric_enabled || NewArchitectureHelper.new_arch_enabled
+
+  ENV['RCT_NEW_ARCH_ENABLED'] = "1"
   ENV['RCT_FABRIC_ENABLED'] = fabric_enabled ? "1" : "0"
   ENV['USE_HERMES'] = hermes_enabled ? "1" : "0"
 


### PR DESCRIPTION
Summary:
In some previous changes ([a607692](https://github.com/facebook/react-native/commit/a6076924bf43dff6cf4d38d51df279edba3882d0) and [6b53205](https://github.com/facebook/react-native/commit/6b5320540adfe16803ef41353f23115d08819309)) we make sure to always include all the pods (including Fabric) and we unify codegen to run in the same way on both architectures.
While doing so, we enabled codegen to run on libraries tat already migrated to Fabric.
These makes those libraries to fail when building as they were not including the Fabric code when the New Architecture is disabled.

This change will make sue that the code is always included, thus the library should always build, and it also make sure that we can control the New/Old Architecture at build time.

## Changelog
[iOS][Changed] - Make sure that libraries always include Fabric code also in the old architecture

Differential Revision: D51617542


