### PR TITLE
Introduce the "platform" option to generate-codegen-artifacts.js

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -376,7 +376,8 @@ class CodegenUtilsTests < Test::Unit::TestCase
                 "command" => "node",
                 "arguments"=> ["~/app/ios/../node_modules/react-native/scripts/generate-codegen-artifacts.js",
                     "-p", "~/app",
-                    "-o", Pod::Config.instance.installation_root]
+                    "-o", Pod::Config.instance.installation_root,
+                    "-t", "ios"]
             }
         ])
     end

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -319,6 +319,7 @@ class CodegenUtils
           "#{relative_installation_root}/#{react_native_path}/scripts/generate-codegen-artifacts.js",
           "-p", "#{app_path}",
           "-o", Pod::Config.instance.installation_root,
+          "-t", "ios",
         ])
       Pod::UI.puts out;
 

--- a/packages/react-native/scripts/generate-codegen-artifacts.js
+++ b/packages/react-native/scripts/generate-codegen-artifacts.js
@@ -17,11 +17,15 @@ const argv = yargs
     alias: 'path',
     description: 'Path to the React Native project root.',
   })
+  .option('t', {
+    alias: 'targetPlatform',
+    description: 'Target platform. Supported values: "android", "ios", "all".',
+  })
   .option('o', {
     alias: 'outputPath',
     description: 'Path where generated artifacts will be output to.',
   })
-  .usage('Usage: $0 -p [path to app]')
-  .demandOption(['p']).argv;
+  .usage('Usage: $0 -p [path to app] -t [target platform] -o [output path]')
+  .demandOption(['p', 't']).argv;
 
-executor.execute(argv.path, argv.outputPath);
+executor.execute(argv.path, argv.targetPlatform, argv.outputPath);

--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -96,7 +96,7 @@ generateCodegenArtifactsFromSchema () {
 generateArtifacts () {
     describe "Generating codegen artifacts"
     pushd "$RCT_SCRIPT_RN_DIR" >/dev/null || exit 1
-        "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$TEMP_OUTPUT_DIR"
+        "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$TEMP_OUTPUT_DIR" --targetPlatform "ios"
     popd >/dev/null || exit 1
 }
 


### PR DESCRIPTION
Summary:
Up until now `generate-codegen-artifacts.js` has been iOS only. But its logic is actually quite general, and this diff makes it platform agnostic.

Changelog: [General][Added] - Introduce the "platform" option to generate-codegen-artifacts.js

Differential Revision: D52257542

