### PR TITLE
[iOS] Fix build fail when "ipconfig getifaddr" does not have IP

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -9,7 +9,7 @@
 # and relies on environment variables (including PWD) set by Xcode
 
 # Print commands before executing them (useful for troubleshooting)
-set -x -e
+set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
 # Enables iOS devices to get the IP address of the machine running Metro
@@ -26,6 +26,9 @@ if [[ ! "$SKIP_BUNDLING_METRO_IP" && "$CONFIGURATION" = *Debug* && ! "$PLATFORM_
 
   echo "$IP" > "$DEST/ip.txt"
 fi
+
+# Fail Xcode build if Build JS Bundle script phase fails
+set -e
 
 if [[ "$SKIP_BUNDLING" ]]; then
   echo "SKIP_BUNDLING enabled; skipping."


### PR DESCRIPTION
One of the build phase scripts fails when IP is assigned to non-en0 interface because "ipconfig getifaddr en0" exits with 1 when IP is not assigned to en0. That produced "PhaseScriptExecution failed with a nonzero exit code" in Xcode. The patch fixes this issue by removing "set -e" and re-enabling it later in the script.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
iOS build fails during ```Bundle React Native code and images``` phase.
The actual error message is ```PhaseScriptExecution failed with a nonzero exit code```.
After doing some debugging it appears the issue is within ```scripts/react-native-xcode.sh``` and was introduced in the commit https://github.com/facebook/react-native/commit/a56e5dad7c31b6e9e6b02333219bc33811215056

The patch removes "set -e" and re-enables it after looping through interfaces. Also, added the original commit comment to explain why it's been added there initially.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[IOS][FIXED] [Fix the build failure when "en0" does not have IP assigned](https://github.com/facebook/react-native/pull/41823/commits/bf34b684b4cb2948bd5566873def7a971d617c8b)

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
