### PR TITLE
(iOS) Fix strict prototype warning

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -91,7 +91,7 @@ RCT_EXTERN_C_END
   {                                                                             \
     return @ #js_name;                                                          \
   }                                                                             \
-  __attribute__((constructor)) static void RCT_CONCAT(initialize_, objc_name)() \
+  __attribute__((constructor)) static void RCT_CONCAT(initialize_, objc_name)(void) \
   {                                                                             \
     RCTRegisterModule([objc_name class]);                                       \
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When using `RCT_EXTERN_REMAP_MODULE` a warning is produced with the following message: "A function declaration without a prototype is deprecated in all versions of C". This warning can be silenced by setting the `CLANG_WARN_STRICT_PROTOTYPES ` build setting. However this PR addresses the underlying problem resulting in no warning messages.

## Changelog:

[IOS] [FIXED] - Fixed strict prototype warning when using the RCT_EXTERN_REMAP_MODULE macro.


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
