### PR TITLE
Deprecate `[RCTConvert UIBarStyle:]`

### DIFF
--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -77,7 +77,7 @@ typedef NSURL RCTFileURL;
 
 + (UIViewContentMode)UIViewContentMode:(id)json;
 #if !TARGET_OS_TV
-+ (UIBarStyle)UIBarStyle:(id)json;
++ (UIBarStyle)UIBarStyle:(id)json __deprecated;
 #endif
 
 + (CGFloat)CGFloat:(id)json;


### PR DESCRIPTION
## Summary:

The enums [UIBarStyleBlackOpaque](https://developer.apple.com/documentation/uikit/uibarstyle/uibarstyleblackopaque) and [UIBarStyleBlackTranslucent](https://developer.apple.com/documentation/uikit/uibarstyle/uibarstyleblacktranslucent) have been deprecated since iOS 13, already below React Native's minimum OS of iOS 13.4. Indeed, they are not available on visionOS and tvOS, making this a source of extra diffs. 

Rather than deprecate and remove those options, I noticed that we don't actually use that `RCTConvert` method in the core repo, and haven't since `0.58-stable` (presumably before the lean core effort). Let's just remove it, it's a conversion that should be easy enough to replicate elsewhere. However, removal is a breaking change, so let's deprecate it for one release (0.74) and remove it for the next one (0.75). For posterity, tracking deprecation with https://github.com/microsoft/react-native-macos/issues/2008 and removal with https://github.com/microsoft/react-native-macos/issues/2009 . 

## Changelog:

[IOS] [DEPRECATED] - Deprecate `[RCTConvert UIBarStyle:]`

## Test Plan:

CI should pass
