### PR TITLE
[iOS] Fixes onChangeText of TextInput is fired with text longer than maxLength

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
@@ -267,7 +267,12 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 - (void)textViewDidChangeSelection:(__unused UITextView *)textView
 {
   if (_lastStringStateWasUpdatedWith && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
-    [self textViewDidChange:_backedTextInputView];
+    BOOL shouldChangeText = [self textView:_backedTextInputView
+                   shouldChangeTextInRange:NSMakeRange(0, _backedTextInputView.text.length)
+                           replacementText:_backedTextInputView.text];
+    if (shouldChangeText) {
+      [self textViewDidChange:_backedTextInputView];
+    }
     _ignoreNextTextInputCall = YES;
   }
   _lastStringStateWasUpdatedWith = _backedTextInputView.attributedText;


### PR DESCRIPTION
## Summary:

Fixes #41893 .

## Changelog:

[IOS] [FIXED] - Fixes onChangeText of TextInput is fired with text longer than maxLength

## Test Plan:

Please see steps from #41893 .
