### PR TITLE
Add gtests for order index logic

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -102,7 +102,7 @@ export interface FlexStyle {
   paddingStart?: DimensionValue | undefined;
   paddingTop?: DimensionValue | undefined;
   paddingVertical?: DimensionValue | undefined;
-  position?: 'absolute' | 'relative' | undefined;
+  position?: 'absolute' | 'relative' | 'static' | undefined;
   right?: DimensionValue | undefined;
   start?: DimensionValue | undefined;
   top?: DimensionValue | undefined;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -484,7 +484,7 @@ type ____LayoutStyle_Internal = $ReadOnly<{
    *  for more details on how `position` differs between React Native
    *  and CSS.
    */
-  position?: 'absolute' | 'relative',
+  position?: 'absolute' | 'relative' | 'static',
 
   /** `flexDirection` controls which directions children of a container go.
    *  `row` goes left to right, `column` goes top to bottom, and you may

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -374,11 +374,6 @@ using namespace facebook::react;
     self.accessibilityIdentifier = RCTNSStringFromString(newViewProps.testId);
   }
 
-  // `zIndex`
-  if (oldViewProps.zIndex != newViewProps.zIndex) {
-    self.layer.zPosition = newViewProps.zIndex.value_or(0);
-  }
-
   _needsInvalidateLayer = _needsInvalidateLayer || needsInvalidateLayer;
 
   _props = std::static_pointer_cast<const ViewProps>(props);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -36,14 +36,7 @@ YogaStylableProps::YogaStylableProps(
 };
 
 /*static*/ const yoga::Style& YogaStylableProps::defaultStyle() {
-  static const auto defaultStyle = []() {
-    yoga::Style style;
-    style.setPositionType(
-        CoreFeatures::positionRelativeDefault ? yoga::PositionType::Relative
-                                              : yoga::PositionType::Static);
-    return style;
-  }();
-
+  static const auto defaultStyle = []() { return yoga::Style{}; }();
   return defaultStyle;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -73,7 +73,8 @@ struct LayoutMetrics {
                this->displayType,
                this->layoutDirection,
                this->pointScaleFactor,
-               this->overflowInset) ==
+               this->overflowInset,
+               this->positionType) ==
         std::tie(
                rhs.frame,
                rhs.contentInsets,
@@ -81,7 +82,8 @@ struct LayoutMetrics {
                rhs.displayType,
                rhs.layoutDirection,
                rhs.pointScaleFactor,
-               rhs.overflowInset);
+               rhs.overflowInset,
+               rhs.positionType);
   }
 
   bool operator!=(const LayoutMetrics& rhs) const {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -181,8 +181,16 @@ static bool shouldFirstPairComesBeforeSecondOne(
     // Tiebreakers look at the positioning and then document order
     auto lhsLayoutableShadowNode =
         traitCast<const LayoutableShadowNode*>(lhs->shadowNode);
-    const auto rhsLayoutableShadowNode =
+    auto rhsLayoutableShadowNode =
         traitCast<const LayoutableShadowNode*>(rhs->shadowNode);
+
+    if (lhsLayoutableShadowNode->getLayoutMetrics().positionType ==
+            PositionType::Static ||
+        rhsLayoutableShadowNode->getLayoutMetrics().positionType ==
+            PositionType::Static) {
+      rhsLayoutableShadowNode =
+          traitCast<const LayoutableShadowNode*>(rhs->shadowNode);
+    }
 
     if (lhsLayoutableShadowNode != nullptr &&
         rhsLayoutableShadowNode != nullptr &&

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/OrderIndexTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/OrderIndexTest.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+#include <react/renderer/components/root/RootComponentDescriptor.h>
+#include <react/renderer/components/scrollview/ScrollViewComponentDescriptor.h>
+#include <react/renderer/components/view/ViewComponentDescriptor.h>
+#include <react/renderer/element/ComponentBuilder.h>
+#include <react/renderer/element/Element.h>
+#include <react/renderer/element/testUtils.h>
+#include <react/renderer/mounting/Differentiator.h>
+#include <react/renderer/mounting/ShadowViewMutation.h>
+#include <react/renderer/mounting/stubs.h>
+
+namespace facebook::react {
+
+class OrderIndexTest : public ::testing::Test {
+ protected:
+  ComponentBuilder builder_;
+  std::shared_ptr<RootShadowNode> rootShadowNode_;
+  std::shared_ptr<ViewShadowNode> nodeA_;
+  std::shared_ptr<ViewShadowNode> nodeB_;
+  std::shared_ptr<ViewShadowNode> nodeC_;
+  std::shared_ptr<ViewShadowNode> nodeD_;
+
+  std::shared_ptr<RootShadowNode> currentRootShadowNode_;
+  StubViewTree currentStubViewTree_;
+
+  OrderIndexTest() : builder_(simpleComponentBuilder()) {
+    // clang-format off
+    auto element =
+        Element<RootShadowNode>()
+          .reference(rootShadowNode_)
+          .tag(1)
+          .children({
+            Element<ViewShadowNode>()
+              .tag(2)
+              .reference(nodeA_),
+            Element<ViewShadowNode>()
+              .tag(3)
+              .reference(nodeB_),
+            Element<ViewShadowNode>()
+              .tag(4)
+              .reference(nodeC_),
+            Element<ViewShadowNode>()
+              .tag(5)
+              .reference(nodeD_),
+          });
+    // clang-format on
+
+    builder_.build(element);
+
+    mutateViewShadowNodeProps_(nodeA_, [](ViewProps& props) {
+      auto& yogaStyle = props.yogaStyle;
+      yogaStyle.setPositionType(yoga::PositionType::Relative);
+      props.backgroundColor = blackColor(); // to ensure it won't get flattened
+    });
+    mutateViewShadowNodeProps_(nodeB_, [](ViewProps& props) {
+      auto& yogaStyle = props.yogaStyle;
+      yogaStyle.setPositionType(yoga::PositionType::Relative);
+      props.backgroundColor = blackColor(); // to ensure it won't get flattened
+    });
+    mutateViewShadowNodeProps_(nodeC_, [](ViewProps& props) {
+      auto& yogaStyle = props.yogaStyle;
+      yogaStyle.setPositionType(yoga::PositionType::Relative);
+      props.backgroundColor = blackColor(); // to ensure it won't get flattened
+    });
+    mutateViewShadowNodeProps_(nodeD_, [](ViewProps& props) {
+      auto& yogaStyle = props.yogaStyle;
+      yogaStyle.setPositionType(yoga::PositionType::Relative);
+      props.backgroundColor = blackColor(); // to ensure it won't get flattened
+    });
+
+    currentRootShadowNode_ = rootShadowNode_;
+    currentRootShadowNode_->layoutIfNeeded();
+    currentStubViewTree_ =
+        buildStubViewTreeWithoutUsingDifferentiator(*currentRootShadowNode_);
+  }
+
+  void mutateViewShadowNodeProps_(
+      const std::shared_ptr<ViewShadowNode>& node,
+      std::function<void(ViewProps& props)> callback) {
+    rootShadowNode_ =
+        std::static_pointer_cast<RootShadowNode>(rootShadowNode_->cloneTree(
+            node->getFamily(), [&](const ShadowNode& oldShadowNode) {
+              auto viewProps = std::make_shared<ViewShadowNodeProps>();
+              callback(*viewProps);
+              return oldShadowNode.clone(ShadowNodeFragment{viewProps});
+            }));
+  }
+
+  void testViewTree_(
+      const std::function<void(StubViewTree const& viewTree)>& callback) {
+    rootShadowNode_->layoutIfNeeded();
+
+    callback(buildStubViewTreeUsingDifferentiator(*rootShadowNode_));
+    callback(buildStubViewTreeWithoutUsingDifferentiator(*rootShadowNode_));
+
+    auto mutations =
+        calculateShadowViewMutations(*currentRootShadowNode_, *rootShadowNode_);
+    currentRootShadowNode_ = rootShadowNode_;
+    currentStubViewTree_.mutate(mutations);
+    callback(currentStubViewTree_);
+  }
+};
+
+TEST_F(OrderIndexTest, defaultOrderIsDocumentOrder) {
+  testViewTree_([this](const StubViewTree& viewTree) {
+    EXPECT_EQ(viewTree.size(), 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 4);
+
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, nodeA_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, nodeB_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, nodeC_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, nodeD_->getTag());
+  });
+}
+
+TEST_F(OrderIndexTest, basicZIndex) {
+  mutateViewShadowNodeProps_(
+      nodeA_, [](ViewProps& props) { props.zIndex = 5; });
+  mutateViewShadowNodeProps_(
+      nodeB_, [](ViewProps& props) { props.zIndex = 10; });
+  mutateViewShadowNodeProps_(
+      nodeC_, [](ViewProps& props) { props.zIndex = 1; });
+  mutateViewShadowNodeProps_(
+      nodeD_, [](ViewProps& props) { props.zIndex = 2; });
+
+  testViewTree_([this](const StubViewTree& viewTree) {
+    EXPECT_EQ(viewTree.size(), 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 4);
+
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, nodeC_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, nodeD_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, nodeA_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, nodeB_->getTag());
+  });
+}
+
+TEST_F(OrderIndexTest, negativeZIndex) {
+  mutateViewShadowNodeProps_(
+      nodeA_, [](ViewProps& props) { props.zIndex = 5; });
+  mutateViewShadowNodeProps_(
+      nodeB_, [](ViewProps& props) { props.zIndex = -10; });
+  mutateViewShadowNodeProps_(
+      nodeC_, [](ViewProps& props) { props.zIndex = -1; });
+  mutateViewShadowNodeProps_(
+      nodeD_, [](ViewProps& props) { props.zIndex = 2; });
+
+  testViewTree_([this](const StubViewTree& viewTree) {
+    EXPECT_EQ(viewTree.size(), 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 4);
+
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, nodeB_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, nodeC_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, nodeD_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, nodeA_->getTag());
+  });
+}
+
+TEST_F(OrderIndexTest, zeroZIndex) {
+  mutateViewShadowNodeProps_(
+      nodeC_, [](ViewProps& props) { props.zIndex = 0; });
+  mutateViewShadowNodeProps_(
+      nodeD_, [](ViewProps& props) { props.zIndex = 0; });
+
+  testViewTree_([this](const StubViewTree& viewTree) {
+    EXPECT_EQ(viewTree.size(), 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 4);
+
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, nodeA_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, nodeB_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, nodeC_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, nodeD_->getTag());
+  });
+}
+
+TEST_F(OrderIndexTest, staticBehindNonStatic) {
+  mutateViewShadowNodeProps_(nodeB_, [](ViewProps& props) {
+    auto& yogaStyle = props.yogaStyle;
+    yogaStyle.setPositionType(yoga::PositionType::Static);
+    props.backgroundColor = blackColor();
+  });
+  mutateViewShadowNodeProps_(nodeD_, [](ViewProps& props) {
+    auto& yogaStyle = props.yogaStyle;
+    yogaStyle.setPositionType(yoga::PositionType::Static);
+    props.backgroundColor = blackColor();
+  });
+
+  testViewTree_([this](const StubViewTree& viewTree) {
+    EXPECT_EQ(viewTree.size(), 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 4);
+
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, nodeB_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, nodeD_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, nodeA_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, nodeC_->getTag());
+  });
+}
+
+TEST_F(OrderIndexTest, zIndexStaticBehindNonStatic) {
+  mutateViewShadowNodeProps_(
+      nodeB_, [](ViewProps& props) { props.zIndex = 5; });
+  mutateViewShadowNodeProps_(
+      nodeC_, [](ViewProps& props) { props.zIndex = -1; });
+  mutateViewShadowNodeProps_(nodeD_, [](ViewProps& props) {
+    auto& yogaStyle = props.yogaStyle;
+    yogaStyle.setPositionType(yoga::PositionType::Static);
+    props.backgroundColor = blackColor();
+  });
+
+  testViewTree_([this](const StubViewTree& viewTree) {
+    EXPECT_EQ(viewTree.size(), 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 4);
+
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, nodeC_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, nodeD_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, nodeA_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, nodeB_->getTag());
+  });
+}
+
+TEST_F(OrderIndexTest, staticDoesNotGetZIndex) {
+  mutateViewShadowNodeProps_(nodeB_, [](ViewProps& props) {
+    auto& yogaStyle = props.yogaStyle;
+    yogaStyle.setPositionType(yoga::PositionType::Static);
+    props.backgroundColor = blackColor();
+    props.zIndex = 5;
+  });
+  mutateViewShadowNodeProps_(nodeD_, [](ViewProps& props) {
+    auto& yogaStyle = props.yogaStyle;
+    yogaStyle.setPositionType(yoga::PositionType::Static);
+    props.backgroundColor = blackColor();
+    props.zIndex = -5;
+  });
+
+  testViewTree_([this](const StubViewTree& viewTree) {
+    EXPECT_EQ(viewTree.size(), 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 4);
+
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, nodeB_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, nodeD_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, nodeA_->getTag());
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, nodeC_->getTag());
+  });
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -262,6 +262,7 @@ TEST_F(StackingContextTest, mostPropsDoNotForceViewsToMaterialize) {
   mutateViewShadowNodeProps_(nodeBA_, [](ViewProps& props) {
     auto& yogaStyle = props.yogaStyle;
     props.zIndex = 42;
+    yogaStyle.setPositionType(yoga::PositionType::Static);
     yogaStyle.setMargin(yoga::Edge::All, yoga::value::points(42));
     props.shadowColor = clearColor();
     props.shadowOpacity = 0.42;
@@ -270,14 +271,15 @@ TEST_F(StackingContextTest, mostPropsDoNotForceViewsToMaterialize) {
   mutateViewShadowNodeProps_(nodeBBA_, [](ViewProps& props) {
     auto& yogaStyle = props.yogaStyle;
     yogaStyle.setPositionType(yoga::PositionType::Relative);
-
     props.borderRadii.all = 42;
     props.borderColors.all = blackColor();
   });
 
   mutateViewShadowNodeProps_(nodeBD_, [](ViewProps& props) {
+    auto& yogaStyle = props.yogaStyle;
     props.onLayout = true;
     props.hitSlop = EdgeInsets{42, 42, 42, 42};
+    yogaStyle.setPositionType(yoga::PositionType::Static);
   });
 
   testViewTree_([](const StubViewTree& viewTree) {

--- a/packages/rn-tester/js/examples/Transform/TransformExample.js
+++ b/packages/rn-tester/js/examples/Transform/TransformExample.js
@@ -247,6 +247,7 @@ const styles = StyleSheet.create({
     marginVertical: 40,
     flex: 1,
     alignSelf: 'center',
+    zIndex: 0,
   },
   flipCard: {
     width: 200,
@@ -255,7 +256,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: 'blue',
     backfaceVisibility: 'hidden',
-    zIndex: 1024,
   },
   flipCard1: {
     position: 'absolute',


### PR DESCRIPTION
Summary: Some tests to ensure that the order of nodes is correct as defiend by order index that is derived from zIndex + positioning. These tests do not ensure that the native platform then goes and lays them out correctly. That will be done later with e2e tests on catalyst

Differential Revision: D52295063


