### PR TITLE
Add GraphNode example for Cxx TMs

### DIFF
--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -65,6 +65,16 @@ std::string NativeCxxModuleExample::consumeCustomHostObject(
   return value->a_ + std::to_string(value->b_);
 }
 
+GraphNode NativeCxxModuleExample::getGraphNode(
+    jsi::Runtime& rt,
+    GraphNode arg) {
+  if (arg.neighbors) {
+    arg.neighbors->emplace_back(GraphNode{.label = "top"});
+    arg.neighbors->emplace_back(GraphNode{.label = "down"});
+  }
+  return arg;
+}
+
 NativeCxxModuleExampleCxxEnumFloat NativeCxxModuleExample::getNumEnum(
     jsi::Runtime& rt,
     NativeCxxModuleExampleCxxEnumInt arg) {

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -56,6 +56,11 @@ export type ValueStruct = {|
 
 export type CustomHostObject = {};
 
+export type GraphNode = {
+  label: string,
+  neighbors?: Array<GraphNode>,
+};
+
 export interface Spec extends TurboModule {
   +getArray: (arg: Array<ObjectStruct | null>) => Array<ObjectStruct | null>;
   +getBool: (arg: boolean) => boolean;
@@ -63,6 +68,7 @@ export interface Spec extends TurboModule {
   +getCustomEnum: (arg: EnumInt) => EnumInt;
   +getCustomHostObject: () => CustomHostObject;
   +consumeCustomHostObject: (customHostObject: CustomHostObject) => string;
+  +getGraphNode: (arg: GraphNode) => GraphNode;
   +getNumEnum: (arg: EnumInt) => EnumFloat;
   +getStrEnum: (arg: EnumNone) => EnumStr;
   +getMap: (arg: {[key: string]: ?number}) => {[key: string]: ?number};

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -42,6 +42,8 @@ type Examples =
   | 'getBool'
   | 'getConstants'
   | 'getCustomEnum'
+  | 'getCustomHostObject'
+  | 'getGraphNode'
   | 'getNumEnum'
   | 'getStrEnum'
   | 'getMap'
@@ -102,6 +104,11 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
       NativeCxxModuleExample?.consumeCustomHostObject(
         NativeCxxModuleExample?.getCustomHostObject(),
       ),
+    getGraphNode: () =>
+      NativeCxxModuleExample?.getGraphNode({
+        label: 'root',
+        neighbors: [{label: 'left'}, {label: 'right'}],
+      }),
     getNumEnum: () => NativeCxxModuleExample?.getNumEnum(EnumInt.IB),
     getStrEnum: () => NativeCxxModuleExample?.getStrEnum(EnumNone.NB),
     getNumber: () => NativeCxxModuleExample?.getNumber(99.95),


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a simple example showing a recursive node inside a collection in a Cxx TM.

Currently we can't auto-generate [the necessary C++ Types](https://reactnative.dev/docs/next/the-new-architecture/cxx-custom-types#struct-generator) - but we can add it later if this scenarios becomes really common.

Differential Revision: D51783974


