### PR TITLE
feature(dev-middleware): add `enableNetworkInspector` experiment

### DIFF
--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -126,5 +126,6 @@ function getExperiments(config: ExperimentsConfig): Experiments {
   return {
     enableNewDebugger: config.enableNewDebugger ?? false,
     enableOpenDebuggerRedirect: config.enableOpenDebuggerRedirect ?? false,
+    enableNetworkInspector: config.enableNetworkInspector ?? false,
   };
 }

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -64,6 +64,7 @@ export default function openDebuggerMiddleware({
         app =>
           app.title === 'React Native Experimental (Improved Chrome Reloads)',
       );
+
       let target;
 
       const launchType: 'launch' | 'redirect' =
@@ -117,6 +118,7 @@ export default function openDebuggerMiddleware({
               frontendInstanceId,
               await browserLauncher.launchDebuggerAppWindow(
                 getDevToolsFrontendUrl(
+                  experiments,
                   target.webSocketDebuggerUrl,
                   serverBaseUrl,
                 ),
@@ -127,6 +129,7 @@ export default function openDebuggerMiddleware({
           case 'redirect':
             res.writeHead(302, {
               Location: getDevToolsFrontendUrl(
+                experiments,
                 target.webSocketDebuggerUrl,
                 // Use a relative URL.
                 '',

--- a/packages/dev-middleware/src/types/Experiments.js
+++ b/packages/dev-middleware/src/types/Experiments.js
@@ -25,8 +25,7 @@ export type Experiments = $ReadOnly<{
   enableOpenDebuggerRedirect: boolean,
 
   /**
-   * Enables the new JS debugger network panel and network CDP events.
-   * When disabled, all CDP events and the network panel are disabled.
+   * Enables the Network panel when launching the custom debugger frontend.
    */
   enableNetworkInspector: boolean,
 }>;

--- a/packages/dev-middleware/src/types/Experiments.js
+++ b/packages/dev-middleware/src/types/Experiments.js
@@ -28,7 +28,7 @@ export type Experiments = $ReadOnly<{
    * Enables the new JS debugger network panel and network CDP events.
    * When disabled, all CDP events and the network panel are disabled.
    */
-  enableNetworkInspector: Boolean,
+  enableNetworkInspector: boolean,
 }>;
 
 export type ExperimentsConfig = Partial<Experiments>;

--- a/packages/dev-middleware/src/types/Experiments.js
+++ b/packages/dev-middleware/src/types/Experiments.js
@@ -23,6 +23,12 @@ export type Experiments = $ReadOnly<{
    * interface.
    */
   enableOpenDebuggerRedirect: boolean,
+
+  /**
+   * Enables the new JS debugger network panel and network CDP events.
+   * When disabled, all CDP events and the network panel are disabled.
+   */
+  enableNetworkInspector: Boolean,
 }>;
 
 export type ExperimentsConfig = Partial<Experiments>;

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -9,10 +9,13 @@
  * @oncall react_native
  */
 
+import type {Experiments} from '../types/Experiments';
+
 /**
  * Get the DevTools frontend URL to debug a given React Native CDP target.
  */
 export default function getDevToolsFrontendUrl(
+  experiments: Experiments,
   webSocketDebuggerUrl: string,
   devServerUrl: string,
 ): string {
@@ -22,5 +25,9 @@ export default function getDevToolsFrontendUrl(
     webSocketDebuggerUrl.replace(/^wss?:\/\//, ''),
   );
 
-  return `${appUrl}?${scheme}=${webSocketUrlWithoutProtocol}&sources.hide_add_folder=true`;
+  const devToolsUrl = `${appUrl}?${scheme}=${webSocketUrlWithoutProtocol}&sources.hide_add_folder=true`;
+
+  return experiments.enableNetworkInspector
+    ? `${devToolsUrl}&unstable_enableNetworkPanel=true`
+    : devToolsUrl;
 }


### PR DESCRIPTION
## Summary:

This enables the network panel/inspector by passing the `unstable_enableNetworkPanel=true` to the React Native JS Inspector. (See https://github.com/facebookexperimental/rn-chrome-devtools-frontend/pull/2)

By setting this inside the `experiments`, we can enable/disable network related CDP handlers within the proxy.

## Changelog:

[GENERAL] [ADDED] - Add `enableNetworkInspector` experiment to enable Network panel and CDP handlers in inspector proxy

## Test Plan:

TBD, will provide a repository using an Expo canary / RN 0.73.0-rc release.
