### PR TITLE
[iOS] Fix NSAppTransportSecurity being overwritten during pod install

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -541,7 +541,8 @@ class ReactNativePodsUtils
                     "NSAppTransportSecurity" => ats_configs
                 }
             else
-                plist["NSAppTransportSecurity"] = ats_configs
+                plist["NSAppTransportSecurity"] ||= {}
+                plist["NSAppTransportSecurity"] = plist["NSAppTransportSecurity"].merge(ats_configs)
             end
             Xcodeproj::Plist.write_to_path(plist, fullPlistPath)
         end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR fixes #41874.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Fix NSAppTransportSecurity being overwritten during pod install

## Test Plan:

1. Delete the whole `NSAppTransportSecurity` in Info.plist and run `pod install`: `NSAllowsArbitraryLoads` and `NSAllowsLocalNetworking` are added as expected.
2. Modify `NSAppTransportSecurity` to only contain `NSExceptionDomains` and run `pod install`: `NSAllowsArbitraryLoads` and `NSAllowsLocalNetworking` are added, and `NSExceptionDomains` is still there.
3. Run `pod install` again: nothing changes.