### PR TITLE
[iOS] Add safe guard when receive network response data too long

### DIFF
--- a/packages/react-native/Libraries/Network/RCTNetworkTask.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworkTask.mm
@@ -164,7 +164,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
     if (!_data) {
       _data = [NSMutableData new];
     }
-    [_data appendData:data];
+    @try {
+      [_data appendData:data];
+    } @catch (NSException *exception) {
+      _status = RCTNetworkTaskFinished;
+      if (_completionBlock) {
+        RCTURLRequestCompletionBlock completionBlock = _completionBlock;
+        [self dispatchCallback:^{
+          completionBlock(self->_response, nil, RCTErrorWithMessage(@"Request's received data too long."));
+        }];
+      }
+      [self invalidate];
+      return;
+    }
+
     length = _data.length;
   }
 

--- a/packages/react-native/Libraries/Network/RCTNetworkTask.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworkTask.mm
@@ -171,7 +171,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
       if (_completionBlock) {
         RCTURLRequestCompletionBlock completionBlock = _completionBlock;
         [self dispatchCallback:^{
-          completionBlock(self->_response, nil, RCTErrorWithMessage(@"Request's received data too long."));
+          completionBlock(
+              self->_response, nil, RCTErrorWithMessage(exception.reason ?: @"Request's received data too long."));
         }];
       }
       [self invalidate];


### PR DESCRIPTION
## Summary:

Fixes #41651 

## Changelog:

[IOS] [FIXED] - Add safe guard when receive network response data too long


## Test Plan:

None.
