### PR TITLE
RNTester: fixed up ScrollViewExample test name

### DIFF
--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -324,7 +324,7 @@ const examples = ([
     },
   },
   {
-    name: 'pressableStickyHeaders',
+    name: 'pressableStickyHeader',
     title: '<ScrollView> Pressable Sticky Header\n',
     description:
       'Press the blue box to toggle it between blue and yellow. The box should remain Pressable after scrolling.',


### PR DESCRIPTION
Summary:
It had a typo: pressableStickyHeader vs pressableStickyHeaders

Changelog: [Internal]

Reviewed By: lunaleaps

Differential Revision: D52378237


