### PR TITLE
Fix horiozntal scrollview scrollTo coordinate space in RTL on oldarch

### DIFF
--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -568,6 +568,10 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
 
 - (void)scrollToOffset:(CGPoint)offset animated:(BOOL)animated
 {
+  if ([self reactLayoutDirection] == UIUserInterfaceLayoutDirectionRightToLeft) {
+    offset.x = _scrollView.contentSize.width - _scrollView.frame.size.width - offset.x;
+  }
+
   if (!CGPointEqualToPoint(_scrollView.contentOffset, offset)) {
     CGRect maxRect = CGRectMake(
         fmin(-_scrollView.contentInset.left, 0),


### PR DESCRIPTION
Summary:
Fabric fixed this a while back with https://github.com/facebook/react-native/commit/9ca460f06405db85d0df60cbe53c304c9127c3bf

Looks like this is still broken on Paper, and now VirtualizedList relies on it. https://github.com/facebook/react-native/pull/38737#discussion_r1437874601

Changelog:
[ios][fixed] - Fix horiozntal scrollview scrollTo coordinate space in RTL on oldarch

Differential Revision: D52451602


