### PR TITLE
feat: allow OOT platforms to use custom resolver.resolveRequest

### DIFF
--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -29,7 +29,10 @@ export type ConfigLoadingContext = $ReadOnly<{
 /**
  * Get the config options to override based on RN CLI inputs.
  */
-function getOverrideConfig(ctx: ConfigLoadingContext): InputConfigT {
+function getOverrideConfig(
+  ctx: ConfigLoadingContext,
+  config: ConfigT,
+): InputConfigT {
   const outOfTreePlatforms = Object.keys(ctx.platforms).filter(
     platform => ctx.platforms[platform].npmPackageName,
   );
@@ -46,6 +49,7 @@ function getOverrideConfig(ctx: ConfigLoadingContext): InputConfigT {
         },
         {},
       ),
+      config.resolver?.resolveRequest,
     );
   }
 
@@ -79,8 +83,6 @@ export default async function loadMetroConfig(
   ctx: ConfigLoadingContext,
   options: YargArguments = {},
 ): Promise<ConfigT> {
-  const overrideConfig = getOverrideConfig(ctx);
-
   const cwd = ctx.root;
   const projectConfig = await resolveConfig(options.config, cwd);
 
@@ -105,11 +107,12 @@ This warning will be removed in future (https://github.com/facebook/metro/issues
     }
   }
 
-  return mergeConfig(
-    await loadConfig({
-      cwd,
-      ...options,
-    }),
-    overrideConfig,
-  );
+  const config = await loadConfig({
+    cwd,
+    ...options,
+  });
+
+  const overrideConfig = getOverrideConfig(ctx, config);
+
+  return mergeConfig(config, overrideConfig);
 }

--- a/packages/community-cli-plugin/src/utils/metroPlatformResolver.js
+++ b/packages/community-cli-plugin/src/utils/metroPlatformResolver.js
@@ -25,9 +25,12 @@ import type {CustomResolver} from 'metro-resolver';
  *    macos: 'react-native-macos'
  * }
  */
-export function reactNativePlatformResolver(platformImplementations: {
-  [platform: string]: string,
-}): CustomResolver {
+export function reactNativePlatformResolver(
+  platformImplementations: {
+    [platform: string]: string,
+  },
+  customResolver: ?CustomResolver,
+): CustomResolver {
   return (context, moduleName, platform) => {
     let modifiedModuleName = moduleName;
     if (platform != null && platformImplementations[platform]) {
@@ -38,6 +41,9 @@ export function reactNativePlatformResolver(platformImplementations: {
           platformImplementations[platform]
         }/${modifiedModuleName.slice('react-native/'.length)}`;
       }
+    }
+    if (customResolver) {
+      return customResolver(context, modifiedModuleName, platform);
     }
     return context.resolveRequest(context, modifiedModuleName, platform);
   };


### PR DESCRIPTION
## Summary:

Currently, when we have an additional platform in `react-native.config.js`, users cannot use custom `resolver.resolveRequest` functions as they are overwritten by `reactNativePlatformResolver`. Goal of this PR is to allow OOT platforms to use additional custom resolvers besides remapping react native imports. 

## Changelog:

[GENERAL] [FIXED] - Allow Out Of Tree platforms to pass custom resolvers

## Test Plan:

1. Add additional platform in `react-native.config.js`
2. Pass custom resolver to `metro.config.js`: 

```js
resolveRequest: (context, moduleName, platform) => {
      console.log('resolveRequest', moduleName, platform);
      return context.resolveRequest(context, moduleName, platform);
 }
```
3. Check if user's `resolveRequest` function is called.