### PR TITLE
Avoid using std::views::filter to fix issues with macosx-x86_64 toolchain

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
@@ -90,25 +90,22 @@ std::tuple<EventPath, EventPath> PointerHoverTracker::diffEventPath(
     ++otherIt;
   }
 
-  auto removedViews =
-      std::ranges::subrange{myIt, myEventPath.rend()} |
-      std::views::transform(
-          [this, &uiManager](const ShadowNode& node) -> const ShadowNode* {
-            return this->getLatestNode(node, uiManager);
-          }) |
-      std::views::filter([](auto n) -> bool { return n != nullptr; }) |
-      std::views::transform([](auto n) -> ShadowNode const& { return *n; });
-  EventPath removed(removedViews.begin(), removedViews.end());
+  EventPath removed;
+  for (const auto& node : std::ranges::subrange{myIt, myEventPath.rend()}) {
+    const auto& latestNode = getLatestNode(node, uiManager);
+    if (latestNode != nullptr) {
+      removed.push_back(*latestNode);
+    }
+  }
 
-  auto addedViews =
-      std::ranges::subrange{otherIt, otherEventPath.rend()} |
-      std::views::transform(
-          [&other, &uiManager](const ShadowNode& node) -> const ShadowNode* {
-            return other.getLatestNode(node, uiManager);
-          }) |
-      std::views::filter([](auto n) -> bool { return n != nullptr; }) |
-      std::views::transform([](auto n) -> ShadowNode const& { return *n; });
-  EventPath added(addedViews.begin(), addedViews.end());
+  EventPath added;
+  for (const auto& node :
+       std::ranges::subrange{otherIt, otherEventPath.rend()}) {
+    const auto& latestNode = other.getLatestNode(node, uiManager);
+    if (latestNode != nullptr) {
+      added.push_back(*latestNode);
+    }
+  }
 
   return std::make_tuple(removed, added);
 }


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] - 

In https://github.com/facebook/react-native/pull/41519 we introduced usage of C++20s range operations, which broke MacOSX desktop builds for the x86_64 targets (e.g. on Intel Mac laptops).

This appears to be a [known issue](https://stackoverflow.com/questions/73929080/error-with-clang-15-and-c20-stdviewsfilter), fixed in the later clang versions, however we need to support the earlier ones as well.

This changes the code to use the good old imperative style to do the same thing, but without using `std::views::filter`, thus working around the problem.

Differential Revision: D52428984


