### PR TITLE
Ensure C++ default tmmd can access the CxxReactPackage

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -10,6 +10,7 @@ package com.facebook.react;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.jni.HybridData;
 import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
@@ -53,13 +54,22 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
   private List<ReactPackage> mPackages;
   private ReactApplicationContext mReactContext;
 
-  protected ReactPackageTurboModuleManagerDelegate() {
-    super();
-  }
-
   protected ReactPackageTurboModuleManagerDelegate(
       ReactApplicationContext reactApplicationContext, List<ReactPackage> packages) {
     super();
+    initialize(reactApplicationContext, packages);
+  }
+
+  protected ReactPackageTurboModuleManagerDelegate(
+      ReactApplicationContext reactApplicationContext,
+      List<ReactPackage> packages,
+      HybridData hybridData) {
+    super(hybridData);
+    initialize(reactApplicationContext, packages);
+  }
+
+  private void initialize(
+      ReactApplicationContext reactApplicationContext, List<ReactPackage> packages) {
     if (mIsLazy) {
       mPackages = packages;
       mReactContext = reactApplicationContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
@@ -28,12 +28,13 @@ private constructor(
     context: ReactApplicationContext,
     packages: List<ReactPackage>,
     private val eagerlyInitializedModules: List<String>,
-    private val cxxReactPackage: CxxReactPackage?,
-) : ReactPackageTurboModuleManagerDelegate(context, packages) {
+    cxxReactPackage: CxxReactPackage?,
+) : ReactPackageTurboModuleManagerDelegate(context, packages, initHybrid(cxxReactPackage)) {
 
-  @DoNotStrip override fun initHybrid() = initHybrid(cxxReactPackage)
-
-  external fun initHybrid(cxxReactPackage: CxxReactPackage?): HybridData?
+  override fun initHybrid(): HybridData? {
+    throw UnsupportedOperationException(
+        "DefaultTurboModuleManagerDelegate.initHybrid() must never be called!")
+  }
 
   override fun getEagerInitModuleNames(): List<String> {
     if (unstable_isLazyTurboModuleDelegate()) {
@@ -62,8 +63,11 @@ private constructor(
         DefaultTurboModuleManagerDelegate(context, packages, eagerInitModuleNames, cxxReactPackage)
   }
 
-  @Synchronized
-  override fun maybeLoadOtherSoLibraries() {
-    DefaultSoLoader.maybeLoadSoLibrary()
+  companion object {
+    init {
+      DefaultSoLoader.maybeLoadSoLibrary()
+    }
+
+    @DoNotStrip @JvmStatic external fun initHybrid(cxxReactPackage: CxxReactPackage?): HybridData?
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
@@ -31,6 +31,11 @@ public abstract class TurboModuleManagerDelegate {
     mHybridData = initHybrid();
   }
 
+  protected TurboModuleManagerDelegate(HybridData hybridData) {
+    maybeLoadOtherSoLibraries();
+    mHybridData = hybridData;
+  }
+
   /**
    * Create and return a TurboModule Java object with name `moduleName`. If `moduleName` isn't a
    * TurboModule, return null.
@@ -77,5 +82,7 @@ public abstract class TurboModuleManagerDelegate {
     return false;
   }
 
+  // TODO(T171231381): Consider removing this method: could we just use the static initializer
+  // of derived classes instead?
   protected synchronized void maybeLoadOtherSoLibraries() {}
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
@@ -22,11 +22,8 @@ abstract class CxxReactPackage {
   protected abstract fun initHybrid(): HybridData
 
   protected constructor() {
-    maybeLoadOtherSoLibraries()
     mHybridData = initHybrid()
   }
-
-  @Synchronized protected open fun maybeLoadOtherSoLibraries(): Unit {}
 
   companion object {
     init {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
@@ -17,13 +17,13 @@ import com.facebook.soloader.SoLoader
 @UnstableReactNativeAPI()
 abstract class CxxReactPackage {
 
-  @DoNotStrip @SuppressWarnings("unused") private val hybridData: HybridData
+  @DoNotStrip @Suppress("NoHungarianNotation") private var mHybridData: HybridData? = initHybrid()
 
   protected abstract fun initHybrid(): HybridData
 
   protected constructor() {
     maybeLoadOtherSoLibraries()
-    hybridData = initHybrid()
+    mHybridData = initHybrid()
   }
 
   @Synchronized protected open fun maybeLoadOtherSoLibraries(): Unit {}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp
@@ -27,7 +27,7 @@ std::function<std::shared_ptr<TurboModule>(
 
 jni::local_ref<DefaultTurboModuleManagerDelegate::jhybriddata>
 DefaultTurboModuleManagerDelegate::initHybrid(
-    jni::alias_ref<jhybridobject>,
+    jni::alias_ref<jclass> jClass,
     jni::alias_ref<CxxReactPackage::javaobject> cxxReactPackage) {
   return makeCxxInstance(cxxReactPackage);
 }
@@ -43,9 +43,12 @@ std::shared_ptr<TurboModule> DefaultTurboModuleManagerDelegate::getTurboModule(
     const std::string& name,
     const std::shared_ptr<CallInvoker>& jsInvoker) {
   if (cxxReactPackage_) {
-    auto module = cxxReactPackage_->cthis()->getModule(name, jsInvoker);
-    if (module) {
-      return module;
+    auto cppPart = cxxReactPackage_->cthis();
+    if (cppPart) {
+      auto module = cppPart->getModule(name, jsInvoker);
+      if (module) {
+        return module;
+      }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.h
@@ -24,7 +24,7 @@ class DefaultTurboModuleManagerDelegate : public jni::HybridClass<
       "Lcom/facebook/react/defaults/DefaultTurboModuleManagerDelegate;";
 
   static jni::local_ref<jhybriddata> initHybrid(
-      jni::alias_ref<jhybridobject>,
+      jni::alias_ref<jclass>,
       jni::alias_ref<CxxReactPackage::javaobject>);
 
   static void registerNatives();
@@ -53,7 +53,7 @@ class DefaultTurboModuleManagerDelegate : public jni::HybridClass<
   jni::global_ref<CxxReactPackage::javaobject> cxxReactPackage_;
 
   DefaultTurboModuleManagerDelegate(
-      jni::alias_ref<CxxReactPackage::javaobject>);
+      jni::alias_ref<CxxReactPackage::javaobject> cxxReactPackage);
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
## The Problem
The cxxReactPackage property isn't initialized by the time initHybrid was executed. So, initHybrid was being called with null as the cxxReactPackage.

Why;
1. The default turbomodule manager delegate receives cxxReactPackage as a constructor param.
2. Java then executes all the constructors of the class hierarchy. This executes initHybrid.
3. Java finally initializes the properties of the derived class: default tmmd.cxxReactPackage (i.e: the parameter to initHybrid). **This is too late**

## The Fix
Move init hybrid to a static method in default turbomodule manager. Call this static method with the passed in cxxreactpackage. And use the resultant HybridData to initialize the turbomodulemanager delegate hierarchy.


Changelog: [Internal]

Reviewed By: javache

Differential Revision: D51550623


