### PR TITLE
[`template`] Use $REACT_NATIVE_PATH instead of relative path

### DIFF
--- a/packages/react-native/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/packages/react-native/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -263,7 +263,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
 		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Summary:

I believe it's valuable to be able to initialise the React Native template into a mono-repo and have it work with zero updates to the configuration.
In its current form the template's Xcode project makes assumptions on the relative location of the `react-native` package, while it could instead use the `REACT_NATIVE_PATH` variable set in the `scripts/cocoapods/utils.rb` script:

https://github.com/facebook/react-native/blob/2441fa284716ef782ec12dd0c2801548f8c47339/packages/react-native/scripts/cocoapods/utils.rb#L82

via

https://github.com/facebook/react-native/blob/2441fa284716ef782ec12dd0c2801548f8c47339/packages/react-native/template/ios/Podfile#L35

## Changelog:

[IOS] [ADDED] - Add use of the `REACT_NATIVE_PATH` in the "Bundle React Native code and images" shell script build phase. This will help apps initialized into a mono-repo which hoists the `react-native` package.

## Test Plan:

I initialized the React Native template into an NPM workspaces mono-repo and experienced a failure running the script phase. I updated it to the code in this PR, which resolved the issue.
