### PR TITLE
Fix comment about adding packages in android template

### DIFF
--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -16,9 +16,8 @@ class MainApplication : Application(), ReactApplication {
   override val reactNativeHost: ReactNativeHost =
       object : DefaultReactNativeHost(this) {
         override fun getPackages(): List<ReactPackage> {
-          // Packages that cannot be autolinked yet can be added manually here, for example:
           return PackageList(this).packages.apply {
-              // Packages that cannot be autolinked yet can be added manually here, for example:
+            // Packages that cannot be autolinked yet can be added manually here, for example:
 	          // add(MyReactNativePackage())
           }
         }

--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -17,7 +17,9 @@ class MainApplication : Application(), ReactApplication {
       object : DefaultReactNativeHost(this) {
         override fun getPackages(): List<ReactPackage> {
           // Packages that cannot be autolinked yet can be added manually here, for example:
-          // packages.add(new MyReactNativePackage());
+          // val packages = PackageList(this).packages
+          // packages.add(MyReactNativePackage())
+          // return packages
           return PackageList(this).packages
         }
 

--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -15,12 +15,11 @@ class MainApplication : Application(), ReactApplication {
 
   override val reactNativeHost: ReactNativeHost =
       object : DefaultReactNativeHost(this) {
-        override fun getPackages(): List<ReactPackage> {
-          return PackageList(this).packages.apply {
-            // Packages that cannot be autolinked yet can be added manually here, for example:
-	          // add(MyReactNativePackage())
-          }
-        }
+        override fun getPackages(): List<ReactPackage> =
+            PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+              add(TWAppTurboReactPackage())
+            }
 
         override fun getJSMainModuleName(): String = "index"
 

--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -17,10 +17,10 @@ class MainApplication : Application(), ReactApplication {
       object : DefaultReactNativeHost(this) {
         override fun getPackages(): List<ReactPackage> {
           // Packages that cannot be autolinked yet can be added manually here, for example:
-          // val packages = PackageList(this).packages
-          // packages.add(MyReactNativePackage())
-          // return packages
-          return PackageList(this).packages
+          return PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+	          // add(MyReactNativePackage())
+          }
         }
 
         override fun getJSMainModuleName(): String = "index"

--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -18,7 +18,7 @@ class MainApplication : Application(), ReactApplication {
         override fun getPackages(): List<ReactPackage> =
             PackageList(this).packages.apply {
               // Packages that cannot be autolinked yet can be added manually here, for example:
-              add(TWAppTurboReactPackage())
+              // add(MyReactNativePackage())
             }
 
         override fun getJSMainModuleName(): String = "index"


### PR DESCRIPTION
## Summary:

I noticed this comment is still in Java in the Kotlin template. It also doesn't really work anymore since there is no packages variable.

To fix it I completed the comment with all code needed for it to work in kotlin. I think an older version of the template used to be more like:

```kotlin
val packages = PackageList(this).packages
// packages.add(MyReactNativePackage())
return packages
```

But then it requires adding a lint suppress annotation since packages variable can be simplified. I think this is simpler even if it makes the comment a few more lines.

## Changelog:

[GENERAL] [FIXED] - Fix comment about adding packages in android template

## Test Plan:

Tested that uncommenting that code works
