### PR TITLE
Rn-tester app: Text input intrinsic size does not look properly in dark mode 

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -16,6 +16,7 @@ import type {
 } from '../../types/RNTesterTypes';
 import type {KeyboardType} from 'react-native/Libraries/Components/TextInput/TextInput';
 
+const {RNTesterThemeContext} = require('../../components/RNTesterTheme');
 const TextInputSharedExamples = require('./TextInputSharedExamples.js');
 const React = require('react');
 const {
@@ -323,7 +324,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const textInputExamples: Array<RNTesterModuleExample> = [
+const examples: Array<RNTesterModuleExample> = [
   ...TextInputSharedExamples,
   {
     title: 'Live Re-Write (ひ -> 日)',
@@ -648,66 +649,71 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     title: 'TextInput Intrinsic Size',
     render: function (): React.Node {
       return (
-        <View>
-          <Text>Singleline TextInput</Text>
-          <View style={{height: 80}}>
-            <TextInput
-              style={{
-                position: 'absolute',
-                fontSize: 16,
-                backgroundColor: '#eeeeee',
-                borderColor: '#666666',
-                borderWidth: 5,
-                borderTopWidth: 20,
-                borderRadius: 10,
-                borderBottomRightRadius: 20,
-                padding: 10,
-                paddingTop: 20,
-              }}
-              testID="singleline_textinput"
-              placeholder="Placeholder defines intrinsic size"
-            />
-          </View>
-          <Text>Multiline TextInput</Text>
-          <View style={{height: 130}}>
-            <TextInput
-              style={{
-                position: 'absolute',
-                fontSize: 16,
-                backgroundColor: '#eeeeee',
-                borderColor: '#666666',
-                borderWidth: 5,
-                borderTopWidth: 20,
-                borderRadius: 10,
-                borderBottomRightRadius: 20,
-                padding: 10,
-                paddingTop: 20,
-                maxHeight: 100,
-              }}
-              testID="multiline_textinput"
-              multiline={true}
-              placeholder="Placeholder defines intrinsic size"
-            />
-          </View>
+        <RNTesterThemeContext.Consumer>
+        {theme => (  
           <View>
-            <TextInput
-              style={{
-                fontSize: 16,
-                backgroundColor: '#eeeeee',
-                borderColor: '#666666',
-                borderWidth: 5,
-                borderTopWidth: 20,
-                borderRadius: 10,
-                borderBottomRightRadius: 20,
-                padding: 10,
-                paddingTop: 20,
-              }}
-              testID="multiline_textinput_with_flex"
-              multiline={true}
-              placeholder="Placeholder defines intrinsic size"
-            />
+            <Text>Singleline TextInput</Text>
+            <View style={{height: 80}}>
+              <TextInput
+                style={{
+                  position: 'absolute',
+                  fontSize: 16,
+                  backgroundColor: theme.BackgroundColor,
+                  borderColor: theme.BorderColor,
+                  borderWidth: 5,
+                  borderTopWidth: 20,
+                  borderRadius: 10,
+                  borderBottomRightRadius: 20,
+                  padding: 10,
+                  paddingTop: 20,                  
+                }} 
+                placeholderTextColor={theme.PlaceholderTextColor}               
+                testID="singleline_textinput"
+                placeholder="Placeholder defines intrinsic size"
+              />
+            </View>
+            <Text>Multiline TextInput</Text>
+            <View style={{height: 130}}>
+              <TextInput
+                style={{
+                  position: 'absolute',
+                  fontSize: 16,
+                  backgroundColor: theme.BackgroundColor,
+                  borderColor: theme.BorderColor,
+                  borderWidth: 5,
+                  borderTopWidth: 20,
+                  borderRadius: 10,
+                  borderBottomRightRadius: 20,
+                  padding: 10,
+                  paddingTop: 20,
+                  maxHeight: 100,
+                }}
+                testID="multiline_textinput"
+                multiline={true}
+                placeholder="Placeholder defines intrinsic size"
+              />
+            </View>
+            <View>
+              <TextInput
+                style={{
+                  fontSize: 16,
+                  backgroundColor: theme.BackgroundColor,
+                  borderColor: theme.BorderColor,
+                  borderWidth: 5,
+                  borderTopWidth: 20,
+                  borderRadius: 10,
+                  borderBottomRightRadius: 20,
+                  padding: 10,
+                  paddingTop: 20,
+                }}
+                testID="multiline_textinput_with_flex"
+                multiline={true}
+                placeholder="Placeholder defines intrinsic size"
+              />
+            </View>
           </View>
-        </View>
+        )}
+      </RNTesterThemeContext.Consumer>
       );
     },
   },
@@ -944,5 +950,5 @@ module.exports = ({
   documentationURL: 'https://reactnative.dev/docs/textinput',
   category: 'Basic',
   description: 'Single and multi-line text inputs.',
-  examples: textInputExamples,
+  examples,
 }: RNTesterModule);

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -14,6 +14,7 @@ import type {
   RNTesterModule,
   RNTesterModuleExample,
 } from '../../types/RNTesterTypes';
+import {useContext} from 'react';
 import type {KeyboardType} from 'react-native/Libraries/Components/TextInput/TextInput';
 
 const {RNTesterThemeContext} = require('../../components/RNTesterTheme');
@@ -323,6 +324,82 @@ const styles = StyleSheet.create({
     width: 24,
   },
 });
+
+const TextInputIntrinsicSizeExample: React.Node = () => {
+  const theme = useContext(RNTesterThemeContext);
+
+  return (
+    <View>
+      <Text style={{color: theme.LabelColor}}>Singleline TextInput</Text>
+      <View style={{height: 80}}>
+        <TextInput
+          style={{
+            position: 'absolute',
+            fontSize: 16,
+            backgroundColor: theme.BackgroundColor,
+            borderColor: theme.BorderColor,
+            borderWidth: 5,
+            borderTopWidth: 20,
+            borderRadius: 10,
+            borderBottomRightRadius: 20,
+            color: theme.LabelColor,
+            padding: 10,
+            paddingTop: 20,
+          }}
+          placeholderTextColor={theme.PlaceholderTextColor}
+          testID="singleline_textinput"
+          placeholder="Placeholder defines intrinsic size"
+        />
+      </View>
+      <Text style={{color: theme.LabelColor}}>Multiline TextInput</Text>
+      <View style={{height: 130}}>
+        <TextInput
+          style={{
+            position: 'absolute',
+            fontSize: 16,
+            backgroundColor: theme.BackgroundColor,
+            borderColor: theme.BorderColor,
+            borderWidth: 5,
+            borderTopWidth: 20,
+            borderRadius: 10,
+            borderBottomRightRadius: 20,
+            color: theme.LabelColor,
+            padding: 10,
+            paddingTop: 20,
+            maxHeight: 100,
+          }}
+          placeholderTextColor={theme.PlaceholderTextColor}
+          testID="multiline_textinput"
+          multiline={true}
+          placeholder="Placeholder defines intrinsic size"
+        />
+      </View>
+      <Text style={{color: theme.LabelColor}}>
+        Multiline TextInput with flex
+      </Text>
+      <View>
+        <TextInput
+          style={{
+            fontSize: 16,
+            backgroundColor: theme.BackgroundColor,
+            borderColor: theme.BorderColor,
+            borderWidth: 5,
+            borderTopWidth: 20,
+            borderRadius: 10,
+            borderBottomRightRadius: 20,
+            color: theme.LabelColor,
+            padding: 10,
+            paddingTop: 20,
+          }}
+          placeholderTextColor={theme.PlaceholderTextColor}
+          testID="multiline_textinput_with_flex"
+          multiline={true}
+          placeholder="Placeholder defines intrinsic size"
+        />
+      </View>
+    </View>
+  );
+};
 
 const examples: Array<RNTesterModuleExample> = [
   ...TextInputSharedExamples,
@@ -647,75 +724,7 @@ const examples: Array<RNTesterModuleExample> = [
   },
   {
     title: 'TextInput Intrinsic Size',
-    render: function (): React.Node {
-      return (
-        <RNTesterThemeContext.Consumer>
-        {theme => (  
-          <View>
-            <Text>Singleline TextInput</Text>
-            <View style={{height: 80}}>
-              <TextInput
-                style={{
-                  position: 'absolute',
-                  fontSize: 16,
-                  backgroundColor: theme.BackgroundColor,
-                  borderColor: theme.BorderColor,
-                  borderWidth: 5,
-                  borderTopWidth: 20,
-                  borderRadius: 10,
-                  borderBottomRightRadius: 20,
-                  padding: 10,
-                  paddingTop: 20,                  
-                }} 
-                placeholderTextColor={theme.PlaceholderTextColor}               
-                testID="singleline_textinput"
-                placeholder="Placeholder defines intrinsic size"
-              />
-            </View>
-            <Text>Multiline TextInput</Text>
-            <View style={{height: 130}}>
-              <TextInput
-                style={{
-                  position: 'absolute',
-                  fontSize: 16,
-                  backgroundColor: theme.BackgroundColor,
-                  borderColor: theme.BorderColor,
-                  borderWidth: 5,
-                  borderTopWidth: 20,
-                  borderRadius: 10,
-                  borderBottomRightRadius: 20,
-                  padding: 10,
-                  paddingTop: 20,
-                  maxHeight: 100,
-                }}
-                testID="multiline_textinput"
-                multiline={true}
-                placeholder="Placeholder defines intrinsic size"
-              />
-            </View>
-            <View>
-              <TextInput
-                style={{
-                  fontSize: 16,
-                  backgroundColor: theme.BackgroundColor,
-                  borderColor: theme.BorderColor,
-                  borderWidth: 5,
-                  borderTopWidth: 20,
-                  borderRadius: 10,
-                  borderBottomRightRadius: 20,
-                  padding: 10,
-                  paddingTop: 20,
-                }}
-                testID="multiline_textinput_with_flex"
-                multiline={true}
-                placeholder="Placeholder defines intrinsic size"
-              />
-            </View>
-          </View>
-        )}
-      </RNTesterThemeContext.Consumer>
-      );
-    },
+    render: TextInputIntrinsicSizeExample,
   },
   {
     title: 'Auto-expanding',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
[Issue](https://github.com/callstack/react-native-visionos/issues/11)
Added RNTesterThemeContext to change styles based on mode.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [CHANGED] - Text Input intrinsic size example

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run both VisionOS and Iphone simulator with light mode and dark mode.
<img width="362" alt="image" src="https://github.com/callstack/react-native-visionos/assets/18408823/f8f0d39f-d3db-4e47-be45-dca189000dfe">
<img width="699" alt="image" src="https://github.com/callstack/react-native-visionos/assets/18408823/1c15c299-5fbf-4169-ac19-e906ee881123">

