### PR TITLE
fix: paddingTop problem for multiline `TextInput`

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1465,9 +1465,9 @@ function InternalTextInput(props: Props): React.Node {
         : RCTSinglelineTextInputView;
 
     const hasPaddingTopStyle =
-      props.style?.padding != null ||
-      props.style?.paddingVertical != null ||
-      props.style?.paddingTop != null;
+      style?.padding != null ||
+      style?.paddingVertical != null ||
+      style?.paddingTop != null;
     if (props.multiline === true && !hasPaddingTopStyle) {
       style = [styles.multilineDefault, style];
     }

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1464,7 +1464,13 @@ function InternalTextInput(props: Props): React.Node {
         ? RCTMultilineTextInputView
         : RCTSinglelineTextInputView;
 
-    style = props.multiline === true ? [styles.multilineInput, style] : style;
+    const hasPaddingTopStyle =
+      props.style?.padding != null ||
+      props.style?.paddingVertical != null ||
+      props.style?.paddingTop != null;
+    if (props.multiline === true && !hasPaddingTopStyle) {
+      style = [styles.multilineInput, style];
+    }
 
     const useOnChangeSync =
       (props.unstable_onChangeSync || props.unstable_onChangeTextSync) &&

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1463,12 +1463,12 @@ function InternalTextInput(props: Props): React.Node {
         ? RCTMultilineTextInputView
         : RCTSinglelineTextInputView;
 
-    const hasPaddingTopStyle =
-      style?.padding != null ||
-      style?.paddingVertical != null ||
-      style?.paddingTop != null;
     const useMultilineDefaultStyle =
-      props.multiline === true && !hasPaddingTopStyle;
+      props.multiline === true &&
+      (style == null ||
+        (style.padding == null &&
+          style.paddingVertical == null &&
+          style.paddingTop == null));
 
     const useOnChangeSync =
       (props.unstable_onChangeSync || props.unstable_onChangeTextSync) &&

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1456,7 +1456,7 @@ function InternalTextInput(props: Props): React.Node {
   }
 
   // $FlowFixMe[underconstrained-implicit-instantiation]
-  let style = flattenStyle(props.style);
+  const style = flattenStyle(props.style);
 
   if (Platform.OS === 'ios') {
     const RCTTextInputView =
@@ -1468,9 +1468,8 @@ function InternalTextInput(props: Props): React.Node {
       style?.padding != null ||
       style?.paddingVertical != null ||
       style?.paddingTop != null;
-    if (props.multiline === true && !hasPaddingTopStyle) {
-      style = [styles.multilineDefault, style];
-    }
+    const useMultilineDefaultStyle =
+      props.multiline === true && !hasPaddingTopStyle;
 
     const useOnChangeSync =
       (props.unstable_onChangeSync || props.unstable_onChangeTextSync) &&
@@ -1500,7 +1499,11 @@ function InternalTextInput(props: Props): React.Node {
         onSelectionChange={_onSelectionChange}
         onSelectionChangeShouldSetResponder={emptyFunctionThatReturnsTrue}
         selection={selection}
-        style={style}
+        style={
+          useMultilineDefaultStyle === true
+            ? [styles.multilineDefault, style]
+            : style
+        }
         text={text}
       />
     );

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1498,11 +1498,10 @@ function InternalTextInput(props: Props): React.Node {
         onSelectionChange={_onSelectionChange}
         onSelectionChangeShouldSetResponder={emptyFunctionThatReturnsTrue}
         selection={selection}
-        style={
-          useMultilineDefaultStyle === true
-            ? [styles.multilineDefault, style]
-            : style
-        }
+        style={StyleSheet.compose(
+          useMultilineDefaultStyle ? styles.multilineDefault : null,
+          style,
+        )}
         text={text}
       />
     );

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1455,8 +1455,7 @@ function InternalTextInput(props: Props): React.Node {
     };
   }
 
-  // $FlowFixMe[underconstrained-implicit-instantiation]
-  const style = flattenStyle(props.style);
+  const style = flattenStyle<TextStyleProp>(props.style);
 
   if (Platform.OS === 'ios') {
     const RCTTextInputView =

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1469,7 +1469,7 @@ function InternalTextInput(props: Props): React.Node {
       props.style?.paddingVertical != null ||
       props.style?.paddingTop != null;
     if (props.multiline === true && !hasPaddingTopStyle) {
-      style = [styles.multilineInput, style];
+      style = [styles.multilineDefault, style];
     }
 
     const useOnChangeSync =
@@ -1777,7 +1777,7 @@ export type TextInputComponentStatics = $ReadOnly<{|
 |}>;
 
 const styles = StyleSheet.create({
-  multilineInput: {
+  multilineDefault: {
     // This default top inset makes RCTMultilineTextInputView seem as close as possible
     // to single-line RCTSinglelineTextInputView defaults, using the system defaults
     // of font size 17 and a height of 31 points.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Fixed: #41773

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [FIXED] - not applying `multilineInput` when props's style has paddingTop related style

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
