### PR TITLE
Fix ReactInstanceManager leak

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -387,7 +387,7 @@ public class ReactInstanceManager {
     mDevSupportManager.handleException(e);
   }
 
-  public void registerCxxErrorHandlerFunc() {
+  private void registerCxxErrorHandlerFunc() {
     Class[] parameterTypes = new Class[1];
     parameterTypes[0] = Exception.class;
     Method handleCxxErrorFunc = null;
@@ -397,6 +397,10 @@ public class ReactInstanceManager {
       FLog.e("ReactInstanceHolder", "Failed to set cxx error handler function", e);
     }
     ReactCxxErrorHandler.setHandleErrorFunc(this, handleCxxErrorFunc);
+  }
+
+  private void unregisterCxxErrorHandlerFunc() {
+    ReactCxxErrorHandler.setHandleErrorFunc(null, null);
   }
 
   static void initializeSoLoaderIfNecessary(Context applicationContext) {
@@ -747,23 +751,22 @@ public class ReactInstanceManager {
     }
 
     moveToBeforeCreateLifecycleState();
-
-    if (mCreateReactContextThread != null) {
-      mCreateReactContextThread = null;
-    }
-
     mMemoryPressureRouter.destroy(mApplicationContext);
+    unregisterCxxErrorHandlerFunc();
 
+    mCreateReactContextThread = null;
     synchronized (mReactContextLock) {
       if (mCurrentReactContext != null) {
         mCurrentReactContext.destroy();
         mCurrentReactContext = null;
       }
     }
+
     mHasStartedCreatingInitialContext = false;
     mCurrentActivity = null;
 
     ResourceDrawableIdHelper.getInstance().clear();
+
     mHasStartedDestroying = false;
     synchronized (mHasStartedDestroying) {
       mHasStartedDestroying.notifyAll();


### PR DESCRIPTION
Summary:
We leak ReactInstanceManager into a static singleton in `ReactCxxErrorHandler.setHandleErrorFunc`. Clean it up in `destroy()`.

Changelog: [Internal]

Differential Revision: D51706624


