### PR TITLE
Enable new lifecycle hooks by default everywhere

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -72,7 +72,7 @@ public class ReactFeatureFlags {
   public static volatile boolean enableBridgelessArchitectureSoftExceptions = false;
 
   /** Does the bridgeless architecture use the new create/reload/destroy routines */
-  public static volatile boolean enableBridgelessArchitectureNewCreateReloadDestroy = false;
+  public static volatile boolean enableBridgelessArchitectureNewCreateReloadDestroy = true;
 
   /** This feature flag enables logs for Fabric */
   public static boolean enableFabricLogs = false;


### PR DESCRIPTION
Summary:
We shipped these new create()/reload()/destroy() methods to the Facebook app:
- Part 1: D50802718
- Part 2: D50803283

This diff just enables them everywhere, by default.

Created from CodeHub with https://fburl.com/edit-in-codehub

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D51590843


