### PR TITLE
Fix android root view group removal during instance re-creation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1296,14 +1296,12 @@ public class ReactInstanceManager {
           uiManager.stopSurface(surfaceId);
         } else {
           FLog.w(ReactConstants.TAG, "Failed to stop surface, UIManager has already gone away");
-          reactRoot.getRootViewGroup().removeAllViews();
         }
       } else {
         ReactSoftExceptionLogger.logSoftException(
             TAG,
             new RuntimeException(
                 "detachRootViewFromInstance called with ReactRootView with invalid id"));
-        reactRoot.getRootViewGroup().removeAllViews();
       }
     } else {
       reactContext
@@ -1312,8 +1310,7 @@ public class ReactInstanceManager {
           .unmountApplicationComponentAtRootTag(reactRoot.getRootViewTag());
     }
 
-    // The view is no longer attached, so mark it as such by resetting its ID.
-    reactRoot.getRootViewGroup().setId(View.NO_ID);
+    clearReactRoot(reactRoot);
   }
 
   @ThreadConfined(UI)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This is my proposed solution to https://github.com/facebook/react-native/issues/41677.

Fixes https://github.com/facebook/react-native/issues/41677.

## Changelog:

[ANDROID] [FIXED] - Fix android root view group removal during instance re-creation

## Test Plan:

Both with fabric enabled and disabled (new architecture):

1. Clone repro repo: https://github.com/wschurman/rn-reload-repro
2. Build and run on android (I use android studio)
3. Click reload button, see timestamp doesn't change (indicating that the view is not removed)
4. Apply this PR as a patch.
5. Re-build and run.
6. Click reload button, see view is correctly disposed of and the new view is set.