### PR TITLE
Move prop diffing for Interop Layer to Adapter

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
@@ -6,11 +6,13 @@
  */
 
 #import "RCTLegacyViewManagerInteropCoordinatorAdapter.h"
+#import <React/RCTFollyConvert.h>
 #import <React/UIView+React.h>
 
 @implementation RCTLegacyViewManagerInteropCoordinatorAdapter {
   RCTLegacyViewManagerInteropCoordinator *_coordinator;
   NSInteger _tag;
+  NSDictionary<NSString *, id> *_oldProps;
 }
 
 - (instancetype)initWithCoordinator:(RCTLegacyViewManagerInteropCoordinator *)coordinator reactTag:(NSInteger)tag
@@ -47,12 +49,102 @@
 
 - (void)setProps:(const folly::dynamic &)props
 {
-  [_coordinator setProps:props forView:self.paperView];
+  if (props.isObject()) {
+    NSDictionary<NSString *, id> *convertedProps = facebook::react::convertFollyDynamicToId(props);
+    NSDictionary<NSString *, id> *diffedProps = [self _diffProps:convertedProps];
+
+    [_coordinator setProps:diffedProps forView:self.paperView];
+    
+    _oldProps = convertedProps;
+  }
 }
 
 - (void)handleCommand:(NSString *)commandName args:(NSArray *)args
 {
   [_coordinator handleCommand:commandName args:args reactTag:_tag paperView:self.paperView];
+}
+
+- (NSDictionary<NSString *, id> *)_diffProps:(NSDictionary<NSString *, id> *)newProps
+{
+  NSMutableDictionary<NSString *, id> *diffedProps = [NSMutableDictionary new];
+
+  [newProps enumerateKeysAndObjectsUsingBlock:^(NSString *key, id newProp, __unused BOOL *stop) {
+    id oldProp = _oldProps[key];
+    if ([self _prop:newProp isDifferentFrom:oldProp]) {
+      diffedProps[key] = newProp;
+    }
+  }];
+
+  return diffedProps;
+}
+
+#pragma mark - Private
+
+- (BOOL)_prop:(id)oldProp isDifferentFrom:(id)newProp
+{
+  // Check for JSON types.
+  // JSON types can be of:
+  // * number
+  // * bool
+  // * String
+  // * Array
+  // * Objects => Dictionaries in ObjectiveC
+  // * Null
+
+  // Check for NULL
+  BOOL bothNil = !oldProp && !newProp;
+  if (bothNil) {
+    return NO;
+  }
+
+  BOOL onlyOneNil = (oldProp && !newProp) || (!oldProp && newProp);
+  if (onlyOneNil) {
+    return YES;
+  }
+
+  if ([self _propIsSameNumber:oldProp second:newProp]) {
+    // Boolean should be captured by NSNumber
+    return NO;
+  }
+
+  if ([self _propIsSameString:oldProp second:newProp]) {
+    return NO;
+  }
+
+  if ([self _propIsSameArray:oldProp second:newProp]) {
+    return NO;
+  }
+
+  if ([self _propIsSameObject:oldProp second:newProp]) {
+    return NO;
+  }
+
+  // Previous behavior, fallback to YES
+  return YES;
+}
+
+- (BOOL)_propIsSameNumber:(id)first second:(id)second
+{
+  return [first isKindOfClass:[NSNumber class]] && [second isKindOfClass:[NSNumber class]] &&
+      [(NSNumber *)first isEqualToNumber:(NSNumber *)second];
+}
+
+- (BOOL)_propIsSameString:(id)first second:(id)second
+{
+  return [first isKindOfClass:[NSString class]] && [second isKindOfClass:[NSString class]] &&
+      [(NSString *)first isEqualToString:(NSString *)second];
+}
+
+- (BOOL)_propIsSameArray:(id)first second:(id)second
+{
+  return [first isKindOfClass:[NSArray class]] && [second isKindOfClass:[NSArray class]] &&
+      [(NSArray *)first isEqualToArray:(NSArray *)second];
+}
+
+- (BOOL)_propIsSameObject:(id)first second:(id)second
+{
+  return [first isKindOfClass:[NSDictionary class]] && [second isKindOfClass:[NSDictionary class]] &&
+      [(NSDictionary *)first isEqualToDictionary:(NSDictionary *)second];
 }
 
 @end

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
@@ -31,7 +31,7 @@ typedef void (^InterceptorBlock)(std::string eventName, folly::dynamic event);
 
 - (void)removeObserveForTag:(NSInteger)tag;
 
-- (void)setProps:(const folly::dynamic &)props forView:(UIView *)view;
+- (void)setProps:(NSDictionary<NSString *, id> *)props forView:(UIView *)view;
 
 - (NSString *)componentViewName;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
@@ -41,8 +41,6 @@ using namespace facebook::react;
    */
   NSMutableArray<id<RCTBridgeMethod>> *_moduleMethods;
   NSMutableDictionary<NSString *, id<RCTBridgeMethod>> *_moduleMethodsByName;
-
-  NSDictionary<NSString *, id> *_oldProps;
 }
 
 - (instancetype)initWithComponentData:(RCTComponentData *)componentData
@@ -98,17 +96,12 @@ using namespace facebook::react;
   return view;
 }
 
-- (void)setProps:(const folly::dynamic &)props forView:(UIView *)view
+- (void)setProps:(NSDictionary<NSString *, id> *)props forView:(UIView *)view
 {
-  if (props.isObject()) {
-    NSDictionary<NSString *, id> *convertedProps = convertFollyDynamicToId(props);
-    NSDictionary<NSString *, id> *diffedProps = [self _diffProps:convertedProps];
-    [_componentData setProps:diffedProps forView:view];
+  [_componentData setProps:props forView:view];
 
-    if ([view respondsToSelector:@selector(didSetProps:)]) {
-      [view performSelector:@selector(didSetProps:) withObject:[diffedProps allKeys]];
-    }
-    _oldProps = convertedProps;
+  if ([view respondsToSelector:@selector(didSetProps:)]) {
+    [view performSelector:@selector(didSetProps:) withObject:[props allKeys]];
   }
 }
 
@@ -250,87 +243,6 @@ using namespace facebook::react;
       cls = class_getSuperclass(cls);
     }
   }
-}
-
-- (NSDictionary<NSString *, id> *)_diffProps:(NSDictionary<NSString *, id> *)newProps
-{
-  NSMutableDictionary<NSString *, id> *diffedProps = [NSMutableDictionary new];
-
-  [newProps enumerateKeysAndObjectsUsingBlock:^(NSString *key, id newProp, __unused BOOL *stop) {
-    id oldProp = _oldProps[key];
-    if ([self _prop:newProp isDifferentFrom:oldProp]) {
-      diffedProps[key] = newProp;
-    }
-  }];
-
-  return diffedProps;
-}
-
-- (BOOL)_prop:(id)oldProp isDifferentFrom:(id)newProp
-{
-  // Check for JSON types.
-  // JSON types can be of:
-  // * number
-  // * bool
-  // * String
-  // * Array
-  // * Objects => Dictionaries in ObjectiveC
-  // * Null
-
-  // Check for NULL
-  BOOL bothNil = !oldProp && !newProp;
-  if (bothNil) {
-    return NO;
-  }
-
-  BOOL onlyOneNil = (oldProp && !newProp) || (!oldProp && newProp);
-  if (onlyOneNil) {
-    return YES;
-  }
-
-  if ([self _propIsSameNumber:oldProp second:newProp]) {
-    // Boolean should be captured by NSNumber
-    return NO;
-  }
-
-  if ([self _propIsSameString:oldProp second:newProp]) {
-    return NO;
-  }
-
-  if ([self _propIsSameArray:oldProp second:newProp]) {
-    return NO;
-  }
-
-  if ([self _propIsSameObject:oldProp second:newProp]) {
-    return NO;
-  }
-
-  // Previous behavior, fallback to YES
-  return YES;
-}
-
-- (BOOL)_propIsSameNumber:(id)first second:(id)second
-{
-  return [first isKindOfClass:[NSNumber class]] && [second isKindOfClass:[NSNumber class]] &&
-      [(NSNumber *)first isEqualToNumber:(NSNumber *)second];
-}
-
-- (BOOL)_propIsSameString:(id)first second:(id)second
-{
-  return [first isKindOfClass:[NSString class]] && [second isKindOfClass:[NSString class]] &&
-      [(NSString *)first isEqualToString:(NSString *)second];
-}
-
-- (BOOL)_propIsSameArray:(id)first second:(id)second
-{
-  return [first isKindOfClass:[NSArray class]] && [second isKindOfClass:[NSArray class]] &&
-      [(NSArray *)first isEqualToArray:(NSArray *)second];
-}
-
-- (BOOL)_propIsSameObject:(id)first second:(id)second
-{
-  return [first isKindOfClass:[NSDictionary class]] && [second isKindOfClass:[NSDictionary class]] &&
-      [(NSDictionary *)first isEqualToDictionary:(NSDictionary *)second];
 }
 
 @end


### PR DESCRIPTION
Summary:
We have only 1 coordinator per class but 1 adapter per instance.
There is a use case where multiple instances of the same components are used but the old_props are not refreshed because we are storing them in the coordinator rather than in the Adapter.

## Changelog:
[iOS][Fixed] - Move old props and prop diffing to the interop layer adapter

Differential Revision: D52368222


