### PR TITLE
Move several libraries to static linking

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/fb/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/fb/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_library(fb
-        SHARED
+        STATIC
         assert.cpp
         log.cpp)
 

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/fbgloginit/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/fbgloginit/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(-fexceptions -fno-omit-frame-pointer)
 
-add_library(glog_init SHARED glog_init.cpp)
+add_library(glog_init STATIC glog_init.cpp)
 
 target_include_directories(glog_init PUBLIC .)
 

--- a/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options(-std=c++20)
 file(GLOB_RECURSE js_error_handler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(
         jserrorhandler
-        SHARED
+        STATIC
         ${js_error_handler_SRC}
 )
 target_include_directories(jserrorhandler PUBLIC .)

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -11,6 +11,6 @@ add_compile_options(
         -std=c++20)
 
 file(GLOB jsinspector_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(jsinspector SHARED ${jsinspector_SRC})
+add_library(jsinspector STATIC ${jsinspector_SRC})
 
 target_include_directories(jsinspector PUBLIC ${REACT_COMMON_DIR})

--- a/packages/react-native/ReactCommon/logger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/logger/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 add_compile_options(-fexceptions)
 
 file(GLOB logger_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(logger SHARED ${logger_SRC})
+add_library(logger STATIC ${logger_SRC})
 
 target_include_directories(logger PUBLIC .)
 

--- a/packages/react-native/ReactCommon/react/config/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/config/CMakeLists.txt
@@ -16,6 +16,6 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_config_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_config SHARED ${react_config_SRC})
+add_library(react_config STATIC ${react_config_SRC})
 
 target_include_directories(react_config PUBLIC ${REACT_COMMON_DIR})

--- a/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_animations_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_animations SHARED ${react_render_animations_SRC})
+add_library(react_render_animations STATIC ${react_render_animations_SRC})
 
 target_include_directories(react_render_animations PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_attributedstring_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_attributedstring SHARED ${react_render_attributedstring_SRC})
+add_library(react_render_attributedstring STATIC ${react_render_attributedstring_SRC})
 
 target_include_directories(react_render_attributedstring PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_native_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(rrc_native SHARED ${rrc_native_SRC})
+add_library(rrc_native STATIC ${rrc_native_SRC})
 
 target_include_directories(rrc_native PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_root_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(rrc_root SHARED ${rrc_root_SRC})
+add_library(rrc_root STATIC ${rrc_root_SRC})
 
 target_include_directories(rrc_root PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_scrollview_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(rrc_scrollview SHARED ${rrc_scrollview_SRC})
+add_library(rrc_scrollview STATIC ${rrc_scrollview_SRC})
 
 target_include_directories(rrc_scrollview PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_text_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(rrc_text SHARED ${rrc_text_SRC})
+add_library(rrc_text STATIC ${rrc_text_SRC})
 
 target_include_directories(rrc_text PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS platform/android/react/renderer/components/androidtextinput/*.cpp)
-add_library(rrc_textinput SHARED ${rrc_textinput_SRC})
+add_library(rrc_textinput STATIC ${rrc_textinput_SRC})
 
 target_include_directories(rrc_textinput
         PUBLIC

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_unimplementedview_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(rrc_unimplementedview SHARED ${rrc_unimplementedview_SRC})
+add_library(rrc_unimplementedview STATIC ${rrc_unimplementedview_SRC})
 
 target_include_directories(rrc_unimplementedview PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_leakchecker_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_leakchecker SHARED ${react_render_leakchecker_SRC})
+add_library(react_render_leakchecker STATIC ${react_render_leakchecker_SRC})
 
 target_include_directories(react_render_leakchecker PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_render_leakchecker

--- a/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_mounting_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_mounting SHARED ${react_render_mounting_SRC})
+add_library(react_render_mounting STATIC ${react_render_mounting_SRC})
 
 target_include_directories(react_render_mounting PRIVATE .)
 target_include_directories(react_render_mounting PUBLIC ${REACT_COMMON_DIR})

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_runtimescheduler_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_runtimescheduler SHARED ${react_render_runtimescheduler_SRC})
+add_library(react_render_runtimescheduler STATIC ${react_render_runtimescheduler_SRC})
 
 target_include_directories(react_render_runtimescheduler PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_scheduler_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_scheduler SHARED ${react_render_scheduler_SRC})
+add_library(react_render_scheduler STATIC ${react_render_scheduler_SRC})
 
 target_include_directories(react_render_scheduler PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_telemetry_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_telemetry SHARED ${react_render_telemetry_SRC})
+add_library(react_render_telemetry STATIC ${react_render_telemetry_SRC})
 
 target_include_directories(react_render_telemetry PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -20,7 +20,7 @@ file(GLOB react_render_textlayourmanager_SRC CONFIGURE_DEPENDS
         platform/android/react/renderer/textlayoutmanager/*.cpp)
 
 add_library(react_render_textlayoutmanager
-        SHARED
+        STATIC
         ${react_render_textlayourmanager_SRC})
 
 target_include_directories(react_render_textlayoutmanager

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_uimanager_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_uimanager SHARED ${react_render_uimanager_SRC})
+add_library(react_render_uimanager STATIC ${react_render_uimanager_SRC})
 
 target_include_directories(react_render_uimanager PUBLIC ${REACT_COMMON_DIR})
 


### PR DESCRIPTION
Summary:
Our Apps in OSS ends up shipping with too many .so files.
I'm attempting to move several libraries from dynamic to static.

This is a first round of it affecnting only libraries which are not
exposed via prefab and that are not having an OnLoad method

Changelog:
[Internal] [Changed] - Move several libraries to static linking

Differential Revision: D51895785


