### PR TITLE
Remove last useges of configFileDir CLI argument

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -376,8 +376,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
                 "command" => "node",
                 "arguments"=> ["~/app/ios/../node_modules/react-native/scripts/generate-codegen-artifacts.js",
                     "-p", "~/app",
-                    "-o", Pod::Config.instance.installation_root,
-                    "-c", ""]
+                    "-o", Pod::Config.instance.installation_root]
             }
         ])
     end

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -319,7 +319,6 @@ class CodegenUtils
           "#{relative_installation_root}/#{react_native_path}/scripts/generate-codegen-artifacts.js",
           "-p", "#{app_path}",
           "-o", Pod::Config.instance.installation_root,
-          "-c", "#{config_file_dir}",
         ])
       Pod::UI.puts out;
 


### PR DESCRIPTION
Summary:
This argument was removed in D51303793. This diff removes all remaining usages of it.

Changelog: [Internal]

Differential Revision: D52035346


