### PR TITLE
Feat:-made the rn Devtools launch error message more brief

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -65,21 +65,18 @@ export type MessageToDevice =
   | DisconnectRequest;
 
 // Page description object that is sent in response to /json HTTP request from debugger.
-export type PageDescription = $ReadOnly<{
-  id: string,
+export type PageDescription = {
   description: string,
-  title: string,
-  faviconUrl: string,
-  devtoolsFrontendUrl: string,
-  type: string,
-  webSocketDebuggerUrl: string,
   deviceName: string,
+  devtoolsFrontendUrl: string,
+  faviconUrl: string,
+  id: string,
+  title: string,
+  type: string,
   vm: string,
-  // Metadata specific to React Native
-  reactNative: $ReadOnly<{
-    logicalDeviceId: string,
-  }>,
-}>;
+  webSocketDebuggerUrl: string,
+  ...
+};
 
 export type JsonPagesListResponse = $ReadOnlyArray<PageDescription>;
 

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -94,9 +94,28 @@ export default function openDebuggerMiddleware({
       if (!target) {
         res.writeHead(404);
         res.end('Unable to find Chrome DevTools inspector target');
-        logger?.warn(
-          'No compatible apps connected. JavaScript debugging can only be used with the Hermes engine.',
-        );
+        if (targets.length === 0) {
+          logger?.warn(
+            'You have no apps connected to the dev server. If your app is running, reload it to reconnect to the dev server.',
+          );
+        } else {
+          const plural = targets.length > 1 ? 'apps' : 'app';
+          const maxSimulatorIdentifier: number = targets.reduce(
+            (max, t) => Math.max(max, t.deviceName.length),
+            0,
+          );
+          const apps = [...targets.entries()]
+            .map(
+              ([i, t]) =>
+                `${i}. [${t.deviceName.padEnd(maxSimulatorIdentifier)}]: ${
+                  t.description
+                } (vm: ${t.vm})`,
+            )
+            .join('\n ');
+          logger?.warn(
+            `JavaScript debugging can only be used with the Hermes engine. Found ${targets.length} connected ${plural}:\n ${apps}`,
+          );
+        }
         eventReporter?.logEvent({
           type: 'launch_debugger_frontend',
           launchType,


### PR DESCRIPTION
Devtool crash messages are really helpful, this PR just make it more verbose which can help the developer to find valuable information about the same 


cc @hoxyq 
😅 you might remember me from react, this is my first PR to react native, looking forward to learn and contribute.