### PR TITLE
Fix cleanAssetCatalog error

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
@@ -16,11 +16,11 @@ import fs from 'fs';
 import path from 'path';
 
 export function cleanAssetCatalog(catalogDir: string): void {
-  const files = fs
+  const imageSets = fs
     .readdirSync(catalogDir)
-    .filter(file => file.endsWith('.imageset'));
-  for (const file of files) {
-    fs.rmSync(path.join(catalogDir, file));
+    .filter(imageSet => imageSet.endsWith('.imageset'));
+  for (const imageSet of imageSets) {
+    fs.rmSync(path.join(catalogDir, imageSet), {recursive: true, force: true});
   }
 }
 

--- a/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
@@ -16,11 +16,11 @@ import fs from 'fs';
 import path from 'path';
 
 export function cleanAssetCatalog(catalogDir: string): void {
-  const imageSets = fs
+  const files = fs
     .readdirSync(catalogDir)
-    .filter(imageSet => imageSet.endsWith('.imageset'));
-  for (const imageSet of imageSets) {
-    fs.rmSync(path.join(catalogDir, imageSet), {recursive: true, force: true});
+    .filter(file => file.endsWith('.imageset'));
+  for (const file of files) {
+    fs.rmSync(path.join(catalogDir, file), {recursive: true, force: true});
   }
 }
 


### PR DESCRIPTION
## Summary:

There is currently an error when building in release on iOS when using asset catalogs (experimental feature that is partially merged https://github.com/facebook/react-native/pull/30129)

This was probably incorrectly migrated from the community cli repo. `.imageset` is actually folders so it needs to be removed with `{recursive: true, force: true}`. I also renamed the variable `files` which is confusing since its folders.

## Changelog:

[IOS] [FIXED] - Fix cleanAssetCatalog error

## Test Plan:

Tested in an app that uses asset catalogs
