### PR TITLE
Create new inspector flag for enabling the C++ packager connection implementation

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -27,6 +27,15 @@ void InspectorFlags::initFromConfig(
         "Flag value was changed after init");
   }
   enableModernCDPRegistry_ = enableModernCDPRegistry;
+  bool enableCxxInspectorPackagerConnection = reactNativeConfig.getBool(
+      "react_native_devx:enable_cxx_inspector_packager_connection");
+  if (enableCxxInspectorPackagerConnection_.has_value()) {
+    assert(
+        *enableCxxInspectorPackagerConnection_ ==
+            enableCxxInspectorPackagerConnection &&
+        "Flag value was changed after init");
+  }
+  enableCxxInspectorPackagerConnection_ = enableCxxInspectorPackagerConnection;
 }
 
 bool InspectorFlags::getEnableModernCDPRegistry() const {
@@ -35,6 +44,14 @@ bool InspectorFlags::getEnableModernCDPRegistry() const {
         << "InspectorFlags::getEnableModernCDPRegistry was called before init";
   }
   return enableModernCDPRegistry_.value_or(false);
+}
+
+bool InspectorFlags::getEnableCxxInspectorPackagerConnection() const {
+  if (!enableCxxInspectorPackagerConnection_.has_value()) {
+    LOG(WARNING)
+        << "InspectorFlags::getEnableCxxInspectorPackagerConnection was called before init";
+  }
+  return enableCxxInspectorPackagerConnection_.value_or(false);
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -33,6 +33,12 @@ class InspectorFlags {
    */
   bool getEnableModernCDPRegistry() const;
 
+  /**
+   * Flag determining if the C++ implementation of InspectorPackagerConnection
+   * should be used instead of the per-platform one.
+   */
+  bool getEnableCxxInspectorPackagerConnection() const;
+
  private:
   InspectorFlags() = default;
   InspectorFlags(const InspectorFlags&) = delete;
@@ -40,6 +46,7 @@ class InspectorFlags {
   ~InspectorFlags() = default;
 
   std::optional<bool> enableModernCDPRegistry_;
+  std::optional<bool> enableCxxInspectorPackagerConnection_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
@@ -16,6 +16,9 @@ bool EmptyReactNativeConfig::getBool(const std::string& param) const {
   if (param == "react_native_devx:enable_modern_cdp_registry") {
     return false;
   }
+  if (param == "react_native_devx:enable_cxx_inspector_packager_connection") {
+    return false;
+  }
   return false;
 }
 


### PR DESCRIPTION
Summary:
In upcoming diffs we will begin integrating the new C++ `InspectorPackagerConnection` (D52134592) into React Native on Android and iOS. This diff adds a shared C++ flag that is the source of truth for whether the new implementation should be enabled.

Changelog: [Internal]

Reviewed By: huntie

Differential Revision: D52335446


