### PR TITLE
Making UIManager not implement JSIModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -547,14 +547,6 @@ public class ReactContext extends ContextWrapper {
     return null;
   }
 
-  public @Nullable JSIModule getJSIModule(JSIModuleType moduleType) {
-    if (!hasActiveReactInstance()) {
-      throw new IllegalStateException(
-          "Unable to retrieve a JSIModule if CatalystInstance is not active.");
-    }
-    return mCatalystInstance.getJSIModule(moduleType);
-  }
-
   @DeprecatedInNewArchitecture(
       message =
           "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.java
@@ -15,7 +15,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.infer.annotation.ThreadConfined;
 
-public interface UIManager extends JSIModule, PerformanceCounter {
+public interface UIManager extends PerformanceCounter {
 
   /** Registers a new root view. @Deprecated call startSurface instead */
   @UiThread
@@ -151,4 +151,10 @@ public interface UIManager extends JSIModule, PerformanceCounter {
   @Deprecated
   @Nullable
   String resolveCustomDirectEventName(@Nullable String eventName);
+
+  /** This method is called after {@link ReactApplicationContext} has been created. */
+  void initialize();
+
+  /** Called before React Native instance is destroyed. */
+  void invalidate();
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -12,8 +12,6 @@ import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.CatalystInstance;
-import com.facebook.react.bridge.JSIModule;
-import com.facebook.react.bridge.JSIModuleType;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.JavaScriptModuleRegistry;
 import com.facebook.react.bridge.NativeArray;
@@ -73,16 +71,6 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   @Override
   public @Nullable String getSourceURL() {
     return mSourceURL.get();
-  }
-
-  @Override
-  public @Nullable JSIModule getJSIModule(JSIModuleType moduleType) {
-    if (moduleType == JSIModuleType.UIManager) {
-      return mReactHost.getUIManager();
-    }
-    throw new UnsupportedOperationException(
-        "getJSIModule is not implemented for bridgeless mode. Trying to get module: "
-            + moduleType.name());
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -10,8 +10,6 @@ package com.facebook.react.uimanager;
 import android.app.Activity;
 import android.content.Context;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.JSIModule;
-import com.facebook.react.bridge.JSIModuleType;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -108,14 +106,6 @@ public class ThemedReactContext extends ReactContext {
   @Override
   public boolean isBridgeless() {
     return mReactApplicationContext.isBridgeless();
-  }
-
-  @Override
-  public JSIModule getJSIModule(JSIModuleType moduleType) {
-    if (isBridgeless()) {
-      return mReactApplicationContext.getJSIModule(moduleType);
-    }
-    return super.getJSIModule(moduleType);
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
@@ -9,7 +9,6 @@ package com.facebook.react.runtime
 
 import android.app.Activity
 import android.content.Context
-import com.facebook.react.bridge.JSIModuleType
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.testutils.shadows.ShadowSoLoader
@@ -49,17 +48,11 @@ class BridgelessReactContextTest {
     Assertions.assertThat(uiManagerModule).isEqualTo(mUiManagerModule)
   }
 
-  @Test(expected = UnsupportedOperationException::class)
-  fun getJSIModule_throwsException() {
-    bridgelessReactContext.getJSIModule(JSIModuleType.TurboModuleManager)
-  }
-
   @Test
-  fun getJSIModuleTest() {
+  fun getFabricUIManagerTest() {
     val fabricUiManager = Mockito.mock(FabricUIManager::class.java)
     doReturn(fabricUiManager).`when`(reactHost).uiManager
-    Assertions.assertThat(bridgelessReactContext.getJSIModule(JSIModuleType.UIManager))
-        .isEqualTo(fabricUiManager)
+    Assertions.assertThat(bridgelessReactContext.getFabricUIManager()).isEqualTo(fabricUiManager)
   }
 
   @Test(expected = UnsupportedOperationException::class)


### PR DESCRIPTION
Summary:
For removal of JSIModule getting rid of the inheritance relationship b/w interfaces UIManager & JSIModule by directly defining `initialize()` and `invalidate()`

Changelog:
[Internal] internal

Reviewed By: philIip, mdvacca

Differential Revision: D49306312


