### PR TITLE
Update these to use latest 0.73.x versions

### DIFF
--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -25,7 +25,7 @@
     "index.js"
   ],
   "dependencies": {
-    "@react-native/codegen": "*"
+    "@react-native/codegen": "0.73.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -31,7 +31,7 @@
     "@babel/eslint-parser": "^7.20.0",
     "@babel/plugin-transform-flow-strip-types": "^7.20.0",
     "@babel/preset-flow": "^7.20.0",
-    "@react-native/codegen": "*",
+    "@react-native/codegen": "0.73.2",
     "flow-parser": "^0.206.0",
     "make-dir": "^2.1.0",
     "pirates": "^4.0.1",

--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -53,7 +53,7 @@
     "@babel/plugin-transform-typescript": "^7.5.0",
     "@babel/plugin-transform-unicode-regex": "^7.0.0",
     "@babel/template": "^7.0.0",
-    "@react-native/babel-plugin-codegen": "*",
+    "@react-native/babel-plugin-codegen": "0.73.1",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "react-refresh": "^0.14.0"
   },

--- a/packages/react-native-babel-transformer/package.json
+++ b/packages/react-native-babel-transformer/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.20.0",
-    "@react-native/babel-preset": "*",
+    "@react-native/babel-preset": "0.73.18",
     "hermes-parser": "0.15.0",
     "nullthrows": "^1.1.1"
   },

--- a/packages/react-native-codegen-typescript-test/package.json
+++ b/packages/react-native-codegen-typescript-test/package.json
@@ -19,7 +19,7 @@
     "prepare": "yarn run build"
   },
   "dependencies": {
-    "@react-native/codegen": "*"
+    "@react-native/codegen": "0.73.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary:

See description in https://github.com/facebook/react-native/pull/42081
Applying those same changes to 0.73 branch but using latest updated versions of those packages. Before merging we should ensure the monorepo deps are using the latest 0.73.x version.

## Changelog:

[GENERAL] [CHANGED] - Remove * dependencies on monorepo packages in 0.73. 

## Test Plan:

Verified that these will now be included in the bump and align process when we update monorepo packages

https://github.com/facebook/react-native/blob/2f92a87e4385d515f718479005c623c04fa1bb83/scripts/monorepo/align-package-versions.js#L39-L63
