### PR TITLE
Fix & Instruction of adding manual native package

### DIFF
--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -17,8 +17,8 @@ class MainApplication : Application(), ReactApplication {
       object : DefaultReactNativeHost(this) {
         override fun getPackages(): List<ReactPackage> =
           PackageList(this).packages.apply {
-              // Packages that cannot be autolinked yet can be added manually here, for example:
-              // add(MyReactNativePackage())
+            // Packages that cannot be autolinked yet can be added manually here, for example:
+            // add(MyReactNativePackage())
           }
 
         override fun getJSMainModuleName(): String = "index"

--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -15,11 +15,11 @@ class MainApplication : Application(), ReactApplication {
 
   override val reactNativeHost: ReactNativeHost =
       object : DefaultReactNativeHost(this) {
-        override fun getPackages(): List<ReactPackage> {
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // packages.add(new MyReactNativePackage());
-          return PackageList(this).packages
-        }
+        override fun getPackages(): List<ReactPackage> =
+          PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+              // add(MyReactNativePackage())
+          }
 
         override fun getJSMainModuleName(): String = "index"
 


### PR DESCRIPTION
Proper Kotlin syntax and instruction on how to add native package manually.
I followed the official documentation and applied the "Kotlin" syntax. I believe it had the leftover comment/instruction of java syntax, which I replaced with Kotlin syntax.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
The comment/instruction on manual native package isn't correct. Also the existing code isn't intuitive for developer to easily add a native package manually.  

## Changelog:
[ANDROID] [CHANGED] - Allowed developer easily add a native package manually, with proper instruction.



## Test Plan:
Applied the change from the official docs - https://reactnative.dev/docs/native-modules-android?android-language=kotlin
Also in my own project - I was able to add native package manually using that syntax. 
![image](https://github.com/facebook/react-native/assets/1908862/89214248-989f-4004-8800-4f85ab99e04a)
