### PR TITLE
Fixed the height result of onContentSizeChange callback on iOS

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.mm
@@ -87,7 +87,6 @@
     return;
   }
 
-  // Fix issue https://github.com/facebook/react-native/issues/35234#issuecomment-1831141903
   CGSize maximumSize = self.layoutMetrics.contentFrame.size;
 
   if (_maximumNumberOfLines == 1) {

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.mm
@@ -87,7 +87,8 @@
     return;
   }
 
-  CGSize maximumSize = self.layoutMetrics.frame.size;
+  // Fix issue https://github.com/facebook/react-native/issues/35234#issuecomment-1831141903
+  CGSize maximumSize = self.layoutMetrics.contentFrame.size;
 
   if (_maximumNumberOfLines == 1) {
     maximumSize.width = CGFLOAT_MAX;


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The height returned by TextInput's 'onContentSizeChange' callback method is incorrect

Because, the borderwidth and horizontal padding are not subtracted from the content width used to calculate the height of the text.

I have seen many people in the same situation in many issues. When I solved, some people suggested I submit a PR.

More information can be found here [#35234](https://github.com/facebook/react-native/issues/35234#issuecomment-1831141903)

## Changelog:

[IOS] [FIXED]  - the wrong height result of onContentSizeChange callback

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

CI Green

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
