### PR TITLE
Allow users to easily override root view background color for iOS (Bridgeless + RCTRootView)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -58,6 +58,7 @@
 @property (nonatomic, strong) RCTBridge *bridge;
 @property (nonatomic, strong) NSString *moduleName;
 @property (nonatomic, strong) NSDictionary *initialProps;
+@property (nonatomic, copy, readonly) UIColor *backgroundColor;
 
 /**
  * It creates a `RCTBridge` using a delegate and some launch options.

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -58,7 +58,6 @@
 @property (nonatomic, strong) RCTBridge *bridge;
 @property (nonatomic, strong) NSString *moduleName;
 @property (nonatomic, strong) NSDictionary *initialProps;
-@property (nonatomic, copy, readonly) UIColor *backgroundColor;
 
 /**
  * It creates a `RCTBridge` using a delegate and some launch options.
@@ -138,5 +137,8 @@
 
 /// Return the bundle URL for the main bundle.
 - (NSURL *)bundleURL;
+
+/// This method returns React Native root view background color for both `RCTRootView` and `RCTFabricSurface`.
+- (UIColor* )backgroundColor;
 
 @end

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -156,9 +156,13 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
   BOOL enableFabric = self.fabricEnabled;
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, enableFabric);
 
-  rootView.backgroundColor = [UIColor systemBackgroundColor];
+  rootView.backgroundColor = self.backgroundColor;
 
   return rootView;
+}
+
+- (UIColor *)backgroundColor {
+  return [UIColor systemBackgroundColor];
 }
 
 - (UIViewController *)createRootViewController

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -107,6 +107,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
         sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact];
 
     rootView = (RCTRootView *)surfaceHostingProxyRootView;
+    rootView.backgroundColor = self.backgroundColor;
   } else {
     if (!self.bridge) {
       self.bridge = [self createBridgeWithDelegate:self launchOptions:launchOptions];


### PR DESCRIPTION
## Summary:

Goal of this PR is to make it even easier to override root view background color for iOS. After this change users could override color by just overriding `backgroundColor` getter in `AppDelegate.mm`: 

```objc
- (UIColor *)backgroundColor {
  return [UIColor redColor];
}
```

This change could be also added to the docs as the official way of doing this.

Edit: I've also added support for overriding `RCTSurfaceHostingProxyRootView` background color (which was set to `white`) 

## Changelog:

[IOS] [ADDED] - Add backgroundColor property to RCTAppDelegate

## Test Plan:

CI Green
