### PR TITLE
Add position type check to layout metrics == operator

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -73,7 +73,8 @@ struct LayoutMetrics {
                this->displayType,
                this->layoutDirection,
                this->pointScaleFactor,
-               this->overflowInset) ==
+               this->overflowInset,
+               this->positionType) ==
         std::tie(
                rhs.frame,
                rhs.contentInsets,
@@ -81,7 +82,8 @@ struct LayoutMetrics {
                rhs.displayType,
                rhs.layoutDirection,
                rhs.pointScaleFactor,
-               rhs.overflowInset);
+               rhs.overflowInset,
+               rhs.positionType);
   }
 
   bool operator!=(const LayoutMetrics& rhs) const {


### PR DESCRIPTION
Summary:
I added position type in D51412428 (https://github.com/facebook/react-native/pull/41819). I didn't notice this == override which makes it so position type in layout metrics will not be updated if it changes.

Changelog: [Internal]

Differential Revision: D52339890


