### PR TITLE
fix TouchableWithoutFeedback and TouchableOpacity dropping onPress in React 18

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -314,6 +314,10 @@ class TouchableOpacity extends React.Component<Props, State> {
     }
   }
 
+  componentDidMount(): void {
+    this.state.pressability.configure(this._createPressabilityConfig());
+  }
+
   componentWillUnmount(): void {
     this.state.pressability.reset();
   }

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -189,6 +189,10 @@ class TouchableWithoutFeedback extends React.Component<Props, State> {
     this.state.pressability.configure(createPressabilityConfig(this.props));
   }
 
+  componentDidMount(): mixed {
+    this.state.pressability.configure(createPressabilityConfig(this.props));
+  }
+
   componentWillUnmount(): void {
     this.state.pressability.reset();
   }


### PR DESCRIPTION
Summary:
## Changelog: 
[General][Fixed] - TouchableWithoutFeedback and TouchableOpacity dropping touches with React 18.


TouchableWithoutFeedback and TouchableOpacity do not trigger onPress when used with React 18. This is because it resets its pressability configuration in `componentWillUnmount`. This is fine, we want to stop deliver events and restart all timers when component is unmounted.
```
componentWillUnmount(): void {
    this.state.pressability.reset();
  }
```

But TouchableWithoutFeedback and TouchableOpacity were not restarting the pressability configuration when component was mounted again. It was restarting the configuration in `componentDidUpdate`, which is not called when component is unmounted and mounted again.

Reviewed By: fkgozali

Differential Revision: D52388699


