### PR TITLE
[`react_native_pods.rb`] Introduce a reusable `resolve_node_module` function

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -24,17 +24,16 @@ $FOLLY_VERSION = '2023.08.07.00'
 
 $START_TIME = Time.now.to_i
 
-# `@react-native-community/cli-platform-ios/native_modules` defines
-# use_native_modules. We use node to resolve its path to allow for
-# different packager and workspace setups. This is reliant on
-# `@react-native-community/cli-platform-ios` being a direct dependency
-# of `react-native`.
-require Pod::Executable.execute_command('node', ['-p',
-  'require.resolve(
-    "@react-native-community/cli-platform-ios/native_modules.rb",
-    {paths: [process.argv[1]]},
-  )', __dir__]).strip
+# This function resolves a path using the node_modules resolution algorithm
+# Using this will allow for different packager and workspace setups.
+def resolve_node_module(request, from)
+  code = "require.resolve(process.argv[1], { paths: [process.argv[2]] })"
+  return Pod::Executable.execute_command('node', ['-p', code, request, from], true).strip
+end
 
+# `@react-native-community/cli-platform-ios/native_modules` defines use_native_modules.
+# This is reliant on `@react-native-community/cli-platform-ios` being a direct dependency of `react-native`.
+require resolve_node_module("@react-native-community/cli-platform-ios/native_modules.rb", __dir__)
 
 def min_ios_version_supported
   return Helpers::Constants.min_ios_version_supported


### PR DESCRIPTION
## Summary:

The React Native project and its related packages ship a lot of Ruby code, through packages published on NPM.
To successfully resolve the path of these "node modules", the project has historically made assumptions on the relative location of these packages. This however breaks down in the context of modern package managers and features such as NPM / Yarn workspaces, since packages may be (partially) hoisted to a parent / root package.

In recent times we've made changes to some of these Ruby files that makes it easier to consume in a hoisted environment: https://github.com/facebook/react-native/pull/36485

I suggest we generalise this by introducing a function, which the other scripts, developers apps and library authors can rely on to successfully resolve a path using the node modules resolution algorithm.

As an alternative, I've considered adding this as a function on the `ReactNativePodsUtils` module, but I felt this is such a versatile helper that it should be globally available. I'd be happy to change this if deemed necessary.

I'd love to follow up the PR with another PR using this utility function in more of the Ruby files of the project and related packages.

## Changelog:

[IOS] [ADDED] - Add a `resolve_node_module` function to the `react_native_pods.rb` script, which will call Node.js to resolve a module path using the node modules resolution algorithm.

## Test Plan:

I've made the change locally and tested that the `bundle exec pod install` command works as expected and verified that the `resolve_node_module` is available and works as expected from the `.podspec` of a library that has been installed into the React Native app that I'm testing with.
