### PR TITLE
Get rid of old APIs in FabricUIManagerProvider

### DIFF
--- a/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactInstanceSpecForTest.java
+++ b/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactInstanceSpecForTest.java
@@ -12,11 +12,9 @@ import androidx.annotation.Nullable;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate;
 import com.facebook.react.bridge.JSExceptionHandler;
-import com.facebook.react.bridge.JSIModuleSpec;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,11 +28,6 @@ import java.util.List;
 @SuppressLint("JavatestsIncorrectFolder")
 public class ReactInstanceSpecForTest {
 
-  public abstract static class JSIModuleBuilder {
-    @Nullable
-    protected abstract List<JSIModuleSpec> build(ReactApplicationContext context);
-  }
-
   private final List<NativeModule> mNativeModules =
       new ArrayList<NativeModule>(Arrays.asList(new FakeWebSocketModule()));
   private final List<Class<? extends JavaScriptModule>> mJSModuleSpecs = new ArrayList<>();
@@ -44,7 +37,6 @@ public class ReactInstanceSpecForTest {
   @Nullable private FabricUIManagerFactory mFabricUIManagerFactory = null;
   @Nullable private JavaScriptExecutorFactory mJavaScriptExecutorFactory = null;
   @Nullable private ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder = null;
-  @Nullable private JSIModuleBuilder mJSIModuleBuilder = null;
 
   public ReactInstanceSpecForTest addNativeModule(NativeModule module) {
     mNativeModules.add(module);
@@ -96,16 +88,6 @@ public class ReactInstanceSpecForTest {
   protected ReactPackageTurboModuleManagerDelegate.Builder
       getReactPackageTurboModuleManagerDelegateBuilder() {
     return mTMMDelegateBuilder;
-  }
-
-  public ReactInstanceSpecForTest setJSIModuleBuilder(@Nullable JSIModuleBuilder builder) {
-    mJSIModuleBuilder = builder;
-    return this;
-  }
-
-  @Nullable
-  protected JSIModuleBuilder getJSIModuleBuilder() {
-    return mJSIModuleBuilder;
   }
 
   public ReactInstanceSpecForTest addPackages(List<ReactPackage> reactPackages) {

--- a/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactInstrumentationTest.java
+++ b/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactInstrumentationTest.java
@@ -102,11 +102,6 @@ public abstract class ReactInstrumentationTest
     return null;
   }
 
-  @Nullable
-  protected ReactInstanceSpecForTest.JSIModuleBuilder getJSIModuleBuilder() {
-    return null;
-  }
-
   /** Override this method to provide extra native modules to be loaded before the app starts */
   protected ReactInstanceSpecForTest createReactInstanceSpecForTest() {
     ReactInstanceSpecForTest reactInstanceSpecForTest =
@@ -119,7 +114,6 @@ public abstract class ReactInstrumentationTest
     }
     reactInstanceSpecForTest.setReactPackageTurboModuleManagerDelegateBuilder(
         getReactPackageTurboModuleManagerDelegateBuilder());
-    reactInstanceSpecForTest.setJSIModuleBuilder(getJSIModuleBuilder());
     return reactInstanceSpecForTest;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -55,8 +55,6 @@ import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.CatalystInstanceImpl;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JSExceptionHandler;
-import com.facebook.react.bridge.JSIModulePackage;
-import com.facebook.react.bridge.JSIModuleType;
 import com.facebook.react.bridge.JavaJSExecutor;
 import com.facebook.react.bridge.JavaScriptExecutor;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
@@ -186,7 +184,6 @@ public class ReactInstanceManager {
   private volatile Boolean mHasStartedDestroying = false;
   private final MemoryPressureRouter mMemoryPressureRouter;
   private final @Nullable JSExceptionHandler mJSExceptionHandler;
-  private final @Nullable JSIModulePackage mJSIModulePackage;
   private final @Nullable UIManagerProvider mUIManagerProvider;
   private final @Nullable ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder;
   private List<ViewManager> mViewManagers;
@@ -235,7 +232,6 @@ public class ReactInstanceManager {
       @Nullable DevBundleDownloadListener devBundleDownloadListener,
       int minNumShakes,
       int minTimeLeftInFrameForNonBatchedOperationMs,
-      @Nullable JSIModulePackage jsiModulePackage,
       @Nullable UIManagerProvider uIManagerProvider,
       @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
       @Nullable ReactPackageTurboModuleManagerDelegate.Builder tmmDelegateBuilder,
@@ -296,7 +292,6 @@ public class ReactInstanceManager {
       }
       mPackages.addAll(packages);
     }
-    mJSIModulePackage = jsiModulePackage;
     mUIManagerProvider = uIManagerProvider;
 
     // Instantiate ReactChoreographer in UI thread.
@@ -1401,19 +1396,15 @@ public class ReactInstanceManager {
       }
     }
 
-    if (mJSIModulePackage != null) {
-      catalystInstance.addJSIModules(
-          mJSIModulePackage.getJSIModules(
-              reactContext, catalystInstance.getJavaScriptContextHolder()));
-    }
     if (mUIManagerProvider != null) {
       UIManager uiManager = mUIManagerProvider.createUIManager(reactContext);
       if (uiManager != null) {
+        catalystInstance.setFabricUIManager(uiManager);
+
+        // Initialize the UIManager
         uiManager.initialize();
         catalystInstance.setFabricUIManager(uiManager);
       }
-    } else if (ReactFeatureFlags.enableFabricRenderer) {
-      catalystInstance.getJSIModule(JSIModuleType.UIManager);
     }
     if (mBridgeIdleDebugListener != null) {
       catalystInstance.addBridgeIdleDebugListener(mBridgeIdleDebugListener);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -20,7 +20,6 @@ import com.facebook.hermes.reactexecutor.HermesExecutorFactory;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JSExceptionHandler;
-import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.NotThreadSafeBridgeIdleDebugListener;
 import com.facebook.react.bridge.UIManagerProvider;
@@ -68,7 +67,6 @@ public class ReactInstanceManagerBuilder {
   private @Nullable JavaScriptExecutorFactory mJavaScriptExecutorFactory;
   private int mMinNumShakes = 1;
   private int mMinTimeLeftInFrameForNonBatchedOperationMs = -1;
-  private @Nullable JSIModulePackage mJSIModulesPackage;
   private @Nullable UIManagerProvider mUIManagerProvider;
   private @Nullable Map<String, RequestHandler> mCustomPackagerCommandHandlers;
   private @Nullable ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder;
@@ -78,12 +76,6 @@ public class ReactInstanceManagerBuilder {
   private @Nullable ChoreographerProvider mChoreographerProvider = null;
 
   /* package protected */ ReactInstanceManagerBuilder() {}
-
-  public ReactInstanceManagerBuilder setJSIModulesPackage(
-      @Nullable JSIModulePackage jsiModulePackage) {
-    mJSIModulesPackage = jsiModulePackage;
-    return this;
-  }
 
   /** Factory for desired implementation of JavaScriptExecutor. */
   public ReactInstanceManagerBuilder setJavaScriptExecutorFactory(
@@ -361,7 +353,6 @@ public class ReactInstanceManagerBuilder {
         mDevBundleDownloadListener,
         mMinNumShakes,
         mMinTimeLeftInFrameForNonBatchedOperationMs,
-        mJSIModulesPackage,
         mUIManagerProvider,
         mCustomPackagerCommandHandlers,
         mTMMDelegateBuilder,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -10,7 +10,6 @@ package com.facebook.react;
 import android.app.Application;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
@@ -85,7 +84,6 @@ public abstract class ReactNativeHost {
             .setLazyViewManagersEnabled(getLazyViewManagersEnabled())
             .setRedBoxHandler(getRedBoxHandler())
             .setJavaScriptExecutorFactory(getJavaScriptExecutorFactory())
-            .setJSIModulesPackage(getJSIModulePackage())
             .setUIManagerProvider(getUIManagerProvider())
             .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
             .setReactPackageTurboModuleManagerDelegateBuilder(
@@ -125,10 +123,6 @@ public abstract class ReactNativeHost {
 
   protected final Application getApplication() {
     return mApplication;
-  }
-
-  protected @Nullable JSIModulePackage getJSIModulePackage() {
-    return null;
   }
 
   protected @Nullable UIManagerProvider getUIManagerProvider() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerProviderImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerProviderImpl.java
@@ -7,10 +7,8 @@
 
 package com.facebook.react.fabric;
 
-import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.CatalystInstance;
-import com.facebook.react.bridge.JSIModuleProvider;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UIManagerProvider;
@@ -19,45 +17,21 @@ import com.facebook.react.uimanager.ViewManagerRegistry;
 import com.facebook.systrace.Systrace;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public class FabricUIManagerProviderImpl
-    implements JSIModuleProvider<UIManager>, UIManagerProvider {
+public class FabricUIManagerProviderImpl implements UIManagerProvider {
 
-  private final @Nullable ReactApplicationContext mReactApplicationContext;
   private final ComponentFactory mComponentFactory;
   private final ReactNativeConfig mConfig;
   private final ViewManagerRegistry mViewManagerRegistry;
 
   public FabricUIManagerProviderImpl(
-      ReactApplicationContext reactApplicationContext,
       ComponentFactory componentFactory,
       ReactNativeConfig config,
       ViewManagerRegistry viewManagerRegistry) {
-    mReactApplicationContext = reactApplicationContext;
     mComponentFactory = componentFactory;
     mConfig = config;
     mViewManagerRegistry = viewManagerRegistry;
   }
 
-  public FabricUIManagerProviderImpl(
-      ComponentFactory componentFactory,
-      ReactNativeConfig config,
-      ViewManagerRegistry viewManagerRegistry) {
-    mReactApplicationContext = null;
-    mComponentFactory = componentFactory;
-    mConfig = config;
-    mViewManagerRegistry = viewManagerRegistry;
-  }
-
-  @Override
-  public UIManager get() {
-    if (mReactApplicationContext != null) {
-      return createUIManager(mReactApplicationContext);
-    }
-    throw new IllegalStateException(
-        "This method shoulndn't be called without ReactContext initialized");
-  }
-
-  @Override
   public UIManager createUIManager(ReactApplicationContext reactApplicationContext) {
     Systrace.beginSection(
         Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "FabricUIManagerProviderImpl.create");

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
@@ -12,7 +12,6 @@ import android.annotation.SuppressLint
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.CatalystInstance
-import com.facebook.react.bridge.JSIModuleType
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
@@ -80,9 +79,6 @@ class NativeAnimatedNodeTraversalTest {
     }
 
     catalystInstanceMock = mock(CatalystInstance::class.java)
-    whenever(catalystInstanceMock.getJSIModule(any(JSIModuleType::class.java))).thenAnswer {
-      uiManagerMock
-    }
     whenever(reactApplicationContextMock.getFabricUIManager()).thenAnswer { uiManagerMock }
     whenever(catalystInstanceMock.getNativeModule(UIManagerModule::class.java)).thenAnswer {
       uiManagerMock


### PR DESCRIPTION
Summary: Getting rid of old APIs in FabricUIManagerProvider and also clearing it of the inheritance dependency it has on JSIModule post it's references have been cleared.

Differential Revision: D51001239


