### PR TITLE
Converge iOS oldarch scrollEventThrottle behavior

### DIFF
--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -674,8 +674,7 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
    * We limit the delta to 17ms so that small throttles intended to enable 60fps updates will not
    * inadvertently filter out any scroll events.
    */
-  if (_allowNextScrollNoMatterWhat ||
-      (_scrollEventThrottle > 0 && _scrollEventThrottle < MAX(0.017, now - _lastScrollDispatchTime))) {
+  if (_allowNextScrollNoMatterWhat || (_scrollEventThrottle < MAX(0.017, now - _lastScrollDispatchTime))) {
     RCT_SEND_SCROLL_EVENT(onScroll, nil);
     // Update dispatch time
     _lastScrollDispatchTime = now;


### PR DESCRIPTION
Summary:
When I went to update documentation, I kinda internalized how inconsistent the API is if we don't change iOS Paper.

The potential for breaks is if an iOS-specific component ignores a warning, and uses `onScroll` without `scrollEventThrottle`, then relies on `onScroll` only being called once.

It didn't seem like we hit this scenario in practice when migrating Fabric ComponentView behavior, and components will need to support it in new arch anyway, so this change takes the less conservative option of unifying the behavior everywhere.

Changelog:
[iOS][Changed] - scrollEventThrottle no longer needs to be set for continuous scroll events

Differential Revision: D51647202


