### PR TITLE
fix: Make generate-legacy-interop-components script take formatting into account

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTLegacyInteropComponents.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTLegacyInteropComponents.mm
@@ -11,7 +11,10 @@
 
 + (NSArray<NSString *> *)legacyInteropComponents
 {
-  return @[ @"RNTMyLegacyNativeView", @"RNTMyNativeView" ];
+  return @[
+			@"RNTMyLegacyNativeView",
+			@"RNTMyNativeView"
+  ];
 }
 
 @end

--- a/packages/react-native/Libraries/AppDelegate/RCTLegacyInteropComponents.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTLegacyInteropComponents.mm
@@ -11,10 +11,7 @@
 
 + (NSArray<NSString *> *)legacyInteropComponents
 {
-  return @[
-			@"RNTMyLegacyNativeView",
-			@"RNTMyNativeView"
-  ];
+  return @[ @"RNTMyLegacyNativeView", @"RNTMyNativeView" ];
 }
 
 @end

--- a/packages/react-native/scripts/codegen/generate-legacy-interop-components.js
+++ b/packages/react-native/scripts/codegen/generate-legacy-interop-components.js
@@ -18,7 +18,7 @@ const PROJECT_FIELD = 'project';
 const IOS_FIELD = 'ios';
 const LEGACY_COMPONENTS_FIELD = 'unstable_reactLegacyComponentNames';
 const OUTPUT_FILE_NAME = 'RCTLegacyInteropComponents.mm';
-const COMPONENTS_IN_ONE_LINE = 3;
+const MAX_CHARS_IN_ONE_LINE = 80;
 
 const argv = yargs
   .option('p', {
@@ -35,9 +35,8 @@ const argv = yargs
 const appRoot = argv.path;
 const outputPath = argv.outputPath;
 
-function fileBody(components) {
+function fileBody(components, isOneLine) {
   // Generate components array string with proper formatting
-  const isOneLine = components.length < COMPONENTS_IN_ONE_LINE;
   const componentsString = components.join(isOneLine ? '' : '\n');
   const componentsArray = isOneLine
     ? `@[${componentsString} ];`
@@ -119,7 +118,7 @@ function generateRCTLegacyInteropComponents() {
     return;
   }
   console.log(`Components found: ${componentNames}`);
-  const isOneLine = componentNames.length < COMPONENTS_IN_ONE_LINE;
+  const isOneLine = componentNames.join().length < MAX_CHARS_IN_ONE_LINE;
   let componentsArray = componentNames.map(
     (name, index) => `${isOneLine ? ' ' : '\t\t\t'}@"${name}",`,
   );
@@ -131,7 +130,7 @@ function generateRCTLegacyInteropComponents() {
   }
 
   const filePath = `${outputPath}/${OUTPUT_FILE_NAME}`;
-  fs.writeFileSync(filePath, fileBody(componentsArray));
+  fs.writeFileSync(filePath, fileBody(componentsArray, isOneLine));
   console.log(`${filePath} updated!`);
 }
 

--- a/packages/react-native/scripts/codegen/generate-legacy-interop-components.js
+++ b/packages/react-native/scripts/codegen/generate-legacy-interop-components.js
@@ -18,6 +18,7 @@ const PROJECT_FIELD = 'project';
 const IOS_FIELD = 'ios';
 const LEGACY_COMPONENTS_FIELD = 'unstable_reactLegacyComponentNames';
 const OUTPUT_FILE_NAME = 'RCTLegacyInteropComponents.mm';
+const COMPONENTS_IN_ONE_LINE = 3;
 
 const argv = yargs
   .option('p', {
@@ -35,6 +36,14 @@ const appRoot = argv.path;
 const outputPath = argv.outputPath;
 
 function fileBody(components) {
+  // Generate components array string with proper formatting
+  const isOneLine = components.length < COMPONENTS_IN_ONE_LINE;
+  const componentsString = components.join(isOneLine ? '' : '\n');
+  const componentsArray = isOneLine
+    ? `@[${componentsString} ];`
+    : `@[
+${componentsString}
+  ];`;
   // eslint-disable duplicate-license-header
   return `/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -49,9 +58,7 @@ function fileBody(components) {
 
 + (NSArray<NSString *> *)legacyInteropComponents
 {
-  return @[
-${components}
-  ];
+  return ${componentsArray}
 }
 
 @end
@@ -112,7 +119,10 @@ function generateRCTLegacyInteropComponents() {
     return;
   }
   console.log(`Components found: ${componentNames}`);
-  let componentsArray = componentNames.map(name => `\t\t\t@"${name}",`);
+  const isOneLine = componentNames.length < COMPONENTS_IN_ONE_LINE;
+  let componentsArray = componentNames.map(
+    (name, index) => `${isOneLine ? ' ' : '\t\t\t'}@"${name}",`,
+  );
   // Remove the last comma
   if (componentsArray.length > 0) {
     componentsArray[componentsArray.length - 1] = componentsArray[
@@ -121,7 +131,7 @@ function generateRCTLegacyInteropComponents() {
   }
 
   const filePath = `${outputPath}/${OUTPUT_FILE_NAME}`;
-  fs.writeFileSync(filePath, fileBody(componentsArray.join('\n')));
+  fs.writeFileSync(filePath, fileBody(componentsArray));
   console.log(`${filePath} updated!`);
 }
 


### PR DESCRIPTION
## Summary:

When Codegen generates interop components it reformats `RCTLegacyInteropComponents.mm` to have each component in a new line. This creates this unnecessary diff every time I run `pod install`. This PR aims to commit a formatted version of the codegen-generated file to avoid creating this diff every time. Here is a reference of Codegen function generating this: https://github.com/facebook/react-native/blob/44d6e4310cc9ad0d711d05e8dd5ee5220738e5b5/packages/react-native/scripts/codegen/generate-legacy-interop-components.js#L53

![CleanShot 2023-12-12 at 14 09 34@2x](https://github.com/facebook/react-native/assets/52801365/2d5454d0-3bcb-484c-aa45-b5286c3ac5ba)

## Changelog:

[INTERNAL] [CHANGED] - Reformat `RCTLegacyInteropComponents` to follow Codegen generated formatting

## Test Plan:

CI Green
