### PR TITLE
CxxReactPackage: Make initHybrid static

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/cxxreactpackage/CxxReactPackage.kt
@@ -17,12 +17,10 @@ import com.facebook.soloader.SoLoader
 @UnstableReactNativeAPI()
 abstract class CxxReactPackage {
 
-  @DoNotStrip @Suppress("NoHungarianNotation") private var mHybridData: HybridData? = initHybrid()
+  @DoNotStrip @Suppress("NoHungarianNotation") private var mHybridData: HybridData?
 
-  protected abstract fun initHybrid(): HybridData
-
-  protected constructor() {
-    mHybridData = initHybrid()
+  protected constructor(hybridData: HybridData?) {
+    mHybridData = hybridData
   }
 
   companion object {


### PR DESCRIPTION
Summary:
## Rationale

Make initHybrid static. So that the derived class can initialize the C++ part with constructor arguments.

**Note:** This diff just applies the fix from D51550623. into CxxReactPackage.

Changelog: [Internal]

Differential Revision: D51642219


