### PR TITLE
Adds "Needs: Author Feedback" if "Needs: Repro" is applied

### DIFF
--- a/.github/workflow-scripts/checkForReproducer.js
+++ b/.github/workflow-scripts/checkForReproducer.js
@@ -8,6 +8,7 @@
  */
 
 const NEEDS_REPRO_LABEL = 'Needs: Repro';
+const NEEDS_AUTHOR_FEEDBACK_LABEL = 'Needs: Author Feedback';
 const NEEDS_REPRO_HEADER = 'Missing Reproducible Example';
 const NEEDS_REPRO_MESSAGE =
   `| :warning: | Missing Reproducible Example |\n` +
@@ -83,7 +84,7 @@ module.exports = async (github, context) => {
   } else {
     await github.rest.issues.addLabels({
       ...issueData,
-      labels: [NEEDS_REPRO_LABEL],
+      labels: [NEEDS_REPRO_LABEL, NEEDS_AUTHOR_FEEDBACK_LABEL],
     });
 
     if (botComment) return;


### PR DESCRIPTION
Summary:
As the title says, if we discover that an issue needs a repro, then we should also apply
the "Needs: Author Feedback" as that will make the issue stale quicker (30 days) rather than (90)

Changelog:
[Internal] [Changed] - Adds "Needs: Author Feedback" if "Needs: Repro" is applied

Reviewed By: NickGerleman

Differential Revision: D51895945


