### PR TITLE
fix: image mock in jest setup

### DIFF
--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -121,7 +121,6 @@ jest
     Image.prefetch = jest.fn();
     Image.prefetchWithMetadata = jest.fn();
     Image.queryCache = jest.fn();
-    Image.resolveAssetSource = jest.fn().mockImplementation(source => source);
 
     return Image;
   })

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -121,7 +121,7 @@ jest
     Image.prefetch = jest.fn();
     Image.prefetchWithMetadata = jest.fn();
     Image.queryCache = jest.fn();
-    Image.resolveAssetSource = jest.fn();
+    Image.resolveAssetSource = jest.fn().mockImplementation(source => source);
 
     return Image;
   })


### PR DESCRIPTION
## Summary:

`resolveAssetSource` should not return nothing by default in jest as some librairies (ex: [react native fast image](https://github.com/DylanVann/react-native-fast-image/blob/9ab80fcd570b7f56da66ab20e52c9a35934067c9/src/index.tsx#L176C71-L176C71)) rely on it!
They use it to compute the image source ; without this mock implementation, all sources disappear from images in test environnement - and we do test them a lot in test env (may be the only part of Images we actually look at in snapshots! )

Relates to issue https://github.com/facebook/react-native/issues/41907 -> not sure it fixes though, as in test the "require" source resolves to an object with assetFileTransformer - still having no width and height in output even with the real `resolveAssetSource`

It was introduced in version 0.73, where Image mock was changed - see PR https://github.com/facebook/react-native/pull/36996

## Changelog:

[GENERAL][FIXED] - fix jest setup for Image.resolveAssetSource

## Test Plan:
Here is a simple test rendering a [FastImage](https://github.com/DylanVann/react-native-fast-image) with `source = { uri : "some-string"}` :

Without the fix : source is "undefined" in test :
<img width="819" alt="image" src="https://github.com/facebook/react-native/assets/67843879/920d3c78-0fa0-4638-b8a3-948ebb3304bf">

With the fix : 
<img width="769" alt="image" src="https://github.com/facebook/react-native/assets/67843879/d4d5097c-41e6-437c-a042-b5f133ca69dc">

the console.log comes from react native fast image and indicates that source is correctly retrieved


I also tested passing a `require(../path.png)` as source : 
Without the fix : 
<img width="797" alt="image" src="https://github.com/facebook/react-native/assets/67843879/f7d04fbc-3b6d-4795-b40a-da11efffbbfd">

With the fix : 
<img width="833" alt="image" src="https://github.com/facebook/react-native/assets/67843879/28fbda76-0b41-4122-be48-1ec7c073640d">

