### PR TITLE
[`@react-native/metro-config`] Added inference of `watchFolders` from NPM/Yarn workspaces

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@react-native/metro-babel-transformer": "^0.74.0",
     "@react-native/js-polyfills": "^0.74.0",
+    "fast-glob": "^3.3.2",
     "metro-config": "^0.80.0",
     "metro-runtime": "^0.80.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4970,6 +4970,17 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-patch@^3.0.0-1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"


### PR DESCRIPTION
## Summary:

When serving the Metro server from a mono-repo leveraging NPM or Yarn workspaces, the developer need to manually configure Metro to include the workspace root in the `watchFolders` (or `projectRoot` as per the suggestion in the Metro config docs).

I'm aware the [team might already be working on a solution](https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#monorepo-workarounds) for this, but I wanted to suggest this in case you hadn't started work on it or hadn't considered this approach.

### Resolving the workspace root

I initially experimented with a solution using [@npmcli/arborist](https://www.npmjs.com/package/@npmcli/arborist) to resolve the workspace root, but I stopped and implemented the `getWorkspaceRoot` function instead as soon as I realised the package only provided async APIs to load the "actual tree".

This PR suggests adding a `getWorkspaceRoot` function to resolve the workspace root, which supports NPM and Yarn workspaces. It use the same dependency to resolve globs (`fast-glob`) which [may occur in Yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/#toc-tips-tricks). I've double-checked that neither NPM nor Yarn supports workspaces outside of descendent folders, i.e. the root will always be in a parent directory of a package.

I've considered using existing packages to find the workspace root, but I wanted a solution that would be robust to malformed `package.json` files and thought the algorithm was simple enough to inline here. If the reviewer thinks this is not important enough, I can update the PR to use the [find-yarn-workspace-root](https://www.npmjs.com/package/find-yarn-workspace-root), which seem to be a fairly safe dependency to take on (with 2 mill. weekly downloads).

## Changelog:

[GENERAL] [ADDED] - Add automatic resolution of NPM / Yarn workspaces root as `watchFolders` in the `@react-native/metro-config` package.

## Test Plan:

I've tested this in an app locally.
The package doesn't have tests setup at the moment, but I'd be happy to contribute some if that's needed / desired by the reviewer.
