### PR TITLE
PaperUIMangaer: Rename viewManagerConfigs -> viewConfigCache

### DIFF
--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -22,15 +22,18 @@ const viewManagerConfigs: {[string]: any | null} = {};
 
 const triedLoadingConfig = new Set<string>();
 
-let NativeUIManagerConstants = {};
-let isNativeUIManagerConstantsSet = false;
-function getConstants(): Object {
-  if (!isNativeUIManagerConstantsSet) {
-    NativeUIManagerConstants = NativeUIManager.getConstants();
-    isNativeUIManagerConstantsSet = true;
-  }
-  return NativeUIManagerConstants;
-}
+const getConstants = (function () {
+  let result = {};
+  let wasCalledOnce = false;
+
+  return (): Object => {
+    if (!wasCalledOnce) {
+      result = NativeUIManager.getConstants();
+      wasCalledOnce = true;
+    }
+    return result;
+  };
+})();
 
 function getViewManagerConfig(viewManagerName: string): any {
   if (


### PR DESCRIPTION
Summary:
I think the new name is more accurate: The viewManagerConfigs variable is really just a cache of all the completed viewConfigs.

Changelog: [Internal]

Reviewed By: dmytrorykun

Differential Revision: D51987208


