### PR TITLE
std::terminate belongs to <exception> header

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <exception>
 #include <stdexcept>
 
 #include <yoga/config/Config.h>


### PR DESCRIPTION
Summary:
See also https://en.cppreference.com/w/cpp/error/terminate.

X-link: https://github.com/facebook/yoga/pull/1511

Differential Revision: D52072882

Pulled By: NickGerleman


