### PR TITLE
Fix type definition of useMergeRefs

### DIFF
--- a/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
@@ -108,7 +108,7 @@ const AnimatedScrollViewWithInvertedRefreshControl = React.forwardRef(
       Props,
       Instance,
     >(intermediatePropsForScrollView);
-    const ref = useMergeRefs<Instance | null>(scrollViewRef, forwardedRef);
+    const ref = useMergeRefs<Instance>(scrollViewRef, forwardedRef);
 
     return (
       // $FlowFixMe[incompatible-use] Investigate useAnimatedProps return value

--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -35,8 +35,7 @@ export default function createAnimatedComponent<TProps: {...}, TInstance>(
         // $FlowFixMe[incompatible-call]
         props,
       );
-      // $FlowFixMe[incompatible-call]
-      const ref = useMergeRefs<TInstance | null>(callbackRef, forwardedRef);
+      const ref = useMergeRefs<TInstance>(callbackRef, forwardedRef);
 
       // Some components require explicit passthrough values for animation
       // to work properly. For example, if an animated component is

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -67,8 +67,7 @@ const ScrollViewStickyHeaderWithForwardedRef: React.AbstractComponent<
   }, []);
   const ref: (React.ElementRef<typeof Animated.View> | null) => void =
     // $FlowFixMe[incompatible-type] - Ref is mutated by `callbackRef`.
-    // $FlowFixMe[incompatible-call]
-    useMergeRefs<Instance | null>(callbackRef, forwardedRef);
+    useMergeRefs<Instance>(callbackRef, forwardedRef);
 
   const offset = useMemo(
     () =>

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -155,7 +155,6 @@ const SwitchWithForwardedRef: React.AbstractComponent<
     typeof SwitchNativeComponent | typeof AndroidSwitchNativeComponent,
   > | null>(null);
 
-  // $FlowFixMe[incompatible-call]
   const ref = useMergeRefs(nativeSwitchRef, forwardedRef);
 
   const [native, setNative] = React.useState({value: (null: ?boolean)});

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1287,10 +1287,7 @@ function InternalTextInput(props: Props): React.Node {
     [mostRecentEventCount, viewCommands],
   );
 
-  const ref = useMergeRefs<TextInputInstance | null>(
-    setLocalRef,
-    props.forwardedRef,
-  );
+  const ref = useMergeRefs<TextInputInstance>(setLocalRef, props.forwardedRef);
 
   const _onChange = (event: ChangeEvent) => {
     const currentText = event.nativeEvent.text;

--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -15,11 +15,10 @@ import type {AbstractImageAndroid, ImageAndroid} from './ImageTypes.flow';
 import flattenStyle from '../StyleSheet/flattenStyle';
 import StyleSheet from '../StyleSheet/StyleSheet';
 import TextAncestor from '../Text/TextAncestor';
-import useMergeRefs from '../Utilities/useMergeRefs';
 import ImageAnalyticsTagContext from './ImageAnalyticsTagContext';
 import {
   unstable_getImageComponentDecorator,
-  useRefWithImageAttachedCallbacks,
+  useWrapRefWithImageAttachedCallbacks,
 } from './ImageInjection';
 import {getImageSourcesFromImageProps} from './ImageSourceUtils';
 import {convertObjectFitToResizeMode} from './ImageUtils';
@@ -200,15 +199,7 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
     const resizeMode =
       objectFit || props.resizeMode || style?.resizeMode || 'cover';
 
-    const imageAttachedCallbacksRef = useRefWithImageAttachedCallbacks();
-
-    const actualRef =
-      useMergeRefs<React.ElementRef<AbstractImageAndroid> | null>(
-        // $FlowFixMe[incompatible-call]
-        forwardedRef,
-        // $FlowFixMe[incompatible-call]
-        imageAttachedCallbacksRef,
-      );
+    const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
 
     return (
       <ImageAnalyticsTagContext.Consumer>

--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -15,11 +15,10 @@ import type {AbstractImageIOS, ImageIOS} from './ImageTypes.flow';
 import {createRootTag} from '../ReactNative/RootTag';
 import flattenStyle from '../StyleSheet/flattenStyle';
 import StyleSheet from '../StyleSheet/StyleSheet';
-import useMergeRefs from '../Utilities/useMergeRefs';
 import ImageAnalyticsTagContext from './ImageAnalyticsTagContext';
 import {
   unstable_getImageComponentDecorator,
-  useRefWithImageAttachedCallbacks,
+  useWrapRefWithImageAttachedCallbacks,
 } from './ImageInjection';
 import {getImageSourcesFromImageProps} from './ImageSourceUtils';
 import {convertObjectFitToResizeMode} from './ImageUtils';
@@ -162,14 +161,7 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
   };
   const accessibilityLabel = props['aria-label'] ?? props.accessibilityLabel;
 
-  const imageAttachedCallbacksRef = useRefWithImageAttachedCallbacks();
-
-  const actualRef = useMergeRefs<React.ElementRef<AbstractImageIOS> | null>(
-    // $FlowFixMe[incompatible-call]
-    forwardedRef,
-    // $FlowFixMe[incompatible-call]
-    imageAttachedCallbacksRef,
-  );
+  const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
 
   return (
     <ImageAnalyticsTagContext.Consumer>

--- a/packages/react-native/Libraries/Image/ImageInjection.js
+++ b/packages/react-native/Libraries/Image/ImageInjection.js
@@ -80,10 +80,8 @@ export function useWrapRefWithImageAttachedCallbacks(
   }
 
   // `useMergeRefs` returns a stable ref if its arguments don't change.
-  return useMergeRefs<ImageInstance | null>(
-    // $FlowFixMe[incompatible-call]
+  return useMergeRefs<ImageInstance>(
     forwardedRef,
-    // $FlowFixMe[incompatible-call]
     imageAttachedCallbacksRef.current,
   );
 }

--- a/packages/react-native/Libraries/Utilities/useMergeRefs.js
+++ b/packages/react-native/Libraries/Utilities/useMergeRefs.js
@@ -8,12 +8,8 @@
  * @format
  */
 
+import * as React from 'react';
 import {useCallback} from 'react';
-
-type CallbackRef<T> = T => mixed;
-type ObjectRef<T> = {current: T, ...};
-
-type Ref<T> = CallbackRef<T> | ObjectRef<T>;
 
 /**
  * Constructs a new ref that forwards new values to each of the given refs. The
@@ -24,11 +20,11 @@ type Ref<T> = CallbackRef<T> | ObjectRef<T>;
  * the returned callback ref is supplied as a `ref` to a React element, this may
  * lead to problems with the given refs being invoked more times than desired.
  */
-export default function useMergeRefs<T>(
-  ...refs: $ReadOnlyArray<?Ref<T>>
-): CallbackRef<T> {
+export default function useMergeRefs<Instance>(
+  ...refs: $ReadOnlyArray<?React.RefSetter<Instance>>
+): (Instance | null) => void {
   return useCallback(
-    (current: T) => {
+    (current: Instance | null) => {
       for (const ref of refs) {
         if (ref != null) {
           if (typeof ref === 'function') {


### PR DESCRIPTION
Summary:
The type definition of `useMergeRefs` is incorrect, which forces all callsites to use `$FlowFixMe`. This fixes the definition and removes all the `$FlowFixMe`s caused by it.

Changelog: [internal]

Differential Revision: D51660716


