### PR TITLE
Deprecate old JSI module APIs

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
@@ -71,6 +71,9 @@ public interface CatalystInstance
   @Nullable
   NativeModule getNativeModule(String moduleName);
 
+  @Deprecated(
+      since =
+          "getJSIModule(JSIModuleType moduleType) is deprecated and will be deleted in the future. Please use ReactInstanceEventListener to subscribe for react instance events instead.")
   JSIModule getJSIModule(JSIModuleType moduleType);
 
   Collection<NativeModule> getNativeModules();
@@ -116,6 +119,7 @@ public interface CatalystInstance
 
   RuntimeScheduler getRuntimeScheduler();
 
+  @Deprecated
   void addJSIModules(List<JSIModuleSpec> jsiModules);
 
   /**
@@ -130,11 +134,9 @@ public interface CatalystInstance
    */
   NativeMethodCallInvokerHolder getNativeMethodCallInvokerHolder();
 
-  /**
-   * For the time being, we want code relying on the old infra to also work with TurboModules.
-   * Hence, we must provide the TurboModuleRegistry to CatalystInstance so that getNativeModule,
-   * hasNativeModule, and getNativeModules can also return TurboModules.
-   */
+  @Deprecated(
+      since =
+          "setTurboModuleManager(JSIModule getter) is deprecated and will be deleted in the future. Please use setTurboModuleRegistry(TurboModuleRegistry turboModuleRegistry)instead.")
   void setTurboModuleManager(JSIModule getter);
 
   @DeprecatedInNewArchitecture(


### PR DESCRIPTION
Summary:
Deprecating the old JSI module APIs: `getJSIModule(JSIModuleType moduleType)`, `addJSIModules(List<JSIModuleSpec> jsiModules)` and `setTurboModuleManager(JSIModule getter)` to further delete them in future release. Deprecating them as of now to cater the OSS use-cases

Changelog:
[Interna] internal

Differential Revision: D50927292


