### PR TITLE
add back ComponentDescriptor::adopt with shared_ptr

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -151,6 +151,23 @@ class ComponentDescriptor {
    * `ModalHostViewComponentDescriptor`.
    */
   virtual void adopt(ShadowNode& shadowNode) const = 0;
+
+  /*
+   * Called immediately after `ShadowNode` is created, cloned or state is
+   * progressed using clonesless state progression (not fully shipped yet).
+   *
+   * Override this method to pass information from custom `ComponentDescriptor`
+   * to new instance of `ShadowNode`.
+   *
+   * Example usages:
+   *   - Inject image manager to `ImageShadowNode` in
+   * `ImageComponentDescriptor`.
+   *   - Set `ShadowNode`'s size from state in
+   * `ModalHostViewComponentDescriptor`.
+   */
+  [[deprecated(
+      "Use overload `adopt` passing in a reference to ShadowNode, do not implement both versions of adopt")]] virtual void
+  adopt(const ShadowNode::Unshared& shadowNode) const = 0;
 };
 
 /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -70,6 +70,10 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
         std::make_shared<ShadowNodeT>(fragment, family, getTraits());
 
     adopt(*shadowNode);
+    // adopt(const ShadowNode::Unshared&) is deprecated
+    // but we need to keep calling it for now until all callsites have been
+    // migrated to use adopt(ShadowNode&)
+    adopt(shadowNode);
 
     return shadowNode;
   }
@@ -80,6 +84,11 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     auto shadowNode = std::make_shared<ShadowNodeT>(sourceShadowNode, fragment);
 
     adopt(*shadowNode);
+    // adopt(const ShadowNode::Unshared&) is deprecated
+    // but we need to keep calling it for now until all callsites have been
+    // migrated to use adopt(ShadowNode&)
+    adopt(shadowNode);
+
     return shadowNode;
   }
 
@@ -170,10 +179,18 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   }
 
  protected:
-  virtual void adopt(ShadowNode& shadowNode) const override {
+  void adopt(ShadowNode& shadowNode) const override {
     // Default implementation does nothing.
     react_native_assert(
         shadowNode.getComponentHandle() == getComponentHandle());
+  }
+
+  [[deprecated(
+      "Use overload `adopt` passing in a reference to ShadowNode, do not implement both versions of adopt")]] void
+  adopt(const ShadowNode::Unshared& shadowNode) const override {
+    // Default implementation does nothing.
+    react_native_assert(
+        shadowNode->getComponentHandle() == getComponentHandle());
   }
 };
 


### PR DESCRIPTION
Summary:
changelog: [Deprecated] Deprecate ComponentDescriptor::adopt with shared_ptr and use new overload passing in a reference.

In D49054000 I changed the signature of `ComponentDescriptor::adopt`, which is a breaking change.
Here, I'm adding it back and marking it as deprecated with option for people to migrate to the new overload of `ComponentDescriptor::adopt`.

Reviewed By: cipolleschi

Differential Revision: D51618172


