### PR TITLE
Omit synthetic Debugger.disable message in modern CDP backend

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InspectorFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InspectorFlags.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge;
+
+import com.facebook.proguard.annotations.DoNotStrip;
+
+/** fbjni interface for reading `jsinspector_modern::InspectorFlags`. */
+@DoNotStrip
+public class InspectorFlags {
+  static {
+    ReactBridge.staticInit();
+  }
+
+  @DoNotStrip
+  public static native boolean getEnableModernCDPRegistry();
+
+  private InspectorFlags() {}
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -33,6 +33,7 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.R;
 import com.facebook.react.bridge.DefaultJSExceptionHandler;
+import com.facebook.react.bridge.InspectorFlags;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactMarker;
@@ -1043,8 +1044,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
             @Override
             public void onPackagerReloadCommand() {
-              // Disable debugger to resume the JsVM & avoid thread locks while reloading
-              mDevServerHelper.disableDebugger();
+              if (!InspectorFlags.getEnableModernCDPRegistry()) {
+                // Disable debugger to resume the JsVM & avoid thread locks while reloading
+                mDevServerHelper.disableDebugger();
+              }
               UiThreadUtil.runOnUiThread(() -> handleReloadJS());
             }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JInspectorFlags.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JInspectorFlags.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JInspectorFlags.h"
+
+#include <jsinspector-modern/InspectorFlags.h>
+
+namespace facebook::react {
+
+bool JInspectorFlags::getEnableModernCDPRegistry(jni::alias_ref<jclass>) {
+  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+  return inspectorFlags.getEnableModernCDPRegistry();
+}
+
+void JInspectorFlags::registerNatives() {
+  javaClassLocal()->registerNatives({
+      makeNativeMethod(
+          "getEnableModernCDPRegistry",
+          JInspectorFlags::getEnableModernCDPRegistry),
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JInspectorFlags.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JInspectorFlags.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace facebook::react {
+
+/**
+ * fbjni interface for reading `jsinspector_modern::InspectorFlags`.
+ */
+class JInspectorFlags : public jni::JavaClass<JInspectorFlags> {
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/bridge/InspectorFlags;";
+
+  static bool getEnableModernCDPRegistry(jni::alias_ref<jclass>);
+
+  static void registerNatives();
+
+ private:
+  JInspectorFlags();
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -24,6 +24,7 @@
 
 #ifdef WITH_INSPECTOR
 #include "JInspector.h"
+#include "JInspectorFlags.h"
 #endif
 
 #ifndef WITH_GLOGINIT
@@ -89,6 +90,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
 #ifdef WITH_INSPECTOR
     JInspector::registerNatives();
+    JInspectorFlags::registerNatives();
 #endif
   });
 }


### PR DESCRIPTION
Summary:
Progress towards an opt-in setup for our new CDP backend.

- For `DevSupportManagerBase` on Android: Conditionally omit sending `Debugger.disable` CDP message when new CDP backend is enabled.

Reviewed By: motiz88

Differential Revision: D52040149


