### PR TITLE
CxxReactPackage: Load So's during class loads

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
@@ -22,11 +22,8 @@ abstract class CxxReactPackage {
   protected abstract fun initHybrid(): HybridData
 
   protected constructor() {
-    maybeLoadOtherSoLibraries()
     mHybridData = initHybrid()
   }
-
-  @Synchronized protected open fun maybeLoadOtherSoLibraries(): Unit {}
 
   companion object {
     init {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
@@ -17,13 +17,13 @@ import com.facebook.soloader.SoLoader
 @UnstableReactNativeAPI()
 abstract class CxxReactPackage {
 
-  @DoNotStrip @SuppressWarnings("unused") private val hybridData: HybridData
+  @DoNotStrip @Suppress("NoHungarianNotation") private var mHybridData: HybridData? = initHybrid()
 
   protected abstract fun initHybrid(): HybridData
 
   protected constructor() {
     maybeLoadOtherSoLibraries()
-    hybridData = initHybrid()
+    mHybridData = initHybrid()
   }
 
   @Synchronized protected open fun maybeLoadOtherSoLibraries(): Unit {}


### PR DESCRIPTION
Summary:
The problem: The Java runtime couldn't find CatalystCxxReactPackage.initHybrid.

Why: I think is because CxxReactPackage loads CatalystCxxReactPackage's so in its constructor. This might be too late to load the derived class's so.

So, I just switched derived delegates to load the so in the static initializer (i.e: the recomended approch for so loading):

https://www.internalfb.com/code/fbsource/[91c4e41c49ed191ac864250ccaec52c01ddaeccc]/fbandroid/libraries/soloader/java/com/facebook/soloader/SoLoader.java?lines=52-54%2C60-61%2C63-67

This way:
1. The So's are loaded plenty early (the method not found error went away).
2. We don't create our own so loading infra, which complicates this abstraction, and makes it harder to work with, even more.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D51550622


