### PR TITLE
Adding getFabricUIManager() APIs to ReactContext

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -26,6 +26,7 @@ import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -552,6 +553,25 @@ public class ReactContext extends ContextWrapper {
           "Unable to retrieve a JSIModule if CatalystInstance is not active.");
     }
     return mCatalystInstance.getJSIModule(moduleType);
+  }
+
+  @DeprecatedInNewArchitecture(
+      message =
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+  /**
+   * Get the UIManager for Fabric from the CatalystInstance.
+   *
+   * @return The UIManager when CatalystInstance is active.
+   */
+  public @Nullable UIManager getFabricUIManager() {
+    if (!hasActiveReactInstance()) {
+      throw new IllegalStateException(
+          "Unable to retrieve a UIManager if CatalystInstance is not active.");
+    }
+    UIManager uiManager = mCatalystInstance.getFabricUIManager();
+    return uiManager != null
+        ? uiManager
+        : (UIManager) mCatalystInstance.getJSIModule(JSIModuleType.UIManager);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -21,6 +21,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
+import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -82,6 +83,11 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
     throw new UnsupportedOperationException(
         "getJSIModule is not implemented for bridgeless mode. Trying to get module: "
             + moduleType.name());
+  }
+
+  @Override
+  public @Nullable UIManager getFabricUIManager() {
+    return mReactHost.getUIManager();
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.JSIModuleType;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UIManager;
 
 /**
  * Wraps {@link ReactContext} with the base {@link Context} passed into the constructor. It provides
@@ -115,5 +116,13 @@ public class ThemedReactContext extends ReactContext {
       return mReactApplicationContext.getJSIModule(moduleType);
     }
     return super.getJSIModule(moduleType);
+  }
+
+  @Override
+  public UIManager getFabricUIManager() {
+    if (isBridgeless()) {
+      return mReactApplicationContext.getFabricUIManager();
+    }
+    return super.getFabricUIManager();
   }
 }


### PR DESCRIPTION
Summary: Adding APIs for `getFabricUIManager()` to ReactContext and it's subclasses. This will replace the `getJSIModule()` post JSI module deletion.

Differential Revision: D51718430


