### PR TITLE
PaperUIManager: Pull getViewManagerConfig() internal state into closure

### DIFF
--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -22,15 +22,18 @@ const viewManagerConfigs: {[string]: any | null} = {};
 
 const triedLoadingConfig = new Set<string>();
 
-let NativeUIManagerConstants = {};
-let isNativeUIManagerConstantsSet = false;
-function getConstants(): Object {
-  if (!isNativeUIManagerConstantsSet) {
-    NativeUIManagerConstants = NativeUIManager.getConstants();
-    isNativeUIManagerConstantsSet = true;
-  }
-  return NativeUIManagerConstants;
-}
+const getConstants = (function () {
+  let result = {};
+  let wasCalledOnce = false;
+
+  return (): Object => {
+    if (!wasCalledOnce) {
+      result = NativeUIManager.getConstants();
+      wasCalledOnce = true;
+    }
+    return result;
+  };
+})();
 
 function getViewManagerConfig(viewManagerName: string): any {
   if (

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -121,34 +121,40 @@ function lazifyViewManagerConfig(viewName: string) {
   viewConfigCache[viewName] = viewConfig;
   if (viewConfig.Manager) {
     defineLazyObjectProperty(viewConfig, 'Constants', {
-      get: () => {
-        const viewManager = NativeModules[viewConfig.Manager];
-        const constants: {[string]: mixed} = {};
-        viewManager &&
-          Object.keys(viewManager).forEach(key => {
-            const value = viewManager[key];
-            if (typeof value !== 'function') {
-              constants[key] = value;
-            }
-          });
-        return constants;
-      },
+      get: getConstantsFromViewManager,
     });
     defineLazyObjectProperty(viewConfig, 'Commands', {
-      get: () => {
-        const viewManager = NativeModules[viewConfig.Manager];
-        const commands: {[string]: number} = {};
-        let index = 0;
-        viewManager &&
-          Object.keys(viewManager).forEach(key => {
-            const value = viewManager[key];
-            if (typeof value === 'function') {
-              commands[key] = index++;
-            }
-          });
-        return commands;
-      },
+      get: mapViewManagerMethodsToIndex,
     });
+  }
+
+  function getConstantsFromViewManager() {
+    const viewManager = NativeModules[viewConfig.Manager];
+    const constants: {[string]: mixed} = {};
+    if (viewManager) {
+      Object.keys(viewManager).forEach(key => {
+        const value = viewManager[key];
+        if (typeof value !== 'function') {
+          constants[key] = value;
+        }
+      });
+    }
+    return constants;
+  }
+
+  function mapViewManagerMethodsToIndex() {
+    const viewManager = NativeModules[viewConfig.Manager];
+    const commands: {[string]: number} = {};
+    let index = 0;
+    if (viewManager) {
+      Object.keys(viewManager).forEach(key => {
+        const value = viewManager[key];
+        if (typeof value === 'function') {
+          commands[key] = index++;
+        }
+      });
+    }
+    return commands;
   }
 }
 

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -74,7 +74,7 @@ function getViewManagerConfig(viewManagerName: string): any {
     triedLoadingConfig.add(viewManagerName);
     if (result != null && result.viewConfig != null) {
       getUIManagerConstantsCache()[viewManagerName] = result.viewConfig;
-      viewConfigCache[viewManagerName] = lazifyViewManagerConfig(
+      viewConfigCache[viewManagerName] = completeViewConfig(
         viewManagerName,
         result.viewConfig,
       );
@@ -119,7 +119,7 @@ const UIManagerJS: UIManagerJSInterface = {
 // $FlowFixMe[prop-missing]
 NativeUIManager.getViewManagerConfig = UIManagerJS.getViewManagerConfig;
 
-function lazifyViewManagerConfig(viewName: string, viewConfig: Object): Object {
+function completeViewConfig(viewName: string, viewConfig: Object): Object {
   if (viewConfig.Manager) {
     defineLazyObjectProperty(viewConfig, 'Constants', {
       get: getConstantsFromViewManager,
@@ -169,7 +169,7 @@ function lazifyViewManagerConfig(viewName: string, viewConfig: Object): Object {
 if (Platform.OS === 'ios') {
   Object.entries(getUIManagerConstantsCache()).forEach(
     ([viewName, viewConfig]) => {
-      viewConfigCache[viewName] = lazifyViewManagerConfig(viewName, viewConfig);
+      viewConfigCache[viewName] = completeViewConfig(viewName, viewConfig);
     },
   );
 } else if (getUIManagerConstantsCache().ViewManagerNames) {


### PR DESCRIPTION
Summary:
## Rationale
Reducing global state inside PaperUIManager makes the file less overwhelming to read.

Changelog: [Internal]

Reviewed By: dmytrorykun

Differential Revision: D51987205


