### PR TITLE
hardcode concurrentRoot in bridgeless

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -159,9 +159,11 @@ using namespace facebook::react;
                                              mode:(DisplayMode)displayMode
                                 initialProperties:(NSDictionary *)properties
 {
+  NSMutableDictionary *resolvedProps = [properties mutableCopy];
+  resolvedProps[@"concurrentRoot"] = @YES;
   RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithSurfacePresenter:[self getSurfacePresenter]
                                                                       moduleName:moduleName
-                                                               initialProperties:properties];
+                                                               initialProperties:resolvedProps];
   surface.surfaceHandler.setDisplayMode(displayMode);
   [self _attachSurface:surface];
 


### PR DESCRIPTION
Summary:
changelog: [iOS][Fix] always enable concurrentRoot in bridgeless 

Fabric should always use ConcurrentRoot.

Reviewed By: christophpurrer

Differential Revision: D52033286


