### PR TITLE
[iOS] Fixes Reject error kind in Fabric

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -278,12 +278,10 @@ jsi::Value ObjCTurboModule::createPromise(jsi::Runtime &runtime, std::string met
                 }
                 return;
               }
-
-              NSDictionary *jsError = RCTJSErrorFromCodeMessageAndNSError(code, message, error);
-              reject->call([jsError](jsi::Runtime &rt, jsi::Function &jsFunction) {
-                jsFunction.call(rt, convertObjCObjectToJSIValue(rt, jsError));
+              reject->call([message](jsi::Runtime &rt, jsi::Function &jsFunction) {
+                jsFunction.call(
+                    rt, createJSRuntimeError(rt, [message ?: @"Unknown error from a native module" UTF8String]));
               });
-
               resolveWasCalled = NO;
               resolve = std::nullopt;
               reject = std::nullopt;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -219,7 +219,7 @@ static jsi::JSError convertNSExceptionToJSError(jsi::Runtime &runtime, NSExcepti
 /**
  * Creates JS error value with current JS runtime and error details.
  */
-static jsi::Value convertJSErrorDetailsToJSValue(jsi::Runtime &runtime, NSDictionary *jsErrorDetails)
+static jsi::Value convertJSErrorDetailsToJSRuntimeError(jsi::Runtime &runtime, NSDictionary *jsErrorDetails)
 {
   // From JS documentation:
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#cause an
@@ -304,7 +304,7 @@ jsi::Value ObjCTurboModule::createPromise(jsi::Runtime &runtime, std::string met
 
               NSDictionary *jsErrorDetails = RCTJSErrorFromCodeMessageAndNSError(code, message, error);
               reject->call([jsErrorDetails](jsi::Runtime &rt, jsi::Function &jsFunction) {
-                auto jsError = convertJSErrorDetailsToJSValue(rt, jsErrorDetails);
+                auto jsError = convertJSErrorDetailsToJSRuntimeError(rt, jsErrorDetails);
                 jsFunction.call(rt, jsError);
               });
               resolveWasCalled = NO;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -192,11 +192,6 @@ static jsi::Value createJSRuntimeError(jsi::Runtime &runtime, const std::string 
   return runtime.global().getPropertyAsFunction(runtime, "Error").call(runtime, message);
 }
 
-static jsi::Value createJSRuntimeError(jsi::Runtime &runtime, const std::string &message, jsi::Object &options)
-{
-  return runtime.global().getPropertyAsFunction(runtime, "Error").call(runtime, message, options);
-}
-
 /**
  * Creates JSError with current JS runtime and NSException stack trace.
  */
@@ -221,15 +216,10 @@ static jsi::JSError convertNSExceptionToJSError(jsi::Runtime &runtime, NSExcepti
  */
 static jsi::Value convertJSErrorDetailsToJSRuntimeError(jsi::Runtime &runtime, NSDictionary *jsErrorDetails)
 {
-  // From JS documentation:
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#cause an
-  // Error can be created with `new Error(message, option);`. the `option` param is a JS object with the
-  // `cause` property. Create a valid `option` object
-  jsi::Object jsErrorOptions = jsi::Object(runtime);
-  jsErrorOptions.setProperty(runtime, "cause", convertObjCObjectToJSIValue(runtime, jsErrorDetails));
   NSString *message = jsErrorDetails[@"message"];
 
-  auto jsError = createJSRuntimeError(runtime, [message UTF8String], jsErrorOptions);
+  auto jsError = createJSRuntimeError(runtime, [message UTF8String]);
+  jsError.asObject(runtime).setProperty(runtime, "cause", convertObjCObjectToJSIValue(runtime, jsErrorDetails));
 
   return jsError;
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -294,8 +294,7 @@ jsi::Value ObjCTurboModule::createPromise(jsi::Runtime &runtime, std::string met
 
               NSDictionary *jsErrorDetails = RCTJSErrorFromCodeMessageAndNSError(code, message, error);
               reject->call([jsErrorDetails](jsi::Runtime &rt, jsi::Function &jsFunction) {
-                auto jsError = convertJSErrorDetailsToJSRuntimeError(rt, jsErrorDetails);
-                jsFunction.call(rt, jsError);
+                jsFunction.call(rt, convertJSErrorDetailsToJSRuntimeError(rt, jsErrorDetails));
               });
               resolveWasCalled = NO;
               resolve = std::nullopt;


### PR DESCRIPTION
## Summary:

Fixes #41950 .

## Changelog:

[IOS] [FIXED] - Fixes Reject error kind in Fabric

## Test Plan:

reject returns `Error`.
