### PR TITLE
Fix the problem that children of textinput would be cleared when setting the selection prop

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1159,6 +1159,8 @@ function InternalTextInput(props: Props): React.Node {
       ? props.value
       : typeof props.defaultValue === 'string'
       ? props.defaultValue
+      : typeof props.value === 'undefined'
+      ? null
       : '';
 
   // This is necessary in case native updates the text and JS decides
@@ -1502,7 +1504,7 @@ function InternalTextInput(props: Props): React.Node {
           useMultilineDefaultStyle ? styles.multilineDefault : null,
           style,
         )}
-        text={text}
+        text={text || ''}
       />
     );
   } else if (Platform.OS === 'android') {
@@ -1568,7 +1570,7 @@ function InternalTextInput(props: Props): React.Node {
         onSelectionChange={_onSelectionChange}
         placeholder={placeholder}
         style={style}
-        text={text}
+        text={text || ''}
         textBreakStrategy={props.textBreakStrategy}
       />
     );


### PR DESCRIPTION
Fix the problem that children of TextInput would be cleared when setting the selection prop.

## Summary:
This PR fix the problem that children of TextInput would be cleared when setting the selection prop. Here is a related [issue](https://github.com/facebook/react-native/issues/41966)

## Changelog:
[GENERAL] [FIXED] - Fix the problem that children of TextInput would be cleared when setting the selection prop.

## Test Plan:
According to logic in [ReactTextInputManager.java](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java#L324), we should pass a null from JS to Java if we don't want to set text of TextInput.