### PR TITLE
Clarify threading of OnViewAttach mount items

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -362,7 +362,7 @@ public class MountItemDispatcher {
       }
       SurfaceMountingManager surfaceMountingManager =
           mMountingManager.getSurfaceManager(item.getSurfaceId());
-      surfaceMountingManager.executeOnViewAttach(item);
+      surfaceMountingManager.scheduleMountItemOnViewAttach(item);
     } else {
       item.execute(mMountingManager);
     }


### PR DESCRIPTION
Summary:
`mOnViewAttachItems` was set to be be concurrent, but this would be unexpected, as all mount item operations occur solely on the main thread.

Simplify this to be just a LinkedList and annotate the methods as being UI thread only.

Changelog: [Internal]

Differential Revision: D51662154


