### PR TITLE
Set InspectorFlags in RCTAppDelegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -84,7 +84,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
   NSDictionary *initProps = updateInitialProps([self prepareInitialProps], fabricEnabled);
 
-  RCTAppSetupPrepareApp(application, enableTM);
+  RCTAppSetupPrepareApp(application, enableTM, *_reactNativeConfig);
 
   UIView *rootView;
   if (enableBridgeless) {

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -11,6 +11,8 @@
 
 #ifdef __cplusplus
 
+#import <react/config/ReactNativeConfig.h>
+
 #import <memory>
 
 #ifndef RCT_USE_HERMES
@@ -44,11 +46,22 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactory
     RCTBridge *bridge,
     const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler);
 
+/**
+ * Register features and experiments prior to app initialization.
+ */
+void RCTAppSetupPrepareApp(
+    UIApplication *application,
+    BOOL turboModuleEnabled,
+    const facebook::react::ReactNativeConfig &reactNativeConfig);
+
 #endif // __cplusplus
 
 RCT_EXTERN_C_BEGIN
 
-void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled);
+[[deprecated("Use the 3-argument overload of RCTAppSetupPrepareApp instead")]] void RCTAppSetupPrepareApp(
+    UIApplication *application,
+    BOOL turboModuleEnabled);
+
 UIView *RCTAppSetupDefaultRootView(
     RCTBridge *bridge,
     NSString *moduleName,

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -24,6 +24,9 @@
 #import <React/RCTFabricSurface.h>
 #import <React/RCTSurfaceHostingProxyRootView.h>
 
+// jsinspector-modern
+#import <jsinspector-modern/InspectorFlags.h>
+
 void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
 {
   RCTEnableTurboModule(turboModuleEnabled);
@@ -33,6 +36,20 @@ void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
   // Metro reconnection logic. Users only need this when running the application using our CLI tooling.
   application.idleTimerDisabled = YES;
 #endif
+}
+
+void RCTAppSetupPrepareApp(
+    UIApplication *application,
+    BOOL turboModuleEnabled,
+    const facebook::react::ReactNativeConfig &reactNativeConfig)
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  RCTAppSetupPrepareApp(application, turboModuleEnabled);
+#pragma clang diagnostic pop
+
+  auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
+  inspectorFlags.initFromConfig(reactNativeConfig);
 }
 
 UIView *


### PR DESCRIPTION
Summary:
Progress towards an opt-in setup for our new CDP backend.

- Wires up D51563107 to conditionally disable the legacy Hermes debugger via `ReactNativeConfig`.
    - **Configuration covered**: iOS, for the `RCTAppDelegate` code path.
- Create C++-only overload of `RCTAppSetupPrepareApp`, deprecate the previous function.

Changelog:
[iOS][Deprecated] - Deprecate `RCTAppSetupPrepareApp`, replaced with C++ overload

Reviewed By: motiz88

Differential Revision: D51589221


