### PR TITLE
Fix dev menu not open

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -199,7 +199,7 @@ RCT_EXPORT_MODULE()
 #if RCT_DEV_MENU
     devMenuToken = [[RCTPackagerConnection sharedPackagerConnection]
         addNotificationHandler:^(id params) {
-          [self.bridge.devMenu show];
+          [[self.moduleRegistry moduleForName:"DevMenu"] show];
         }
                          queue:dispatch_get_main_queue()
                      forMethod:@"devMenu"];


### PR DESCRIPTION
Summary:
Bridgeless dev menu couldn't open due to self.bridge being null here.

Changelog:
[Android][Changed] - Fix dev menu not open for Bridgeless

Reviewed By: cortinico

Differential Revision: D51746610


