### PR TITLE
[RN][iOS] Improve Swift support for 3rd party libs

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -33,7 +33,8 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "dummyFile.cpp"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",
-                            "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
+                            "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+                            "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
     s.header_mappings_dir     = './'

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -27,7 +27,10 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "react/debug"
-  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
+  s.pod_target_xcconfig    = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+    "DEFINES_MODULE" => "YES"
+  }
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_debug"

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -49,7 +49,11 @@ Pod::Spec.new do |s|
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
   end
 
-  s.pod_target_xcconfig  = { "USE_HEADERMAP" => "NO", "HEADER_SEARCH_PATHS" => header_search_paths.join(" ") }
+  s.pod_target_xcconfig  = {
+    "USE_HEADERMAP" => "NO",
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(" "),
+    "DEFINES_MODULE" => "YES"
+  }
 
   s.dependency "glog"
   s.dependency "RCT-Folly/Fabric", folly_version

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -44,7 +44,9 @@ Pod::Spec.new do |s|
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-    "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
+    "DEFINES_MODULE" => "YES"
+  }
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_utils"


### PR DESCRIPTION
## Summary:
We are suggesting and migrating 3rd party libs to use `install_modules_dependencies` in their podspecs.
However, when some of those libs uses Swift, they become incompatible with some of the pods we expose because we forgot to define modules in those libraries.

With these changes, they would be able to be installed correctly in a 0.72 react Native app.

## Changelog:
[Internal] - Improve Swift support by defining modules in React-Fabric, React-graphics, React-utils and React-debug.

## Test Plan:
Tested locally by running:
```
npx react-native@0.72.7 init NewApp --version 0.72.7 --skip-install
cd NewApp
yarn add lottie-react-native
cd ios
bundle install
RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
open NewApp.xcworkspace
```
<kbd>⌘</kbd> + <kbd>B</kbd>

Observe the app failing to build.

Apply these changes:
```
RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
open NewApp.xcworkspace
```
<kbd>⌘</kbd> + <kbd>B</kbd>

Observer the app build successfully
