### PR TITLE
Rename prefix of binaryCompatibilityValidator properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,14 +24,13 @@ fun getListReactAndroidProperty(name: String) = reactAndroidProperties.getProper
 
 apiValidation {
   ignoredPackages.addAll(
-      getListReactAndroidProperty("react.internal.binaryCompatibilityValidator.ignoredPackages"))
-  ignoredClasses.addAll(
-      getListReactAndroidProperty("react.internal.binaryCompatibilityValidator.ignoredClasses"))
+      getListReactAndroidProperty("binaryCompatibilityValidator.ignoredPackages"))
+  ignoredClasses.addAll(getListReactAndroidProperty("binaryCompatibilityValidator.ignoredClasses"))
   nonPublicMarkers.addAll(
-      getListReactAndroidProperty("react.internal.binaryCompatibilityValidator.nonPublicMarkers"))
+      getListReactAndroidProperty("binaryCompatibilityValidator.nonPublicMarkers"))
   validationDisabled =
       reactAndroidProperties
-          .getProperty("react.internal.binaryCompatibilityValidator.validationDisabled")
+          .getProperty("binaryCompatibilityValidator.validationDisabled")
           ?.toBoolean() == true
 }
 

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -9,8 +9,8 @@ android.enableJetifier=true
 react.internal.disableJavaVersionAlignment=true
 
 # Binary Compatibility Validator properties
-react.internal.binaryCompatibilityValidator.ignoredClasses=com.facebook.react.BuildConfig
-react.internal.binaryCompatibilityValidator.ignoredPackages=com.facebook.debug,\
+binaryCompatibilityValidator.ignoredClasses=com.facebook.react.BuildConfig
+binaryCompatibilityValidator.ignoredPackages=com.facebook.debug,\
   com.facebook.fbreact,\
   com.facebook.hermes,\
   com.facebook.perftest,\
@@ -22,7 +22,7 @@ react.internal.binaryCompatibilityValidator.ignoredPackages=com.facebook.debug,\
   com.facebook.react.processing,\
   com.facebook.systrace,\
   com.facebook.yoga
-react.internal.binaryCompatibilityValidator.nonPublicMarkers=com.facebook.react.common.annotations.VisibleForTesting,\
+binaryCompatibilityValidator.nonPublicMarkers=com.facebook.react.common.annotations.VisibleForTesting,\
   com.facebook.react.common.annotations.UnstableReactNativeAPI
-react.internal.binaryCompatibilityValidator.validationDisabled=true
-react.internal.binaryCompatibilityValidator.outputApiFileName=ReactAndroid
+binaryCompatibilityValidator.validationDisabled=true
+binaryCompatibilityValidator.outputApiFileName=ReactAndroid


### PR DESCRIPTION
Summary:
binaryCompatibilityValidator is a generic library, it shouldn't have referecences to react. I'm renaming:

```
react.internal.binaryCompatibilityValidator...
```

by

```
binaryCompatibilityValidator...
```

changelog: [internal] internal

Reviewed By: philIip

Differential Revision: D52380035


