### PR TITLE
fix(rn-tester): add missing params when running Android app from watch mode

### DIFF
--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -30,6 +30,7 @@ module.exports = {
       manifestPath:
         'packages/rn-tester/android/app/src/main/AndroidManifest.xml',
       packageName: 'com.facebook.react.uiapp',
+      watchModeCommandParams: ['--mode HermesDebug'],
     },
   },
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Passed `--mode HermesDebug` to `run-android` command when running from watch mode by pressing `a` on terminal running a dev server. The flag is the same as in the `package.json`:
https://github.com/facebook/react-native/blob/27f38f6f0647ec1809ee0a0d8e9da3a77a9115b1/packages/rn-tester/package.json#L17

## Changelog:

[INTERNAL] [CHANGED] - Add missing params when running Android app from watch mode by pressing `a`

## Test Plan:

Run `yarn start` press `a` in the watch mode, and Android app should be build and launch correctly.