### PR TITLE
Use didReceiveMessageWithString in RCTInspectorPackagerConnection

### DIFF
--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
@@ -30,7 +30,6 @@ typedef RCTBundleStatus * (^RCTBundleStatusProvider)(void);
 @interface RCTInspectorRemoteConnection : NSObject
 - (void)onMessage:(NSString *)message;
 - (void)onDisconnect;
-- (void)handleBackgroundEvent:(NSNotification *)notification;
 @end
 
 #endif

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -197,15 +197,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 }
 
 // analogous to InspectorPackagerConnection.Connection.onMessage(...)
-- (void)webSocket:(__unused SRWebSocket *)webSocket didReceiveMessage:(id)opaqueMessage
+- (void)webSocket:(__unused SRWebSocket *)webSocket didReceiveMessageWithString:(nonnull NSString *)messageText
 {
-  // warn but don't die on unrecognized messages
-  if (![opaqueMessage isKindOfClass:[NSString class]]) {
-    RCTLogWarn(@"Unrecognized inspector message, object is of type: %@", [opaqueMessage class]);
-    return;
-  }
-
-  NSString *messageText = opaqueMessage;
   NSError *error = nil;
   id parsedJSON = RCTJSONParse(messageText, &error);
   if (error) {

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -325,47 +325,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   if (self = [super init]) {
     _owningPackagerConnection = owningPackagerConnection;
     _pageId = pageId;
-    [self addObserverFor:UIApplicationDidEnterBackgroundNotification];
-    [self addObserverFor:UIApplicationWillEnterForegroundNotification];
   }
   return self;
-}
-
-- (void)addObserverFor:(NSString *)notificationName
-{
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleBackgroundEvent:)
-                                               name:notificationName
-                                             object:nil];
-}
-
-- (void)consoleInfo:(NSString *)message format:(NSString *)format
-{
-  if (!message) {
-    return;
-  }
-  NSNumber *now = @([[NSDate date] timeIntervalSince1970] * 1000);
-  NSDictionary *json = @{
-    @"method" : @"Runtime.consoleAPICalled",
-    @"params" : @{@"type" : @"info", @"args" : format == nil ? @[ message ] : @[ message, format ], @"timestamp" : now}
-  };
-  NSError *error = nil;
-  NSData *data = [NSJSONSerialization dataWithJSONObject:json options:0 error:&error];
-  if (error != nil) {
-    NSLog(@"Unable to serialize a console.warn() message: %@", error);
-    return;
-  }
-  NSString *str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  [self onMessage:str];
-}
-
-- (void)handleBackgroundEvent:(NSNotification *)notification
-{
-  if ([notification.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
-    [self consoleInfo:@"App has moved into the %cforeground" format:@"font-weight: bold"];
-  } else if ([notification.name isEqualToString:UIApplicationDidEnterBackgroundNotification]) {
-    [self consoleInfo:@"App has moved into the %cbackground" format:@"font-weight: bold"];
-  }
 }
 
 - (void)onMessage:(NSString *)message


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Switches `RCTInspectorPackagerConnection` to use the recommended and type-safe `didReceiveMessageWithString` method to receive messages from SRWebSocket.

Differential Revision: D52257082


