### PR TITLE
Improve setting props of the Interop Layer

### DIFF
--- a/packages/react-native/React/Views/RCTComponentData.m
+++ b/packages/react-native/React/Views/RCTComponentData.m
@@ -366,23 +366,22 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
 
 - (void)setProps:(NSDictionary<NSString *, id> *)props forView:(id<RCTComponent>)view
 {
+  [self setProps:props forView:view isShadowView:NO];
+}
+
+- (void)setProps:(NSDictionary<NSString *, id> *)props forShadowView:(RCTShadowView *)shadowView
+{
+  [self setProps:props forView:shadowView isShadowView:YES];
+}
+
+- (void)setProps:(NSDictionary<NSString *, id> *)props forView:(id<RCTComponent>)view isShadowView:(BOOL)isShadowView
+{
   if (!view) {
     return;
   }
 
   [props enumerateKeysAndObjectsUsingBlock:^(NSString *key, id json, __unused BOOL *stop) {
-    [self propBlockForKey:key isShadowView:NO](view, json);
-  }];
-}
-
-- (void)setProps:(NSDictionary<NSString *, id> *)props forShadowView:(RCTShadowView *)shadowView
-{
-  if (!shadowView) {
-    return;
-  }
-
-  [props enumerateKeysAndObjectsUsingBlock:^(NSString *key, id json, __unused BOOL *stop) {
-    [self propBlockForKey:key isShadowView:YES](shadowView, json);
+    [self propBlockForKey:key isShadowView:isShadowView](view, json);
   }];
 }
 


### PR DESCRIPTION
Summary:
Previously, every time a component was updated, we were passing all the props to the interoperated component.
With this change, we are going to only pass the props that are changed.

As a safety feature, if the new codepath is not able to detect the type of the prop properly, it will fall back to the previous behavior.

## Changelog:
[Internal] - Only pass props to the interoperated component when they changes

Reviewed By: sammy-SC

Differential Revision: D51755764


