### PR TITLE
Improved RNTester deeplink support to go straight to a specific example

### DIFF
--- a/packages/rn-tester/js/components/RNTesterModuleContainer.js
+++ b/packages/rn-tester/js/components/RNTesterModuleContainer.js
@@ -85,7 +85,7 @@ export default function RNTesterModuleContainer(props: Props): React.Node {
     },
   ];
 
-  return module.showIndividualExamples === true && example != null ? (
+  return example != null ? (
     <>
       <RNTTestDetails
         title={example.title}
@@ -93,7 +93,7 @@ export default function RNTesterModuleContainer(props: Props): React.Node {
         expect={example.expect}
         theme={theme}
       />
-      <View style={styles.examplesContainer}>
+      <View style={styles.examplesContainer} testID="example-container">
         <example.render />
       </View>
     </>

--- a/packages/rn-tester/js/types/RNTesterTypes.js
+++ b/packages/rn-tester/js/types/RNTesterTypes.js
@@ -62,6 +62,7 @@ export type RNTesterNavigationState = {
   activeModuleExampleKey: null | string,
   screen: ScreenTypes,
   recentlyUsed: ComponentList,
+  hadDeepLink: boolean,
 };
 
 export type RNTesterJsStallsState = {

--- a/packages/rn-tester/js/utils/RNTesterNavigationReducer.js
+++ b/packages/rn-tester/js/utils/RNTesterNavigationReducer.js
@@ -57,7 +57,13 @@ export const RNTesterNavigationReducer = (
   action: {type: $Keys<typeof RNTesterNavigationActionsType>, data?: any},
 ): RNTesterNavigationState => {
   const {
-    data: {key = null, title = null, exampleType = null, screen = null} = {},
+    data: {
+      key = null,
+      title = null,
+      exampleKey = null,
+      exampleType = null,
+      screen = null,
+    } = {},
   } = action;
 
   switch (action.type) {
@@ -68,6 +74,7 @@ export const RNTesterNavigationReducer = (
         activeModuleTitle: null,
         activeModuleExampleKey: null,
         screen,
+        hadDeepLink: false,
       };
 
     case RNTesterNavigationActionsType.MODULE_CARD_PRESS:
@@ -91,14 +98,20 @@ export const RNTesterNavigationReducer = (
       };
 
     case RNTesterNavigationActionsType.BACK_BUTTON_PRESS:
-      // Go back to module or list
+      // Go back to module or list.
+      // If there was a deeplink navigation, pressing Back should bring us back to the root.
       return {
         ...state,
         activeModuleExampleKey: null,
         activeModuleKey:
-          state.activeModuleExampleKey != null ? state.activeModuleKey : null,
+          !state.hadDeepLink && state.activeModuleExampleKey != null
+            ? state.activeModuleKey
+            : null,
         activeModuleTitle:
-          state.activeModuleExampleKey != null ? state.activeModuleTitle : null,
+          !state.hadDeepLink && state.activeModuleExampleKey != null
+            ? state.activeModuleTitle
+            : null,
+        hadDeepLink: false,
       };
 
     case RNTesterNavigationActionsType.EXAMPLE_OPEN_URL_REQUEST:
@@ -106,7 +119,8 @@ export const RNTesterNavigationReducer = (
         ...state,
         activeModuleKey: key,
         activeModuleTitle: title,
-        activeModuleExampleKey: null,
+        activeModuleExampleKey: exampleKey,
+        hadDeepLink: true,
       };
 
     default:

--- a/packages/rn-tester/js/utils/testerStateUtils.js
+++ b/packages/rn-tester/js/utils/testerStateUtils.js
@@ -29,6 +29,7 @@ export const initialNavigationState: RNTesterNavigationState = {
   activeModuleExampleKey: null,
   screen: Screens.COMPONENTS,
   recentlyUsed: {components: [], apis: []},
+  hadDeepLink: false,
 };
 
 const filterEmptySections = (examplesList: ExamplesList): any => {


### PR DESCRIPTION
Summary:
Improved RNTester URL deeplink support to cover:
*  `rntester://example/<moduleKey>`
*  `rntester://example/<moduleKey>/<exampleKey>`

Extra details:
* For example modules that do not specify `showIndividualExamples: true`, allow deeplink URL with the specific exampleKey to only render the specific example, instead of all of them.
* Added flexibility for moduleKey: search for optional suffixes ("Index", "Example").
* Adjusted Back button action to properly go back to the root after a deeplink.
* Added `example-container` generic testID on the example wrapper component.

Changelog: [Internal]

Differential Revision: D52227013


