### PR TITLE
[iOS][CI] Install bundler versions depending on Ruby version

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -57,7 +57,11 @@ commands:
 
             # Set ruby dependencies
             rbenv global << parameters.ruby_version >>
-            gem install bundler
+            if [[ << parameters.ruby_version >> == "2.6.10" ]]; then
+              gem install bundler -v 2.4.22
+            else
+              gem install bundler
+            fi
             bundle check || bundle install --path vendor/bundle --clean
       - save_cache:
           key: *rbenv_cache_key


### PR DESCRIPTION
## Summary:

Since yesterday evening (why it is always friday evening???) CircleCI or Gem decided to update the default bundler version that is installed with `gem bundle install`.
Therefore, CI for iOS stopped working.

This change installs bundler's versions so that they are compatible with the Ruby version. 

## Changelog:

[Internal] - Fix CI for iOS installing versions of bundler that are compatible with Ruby

## Test Plan:
CircleCI is green
