### PR TITLE
fix: add isChildPublicInstance to ReactNativeTypes (#27788)

### DIFF
--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,7 @@
  * @noformat
  * @flow strict
  * @nolint
- * @generated SignedSource<<1836a1b6639552dce12199ef2c85f63d>>
+ * @generated SignedSource<<30640e7dd83e22e14db1648ca63f4316>>
  */
 
 import type {ElementRef, ElementType, Element, AbstractComponent} from 'react';
@@ -193,6 +193,10 @@ export type ReactNativeType = {
   findNodeHandle<TElementType: ElementType>(
     componentOrHandle: ?(ElementRef<TElementType> | number),
   ): ?number,
+  isChildPublicInstance(
+    parent: PublicInstance | HostComponent<mixed>,
+    child: PublicInstance | HostComponent<mixed>,
+  ): boolean,
   dispatchCommand(
     handle: ElementRef<HostComponent<mixed>>,
     command: string,
@@ -231,6 +235,7 @@ export type ReactFabricType = {
     command: string,
     args: Array<mixed>,
   ): void,
+  isChildPublicInstance(parent: PublicInstance, child: PublicInstance): boolean,
   sendAccessibilityEvent(
     handle: ElementRef<HostComponent<mixed>>,
     eventType: string,

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
@@ -7,7 +7,7 @@
  * @noformat
  * @flow strict-local
  * @nolint
- * @generated SignedSource<<3cf9b746913da1666cb5bce0ae12d978>>
+ * @generated SignedSource<<73af5b3fe29d226634ed64bc861634df>>
  */
 
 'use strict';
@@ -24,13 +24,11 @@ export const customBubblingEventTypes: {
       skipBubbling?: ?boolean,
     }>,
   }>,
-  ...
 } = {};
 export const customDirectEventTypes: {
   [eventName: string]: $ReadOnly<{
     registrationName: string,
   }>,
-  ...
 } = {};
 
 const viewConfigCallbacks = new Map<string, ?() => ViewConfig>();


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Follow-up on https://github.com/facebook/react/pull/27783.

React Native is actually using `ReactNativeTypes`, which are synced from
this repo. In order to make `isChildPublicInstance` visible for
renderers inside React Native repository, we need to list it in
`ReactNativeTypes`.

Because of current circular dependency between React Native and React,
it is impossible to actually type it properly:
- Can't import any types in `ReactNativeTypes` from local files, because
it will break React Native, once synced.
- Implementations can't use real types in their definitions, because it
will break these checks:

https://github.com/facebook/react/blob/223db40d5a04dc3311f963f5296675f7f43139e8/packages/react-native-renderer/fabric.js#L12-L13

https://github.com/facebook/react/blob/223db40d5a04dc3311f963f5296675f7f43139e8/packages/react-native-renderer/index.js#L12-L14

DiffTrain build for commit https://github.com/facebook/react/commit/c29ca23af91d8aeb9e175c08a0866ba54286f0f3.

Differential Revision: D51849040


