### PR TITLE
Change strict layout conformance to not use the new static changes

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -497,7 +497,8 @@ YGErrata YogaLayoutableShadowNode::resolveErrata(YGErrata defaultErrata) const {
       case LayoutConformance::Classic:
         return YGErrataAll;
       case LayoutConformance::Strict:
-        return YGErrataNone;
+        // This is temporary until the default position type is relative
+        return YGErrataPositionStaticBehavesLikeRelative;
       case LayoutConformance::Undefined:
         return defaultErrata;
     }


### PR DESCRIPTION
Summary:
I am currently implementing position: static in Yoga. I have a huge stack of changes that is ready to ship but we are waiting on the default position type to be relative before shipping. The reason being, my changes will affect a whole ton of styles where there is no position set so if we can make static no longer the default we can safely ship this new code. However, this will take a while and keeping up with this stack of diffs though merge conflicts, flakey tests, and general slowness for my IDE is getting annoying. So a solution here is to ship that stack and make it so that no one gets this functionality by changing the strict layout conformance to include the errata that is gating my changes. The end result being that the code can be shipped but will have no affect at the time being.

Right now, because that code is in a different branch and not on prod, this change will do nothing.

Changelog: [Internal]

Differential Revision: D51731778


