### PR TITLE
Fix react-native-codegen

### DIFF
--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -11,7 +11,7 @@
     "index.js"
   ],
   "dependencies": {
-    "react-native-codegen": "*"
+    "react-native-codegen": "0.71.6"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0"

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -20,7 +20,7 @@
     "flow-parser": "^0.185.0",
     "make-dir": "^2.1.0",
     "pirates": "^4.0.1",
-    "react-native-codegen": "*",
+    "react-native-codegen": "0.71.6",
     "source-map-support": "0.5.0"
   },
   "license": "MIT"


### PR DESCRIPTION
## Summary:

Pin the versions of monorepo deps such that we don't accidentally pull updated monorepo libs as we don't follow semver. A patch may not be backwards compat

Note: This change has also been applied to 72, 73, and main. I'm not sure this makes that much sense in 71 as we don't have a lot of monorepo deps set up yet.

## Changelog:
[GENERAL] [CHANGED] - Pin monorepo deps - react-native-codegen


## Test Plan:

n/a