### PR TITLE
Small refactor of image attached callbacks logic

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -15,11 +15,10 @@ import type {AbstractImageAndroid, ImageAndroid} from './ImageTypes.flow';
 import flattenStyle from '../StyleSheet/flattenStyle';
 import StyleSheet from '../StyleSheet/StyleSheet';
 import TextAncestor from '../Text/TextAncestor';
-import useMergeRefs from '../Utilities/useMergeRefs';
 import ImageAnalyticsTagContext from './ImageAnalyticsTagContext';
 import {
   unstable_getImageComponentDecorator,
-  useRefWithImageAttachedCallbacks,
+  useWrapRefWithImageAttachedCallbacks,
 } from './ImageInjection';
 import {getImageSourcesFromImageProps} from './ImageSourceUtils';
 import {convertObjectFitToResizeMode} from './ImageUtils';
@@ -200,15 +199,7 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
     const resizeMode =
       objectFit || props.resizeMode || style?.resizeMode || 'cover';
 
-    const imageAttachedCallbacksRef = useRefWithImageAttachedCallbacks();
-
-    const actualRef =
-      useMergeRefs<React.ElementRef<AbstractImageAndroid> | null>(
-        // $FlowFixMe[incompatible-call]
-        forwardedRef,
-        // $FlowFixMe[incompatible-call]
-        imageAttachedCallbacksRef,
-      );
+    const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
 
     return (
       <ImageAnalyticsTagContext.Consumer>

--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -15,11 +15,10 @@ import type {AbstractImageIOS, ImageIOS} from './ImageTypes.flow';
 import {createRootTag} from '../ReactNative/RootTag';
 import flattenStyle from '../StyleSheet/flattenStyle';
 import StyleSheet from '../StyleSheet/StyleSheet';
-import useMergeRefs from '../Utilities/useMergeRefs';
 import ImageAnalyticsTagContext from './ImageAnalyticsTagContext';
 import {
   unstable_getImageComponentDecorator,
-  useRefWithImageAttachedCallbacks,
+  useWrapRefWithImageAttachedCallbacks,
 } from './ImageInjection';
 import {getImageSourcesFromImageProps} from './ImageSourceUtils';
 import {convertObjectFitToResizeMode} from './ImageUtils';
@@ -162,14 +161,7 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
   };
   const accessibilityLabel = props['aria-label'] ?? props.accessibilityLabel;
 
-  const imageAttachedCallbacksRef = useRefWithImageAttachedCallbacks();
-
-  const actualRef = useMergeRefs<React.ElementRef<AbstractImageIOS> | null>(
-    // $FlowFixMe[incompatible-call]
-    forwardedRef,
-    // $FlowFixMe[incompatible-call]
-    imageAttachedCallbacksRef,
-  );
+  const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
 
   return (
     <ImageAnalyticsTagContext.Consumer>


### PR DESCRIPTION
Summary:
I did a hotfix for this logic in D51618512. This does a small refactor to improve the code (moving more shared code to the hook and avoiding creating a closure unnecessarily in every call to it).

Changelog: [internal]

Reviewed By: javache

Differential Revision: D51660288


