### PR TITLE
Remove deprecated RCTBundleURLProvider options

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.h
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.h
@@ -119,27 +119,11 @@ RCT_EXTERN void RCTBundleURLProviderAllowPackagerServerAccess(BOOL allowed);
  * - enableDev: Whether to keep or remove `__DEV__` blocks from the bundle.
  * - enableMinification: Enables or disables minification. Usually production bundles are minified and development
  *     bundles are not.
+ * - inlineSourceMap: When true, the bundler will inline the source map in the bundle
  * - modulesOnly: When true, will only send module definitions without polyfills and without the require-runtime.
  * - runModule: When true, will run the main module after defining all modules. This is used in the main bundle but not
  *     in split bundles.
  */
-+ (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
-                       packagerHost:(NSString *)packagerHost
-                          enableDev:(BOOL)enableDev
-                 enableMinification:(BOOL)enableMinification
-    __deprecated_msg(
-        "Use `jsBundleURLForBundleRoot:packagerHost:enableDev:enableMinification:inlineSourceMap:` instead");
-
-+ (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
-                       packagerHost:(NSString *)packagerHost
-                     packagerScheme:(NSString *)scheme
-                          enableDev:(BOOL)enableDev
-                 enableMinification:(BOOL)enableMinification
-                        modulesOnly:(BOOL)modulesOnly
-                          runModule:(BOOL)runModule
-    __deprecated_msg(
-        "Use jsBundleURLForBundleRoot:packagerHost:enableDev:enableMinification:inlineSourceMap:modulesOnly:runModule:`  instead");
-
 + (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
                        packagerHost:(NSString *)packagerHost
                           enableDev:(BOOL)enableDev

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -249,23 +249,7 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                        packagerHost:(NSString *)packagerHost
                           enableDev:(BOOL)enableDev
                  enableMinification:(BOOL)enableMinification
-{
-  return [self jsBundleURLForBundleRoot:bundleRoot
-                           packagerHost:packagerHost
-                         packagerScheme:nil
-                              enableDev:enableDev
-                     enableMinification:enableMinification
-                        inlineSourceMap:NO
-                            modulesOnly:NO
-                              runModule:YES];
-}
-
-+ (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
-                       packagerHost:(NSString *)packagerHost
-                          enableDev:(BOOL)enableDev
-                 enableMinification:(BOOL)enableMinification
                     inlineSourceMap:(BOOL)inlineSourceMap
-
 {
   return [self jsBundleURLForBundleRoot:bundleRoot
                            packagerHost:packagerHost
@@ -275,24 +259,6 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                         inlineSourceMap:inlineSourceMap
                             modulesOnly:NO
                               runModule:YES];
-}
-
-+ (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
-                       packagerHost:(NSString *)packagerHost
-                     packagerScheme:(NSString *)scheme
-                          enableDev:(BOOL)enableDev
-                 enableMinification:(BOOL)enableMinification
-                        modulesOnly:(BOOL)modulesOnly
-                          runModule:(BOOL)runModule
-{
-  return [self jsBundleURLForBundleRoot:bundleRoot
-                           packagerHost:packagerHost
-                         packagerScheme:nil
-                              enableDev:enableDev
-                     enableMinification:enableMinification
-                        inlineSourceMap:NO
-                            modulesOnly:modulesOnly
-                              runModule:runModule];
 }
 
 + (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/commit/f7219ec02d71d2f0f6c71af4d5c3d4850a898fd8 deprecated some of the methods in `RCTBundleURLProvider, and is part of React Native version 0.73. Let's remove the deprecated options for React Native 0.74+

## Changelog:

[IOS] [REMOVED] - Remove deprecated RCTBundleURLProvider options

## Test Plan:

CI should pass.
