### PR TITLE
Fix init for out-of-tree platforms by passing name to CLI

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const {version: currentVersion} = require('./package.json');
+const {name, version: currentVersion} = require('./package.json');
 const cli = require('@react-native-community/cli');
 const chalk = require('chalk');
 const {get} = require('https');
@@ -66,7 +66,7 @@ async function main() {
       // Ignore errors, since it's a nice to have warning
     }
   }
-  return cli.run();
+  return cli.run(name);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

To unlock ~~certain OOT platform capabilities~~ seamless `init` integration for out-of-tree platforms with CLI, we need to pass the package name to it. This change landed on 0.73 branch already: https://github.com/facebook/react-native/pull/41530

Depends on #41722 

## Changelog:

[INTERNAL] [ADDED] - Fix init for out-of-tree platforms by passing name to CLI


## Test Plan:

CI green
