### PR TITLE
Add functions to check whether the New Arch is enabled at runtime

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -11,6 +11,7 @@
 @class RCTBridge;
 @protocol RCTBridgeDelegate;
 @protocol RCTComponentViewProtocol;
+@class RCTRootView;
 @class RCTSurfacePresenterBridgeAdapter;
 
 /**
@@ -86,6 +87,26 @@
 - (UIView *)createRootViewWithBridge:(RCTBridge *)bridge
                           moduleName:(NSString *)moduleName
                            initProps:(NSDictionary *)initProps;
+/**
+ * This method can be used to customize the rootView that is passed to React Native.
+ * A typical example is to override this method in the AppDelegate to change the background color.
+ * To achieve this, add in your `AppDelegate.mm`:
+ * ```
+ * - (void)customizeRootView:(RCTRootView *)rootView
+ * {
+ *   rootView.backgroundColor = [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *traitCollection) {
+ *     if ([traitCollection userInterfaceStyle] == UIUserInterfaceStyleDark) {
+ *       return [UIColor blackColor];
+ *     } else {
+ *       return [UIColor whiteColor];
+ *     }
+ *   }];
+ * }
+ * ```
+ *
+ * @parameter: rootView - The root view to customize.
+ */
+- (void)customizeRootView:(RCTRootView *)rootView;
 
 /**
  * It creates the RootViewController.

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -10,6 +10,7 @@
 #import <React/RCTLog.h>
 #import <React/RCTRootView.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <React/RCTUtils.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import "RCTAppSetupUtils.h"
 
@@ -79,9 +80,10 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  RCTSetNewArchEnabled([self newArchEnabled]);
   BOOL enableTM = self.turboModuleEnabled;
-  BOOL enableBridgeless = self.bridgelessEnabled;
   BOOL fabricEnabled = self.fabricEnabled;
+  BOOL enableBridgeless = self.bridgelessEnabled;
 
   NSDictionary *initProps = updateInitialProps([self prepareInitialProps], fabricEnabled);
 

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -16,6 +16,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Whether the New Architecture is enabled or not
+RCT_EXTERN BOOL RCTIsNewArchEnabled(void);
+RCT_EXTERN void RCTSetNewArchEnabled(BOOL enabled);
+
 // JSON serialization/deserialization
 RCT_EXTERN NSString *__nullable RCTJSONStringify(id __nullable jsonObject, NSError **error);
 RCT_EXTERN id __nullable RCTJSONParse(NSString *__nullable jsonString, NSError **error);

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -33,6 +33,20 @@ NSString *__nullable RCTHomePathForURL(NSURL *__nullable URL);
 // Determines if a given image URL refers to a image in Home directory (~)
 BOOL RCTIsHomeAssetURL(NSURL *__nullable imageURL);
 
+// Whether the New Architecture is enabled or not
+static BOOL _newArchEnabled = false;
+BOOL RCTIsNewArchEnabled(void)
+{
+  return _newArchEnabled;
+}
+void RCTSetNewArchEnabled(BOOL enabled)
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    _newArchEnabled = enabled;
+  });
+}
+
 static NSString *__nullable _RCTJSONStringifyNoRetry(id __nullable jsonObject, NSError **error)
 {
   if (!jsonObject) {


### PR DESCRIPTION
Summary:
This change is the last pieces of removing `RCT_NEW_ARCH_ENABLED` flag and defragmenting the build setup on iOS.

Before, 3rd party libraries had to use the `#if RCT_NEW_ARCH_ENABLED` flag to compile in and out segment of code depending on whether the new architecture was turned on or not.

After the recent changes, we can now expose the `RCTIsNewArchEnabled()` function to read whether the New Arch is enabled at runtime or not.
This will promote better code practices as we can replace ugly, compile time, `#if-#else-#endif`s with a more readable and natural regular obj-c code.
We can also use inheritance to have different implementation based on the architecture.

To use the new function, a 3rd party library have to:
1. `#import <React/RCTUtils.h>` (if they use the  `install_modules_dependencies` function we provide, they can already do it)
2. invoke `RCTIsNewArchEnabled()` which returns a BOOL.
3. implement the code accordingly, depending on the New arch state.

**Note:** we implemented also the `RCTSetNewArchEnabled` function. This is called as soon as React Native is initialized in the `RCTAppDelegate`. The method can be called only once per React Native lifecycle. Subsequent calls to that method are ignored.

## Changelog:
[iOS][Added] - Added the `RCTIsNewArchEnabled()` to check whether the New Arch is enabled at runtime.

Differential Revision: D52445107


