### PR TITLE
remove unused methods from RCTAppearance

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -133,14 +133,6 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)
   return @[ @"appearanceChanged" ];
 }
 
-- (void)startObserving
-{
-}
-
-- (void)stopObserving
-{
-}
-
 - (void)invalidate
 {
   [super invalidate];


### PR DESCRIPTION
Summary:
Changelog: [Internal]

these overrides do nothing, the superclass leaves these empty as well. remove

Differential Revision: D51968873


