### PR TITLE
Fix: image resize mode on iOS in release build.

### DIFF
--- a/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
@@ -11,6 +11,7 @@
 #import <memory>
 
 #import <React/RCTUtils.h>
+#import <React/RCTImageUtils.h>
 #import <ReactCommon/RCTTurboModule.h>
 
 #import "RCTImagePlugins.h"
@@ -49,7 +50,7 @@ RCT_EXPORT_MODULE()
                                          partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
                                           completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
 {
-  UIImage *image = RCTImageFromLocalAssetURL(imageURL);
+  UIImage *image = RCTDecodeImageWithLocalAssetURL(imageURL, size, scale, resizeMode);
   if (image) {
     if (progressHandler) {
       progressHandler(1, 1);

--- a/packages/react-native/Libraries/Image/RCTImageUtils.h
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.h
@@ -64,6 +64,16 @@ RCT_EXTERN UIImage *__nullable
 RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode);
 
 /**
+ * This function takes the source url for an image and decodes it at the
+ * specified size. If the original image is smaller than the destination size,
+ * the resultant image's scale will be decreased to compensate, so the
+ * width/height of the returned image is guaranteed to be >= destSize.
+ * Pass a destSize of CGSizeZero to decode the image at its original size.
+ */
+RCT_EXTERN UIImage *__nullable
+RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode);
+
+/**
  * This function takes the source data for an image and decodes just the
  * metadata, without decompressing the image itself.
  */

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -55,6 +55,68 @@ static CGImagePropertyOrientation CGImagePropertyOrientationFromUIImageOrientati
   }
 }
 
+static UIImage* decodeImageFromCGImageSourceRef(
+    CGImageSourceRef sourceRef,
+    CGSize destSize,
+    CGFloat destScale,
+    RCTResizeMode resizeMode)
+{
+  if (!sourceRef) {
+    return nil;
+  }
+
+  // Get original image size
+  CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(sourceRef, 0, NULL);
+  if (!imageProperties) {
+    CFRelease(sourceRef);
+    return nil;
+  }
+  NSNumber *width = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelWidth);
+  NSNumber *height = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight);
+  CGSize sourceSize = {width.doubleValue, height.doubleValue};
+  CFRelease(imageProperties);
+
+  if (CGSizeEqualToSize(destSize, CGSizeZero)) {
+    destSize = sourceSize;
+    if (!destScale) {
+      destScale = 1;
+    }
+  } else if (!destScale) {
+    destScale = RCTScreenScale();
+  }
+
+  if (resizeMode == RCTResizeModeStretch) {
+    // Decoder cannot change aspect ratio, so RCTResizeModeStretch is equivalent
+    // to RCTResizeModeCover for our purposes
+    resizeMode = RCTResizeModeCover;
+  }
+
+  // Calculate target size
+  CGSize targetSize = RCTTargetSize(sourceSize, 1, destSize, destScale, resizeMode, NO);
+  CGSize targetPixelSize = RCTSizeInPixels(targetSize, destScale);
+  CGFloat maxPixelSize =
+    fmax(fmin(sourceSize.width, targetPixelSize.width), fmin(sourceSize.height, targetPixelSize.height));
+
+  NSDictionary<NSString *, NSNumber *> *options = @{
+    (id)kCGImageSourceShouldAllowFloat : @YES,
+    (id)kCGImageSourceCreateThumbnailWithTransform : @YES,
+    (id)kCGImageSourceCreateThumbnailFromImageAlways : @YES,
+    (id)kCGImageSourceThumbnailMaxPixelSize : @(maxPixelSize),
+  };
+
+  // Get thumbnail
+  CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(sourceRef, 0, (__bridge CFDictionaryRef)options);
+  CFRelease(sourceRef);
+  if (!imageRef) {
+    return nil;
+  }
+
+  // Return image
+  UIImage *image = [UIImage imageWithCGImage:imageRef scale:destScale orientation:UIImageOrientationUp];
+  CGImageRelease(imageRef);
+  return image;
+}
+
 CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {
   if (CGSizeEqualToSize(destSize, CGSizeZero)) {
@@ -257,59 +319,20 @@ BOOL RCTUpscalingRequired(
 UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {
   CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
-  if (!sourceRef) {
-    return nil;
+  UIImage* image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
+
+  return image;
+}
+
+UIImage *__nullable RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
+{
+  CGImageSourceRef sourceRef = CGImageSourceCreateWithURL((__bridge CFURLRef)url, NULL);
+  UIImage* image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
+
+  if (!image) {
+    image = RCTImageFromLocalAssetURL(url);
   }
 
-  // Get original image size
-  CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(sourceRef, 0, NULL);
-  if (!imageProperties) {
-    CFRelease(sourceRef);
-    return nil;
-  }
-  NSNumber *width = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelWidth);
-  NSNumber *height = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight);
-  CGSize sourceSize = {width.doubleValue, height.doubleValue};
-  CFRelease(imageProperties);
-
-  if (CGSizeEqualToSize(destSize, CGSizeZero)) {
-    destSize = sourceSize;
-    if (!destScale) {
-      destScale = 1;
-    }
-  } else if (!destScale) {
-    destScale = RCTScreenScale();
-  }
-
-  if (resizeMode == RCTResizeModeStretch) {
-    // Decoder cannot change aspect ratio, so RCTResizeModeStretch is equivalent
-    // to RCTResizeModeCover for our purposes
-    resizeMode = RCTResizeModeCover;
-  }
-
-  // Calculate target size
-  CGSize targetSize = RCTTargetSize(sourceSize, 1, destSize, destScale, resizeMode, NO);
-  CGSize targetPixelSize = RCTSizeInPixels(targetSize, destScale);
-  CGFloat maxPixelSize =
-      fmax(fmin(sourceSize.width, targetPixelSize.width), fmin(sourceSize.height, targetPixelSize.height));
-
-  NSDictionary<NSString *, NSNumber *> *options = @{
-    (id)kCGImageSourceShouldAllowFloat : @YES,
-    (id)kCGImageSourceCreateThumbnailWithTransform : @YES,
-    (id)kCGImageSourceCreateThumbnailFromImageAlways : @YES,
-    (id)kCGImageSourceThumbnailMaxPixelSize : @(maxPixelSize),
-  };
-
-  // Get thumbnail
-  CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(sourceRef, 0, (__bridge CFDictionaryRef)options);
-  CFRelease(sourceRef);
-  if (!imageRef) {
-    return nil;
-  }
-
-  // Return image
-  UIImage *image = [UIImage imageWithCGImage:imageRef scale:destScale orientation:UIImageOrientationUp];
-  CGImageRelease(imageRef);
   return image;
 }
 

--- a/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
@@ -11,6 +11,7 @@
 #import <memory>
 
 #import <React/RCTUtils.h>
+#import <React/RCTImageUtils.h>
 #import <ReactCommon/RCTTurboModule.h>
 
 #import "RCTImagePlugins.h"
@@ -49,7 +50,7 @@ RCT_EXPORT_MODULE()
                                          partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
                                           completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
 {
-  UIImage *image = RCTImageFromLocalAssetURL(imageURL);
+  UIImage *image = RCTDecodeImageWithLocalAssetURL(imageURL, size, scale, resizeMode);
   if (image) {
     if (progressHandler) {
       progressHandler(1, 1);


### PR DESCRIPTION
## Summary:

Fixes #28670

On iOS, when you want to use an Image with a different resizeMode than the default one, it does not work in release build if the image is a local asset. The reason that it works in debug only is because it's using the method `RCTDecodeImageWithData` which is handling the resize mode properly. But in release build it is using `RCTImageFromLocalAssetURL` which is only made to load an image by url, so the resize mode is just never used.

In this PR, I've created a new `RCTDecodeImageWithLocalAssetURL` which will share the same resize strategy that was used in `RCTDecodeImageWithData` but it will load the image by URL instead of by Data. I've kept a fallback to use `RCTImageFromLocalAssetURL` in case that the image cannot be loaded to make sure that this edge case is still handled like it was previously.

## Changelog:

[IOS] [FIXED] - Image `resizeMode` in release build #28670

## Test Plan:

## Without Fix
#### Debug  | Release
<img src="https://github.com/facebook/react-native/assets/69216913/0ac5777a-a13b-406d-965e-c4d077ad9252" width="150" /> <img src="https://github.com/facebook/react-native/assets/69216913/283ac5ca-0e3e-4cc7-87fb-530438400189" width="150" />

## With Fix
#### Debug  | Release
<img src="https://github.com/facebook/react-native/assets/69216913/0ac5777a-a13b-406d-965e-c4d077ad9252" width="150" /> <img src="https://github.com/facebook/react-native/assets/69216913/eff8a907-d182-4bfc-929c-547fb46d1a73" width="150" />
