### PR TITLE
fix(react-native): iOS font heavy weight mapping to 800

### DIFF
--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -47,7 +47,7 @@ static RCTFontWeight weightOfFont(UIFont *font)
       @(UIFontWeightHeavy),
       @(UIFontWeightHeavy),
       @(UIFontWeightBold),
-      @(UIFontWeightHeavy),
+      @(UIFontWeightBlack),
       @(UIFontWeightBlack)
     ];
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Font Weight Alignment for `Heavy` in React Native

The typical font-weight value for `Heavy` fonts is 900, yet Apple designates `UIFontWeightHeavy` as 800.

This adjustment may seem unconventional, but it addresses the trade-off between adhering to iOS default design patterns and ensuring consistency across platforms (Android and Web). Embracing the principle of "write once, run everywhere," minimising discrepancies between platforms reduces confusion and extra effort, even if it doesn't strictly classify as an error but rather a deviation from expectations.

For more insights, refer to the common weight name mapping documented on [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-weight#common_weight_name_mapping).

The proposed change involves mapping `Heavy` PostScript Name fonts to be treated as a font weight of 900.


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [CHANGED] - iOS font heavy weight mapping from 800 to 900, to match web expectation

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
