### PR TITLE
fix: add verdaccio generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ vendor/
 
 # CircleCI
 .circleci/generated_config.yml
+.circleci/storage


### PR DESCRIPTION
## Summary:

When working with Verdaccio (testing the template, releasing packages) - I've stumbled upon a lot of changes in the repo: 


![CleanShot 2023-12-04 at 13 14 12@2x](https://github.com/facebook/react-native/assets/52801365/74ce53a2-b885-41f4-9a12-968a8577285e)

## Changelog:

[INTERNAL] [ADDED] - Add verdaccio generated files to .gitignore

## Test Plan:

CI Green
