### PR TITLE
Refactor ScrollView example to trigger onScrollToTop

### DIFF
--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -193,6 +193,59 @@ function ContentOffsetList(): React.Node {
   );
 }
 
+function ScrollViewScrollToExample(): React.Node {
+  let _scrollView: ?React.ElementRef<typeof ScrollView>;
+  const [scrolledToTop, setScrolledToTop] = useState(false);
+  const textStyle = {color: 'blue', marginBottom: 10, textAlign: 'center'};
+  return (
+    <View>
+      {scrolledToTop ? (
+        <Text style={textStyle}>scrolledToTop invoked</Text>
+      ) : null}
+      <ScrollView
+        accessibilityRole="grid"
+        ref={scrollView => {
+          _scrollView = scrollView;
+        }}
+        automaticallyAdjustContentInsets={false}
+        nestedScrollEnabled
+        onScroll={() => {
+          console.log('onScroll!');
+          setScrolledToTop(false);
+        }}
+        onScrollToTop={() => {
+          setScrolledToTop(true);
+        }}
+        scrollEventThrottle={200}
+        style={styles.scrollView}
+        testID="scroll_vertical">
+        {ITEMS.map(createItemRow)}
+      </ScrollView>
+      <Button
+        label="Scroll to top"
+        onPress={() => {
+          nullthrows<$FlowFixMe>(_scrollView).scrollTo({y: 0});
+        }}
+        testID="scroll_to_top_button"
+      />
+      <Button
+        label="Scroll to bottom"
+        onPress={() => {
+          nullthrows<$FlowFixMe>(_scrollView).scrollToEnd({animated: true});
+        }}
+        testID="scroll_to_bottom_button"
+      />
+      <Button
+        label="Flash scroll indicators"
+        onPress={() => {
+          nullthrows<$FlowFixMe>(_scrollView).flashScrollIndicators();
+        }}
+        testID="flash_scroll_indicators_button"
+      />
+    </View>
+  );
+}
+
 exports.displayName = 'ScrollViewExample';
 exports.title = 'ScrollView';
 exports.documentationURL = 'https://reactnative.dev/docs/scrollview';
@@ -205,49 +258,7 @@ const examples = ([
     title: '<ScrollView>\n',
     description:
       'To make content scrollable, wrap it within a <ScrollView> component',
-    render: function (): React.Node {
-      let _scrollView: ?React.ElementRef<typeof ScrollView>;
-      return (
-        <View>
-          <ScrollView
-            accessibilityRole="grid"
-            ref={scrollView => {
-              _scrollView = scrollView;
-            }}
-            automaticallyAdjustContentInsets={false}
-            nestedScrollEnabled
-            onScroll={() => {
-              console.log('onScroll!');
-            }}
-            scrollEventThrottle={200}
-            style={styles.scrollView}
-            testID="scroll_vertical">
-            {ITEMS.map(createItemRow)}
-          </ScrollView>
-          <Button
-            label="Scroll to top"
-            onPress={() => {
-              nullthrows<$FlowFixMe>(_scrollView).scrollTo({y: 0});
-            }}
-            testID="scroll_to_top_button"
-          />
-          <Button
-            label="Scroll to bottom"
-            onPress={() => {
-              nullthrows<$FlowFixMe>(_scrollView).scrollToEnd({animated: true});
-            }}
-            testID="scroll_to_bottom_button"
-          />
-          <Button
-            label="Flash scroll indicators"
-            onPress={() => {
-              nullthrows<$FlowFixMe>(_scrollView).flashScrollIndicators();
-            }}
-            testID="flash_scroll_indicators_button"
-          />
-        </View>
-      );
-    },
+    render: ScrollViewScrollToExample,
   },
   {
     name: 'horizontalScrollTo',


### PR DESCRIPTION
Summary:
The current scrollViewExamples does not trigger the OnScrollToTop event.
This change for Paper adds that and refactors the codebase to isolate that example.

## Changelog:
[Internal] - Improve RNTester ScrollView example adding OnScrollView event.

Reviewed By: sammy-SC

Differential Revision: D52509669


