### PR TITLE
Add InspectorFlags, conditionally disable Hermes CDP registration

### DIFF
--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -13,6 +13,7 @@
 #include <cxxreact/SystraceSection.h>
 #include <hermes/hermes.h>
 #include <jsi/decorator.h>
+#include <jsinspector-modern/InspectorFlags.h>
 
 #include <hermes/inspector-modern/chrome/Registration.h>
 #include <hermes/inspector/RuntimeAdapter.h>
@@ -200,11 +201,14 @@ std::unique_ptr<JSExecutor> HermesExecutorFactory::createJSExecutor(
   }
 
   HermesRuntime& hermesRuntimeRef = *hermesRuntime;
+  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+  bool enableDebugger =
+      !inspectorFlags.getEnableModernCDPRegistry() && enableDebugger_;
   auto decoratedRuntime = std::make_shared<DecoratedRuntime>(
       std::move(hermesRuntime),
       hermesRuntimeRef,
       jsQueue,
-      enableDebugger_,
+      enableDebugger,
       debuggerName_);
 
   // So what do we have now?

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -14,3 +14,7 @@ file(GLOB jsinspector_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(jsinspector STATIC ${jsinspector_SRC})
 
 target_include_directories(jsinspector PUBLIC ${REACT_COMMON_DIR})
+
+target_link_libraries(jsinspector
+        glog
+)

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <glog/logging.h>
+#include <cassert>
+
+#include "InspectorFlags.h"
+
+namespace facebook::react::jsinspector_modern {
+
+InspectorFlags& InspectorFlags::getInstance() {
+  static InspectorFlags instance;
+  return instance;
+}
+
+void InspectorFlags::initFromConfig(
+    const ReactNativeConfig& reactNativeConfig) {
+  bool enableModernCDPRegistry =
+      reactNativeConfig.getBool("react_native_devx:enable_modern_cdp_registry");
+  if (enableModernCDPRegistry_.has_value()) {
+    assert(
+        *enableModernCDPRegistry_ == enableModernCDPRegistry &&
+        "Flag value was changed after init");
+  }
+  enableModernCDPRegistry_ = enableModernCDPRegistry;
+}
+
+bool InspectorFlags::getEnableModernCDPRegistry() const {
+  if (!enableModernCDPRegistry_.has_value()) {
+    LOG(WARNING)
+        << "InspectorFlags::getEnableModernCDPRegistry was called before init";
+  }
+  return enableModernCDPRegistry_.value_or(false);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <react/config/ReactNativeConfig.h>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A container for all inspector related feature flags (Meyers singleton
+ * pattern). Flags must be set before they are accessed and are static for the
+ * lifetime of the app.
+ */
+class InspectorFlags {
+ public:
+  static InspectorFlags& getInstance();
+
+  /**
+   * Initialize flags from a `ReactNativeConfig` instance. Validates that flag
+   * values are not changed across multiple calls.
+   */
+  void initFromConfig(const ReactNativeConfig& reactNativeConfig);
+
+  /**
+   * Flag determining if the modern CDP backend should be enabled.
+   */
+  bool getEnableModernCDPRegistry() const;
+
+ private:
+  InspectorFlags() = default;
+  InspectorFlags(const InspectorFlags&) = delete;
+  InspectorFlags& operator=(const InspectorFlags&) = delete;
+  ~InspectorFlags() = default;
+
+  std::optional<bool> enableModernCDPRegistry_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -28,4 +28,8 @@ Pod::Spec.new do |s|
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = 'jsinspector'
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
+
+  s.dependency "glog"
+
+  add_dependency(s, "React-nativeconfig")
 end

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
@@ -23,6 +23,9 @@ bool EmptyReactNativeConfig::getBool(const std::string& param) const {
   if (param == "react_fabric:enabled_layout_animations_ios") {
     return true;
   }
+  if (param == "react_native_devx:enable_modern_cdp_registry") {
+    return false;
+  }
   return false;
 }
 

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -8,6 +8,7 @@
 #include "HermesInstance.h"
 
 #include <jsi/jsilib.h>
+#include <jsinspector-modern/InspectorFlags.h>
 
 #ifdef HERMES_ENABLE_DEBUGGER
 #include <hermes/inspector-modern/chrome/Registration.h>
@@ -141,10 +142,13 @@ std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
       hermes::makeHermesRuntime(runtimeConfigBuilder.build());
 
 #ifdef HERMES_ENABLE_DEBUGGER
-  std::unique_ptr<DecoratedRuntime> decoratedRuntime =
-      std::make_unique<DecoratedRuntime>(
-          std::move(hermesRuntime), msgQueueThread);
-  return std::make_unique<JSIRuntimeHolder>(std::move(decoratedRuntime));
+  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+  if (!inspectorFlags.getEnableModernCDPRegistry()) {
+    std::unique_ptr<DecoratedRuntime> decoratedRuntime =
+        std::make_unique<DecoratedRuntime>(
+            std::move(hermesRuntime), msgQueueThread);
+    return std::make_unique<JSIRuntimeHolder>(std::move(decoratedRuntime));
+  }
 #endif
 
   return std::make_unique<JSIRuntimeHolder>(std::move(hermesRuntime));

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -98,6 +98,7 @@ PODS:
     - React-Core
     - React-debug
     - React-Fabric
+    - React-FabricImage
     - React-graphics
     - React-jsi
     - React-jsiexecutor
@@ -920,7 +921,6 @@ PODS:
     - React-debug
     - React-Fabric
     - React-graphics
-    - React-RCTImage
     - React-rendererdebug
     - React-utils
   - React-jserrorhandler (1000.0.0):
@@ -944,7 +944,11 @@ PODS:
     - React-cxxreact (= 1000.0.0)
     - React-jsi (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
-  - React-jsinspector (1000.0.0)
+  - React-jsinspector (1000.0.0):
+    - glog
+    - React-nativeconfig
+  - React-jsitracing (1000.0.0):
+    - React-jsi
   - React-logger (1000.0.0):
     - glog
   - React-Mapbuffer (1000.0.0):
@@ -978,13 +982,21 @@ PODS:
     - RCTTypeSafety
     - React-Core
     - React-CoreModules
+    - React-debug
+    - React-Fabric
+    - React-graphics
     - React-hermes
     - React-nativeconfig
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTImage
     - React-RCTNetwork
+    - React-rendererdebug
+    - React-RuntimeApple
+    - React-RuntimeCore
+    - React-RuntimeHermes
     - React-runtimescheduler
+    - React-utils
     - ReactCommon
   - React-RCTBlob (1000.0.0):
     - hermes-engine
@@ -1075,8 +1087,44 @@ PODS:
     - RCT-Folly (= 2023.08.07.00)
     - React-debug
   - React-rncore (1000.0.0)
+  - React-RuntimeApple (1000.0.0):
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2023.08.07.00)
+    - React-callinvoker
+    - React-Core/Default
+    - React-CoreModules
+    - React-cxxreact
+    - React-jserrorhandler
+    - React-jsi
+    - React-jsiexecutor
+    - React-Mapbuffer
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RuntimeCore
+    - React-runtimeexecutor
+    - React-RuntimeHermes
+    - React-utils
+  - React-RuntimeCore (1000.0.0):
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2023.08.07.00)
+    - React-cxxreact
+    - React-jserrorhandler
+    - React-jsi
+    - React-jsiexecutor
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
   - React-runtimeexecutor (1000.0.0):
     - React-jsi (= 1000.0.0)
+  - React-RuntimeHermes (1000.0.0):
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2023.08.07.00)
+    - React-jsi
+    - React-jsitracing
+    - React-nativeconfig
+    - React-RuntimeCore
+    - React-utils
   - React-runtimescheduler (1000.0.0):
     - glog
     - hermes-engine
@@ -1195,6 +1243,7 @@ DEPENDENCIES:
   - React-jsi (from `../react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../react-native/ReactCommon/jsinspector-modern`)
+  - React-jsitracing (from `../react-native/ReactCommon/hermes/executor/`)
   - React-logger (from `../react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../react-native/ReactCommon`)
   - React-nativeconfig (from `../react-native/ReactCommon`)
@@ -1215,7 +1264,10 @@ DEPENDENCIES:
   - React-RCTVibration (from `../react-native/Libraries/Vibration`)
   - React-rendererdebug (from `../react-native/ReactCommon/react/renderer/debug`)
   - React-rncore (from `../react-native/ReactCommon`)
+  - React-RuntimeApple (from `../react-native/ReactCommon/react/runtime/platform/ios`)
+  - React-RuntimeCore (from `../react-native/ReactCommon/react/runtime`)
   - React-runtimeexecutor (from `../react-native/ReactCommon/runtimeexecutor`)
+  - React-RuntimeHermes (from `../react-native/ReactCommon/react/runtime`)
   - React-runtimescheduler (from `../react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../react-native/ReactCommon/react/utils`)
   - ReactCommon-Samples (from `../react-native/ReactCommon/react/nativemodule/samples`)
@@ -1286,6 +1338,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../react-native/ReactCommon/jsinspector-modern"
+  React-jsitracing:
+    :path: "../react-native/ReactCommon/hermes/executor/"
   React-logger:
     :path: "../react-native/ReactCommon/logger"
   React-Mapbuffer:
@@ -1326,8 +1380,14 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/react/renderer/debug"
   React-rncore:
     :path: "../react-native/ReactCommon"
+  React-RuntimeApple:
+    :path: "../react-native/ReactCommon/react/runtime/platform/ios"
+  React-RuntimeCore:
+    :path: "../react-native/ReactCommon/react/runtime"
   React-runtimeexecutor:
     :path: "../react-native/ReactCommon/runtimeexecutor"
+  React-RuntimeHermes:
+    :path: "../react-native/ReactCommon/react/runtime"
   React-runtimescheduler:
     :path: "../react-native/ReactCommon/react/renderer/runtimescheduler"
   React-utils:
@@ -1347,9 +1407,9 @@ SPEC CHECKSUMS:
   FBLazyVector: f4492a543c5a8fa1502d3a5867e3f7252497cfe8
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 3cf266f7eba66a16bcc83d939def2899e6d1a717
-  MyNativeView: 1fb0d21fda6ef12fd5f425f9888c81345a86a3e7
-  NativeCxxModuleExample: 19d10636011c914264a5922c6f0f22a2e8fd0910
+  hermes-engine: 2ba04c55f458b759ed05e05b4b7044a6ea39e332
+  MyNativeView: 1ec1acd16067ac22bced65cf00a900a7926bd393
+  NativeCxxModuleExample: f74b5dd25436f3a7f696c4b1be7e0d8da686cd72
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   RCT-Folly: 823c6f6ec910a75d4ad28898b4a11cdee140b92a
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
@@ -1357,20 +1417,21 @@ SPEC CHECKSUMS:
   RCTTypeSafety: 5f57d4ae5dfafc85a0f575d756c909b584722c52
   React: cb6dc75e09f32aeddb4d8fb58a394a67219a92fe
   React-callinvoker: bae59cbd6affd712bbfc703839dad868ff35069d
-  React-Codegen: c1e6ea0005a6ecf187d2772f14e5386f1c1f4853
-  React-Core: aaf2be188dfb2c342bc504042a92bfff31e2048f
+  React-Codegen: feef8181325890b506018f693c1293f1aa627cea
+  React-Core: 561b644397db48cf93bccb40184e968d40b75996
   React-CoreModules: ad1b7cb8efe5f3c7e88548b6ea6aad8507774471
   React-cxxreact: 04bf6a12caa850f5d2c7bd6d66dfecd4741989b5
   React-debug: 296b501a90c41f83961f58c6d96a01330d499da5
-  React-Fabric: d9d966fc90b6b3efd047e19df3c13c36e7e8458b
+  React-Fabric: ee767af0ad7ec93e67a82cd702bdc3c24086d963
   React-FabricImage: ca726038a733ebc92724728dc3a1823cd60fc74f
   React-graphics: fe23f0be844a21d42642596183f8ce0e54861ecf
   React-hermes: f192759ffeb9714917e9c39850ac349d8ea982d8
-  React-ImageManager: 691c4a56320ab9ab10482cd6306b3a4da004b79c
+  React-ImageManager: 716592dcbe11a4960e1eb3d82adb264ee15b5f6d
   React-jserrorhandler: 79fb3a8860fb1ea22dc77765aac15775593d4f8f
   React-jsi: 81f4e5b414c992c16c02e22e975a45aeb2b166e4
   React-jsiexecutor: 1212e26a01ce4de7443123f0ce090ec1affb3220
-  React-jsinspector: c867db3338992200616103b2f0ca6882c0c0482d
+  React-jsinspector: 990c9583811f8a5e9ef9911787f862e40beb5a37
+  React-jsitracing: dd08057dd5b74119cb406beb42028da85ed5b8a5
   React-logger: 8486d7a1d32b972414b1d34a93470ee2562c6ee2
   React-Mapbuffer: fd0d0306c1c4326be5f18a61e978d32a66b20a85
   React-nativeconfig: 40a2c848083ef4065c163c854e1c82b5f9e9db84
@@ -1378,9 +1439,9 @@ SPEC CHECKSUMS:
   React-perflogger: 70d009f755dd10002183454cdf5ad9b22de4a1d7
   React-RCTActionSheet: 943bd5f540f3af1e5a149c13c4de81858edf718a
   React-RCTAnimation: 750184a8efe97073d15215f6465d96cbb3d3b5ba
-  React-RCTAppDelegate: 722aead43eaaf2200ae93ba48779bb28da451593
+  React-RCTAppDelegate: 5dbbcec464358484334ed60b68e248e7694fa609
   React-RCTBlob: 20a233b87b0748b5ec5fd52cb6e1668e651ed775
-  React-RCTFabric: 0013c2447102a997cc54997197af85dad5f663ef
+  React-RCTFabric: d6c5afadce666f80006708c09d3d09dc7ab27240
   React-RCTImage: 16f53775b5d50cbd060f758fc2fcff0934e5eead
   React-RCTLinking: efa67827466e50e07c5471447c12e474cbc5e336
   React-RCTNetwork: ce2bd048cbdf9101ec255d486310709f19600e79
@@ -1391,15 +1452,18 @@ SPEC CHECKSUMS:
   React-RCTVibration: 14322c13fb0c5cc2884b714b11d277dc7fc326c4
   React-rendererdebug: 2e58409db231638bc3e78143d8844066a3302939
   React-rncore: e903b3d2819a25674403c548ec103f34bf02ba2b
+  React-RuntimeApple: baf78bbf17710a844bbf6bbdf85605979ce097dc
+  React-RuntimeCore: 35e84b0f8774ec5987a39802e59b538c15fdea9e
   React-runtimeexecutor: e1c32bc249dd3cf3919cb4664fd8dc84ef70cff7
+  React-RuntimeHermes: cc42f8965d813cdc8fdaae5009f6e2011fce9b15
   React-runtimescheduler: 6529d155a98010b6e8f0a3a86d4184b89a886633
   React-utils: 87ed8c079c9991831112fe716f2686c430699fc3
   ReactCommon: 4511ea0e8f349de031de7cad88c2ecf871ab69f9
   ReactCommon-Samples: cfc3383af93a741319e038977c2ae1082e4ff49e
-  ScreenshotManager: 753da20873c2ada484bdee4143a7248084d3fd35
+  ScreenshotManager: d9c4ee0cfd08bf51f3d8eb0e53d6dc25846331f2
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: dcc90b6f6863e467adabdd4f4bd963da1faddf1d
+  Yoga: ba060e7ec094e57aa646d6413e40608303556227
 
-PODFILE CHECKSUM: 426f495a1ad44f3cabea3b7dd2b66a0b71083e26
+PODFILE CHECKSUM: 5afcf37691103b83159fb73be088b7cadc67af7b
 
 COCOAPODS: 1.13.0


### PR DESCRIPTION
Summary:
Progress towards an opt-in setup for our new CDP backend.

- Adds `InspectorFlags.h`, a singleton intended to allow convienient access to static boolean feature flags for the new CDP backend/inspector features across platforms. This will be written to in upcoming diffs, with the accessor for `enable_modern_cdp_registry` soft-defaulting to `false` here.
- References this to conditionally disable CDP registration in `HermesExecutorFactory` (Bridge) and `HermesInstance` (Bridgeless) code paths.
- Stubs a `false` value for `react_native_devx:enable_modern_cdp_registry` in `EmptyReactNativeConfig` (documentation/convenience point for open source partners and integrators).

Changelog: [Internal]

Differential Revision: D51563107


