### PR TITLE
PaperUIManager: Rename getConstants() -> getUIManagerConstantsCache()

### DIFF
--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -22,15 +22,18 @@ const viewManagerConfigs: {[string]: any | null} = {};
 
 const triedLoadingConfig = new Set<string>();
 
-let NativeUIManagerConstants = {};
-let isNativeUIManagerConstantsSet = false;
-function getConstants(): Object {
-  if (!isNativeUIManagerConstantsSet) {
-    NativeUIManagerConstants = NativeUIManager.getConstants();
-    isNativeUIManagerConstantsSet = true;
-  }
-  return NativeUIManagerConstants;
-}
+const getConstants = (function () {
+  let result = {};
+  let wasCalledOnce = false;
+
+  return (): Object => {
+    if (!wasCalledOnce) {
+      result = NativeUIManager.getConstants();
+      wasCalledOnce = true;
+    }
+    return result;
+  };
+})();
 
 function getViewManagerConfig(viewManagerName: string): any {
   if (


### PR DESCRIPTION
Summary:
## Rationale

The new name makes it clear:
* The constants come from NativeUIManager
* The constants are cached (i.e: computed once).

I might further improve the name later, after I further develop my understanding of this method. 

Changelog: [Internal]

Reviewed By: dmytrorykun

Differential Revision: D51987399


