### PR TITLE
BridgelessUIManager: Finish createView, updateView, setChildren, manageChildren

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.android.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.android.js
@@ -9,6 +9,7 @@
  */
 
 import UIManager from '../../ReactNative/UIManager';
+import nullthrows from 'nullthrows';
 
 /**
  * This is a function exposed to the React Renderer that can be used by the
@@ -19,13 +20,13 @@ function legacySendAccessibilityEvent(
   eventType: string,
 ): void {
   if (eventType === 'focus') {
-    UIManager.sendAccessibilityEvent(
+    nullthrows(UIManager.sendAccessibilityEvent)(
       reactTag,
       UIManager.getConstants().AccessibilityEventTypes.typeViewFocused,
     );
   }
   if (eventType === 'click') {
-    UIManager.sendAccessibilityEvent(
+    nullthrows(UIManager.sendAccessibilityEvent)(
       reactTag,
       UIManager.getConstants().AccessibilityEventTypes.typeViewClicked,
     );

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -14,6 +14,7 @@ import type {RootTag} from '../Types/RootTagTypes';
 import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
 import {unstable_hasComponent} from '../NativeComponent/NativeComponentRegistryUnstable';
+import Platform from '../Utilities/Platform';
 import nullthrows from 'nullthrows';
 
 function raiseSoftError(methodName: string, details?: string): void {
@@ -96,8 +97,53 @@ const UIManagerJSOverridenAPIs = {
   },
 };
 
+const UIManagerJSPlatformAPIs = Platform.select({
+  android: {
+    getConstantsForViewManager: (viewManagerName: string): Object => {
+      raiseSoftError('getConstantsForViewManager');
+      return {};
+    },
+    getDefaultEventTypes: (): Array<string> => {
+      raiseSoftError('getDefaultEventTypes');
+      return [];
+    },
+    setLayoutAnimationEnabledExperimental: (enabled: boolean): void => {
+      raiseSoftError('setLayoutAnimationEnabledExperimental');
+    },
+    // Please use AccessibilityInfo.sendAccessibilityEvent instead.
+    // See SetAccessibilityFocusExample in AccessibilityExample.js for a migration example.
+    sendAccessibilityEvent: (reactTag: ?number, eventType: number): void => {
+      raiseSoftError('sendAccessibilityEvent');
+    },
+    showPopupMenu: (
+      reactTag: ?number,
+      items: Array<string>,
+      error: (error: Object) => void,
+      success: (event: string, selected?: number) => void,
+    ): void => {
+      raiseSoftError('showPopupMenu');
+    },
+    dismissPopupMenu: (): void => {
+      raiseSoftError('dismissPopupMenu');
+    },
+  },
+  ios: {
+    lazilyLoadView: (name: string): Object => {
+      raiseSoftError('lazilyLoadView');
+      return {};
+    },
+    focus: (reactTag: ?number): void => {
+      raiseSoftError('focus');
+    },
+    blur: (reactTag: ?number): void => {
+      raiseSoftError('blur');
+    },
+  },
+});
+
 const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
   ...UIManagerJSOverridenAPIs,
+  ...UIManagerJSPlatformAPIs,
   getViewManagerConfig: (viewManagerName: string): mixed => {
     if (getUIManagerConstants) {
       return getUIManagerConstantsCache()[viewManagerName];
@@ -120,18 +166,6 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
       return null;
     }
   },
-  getConstantsForViewManager: (viewManagerName: string): Object => {
-    raiseSoftError('getConstantsForViewManager');
-    return {};
-  },
-  getDefaultEventTypes: (): Array<string> => {
-    raiseSoftError('getDefaultEventTypes');
-    return [];
-  },
-  lazilyLoadView: (name: string): Object => {
-    raiseSoftError('lazilyLoadView');
-    return {};
-  },
   createView: (
     reactTag: ?number,
     viewName: string,
@@ -142,12 +176,6 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
   },
   updateView: (reactTag: number, viewName: string, props: Object): void => {
     raiseSoftError('updateView');
-  },
-  focus: (reactTag: ?number): void => {
-    raiseSoftError('focus');
-  },
-  blur: (reactTag: ?number): void => {
-    raiseSoftError('blur');
   },
   findSubviewIn: (
     reactTag: ?number,
@@ -203,27 +231,6 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
     removeAtIndices: Array<number>,
   ): void => {
     raiseSoftError('manageChildren');
-  },
-
-  // Android only
-  setLayoutAnimationEnabledExperimental: (enabled: boolean): void => {
-    raiseSoftError('setLayoutAnimationEnabledExperimental');
-  },
-  // Please use AccessibilityInfo.sendAccessibilityEvent instead.
-  // See SetAccessibilityFocusExample in AccessibilityExample.js for a migration example.
-  sendAccessibilityEvent: (reactTag: ?number, eventType: number): void => {
-    raiseSoftError('sendAccessibilityEvent');
-  },
-  showPopupMenu: (
-    reactTag: ?number,
-    items: Array<string>,
-    error: (error: Object) => void,
-    success: (event: string, selected?: number) => void,
-  ): void => {
-    raiseSoftError('showPopupMenu');
-  },
-  dismissPopupMenu: (): void => {
-    raiseSoftError('dismissPopupMenu');
   },
 };
 

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -97,6 +97,38 @@ const UIManagerJSOverridenAPIs = {
   },
 };
 
+/**
+ * Leave Unimplemented: The only thing that called these methods was the paper renderer.
+ * In OSS, the New Architecture will just use the Fabric renderer, which uses
+ * different APIs.
+ */
+const UIManagerJSUnusedAPIs = {
+  createView: (
+    reactTag: ?number,
+    viewName: string,
+    rootTag: RootTag,
+    props: Object,
+  ): void => {
+    raiseSoftError('createView');
+  },
+  updateView: (reactTag: number, viewName: string, props: Object): void => {
+    raiseSoftError('updateView');
+  },
+  setChildren: (containerTag: ?number, reactTags: Array<number>): void => {
+    raiseSoftError('setChildren');
+  },
+  manageChildren: (
+    containerTag: ?number,
+    moveFromIndices: Array<number>,
+    moveToIndices: Array<number>,
+    addChildReactTags: Array<number>,
+    addAtIndices: Array<number>,
+    removeAtIndices: Array<number>,
+  ): void => {
+    raiseSoftError('manageChildren');
+  },
+};
+
 const UIManagerJSPlatformAPIs = Platform.select({
   android: {
     getConstantsForViewManager: (viewManagerName: string): Object => {
@@ -144,6 +176,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
 const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
   ...UIManagerJSOverridenAPIs,
   ...UIManagerJSPlatformAPIs,
+  ...UIManagerJSUnusedAPIs,
   getViewManagerConfig: (viewManagerName: string): mixed => {
     if (getUIManagerConstants) {
       return getUIManagerConstantsCache()[viewManagerName];
@@ -165,17 +198,6 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
       raiseSoftError('getConstants');
       return null;
     }
-  },
-  createView: (
-    reactTag: ?number,
-    viewName: string,
-    rootTag: RootTag,
-    props: Object,
-  ): void => {
-    raiseSoftError('createView');
-  },
-  updateView: (reactTag: number, viewName: string, props: Object): void => {
-    raiseSoftError('updateView');
   },
   findSubviewIn: (
     reactTag: ?number,
@@ -218,19 +240,6 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
     newReactTag: ?number,
   ): void => {
     raiseSoftError('replaceExistingNonRootView');
-  },
-  setChildren: (containerTag: ?number, reactTags: Array<number>): void => {
-    raiseSoftError('setChildren');
-  },
-  manageChildren: (
-    containerTag: ?number,
-    moveFromIndices: Array<number>,
-    moveToIndices: Array<number>,
-    addChildReactTags: Array<number>,
-    addAtIndices: Array<number>,
-    removeAtIndices: Array<number>,
-  ): void => {
-    raiseSoftError('manageChildren');
   },
 };
 

--- a/packages/react-native/Libraries/ReactNative/NativeUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/NativeUIManager.js
@@ -15,9 +15,6 @@ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   +getConstants: () => Object;
-  +getConstantsForViewManager: (viewManagerName: string) => Object;
-  +getDefaultEventTypes: () => Array<string>;
-  +lazilyLoadView: (name: string) => Object; // revisit return
   +createView: (
     reactTag: ?number,
     viewName: string,
@@ -25,8 +22,6 @@ export interface Spec extends TurboModule {
     props: Object,
   ) => void;
   +updateView: (reactTag: number, viewName: string, props: Object) => void;
-  +focus: (reactTag: ?number) => void;
-  +blur: (reactTag: ?number) => void;
   +findSubviewIn: (
     reactTag: ?number,
     point: Array<number>,
@@ -107,15 +102,22 @@ export interface Spec extends TurboModule {
   ) => void;
 
   // Android only
-  +setLayoutAnimationEnabledExperimental: (enabled: boolean) => void;
-  +sendAccessibilityEvent: (reactTag: ?number, eventType: number) => void;
-  +showPopupMenu: (
+  +getConstantsForViewManager?: (viewManagerName: string) => Object;
+  +getDefaultEventTypes?: () => Array<string>;
+  +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
+  +sendAccessibilityEvent?: (reactTag: ?number, eventType: number) => void;
+  +showPopupMenu?: (
     reactTag: ?number,
     items: Array<string>,
     error: (error: Object) => void,
     success: (event: string, selected?: number) => void,
   ) => void;
-  +dismissPopupMenu: () => void;
+  +dismissPopupMenu?: () => void;
+
+  // ios only
+  +lazilyLoadView?: (name: string) => Object; // revisit return
+  +focus?: (reactTag: ?number) => void;
+  +blur?: (reactTag: ?number) => void;
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>('UIManager'): Spec);

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -12,6 +12,7 @@ import type {RootTag} from '../Types/RootTagTypes';
 import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
 import NativeUIManager from './NativeUIManager';
+import nullthrows from 'nullthrows';
 
 const NativeModules = require('../BatchedBridge/NativeModules');
 const defineLazyObjectProperty = require('../Utilities/defineLazyObjectProperty');
@@ -67,7 +68,7 @@ function getViewManagerConfig(viewManagerName: string): any {
     NativeUIManager.lazilyLoadView &&
     !triedLoadingConfig.has(viewManagerName)
   ) {
-    const result = NativeUIManager.lazilyLoadView(viewManagerName);
+    const result = nullthrows(NativeUIManager.lazilyLoadView)(viewManagerName);
     triedLoadingConfig.add(viewManagerName);
     if (result != null && result.viewConfig != null) {
       getConstants()[viewManagerName] = result.viewConfig;
@@ -161,7 +162,8 @@ if (Platform.OS === 'ios') {
 } else if (getConstants().ViewManagerNames) {
   NativeUIManager.getConstants().ViewManagerNames.forEach(viewManagerName => {
     defineLazyObjectProperty(NativeUIManager, viewManagerName, {
-      get: () => NativeUIManager.getConstantsForViewManager(viewManagerName),
+      get: () =>
+        nullthrows(NativeUIManager.getConstantsForViewManager)(viewManagerName),
     });
   });
 }

--- a/packages/react-native/Libraries/ReactNative/UIManager.d.ts
+++ b/packages/react-native/Libraries/ReactNative/UIManager.d.ts
@@ -112,7 +112,9 @@ export interface UIManagerStatic {
    *
    *     UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
    */
-  setLayoutAnimationEnabledExperimental(value: boolean): void;
+  setLayoutAnimationEnabledExperimental?:
+    | ((value: boolean) => void)
+    | undefined;
 
   /**
    * Used to display an Android PopupMenu. If a menu item is pressed, the success callback will
@@ -126,12 +128,14 @@ export interface UIManagerStatic {
    *
    * Note that this works only on Android
    */
-  showPopupMenu(
-    node: number,
-    items: string[],
-    error: () => void /* currently unused */,
-    success: (item: string, index: number | undefined) => void,
-  ): void;
+  showPopupMenu?:
+    | ((
+        node: number,
+        items: string[],
+        error: () => void /* currently unused */,
+        success: (item: string, index: number | undefined) => void,
+      ) => void)
+    | undefined;
 
   getViewManagerConfig: (name: string) => {
     Commands: {[key: string]: number};

--- a/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -20,6 +20,7 @@ const pointsDiffer = require('../Utilities/differ/pointsDiffer');
 const sizesDiffer = require('../Utilities/differ/sizesDiffer');
 const UIManager = require('./UIManager');
 const invariant = require('invariant');
+const nullthrows = require('nullthrows');
 
 function getNativeComponentAttributes(uiViewClassName: string): any {
   const viewConfig = UIManager.getViewManagerConfig(uiViewClassName);
@@ -105,7 +106,10 @@ function attachDefaultEventTypes(viewConfig: any) {
   const constants = UIManager.getConstants();
   if (constants.ViewManagerNames || constants.LazyViewManagersEnabled) {
     // Lazy view managers enabled.
-    viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
+    viewConfig = merge(
+      viewConfig,
+      nullthrows(UIManager.getDefaultEventTypes)(),
+    );
   } else {
     viewConfig.bubblingEventTypes = merge(
       viewConfig.bubblingEventTypes,


### PR DESCRIPTION
Summary:
These methods should not be implemented in the new architecture.

The **only** code that called these UIManagerModule methods was the paper renderer. And the New Architecture should instead use the Fabric renderer.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D52345416


