### PR TITLE
Add Float and Int type support for iOS  modules

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -260,11 +260,11 @@ function getParamObjCType(
     case 'NumberTypeAnnotation':
       return notStruct(isRequired ? 'double' : 'NSNumber *');
     case 'FloatTypeAnnotation':
-      return notStruct(isRequired ? 'double' : 'NSNumber *');
+      return notStruct(isRequired ? 'float' : 'NSNumber *');
     case 'DoubleTypeAnnotation':
       return notStruct(isRequired ? 'double' : 'NSNumber *');
     case 'Int32TypeAnnotation':
-      return notStruct(isRequired ? 'double' : 'NSNumber *');
+      return notStruct(isRequired ? 'NSInteger' : 'NSNumber *');
     case 'BooleanTypeAnnotation':
       return notStruct(isRequired ? 'BOOL' : 'NSNumber *');
     case 'EnumDeclaration':


### PR DESCRIPTION
Summary:
This diff changes how numeric types are generated for Objective-C native modules.
Before this diff:
|Codegen Type|Objective-C Type|
| -- | -- |
|number|double|
|Float|double|
|Double|double|
|Int32|double|
After this diff:
|Codegen Type|Objective-C Type|
| -- | -- |
|number|double|
|Float|**float**|
|Double|double|
|Int32|**NSInteger**|

Changelog: [iOS][Breaking] - Codegen: mapping for numeric types is changed for Objective-C native modules. `Float` -> `float`; `Int32` -> `NSInteger`.

Differential Revision: D52479442


