### PR TITLE
Remove flow exact object syntax {| brace pipe |} from TM example

### DIFF
--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -36,23 +36,23 @@ export type UnionFloat = 1.44 | 2.88 | 5.76;
 export type UnionString = 'One' | 'Two' | 'Three';
 export type UnionObject = {value: number} | {low: string};
 
-export type ConstantsStruct = {|
+export type ConstantsStruct = {
   const1: boolean,
   const2: number,
   const3: string,
-|};
+};
 
-export type ObjectStruct = {|
+export type ObjectStruct = {
   a: number,
   b: string,
   c?: ?string,
-|};
+};
 
-export type ValueStruct = {|
+export type ValueStruct = {
   x: number,
   y: string,
   z: ObjectStruct,
-|};
+};
 
 export type CustomHostObject = {};
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

`exact_by_default` (https://flow.org/en/docs/types/objects/#exact-and-inexact-object-types) is turned on - https://github.com/facebook/react-native/blob/main/.flowconfig#L40 - so we don't need these extra `|`.

Differential Revision: D51803601


