### PR TITLE
clean up unused methods from NativeBugReporting

### DIFF
--- a/packages/react-native/Libraries/BugReporting/NativeBugReporting.js
+++ b/packages/react-native/Libraries/BugReporting/NativeBugReporting.js
@@ -15,7 +15,6 @@ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 export interface Spec extends TurboModule {
   +startReportAProblemFlow: () => void;
   +setExtraData: (extraData: Object, extraFiles: Object) => void;
-  +setCategoryID: (categoryID: string) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('BugReporting'): ?Spec);


### PR DESCRIPTION
Summary:
Changelog: [Internal]

this is unused anywhere, delete. for some reason we only have the spec file in oss but no native implementation

Reviewed By: christophpurrer

Differential Revision: D51968870


