### PR TITLE
Ignore the one-time NullPointerException and print error log

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadHandler.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadHandler.java
@@ -10,6 +10,8 @@ package com.facebook.react.bridge.queue;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import com.facebook.common.logging.FLog;
+import com.facebook.react.common.ReactConstants;
 
 /** Handler that can catch and dispatch Exceptions to an Exception handler. */
 public class MessageQueueThreadHandler extends Handler {
@@ -26,6 +28,15 @@ public class MessageQueueThreadHandler extends Handler {
     try {
       super.dispatchMessage(msg);
     } catch (Exception e) {
+      if (e instanceof NullPointerException) {
+        FLog.e(
+            ReactConstants.TAG,
+            "Caught NullPointerException when dispatching message in MessageQueueThreadHandler. This is likely caused by runnable"
+                + "(msg.callback) being nulled in Android Handler after dispatching and before handling (see T170239922 for more details)."
+                + "Currently we observe that it only happen once which is during initialisation. Due to fixing probably involve Android "
+                + "System code, we decide to ignore here for now and print an error message for debugging purpose in case this cause more serious issues in future.");
+        return;
+      }
       mExceptionHandler.handleException(e);
     }
   }


### PR DESCRIPTION
Summary:
Why ignore for now?
- It only happen once during initialization and doesn't cause any breakages for RNTester
- The race condition happens in Android System code which is hard to tackle:
```Exception in native call
java.lang.NullPointerException: java.lang.NullPointerException
	at com.facebook.jni.NativeRunnable.run(Native Method)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:30)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:235)
	at java.lang.Thread.run(Thread.java:1012)
```
From stack trace message.callback is checked in 
```at android.os.Handler.dispatchMessage(Handler.java:99)```
but becomes null in
```at android.os.Handler.handleCallback(Handler.java:958)```

[Android source code](https://l.facebook.com/l.php?u=https%3A%2F%2Fandroid.googlesource.com%2Fplatform%2Fframeworks%2Fbase%2F%2B%2Fmaster%2Fcore%2Fjava%2Fandroid%2Fos%2FHandler.java&h=AT1aQS0Vmknao8kLbYE_hhLj1G3idUf69jFQE3ZLAqjrbcMX4OdQUV1dzZpAkAvLaZ9HAOanpsKCC8z59Ce9XJa6cOhQL2L95gM9iMrSr7FbrpTKPLKbWjDmTz89WUL2pQprnBVKyA8) of Handler.

Reviewed By: cortinico

Differential Revision: D51550240


