### PR TITLE
Update VirtualizedList's content layout in `onScroll`

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1711,6 +1711,13 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       visibleLength,
       zoomScale,
     };
+    this._listMetrics.notifyListContentLayout({
+      layout: {
+        width: e.nativeEvent.contentSize.width,
+        height: e.nativeEvent.contentSize.height
+      },
+      orientation: this._orientation(),
+    });
     if (this.state.pendingScrollUpdateCount > 0) {
       this.setState(state => ({
         pendingScrollUpdateCount: state.pendingScrollUpdateCount - 1,

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1714,7 +1714,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     this._listMetrics.notifyListContentLayout({
       layout: {
         width: e.nativeEvent.contentSize.width,
-        height: e.nativeEvent.contentSize.height
+        height: e.nativeEvent.contentSize.height,
       },
       orientation: this._orientation(),
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

https://github.com/facebook/react-native/pull/38529 introduced some changes to the internal state of `VirtualizedList`, replacing `_scrollMetrics.contentLength` with `_listMetrics.getContentLength()` and `_listMetrics.notifyListContentLayout(...)`.

I'm not sure whether it was done on purpose or by accident, but setting the `contentLength` in the `onScroll` handler [here](https://github.com/facebook/react-native/pull/38529/files#diff-b450c5c4ec05ca5221b18a829f764b8397eed35a93f388893debb184591b0207L1685) was removed instead of being updated to call the new method.

I'm not sure whether it has any impact on apps, but testing relying on `testing-library` and its `fireEvent.scroll` do not work anymore due to this change.

cc. @NickGerleman as they are the author of the aforementioned PR

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Fix `VirualizedList` not updating its content length on scroll events

## Test Plan:

I found the problem during upgrade of the Expensify app to React Native 0.73 when some of the tests started failing. I guess it should be easy to tell whether the original change was deliberate or accidental, but if it's necessary I can prepare a reproduction with a simple failing test.
