### PR TITLE
Add function to customise RootView in Bridgeless

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -11,6 +11,7 @@
 @class RCTBridge;
 @protocol RCTBridgeDelegate;
 @protocol RCTComponentViewProtocol;
+@class RCTRootView;
 @class RCTSurfacePresenterBridgeAdapter;
 
 /**
@@ -86,6 +87,26 @@
 - (UIView *)createRootViewWithBridge:(RCTBridge *)bridge
                           moduleName:(NSString *)moduleName
                            initProps:(NSDictionary *)initProps;
+/**
+ * This method can be used to customize the rootView that is passed to React Native.
+ * A typical example is to override this method in the AppDelegate to change the background color.
+ * To achieve this, add in your `AppDelegate.mm`:
+ * ```
+ * - (void)customizeRootView:(RCTRootView *)rootView
+ * {
+ *   rootView.backgroundColor = [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *traitCollection) {
+ *     if ([traitCollection userInterfaceStyle] == UIUserInterfaceStyleDark) {
+ *       return [UIColor blackColor];
+ *     } else {
+ *       return [UIColor whiteColor];
+ *     }
+ *   }];
+ * }
+ * ```
+ *
+ * @parameter: rootView - The root view to customize.
+ */
+- (void)customizeRootView:(RCTRootView *)rootView;
 
 /**
  * It creates the RootViewController.


### PR DESCRIPTION
Summary:
This change adds an extra function to customise the RootView in both Bridge and Bridgeless mode.
To nudge users in a migration, we also add a warning message for next version that should push our users to migrate away from the old implementation to the new one.
*The Warning is shown ONLY when the user do customise the rootView*. For users which were not customising the Root View, the warning will not appear.

The documentation of the new method plus the warning should guide the users toward the right migration path.

## Changelog
[iOS][Added] - Added the customiseRootView method which is called in both bridge and bridgeless. Added also a warning for 0.74 with instructions on how to migrate.

Differential Revision: D52442598

## TestPlan
Tested locally on RNTester:
| Bridge/Bridgeless | Light Theme | Dark Theme |
| --- | --- | --- |
| Bridge Mode | <img width="1033" alt="Screenshot 2023-12-28 at 10 32 54" src="https://github.com/facebook/react-native/assets/11162307/04b8c330-8594-4295-8d75-533733bb4237"> | <img width="1215" alt="Screenshot 2023-12-28 at 10 33 18" src="https://github.com/facebook/react-native/assets/11162307/8334cd0c-a30d-42fa-9509-579dd9e9eb24"> |
| Bridgeless | <img width="1145" alt="Screenshot 2023-12-28 at 10 51 00" src="https://github.com/facebook/react-native/assets/11162307/9b70c83b-b8aa-43ff-9f9a-57fa03a9f0b4"> | <img width="1223" alt="Screenshot 2023-12-28 at 10 50 47" src="https://github.com/facebook/react-native/assets/11162307/54f23c37-8148-4eca-a47b-1958f24fa184"> |


