### PR TITLE
Fix the problem that children of textinput would be cleared when setting the selection prop

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1159,6 +1159,8 @@ function InternalTextInput(props: Props): React.Node {
       ? props.value
       : typeof props.defaultValue === 'string'
       ? props.defaultValue
+      : typeof props.value === 'undefined'
+      ? null
       : '';
 
   // This is necessary in case native updates the text and JS decides

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -198,7 +198,7 @@ describe('TextInput tests', () => {
         rejectResponderTermination={true}
         selection={null}
         submitBehavior="blurAndSubmit"
-        text=""
+        text={null}
         textContentType="emailAddress"
         underlineColorAndroid="transparent"
       />
@@ -244,7 +244,7 @@ describe('TextInput', () => {
         rejectResponderTermination={true}
         selection={null}
         submitBehavior="blurAndSubmit"
-        text=""
+        text={null}
         underlineColorAndroid="transparent"
       />
     `);
@@ -291,7 +291,7 @@ describe('TextInput compat with web', () => {
         selection={null}
         submitBehavior="blurAndSubmit"
         testID="testID"
-        text=""
+        text={null}
         underlineColorAndroid="transparent"
       />
     `);
@@ -423,7 +423,7 @@ describe('TextInput compat with web', () => {
         role="main"
         selection={null}
         submitBehavior="blurAndSubmit"
-        text=""
+        text={null}
         underlineColorAndroid="transparent"
       />
     `);
@@ -475,7 +475,7 @@ describe('TextInput compat with web', () => {
           }
         }
         submitBehavior="blurAndSubmit"
-        text=""
+        text={null}
         underlineColorAndroid="transparent"
       />
     `);


### PR DESCRIPTION
Fix the problem that children of TextInput would be cleared when setting the selection prop.

## Summary:
This PR Fix the problem that children of TextInput would be cleared when setting the selection prop. Here is a related [issue](https://github.com/facebook/react-native/issues/41966)

## Changelog:
[GENERAL] [FIXED] - Fix the problem that children of TextInput would be cleared when setting the selection prop.

## Test Plan:
According to logic in [ReactTextInputManager.java](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java#L324), we should pass a null from JS to Java if we don't want to set text of TextInput.
