### PR TITLE
Replace utils.parseArgs with yargs

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -52,7 +52,8 @@
     "hermes-estree": "0.18.0",
     "micromatch": "^4.0.4",
     "prettier": "2.8.8",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "yargs": "^17.6.2"
   },
   "peerDependencies": {
     "@babel/preset-env": "^7.1.6"

--- a/packages/react-native-codegen/src/cli/combine/__tests__/combine-utils-test.js
+++ b/packages/react-native-codegen/src/cli/combine/__tests__/combine-utils-test.js
@@ -11,67 +11,7 @@
 
 'use-strict';
 
-const {filterJSFile, parseArgs} = require('../combine-utils.js');
-
-describe('parseArgs', () => {
-  const nodeBin = 'node';
-  const combineApp = 'app';
-  const schemaJson = 'schema.json';
-  const specFile1 = 'NativeSpec.js';
-  const specFile2 = 'SpecNativeComponent.js';
-
-  describe('when no platform provided', () => {
-    it('returns null platform, schema and fileList', () => {
-      const {platform, outfile, fileList} = parseArgs([
-        nodeBin,
-        combineApp,
-        schemaJson,
-        specFile1,
-        specFile2,
-      ]);
-
-      expect(platform).toBeNull();
-      expect(outfile).toBe(schemaJson);
-      expect(fileList).toStrictEqual([specFile1, specFile2]);
-    });
-  });
-
-  describe('when platform passed with --platform', () => {
-    it('returns the platform, the schema and the fileList', () => {
-      const {platform, outfile, fileList} = parseArgs([
-        nodeBin,
-        combineApp,
-        '--platform',
-        'ios',
-        schemaJson,
-        specFile1,
-        specFile2,
-      ]);
-
-      expect(platform).toBe('ios');
-      expect(outfile).toBe(schemaJson);
-      expect(fileList).toStrictEqual([specFile1, specFile2]);
-    });
-  });
-
-  describe('when platform passed with -p', () => {
-    it('returns the platform, the schema and the fileList', () => {
-      const {platform, outfile, fileList} = parseArgs([
-        nodeBin,
-        combineApp,
-        '-p',
-        'android',
-        schemaJson,
-        specFile1,
-        specFile2,
-      ]);
-
-      expect(platform).toBe('android');
-      expect(outfile).toBe(schemaJson);
-      expect(fileList).toStrictEqual([specFile1, specFile2]);
-    });
-  });
-});
+const {filterJSFile} = require('../combine-utils.js');
 
 describe('filterJSFile', () => {
   describe('When the file is not a Spec file', () => {

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
@@ -14,10 +14,26 @@
 const {
   combineSchemasInFileListAndWriteToFile,
 } = require('./combine-js-to-schema');
-const {parseArgs} = require('./combine-utils');
+const yargs = require('yargs');
 
-const parsedArgs = parseArgs(process.argv);
+const argv = yargs
+  .option('p', {
+    alias: 'platform',
+  })
+  .option('e', {
+    alias: 'exclude',
+  })
+  .parseSync();
 
-const {platform, outfile, fileList, exclude} = parsedArgs;
+const [outfile, ...fileList] = argv._;
+const platform: ?string = argv.platform;
+const exclude: string = argv.exclude;
+const excludeRegExp: ?RegExp =
+  exclude != null && exclude !== '' ? new RegExp(exclude) : null;
 
-combineSchemasInFileListAndWriteToFile(fileList, platform, outfile, exclude);
+combineSchemasInFileListAndWriteToFile(
+  fileList,
+  platform != null ? platform.toLowerCase() : platform,
+  outfile,
+  excludeRegExp,
+);

--- a/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
@@ -18,27 +18,29 @@ import type {
 
 const assert = require('assert');
 const fs = require('fs');
-const util = require('util');
+const yargs = require('yargs');
 
-const {values: args} = util.parseArgs({
-  options: {
-    platform: {
-      type: 'string',
-    },
-    output: {
-      type: 'string',
-    },
-    ['schema-query']: {
-      type: 'string',
-    },
-  },
-});
-if (!['iOS', 'android'].includes(args.platform)) {
-  throw new Error(`Invalid platform ${args.platform}`);
+const argv = yargs
+  .option('p', {
+    alias: 'platform',
+    type: 'string',
+    demandOption: true,
+  })
+  .option('o', {
+    alias: 'output',
+  })
+  .option('s', {
+    alias: 'schema-query',
+  })
+  .parseSync();
+
+const platform: string = argv.platform.toLowerCase();
+const output: string = argv.output;
+const schemaQuery: string = argv.s;
+
+if (!['ios', 'android'].includes(platform)) {
+  throw new Error(`Invalid platform ${platform}`);
 }
-const platform = args.platform;
-const output = args.output;
-const schemaQuery: string = args['schema-query'];
 
 if (!schemaQuery.startsWith('@')) {
   throw new Error(

--- a/packages/react-native-codegen/src/cli/combine/combine-utils.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-utils.js
@@ -12,43 +12,6 @@
 'use strict';
 
 const path = require('path');
-const util = require('util');
-
-function parseArgs(args: string[]): {
-  platform: ?string,
-  outfile: string,
-  fileList: string[],
-  exclude: ?RegExp,
-} {
-  const parsedArgs = util.parseArgs({
-    args: args.slice(2),
-    options: {
-      platform: {
-        short: 'p',
-        type: 'string',
-      },
-      exclude: {
-        short: 'e',
-        type: 'string',
-      },
-    },
-    allowPositionals: true,
-  });
-
-  const {
-    values: {platform, exclude},
-    positionals: files,
-  } = parsedArgs;
-
-  const [outfile, ...fileList] = files;
-
-  return {
-    platform: platform ?? null,
-    outfile,
-    fileList,
-    exclude: exclude != null && exclude !== '' ? new RegExp(exclude) : null,
-  };
-}
 
 /**
  * This function is used by the CLI to decide whether a JS/TS file has to be processed or not by the Codegen.
@@ -97,6 +60,5 @@ function filterJSFile(
 }
 
 module.exports = {
-  parseArgs,
   filterJSFile,
 };


### PR DESCRIPTION
Summary:
`utils.parseArgs` are only available in Node >=18.3, we can't use this function because we target Node >=18.0.
This diff replaces `utils.parseArgs` with `yargs`.

Changelog: [Internal]

Differential Revision: D52117818


