### PR TITLE
feat: Optimise RCTKeyWindow() calls in RCTForceTouchAvailable method

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -578,12 +578,10 @@ BOOL RCTForceTouchAvailable(void)
   static BOOL forceSupported;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    forceSupported =
-        [UITraitCollection class] && [UITraitCollection instancesRespondToSelector:@selector(forceTouchCapability)];
+    forceSupported = [UITraitCollection currentTraitCollection].forceTouchCapability == UIForceTouchCapabilityAvailable;
   });
-
-  return forceSupported &&
-      (RCTKeyWindow() ?: [UIView new]).traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable;
+    
+  return forceSupported;
 }
 
 NSError *RCTErrorWithMessage(NSString *message)

--- a/packages/react-native/React/UIUtils/RCTUIUtils.m
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.m
@@ -14,8 +14,7 @@ RCTDimensions RCTGetDimensions(CGFloat fontScale)
   UIScreen *mainScreen = UIScreen.mainScreen;
   CGSize screenSize = mainScreen.bounds.size;
 
-  UIView *mainWindow;
-  mainWindow = RCTKeyWindow();
+  UIView *mainWindow = RCTKeyWindow();
   // We fallback to screen size if a key window is not found.
   CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
 


### PR DESCRIPTION
## Summary:

This PR optimises RCTKeyWindow() calls in `RCTForceTouchAvailable` method. This method was calling RCTKeyWindow hundreds of times while scrolling on the screen. 

Before: 

On the video you can see that this function is being called **350 times** just from simple list scrolling. RCTKeyWindow is looping over app windows so it's not a cheap operation. 

https://github.com/facebook/react-native/assets/52801365/5b69cbd6-d148-4d06-b672-bd7b60472c13


After: the function is called only few times at the start of the app to get initial layout measurements.

Solution: I think we can check just once for the force touch capabilities as devices can't change it on the fly 

## Changelog:

[IOS] [FIXED] - Optimise RCTKeyWindow() calls in RCTForceTouchAvailable method

## Test Plan:

CI Green