### PR TITLE
fix: Fix iOS build error when `en0` is not available

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -15,7 +15,7 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 # Enables iOS devices to get the IP address of the machine running Metro
 if [[ ! "$SKIP_BUNDLING_METRO_IP" && "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
   for num in 0 1 2 3 4 5 6 7 8; do
-    IP=$(ipconfig getifaddr en${num})
+    IP=$(ipconfig getifaddr en${num} || true)
     if [ ! -z "$IP" ]; then
       break
     fi


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes a build error that happens when trying to find the host IP address.

The `react-native-xcode.sh` script tries to find the host machines IP address by looping through all network interfaces:

```sh
for num in 0 1 2 3 4 5 6 7 8; do
  IP=$(ipconfig getifaddr en${num})
  if [ ! -z "$IP" ]; then
    break
  fi
done
```

This works when the network interface is on `en0`, but when `en0` is empty, it will immediately cause the build to fail, even though it would've worked on the next iteration (`en1`).

This is due to the fact that the script runs with `set -e`, meaning any error exit code will cause the entire script to fail - and `ipconfig` will return an exit code of `1` when the network interface `en0` can't be found.

This fixes that error by ignoring the error codes of `ipconfig`, which is what the script was intended to do anyways (it loops over all 9 different interfaces), by adding a `|| true` clause.


Before:

![Screenshot 2023-12-09 at 13 33 21](https://github.com/facebook/react-native/assets/15199031/21eed96d-a555-4ccc-8c42-53dc7b8d73c9)

After:

![Screenshot 2023-12-09 at 13 33 11](https://github.com/facebook/react-native/assets/15199031/4b1e4f3a-924b-4338-a6cd-76eac73b5df5)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Fix 0.73 build error when `ipconfig` fails to find the IP address

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Run a build on a machine where `ipconfig getifaddr en0` returns nothing.