### PR TITLE
Make positionAbsoluteChild the sole place that matters when determining absolute node's position

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.java
@@ -14,6 +14,7 @@ public enum YogaErrata {
   STRETCH_FLEX_BASIS(1),
   STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION(2),
   POSITION_STATIC_BEHAVES_LIKE_RELATIVE(4),
+  ABSOLUTE_POSITIONING(8),
   ALL(2147483647),
   CLASSIC(2147483646);
 
@@ -33,6 +34,7 @@ public enum YogaErrata {
       case 1: return STRETCH_FLEX_BASIS;
       case 2: return STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION;
       case 4: return POSITION_STATIC_BEHAVES_LIKE_RELATIVE;
+      case 8: return ABSOLUTE_POSITIONING;
       case 2147483647: return ALL;
       case 2147483646: return CLASSIC;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -99,6 +99,8 @@ const char* YGErrataToString(const YGErrata value) {
       return "starting-ending-edge-from-flex-direction";
     case YGErrataPositionStaticBehavesLikeRelative:
       return "position-static-behaves-like-relative";
+    case YGErrataAbsolutePositioning:
+      return "absolute-positioning";
     case YGErrataAll:
       return "all";
     case YGErrataClassic:

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -58,6 +58,7 @@ YG_ENUM_DECL(
     YGErrataStretchFlexBasis = 1,
     YGErrataStartingEndingEdgeFromFlexDirection = 2,
     YGErrataPositionStaticBehavesLikeRelative = 4,
+    YGErrataAbsolutePositioning = 8,
     YGErrataAll = 2147483647,
     YGErrataClassic = 2147483646)
 YG_DEFINE_ENUM_FLAG_OPERATORS(YGErrata)

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.h
@@ -35,14 +35,25 @@ bool calculateLayoutInternal(
     const uint32_t depth,
     const uint32_t generationCount);
 
+// Given an offset to an edge, returns the offset to the opposite edge on the
+// same axis. This assumes that the width/height of both nodes is determined at
+// this point.
+inline float getPositionOfOppositeEdge(
+    float position,
+    FlexDirection axis,
+    const yoga::Node* const containingNode,
+    const yoga::Node* const node) {
+  return containingNode->getLayout().measuredDimension(dimension(axis)) -
+      node->getLayout().measuredDimension(dimension(axis)) - position;
+}
+
 inline void setChildTrailingPosition(
     const yoga::Node* const node,
     yoga::Node* const child,
     const FlexDirection axis) {
-  const float size = child->getLayout().measuredDimension(dimension(axis));
   child->setLayoutPosition(
-      node->getLayout().measuredDimension(dimension(axis)) - size -
-          child->getLayout().position(flexStartEdge(axis)),
+      getPositionOfOppositeEdge(
+          child->getLayout().position(flexStartEdge(axis)), axis, node, child),
       flexEndEdge(axis));
 }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
@@ -20,6 +20,7 @@ enum class Errata : uint32_t {
   StretchFlexBasis = YGErrataStretchFlexBasis,
   StartingEndingEdgeFromFlexDirection = YGErrataStartingEndingEdgeFromFlexDirection,
   PositionStaticBehavesLikeRelative = YGErrataPositionStaticBehavesLikeRelative,
+  AbsolutePositioning = YGErrataAbsolutePositioning,
   All = YGErrataAll,
   Classic = YGErrataClassic,
 };


### PR DESCRIPTION
Summary:
Absolute nodes can be laid out by themselves and do not have to care about what is happening to their siblings. Because of this we can make `positionAbsoluteChild` the sole place where we handle this logic. Right now that is scattered around algorithm with many `if (child is absolute)` cases everywhere. This makes implementing position static a lot harder since we are relying on the CB to do all this work, not the parent.

With this change the only time we set position for an absolute node and it matter (i.e. not overwritten) is in `positionAbsoluteChild`

Reviewed By: NickGerleman

Differential Revision: D51290723


