### PR TITLE
Fix incorrect wrapping of refs in Image component

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -15,10 +15,11 @@ import type {AbstractImageAndroid, ImageAndroid} from './ImageTypes.flow';
 import flattenStyle from '../StyleSheet/flattenStyle';
 import StyleSheet from '../StyleSheet/StyleSheet';
 import TextAncestor from '../Text/TextAncestor';
+import useMergeRefs from '../Utilities/useMergeRefs';
 import ImageAnalyticsTagContext from './ImageAnalyticsTagContext';
 import {
   unstable_getImageComponentDecorator,
-  useWrapRefWithImageAttachedCallbacks,
+  useRefWithImageAttachedCallbacks,
 } from './ImageInjection';
 import {getImageSourcesFromImageProps} from './ImageSourceUtils';
 import {convertObjectFitToResizeMode} from './ImageUtils';
@@ -199,7 +200,15 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
     const resizeMode =
       objectFit || props.resizeMode || style?.resizeMode || 'cover';
 
-    const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
+    const imageAttachedCallbacksRef = useRefWithImageAttachedCallbacks();
+
+    const actualRef =
+      useMergeRefs<React.ElementRef<AbstractImageAndroid> | null>(
+        // $FlowFixMe[incompatible-call]
+        forwardedRef,
+        // $FlowFixMe[incompatible-call]
+        imageAttachedCallbacksRef,
+      );
 
     return (
       <ImageAnalyticsTagContext.Consumer>

--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -15,10 +15,11 @@ import type {AbstractImageIOS, ImageIOS} from './ImageTypes.flow';
 import {createRootTag} from '../ReactNative/RootTag';
 import flattenStyle from '../StyleSheet/flattenStyle';
 import StyleSheet from '../StyleSheet/StyleSheet';
+import useMergeRefs from '../Utilities/useMergeRefs';
 import ImageAnalyticsTagContext from './ImageAnalyticsTagContext';
 import {
   unstable_getImageComponentDecorator,
-  useWrapRefWithImageAttachedCallbacks,
+  useRefWithImageAttachedCallbacks,
 } from './ImageInjection';
 import {getImageSourcesFromImageProps} from './ImageSourceUtils';
 import {convertObjectFitToResizeMode} from './ImageUtils';
@@ -161,7 +162,14 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
   };
   const accessibilityLabel = props['aria-label'] ?? props.accessibilityLabel;
 
-  const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
+  const imageAttachedCallbacksRef = useRefWithImageAttachedCallbacks();
+
+  const actualRef = useMergeRefs<React.ElementRef<AbstractImageIOS> | null>(
+    // $FlowFixMe[incompatible-call]
+    forwardedRef,
+    // $FlowFixMe[incompatible-call]
+    imageAttachedCallbacksRef,
+  );
 
   return (
     <ImageAnalyticsTagContext.Consumer>

--- a/packages/react-native/Libraries/Image/ImageInjection.js
+++ b/packages/react-native/Libraries/Image/ImageInjection.js
@@ -52,19 +52,10 @@ export function unstable_unregisterImageAttachedCallback(
   imageAttachedCallbacks.delete(callback);
 }
 
-type ProxyRef = (ImageInstance | null) => void;
-
-export function useWrapRefWithImageAttachedCallbacks(
-  forwardedRef?: React.Ref<ImageComponent>,
-): ProxyRef {
+export function useRefWithImageAttachedCallbacks(): React.RefSetter<ImageInstance> {
   const pendingCleanupCallbacks = useRef<Array<() => void>>([]);
-  const proxyRef = useRef<ProxyRef>(node => {
-    if (typeof forwardedRef === 'function') {
-      forwardedRef(node);
-    } else if (typeof forwardedRef === 'object' && forwardedRef != null) {
-      forwardedRef.current = node;
-    }
 
+  const ref = useRef((node: ImageInstance | null) => {
     if (node == null) {
       if (pendingCleanupCallbacks.current.length > 0) {
         pendingCleanupCallbacks.current.forEach(cb => cb());
@@ -80,5 +71,5 @@ export function useWrapRefWithImageAttachedCallbacks(
     }
   });
 
-  return proxyRef.current;
+  return ref.current;
 }


### PR DESCRIPTION
Summary:
This fixes a bug in the original implementation of image attached callbacks (still experimental). The problem was that we were unconditionally caching the ref passed to the underlying image component, which meant that whenever users passed new ref setters we wouldn't call them again.

This fixes that by forcing the creation of a new ref value whenever a new ref is passed to the image component.

Changelog: [internal]

Differential Revision: D51618512


