### PR TITLE
Change offsetParent, offsetTop and offsetLeft to respect positioned ancestor, not parent

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -296,6 +296,48 @@ ShadowNode::Shared UIManager::getNewestParentOfShadowNode(
       parentOfParentPair.second);
 }
 
+ShadowNode::Shared UIManager::getNewestPositionedAncestorOfShadowNode(
+    const ShadowNode& shadowNode) const {
+  auto rootShadowNode = ShadowNode::Shared{};
+  shadowTreeRegistry_.visit(
+      shadowNode.getSurfaceId(), [&](const ShadowTree& shadowTree) {
+        rootShadowNode = shadowTree.getCurrentRevision().rootShadowNode;
+      });
+
+  if (!rootShadowNode) {
+    return nullptr;
+  }
+
+  auto ancestors = shadowNode.getFamily().getAncestors(*rootShadowNode);
+
+  if (ancestors.empty()) {
+    return nullptr;
+  }
+
+  for (auto it = ancestors.rbegin(); it != ancestors.rend(); it++) {
+    const auto layoutableAncestorShadowNode =
+        traitCast<const LayoutableShadowNode*>(&(it->first.get()));
+    if (layoutableAncestorShadowNode == nullptr) {
+      return nullptr;
+    }
+    if (layoutableAncestorShadowNode->getLayoutMetrics().positionType !=
+        PositionType::Static) {
+      // We have found our nearest positioned ancestor, now to get a shared
+      // pointer of it
+      it++;
+      if (it != ancestors.rend()) {
+        return it->first.get().getChildren().at(it->second);
+      }
+      // else the positioned ancestor is the root which we return outside of the
+      // loop
+    }
+  }
+
+  // If there is no positioned ancestor then we just consider the root
+  // to be one
+  return rootShadowNode;
+}
+
 std::string UIManager::getTextContentInNewestCloneOfShadowNode(
     const ShadowNode& shadowNode) const {
   auto newestCloneOfShadowNode = getNewestCloneOfShadowNode(shadowNode);

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -96,6 +96,9 @@ class UIManager final : public ShadowTreeDelegate {
   ShadowNode::Shared getNewestParentOfShadowNode(
       const ShadowNode& shadowNode) const;
 
+  ShadowNode::Shared getNewestPositionedAncestorOfShadowNode(
+      const ShadowNode& shadowNode) const;
+
   std::string getTextContentInNewestCloneOfShadowNode(
       const ShadowNode& shadowNode) const;
 


### PR DESCRIPTION
Summary:
These offset methods are supposed to be in reference to the node's nearest positioned (non-static) ancestor: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent. Right now, because static did not exist, they return the offset from the parent. This changes it so that the API is spec compliant and will look at the position of its ancestors before settling on the right offset. I added a helper `getNewestPositionedAncestorOfShadowNode` to get the correct node. Then I use that to calculate the proper offset

Changelog: [Internal]

Reviewed By: rubennorte, NickGerleman

Differential Revision: D51414950


