### PR TITLE
Extract binaryCompatibilityValidator into gradle.properties file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,29 +20,19 @@ File("$rootDir/packages/react-native/ReactAndroid/gradle.properties").inputStrea
   reactAndroidProperties.load(it)
 }
 
+fun getListReactAndroidProperty(name: String) = reactAndroidProperties.getProperty(name).split(",")
+
 apiValidation {
   ignoredPackages.addAll(
-      listOf(
-          "com.facebook.fbreact",
-          "com.facebook.react.flipper",
-          "com.facebook.debug",
-          "com.facebook.hermes",
-          "com.facebook.perftest",
-          "com.facebook.proguard",
-          "com.facebook.react.module.processing",
-          "com.facebook.systrace",
-          "com.facebook.yoga",
-          "com.facebook.react.internal",
-          "com.facebook.react.bridgeless.internal"))
-
-  ignoredClasses.addAll(listOf("com.facebook.react.BuildConfig"))
-
+      getListReactAndroidProperty("react.internal.binaryCompatibilityValidator.ignoredPackages"))
+  ignoredClasses.addAll(
+      getListReactAndroidProperty("react.internal.binaryCompatibilityValidator.ignoredClasses"))
   nonPublicMarkers.addAll(
-      listOf(
-          "com.facebook.react.common.annotations.UnstableReactNativeAPI",
-          "com.facebook.react.common.annotations.VisibleForTesting"))
-
-  validationDisabled = true
+      getListReactAndroidProperty("react.internal.binaryCompatibilityValidator.nonPublicMarkers"))
+  validationDisabled =
+      reactAndroidProperties
+          .getProperty("react.internal.binaryCompatibilityValidator.validationDisabled")
+          ?.toBoolean() == true
 }
 
 version =

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -7,3 +7,22 @@ android.enableJetifier=true
 # We want to have more fine grained control on the Java version for
 # ReactAndroid, therefore we disable RGNP Java version alignment mechanism
 react.internal.disableJavaVersionAlignment=true
+
+# Binary Compatibility Validator properties
+react.internal.binaryCompatibilityValidator.ignoredClasses=com.facebook.react.BuildConfig
+react.internal.binaryCompatibilityValidator.ignoredPackages=com.facebook.debug,\
+  com.facebook.fbreact,\
+  com.facebook.hermes,\
+  com.facebook.perftest,\
+  com.facebook.proguard,\
+  com.facebook.react.bridgeless.internal,\
+  com.facebook.react.flipper,\
+  com.facebook.react.internal,\
+  com.facebook.react.module.processing,\
+  com.facebook.react.processing,\
+  com.facebook.systrace,\
+  com.facebook.yoga
+react.internal.binaryCompatibilityValidator.nonPublicMarkers=com.facebook.react.common.annotations.VisibleForTesting,\
+  com.facebook.react.common.annotations.UnstableReactNativeAPI
+react.internal.binaryCompatibilityValidator.validationDisabled=true
+react.internal.binaryCompatibilityValidator.outputApiFileName=ReactAndroid


### PR DESCRIPTION
Summary:
In this diff I'm extracting binaryCompatibilityValidator configuration into gradle.properties file. The goal is to reuse these properties from BUCK

changelog:[Internal] internal

Reviewed By: cortinico

Differential Revision: D51402033


