### PR TITLE
C++ InspectorPackagerConnection tests

### DIFF
--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
@@ -10,13 +10,6 @@
 
 #if RCT_DEV || RCT_REMOTE_PROFILE
 
-@interface RCTBundleStatus : NSObject
-@property (atomic, assign) BOOL isLastBundleDownloadSuccess;
-@property (atomic, assign) NSTimeInterval bundleUpdateTimestamp;
-@end
-
-typedef RCTBundleStatus * (^RCTBundleStatusProvider)(void);
-
 @interface RCTInspectorPackagerConnection : NSObject
 - (instancetype)initWithURL:(NSURL *)url;
 
@@ -24,7 +17,6 @@ typedef RCTBundleStatus * (^RCTBundleStatusProvider)(void);
 - (void)connect;
 - (void)closeQuietly;
 - (void)sendEventToAllConnections:(NSString *)event;
-- (void)setBundleStatusProvider:(RCTBundleStatusProvider)bundleStatusProvider;
 @end
 
 @interface RCTInspectorRemoteConnection : NSObject

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -21,16 +21,12 @@
 
 const int RECONNECT_DELAY_MS = 2000;
 
-@implementation RCTBundleStatus
-@end
-
 @interface RCTInspectorPackagerConnection () <SRWebSocketDelegate> {
   NSURL *_url;
   NSMutableDictionary<NSString *, RCTInspectorLocalConnection *> *_inspectorConnections;
   SRWebSocket *_webSocket;
   BOOL _closed;
   BOOL _suppressConnectionErrors;
-  RCTBundleStatusProvider _bundleStatusProvider;
 }
 @end
 
@@ -58,11 +54,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
     _inspectorConnections = [NSMutableDictionary new];
   }
   return self;
-}
-
-- (void)setBundleStatusProvider:(RCTBundleStatusProvider)bundleStatusProvider
-{
-  _bundleStatusProvider = bundleStatusProvider;
 }
 
 - (void)handleProxyMessage:(NSDictionary<NSString *, id> *)message
@@ -148,19 +139,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   NSArray<RCTInspectorPage *> *pages = [RCTInspector pages];
   NSMutableArray *array = [NSMutableArray arrayWithCapacity:pages.count];
 
-  RCTBundleStatusProvider statusProvider = _bundleStatusProvider;
-  RCTBundleStatus *bundleStatus = statusProvider == nil ? nil : statusProvider();
-
   for (RCTInspectorPage *page in pages) {
     NSDictionary *jsonPage = @{
       @"id" : [@(page.id) stringValue],
       @"title" : page.title,
       @"app" : [[NSBundle mainBundle] bundleIdentifier],
       @"vm" : page.vm,
-      @"isLastBundleDownloadSuccess" : bundleStatus == nil ? [NSNull null]
-                                                           : @(bundleStatus.isLastBundleDownloadSuccess),
-      @"bundleUpdateTimestamp" : bundleStatus == nil ? [NSNull null]
-                                                     : @((long)bundleStatus.bundleUpdateTimestamp * 1000),
     };
     [array addObject:jsonPage];
   }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2041,7 +2041,7 @@ public class com/facebook/react/devsupport/DefaultDevSupportManagerFactory : com
 
 public class com/facebook/react/devsupport/DevServerHelper {
 	public static final field RELOAD_APP_EXTRA_JS_PROXY Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;Ljava/lang/String;Lcom/facebook/react/devsupport/InspectorPackagerConnection$BundleStatusProvider;Lcom/facebook/react/packagerconnection/PackagerConnectionSettings;)V
+	public fun <init> (Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;Ljava/lang/String;Lcom/facebook/react/packagerconnection/PackagerConnectionSettings;)V
 	public fun closeInspectorConnection ()V
 	public fun closePackagerConnection ()V
 	public fun disableDebugger ()V
@@ -2198,21 +2198,10 @@ public abstract interface class com/facebook/react/devsupport/HMRClient : com/fa
 }
 
 public class com/facebook/react/devsupport/InspectorPackagerConnection {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/devsupport/InspectorPackagerConnection$BundleStatusProvider;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun closeQuietly ()V
 	public fun connect ()V
 	public fun sendEventToAllConnections (Ljava/lang/String;)V
-}
-
-public class com/facebook/react/devsupport/InspectorPackagerConnection$BundleStatus {
-	public field isLastDownloadSuccess Ljava/lang/Boolean;
-	public field updateTimestamp J
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Boolean;J)V
-}
-
-public abstract interface class com/facebook/react/devsupport/InspectorPackagerConnection$BundleStatusProvider {
-	public abstract fun getBundleStatus ()Lcom/facebook/react/devsupport/InspectorPackagerConnection$BundleStatus;
 }
 
 public class com/facebook/react/devsupport/JSCHeapCapture : com/facebook/fbreact/specs/NativeJSCHeapCaptureSpec {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -108,16 +108,13 @@ public class DevServerHelper {
 
   private @Nullable JSPackagerClient mPackagerClient;
   private @Nullable InspectorPackagerConnection mInspectorPackagerConnection;
-  private final InspectorPackagerConnection.BundleStatusProvider mBundlerStatusProvider;
 
   public DevServerHelper(
       DeveloperSettings developerSettings,
       String packageName,
-      InspectorPackagerConnection.BundleStatusProvider bundleStatusProvider,
       PackagerConnectionSettings packagerConnectionSettings) {
     mSettings = developerSettings;
     mPackagerConnectionSettings = packagerConnectionSettings;
-    mBundlerStatusProvider = bundleStatusProvider;
     mClient =
         new OkHttpClient.Builder()
             .connectTimeout(HTTP_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
@@ -214,8 +211,7 @@ public class DevServerHelper {
       @Override
       protected Void doInBackground(Void... params) {
         mInspectorPackagerConnection =
-            new InspectorPackagerConnection(
-                getInspectorDeviceUrl(), mPackageName, mBundlerStatusProvider);
+            new InspectorPackagerConnection(getInspectorDeviceUrl(), mPackageName);
         mInspectorPackagerConnection.connect();
         return null;
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -114,8 +114,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   private @Nullable List<ErrorCustomizer> mErrorCustomizers;
   private @Nullable PackagerLocationCustomizer mPackagerLocationCustomizer;
 
-  private final InspectorPackagerConnection.BundleStatus mBundleStatus;
-
   private @Nullable final Map<String, RequestHandler> mCustomPackagerCommandHandlers;
 
   private @Nullable final SurfaceDelegateFactory mSurfaceDelegateFactory;
@@ -135,12 +133,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     mApplicationContext = applicationContext;
     mJSAppBundleName = packagerPathForJSBundleName;
     mDevSettings = new DevInternalSettings(applicationContext, this::reloadSettings);
-    mBundleStatus = new InspectorPackagerConnection.BundleStatus();
     mDevServerHelper =
         new DevServerHelper(
             mDevSettings,
             mApplicationContext.getPackageName(),
-            () -> mBundleStatus,
             mDevSettings.getPackagerConnectionSettings());
     mBundleDownloadListener = devBundleDownloadListener;
 
@@ -887,10 +883,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
           @Override
           public void onSuccess() {
             hideDevLoadingView();
-            synchronized (DevSupportManagerBase.this) {
-              mBundleStatus.isLastDownloadSuccess = true;
-              mBundleStatus.updateTimestamp = System.currentTimeMillis();
-            }
             if (mBundleDownloadListener != null) {
               mBundleDownloadListener.onSuccess();
             }
@@ -912,9 +904,6 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
           @Override
           public void onFailure(final Exception cause) {
             hideDevLoadingView();
-            synchronized (DevSupportManagerBase.this) {
-              mBundleStatus.isLastDownloadSuccess = false;
-            }
             if (mBundleDownloadListener != null) {
               mBundleDownloadListener.onFailure(cause);
             }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
@@ -33,14 +33,11 @@ public class InspectorPackagerConnection {
   private final Connection mConnection;
   private final Map<String, Inspector.LocalConnection> mInspectorConnections;
   private final String mPackageName;
-  private BundleStatusProvider mBundleStatusProvider;
 
-  public InspectorPackagerConnection(
-      String url, String packageName, BundleStatusProvider bundleStatusProvider) {
+  public InspectorPackagerConnection(String url, String packageName) {
     mConnection = new Connection(url);
     mInspectorConnections = new HashMap<>();
     mPackageName = packageName;
-    mBundleStatusProvider = bundleStatusProvider;
   }
 
   public void connect() {
@@ -150,15 +147,12 @@ public class InspectorPackagerConnection {
   private JSONArray getPages() throws JSONException {
     List<Inspector.Page> pages = Inspector.getPages();
     JSONArray array = new JSONArray();
-    BundleStatus bundleStatus = mBundleStatusProvider.getBundleStatus();
     for (Inspector.Page page : pages) {
       JSONObject jsonPage = new JSONObject();
       jsonPage.put("id", String.valueOf(page.getId()));
       jsonPage.put("title", page.getTitle());
       jsonPage.put("app", mPackageName);
       jsonPage.put("vm", page.getVM());
-      jsonPage.put("isLastBundleDownloadSuccess", bundleStatus.isLastDownloadSuccess);
-      jsonPage.put("bundleUpdateTimestamp", bundleStatus.updateTimestamp);
       array.put(jsonPage);
     }
     return array;
@@ -316,23 +310,5 @@ public class InspectorPackagerConnection {
         mWebSocket = null;
       }
     }
-  }
-
-  public static class BundleStatus {
-    public Boolean isLastDownloadSuccess;
-    public long updateTimestamp = -1;
-
-    public BundleStatus(Boolean isLastDownloadSuccess, long updateTimestamp) {
-      this.isLastDownloadSuccess = isLastDownloadSuccess;
-      this.updateTimestamp = updateTimestamp;
-    }
-
-    public BundleStatus() {
-      this(false, -1);
-    }
-  }
-
-  public interface BundleStatusProvider {
-    BundleStatus getBundleStatus();
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
@@ -16,7 +16,6 @@ import android.content.Context;
 public final class PerftestDevSupportManager extends DisabledDevSupportManager {
   private final DevServerHelper mDevServerHelper;
   private final DevInternalSettings mDevSettings;
-  private final InspectorPackagerConnection.BundleStatus mBundleStatus;
 
   public PerftestDevSupportManager(Context applicationContext) {
     mDevSettings =
@@ -26,12 +25,10 @@ public final class PerftestDevSupportManager extends DisabledDevSupportManager {
               @Override
               public void onInternalSettingsChanged() {}
             });
-    mBundleStatus = new InspectorPackagerConnection.BundleStatus();
     mDevServerHelper =
         new DevServerHelper(
             mDevSettings,
             applicationContext.getPackageName(),
-            (InspectorPackagerConnection.BundleStatusProvider) () -> mBundleStatus,
             mDevSettings.getPackagerConnectionSettings());
   }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -16,5 +16,6 @@ add_library(jsinspector STATIC ${jsinspector_SRC})
 target_include_directories(jsinspector PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector
+        folly_runtime
         glog
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "InspectorPackagerConnection.h"
+#include "InspectorInterfaces.h"
+#include "InspectorPackagerConnectionImpl.h"
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <glog/logging.h>
+#include <cerrno>
+#include <chrono>
+
+namespace facebook::react::jsinspector_modern {
+
+static constexpr const std::chrono::duration RECONNECT_DELAY =
+    std::chrono::milliseconds{2000};
+static constexpr const char* INVALID = "<invalid>";
+
+static folly::dynamic makePageIdPayload(std::string_view pageId) {
+  return folly::dynamic::object("id", pageId);
+}
+
+/*
+TODO(moti): Remove this comment, which is only here to help the diff tool
+understand the relationship between this file and
+RCTInspectorPackagerConnection.m.
+
+@implementation RCTInspectorPackagerConnection
+
+*/
+
+// InspectorPackagerConnection::Impl method definitions
+
+std::shared_ptr<InspectorPackagerConnection::Impl>
+InspectorPackagerConnection::Impl::create(
+    std::string url,
+    std::string app,
+    std::unique_ptr<InspectorPackagerConnectionDelegate> delegate) {
+  // No make_shared because the constructor is private
+  return std::shared_ptr<InspectorPackagerConnection::Impl>(
+      new InspectorPackagerConnection::Impl(url, app, std::move(delegate)));
+}
+
+InspectorPackagerConnection::Impl::Impl(
+    std::string url,
+    std::string app,
+    std::unique_ptr<InspectorPackagerConnectionDelegate> delegate)
+    : url_(std::move(url)),
+      app_(std::move(app)),
+      delegate_(std::move(delegate)) {}
+
+void InspectorPackagerConnection::Impl::handleProxyMessage(
+    folly::const_dynamic_view message) {
+  std::string event = message.descend("event").string_or(INVALID);
+  if (event == "getPages") {
+    sendEvent("getPages", pages());
+  } else if (event == "wrappedEvent") {
+    handleWrappedEvent(message.descend("payload"));
+  } else if (event == "connect") {
+    handleConnect(message.descend("payload"));
+  } else if (event == "disconnect") {
+    handleDisconnect(message.descend("payload"));
+  } else {
+    LOG(ERROR) << "Unknown event: " << event;
+  }
+}
+
+void InspectorPackagerConnection::Impl::sendEventToAllConnections(
+    std::string event) {
+  for (auto& connection : inspectorConnections_) {
+    connection.second->sendMessage(event);
+  }
+}
+
+void InspectorPackagerConnection::Impl::closeAllConnections() {
+  for (auto& connection : inspectorConnections_) {
+    connection.second->disconnect();
+  }
+  inspectorConnections_.clear();
+}
+
+void InspectorPackagerConnection::Impl::handleConnect(
+    folly::const_dynamic_view payload) {
+  std::string pageId = payload.descend("pageId").string_or(INVALID);
+  auto existingConnectionIt = inspectorConnections_.find(pageId);
+  if (existingConnectionIt != inspectorConnections_.end()) {
+    auto existingConnection = std::move(existingConnectionIt->second);
+    inspectorConnections_.erase(existingConnectionIt);
+    existingConnection->disconnect();
+    LOG(WARNING) << "Already connected: " << pageId;
+    return;
+  }
+  int pageIdInt;
+  try {
+    pageIdInt = std::stoi(pageId);
+  } catch (...) {
+    LOG(ERROR) << "Invalid page id: " << pageId;
+    return;
+  }
+  auto remoteConnection =
+      std::make_unique<InspectorPackagerConnection::RemoteConnectionImpl>(
+          weak_from_this(), pageId);
+  auto& inspector = getInspectorInstance();
+  auto inspectorConnection =
+      inspector.connect(pageIdInt, std::move(remoteConnection));
+  inspectorConnections_.emplace(pageId, std::move(inspectorConnection));
+}
+
+void InspectorPackagerConnection::Impl::handleDisconnect(
+    folly::const_dynamic_view payload) {
+  std::string pageId = payload.descend("pageId").string_or(INVALID);
+  auto inspectorConnection = removeConnectionForPage(pageId);
+  if (inspectorConnection) {
+    inspectorConnection->disconnect();
+  }
+}
+
+std::unique_ptr<ILocalConnection>
+InspectorPackagerConnection::Impl::removeConnectionForPage(std::string pageId) {
+  auto it = inspectorConnections_.find(pageId);
+  if (it != inspectorConnections_.end()) {
+    auto connection = std::move(it->second);
+    inspectorConnections_.erase(it);
+    return connection;
+  }
+  return nullptr;
+}
+
+void InspectorPackagerConnection::Impl::handleWrappedEvent(
+    folly::const_dynamic_view payload) {
+  std::string pageId = payload.descend("pageId").string_or(INVALID);
+  std::string wrappedEvent = payload.descend("wrappedEvent").string_or(INVALID);
+  auto connectionIt = inspectorConnections_.find(pageId);
+  if (connectionIt == inspectorConnections_.end()) {
+    LOG(WARNING) << "Not connected to page: " << pageId
+                 << " , failed trying to handle event: " << wrappedEvent;
+    return;
+  }
+  connectionIt->second->sendMessage(wrappedEvent);
+}
+
+folly::dynamic InspectorPackagerConnection::Impl::pages() {
+  auto& inspector = getInspectorInstance();
+  auto pages = inspector.getPages();
+  folly::dynamic array = folly::dynamic::array();
+
+  for (const auto& page : pages) {
+    array.push_back(folly::dynamic::object("id", std::to_string(page.id))(
+        "title", page.title)("app", app_)("vm", page.vm));
+  }
+  return array;
+}
+
+void InspectorPackagerConnection::Impl::sendWrappedEvent(
+    std::string pageId,
+    std::string message) {
+  sendEvent(
+      "wrappedEvent",
+      folly::dynamic::object("pageId", pageId)("wrappedEvent", message));
+}
+
+void InspectorPackagerConnection::Impl::sendEvent(
+    std::string event,
+    folly::dynamic payload) {
+  folly::dynamic message =
+      folly::dynamic::object("event", event)("payload", payload);
+  sendToPackager(message);
+}
+
+void InspectorPackagerConnection::Impl::didFailWithError(
+    std::optional<int> posixCode,
+    std::string error) {
+  if (webSocket_) {
+    abort(posixCode, "WebSocket exception", error);
+  }
+}
+
+void InspectorPackagerConnection::Impl::didReceiveMessage(
+    std::string_view message) {
+  folly::dynamic parsedJSON;
+  try {
+    parsedJSON = folly::parseJson(message);
+  } catch (const folly::json::parse_error& e) {
+    LOG(ERROR) << "Unrecognized inspector message, string was not valid JSON: "
+               << e.what();
+    return;
+  }
+  handleProxyMessage(std::move(parsedJSON));
+}
+
+void InspectorPackagerConnection::Impl::didClose() {
+  webSocket_.reset();
+  closeAllConnections();
+  if (!closed_) {
+    reconnect();
+  }
+}
+
+bool InspectorPackagerConnection::Impl::isConnected() const {
+  return webSocket_ != nullptr;
+}
+
+void InspectorPackagerConnection::Impl::connect() {
+  if (closed_) {
+    LOG(ERROR)
+        << "Illegal state: Can't connect after having previously been closed.";
+    return;
+  }
+  webSocket_ = delegate_->connectWebSocket(url_, weak_from_this());
+}
+
+void InspectorPackagerConnection::Impl::reconnect() {
+  if (closed_) {
+    LOG(ERROR)
+        << "Illegal state: Can't reconnect after having previously been closed.";
+    return;
+  }
+
+  if (!suppressConnectionErrors_) {
+    LOG(WARNING) << "Couldn't connect to packager, will silently retry";
+    suppressConnectionErrors_ = true;
+  }
+
+  delegate_->scheduleCallback(
+      [weakSelf = weak_from_this()] {
+        auto strongSelf = weakSelf.lock();
+        if (strongSelf && !strongSelf->closed_) {
+          strongSelf->connect();
+        }
+      },
+      RECONNECT_DELAY);
+}
+
+void InspectorPackagerConnection::Impl::closeQuietly() {
+  closed_ = true;
+  disposeWebSocket();
+}
+
+void InspectorPackagerConnection::Impl::sendToPackager(folly::dynamic message) {
+  if (!webSocket_) {
+    return;
+  }
+
+  webSocket_->send(folly::toJson(message));
+}
+
+void InspectorPackagerConnection::Impl::abort(
+    std::optional<int> posixCode,
+    const std::string& message,
+    const std::string& cause) {
+  // Don't log ECONNREFUSED at all; it's expected in cases where the server
+  // isn't listening.
+  if (posixCode != ECONNREFUSED) {
+    LOG(INFO) << "Error occurred, shutting down websocket connection: "
+              << message << " " << cause;
+  }
+  closeAllConnections();
+  disposeWebSocket();
+}
+
+void InspectorPackagerConnection::Impl::disposeWebSocket() {
+  webSocket_.reset();
+}
+
+/*
+
+@end
+
+TODO(moti): Remove this comment, which is only here to help the diff tool
+understand the relationship between this file and
+RCTInspectorPackagerConnection.m.
+
+@implementation RCTInspectorRemoteConnection
+
+*/
+
+// InspectorPackagerConnection::RemoteConnectionImpl method definitions
+
+InspectorPackagerConnection::RemoteConnectionImpl::RemoteConnectionImpl(
+    std::weak_ptr<InspectorPackagerConnection::Impl> owningPackagerConnection,
+    std::string pageId)
+    : owningPackagerConnection_(owningPackagerConnection),
+      pageId_(std::move(pageId)) {}
+
+void InspectorPackagerConnection::RemoteConnectionImpl::onMessage(
+    std::string message) {
+  auto owningPackagerConnectionStrong = owningPackagerConnection_.lock();
+  if (!owningPackagerConnectionStrong) {
+    return;
+  }
+  owningPackagerConnectionStrong->sendWrappedEvent(pageId_, message);
+}
+
+void InspectorPackagerConnection::RemoteConnectionImpl::onDisconnect() {
+  auto owningPackagerConnectionStrong = owningPackagerConnection_.lock();
+  if (owningPackagerConnectionStrong) {
+    owningPackagerConnectionStrong->sendEvent(
+        "disconnect", makePageIdPayload(pageId_));
+  }
+}
+
+// InspectorPackagerConnection method definitions
+
+InspectorPackagerConnection::InspectorPackagerConnection(
+    std::string url,
+    std::string app,
+    std::unique_ptr<InspectorPackagerConnectionDelegate> delegate)
+    : impl_(Impl::create(url, app, std::move(delegate))) {}
+
+bool InspectorPackagerConnection::isConnected() const {
+  return impl_->isConnected();
+}
+
+void InspectorPackagerConnection::connect() {
+  impl_->connect();
+}
+
+void InspectorPackagerConnection::closeQuietly() {
+  impl_->closeQuietly();
+}
+
+void InspectorPackagerConnection::sendEventToAllConnections(std::string event) {
+  impl_->sendEventToAllConnections(event);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "WebSocketInterfaces.h"
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace facebook::react::jsinspector_modern {
+
+class InspectorPackagerConnectionDelegate;
+
+/**
+ * A platform-agnostic implementation of the "device" side of the React Native
+ * inspector-proxy protocol. The protocol multiplexes one or more debugger
+ * connections over a single socket.
+ * InspectorPackagerConnection will automatically attempt to reconnect after a
+ * delay if the connection fails or is lost.
+ */
+class InspectorPackagerConnection {
+ public:
+  /**
+   * Creates a new connection instance. Connections start in the disconnected
+   * state; connect() should be called to establish a connection.
+   * \param url The WebSocket URL where the inspector-proxy server is listening.
+   * \param app The name of the application being debugged.
+   * \param delegate An interface to platform-specific methods for creating a
+   * WebSocket, scheduling async work, etc.
+   */
+  InspectorPackagerConnection(
+      std::string url,
+      std::string app,
+      std::unique_ptr<InspectorPackagerConnectionDelegate> delegate);
+  bool isConnected() const;
+  void connect();
+  void closeQuietly();
+  void sendEventToAllConnections(std::string event);
+
+ private:
+  class Impl;
+  class RemoteConnectionImpl;
+
+  std::shared_ptr<Impl> impl_;
+};
+
+/**
+ * An interface implemented by each supported platform to provide
+ * platform-specific functionality required by InspectorPackagerConnection.
+ */
+class InspectorPackagerConnectionDelegate {
+ public:
+  virtual ~InspectorPackagerConnectionDelegate() = default;
+
+  /**
+   * Creates a new WebSocket connection. The WebSocket must be in a connected
+   * state when created, and automatically disconnect when destroyed.
+   */
+  virtual std::unique_ptr<IWebSocket> connectWebSocket(
+      const std::string& url,
+      std::weak_ptr<IWebSocketDelegate> delegate) = 0;
+
+  /**
+   * Schedules a function to run after a delay. If the function is called
+   * asynchronously, the implementer of InspectorPackagerConnectionDelegate
+   * is responsible for thread safety (e.g. scheduling the callback on the same
+   * thread that called scheduleCallback, or otherwise ensuring
+   * synchronization). The callback MAY be dropped and never called, e.g. if the
+   * application is terminating.
+   */
+  virtual void scheduleCallback(
+      std::function<void(void)> callback,
+      std::chrono::milliseconds delayMs) = 0;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "InspectorInterfaces.h"
+#include "InspectorPackagerConnection.h"
+
+#include <folly/dynamic.h>
+#include <unordered_map>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Internals of InspectorPackagerConnection.
+ */
+class InspectorPackagerConnection::Impl
+    : public IWebSocketDelegate,
+      // Used to generate `weak_ptr`s we can pass around.
+      public std::enable_shared_from_this<InspectorPackagerConnection::Impl> {
+ public:
+  /**
+   * Implements InspectorPackagerConnection's constructor.
+   */
+  static std::shared_ptr<Impl> create(
+      std::string url,
+      std::string app,
+      std::unique_ptr<InspectorPackagerConnectionDelegate> delegate);
+
+  // InspectorPackagerConnection's public API
+  bool isConnected() const;
+  void connect();
+  void closeQuietly();
+  void sendEventToAllConnections(std::string event);
+  std::unique_ptr<ILocalConnection> removeConnectionForPage(std::string pageId);
+
+  // Exposed for RemoteConnectionImpl's use
+  void sendEvent(std::string event, folly::dynamic payload);
+  // Exposed for RemoteConnectionImpl's use
+  void sendWrappedEvent(std::string pageId, std::string message);
+
+ private:
+  Impl(
+      std::string url,
+      std::string app,
+      std::unique_ptr<InspectorPackagerConnectionDelegate> delegate);
+  Impl(const Impl&) = delete;
+  Impl& operator=(const Impl&) = delete;
+
+  void handleDisconnect(folly::const_dynamic_view payload);
+  void handleConnect(folly::const_dynamic_view payload);
+  void handleWrappedEvent(folly::const_dynamic_view wrappedEvent);
+  void handleProxyMessage(folly::const_dynamic_view message);
+  folly::dynamic pages();
+  void reconnect();
+  void closeAllConnections();
+  void disposeWebSocket();
+  void sendToPackager(folly::dynamic message);
+
+  void abort(
+      std::optional<int> posixCode,
+      const std::string& message,
+      const std::string& cause);
+
+  // IWebSocketDelegate methods
+  virtual void didFailWithError(std::optional<int> posixCode, std::string error)
+      override;
+  virtual void didReceiveMessage(std::string_view message) override;
+  virtual void didClose() override;
+
+  std::string url_;
+  std::string app_;
+  std::unique_ptr<InspectorPackagerConnectionDelegate> delegate_;
+
+  std::unordered_map<std::string, std::unique_ptr<ILocalConnection>>
+      inspectorConnections_;
+  std::unique_ptr<IWebSocket> webSocket_;
+  bool closed_{false};
+  bool suppressConnectionErrors_{false};
+};
+
+class InspectorPackagerConnection::RemoteConnectionImpl
+    : public IRemoteConnection {
+ public:
+  RemoteConnectionImpl(
+      std::weak_ptr<InspectorPackagerConnection::Impl> owningPackagerConnection,
+      std::string pageId);
+
+  // IRemoteConnection methods
+  void onMessage(std::string message) override;
+  void onDisconnect() override;
+
+ private:
+  std::weak_ptr<InspectorPackagerConnection::Impl> owningPackagerConnection_;
+  std::string pageId_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -16,6 +16,9 @@ else
   source[:tag] = "v#{version}"
 end
 
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
+folly_version = '2023.08.07.00'
+
 Pod::Spec.new do |s|
   s.name                   = "React-jsinspector"
   s.version                = version
@@ -27,9 +30,12 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = 'jsinspector'
-  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
-
+  s.compiler_flags         = folly_compiler_flags
+  s.pod_target_xcconfig    = {
+                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\"",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++20"
+                             }
   s.dependency "glog"
-
-  add_dependency(s, "React-nativeconfig")
+  s.dependency "RCT-Folly", folly_version
+  s.dependency "React-nativeconfig"
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Simplified interface to a WebSocket connection.
+ * The socket MUST be initially open when constructed.
+ */
+class IWebSocket {
+ public:
+  /**
+   * If still connected when destroyed, the socket MUST automatically send an
+   * "end of session" message and disconnect.
+   */
+  virtual ~IWebSocket() = default;
+
+  /**
+   * Sends a message over the socket. This function may be called on any thread
+   * without synchronization.
+   * \param message Message to send, in UTF-8 encoding.
+   */
+  virtual void send(std::string_view message) = 0;
+};
+
+class IWebSocketDelegate {
+ public:
+  virtual ~IWebSocketDelegate() = default;
+
+  /**
+   * Called when the socket has encountered an error.
+   * \param posixCode POSIX errno value if available, otherwise nullopt.
+   * \param error Error description.
+   */
+  virtual void didFailWithError(
+      std::optional<int> posixCode,
+      std::string error) = 0;
+
+  /**
+   * Called when a message has been received from the socket.
+   * \param message Message received, in UTF-8 encoding.
+   */
+  virtual void didReceiveMessage(std::string_view message) = 0;
+
+  /**
+   * Called when the socket has been closed.
+   */
+  virtual void didClose() = 0;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/FollyDynamicMatchers.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/FollyDynamicMatchers.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <folly/json_pointer.h>
+#include <gmock/gmock.h>
+
+#include "FollyDynamicMatchers.h"
+
+namespace facebook::folly_dynamic_matchers_utils {
+
+std::string as_string(std::string value) {
+  return value;
+}
+std::string as_string(folly::dynamic value) {
+  return value.asString();
+}
+
+std::string explain_error(
+    folly::dynamic::json_pointer_resolution_error<folly::dynamic const> error) {
+  using err_code = folly::dynamic::json_pointer_resolution_error_code;
+
+  switch (error.error_code) {
+    case err_code::key_not_found:
+      return "key not found";
+    case err_code::index_out_of_bounds:
+      return "index out of bounds";
+    case err_code::append_requested:
+      return "append requested";
+    case err_code::index_not_numeric:
+      return "array index is not numeric";
+    case err_code::index_has_leading_zero:
+      return "leading zero not allowed when indexing arrays";
+    case err_code::element_not_object_or_array:
+      return "element is neither an object nor an array";
+    case err_code::json_pointer_out_of_bounds:
+      return "JSON pointer out of bounds";
+    case err_code::other:
+      return "unknown error";
+    default:
+      assert(false && "unhandled error code");
+      return "<unhandled error code>";
+  }
+}
+} // namespace facebook::folly_dynamic_matchers_utils

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/FollyDynamicMatchers.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/FollyDynamicMatchers.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <folly/json_pointer.h>
+#include <gmock/gmock.h>
+
+namespace facebook {
+
+namespace folly_dynamic_matchers_utils {
+
+std::string as_string(std::string value);
+std::string as_string(folly::dynamic value);
+std::string explain_error(
+    folly::dynamic::json_pointer_resolution_error<folly::dynamic const> error);
+
+} // namespace folly_dynamic_matchers_utils
+
+// GTest / GMock compatible matchers for `folly::dynamic` values.
+
+/**
+ * Parses a JSON string into a folly::dynamic, then matches it against the
+ * given matcher.
+ */
+MATCHER_P(
+    JsonParsed,
+    innerMatcher,
+    std::string{"parsed as JSON "} +
+        testing::DescribeMatcher<folly::dynamic>(innerMatcher, negation)) {
+  using namespace ::testing;
+  using namespace folly_dynamic_matchers_utils;
+  const auto& json = arg;
+  folly::dynamic parsed = folly::parseJson(as_string(json));
+  return ExplainMatchResult(innerMatcher, parsed, result_listener);
+}
+
+/**
+ * Given a folly::dynamic argument, asserts that it is deeply equal to the
+ * result of parsing the given JSON string.
+ */
+MATCHER_P(
+    JsonEq,
+    expected,
+    std::string{"deeply equals "} +
+        folly::toPrettyJson(folly::parseJson(expected))) {
+  using namespace ::testing;
+  return ExplainMatchResult(
+      JsonParsed(Eq(folly::parseJson(expected))), arg, result_listener);
+}
+
+/**
+ * A higher-order matcher that applies an inner matcher to the value at a
+ * particular JSON Pointer location within a folly::dynamic.
+ */
+MATCHER_P2(
+    AtJsonPtr,
+    jsonPointer,
+    innerMatcher,
+    std::string{"value at "} + jsonPointer + " " +
+        testing::DescribeMatcher<folly::dynamic>(innerMatcher, negation)) {
+  using namespace ::testing;
+  using namespace folly_dynamic_matchers_utils;
+  auto resolved_ptr = arg.try_get_ptr(folly::json_pointer::parse(jsonPointer));
+  if (resolved_ptr.hasValue()) {
+    return ExplainMatchResult(
+        innerMatcher, *resolved_ptr.value().value, result_listener);
+  }
+  *result_listener << "has no value at " << jsonPointer << " because of error: "
+                   << explain_error(resolved_ptr.error());
+  return false;
+}
+
+} // namespace facebook

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <jsinspector-modern/InspectorInterfaces.h>
+#include <jsinspector-modern/InspectorPackagerConnection.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+// Configurable mocks of various interfaces required by the inspector API.
+
+namespace facebook::react::jsinspector_modern {
+
+class MockWebSocket : public IWebSocket {
+ public:
+  MockWebSocket(
+      const std::string& url,
+      std::weak_ptr<IWebSocketDelegate> delegate)
+      : url{url}, delegate{delegate} {
+    EXPECT_TRUE(this->delegate.lock())
+        << "Delegate should exist when provided to createWebSocket";
+  }
+
+  const std::string url;
+  std::weak_ptr<IWebSocketDelegate> delegate;
+
+  /**
+   * Convenience method to access the delegate from tests.
+   * \pre The delegate has not been destroyed.
+   */
+  IWebSocketDelegate& getDelegate() {
+    auto delegateStrong = this->delegate.lock();
+    EXPECT_TRUE(delegateStrong);
+    return *delegateStrong;
+  }
+
+  // IWebSocket methods
+  MOCK_METHOD(void, send, (std::string_view message), (override));
+};
+
+class MockLocalConnection : public ILocalConnection {
+ public:
+  explicit MockLocalConnection(
+      std::unique_ptr<IRemoteConnection> remoteConnection)
+      : remoteConnection_{std::move(remoteConnection)} {}
+
+  IRemoteConnection& getRemoteConnection() {
+    return *remoteConnection_;
+  }
+
+  // ILocalConnection methods
+  MOCK_METHOD(void, sendMessage, (std::string message), (override));
+  MOCK_METHOD(void, disconnect, (), (override));
+
+ private:
+  std::unique_ptr<IRemoteConnection> remoteConnection_;
+};
+
+class MockInspectorPackagerConnectionDelegate
+    : public InspectorPackagerConnectionDelegate {
+ public:
+  MockInspectorPackagerConnectionDelegate() {
+    using namespace testing;
+    ON_CALL(*this, scheduleCallback(_, _)).WillByDefault(InvokeArgument<0>());
+  }
+
+  // InspectorPackagerConnectionDelegate methods
+  MOCK_METHOD(
+      std::unique_ptr<IWebSocket>,
+      connectWebSocket,
+      (const std::string& url, std::weak_ptr<IWebSocketDelegate> delegate),
+      (override));
+  MOCK_METHOD(
+      void,
+      scheduleCallback,
+      (std::function<void(void)> callback, std::chrono::milliseconds delayMs),
+      (override));
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
@@ -1,0 +1,758 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/Format.h>
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <jsinspector-modern/InspectorInterfaces.h>
+#include <jsinspector-modern/InspectorPackagerConnection.h>
+
+#include <functional>
+#include <memory>
+
+#include "FollyDynamicMatchers.h"
+#include "InspectorMocks.h"
+#include "UniquePtrFactory.h"
+
+using namespace ::testing;
+using namespace std::literals::string_literals;
+using folly::dynamic, folly::parseJson, folly::toJson, folly::format,
+    folly::sformat;
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+class InspectorPackagerConnectionTest : public testing::Test {
+ protected:
+  InspectorPackagerConnectionTest()
+      : packagerConnection_(InspectorPackagerConnection{
+            "ws://mock-host:12345",
+            "my-app",
+            packagerConnectionDelegates_.make_unique()}) {
+    ON_CALL(*packagerConnectionDelegate(), connectWebSocket(_, _))
+        .WillByDefault(webSockets_.lazily_make_unique<
+                       const std::string&,
+                       std::weak_ptr<IWebSocketDelegate>>());
+  }
+
+  ~InspectorPackagerConnectionTest() override {
+    // Clean up all pages currently registered with the inspector.
+    std::vector<int> pagesToRemove;
+    for (auto& page : getInspectorInstance().getPages()) {
+      pagesToRemove.push_back(page.id);
+    }
+    for (auto id : pagesToRemove) {
+      getInspectorInstance().removePage(id);
+    }
+  }
+
+  MockInspectorPackagerConnectionDelegate* packagerConnectionDelegate() {
+    // We only create one PackagerConnectionDelegate per test.
+    EXPECT_EQ(packagerConnectionDelegates_.objectsVended(), 1);
+    return packagerConnectionDelegates_[0];
+  }
+
+  UniquePtrFactory<MockInspectorPackagerConnectionDelegate>
+      packagerConnectionDelegates_;
+  /**
+   * webSockets_ will hold the WebSocket instance(s) owned by
+   * packagerConnection_ while also allowing us to access them during
+   * the test. We can send messages *to* packagerConnection_ by
+   * calling webSockets_[i]->getDelegate().didReceiveMessage(...). Messages
+   * *from* packagerConnection_ will be found as calls to
+   * webSockets_[i]->send, which is a mock method installed by gmock.
+   * These are strict mocks, so method calls will fail if they are not
+   * expected with a corresponding call to EXPECT_CALL(...) - for example
+   * if unexpected WebSocket messages are sent.
+   */
+  UniquePtrFactory<StrictMock<MockWebSocket>> webSockets_;
+  /**
+   * localConnections_ will hold the LocalConnection instances owned
+   * by packagerConnection_ while also allowing us to access them
+   * during the test.
+   * These are strict mocks, so method calls will fail if they are not
+   * expected with a corresponding call to EXPECT_CALL(...).
+   */
+  UniquePtrFactory<StrictMock<MockLocalConnection>> localConnections_;
+  std::optional<InspectorPackagerConnection> packagerConnection_;
+};
+
+} // namespace
+
+TEST_F(InspectorPackagerConnectionTest, TestConnectThenDestroy) {
+  packagerConnection_->connect();
+
+  // The connection should be established immediately.
+  ASSERT_TRUE(webSockets_[0]);
+  EXPECT_EQ(webSockets_[0]->url, "ws://mock-host:12345");
+  EXPECT_TRUE(packagerConnection_->isConnected());
+
+  // Destroying packagerConnection_ should close the underlying WebSocket (by
+  // destroying it).
+  packagerConnection_.reset();
+  EXPECT_FALSE(webSockets_[0]);
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestConnectMultipleTimes) {
+  packagerConnection_->connect();
+
+  packagerConnection_->connect();
+
+  // The WebSocket gets recreated and the connection is in a valid state.
+  EXPECT_FALSE(webSockets_[0]);
+  ASSERT_TRUE(webSockets_[1]);
+  EXPECT_EQ(webSockets_[1]->url, "ws://mock-host:12345");
+  EXPECT_TRUE(packagerConnection_->isConnected());
+
+  // Destroying packagerConnection_ should close the underlying WebSocket (by
+  // destroying it).
+  packagerConnection_.reset();
+  EXPECT_FALSE(webSockets_[1]);
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestCloseQuietly) {
+  packagerConnection_->connect();
+
+  ASSERT_TRUE(webSockets_[0]);
+  EXPECT_TRUE(packagerConnection_->isConnected());
+
+  packagerConnection_->closeQuietly();
+  EXPECT_FALSE(packagerConnection_->isConnected());
+  EXPECT_FALSE(webSockets_[0]);
+
+  // Calling closeQuietly again has no effect.
+  packagerConnection_->closeQuietly();
+  EXPECT_FALSE(packagerConnection_->isConnected());
+  EXPECT_FALSE(webSockets_[0]);
+
+  // Connecting again is a noop (except for logging an error).
+  packagerConnection_->connect();
+  EXPECT_FALSE(packagerConnection_->isConnected());
+  EXPECT_FALSE(webSockets_[0]);
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestGetPages) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+
+  // The list of pages is empty at first.
+  EXPECT_CALL(*webSockets_[0], send(JsonEq(R"({
+      "event": "getPages",
+      "payload": []
+    })")))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(R"({
+      "event": "getPages"
+    })");
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // getPages now reports the page we registered.
+  EXPECT_CALL(
+      *webSockets_[0],
+      send(JsonParsed(AllOf(
+          AtJsonPtr("/event", Eq("getPages")),
+          AtJsonPtr(
+              "/payload",
+              ElementsAreArray({AllOf(
+                  AtJsonPtr("/app", Eq("my-app")),
+                  AtJsonPtr("/title", Eq("mock-title")),
+                  AtJsonPtr("/vm", Eq("mock-vm")),
+                  AtJsonPtr("/id", Eq(std::to_string(pageId))))}))))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(R"({
+      "event": "getPages"
+    })");
+
+  getInspectorInstance().removePage(pageId);
+
+  // getPages is back to reporting no pages.
+  EXPECT_CALL(
+      *webSockets_[0],
+      send(JsonEq(
+          R"({
+              "event": "getPages",
+              "payload": []
+            })")))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(R"({
+      "event": "getPages"
+    })");
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestSendReceiveEvents) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect to the page.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Send an event from the mocked backend (local) to the frontend (remote)
+  // and observe it being sent via the socket.
+  EXPECT_CALL(
+      *webSockets_[0],
+      send(JsonParsed(AllOf(
+          AtJsonPtr("/event", Eq("wrappedEvent")),
+          AtJsonPtr("/payload/pageId", Eq(std::to_string(pageId))),
+          AtJsonPtr(
+              "/payload/wrappedEvent",
+              JsonEq(
+                  R"({
+                    "method": "FakeDomain.eventTriggered",
+                    "params": ["arg1", "arg2"]
+                  })"))))))
+      .RetiresOnSaturation();
+  localConnections_[0]->getRemoteConnection().onMessage(R"({
+                                                            "method": "FakeDomain.eventTriggered",
+                                                            "params": ["arg1", "arg2"]
+                                                          })");
+
+  // Send an event from the frontend (remote) to the backend (local) and
+  // observe it being received by localConnection.
+  EXPECT_CALL(
+      *localConnections_[0],
+      sendMessage(JsonParsed(AllOf(
+          AtJsonPtr("/method", Eq("FakeDomain.fakeMethod")),
+          AtJsonPtr("/id", Eq(1234)),
+          AtJsonPtr("/params", ElementsAre("arg1", "arg2"))))))
+      .RetiresOnSaturation();
+
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "wrappedEvent",
+          "payload": {{
+            "pageId": {0},
+            "wrappedEvent": {1}
+          }}
+        }})",
+      toJson(std::to_string(pageId)),
+      toJson(R"({
+                "method": "FakeDomain.fakeMethod",
+                "id": 1234,
+                "params": ["arg1", "arg2"]
+              })")));
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestSendReceiveEventsToMultiplePages) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+
+  std::vector<int> pageIds;
+
+  const int kNumPages = 2;
+  for (int i = 0; i < kNumPages; ++i) {
+    pageIds.push_back(getInspectorInstance().addPage(
+        "mock-title",
+        "mock-vm",
+        localConnections_
+            .lazily_make_unique<std::unique_ptr<IRemoteConnection>>()));
+    if (i > 0) {
+      ASSERT_NE(pageIds[i], pageIds[i - 1])
+          << "Received duplicate page IDs from inspector.";
+    }
+  }
+
+  for (int i = 0; i < kNumPages; ++i) {
+    // Connect to the i-th page.
+    webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+        R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+        toJson(std::to_string(pageIds[i]))));
+    ASSERT_TRUE(localConnections_[i]);
+  }
+
+  // Send an event from each LocalConnection and observe it being sent via
+  // the socket.
+  for (int i = 0; i < kNumPages; ++i) {
+    // Generate a unique method name for this page to validate that we are
+    // routing the events correctly.
+    std::string method =
+        "FakeDomain.eventFromPage"s + std::to_string(pageIds[i]);
+    EXPECT_CALL(
+        *webSockets_[0],
+        send(JsonParsed(AllOf(
+            AtJsonPtr("/event", Eq("wrappedEvent")),
+            AtJsonPtr("/payload/pageId", Eq(std::to_string(pageIds[i]))),
+            AtJsonPtr(
+                "/payload/wrappedEvent",
+                JsonParsed(AtJsonPtr("/method", Eq(method))))))))
+        .RetiresOnSaturation();
+    localConnections_[i]->getRemoteConnection().onMessage(
+        toJson(dynamic::object("method", method)));
+  }
+
+  // Send an event from the frontend (remote) to the backend (local) and
+  // observe it being received by each LocalConnection.
+  for (int i = 0; i < kNumPages; ++i) {
+    // Generate a unique method name for this page to validate that we are
+    // routing the events correctly.
+    std::string method =
+        "FakeDomain.methodToPage"s + std::to_string(pageIds[i]);
+    EXPECT_CALL(
+        *localConnections_[i],
+        sendMessage(JsonParsed(AtJsonPtr("/method", Eq(method)))))
+        .RetiresOnSaturation();
+    webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+        R"({{
+            "event": "wrappedEvent",
+            "payload": {{
+              "pageId": {0},
+              "wrappedEvent": {1}
+            }}
+          }})",
+        toJson(std::to_string(pageIds[i])),
+        toJson(toJson(dynamic::object("method", method)))));
+  }
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestSendEventToAllConnections) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect to the page.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Impersonate the frontend (remote) to send a message to all (local)
+  // connections.
+  EXPECT_CALL(
+      *localConnections_[0],
+      sendMessage(JsonParsed(AllOf(
+          AtJsonPtr("/method", Eq("FakeDomain.fakeMethod")),
+          AtJsonPtr("/id", Eq(1234)),
+          AtJsonPtr("/params", ElementsAre("arg1", "arg2"))))))
+      .RetiresOnSaturation();
+  packagerConnection_->sendEventToAllConnections(R"({
+    "method": "FakeDomain.fakeMethod",
+    "id": 1234,
+    "params": ["arg1", "arg2"]
+  })");
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestConnectThenDisconnect) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect to the page.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Disconnect from the page.
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "disconnect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  EXPECT_FALSE(localConnections_[0]);
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestConnectThenCloseSocket) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect to the page.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Notify that the socket was closed.
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didClose();
+  EXPECT_FALSE(localConnections_[0]);
+}
+
+TEST_F(
+    InspectorPackagerConnectionTest,
+    TestConnectWhileAlreadyConnectedCausesDisconnection) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect to the page.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Try connecting to the same page again. This results in a disconnection.
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  EXPECT_FALSE(localConnections_[0]);
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestMultipleDisconnect) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect to the page.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Disconnect from the page.
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "disconnect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  EXPECT_FALSE(localConnections_[0]);
+
+  // Disconnect again. This is a noop.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "disconnect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  EXPECT_FALSE(localConnections_[0]);
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestDisconnectThenSendEvent) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect to the page.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Disconnect from the page.
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "disconnect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  EXPECT_FALSE(localConnections_[0]);
+
+  // Send an event from the frontend (remote) to the backend (local). This
+  // is a noop.
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "wrappedEvent",
+          "payload": {{
+            "pageId": {0},
+            "wrappedEvent": {1}
+          }}
+        }})",
+      toJson(std::to_string(pageId)),
+      toJson(R"({
+                "method": "FakeDomain.fakeMethod",
+                "id": 1234,
+                "params": ["arg1", "arg2"]
+              })")));
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestSendEventToUnknownPage) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+
+  // Send an event from the frontend (remote) to the backend (local). This
+  // is a noop (except for logging).
+  webSockets_[0]->getDelegate().didReceiveMessage(sformat(
+      R"({{
+          "event": "wrappedEvent",
+          "payload": {{
+            "pageId": "1234",
+            "wrappedEvent": {0}
+          }}
+        }})",
+      toJson(R"({
+                "method": "FakeDomain.fakeMethod",
+                "id": 1234,
+                "params": ["arg1", "arg2"]
+              })")));
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestReconnectSuccessful) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  ASSERT_TRUE(webSockets_[0]);
+  EXPECT_CALL(*packagerConnectionDelegate(), scheduleCallback(_, _))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didClose();
+  EXPECT_FALSE(webSockets_[0]);
+  EXPECT_TRUE(webSockets_[1]);
+  EXPECT_TRUE(packagerConnection_->isConnected());
+
+  // Stops attempting to reconnect after closeQuietly
+
+  packagerConnection_->closeQuietly();
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestReconnectFailure) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  ASSERT_TRUE(webSockets_[0]);
+  EXPECT_CALL(*packagerConnectionDelegate(), scheduleCallback(_, _))
+      .Times(2)
+      .RetiresOnSaturation();
+
+  webSockets_[0]->getDelegate().didClose();
+  EXPECT_FALSE(webSockets_[0]);
+  ASSERT_TRUE(webSockets_[1]);
+  webSockets_[1]->getDelegate().didClose();
+  EXPECT_FALSE(webSockets_[1]);
+  ASSERT_TRUE(webSockets_[2]);
+  EXPECT_TRUE(packagerConnection_->isConnected());
+
+  // Stops attempting to reconnect after closeQuietly
+
+  packagerConnection_->closeQuietly();
+
+  EXPECT_FALSE(webSockets_[2]);
+  EXPECT_FALSE(packagerConnection_->isConnected());
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestUnknownEvent) {
+  packagerConnection_->connect();
+  ASSERT_TRUE(webSockets_[0]);
+
+  // This is a noop (other than logging an error).
+  webSockets_[0]->getDelegate().didReceiveMessage(R"({"event": "foo"})");
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestMalformedEvent) {
+  packagerConnection_->connect();
+  ASSERT_TRUE(webSockets_[0]);
+
+  // This is a noop (other than logging an error).
+  webSockets_[0]->getDelegate().didReceiveMessage("this is not json");
+  webSockets_[0]->getDelegate().didReceiveMessage("{");
+  webSockets_[0]->getDelegate().didReceiveMessage("");
+}
+
+TEST_F(InspectorPackagerConnectionTest, TestEventsNotConformingToType) {
+  packagerConnection_->connect();
+  ASSERT_TRUE(webSockets_[0]);
+
+  // These are all noops (other than logging an error).
+  webSockets_[0]->getDelegate().didReceiveMessage(R"({})");
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      R"({"event": "wrappedEvent"})");
+  webSockets_[0]->getDelegate().didReceiveMessage(R"({"event": "connect"})");
+  webSockets_[0]->getDelegate().didReceiveMessage(R"({"event": "disconnect"})");
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      R"({"payload": {"pageId": "1"}})");
+}
+
+TEST_F(
+    InspectorPackagerConnectionTest,
+    TestWebSocketDelegateIsDestroyedWithConnectionByDefault) {
+  packagerConnection_->connect();
+  ASSERT_TRUE(webSockets_[0]);
+
+  std::weak_ptr delegate = webSockets_[0]->delegate;
+  EXPECT_TRUE(delegate.lock());
+
+  packagerConnection_.reset();
+  EXPECT_FALSE(delegate.lock());
+}
+
+// Edge case: When the C++ layer has released the InspectorPackagerConnection,
+// the platform bindings can still call methods on IWebSocketDelegate through
+// a shared_ptr (typically _briefly_ upgraded from the weak_ptr we provide).
+TEST_F(
+    InspectorPackagerConnectionTest,
+    TestWebSocketDelegateCanOutliveConnection) {
+  // Configure gmock to expect calls in a specific order.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+  ASSERT_TRUE(webSockets_[0]);
+
+  std::shared_ptr retainedWebSocketDelegate = webSockets_[0]->delegate.lock();
+  ASSERT_TRUE(retainedWebSocketDelegate);
+
+  // Destroy our InspectorPackagerConnection. We can't call methods on it
+  // anymore, but its internals are still valid and it is still responding to
+  // socket messages.
+  packagerConnection_.reset();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-title",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect to the page.
+  retainedWebSocketDelegate->didReceiveMessage(sformat(
+      R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+      toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Send an event from the frontend (remote) to the backend (local) and
+  // observe it being received by localConnection.
+  EXPECT_CALL(
+      *localConnections_[0],
+      sendMessage(JsonParsed(AllOf(
+          AtJsonPtr("/method", Eq("FakeDomain.fakeMethod")),
+          AtJsonPtr("/id", Eq(1234)),
+          AtJsonPtr("/params", ElementsAre("arg1", "arg2"))))))
+      .RetiresOnSaturation();
+
+  retainedWebSocketDelegate->didReceiveMessage(sformat(
+      R"({{
+          "event": "wrappedEvent",
+          "payload": {{
+            "pageId": {0},
+            "wrappedEvent": {1}
+          }}
+        }})",
+      toJson(std::to_string(pageId)),
+      toJson(R"({
+                "method": "FakeDomain.fakeMethod",
+                "id": 1234,
+                "params": ["arg1", "arg2"]
+              })")));
+
+  retainedWebSocketDelegate.reset();
+  EXPECT_FALSE(localConnections_[0]);
+  EXPECT_FALSE(webSockets_[0]);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/UniquePtrFactory.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/UniquePtrFactory.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+namespace facebook {
+
+/**
+ * A factory that creates objects of type T wrapped in unique_ptr, and provides
+ * non-owning access to those objects. Note that the factory MUST outlive the
+ * objects it creates.
+ *
+ * Example usage:
+ *
+ * struct Foo { virtual ~foo() = default; };
+ * UniquePtrFactory<Foo> objects;
+ * std::unique_ptr<Foo> object = objects.make_unique();
+ * assert(objects[0] == object.get());
+ * object.reset();
+ * assert(objects[0] == nullptr);
+ *
+ * See UniquePtrFactoryTest.cpp for more examples.
+ */
+template <typename T>
+class UniquePtrFactory {
+  static_assert(
+      std::has_virtual_destructor_v<T>,
+      "T must have a virtual destructor");
+
+ public:
+  /**
+   * Creates a new object of type T, and returns a unique_ptr wrapping it.
+   */
+  template <typename... Args>
+  std::unique_ptr<T> make_unique(Args&&... args) {
+    size_t index = objectPtrs_.size();
+    auto ptr =
+        std::make_unique<Facade>(*this, index, std::forward<Args>(args)...);
+    objectPtrs_.push_back(ptr.get());
+    return ptr;
+  }
+
+  /**
+   * Returns a function that can be used to create objects of type T. The
+   * function may only be used while the factory is alive.
+   */
+  template <typename... Args>
+  std::function<std::unique_ptr<T>(Args&&...)> lazily_make_unique() {
+    return [this](Args&&... args) {
+      return make_unique(std::forward<Args>(args)...);
+    };
+  }
+
+  /**
+   * Returns a pointer to the `index`th object created by this factory,
+   * or nullptr if the object has been destroyed (or not created yet).
+   */
+  T* operator[](size_t index) {
+    return index >= objectPtrs_.size() ? nullptr : objectPtrs_[index];
+  }
+
+  /**
+   * Returns a pointer to the `index`th object created by this factory,
+   * or nullptr if the object has been destroyed (or not created yet).
+   */
+  const T* operator[](size_t index) const {
+    return index >= objectPtrs_.size() ? nullptr : objectPtrs_[index];
+  }
+
+  /**
+   * Returns the total number of objects created by this factory, including
+   * those that have already been destroyed.
+   */
+  size_t objectsVended() const {
+    return objectPtrs_.size();
+  }
+
+ private:
+  friend class Facade;
+
+  /**
+   * Extends T to clean up the reference in objectPtrs_ when the object is
+   * destroyed.
+   */
+  class Facade : public T {
+   public:
+    template <typename... Args>
+    Facade(UniquePtrFactory& container, size_t index, Args&&... args)
+        : T(std::forward<Args>(args)...),
+          container_(container),
+          index_(index) {}
+
+    virtual ~Facade() override {
+      container_.objectPtrs_[index_] = nullptr;
+    }
+
+    UniquePtrFactory& container_;
+    size_t index_;
+  };
+  std::vector<T*> objectPtrs_;
+};
+
+} // namespace facebook

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/UniquePtrFactoryTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/UniquePtrFactoryTest.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "UniquePtrFactory.h"
+
+using namespace ::testing;
+
+namespace {
+
+struct Foo {
+  explicit Foo(int v) : value(v) {}
+
+  // Required for UniquePtrFactory
+  virtual ~Foo() = default;
+
+  int value{0};
+};
+
+} // namespace
+
+namespace facebook {
+
+TEST(UniquePtrFactoryTest, KitchenSink) {
+  UniquePtrFactory<Foo> fooObjects;
+
+  EXPECT_EQ(fooObjects[0], nullptr)
+      << "objects should be nullptr before being created";
+  EXPECT_EQ(fooObjects.objectsVended(), 0);
+
+  auto foo0 = fooObjects.make_unique(100);
+  EXPECT_EQ(foo0.get(), fooObjects[0]);
+  EXPECT_EQ(fooObjects.objectsVended(), 1);
+
+  auto foo1 = fooObjects.make_unique(200);
+  EXPECT_EQ(foo1.get(), fooObjects[1]);
+  EXPECT_EQ(fooObjects.objectsVended(), 2);
+
+  foo0.reset();
+  EXPECT_EQ(fooObjects[0], nullptr)
+      << "objects should be nullptr after being destroyed";
+  EXPECT_EQ(fooObjects.objectsVended(), 2)
+      << "objectsVended should never decrease";
+  EXPECT_EQ(foo1.get(), fooObjects[1])
+      << "foo1 should not be affected by foo0 being reset";
+
+  foo1.reset();
+  EXPECT_EQ(fooObjects[1], nullptr)
+      << "objects should be nullptr after being destroyed";
+  EXPECT_EQ(fooObjects.objectsVended(), 2);
+
+  auto foo2 = fooObjects.make_unique(300);
+  EXPECT_EQ(foo2.get(), fooObjects[2]);
+  EXPECT_EQ(fooObjects.objectsVended(), 3);
+}
+
+TEST(UniquePtrFactoryTest, LazilyMakeUnique) {
+  UniquePtrFactory<Foo> fooObjects;
+
+  EXPECT_EQ(fooObjects[0], nullptr)
+      << "objects should be nullptr before being created";
+  EXPECT_EQ(fooObjects.objectsVended(), 0);
+
+  auto makeFoo = fooObjects.lazily_make_unique<int>();
+
+  EXPECT_EQ(fooObjects[0], nullptr)
+      << "an object should not be created until makeFoo is called";
+  EXPECT_EQ(fooObjects.objectsVended(), 0);
+
+  auto foo0 = makeFoo(100);
+  EXPECT_EQ(foo0.get(), fooObjects[0]);
+  EXPECT_EQ(fooObjects.objectsVended(), 1);
+
+  auto foo1 = makeFoo(200);
+  EXPECT_EQ(foo1.get(), fooObjects[1]);
+  EXPECT_EQ(fooObjects.objectsVended(), 2);
+}
+
+} // namespace facebook


### PR DESCRIPTION
Summary:
Changelog: [Internal]

C++ unit tests for D52134592. The tests heavily use gtest / gmock features to mock the various interfaces associated with `InspectorPackagerConnection` (see `InspectorMocks.h`) and to make it easy to write complex assertions on dynamic and JSON values (see `FollyDynamicMatchers.h`).

To simplify access to the mock objects while they are owned by the `InspectorPackagerConnection` under test, I've also created the `UniquePtrFactory` helper (see doc comments and unit tests that fully explain its functionality).

Reviewed By: huntie

Differential Revision: D52134593


