### PR TITLE
Lint source files, sort imports, remove unused imports

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -9,6 +9,7 @@
  * @oncall react_native
  */
 
+import type {EventReporter} from '../types/EventReporter';
 import type {
   DebuggerRequest,
   ErrorResponse,
@@ -22,10 +23,9 @@ import type {
 
 import DeviceEventReporter from './DeviceEventReporter';
 import * as fs from 'fs';
-import * as path from 'path';
 import fetch from 'node-fetch';
+import * as path from 'path';
 import WS from 'ws';
-import type {EventReporter} from '../types/EventReporter';
 
 const debug = require('debug')('Metro:InspectorProxy');
 

--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -14,11 +14,8 @@ import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type AnimatedNode from '../nodes/AnimatedNode';
 import type AnimatedValue from '../nodes/AnimatedValue';
 
-import Platform from '../../Utilities/Platform';
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
-import AnimatedColor from '../nodes/AnimatedColor';
 import AnimatedProps from '../nodes/AnimatedProps';
-import AnimatedValueXY from '../nodes/AnimatedValueXY';
 
 export type EndResult = {finished: boolean, value?: number, ...};
 export type EndCallback = (result: EndResult) => void;

--- a/packages/react-native/Libraries/DOM/OldStyleCollections/DOMRectList.js.flow
+++ b/packages/react-native/Libraries/DOM/OldStyleCollections/DOMRectList.js.flow
@@ -8,8 +8,8 @@
  * @flow strict
  */
 
-import type {ArrayLike} from './ArrayLikeUtils';
 import type DOMRectReadOnly from '../Geometry/DOMRectReadOnly';
+import type {ArrayLike} from './ArrayLikeUtils';
 
 declare export default class DOMRectList
   implements Iterable<DOMRectReadOnly>, ArrayLike<DOMRectReadOnly>

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-import type {Spec as FabricUIManagerSpec} from '../ReactNative/FabricUIManager';
 import type {
   LayoutAnimationConfig as LayoutAnimationConfig_,
   LayoutAnimationProperty,

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -156,6 +156,16 @@ const onScrollToIndexFailed = (info: {
    */
 };
 
+// $FlowFixMe[missing-local-annot]
+const ItemSeparatorComponent = info => (
+  <CustomSeparatorComponent {...info} text="ITEM SEPARATOR" />
+);
+
+// $FlowFixMe[missing-local-annot]
+const SectionSeparatorComponent = info => (
+  <CustomSeparatorComponent {...info} text="SECTION SEPARATOR" />
+);
+
 export function SectionList_scrollable(Props: {
   ...
 }): React.Element<typeof RNTesterPage> {
@@ -280,14 +290,8 @@ export function SectionList_scrollable(Props: {
         ref={ref}
         ListHeaderComponent={HeaderComponent}
         ListFooterComponent={FooterComponent}
-        // $FlowFixMe[missing-local-annot]
-        SectionSeparatorComponent={info => (
-          <CustomSeparatorComponent {...info} text="SECTION SEPARATOR" />
-        )}
-        // $FlowFixMe[missing-local-annot]
-        ItemSeparatorComponent={info => (
-          <CustomSeparatorComponent {...info} text="ITEM SEPARATOR" />
-        )}
+        SectionSeparatorComponent={SectionSeparatorComponent}
+        ItemSeparatorComponent={ItemSeparatorComponent}
         accessibilityRole="list"
         debug={debug}
         inverted={inverted}

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -323,7 +323,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const examples: Array<RNTesterModuleExample> = [
+const textInputExamples: Array<RNTesterModuleExample> = [
   ...TextInputSharedExamples,
   {
     title: 'Live Re-Write (ひ -> 日)',
@@ -944,5 +944,5 @@ module.exports = ({
   documentationURL: 'https://reactnative.dev/docs/textinput',
   category: 'Basic',
   description: 'Single and multi-line text inputs.',
-  examples,
+  examples: textInputExamples,
 }: RNTesterModule);

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -16,18 +16,17 @@
  * and to make it more accessible for other devs to play around with.
  */
 
-const {exec, pushd, popd, pwd, cd, sed} = require('shelljs');
-const updateTemplatePackage = require('./update-template-package');
-const yargs = require('yargs');
-const path = require('path');
-
 const {
   checkPackagerRunning,
-  maybeLaunchAndroidEmulator,
   launchPackagerInSeparateWindow,
-  setupCircleCIArtifacts,
+  maybeLaunchAndroidEmulator,
   prepareArtifacts,
+  setupCircleCIArtifacts,
 } = require('./testing-utils');
+const updateTemplatePackage = require('./update-template-package');
+const path = require('path');
+const {cd, exec, popd, pushd, pwd, sed} = require('shelljs');
+const yargs = require('yargs');
 
 const argv = yargs
   .option('t', {


### PR DESCRIPTION
## Summary:

This PR lints source files using eslint. I've executed `yarn lint --fix` and also manually fixed some of eslint issues. 

Before: 

![CleanShot 2023-12-07 at 12 07 10@2x](https://github.com/facebook/react-native/assets/52801365/2b00cf23-e5a0-46b8-802f-adcb67224111)


After: 

![CleanShot 2023-12-07 at 12 06 24@2x](https://github.com/facebook/react-native/assets/52801365/bb05b2c0-2b27-4f99-b7b4-cb47a51a3885)


## Changelog:

[GENERAL] [FIXED] - Lint source files, sort imports, remove unused ones

## Test Plan:

CI Green
