### PR TITLE
fix bug in controlled selection #41966

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1157,9 +1157,8 @@ function InternalTextInput(props: Props): React.Node {
   // that we have in JS.
   useLayoutEffect(() => {
     const nativeUpdate: {text?: string, selection?: Selection} = {};
-    const haveValue = typeof props.value === 'string';
 
-    if (lastNativeText !== props.value && haveValue) {
+    if (lastNativeText !== props.value && typeof props.value === 'string') {
       nativeUpdate.text = props.value;
       setLastNativeText(props.value);
     }
@@ -1182,7 +1181,7 @@ function InternalTextInput(props: Props): React.Node {
       viewCommands.setTextAndSelection(
         inputRef.current,
         mostRecentEventCount,
-        haveValue ? text : null,
+        typeof props.value === 'string' ? text : null,
         selection?.start ?? -1,
         selection?.end ?? -1,
       );

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1181,7 +1181,7 @@ function InternalTextInput(props: Props): React.Node {
       viewCommands.setTextAndSelection(
         inputRef.current,
         mostRecentEventCount,
-        text,
+        !props.value ? null : text,
         selection?.start ?? -1,
         selection?.end ?? -1,
       );

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1157,8 +1157,9 @@ function InternalTextInput(props: Props): React.Node {
   // that we have in JS.
   useLayoutEffect(() => {
     const nativeUpdate: {text?: string, selection?: Selection} = {};
+    const haveValue = typeof props.value === 'string';
 
-    if (lastNativeText !== props.value && typeof props.value === 'string') {
+    if (lastNativeText !== props.value && haveValue) {
       nativeUpdate.text = props.value;
       setLastNativeText(props.value);
     }
@@ -1181,7 +1182,7 @@ function InternalTextInput(props: Props): React.Node {
       viewCommands.setTextAndSelection(
         inputRef.current,
         mostRecentEventCount,
-        !props.value ? null : text,
+        haveValue ? text : null,
         selection?.start ?? -1,
         selection?.end ?? -1,
       );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This fixes bug #41966 in changing selection via controlled selection of the TextInput when using children (when prop.value is not used). 

## Changelog:

[ANDROID] [FIXED] - fix changing controlled selection of TextInput when using children

## Test Plan:

![Peek 2023-12-18 21-18](https://github.com/facebook/react-native/assets/280241/f768d67c-dbff-49cc-8018-dd70e6ce8bf0)

This is the [repo of the bug](https://github.com/jcubic/react-native-text-input.git), it's fixed after the change. If unit tests are required I would need a hit on how to write them.