### PR TITLE
Ensure Bridge and Bridgeless register native modules using the same order

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -208,11 +208,12 @@ final class ReactInstance {
     Systrace.beginSection(
         Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.initialize#initTurboModules");
 
-    mReactPackages = new ArrayList<>(mDelegate.getReactPackages());
+    mReactPackages = new ArrayList<>();
     mReactPackages.add(
         new CoreReactPackage(
             bridgelessReactContext.getDevSupportManager(),
             bridgelessReactContext.getDefaultHardwareBackBtnHandler()));
+    mReactPackages.addAll(mDelegate.getReactPackages());
 
     TurboModuleManagerDelegate turboModuleManagerDelegate =
         mDelegate


### PR DESCRIPTION
Summary: I've noticed that Bridge and Bridgeless initialize the list of ReactPackages using a different order, we are fixing it in this diff

Reviewed By: philIip

Differential Revision: D52145148


