### PR TITLE
Remove unused bundle status reporting from inspector infra

### DIFF
--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
@@ -30,7 +30,6 @@ typedef RCTBundleStatus * (^RCTBundleStatusProvider)(void);
 @interface RCTInspectorRemoteConnection : NSObject
 - (void)onMessage:(NSString *)message;
 - (void)onDisconnect;
-- (void)handleBackgroundEvent:(NSNotification *)notification;
 @end
 
 #endif

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
@@ -10,13 +10,6 @@
 
 #if RCT_DEV || RCT_REMOTE_PROFILE
 
-@interface RCTBundleStatus : NSObject
-@property (atomic, assign) BOOL isLastBundleDownloadSuccess;
-@property (atomic, assign) NSTimeInterval bundleUpdateTimestamp;
-@end
-
-typedef RCTBundleStatus * (^RCTBundleStatusProvider)(void);
-
 @interface RCTInspectorPackagerConnection : NSObject
 - (instancetype)initWithURL:(NSURL *)url;
 
@@ -24,7 +17,6 @@ typedef RCTBundleStatus * (^RCTBundleStatusProvider)(void);
 - (void)connect;
 - (void)closeQuietly;
 - (void)sendEventToAllConnections:(NSString *)event;
-- (void)setBundleStatusProvider:(RCTBundleStatusProvider)bundleStatusProvider;
 @end
 
 @interface RCTInspectorRemoteConnection : NSObject

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -197,15 +197,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 }
 
 // analogous to InspectorPackagerConnection.Connection.onMessage(...)
-- (void)webSocket:(__unused SRWebSocket *)webSocket didReceiveMessage:(id)opaqueMessage
+- (void)webSocket:(__unused SRWebSocket *)webSocket didReceiveMessageWithString:(nonnull NSString *)messageText
 {
-  // warn but don't die on unrecognized messages
-  if (![opaqueMessage isKindOfClass:[NSString class]]) {
-    RCTLogWarn(@"Unrecognized inspector message, object is of type: %@", [opaqueMessage class]);
-    return;
-  }
-
-  NSString *messageText = opaqueMessage;
   NSError *error = nil;
   id parsedJSON = RCTJSONParse(messageText, &error);
   if (error) {

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -21,16 +21,12 @@
 
 const int RECONNECT_DELAY_MS = 2000;
 
-@implementation RCTBundleStatus
-@end
-
 @interface RCTInspectorPackagerConnection () <SRWebSocketDelegate> {
   NSURL *_url;
   NSMutableDictionary<NSString *, RCTInspectorLocalConnection *> *_inspectorConnections;
   SRWebSocket *_webSocket;
   BOOL _closed;
   BOOL _suppressConnectionErrors;
-  RCTBundleStatusProvider _bundleStatusProvider;
 }
 @end
 
@@ -58,11 +54,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
     _inspectorConnections = [NSMutableDictionary new];
   }
   return self;
-}
-
-- (void)setBundleStatusProvider:(RCTBundleStatusProvider)bundleStatusProvider
-{
-  _bundleStatusProvider = bundleStatusProvider;
 }
 
 - (void)handleProxyMessage:(NSDictionary<NSString *, id> *)message
@@ -148,19 +139,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   NSArray<RCTInspectorPage *> *pages = [RCTInspector pages];
   NSMutableArray *array = [NSMutableArray arrayWithCapacity:pages.count];
 
-  RCTBundleStatusProvider statusProvider = _bundleStatusProvider;
-  RCTBundleStatus *bundleStatus = statusProvider == nil ? nil : statusProvider();
-
   for (RCTInspectorPage *page in pages) {
     NSDictionary *jsonPage = @{
       @"id" : [@(page.id) stringValue],
       @"title" : page.title,
       @"app" : [[NSBundle mainBundle] bundleIdentifier],
       @"vm" : page.vm,
-      @"isLastBundleDownloadSuccess" : bundleStatus == nil ? [NSNull null]
-                                                           : @(bundleStatus.isLastBundleDownloadSuccess),
-      @"bundleUpdateTimestamp" : bundleStatus == nil ? [NSNull null]
-                                                     : @((long)bundleStatus.bundleUpdateTimestamp * 1000),
     };
     [array addObject:jsonPage];
   }

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -325,47 +325,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   if (self = [super init]) {
     _owningPackagerConnection = owningPackagerConnection;
     _pageId = pageId;
-    [self addObserverFor:UIApplicationDidEnterBackgroundNotification];
-    [self addObserverFor:UIApplicationWillEnterForegroundNotification];
   }
   return self;
-}
-
-- (void)addObserverFor:(NSString *)notificationName
-{
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleBackgroundEvent:)
-                                               name:notificationName
-                                             object:nil];
-}
-
-- (void)consoleInfo:(NSString *)message format:(NSString *)format
-{
-  if (!message) {
-    return;
-  }
-  NSNumber *now = @([[NSDate date] timeIntervalSince1970] * 1000);
-  NSDictionary *json = @{
-    @"method" : @"Runtime.consoleAPICalled",
-    @"params" : @{@"type" : @"info", @"args" : format == nil ? @[ message ] : @[ message, format ], @"timestamp" : now}
-  };
-  NSError *error = nil;
-  NSData *data = [NSJSONSerialization dataWithJSONObject:json options:0 error:&error];
-  if (error != nil) {
-    NSLog(@"Unable to serialize a console.warn() message: %@", error);
-    return;
-  }
-  NSString *str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  [self onMessage:str];
-}
-
-- (void)handleBackgroundEvent:(NSNotification *)notification
-{
-  if ([notification.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
-    [self consoleInfo:@"App has moved into the %cforeground" format:@"font-weight: bold"];
-  } else if ([notification.name isEqualToString:UIApplicationDidEnterBackgroundNotification]) {
-    [self consoleInfo:@"App has moved into the %cbackground" format:@"font-weight: bold"];
-  }
 }
 
 - (void)onMessage:(NSString *)message

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -108,16 +108,13 @@ public class DevServerHelper {
 
   private @Nullable JSPackagerClient mPackagerClient;
   private @Nullable InspectorPackagerConnection mInspectorPackagerConnection;
-  private final InspectorPackagerConnection.BundleStatusProvider mBundlerStatusProvider;
 
   public DevServerHelper(
       DeveloperSettings developerSettings,
       String packageName,
-      InspectorPackagerConnection.BundleStatusProvider bundleStatusProvider,
       PackagerConnectionSettings packagerConnectionSettings) {
     mSettings = developerSettings;
     mPackagerConnectionSettings = packagerConnectionSettings;
-    mBundlerStatusProvider = bundleStatusProvider;
     mClient =
         new OkHttpClient.Builder()
             .connectTimeout(HTTP_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
@@ -214,8 +211,7 @@ public class DevServerHelper {
       @Override
       protected Void doInBackground(Void... params) {
         mInspectorPackagerConnection =
-            new InspectorPackagerConnection(
-                getInspectorDeviceUrl(), mPackageName, mBundlerStatusProvider);
+            new InspectorPackagerConnection(getInspectorDeviceUrl(), mPackageName);
         mInspectorPackagerConnection.connect();
         return null;
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -114,9 +114,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   private @Nullable List<ErrorCustomizer> mErrorCustomizers;
   private @Nullable PackagerLocationCustomizer mPackagerLocationCustomizer;
 
-  private final InspectorPackagerConnection.BundleStatus mBundleStatus;
-
-  private @Nullable final Map<String, RequestHandler> mCustomPackagerCommandHandlers;
+    private @Nullable final Map<String, RequestHandler> mCustomPackagerCommandHandlers;
 
   private @Nullable final SurfaceDelegateFactory mSurfaceDelegateFactory;
 
@@ -135,12 +133,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     mApplicationContext = applicationContext;
     mJSAppBundleName = packagerPathForJSBundleName;
     mDevSettings = new DevInternalSettings(applicationContext, this::reloadSettings);
-    mBundleStatus = new InspectorPackagerConnection.BundleStatus();
     mDevServerHelper =
         new DevServerHelper(
             mDevSettings,
             mApplicationContext.getPackageName(),
-            () -> mBundleStatus,
             mDevSettings.getPackagerConnectionSettings());
     mBundleDownloadListener = devBundleDownloadListener;
 
@@ -887,10 +883,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
           @Override
           public void onSuccess() {
             hideDevLoadingView();
-            synchronized (DevSupportManagerBase.this) {
-              mBundleStatus.isLastDownloadSuccess = true;
-              mBundleStatus.updateTimestamp = System.currentTimeMillis();
-            }
             if (mBundleDownloadListener != null) {
               mBundleDownloadListener.onSuccess();
             }
@@ -912,9 +904,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
           @Override
           public void onFailure(final Exception cause) {
             hideDevLoadingView();
-            synchronized (DevSupportManagerBase.this) {
-              mBundleStatus.isLastDownloadSuccess = false;
-            }
             if (mBundleDownloadListener != null) {
               mBundleDownloadListener.onFailure(cause);
             }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
@@ -33,14 +33,12 @@ public class InspectorPackagerConnection {
   private final Connection mConnection;
   private final Map<String, Inspector.LocalConnection> mInspectorConnections;
   private final String mPackageName;
-  private BundleStatusProvider mBundleStatusProvider;
 
   public InspectorPackagerConnection(
-      String url, String packageName, BundleStatusProvider bundleStatusProvider) {
+      String url, String packageName) {
     mConnection = new Connection(url);
     mInspectorConnections = new HashMap<>();
     mPackageName = packageName;
-    mBundleStatusProvider = bundleStatusProvider;
   }
 
   public void connect() {
@@ -150,15 +148,12 @@ public class InspectorPackagerConnection {
   private JSONArray getPages() throws JSONException {
     List<Inspector.Page> pages = Inspector.getPages();
     JSONArray array = new JSONArray();
-    BundleStatus bundleStatus = mBundleStatusProvider.getBundleStatus();
     for (Inspector.Page page : pages) {
       JSONObject jsonPage = new JSONObject();
       jsonPage.put("id", String.valueOf(page.getId()));
       jsonPage.put("title", page.getTitle());
       jsonPage.put("app", mPackageName);
       jsonPage.put("vm", page.getVM());
-      jsonPage.put("isLastBundleDownloadSuccess", bundleStatus.isLastDownloadSuccess);
-      jsonPage.put("bundleUpdateTimestamp", bundleStatus.updateTimestamp);
       array.put(jsonPage);
     }
     return array;
@@ -316,23 +311,5 @@ public class InspectorPackagerConnection {
         mWebSocket = null;
       }
     }
-  }
-
-  public static class BundleStatus {
-    public Boolean isLastDownloadSuccess;
-    public long updateTimestamp = -1;
-
-    public BundleStatus(Boolean isLastDownloadSuccess, long updateTimestamp) {
-      this.isLastDownloadSuccess = isLastDownloadSuccess;
-      this.updateTimestamp = updateTimestamp;
-    }
-
-    public BundleStatus() {
-      this(false, -1);
-    }
-  }
-
-  public interface BundleStatusProvider {
-    BundleStatus getBundleStatus();
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
@@ -16,7 +16,6 @@ import android.content.Context;
 public final class PerftestDevSupportManager extends DisabledDevSupportManager {
   private final DevServerHelper mDevServerHelper;
   private final DevInternalSettings mDevSettings;
-  private final InspectorPackagerConnection.BundleStatus mBundleStatus;
 
   public PerftestDevSupportManager(Context applicationContext) {
     mDevSettings =
@@ -26,12 +25,10 @@ public final class PerftestDevSupportManager extends DisabledDevSupportManager {
               @Override
               public void onInternalSettingsChanged() {}
             });
-    mBundleStatus = new InspectorPackagerConnection.BundleStatus();
     mDevServerHelper =
         new DevServerHelper(
             mDevSettings,
             applicationContext.getPackageName(),
-            (InspectorPackagerConnection.BundleStatusProvider) () -> mBundleStatus,
             mDevSettings.getPackagerConnectionSettings());
   }
 


### PR DESCRIPTION
Summary:
The version of `inspector-proxy` included with React Native has not used the `isLastBundleDownloadSuccess` and `bundleUpdateTimestamp` properties in years. This diff removes the backend support for reporting them (in preparation for a C++ rewrite of this infrastructure). We can consider bringing a similar feature back in the future on top of the modern CDP infra (which we are currently building).

Changelog: [Internal]

Differential Revision: D52258567


