### PR TITLE
Back out "Add log message if App moves to background"

### DIFF
--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
@@ -30,7 +30,6 @@ typedef RCTBundleStatus * (^RCTBundleStatusProvider)(void);
 @interface RCTInspectorRemoteConnection : NSObject
 - (void)onMessage:(NSString *)message;
 - (void)onDisconnect;
-- (void)handleBackgroundEvent:(NSNotification *)notification;
 @end
 
 #endif

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -325,47 +325,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   if (self = [super init]) {
     _owningPackagerConnection = owningPackagerConnection;
     _pageId = pageId;
-    [self addObserverFor:UIApplicationDidEnterBackgroundNotification];
-    [self addObserverFor:UIApplicationWillEnterForegroundNotification];
   }
   return self;
-}
-
-- (void)addObserverFor:(NSString *)notificationName
-{
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleBackgroundEvent:)
-                                               name:notificationName
-                                             object:nil];
-}
-
-- (void)consoleInfo:(NSString *)message format:(NSString *)format
-{
-  if (!message) {
-    return;
-  }
-  NSNumber *now = @([[NSDate date] timeIntervalSince1970] * 1000);
-  NSDictionary *json = @{
-    @"method" : @"Runtime.consoleAPICalled",
-    @"params" : @{@"type" : @"info", @"args" : format == nil ? @[ message ] : @[ message, format ], @"timestamp" : now}
-  };
-  NSError *error = nil;
-  NSData *data = [NSJSONSerialization dataWithJSONObject:json options:0 error:&error];
-  if (error != nil) {
-    NSLog(@"Unable to serialize a console.warn() message: %@", error);
-    return;
-  }
-  NSString *str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  [self onMessage:str];
-}
-
-- (void)handleBackgroundEvent:(NSNotification *)notification
-{
-  if ([notification.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
-    [self consoleInfo:@"App has moved into the %cforeground" format:@"font-weight: bold"];
-  } else if ([notification.name isEqualToString:UIApplicationDidEnterBackgroundNotification]) {
-    [self consoleInfo:@"App has moved into the %cbackground" format:@"font-weight: bold"];
-  }
 }
 
 - (void)onMessage:(NSString *)message


### PR DESCRIPTION
Summary:
Original commit changeset: 29e1aba9c4ea

Original Phabricator Diff: D49956535

D49956535 added the new behaviour of logging helpful messages to the CDP console when the app is backgrounded/foregrounded. The underlying UX issue is legitimate: how do we reinforce the mental connection between the debugger frontend and the app being debugged, when they might be running in different windows or even machines, and particularly when the app might be backgrounded while the debugger frontend remains active.

However, this implementation is too closely coupled to the socket management layer, and is iOS-specific to boot. I'm removing it here to simplify porting `RCTInspectorPackagerConnection` to C++. We can revisit this UX problem later - preferably by investigating how it's handled in the case of Chrome Android and a remote DevTools client.

This feature has not been included in an OSS release of React Native yet, so very few users will be affected by its removal.

Changelog: [iOS][Removed] - Revert D49956535; remove console.log notification in DevTools if app transitions between back/foreground.

Reviewed By: blakef

Differential Revision: D51468311


