### PR TITLE
Add Float and Int type support for Android  modules

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -136,11 +136,11 @@ function translateFunctionParamToJavaType(
     case 'NumberTypeAnnotation':
       return wrapOptional('double', isRequired);
     case 'FloatTypeAnnotation':
-      return wrapOptional('double', isRequired);
+      return wrapOptional('float', isRequired);
     case 'DoubleTypeAnnotation':
       return wrapOptional('double', isRequired);
     case 'Int32TypeAnnotation':
-      return wrapOptional('double', isRequired);
+      return wrapOptional('int', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapOptional('boolean', isRequired);
     case 'EnumDeclaration':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -334,9 +334,9 @@ function translateReturnTypeToJniType(
     case 'DoubleTypeAnnotation':
       return nullable ? 'Ljava/lang/Double;' : 'D';
     case 'FloatTypeAnnotation':
-      return nullable ? 'Ljava/lang/Double;' : 'D';
+      return nullable ? 'Ljava/lang/Float;' : 'F';
     case 'Int32TypeAnnotation':
-      return nullable ? 'Ljava/lang/Double;' : 'D';
+      return nullable ? 'Ljava/lang/Integer;' : 'I';
     case 'PromiseTypeAnnotation':
       return 'Lcom/facebook/react/bridge/Promise;';
     case 'GenericObjectTypeAnnotation':


### PR DESCRIPTION
Summary:
This diff changes how numeric types are generated for Android native modules.
Before this diff:
|Codegen Type|Java Type|
| -- | -- |
|number|double|
|Float|double|
|Double|double|
|Int32|double|
After this diff:
|Codegen Type|Java Type|
| -- | -- |
|number|double|
|Float|**float**|
|Double|double|
|Int32|**int**|

Changelog: [Android][Breaking] - Codegen: mapping for numeric types is changed for Android native modules. `Float` -> `float`; `Int32` -> `int`.

Differential Revision: D52420921


