### PR TITLE
Fix warm start logging for ReactMarker

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
@@ -53,9 +53,13 @@ void StartupLogger::logStartupEvent(
     double markerTime) {
   switch (markerId) {
     case ReactMarkerId::APP_STARTUP_START:
-      if (std::isnan(appStartupStartTime)) {
-        appStartupStartTime = markerTime;
+      if (!std::isnan(appStartupStartTime)) {
+        // We had a startup start time, which indicates a warm start (user
+        // closed the app and start again). In this case we need to invalidate
+        // all other startup timings.
+        reset();
       }
+      appStartupStartTime = markerTime;
       return;
 
     case ReactMarkerId::APP_STARTUP_STOP:
@@ -91,6 +95,15 @@ void StartupLogger::logStartupEvent(
     default:
       return;
   }
+}
+
+void StartupLogger::reset() {
+  appStartupStartTime = std::nan("");
+  appStartupEndTime = std::nan("");
+  initReactRuntimeStartTime = std::nan("");
+  initReactRuntimeEndTime = std::nan("");
+  runJSBundleStartTime = std::nan("");
+  runJSBundleEndTime = std::nan("");
 }
 
 double StartupLogger::getAppStartupStartTime() {

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
@@ -74,6 +74,7 @@ class RN_EXPORT StartupLogger {
   static StartupLogger& getInstance();
 
   void logStartupEvent(const ReactMarkerId markerName, double markerTime);
+  void reset();
   double getAppStartupStartTime();
   double getInitReactRuntimeStartTime();
   double getInitReactRuntimeEndTime();


### PR DESCRIPTION
Summary: This diff fixes app warm start time. Before this change, we cache the first time when app start timing is logged, and ignore future loggings. Some apps are warm started and the startup time should be updated.

Reviewed By: dmitry-voronkevich

Differential Revision: D50481710


