### PR TITLE
Remove exclude for normalize-colors in template test setup

### DIFF
--- a/scripts/template/initialize.js
+++ b/scripts/template/initialize.js
@@ -65,11 +65,6 @@ async function install() {
           return;
         }
 
-        // TODO: Fix normalize-colors publishing in Verdaccio
-        if (packageManifest.name === '@react-native/normalize-colors') {
-          return;
-        }
-
         execSync(
           'npm publish --registry http://localhost:4873 --access public',
           {


### PR DESCRIPTION
Summary:
Intends to fix failing `test_*_template` jobs in CircleCI, broken after D52337762.

Changelog: [Internal]

Differential Revision: D52364225


