### PR TITLE
feat: support isChildPublicInstance from renderer

### DIFF
--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -9,6 +9,7 @@
  */
 
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
+import type ReactFabricHostComponent from './ReactFabricPublicInstance/ReactFabricHostComponent';
 import type {Element, ElementRef, ElementType} from 'react';
 
 import {type RootTag} from './RootTag';
@@ -109,4 +110,14 @@ export function unstable_batchedUpdates<T>(
 
 export function isProfilingRenderer(): boolean {
   return Boolean(__DEV__);
+}
+
+export function isChildPublicInstance(
+  parentInstance: ReactFabricHostComponent | HostComponent<mixed>,
+  childInstance: ReactFabricHostComponent | HostComponent<mixed>,
+): boolean {
+  return require('../Renderer/shims/ReactNative').isChildPublicInstance(
+    parentInstance,
+    childInstance,
+  );
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds `isChildPublicInstance` to renderers implementations, which makes it available for usage from `RendererProxy`.

Differential Revision: D51822905


