### PR TITLE
[iOS] Fabric: Fixes image blob url not work

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -61,11 +61,11 @@ id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass)
   } else if (moduleClass == RCTNetworking.class) {
     return [[moduleClass alloc]
         initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(RCTModuleRegistry *moduleRegistry) {
-          return @[
-            [RCTHTTPRequestHandler new],
-            [RCTDataRequestHandler new],
-            [RCTFileRequestHandler new],
-          ];
+          return [NSArray arrayWithObjects:[RCTHTTPRequestHandler new],
+                                           [RCTDataRequestHandler new],
+                                           [RCTFileRequestHandler new],
+                                           [moduleRegistry moduleForName:"BlobModule"],
+                                           nil];
         }];
   }
   // No custom initializer here.


### PR DESCRIPTION
## Summary:

Added image blob url support.

Before:
![image](https://github.com/facebook/react-native/assets/5061845/35835e06-1946-4cc0-9f09-ad8201c7d9b5)

After:
![image](https://github.com/facebook/react-native/assets/5061845/cde4b3cf-039c-42ba-b1d0-15e5e898df72)


## Changelog:

[IOS] [FIXED] - Fabric: Fixes image blob url not work

## Test Plan:

none.
