### PR TITLE
feat: make codegen take OOT Apple platforms into account

### DIFF
--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -83,6 +83,7 @@ type LibraryOptions = $ReadOnly<{
 type SchemasOptions = $ReadOnly<{
   schemas: {[string]: SchemaType},
   outputDirectory: string,
+  supportedApplePlatforms?: {[string]: {[string]: boolean}},
 }>;
 
 type LibraryGenerators =
@@ -289,7 +290,7 @@ module.exports = {
     return checkOrWriteFiles(generatedFiles, test);
   },
   generateFromSchemas(
-    {schemas, outputDirectory}: SchemasOptions,
+    {schemas, outputDirectory, supportedApplePlatforms}: SchemasOptions,
     {generators, test}: SchemasConfig,
   ): boolean {
     Object.keys(schemas).forEach(libraryName =>
@@ -300,13 +301,15 @@ module.exports = {
 
     for (const name of generators) {
       for (const generator of SCHEMAS_GENERATORS[name]) {
-        generator(schemas).forEach((contents: string, fileName: string) => {
-          generatedFiles.push({
-            name: fileName,
-            content: contents,
-            outputDir: outputDirectory,
-          });
-        });
+        generator(schemas, supportedApplePlatforms).forEach(
+          (contents: string, fileName: string) => {
+            generatedFiles.push({
+              name: fileName,
+              content: contents,
+              outputDir: outputDirectory,
+            });
+          },
+        );
       }
     }
     return checkOrWriteFiles(generatedFiles, test);

--- a/packages/react-native-codegen/src/generators/components/ComponentsProviderUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsProviderUtils.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+const APPLE_PLATFORMS_MACRO_MAP = {
+  ios: 'TARGET_OS_IOS',
+  macos: 'TARGET_OS_OSX',
+  tvos: 'TARGET_OS_TV',
+  visionos: 'TARGET_OS_VISION',
+};
+
+/**
+ * Adds compiler macros to the file template to exclude unsupported platforms.
+ */
+function generateSupportedApplePlatformsMacro(
+  fileTemplate: string,
+  supportedPlatformsMap: ?{[string]: boolean},
+): string {
+  if (!supportedPlatformsMap) {
+    return fileTemplate;
+  }
+
+  const compilerMacroString = Object.keys(supportedPlatformsMap)
+    .reduce((acc: string[], platform) => {
+      if (!supportedPlatformsMap[platform]) {
+        return [...acc, `!${APPLE_PLATFORMS_MACRO_MAP[platform]}`];
+      }
+      return acc;
+    }, [])
+    .join(' && ');
+
+  if (!compilerMacroString) {
+    return fileTemplate;
+  }
+
+  return `#if ${compilerMacroString}
+${fileTemplate}
+#endif
+`;
+}
+
+module.exports = {
+  generateSupportedApplePlatformsMacro,
+};

--- a/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderH.js
@@ -12,6 +12,10 @@
 
 import type {SchemaType} from '../../CodegenSchema';
 
+const {
+  generateSupportedApplePlatformsMacro,
+} = require('./ComponentsProviderUtils');
+
 // File path -> contents
 type FilesOutput = Map<string, string>;
 
@@ -62,13 +66,18 @@ Class<RCTComponentViewProtocol> ${className}Cls(void) __attribute__((used)); // 
 `.trim();
 
 module.exports = {
-  generate(schemas: {[string]: SchemaType}): FilesOutput {
+  generate(
+    schemas: {[string]: SchemaType},
+    supportedApplePlatforms?: {[string]: {[string]: boolean}},
+  ): FilesOutput {
     const fileName = 'RCTThirdPartyFabricComponentsProvider.h';
 
     const lookupFuncs = Object.keys(schemas)
       .map(libraryName => {
         const schema = schemas[libraryName];
-        return Object.keys(schema.modules)
+        const librarySupportedApplePlatforms =
+          supportedApplePlatforms?.[libraryName];
+        const generatedLookup = Object.keys(schema.modules)
           .map(moduleName => {
             const module = schema.modules[moduleName];
             if (module.type !== 'Component') {
@@ -99,6 +108,11 @@ module.exports = {
           })
           .filter(Boolean)
           .join('\n');
+
+        return generateSupportedApplePlatformsMacro(
+          generatedLookup,
+          librarySupportedApplePlatforms,
+        );
       })
       .join('\n');
 

--- a/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderObjCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderObjCpp.js
@@ -12,6 +12,10 @@
 
 import type {SchemaType} from '../../CodegenSchema';
 
+const {
+  generateSupportedApplePlatformsMacro,
+} = require('./ComponentsProviderUtils');
+
 // File path -> contents
 type FilesOutput = Map<string, string>;
 
@@ -58,13 +62,19 @@ const LookupMapTemplate = ({
     {"${className}", ${className}Cls}, // ${libraryName}`;
 
 module.exports = {
-  generate(schemas: {[string]: SchemaType}): FilesOutput {
+  generate(
+    schemas: {[string]: SchemaType},
+    supportedApplePlatforms?: {[string]: {[string]: boolean}},
+  ): FilesOutput {
     const fileName = 'RCTThirdPartyFabricComponentsProvider.mm';
 
     const lookupMap = Object.keys(schemas)
       .map(libraryName => {
         const schema = schemas[libraryName];
-        return Object.keys(schema.modules)
+        const librarySupportedApplePlatforms =
+          supportedApplePlatforms?.[libraryName];
+
+        const generatedLookup = Object.keys(schema.modules)
           .map(moduleName => {
             const module = schema.modules[moduleName];
             if (module.type !== 'Component') {
@@ -96,7 +106,13 @@ module.exports = {
 
             return componentTemplates.length > 0 ? componentTemplates : null;
           })
-          .filter(Boolean);
+          .filter(Boolean)
+          .join('\n');
+
+        return generateSupportedApplePlatformsMacro(
+          generatedLookup,
+          librarySupportedApplePlatforms,
+        );
       })
       .join('\n');
 

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderObjCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderObjCpp-test.js.snap
@@ -70,7 +70,8 @@ Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char
     {\\"MultiComponent1NativeComponent\\", MultiComponent1NativeComponentCls}, // TWO_COMPONENTS_SAME_FILE,
     {\\"MultiComponent2NativeComponent\\", MultiComponent2NativeComponentCls}, // TWO_COMPONENTS_SAME_FILE
 
-    {\\"MultiFile1NativeComponent\\", MultiFile1NativeComponentCls}, // TWO_COMPONENTS_DIFFERENT_FILES,
+    {\\"MultiFile1NativeComponent\\", MultiFile1NativeComponentCls}, // TWO_COMPONENTS_DIFFERENT_FILES
+
     {\\"MultiFile2NativeComponent\\", MultiFile2NativeComponentCls}, // TWO_COMPONENTS_DIFFERENT_FILES
 
     {\\"CommandNativeComponent\\", CommandNativeComponentCls}, // COMMANDS

--- a/packages/react-native/scripts/codegen/__test_fixtures__/test-library-2/test-library-2.podspec
+++ b/packages/react-native/scripts/codegen/__test_fixtures__/test-library-2/test-library-2.podspec
@@ -1,0 +1,7 @@
+Pod::Spec.new do |s|
+  s.name         = "test-library-2"
+  s.version      = "0.0.0"
+  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "13.0"
+  s.tvos.deployment_target = "1.0"
+end

--- a/packages/react-native/scripts/codegen/__test_fixtures__/test-library/test-library.podspec
+++ b/packages/react-native/scripts/codegen/__test_fixtures__/test-library/test-library.podspec
@@ -1,0 +1,5 @@
+Pod::Spec.new do |s|
+  s.name         = "test-library"
+  s.version      = "0.0.0"
+  s.platforms    = { :ios => "9.0", :osx => "13.0", visionos: "1.0" }
+end

--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -87,6 +87,44 @@ describe('extractLibrariesFromJSON', () => {
   });
 });
 
+describe('extractSupportedApplePlatforms', () => {
+  it('extracts platforms when podspec specifies object of platforms', () => {
+    const myDependency = 'test-library';
+    const myDependencyPath = path.join(
+      __dirname,
+      `../__test_fixtures__/${myDependency}`,
+    );
+    let platforms = underTest._extractSupportedApplePlatforms(
+      myDependency,
+      myDependencyPath,
+    );
+    expect(platforms).toEqual({
+      ios: true,
+      macos: true,
+      tvos: false,
+      visionos: true,
+    });
+  });
+
+  it('extracts platforms when podspec specifies platforms separately', () => {
+    const myDependency = 'test-library-2';
+    const myDependencyPath = path.join(
+      __dirname,
+      `../__test_fixtures__/${myDependency}`,
+    );
+    let platforms = underTest._extractSupportedApplePlatforms(
+      myDependency,
+      myDependencyPath,
+    );
+    expect(platforms).toEqual({
+      ios: true,
+      macos: true,
+      tvos: true,
+      visionos: false,
+    });
+  });
+});
+
 describe('delete empty files and folders', () => {
   beforeEach(() => {
     jest.resetModules();


### PR DESCRIPTION
## Summary:

### The problem

1. We have a library that's supported on iOS but doesn't have support for visionOS.
2. We run pod install
3. Codegen runs and generates Code for this library and tries to reference library class in `RCTThirdPartyFabricComponentsProvider`
4. Example:

```objc
Class<RCTComponentViewProtocol> RNCSafeAreaProviderCls(void) __attribute__((used)); // 0
```

This is an issue because the library files are not linked for visionOS platform (because code is linked only for iOS due to pod supporting only iOS). 

### Solution

Make codegen take Apple OOT platforms into account by adding compiler macros if the given platform doesn't explicitly support this platform in the native package's podspec file. 

Example generated output for library supporting only `ios` and `visionos` in podspec: 

![CleanShot 2023-12-22 at 15 48 22@2x](https://github.com/facebook/react-native/assets/52801365/0cdfe7f5-441d-4466-8713-5f65feef26e7)

I used compiler conditionals because not every platform works the same, and if in the future let's say react-native-visionos were merged upstream compiler conditionals would still work. 

Also tvOS uses Xcode targets to differentiate which platform it builds so conditionally adding things to the generated file wouldn't work.


## Changelog:

[IOS] [ADDED] - make codegen take OOT Apple platforms into account

## Test Plan:

1. Generate a sample app with a template
5. Add third-party library (In my case it was https://github.com/callstack/react-native-slider)
6. Check if generated codegen code includes compiler macros