### PR TITLE
Throw parser error in case direct recursive types are not nullable

### DIFF
--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -217,6 +217,20 @@ class UnsupportedObjectPropertyValueTypeAnnotationParserError extends ParserErro
   }
 }
 
+class UnsupportedObjectDirectRecursivePropertyParserError extends ParserError {
+  constructor(
+    propertyName: string,
+    propertyValueAST: $FlowFixMe,
+    nativeModuleName: string,
+  ) {
+    super(
+      nativeModuleName,
+      propertyValueAST,
+      `Object property '${propertyName}' is direct recursive and must be nullable.`,
+    );
+  }
+}
+
 /**
  * Function parsing errors
  */
@@ -405,6 +419,7 @@ module.exports = {
   UnsupportedModulePropertyParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
+  UnsupportedObjectDirectRecursivePropertyParserError,
   UnusedModuleInterfaceParserError,
   MoreThanOneModuleRegistryCallsParserError,
   UntypedModuleRegistryCallParserError,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -61,6 +61,7 @@ const {
   MissingTypeParameterGenericParserError,
   MoreThanOneTypeParameterGenericParserError,
   UnnamedFunctionParamParserError,
+  UnsupportedObjectDirectRecursivePropertyParserError,
 } = require('./errors');
 const {
   createParserErrorCapturer,
@@ -208,6 +209,13 @@ function parseObjectProperty(
         : parentObject.id &&
           parentObject.id.name === languageTypeAnnotation.id?.name)
     ) {
+      if (!optional) {
+        throw new UnsupportedObjectDirectRecursivePropertyParserError(
+          name,
+          languageTypeAnnotation,
+          hasteModuleName,
+        );
+      }
       return {
         name,
         optional,


### PR DESCRIPTION
Summary:
Direct recursive member types require infinite memory and aren't possible with current hardware.

Throw parser error to make this visible.

Changelog: [Internal]

Differential Revision: D51999832


