### PR TITLE
Introduce "npx react-native codegen" command

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -17,6 +17,33 @@ const {
   startCommand,
 } = require('@react-native/community-cli-plugin');
 
+const codegenCommand = {
+  name: 'codegen',
+  options: [
+    {
+      name: '--path <path>',
+      description: 'Path to the React Native project root.',
+      default: process.cwd(),
+    },
+    {
+      name: '--platform <string>',
+      description:
+        'Target platform. Supported values: "android", "ios", "all".',
+      default: 'all',
+    },
+    {
+      name: '--outputPath <path>',
+      description: 'Path where generated artifacts will be output to.',
+    },
+  ],
+  func: (argv, config, args) =>
+    require('./scripts/codegen/generate-artifacts-executor').execute(
+      args.path,
+      args.platform,
+      args.outputPath,
+    ),
+};
+
 module.exports = {
   commands: [
     ...ios.commands,
@@ -24,6 +51,7 @@ module.exports = {
     bundleCommand,
     ramBundleCommand,
     startCommand,
+    codegenCommand,
   ],
   platforms: {
     ios: {


### PR DESCRIPTION
Summary:
This diff introduces the `npx react-native codegen` command.
It runs the codegen for the `package.json` file in current working directory.

Changelog: [General][Added] - Introduce "npx react-native codegen" command.

Reviewed By: cipolleschi

Differential Revision: D51495465


