### PR TITLE
Removing Fabric check from UIManagerProvider

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1406,14 +1406,14 @@ public class ReactInstanceManager {
           mJSIModulePackage.getJSIModules(
               reactContext, catalystInstance.getJavaScriptContextHolder()));
     }
-    if (ReactFeatureFlags.enableFabricRenderer) {
-      if (mUIManagerProvider != null) {
-        UIManager uiManager = mUIManagerProvider.createUIManager(reactContext);
+    if (mUIManagerProvider != null) {
+      UIManager uiManager = mUIManagerProvider.createUIManager(reactContext);
+      if (uiManager != null) {
         uiManager.initialize();
         catalystInstance.setFabricUIManager(uiManager);
-      } else {
-        catalystInstance.getJSIModule(JSIModuleType.UIManager);
       }
+    } else if (ReactFeatureFlags.enableFabricRenderer) {
+      catalystInstance.getJSIModule(JSIModuleType.UIManager);
     }
     if (mBridgeIdleDebugListener != null) {
       catalystInstance.addBridgeIdleDebugListener(mBridgeIdleDebugListener);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -132,7 +132,7 @@ public abstract class ReactNativeHost {
   }
 
   protected @Nullable UIManagerProvider getUIManagerProvider() {
-    return null;
+    return reactApplicationContext -> null;
   }
 
   /** Returns whether or not to treat it as normal if Activity is null. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.kt
@@ -18,5 +18,5 @@ import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
 fun interface UIManagerProvider {
 
   /* Provides a {@link com.facebook.react.bridge.UIManager} for the context received as a parameter. */
-  fun createUIManager(context: ReactApplicationContext): UIManager
+  fun createUIManager(context: ReactApplicationContext): UIManager?
 }


### PR DESCRIPTION
Summary: Moving the check for Fabric i.e. `ReactFeatureFlags.enableFabricRenderer` to old JSI Module path logic instead of new UIManagerProvider path for Fabric initialization and changing the default of UIManagerProvider from `null` -> `reactApplicationContext -> null;` since we are adding null check on the returned `UIManager`

Differential Revision: D52273097


