### PR TITLE
Remove RCTDeviceInfo notification center observers when invalidating

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -80,6 +80,7 @@ RCT_EXPORT_MODULE()
 - (void)invalidate
 {
   _invalidated = YES;
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 static BOOL RCTIsIPhoneNotched()


### PR DESCRIPTION
## Summary:

RCTDeviceInfo NSNotificationCenter observers never get removed, even after invaliding modules. 

In scenarios where the `RCTUserInterfaceStyleDidChangeNotification` notification is manually posted after invaliding a bridge, the app will crash due to the [interfaceFrameDidChange](https://github.com/facebook/react-native/blob/625d0ece6da80df6e3e3ee7daa1f7f59ddbbf387/packages/react-native/React/CoreModules/RCTDeviceInfo.mm#L210-L233) function being unable to get `_exportedDimensions` from the old (invalidated) bridge
 
## Changelog:

[IOS][CHANGED] - Remove RCTDeviceInfo notification center observers when invalidating

## Test Plan:

Invalidate a bridge and then post a RCTUserInterfaceStyleDidChangeNotification notification 
