### PR TITLE
Bump minimum version of activesupport for CVE-2023-38037

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.13'
-gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,11 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (6.1.7.3)
+    activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
@@ -63,10 +62,10 @@ GEM
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
-    minitest (5.18.0)
+    minitest (5.20.0)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
@@ -85,17 +84,16 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 6.1.7.3, < 7.1.0)
+  activesupport (>= 6.1.7.5, < 7.1.0)
   cocoapods (~> 1.13)
 
 RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.4.7
+   2.4.12

--- a/packages/react-native/template/Gemfile
+++ b/packages/react-native/template/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.13'
-gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -5,4 +5,4 @@ ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.13'
 gem 'rexml'
-gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'


### PR DESCRIPTION

## Summary:

Bump activesupport to minimum 6.1.7.5 CVE-2023-38037. More details https://github.com/advisories/GHSA-cr5q-6q9f-rq6q
## Changelog:

[IOS] [SECURITY] - Bump activesupport to minimum 6.1.7.5 CVE-2023-38037.
