### PR TITLE
Fix broken RN Tester custom ViewManager

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.kt
@@ -35,13 +35,15 @@ internal class MyLegacyViewManager(reactContext: ReactApplicationContext) :
   }
 
   @ReactProp(name = ViewProps.COLOR)
-  fun setColor(view: MyNativeView, color: String?) {
-    color?.let { view.setBackgroundColor(Color.parseColor(it)) }
-  }
+  fun setColor(view: MyNativeView, color: String?): Unit =
+      when (color) {
+        null -> view.setBackgroundColor(Color.TRANSPARENT)
+        else -> view.setBackgroundColor(Color.parseColor(color))
+      }
 
   @ReactProp(name = "cornerRadius")
-  fun setCornerRadius(view: MyNativeView, cornerRadius: Float?) {
-    cornerRadius?.let { view.setCornerRadius(it) }
+  fun setCornerRadius(view: MyNativeView, cornerRadius: Float) {
+    view.setCornerRadius(cornerRadius)
   }
 
   override fun getExportedViewConstants(): Map<String, Any> = mapOf("PI" to 3.14)


### PR DESCRIPTION
Summary:
RN-Tester is currently instacrashing due to a method accepting a `Float?` rather than a `Float`.
`Float` from Kotlin gets converted to Java's `float`, while `Float?` gets converted to the boxed type, which is not recognized by the framework and is making the app crash.

On top of this, the implementation of `setColor` was wrong as we don't properly handle the null case. Fixing it here as well.

Changelog:
[Internal] [Changed] - Fix broken RN Tester custom ViewManager

Differential Revision: D51667346


