### PR TITLE
[RN][CI] Fix e2e test setup

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -61,7 +61,7 @@ commands:
 
             # Set ruby dependencies
             rbenv global << parameters.ruby_version >>
-            if [[ << parameters.ruby_version >> == "2.6.10" ]]; then
+            if [[ $(echo << parameters.ruby_version >> | awk -F'.' '{print $1}') == "2" ]]; then
               gem install bundler -v 2.4.22
             else
               gem install bundler


### PR DESCRIPTION
## Summary:
`test_e2e_ios` is failing because the default bundler version that is installed in CI does not support Ruby 2 anymore.

This PR ports the same fix @fortmarek did for 0.72 in #41989

## Changelog:
[Internal] - Fix test_e2e_ios in CI

## Test Plan:
CircleCI is green