### PR TITLE
iOS: renamed experimental new-arch-only flag to clarify its intent

### DIFF
--- a/packages/react-native/React/Base/RCTAssert.m
+++ b/packages/react-native/React/Base/RCTAssert.m
@@ -234,7 +234,7 @@ RCTFatalExceptionHandler RCTGetFatalExceptionHandler(void)
 
 // MARK: - New Architecture Validation - Enable Reporting
 
-#if RCT_ONLY_NEW_ARCHITECTURE
+#if RCT_ONLY_NEW_ARCHITECTURE_EXPERIMENTAL_DO_NOT_USE
 static RCTNotAllowedValidation minValidationLevel = RCTNotAllowedInBridgeless;
 #else
 static RCTNotAllowedValidation minValidationLevel = RCTNotAllowedValidationDisabled;
@@ -242,7 +242,7 @@ static RCTNotAllowedValidation minValidationLevel = RCTNotAllowedValidationDisab
 
 __attribute__((used)) RCT_EXTERN void RCTNewArchitectureSetMinValidationLevel(RCTNotAllowedValidation level)
 {
-#if RCT_ONLY_NEW_ARCHITECTURE
+#if RCT_ONLY_NEW_ARCHITECTURE_EXPERIMENTAL_DO_NOT_USE
   // Cannot disable the reporting in this mode.
 #else
   minValidationLevel = level;
@@ -325,7 +325,7 @@ void RCTEnforceNewArchitectureValidation(RCTNotAllowedValidation type, id contex
 
 void RCTErrorNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra)
 {
-#if RCT_ONLY_NEW_ARCHITECTURE
+#if RCT_ONLY_NEW_ARCHITECTURE_EXPERIMENTAL_DO_NOT_USE
   newArchitectureValidationInternal(RCTLogLevelFatal, type, context, extra);
 #else
   newArchitectureValidationInternal(RCTLogLevelError, type, context, extra);
@@ -339,7 +339,7 @@ void RCTLogNewArchitectureValidation(RCTNotAllowedValidation type, id context, N
 
 void RCTNewArchitectureValidationPlaceholder(RCTNotAllowedValidation type, id context, NSString *extra)
 {
-#if RCT_ONLY_NEW_ARCHITECTURE
+#if RCT_ONLY_NEW_ARCHITECTURE_EXPERIMENTAL_DO_NOT_USE
   newArchitectureValidationInternal(RCTLogLevelInfo, type, context, extra);
 #endif
 }

--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -185,8 +185,8 @@
  * Controls for activating the new architecture without the legacy system.
  * Note: this is work in progress.
  */
-#ifdef REACT_NATIVE_FORCE_NEW_ARCHITECTURE
-#define RCT_ONLY_NEW_ARCHITECTURE 1
+#ifdef REACT_NATIVE_FORCE_NEW_ARCHITECTURE_EXPERIMENTAL_DO_NOT_USE
+#define RCT_ONLY_NEW_ARCHITECTURE_EXPERIMENTAL_DO_NOT_USE 1
 #else
-#define RCT_ONLY_NEW_ARCHITECTURE 0
+#define RCT_ONLY_NEW_ARCHITECTURE_EXPERIMENTAL_DO_NOT_USE 0
 #endif


### PR DESCRIPTION
Summary:
This existing flag was for experimental (WIP) purpose only, and is undocumented, by design. Let's rename it so to make it clear. Libraries/Apps should not use this flag.

Changelog: [Internal]

Differential Revision: D52424750


