### PR TITLE
Update `MainActivity.kt` to correctly return placeholder name

### DIFF
--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainActivity.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainActivity.kt
@@ -11,7 +11,9 @@ class MainActivity : ReactActivity() {
    * Returns the name of the main component registered from JavaScript. This is used to schedule
    * rendering of the component.
    */
-  override fun getMainComponentName(): String = "HelloWorld"
+  override fun getMainComponentName(): String {
+    return "HelloWorld"
+  }
 
   /**
    * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Related https://github.com/react-native-community/cli/issues/2205

CLI when replacing placeholders in `init` command is looking for `return "HelloWorld"`, but during template's conversation from Java to Kotlin this function was simplified, and scripting for editing template doesn't see this anymore. 

## Changelog:


[ANDROID] [FIXED] - Update `MainActivity.kt` to correctly return placeholder name

## Test Plan:

`npx react-native init appname --package-name com.asdf.zxcv` shouldn't replace main component name in `MainActivity.kt` with package name.
