### PR TITLE
Fix CocoaPods crash with nonexistent files

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -139,6 +139,10 @@ class PBXFileRefMock
         @name = name
         @path = name
     end
+
+    def real_path
+        @path
+    end
 end
 
 class XCConfigMock

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -797,6 +797,8 @@ class UtilsTests < Test::Unit::TestCase
 
     def test_applyATSConfig_plistNil
         # Arrange
+        FileMock.mocked_existing_files("Info.plist")
+        FileMock.mocked_existing_files("Extension-Info.plist")
         user_project_mock = prepare_user_project_mock_with_plists()
         pods_projects_mock = PodsProjectMock.new([], {"some_pod" => {}})
         installer = InstallerMock.new(pods_projects_mock, [
@@ -804,7 +806,7 @@ class UtilsTests < Test::Unit::TestCase
         ])
 
         # # Act
-        ReactNativePodsUtils.apply_ats_config(installer)
+        ReactNativePodsUtils.apply_ats_config(installer, file_manager: FileMock)
 
         # # Assert
         assert_equal(user_project_mock.files.length, 2)
@@ -820,6 +822,8 @@ class UtilsTests < Test::Unit::TestCase
 
     def test_applyATSConfig_plistNonNil
         # Arrange
+        FileMock.mocked_existing_files("Info.plist")
+        FileMock.mocked_existing_files("Extension-Info.plist")
         user_project_mock = prepare_user_project_mock_with_plists()
         pods_projects_mock = PodsProjectMock.new([], {"some_pod" => {}})
         installer = InstallerMock.new(pods_projects_mock, [
@@ -829,7 +833,7 @@ class UtilsTests < Test::Unit::TestCase
         Xcodeproj::Plist.write_to_path({}, "/test/Extension-Info.plist")
 
         # # Act
-        ReactNativePodsUtils.apply_ats_config(installer)
+        ReactNativePodsUtils.apply_ats_config(installer, file_manager: FileMock)
 
         # # Assert
         assert_equal(user_project_mock.files.length, 2)

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -519,11 +519,11 @@ class ReactNativePodsUtils
         ReactNativePodsUtils.update_header_paths_if_depends_on(target_installation_result, "React-ImageManager", header_search_paths)
     end
 
-    def self.get_plist_paths_from(user_project)
+    def self.get_plist_paths_from(user_project, file_manager)
         info_plists = user_project
           .files
           .select { |p|
-            p.name&.end_with?('Info.plist')
+            file_manager.exist?(p.real_path) && p.name&.end_with?('Info.plist')
           }
         return info_plists
       end
@@ -547,11 +547,11 @@ class ReactNativePodsUtils
         end
     end
 
-    def self.apply_ats_config(installer)
+    def self.apply_ats_config(installer, file_manager: File)
         user_project = installer.aggregate_targets
                     .map{ |t| t.user_project }
                     .first
-        plistPaths = self.get_plist_paths_from(user_project)
+        plistPaths = self.get_plist_paths_from(user_project, file_manager)
         self.update_ats_in_plist(plistPaths, user_project.path.parent)
     end
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Xcode Projects can contain files that don't exist _until build time_. If one of these happens to end with `Info.plist` (as is this case with our project), CocoaPods will crash, since `utils.rb` tries to patch all of these with ATS stuff. In the case where these files don't exist on disk, this CocoaPods post-install job should simply ignore those file references.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - Fixed CocoaPods crashing when Xcode project contains non-existent -Info.plist file

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I've refactored the `apply_ats_config` method to also accept a `file_manager` param so that the file manager can be mocked in the unit tests. I have confirmed that the unit tests continue to pass, and also when I have applied the changes to `utils.rb` in react native in our main project's `node_modules`, a `pod install` now no longer crashes.