### PR TITLE
Add position type to LayoutMetrics

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -98,6 +98,18 @@ inline std::optional<Float> optionalFloatFromYogaValue(
   }
 }
 
+static inline PositionType positionTypeFromYogaPositionType(
+    yoga::PositionType positionType) {
+  switch (positionType) {
+    case yoga::PositionType::Static:
+      return PositionType::Static;
+    case yoga::PositionType::Relative:
+      return PositionType::Relative;
+    case yoga::PositionType::Absolute:
+      return PositionType::Absolute;
+  }
+}
+
 inline LayoutMetrics layoutMetricsFromYogaNode(yoga::Node& yogaNode) {
   auto layoutMetrics = LayoutMetrics{};
 
@@ -128,6 +140,9 @@ inline LayoutMetrics layoutMetricsFromYogaNode(yoga::Node& yogaNode) {
   layoutMetrics.displayType =
       yogaNode.getStyle().display() == yoga::Display::None ? DisplayType::None
                                                            : DisplayType::Flex;
+
+  layoutMetrics.positionType =
+      positionTypeFromYogaPositionType(yogaNode.getStyle().positionType());
 
   layoutMetrics.layoutDirection =
       YGNodeLayoutGetDirection(&yogaNode) == YGDirectionRTL

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -29,6 +29,8 @@ struct LayoutMetrics {
   EdgeInsets borderWidth{0};
   // See `DisplayType` for all possible options.
   DisplayType displayType{DisplayType::Flex};
+  // See `PositionType` for all possible options.
+  PositionType positionType{PositionType::Static};
   // See `LayoutDirection` for all possible options.
   LayoutDirection layoutDirection{LayoutDirection::Undefined};
   // Whether React Native treated cardinal directions as flow-relative

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutPrimitives.h
@@ -22,6 +22,12 @@ enum class DisplayType {
   Inline = 2,
 };
 
+enum class PositionType {
+  Static = 0,
+  Relative = 1,
+  Absolute = 2,
+};
+
 /*
  * User interface layout direction.
  */


### PR DESCRIPTION
Summary:
This will be needed in order to access the position type while implementing offsetLeft/Top, which needs to know if a node is static or not to get the proper offset. This is simply making the position type available to be read from LayoutMetrics. 

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D51412428


