### PR TITLE
Add the DoubleConversion dependency to third-party libraries

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -163,6 +163,7 @@ class NewArchitectureTests < Test::Unit::TestCase
                 { :dependency_name => "React-debug" },
                 { :dependency_name => "React-ImageManager" },
                 { :dependency_name => "React-rendererdebug" },
+                { :dependency_name => "DoubleConversion" },
                 { :dependency_name => "hermes-engine" }
         ])
     end
@@ -203,6 +204,7 @@ class NewArchitectureTests < Test::Unit::TestCase
                 { :dependency_name => "React-debug" },
                 { :dependency_name => "React-ImageManager" },
                 { :dependency_name => "React-rendererdebug" },
+                { :dependency_name => "DoubleConversion" },
                 { :dependency_name => "hermes-engine" }
             ]
         )

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -128,6 +128,8 @@ class NewArchitectureHelper
         spec.dependency "React-debug"
         spec.dependency "React-ImageManager"
         spec.dependency "React-rendererdebug"
+        # This dependency is required for the cases when the pod includes generated sources, specifically Props.cpp.
+        spec.dependency "DoubleConversion"
 
         if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
             spec.dependency "hermes-engine"


### PR DESCRIPTION
Summary:
This diff adds the `DoubleConversion` dependency to the `install_modules_dependencies` function, that installs all the dependencies that third-party libraries might need.
The libraries will need the `DoubleConversion` pod if they include the generated Fabric files.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D51848314


