### PR TITLE
Remove duplicated jobs in CircleCI

### DIFF
--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -62,18 +62,17 @@
           flavor: "Debug"
           executor: reactnativeios-lts
       - test_ios_template:
+          architecture: "OldArch"
           requires:
             - build_npm_package
           matrix:
             parameters:
-              architecture: ["NewArch", "OldArch"]
               flavor: ["Debug", "Release"]
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
             exclude:
               # This config is tested with Ruby 3.2.0. Let's not double test it.
-              - architecture: "NewArch"
-                flavor: "Debug"
+              - flavor: "Debug"
                 jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
       - test_ios_rntester:
@@ -84,33 +83,30 @@
           architecture: "NewArch"
           executor: reactnativeios-lts
       - test_ios_rntester:
+          architecture: "NewArch"
           requires:
             - build_hermes_macos
           matrix:
             parameters:
-              architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
             exclude:
               # Tested by test_ios-Hermes
-              - architecture: "OldArch"
-                jsengine: "Hermes"
+              - jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
               # Tested by test_ios-JSC
-              - architecture: "OldArch"
-                jsengine: "JSC"
+              - jsengine: "JSC"
                 use_frameworks: "StaticLibraries"
               # Tested with Ruby 3.2.0, do not test this twice.
-              - architecture: "NewArch"
-                jsengine: "Hermes"
+              - jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
       - test_ios_rntester:
           run_unit_tests: true
-          architecture: "OldArch"
           use_frameworks: "StaticLibraries"
           ruby_version: "2.6.10"
           requires:
             - build_hermes_macos
           matrix:
             parameters:
+              architecture: ["OldArch", "NewArch"]
               jsengine: ["Hermes", "JSC"]

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -53,18 +53,17 @@
           flavor: "Debug"
           executor: reactnativeios-lts
       - test_ios_template:
+          architecture: "OldArch"
           requires:
             - build_npm_package
           matrix:
             parameters:
-              architecture: ["NewArch", "OldArch"]
               flavor: ["Debug", "Release"]
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
             exclude:
              # Tested with Ruby 3.2.0, let's not double test this
-              - architecture: "NewArch"
-                flavor: "Debug"
+              - flavor: "Debug"
                 jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
       - test_ios_rntester:
@@ -75,33 +74,30 @@
           architecture: "NewArch"
           executor: reactnativeios-lts
       - test_ios_rntester:
+          architecture: "NewArch"
           requires:
             - build_hermes_macos
           matrix:
             parameters:
-              architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
             exclude:
               # Tested by test_ios-Hermes
-              - architecture: "OldArch"
-                jsengine: "Hermes"
+              - jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
               # Tested by test_ios-JSC
-              - architecture: "OldArch"
-                jsengine: "JSC"
+              - jsengine: "JSC"
                 use_frameworks: "StaticLibraries"
               # Tested with Ruby 3.2.0, let's not double test this
-              - architecture: "NewArch"
-                jsengine: "Hermes"
+              - jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
       - test_ios_rntester:
           run_unit_tests: true
-          architecture: "OldArch"
           use_frameworks: "StaticLibraries"
           ruby_version: "2.6.10"
           requires:
             - build_hermes_macos
           matrix:
             parameters:
+              architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -19,10 +19,10 @@ end
 folly_flags = ' -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1'
 folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
 
-is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+is_new_arch_enabled = ENV["USE_NEW_ARCH"] == "1"
 use_hermes =  ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
-new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
+new_arch_enabled_flag = (is_new_arch_enabled ? " -DUSE_NEW_ARCH" : "")
 is_fabric_enabled = is_new_arch_enabled || ENV["RCT_FABRIC_ENABLED"]
 hermes_flag = (use_hermes ? " -DUSE_HERMES" : "")
 other_cflags = "$(inherited)" + folly_flags + new_arch_enabled_flag + hermes_flag

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -93,9 +93,10 @@ def use_react_native! (
   # Better to rely and enable this environment flag if the new architecture is turned on using flags.
   relative_path_from_current = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
   react_native_version = NewArchitectureHelper.extract_react_native_version(File.join(relative_path_from_current, path))
-  ENV['RCT_NEW_ARCH_ENABLED'] = NewArchitectureHelper.compute_new_arch_enabled(new_arch_enabled, react_native_version)
-
+  ENV['USE_NEW_ARCH'] = NewArchitectureHelper.compute_new_arch_enabled(new_arch_enabled, react_native_version)
   fabric_enabled = fabric_enabled || NewArchitectureHelper.new_arch_enabled
+
+  ENV['RCT_NEW_ARCH_ENABLED'] = "1"
   ENV['RCT_FABRIC_ENABLED'] = fabric_enabled ? "1" : "0"
   ENV['USE_HERMES'] = hermes_enabled ? "1" : "0"
 


### PR DESCRIPTION
Summary:
With the previous changes on the Pod configuration, the build setup for the New and Old architecture are the same.
The only observable difference happens at runtime.

This change:
1. Removes the build job that are split by architecture (which is now duplicated work)
2. Add two more test jobs to run runtime tests (unit and integration test) to make sure that the two architectures continue working.

## Changelog:
[Internal] - [CI] Remove duplicated build jobs, add tests jobs

Differential Revision: D51659275


