### PR TITLE
Enhance IP address retrieval for iOS devices in Metro bundler setup

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -15,7 +15,7 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 # Enables iOS devices to get the IP address of the machine running Metro
 if [[ ! "$SKIP_BUNDLING_METRO_IP" && "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
   for num in 0 1 2 3 4 5 6 7 8; do
-    IP=$(ipconfig getifaddr en${num})
+    IP=$(ipconfig getifaddr en${num} || echo "")
     if [ ! -z "$IP" ]; then
       break
     fi


### PR DESCRIPTION
## Summary:
After introducing this commit https://github.com/facebook/react-native/commit/a56e5dad7c31b6e9e6b02333219bc33811215056 script may fail in some circumstances.

Example:
When there is IP address available only for en1 and not en0, first "ipconfig" command in the loop fails with error code 1 and cancels whole script.

## Changelog:
[iOS] [Fixed] - [enhance IP address retrieval for iOS devices in Metro bundler setup](https://github.com/facebook/react-native/pull/41839/commits/6a351db158dadf944933173aa0150435c742001f)