### PR TITLE
Extend default tmmdelegate to support many cxxreactpackages

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
@@ -28,8 +28,8 @@ private constructor(
     context: ReactApplicationContext,
     packages: List<ReactPackage>,
     private val eagerlyInitializedModules: List<String>,
-    cxxReactPackage: CxxReactPackage?,
-) : ReactPackageTurboModuleManagerDelegate(context, packages, initHybrid(cxxReactPackage)) {
+    cxxReactPackages: List<CxxReactPackage>,
+) : ReactPackageTurboModuleManagerDelegate(context, packages, initHybrid(cxxReactPackages)) {
 
   override fun initHybrid(): HybridData? {
     throw UnsupportedOperationException(
@@ -47,20 +47,20 @@ private constructor(
 
   class Builder : ReactPackageTurboModuleManagerDelegate.Builder() {
     private var eagerInitModuleNames: List<String> = emptyList()
-    private var cxxReactPackage: CxxReactPackage? = null
+    private var cxxReactPackages: MutableList<CxxReactPackage> = mutableListOf()
 
     fun setEagerInitModuleNames(eagerInitModuleNames: List<String>): Builder {
       this.eagerInitModuleNames = eagerInitModuleNames
       return this
     }
 
-    fun setCxxReactPackage(cxxReactPackage: CxxReactPackage): Builder {
-      this.cxxReactPackage = cxxReactPackage
+    fun addCxxReactPackage(cxxReactPackage: CxxReactPackage): Builder {
+      this.cxxReactPackages.add(cxxReactPackage)
       return this
     }
 
     override fun build(context: ReactApplicationContext, packages: List<ReactPackage>) =
-        DefaultTurboModuleManagerDelegate(context, packages, eagerInitModuleNames, cxxReactPackage)
+        DefaultTurboModuleManagerDelegate(context, packages, eagerInitModuleNames, cxxReactPackages)
   }
 
   companion object {
@@ -68,6 +68,8 @@ private constructor(
       DefaultSoLoader.maybeLoadSoLibrary()
     }
 
-    @DoNotStrip @JvmStatic external fun initHybrid(cxxReactPackage: CxxReactPackage?): HybridData?
+    @DoNotStrip
+    @JvmStatic
+    external fun initHybrid(cxxReactPackages: List<CxxReactPackage>): HybridData?
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <ReactCommon/CxxReactPackage.h>
 #include <ReactCommon/JavaTurboModule.h>
@@ -25,7 +26,7 @@ class DefaultTurboModuleManagerDelegate : public jni::HybridClass<
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jclass>,
-      jni::alias_ref<CxxReactPackage::javaobject>);
+      jni::alias_ref<jni::JList<CxxReactPackage::javaobject>::javaobject>);
 
   static void registerNatives();
 
@@ -50,10 +51,11 @@ class DefaultTurboModuleManagerDelegate : public jni::HybridClass<
   friend HybridBase;
   using HybridBase::HybridBase;
 
-  jni::global_ref<CxxReactPackage::javaobject> cxxReactPackage_;
+  std::vector<jni::global_ref<CxxReactPackage::javaobject>> cxxReactPackages_;
 
   DefaultTurboModuleManagerDelegate(
-      jni::alias_ref<CxxReactPackage::javaobject> cxxReactPackage);
+      jni::alias_ref<jni::JList<CxxReactPackage::javaobject>::javaobject>
+          cxxReactPackage);
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Just like how React Native can have n ReactPackages, it will support n CxxReactPackages.

This way, many applications can share common CxxReactPackages.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D51484844


