### PR TITLE
Update docs link for metro.config.js in template

### DIFF
--- a/packages/react-native/template/metro.config.js
+++ b/packages/react-native/template/metro.config.js
@@ -2,7 +2,7 @@ const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 
 /**
  * Metro configuration
- * https://facebook.github.io/metro/docs/configuration
+ * https://reactnative.dev/docs/metro
  *
  * @type {import('metro-config').MetroConfig}
  */


### PR DESCRIPTION
## Summary

Small edit to point to the newer React Native docs guide for Metro, which includes more clarity on the `metro.config.js` file setup in React Native projects.

Changelog: [Internal]

## Test Plan

—
