### PR TITLE
Make JS and TS tests independent of react-native package name

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,6 +41,9 @@ module.exports = {
     platforms: ['ios', 'android'],
   },
   moduleNameMapper: {
+    // These mappers allow out-of-tree platforms tests to seamlessly resolve RN imports
+    '^react-native/(.*)': '<rootDir>/packages/react-native/$1',
+    '^react-native$': '<rootDir>/packages/react-native/index.js',
     // This module is internal to Meta and used by their custom React renderer.
     // In tests, we can just use a mock.
     '^ReactNativeInternalFeatureFlags$':

--- a/packages/react-native/types/tsconfig.json
+++ b/packages/react-native/types/tsconfig.json
@@ -1,15 +1,18 @@
 {
-    "compilerOptions": {
-      "module": "commonjs",
-      "lib": ["es6"],
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "strictFunctionTypes": true,
-      "strictNullChecks": true,
-      "types": [],
-      "jsx": "react",
-      "noEmit": true,
-      "forceConsistentCasingInFileNames": true,
-      "paths": {"react-native": ["."]}
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "types": [],
+    "jsx": "react",
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "react-native": ["."],
+      "react-native/*": ["../*"]
     }
   }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When working with OOT platforms we need to change the `react-native` package name to something else, which breaks JS and TS tests. This change makes sure that `react-native` imports map to the `packages/react-native`, allowing us to reduce the scope of the fork. It should be transparent to the core platforms.

## Changelog:

[INTERNAL] [FIXED] - Make JS and TS tests independent of react-native package name

## Test Plan:

CI green