### PR TITLE
Bump Android Docker Image to v12

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -25,7 +25,7 @@ references:
   android-defaults: &android-defaults
     working_directory: ~/react-native
     docker:
-      - image: reactnativecommunity/react-native-android:v11.0
+      - image: reactnativecommunity/react-native-android:v12.0
     environment:
       - TERM: "dumb"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false'


### PR DESCRIPTION
Summary:
Bumping the docker image used inside CircleCI to v12
This image contains NDK 26.0.10792818 which was bumped recently.

Without it the CI will attempt to download it everytime consuming time and bandwidth

Changelog:
[Internal] [Changed] - Bump Android Docker Image to v12

Reviewed By: NickGerleman

Differential Revision: D51897068


