### PR TITLE
Remove * dependencies on @react-native

### DIFF
--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -25,7 +25,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@react-native/codegen": "*"
+    "@react-native/codegen": "0.74.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -31,7 +31,7 @@
     "@babel/eslint-parser": "^7.20.0",
     "@babel/plugin-transform-flow-strip-types": "^7.20.0",
     "@babel/preset-flow": "^7.20.0",
-    "@react-native/codegen": "*",
+    "@react-native/codegen": "0.74.0",
     "make-dir": "^2.1.0",
     "pirates": "^4.0.1",
     "source-map-support": "0.5.0"

--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -54,7 +54,7 @@
     "@babel/plugin-transform-typescript": "^7.5.0",
     "@babel/plugin-transform-unicode-regex": "^7.0.0",
     "@babel/template": "^7.0.0",
-    "@react-native/babel-plugin-codegen": "*",
+    "@react-native/babel-plugin-codegen": "0.74.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "react-refresh": "^0.14.0"
   },

--- a/packages/react-native-babel-transformer/package.json
+++ b/packages/react-native-babel-transformer/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.20.0",
-    "@react-native/babel-preset": "*",
+    "@react-native/babel-preset": "0.74.0",
     "hermes-parser": "0.18.2",
     "nullthrows": "^1.1.1"
   },

--- a/packages/react-native-codegen-typescript-test/package.json
+++ b/packages/react-native-codegen-typescript-test/package.json
@@ -19,7 +19,7 @@
     "prepare": "yarn run build"
   },
   "dependencies": {
-    "@react-native/codegen": "*"
+    "@react-native/codegen": "0.74.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary:

See https://github.com/facebook/react-native/issues/41929 for an issue on multiple monorepo packages being installed. The reason is that `*` resolves to whatever is tagged `latest` on npm. 

We still need to fix the fact that our monorepo publish script will update the latest tag everytime we publish. For now, we should remove these from `main` and we will also update this in the 0.73 release branch.

I've left the two peer dependencies on `react-native` to keep at `*`. 
```
virtualized-lists/package.json
30:    "react-native": "*"

rn-tester/package.json
32:    "react-native": "*"
```

As a peer-dependency this won't be a problem in terms of installing a second `react-native`. I thought about updating these to `nightly`, but that would install multiple nightly react-natives as the tag will be updated with each nightly release. I think for now this is fine and something we can revisit.

Things left to do 
- [ ] Fix monorepo publish script to not update `--latest`
- [ ] Do the same thing for 0.73, 0.72, 0.71
    - [ ] For 0.73: https://github.com/facebook/react-native/pull/42082
- [ ] Remove ^ dependencies on monorepo packages: 
	- [ ] For main: D52440454, https://github.com/facebook/react-native/pull/42086
    - [ ] For 0.73 https://github.com/facebook/react-native/pull/41958
- [ ] Re-evaluate how we bump and align monorepo packages when we cut a release branch. I forget if we manually update this when we cut or if there is a script. We may want to change the script and have `main` dependencies point to some fake version like `1000.0.0` and only update these on nightly publishes. Regardless, this will need some discussion.

## Changelog:

[GENERAL] [CHANGED] - Be explicit about what monorepo versions we are using

## Test Plan:
N/A