### PR TITLE
Implement onScrollToTop event for Fabric

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -472,6 +472,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 - (void)scrollViewDidScrollToTop:(UIScrollView *)scrollView
 {
   _isUserTriggeredScrolling = NO;
+  static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScrollToTop([self _scrollViewMetrics]);
   [self _updateStateWithContentOffset];
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.cpp
@@ -64,6 +64,14 @@ void ScrollViewEventEmitter::onScroll(
   });
 }
 
+void ScrollViewEventEmitter::onScrollToTop(
+    const ScrollViewMetrics& scrollViewMetrics) const {
+  dispatchUniqueEvent(
+      "scrollToTop", [scrollViewMetrics](jsi::Runtime& runtime) {
+        return scrollViewMetricsPayload(runtime, scrollViewMetrics);
+      });
+}
+
 void ScrollViewEventEmitter::onScrollBeginDrag(
     const ScrollViewMetrics& scrollViewMetrics) const {
   dispatchScrollViewEvent("scrollBeginDrag", scrollViewMetrics);

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
@@ -33,6 +33,7 @@ class ScrollViewEventEmitter : public ViewEventEmitter {
   void onScrollEndDrag(const ScrollViewMetrics& scrollViewMetrics) const;
   void onMomentumScrollBegin(const ScrollViewMetrics& scrollViewMetrics) const;
   void onMomentumScrollEnd(const ScrollViewMetrics& scrollViewMetrics) const;
+  void onScrollToTop(const ScrollViewMetrics& scrollViewMetrics) const;
 
  private:
   void dispatchScrollViewEvent(

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -193,6 +193,59 @@ function ContentOffsetList(): React.Node {
   );
 }
 
+function ScrollViewScrollToExample(): React.Node {
+  let _scrollView: ?React.ElementRef<typeof ScrollView>;
+  const [scrolledToTop, setScrolledToTop] = useState(false);
+  const textStyle = {color: 'blue', marginBottom: 10, textAlign: 'center'};
+  return (
+    <View>
+      {scrolledToTop ? (
+        <Text style={textStyle}>scrolledToTop invoked</Text>
+      ) : null}
+      <ScrollView
+        accessibilityRole="grid"
+        ref={scrollView => {
+          _scrollView = scrollView;
+        }}
+        automaticallyAdjustContentInsets={false}
+        nestedScrollEnabled
+        onScroll={() => {
+          console.log('onScroll!');
+          setScrolledToTop(false);
+        }}
+        onScrollToTop={() => {
+          setScrolledToTop(true);
+        }}
+        scrollEventThrottle={200}
+        style={styles.scrollView}
+        testID="scroll_vertical">
+        {ITEMS.map(createItemRow)}
+      </ScrollView>
+      <Button
+        label="Scroll to top"
+        onPress={() => {
+          nullthrows<$FlowFixMe>(_scrollView).scrollTo({y: 0});
+        }}
+        testID="scroll_to_top_button"
+      />
+      <Button
+        label="Scroll to bottom"
+        onPress={() => {
+          nullthrows<$FlowFixMe>(_scrollView).scrollToEnd({animated: true});
+        }}
+        testID="scroll_to_bottom_button"
+      />
+      <Button
+        label="Flash scroll indicators"
+        onPress={() => {
+          nullthrows<$FlowFixMe>(_scrollView).flashScrollIndicators();
+        }}
+        testID="flash_scroll_indicators_button"
+      />
+    </View>
+  );
+}
+
 exports.displayName = 'ScrollViewExample';
 exports.title = 'ScrollView';
 exports.documentationURL = 'https://reactnative.dev/docs/scrollview';
@@ -205,49 +258,7 @@ const examples = ([
     title: '<ScrollView>\n',
     description:
       'To make content scrollable, wrap it within a <ScrollView> component',
-    render: function (): React.Node {
-      let _scrollView: ?React.ElementRef<typeof ScrollView>;
-      return (
-        <View>
-          <ScrollView
-            accessibilityRole="grid"
-            ref={scrollView => {
-              _scrollView = scrollView;
-            }}
-            automaticallyAdjustContentInsets={false}
-            nestedScrollEnabled
-            onScroll={() => {
-              console.log('onScroll!');
-            }}
-            scrollEventThrottle={200}
-            style={styles.scrollView}
-            testID="scroll_vertical">
-            {ITEMS.map(createItemRow)}
-          </ScrollView>
-          <Button
-            label="Scroll to top"
-            onPress={() => {
-              nullthrows<$FlowFixMe>(_scrollView).scrollTo({y: 0});
-            }}
-            testID="scroll_to_top_button"
-          />
-          <Button
-            label="Scroll to bottom"
-            onPress={() => {
-              nullthrows<$FlowFixMe>(_scrollView).scrollToEnd({animated: true});
-            }}
-            testID="scroll_to_bottom_button"
-          />
-          <Button
-            label="Flash scroll indicators"
-            onPress={() => {
-              nullthrows<$FlowFixMe>(_scrollView).flashScrollIndicators();
-            }}
-            testID="flash_scroll_indicators_button"
-          />
-        </View>
-      );
-    },
+    render: ScrollViewScrollToExample,
   },
   {
     name: 'horizontalScrollTo',


### PR DESCRIPTION
Summary:
Scroll view was not emitting the `onScrollToTop` event when the user tapped on the status bar.
This change fixes this by adding the event to the C++ Event Emitter and by invoking it into the `RCTScrollViewComponentView`

## Changelog
[iOS][Added] - Add onScrollToTop event in Fabric

Differential Revision: D52509919


