### PR TITLE
feat: refactor `RCTKeyWindow` to be more resilient and work in multi-window apps

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -547,13 +547,20 @@ UIWindow *__nullable RCTKeyWindow(void)
   if (RCTRunningInAppExtension()) {
     return nil;
   }
+    
+  for (UIScene* scene in RCTSharedApplication().connectedScenes) {
+    if (scene.activationState != UISceneActivationStateForegroundActive || ![scene isKindOfClass:[UIWindowScene class]]) {
+      continue;
+    }
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
 
-  // TODO: replace with a more robust solution
-  for (UIWindow *window in RCTSharedApplication().windows) {
-    if (window.keyWindow) {
-      return window;
+    for (UIWindow *window in windowScene.windows) {
+      if (window.isKeyWindow) {
+        return window;
+      }
     }
   }
+    
   return nil;
 }
 

--- a/packages/react-native/React/CoreModules/RCTAlertController.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertController.mm
@@ -20,17 +20,7 @@
 - (UIWindow *)alertWindow
 {
   if (_alertWindow == nil) {
-    _alertWindow = [self getUIWindowFromScene];
-
-    if (_alertWindow == nil) {
-      UIWindow *keyWindow = RCTSharedApplication().keyWindow;
-      if (keyWindow) {
-        _alertWindow = [[UIWindow alloc] initWithFrame:keyWindow.bounds];
-      } else {
-        // keyWindow is nil, so we cannot create and initialize _alertWindow
-        NSLog(@"Unable to create alert window: keyWindow is nil");
-      }
-    }
+    _alertWindow = [[UIWindow alloc] initWithWindowScene:RCTKeyWindow().windowScene];
 
     if (_alertWindow) {
       _alertWindow.rootViewController = [UIViewController new];
@@ -63,18 +53,6 @@
   _alertWindow.windowScene = nil;
 
   _alertWindow = nil;
-}
-
-- (UIWindow *)getUIWindowFromScene
-{
-  for (UIScene *scene in RCTSharedApplication().connectedScenes) {
-    if (scene.activationState == UISceneActivationStateForegroundActive &&
-        [scene isKindOfClass:[UIWindowScene class]]) {
-      return [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
-    }
-  }
-
-  return nil;
 }
 
 @end

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -113,11 +113,13 @@ RCT_EXPORT_MODULE()
 
   dispatch_async(dispatch_get_main_queue(), ^{
     self->_showDate = [NSDate date];
+
     if (!self->_window && !RCTRunningInTestEnvironment()) {
-      UIWindow *window = RCTSharedApplication().keyWindow;
+      UIWindow *window = RCTKeyWindow();
       CGFloat windowWidth = window.bounds.size.width;
 
-      self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, windowWidth, window.safeAreaInsets.top + 10)];
+      self->_window = [[UIWindow alloc] initWithWindowScene:window.windowScene];
+      self->_window.frame = CGRectMake(0, 0, windowWidth, window.safeAreaInsets.top + 10);
       self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, window.safeAreaInsets.top - 10, windowWidth, 20)];
       [self->_window addSubview:self->_label];
 
@@ -134,9 +136,6 @@ RCT_EXPORT_MODULE()
 
     self->_window.backgroundColor = backgroundColor;
     self->_window.hidden = NO;
-
-    UIWindowScene *scene = (UIWindowScene *)RCTSharedApplication().connectedScenes.anyObject;
-    self->_window.windowScene = scene;
   });
 
   [self hideBannerAfter:15.0];


### PR DESCRIPTION
## Summary:

This PRs refactors `RCTKeyWindow()` to be more resilient and work in multi-window apps. After my recent PR got merged (#41935) it significantly reduced the number of calls to `RCTKeyWindow()` and now it's called only when necessary. So this PR makes this function a bit more resource intensive but it guarantees that we will find current scene's key window.

This would also fix some brownfield scenarios where React Native is working in multi-window mode and in the future allow us to more easily adopt `UIWindowSceneDelegate`

## Changelog:

[IOS] [CHANGED] - refactor `RCTKeyWindow` to be more resilient and work in multi-window apps

## Test Plan:

Checkout RNTester example for Alerts and LoadingView. 


https://github.com/facebook/react-native/assets/52801365/8cf4d698-db6d-4a12-8d8d-7a5acf34858b


