### PR TITLE
docs: bump minSdk to 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ React Native is developed and supported by many companies and individual core co
 
 ## 📋 Requirements
 
-React Native apps may target iOS 13.4 and Android 5.0 (API 21) or newer. You may use Windows, macOS, or Linux as your development operating system, though building and running iOS apps is limited to macOS. Tools like [Expo](https://expo.dev) can be used to work around this.
+React Native apps may target iOS 13.4 and Android 6.0 (API 23) or newer. You may use Windows, macOS, or Linux as your development operating system, though building and running iOS apps is limited to macOS. Tools like [Expo](https://expo.dev) can be used to work around this.
 
 ## 🎉 Building your first React Native app
 


### PR DESCRIPTION
## Summary:
The Android minSdk has been bumped in https://github.com/facebook/react-native/pull/38874 but not in the README.

## Changelog:
[General] [Fixed] - Updated docs to match Android 6.0 (API 23) minimum requirement.

## Test Plan:
N/A
