### PR TITLE
Add print-packages as a command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint-java": "node ./scripts/lint-java.js",
     "lint": "eslint .",
     "prettier": "prettier --write \"./**/*.{js,md,yml,ts,tsx}\"",
+    "print-packages": "node ./scripts/monorepo/print",
     "shellcheck": "./scripts/circleci/analyze_scripts.sh",
     "start": "cd packages/rn-tester && npm run start",
     "test-android": "./gradlew :packages:react-native:ReactAndroid:test",

--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -11,6 +11,7 @@ const {
   applyPackageVersions,
   getNpmInfo,
   getPackageVersionStrByTag,
+  getVersionsBySpec,
   publishPackage,
 } = require('../npm-utils');
 
@@ -123,6 +124,51 @@ describe('npm-utils', () => {
         version: `0.0.0-prealpha-2023100415`,
         tag: 'prealpha',
       });
+    });
+  });
+
+  describe('getVersionsBySpec', () => {
+    it('should return array when single version returned', () => {
+      execMock.mockImplementationOnce(() => ({code: 0, stdout: '"0.72.0" \n'}));
+
+      const versions = getVersionsBySpec('mypackage', '^0.72.0');
+      expect(versions).toEqual(['0.72.0']);
+    });
+
+    it('should return array of versions', () => {
+      execMock.mockImplementationOnce(() => ({
+        code: 0,
+        stdout: '[\n"0.73.0",\n"0.73.1"\n]\n',
+      }));
+
+      const versions = getVersionsBySpec('mypackage', '^0.73.0');
+      expect(versions).toEqual(['0.73.0', '0.73.1']);
+    });
+
+    it('should return error summary if E404', () => {
+      const error =
+        `npm ERR! code E404\n` +
+        `npm ERR! 404 No match found for version ^0.72.0\n` +
+        `npm ERR! 404\n` +
+        `npm ERR! 404  '@react-native/community-cli-plugin@^0.72.0' is not in this registry.\n` +
+        `npm ERR! 404\n` +
+        `npm ERR! 404 Note that you can also install from a\n` +
+        `npm ERR! 404 tarball, folder, http url, or git url.\n` +
+        `{\n` +
+        `  "error": {\n` +
+        `    "code": "E404",\n` +
+        `    "summary": "No match found for version ^0.72.0",\n` +
+        `    "detail": "\n '@react-native/community-cli-plugin@^0.72.0' is not in this registry.\n\nNote that you can also install from a\ntarball, folder, http url, or git url."\n` +
+        `  }\n` +
+        `}\n`;
+      execMock.mockImplementationOnce(() => ({
+        code: 1,
+        stderr: error,
+      }));
+
+      expect(() => {
+        getVersionsBySpec('mypackage', '^0.72.0');
+      }).toThrow('No match found for version ^0.72.0');
     });
   });
 });

--- a/scripts/monorepo/print/index.js
+++ b/scripts/monorepo/print/index.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-const {getLatestVersionBySpec} = require('../../npm-utils');
+const {getVersionsBySpec} = require('../../npm-utils');
 const forEachPackage = require('../for-each-package');
 const {exit} = require('shelljs');
 const yargs = require('yargs');
@@ -35,6 +35,12 @@ const {
   })
   .strict();
 
+function reversePatchComp(semverA, semverB) {
+  const patchA = parseInt(semverA.split('.')[2], 10);
+  const patchB = parseInt(semverB.split('.')[2], 10);
+  return patchB - patchA;
+}
+
 const main = () => {
   const data = [];
   forEachPackage(
@@ -53,13 +59,13 @@ const main = () => {
 
         if (isPublic && minor !== 0) {
           try {
-            const version = getLatestVersionBySpec(
+            const versions = getVersionsBySpec(
               packageManifest.name,
               `^0.${minor}.0`,
-            );
-            packageInfo[`Version (${minor})`] = version;
+            ).sort(reversePatchComp);
+            packageInfo[`Version (${minor})`] = versions[0];
           } catch (e) {
-            packageInfo[`Version (${minor})`] = 'n/a';
+            packageInfo[`Version (${minor})`] = e.message;
           }
         }
         data.push(packageInfo);

--- a/scripts/monorepo/print/index.js
+++ b/scripts/monorepo/print/index.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const {echo, exit} = require('shelljs');
+const forEachPackage = require('../for-each-package');
+const yargs = require('yargs');
+
+const {
+  argv: {private, public},
+} = yargs
+  .option('private', {
+    type: 'boolean',
+    describe: 'Only list private packages',
+  })
+  .option('public', {
+    type: 'boolean',
+    describe: 'Only list public packages',
+  })
+  .strict();
+
+const main = () => {
+  forEachPackage(
+    (_packageAbsolutePath, _packageRelativePathFromRoot, packageManifest) => {
+      const packageName = packageManifest.name;
+      const isPublic = !packageManifest.private;
+      if ((public && isPublic) || (private && !isPublic)) {
+        echo(`${packageName}, ${packageManifest.version}`);
+      } else if (!private && !public) {
+        echo(
+          `${isPublic ? '\u{1F4E6}' : '\u{1F512}'} ${
+            packageManifest.version
+          } ${packageName}`,
+        );
+      }
+    },
+    {includeReactNative: true},
+  );
+  exit(0);
+};
+
+main();

--- a/scripts/monorepo/print/index.js
+++ b/scripts/monorepo/print/index.js
@@ -30,12 +30,12 @@ const main = () => {
       const packageName = packageManifest.name;
       const isPublic = !packageManifest.private;
       if ((public && isPublic) || (private && !isPublic)) {
-        echo(`${packageName}, ${packageManifest.version}`);
+        echo(`${packageName} ${packageManifest.version}`);
       } else if (!private && !public) {
         echo(
-          `${isPublic ? '\u{1F4E6}' : '\u{1F512}'} ${
+          `${isPublic ? '\u{1F4E6}' : '\u{1F512}'} ${packageName} ${
             packageManifest.version
-          } ${packageName}`,
+          }`,
         );
       }
     },


### PR DESCRIPTION
## Summary:

Working on releases, I'm often looking for the name of our monorepo packages (as sometimes the name doesn't align with the directory) and also getting a list of the versions of everything, as well as if its private/public -- which I've interpreted to mean that we publish it or we don't. I thought this might be convenient to add.

## Changelog:
[Internal] - Add `print-packages` as a command to print our monorepo packages (including react-native)

## Test Plan:

```
❯ yarn print-packages
yarn run v1.22.19
$ node ./scripts/monorepo/print
┌─────────┬─────────┬─────────────────────────────────────────┬────────────────┐
│ (index) │ Public? │                  Name                   │ Version (main) │
├─────────┼─────────┼─────────────────────────────────────────┼────────────────┤
│    0    │  '✅'   │     '@react-native/assets-registry'     │    '0.74.0'    │
│    1    │  '✅'   │  '@react-native/babel-plugin-codegen'   │    '0.74.0'    │
│    2    │  '✅'   │  '@react-native/community-cli-plugin'   │    '0.74.0'    │
│    3    │  '✅'   │    '@react-native/debugger-frontend'    │    '0.74.0'    │
│    4    │  '✅'   │     '@react-native/dev-middleware'      │    '0.74.0'    │
│    5    │  '✅'   │      '@react-native/eslint-config'      │    '0.74.0'    │
│    6    │  '✅'   │      '@react-native/eslint-plugin'      │    '0.74.0'    │
│    7    │  '✅'   │   '@react-native/eslint-plugin-specs'   │    '0.74.0'    │
│    8    │  '❌'   │ '@react-native/hermes-inspector-msggen' │    '0.72.0'    │
│    9    │  '✅'   │      '@react-native/metro-config'       │    '0.74.0'    │
│   10    │  '✅'   │    '@react-native/normalize-colors'     │    '0.74.1'    │
│   11    │  '✅'   │      '@react-native/js-polyfills'       │    '0.74.0'    │
│   12    │  '✅'   │             'react-native'              │   '1000.0.0'   │
│   13    │  '✅'   │      '@react-native/babel-preset'       │    '0.74.0'    │
│   14    │  '✅'   │ '@react-native/metro-babel-transformer' │    '0.74.0'    │
│   15    │  '❌'   │          '@react-native/bots'           │    '0.0.0'     │
│   16    │  '✅'   │         '@react-native/codegen'         │    '0.74.0'    │
│   17    │  '❌'   │ '@react-native/codegen-typescript-test' │    '0.0.1'     │
│   18    │  '✅'   │      '@react-native/gradle-plugin'      │    '0.74.0'    │
│   19    │  '❌'   │         '@react-native/tester'          │    '0.0.1'     │
│   20    │  '❌'   │       '@react-native/tester-e2e'        │    '0.0.1'     │
│   21    │  '✅'   │    '@react-native/typescript-config'    │    '0.74.0'    │
│   22    │  '✅'   │    '@react-native/virtualized-lists'    │    '0.74.0'    │
└─────────┴─────────┴─────────────────────────────────────────┴────────────────┘
✨  Done in 0.55s.
```

Also added filter flag for private/public
```
❯ yarn print-packages --type private
yarn run v1.22.19
$ node ./scripts/monorepo/print --type private
┌─────────┬─────────┬─────────────────────────────────────────┬────────────────┐
│ (index) │ Public? │                  Name                   │ Version (main) │
├─────────┼─────────┼─────────────────────────────────────────┼────────────────┤
│    0    │  '❌'   │ '@react-native/hermes-inspector-msggen' │    '0.72.0'    │
│    1    │  '❌'   │          '@react-native/bots'           │    '0.0.0'     │
│    2    │  '❌'   │ '@react-native/codegen-typescript-test' │    '0.0.1'     │
│    3    │  '❌'   │         '@react-native/tester'          │    '0.0.1'     │
│    4    │  '❌'   │       '@react-native/tester-e2e'        │    '0.0.1'     │
└─────────┴─────────┴─────────────────────────────────────────┴────────────────┘
✨  Done in 0.16s.
```

Also added a npm query where you can see the latest published version of a minor
```
❯ yarn print-packages --type public --minor 72
yarn run v1.22.19
$ node ./scripts/monorepo/print --type public --minor 72
┌─────────┬─────────┬─────────────────────────────────────────┬────────────────┬──────────────────────────────────────┐
│ (index) │ Public? │                  Name                   │ Version (main) │             Version (72)             │
├─────────┼─────────┼─────────────────────────────────────────┼────────────────┼──────────────────────────────────────┤
│    0    │  '✅'   │     '@react-native/assets-registry'     │    '0.74.0'    │               '0.72.0'               │
│    1    │  '✅'   │  '@react-native/babel-plugin-codegen'   │    '0.74.0'    │               '0.72.3'               │
│    2    │  '✅'   │  '@react-native/community-cli-plugin'   │    '0.74.0'    │ 'No match found for version ^0.72.0' │
│    3    │  '✅'   │    '@react-native/debugger-frontend'    │    '0.74.0'    │ 'No match found for version ^0.72.0' │
│    4    │  '✅'   │     '@react-native/dev-middleware'      │    '0.74.0'    │ 'No match found for version ^0.72.0' │
│    5    │  '✅'   │      '@react-native/eslint-config'      │    '0.74.0'    │               '0.72.2'               │
│    6    │  '✅'   │      '@react-native/eslint-plugin'      │    '0.74.0'    │               '0.72.0'               │
│    7    │  '✅'   │   '@react-native/eslint-plugin-specs'   │    '0.74.0'    │               '0.72.4'               │
│    8    │  '✅'   │      '@react-native/metro-config'       │    '0.74.0'    │              '0.72.11'               │
│    9    │  '✅'   │    '@react-native/normalize-colors'     │    '0.74.1'    │               '0.72.0'               │
│   10    │  '✅'   │      '@react-native/js-polyfills'       │    '0.74.0'    │               '0.72.1'               │
│   11    │  '✅'   │             'react-native'              │   '1000.0.0'   │               '0.72.8'               │
│   12    │  '✅'   │      '@react-native/babel-preset'       │    '0.74.0'    │ 'No match found for version ^0.72.0' │
│   13    │  '✅'   │ '@react-native/metro-babel-transformer' │    '0.74.0'    │ 'No match found for version ^0.72.0' │
│   14    │  '✅'   │         '@react-native/codegen'         │    '0.74.0'    │               '0.72.8'               │
│   15    │  '✅'   │      '@react-native/gradle-plugin'      │    '0.74.0'    │              '0.72.11'               │
│   16    │  '✅'   │    '@react-native/typescript-config'    │    '0.74.0'    │ 'No match found for version ^0.72.0' │
│   17    │  '✅'   │    '@react-native/virtualized-lists'    │    '0.74.0'    │               '0.72.8'               │
└─────────┴─────────┴─────────────────────────────────────────┴────────────────┴──────────────────────────────────────┘
```