### PR TITLE
Use conditional type to flattern RN styles

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -912,8 +912,10 @@ export type ____Styles_Internal = {
   ...
 };
 
-// $FlowFixMe[deprecated-type]
-export type ____FlattenStyleProp_Internal<+TStyleProp> = $Call<
-  <T>(GenericStyleProp<T>) => T,
-  TStyleProp,
->;
+export type ____FlattenStyleProp_Internal<
+  +TStyleProp: GenericStyleProp<mixed>,
+> = TStyleProp extends null | void | false | ''
+  ? empty
+  : TStyleProp extends $ReadOnlyArray<infer V>
+  ? ____FlattenStyleProp_Internal<V>
+  : TStyleProp;

--- a/packages/react-native/Libraries/StyleSheet/flattenStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/flattenStyle.js
@@ -13,8 +13,7 @@
 import type {DangerouslyImpreciseStyleProp} from './StyleSheet';
 import type {____FlattenStyleProp_Internal} from './StyleSheetTypes';
 
-// $FlowFixMe[unsupported-variance-annotation]
-function flattenStyle<+TStyleProp: DangerouslyImpreciseStyleProp>(
+function flattenStyle<TStyleProp: DangerouslyImpreciseStyleProp>(
   style: ?TStyleProp,
   // $FlowFixMe[underconstrained-implicit-instantiation]
 ): ?____FlattenStyleProp_Internal<TStyleProp> {
@@ -23,6 +22,7 @@ function flattenStyle<+TStyleProp: DangerouslyImpreciseStyleProp>(
   }
 
   if (!Array.isArray(style)) {
+    // $FlowFixMe[incompatible-return]
     return style;
   }
 


### PR DESCRIPTION
Summary:
`GenericStyleProp` is defined as

```
type GenericStyleProp<+T> =
  | null
  | void
  | T
  | false
  | ''
  | $ReadOnlyArray<GenericStyleProp<T>>;
```

and `____FlattenStyleProp_Internal` is designed to reverse it. We can use conditional type to achieve it instead of $Call:

`null | void | false | ''` doesn't contribute to anything doing reversal, so they are mapped to empty. When we encounter $ReadOnlyArray, we recursively apply `____FlattenStyleProp_Internal`. Otherwise, we return the input type.

Changelog: [Internal]

Differential Revision: D52142082


