### PR TITLE
Removing Fabric check from UIManagerProvider (#41664)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1406,14 +1406,14 @@ public class ReactInstanceManager {
           mJSIModulePackage.getJSIModules(
               reactContext, catalystInstance.getJavaScriptContextHolder()));
     }
-    if (ReactFeatureFlags.enableFabricRenderer) {
-      if (mUIManagerProvider != null) {
-        UIManager uiManager = mUIManagerProvider.createUIManager(reactContext);
-        uiManager.initialize();
-        catalystInstance.setFabricUIManager(uiManager);
-      } else {
-        catalystInstance.getJSIModule(JSIModuleType.UIManager);
-      }
+    // The setFabricUIManager API is valid even if enableFabricRenderer is false because
+    // apps that override getUIManagerProvider() are indicating they want to use Fabric.
+    if (mUIManagerProvider != null) {
+      UIManager uiManager = mUIManagerProvider.createUIManager(reactContext);
+      uiManager.initialize();
+      catalystInstance.setFabricUIManager(uiManager);
+    } else if (ReactFeatureFlags.enableFabricRenderer) {
+      catalystInstance.getJSIModule(JSIModuleType.UIManager);
     }
     if (mBridgeIdleDebugListener != null) {
       catalystInstance.addBridgeIdleDebugListener(mBridgeIdleDebugListener);


### PR DESCRIPTION
Summary:

Moving the check for Fabric i.e. `ReactFeatureFlags.enableFabricRenderer` to old JSI Module path logic instead of new UIManagerProvider path for Fabric initialization

Reviewed By: philIip

Differential Revision: D51610399


