### PR TITLE
RNTester iOS: internal profiling test setup

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -49,6 +49,14 @@ NSString *kBundlePath = @"js/RNTesterApp.ios";
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+#ifdef RN_DISABLE_OSS_PLUGIN_HEADER
+  // FB-internal app backgrounding setup.
+  RCTFBAppInitApplicationDidEnterBackground(application);
+#endif
+}
+
 - (NSDictionary *)prepareInitialProps
 {
   NSMutableDictionary *initProps = [NSMutableDictionary new];


### PR DESCRIPTION
Summary:
Proxying background handling to set up Meta internal test infra.

Changelog: [Internal]

Differential Revision: D52420805


