### PR TITLE
Add number type support for componetns

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
@@ -434,7 +434,7 @@ namespace JS {
       struct Builder {
         struct Input {
           std::optional<bool> D;
-          id<NSObject> _Nullable  A;
+          id<NSObject> _Nullable A;
           std::optional<JS::NativeOptionalObjectTurboModule::ConstantsE::Builder> E;
           NSString *F;
         };
@@ -1780,7 +1780,7 @@ namespace JS {
       struct Builder {
         struct Input {
           std::optional<bool> D;
-          id<NSObject> _Nullable  A;
+          id<NSObject> _Nullable A;
           std::optional<JS::NativeOptionalObjectTurboModule::ConstantsE::Builder> E;
           NSString *F;
         };

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -33,6 +33,10 @@ export type BooleanTypeAnnotation = $ReadOnly<{
   type: 'BooleanTypeAnnotation',
 }>;
 
+export type NumberTypeAnnotation = $ReadOnly<{
+  type: 'NumberTypeAnnotation',
+}>;
+
 export type Int32TypeAnnotation = $ReadOnly<{
   type: 'Int32TypeAnnotation',
 }>;
@@ -210,6 +214,7 @@ export type CommandTypeAnnotation = FunctionTypeAnnotation<
 export type CommandParamTypeAnnotation =
   | ReservedTypeAnnotation
   | BooleanTypeAnnotation
+  | NumberTypeAnnotation
   | Int32TypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation

--- a/packages/react-native-codegen/src/generators/TypeUtils/Cxx/index.js
+++ b/packages/react-native-codegen/src/generators/TypeUtils/Cxx/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+function wrapOptional(type: string, isRequired: boolean): string {
+  return isRequired ? type : `std::optional<${type}>`;
+}
+
+module.exports = {
+  wrapOptional,
+};

--- a/packages/react-native-codegen/src/generators/TypeUtils/Java/index.js
+++ b/packages/react-native-codegen/src/generators/TypeUtils/Java/index.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+const objectTypeForPrimitiveType = {
+  boolean: 'Boolean',
+  double: 'Double',
+  float: 'Float',
+  int: 'Integer',
+};
+
+function wrapOptional(type: string, isRequired: boolean): string {
+  return isRequired
+    ? type
+    : `@Nullable ${objectTypeForPrimitiveType[type] ?? type}`;
+}
+
+module.exports = {
+  wrapOptional,
+};

--- a/packages/react-native-codegen/src/generators/TypeUtils/Objective-C/index.js
+++ b/packages/react-native-codegen/src/generators/TypeUtils/Objective-C/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+function wrapOptional(type: string, isRequired: boolean): string {
+  return isRequired ? type : `${type} _Nullable`;
+}
+
+module.exports = {
+  wrapOptional,
+};

--- a/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
@@ -62,6 +62,7 @@ function getNativeTypeFromAnnotation(
     case 'BooleanTypeAnnotation':
     case 'StringTypeAnnotation':
     case 'Int32TypeAnnotation':
+    case 'NumberTypeAnnotation':
     case 'DoubleTypeAnnotation':
     case 'FloatTypeAnnotation':
       return getCppTypeForAnnotation(typeAnnotation.type);

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -25,6 +25,7 @@ function getCppTypeForAnnotation(
   type:
     | 'BooleanTypeAnnotation'
     | 'StringTypeAnnotation'
+    | 'NumberTypeAnnotation'
     | 'Int32TypeAnnotation'
     | 'DoubleTypeAnnotation'
     | 'FloatTypeAnnotation'
@@ -35,6 +36,8 @@ function getCppTypeForAnnotation(
       return 'bool';
     case 'StringTypeAnnotation':
       return 'std::string';
+    case 'NumberTypeAnnotation':
+      return 'double';
     case 'Int32TypeAnnotation':
       return 'int';
     case 'DoubleTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/components/GenerateComponentHObjCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateComponentHObjCpp.js
@@ -163,6 +163,8 @@ function getObjCParamType(param: Param): string {
       }
     case 'BooleanTypeAnnotation':
       return 'BOOL';
+    case 'NumberTypeAnnotation':
+      return 'double';
     case 'DoubleTypeAnnotation':
       return 'double';
     case 'FloatTypeAnnotation':
@@ -192,6 +194,8 @@ function getObjCExpectedKindParamType(param: Param): string {
           throw new Error(`Receieved invalid type: ${typeAnnotation.name}`);
       }
     case 'BooleanTypeAnnotation':
+      return '[NSNumber class]';
+    case 'NumberTypeAnnotation':
       return '[NSNumber class]';
     case 'DoubleTypeAnnotation':
       return '[NSNumber class]';
@@ -223,6 +227,8 @@ function getReadableExpectedKindParamType(param: Param): string {
       }
     case 'BooleanTypeAnnotation':
       return 'boolean';
+    case 'NumberTypeAnnotation':
+      return 'double';
     case 'DoubleTypeAnnotation':
       return 'double';
     case 'FloatTypeAnnotation':
@@ -256,6 +262,8 @@ function getObjCRightHandAssignmentParamType(
       }
     case 'BooleanTypeAnnotation':
       return `[(NSNumber *)arg${index} boolValue]`;
+    case 'NumberTypeAnnotation':
+      return `[(NSNumber *)arg${index} doubleValue]`;
     case 'DoubleTypeAnnotation':
       return `[(NSNumber *)arg${index} doubleValue]`;
     case 'FloatTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
@@ -194,6 +194,8 @@ function getCommandArgJavaType(
       }
     case 'BooleanTypeAnnotation':
       return `args.getBoolean(${index})`;
+    case 'NumberTypeAnnotation':
+      return `args.getDouble(${index})`;
     case 'DoubleTypeAnnotation':
       return `args.getDouble(${index})`;
     case 'FloatTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaInterface.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaInterface.js
@@ -163,6 +163,8 @@ function getCommandArgJavaType(param: NamedShape<CommandParamTypeAnnotation>) {
       }
     case 'BooleanTypeAnnotation':
       return 'boolean';
+    case 'NumberTypeAnnotation':
+      return 'double';
     case 'DoubleTypeAnnotation':
       return 'double';
     case 'FloatTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -22,6 +22,7 @@ import type {
 import type {AliasResolver} from './Utils';
 
 const {unwrapNullable} = require('../../parsers/parsers-commons');
+const {wrapOptional} = require('../TypeUtils/Java');
 const {createAliasResolver, getModules} = require('./Utils');
 
 type FilesOutput = Map<string, string>;
@@ -111,13 +112,8 @@ function translateFunctionParamToJavaType(
   const [typeAnnotation, nullable] =
     unwrapNullable<NativeModuleParamTypeAnnotation>(nullableTypeAnnotation);
   const isRequired = !optional && !nullable;
-
-  function wrapNullable(javaType: string, nullableType?: string) {
-    if (!isRequired) {
-      imports.add('javax.annotation.Nullable');
-      return `@Nullable ${nullableType ?? javaType}`;
-    }
-    return javaType;
+  if (!isRequired) {
+    imports.add('javax.annotation.Nullable');
   }
 
   // FIXME: support class alias for args
@@ -130,41 +126,41 @@ function translateFunctionParamToJavaType(
     case 'ReservedTypeAnnotation':
       switch (realTypeAnnotation.name) {
         case 'RootTag':
-          return wrapNullable('double', 'Double');
+          return wrapOptional('double', isRequired);
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(createErrorMessage(realTypeAnnotation.name));
       }
     case 'StringTypeAnnotation':
-      return wrapNullable('String');
+      return wrapOptional('String', isRequired);
     case 'NumberTypeAnnotation':
-      return wrapNullable('double', 'Double');
+      return wrapOptional('double', isRequired);
     case 'FloatTypeAnnotation':
-      return wrapNullable('double', 'Double');
+      return wrapOptional('double', isRequired);
     case 'DoubleTypeAnnotation':
-      return wrapNullable('double', 'Double');
+      return wrapOptional('double', isRequired);
     case 'Int32TypeAnnotation':
-      return wrapNullable('double', 'Double');
+      return wrapOptional('double', isRequired);
     case 'BooleanTypeAnnotation':
-      return wrapNullable('boolean', 'Boolean');
+      return wrapOptional('boolean', isRequired);
     case 'EnumDeclaration':
       switch (realTypeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
-          return wrapNullable('double', 'Double');
+          return wrapOptional('double', isRequired);
         case 'StringTypeAnnotation':
-          return wrapNullable('String');
+          return wrapOptional('String', isRequired);
         default:
           throw new Error(createErrorMessage(realTypeAnnotation.type));
       }
     case 'UnionTypeAnnotation':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
-          return wrapNullable('double', 'Double');
+          return wrapOptional('double', isRequired);
         case 'ObjectTypeAnnotation':
           imports.add('com.facebook.react.bridge.ReadableMap');
-          return wrapNullable('ReadableMap');
+          return wrapOptional('ReadableMap', isRequired);
         case 'StringTypeAnnotation':
-          return wrapNullable('String');
+          return wrapOptional('String', isRequired);
         default:
           throw new Error(
             `Unsupported union member returning value, found: ${realTypeAnnotation.memberType}"`,
@@ -172,17 +168,17 @@ function translateFunctionParamToJavaType(
       }
     case 'ObjectTypeAnnotation':
       imports.add('com.facebook.react.bridge.ReadableMap');
-      return wrapNullable('ReadableMap');
+      return wrapOptional('ReadableMap', isRequired);
     case 'GenericObjectTypeAnnotation':
       // Treat this the same as ObjectTypeAnnotation for now.
       imports.add('com.facebook.react.bridge.ReadableMap');
-      return wrapNullable('ReadableMap');
+      return wrapOptional('ReadableMap', isRequired);
     case 'ArrayTypeAnnotation':
       imports.add('com.facebook.react.bridge.ReadableArray');
-      return wrapNullable('ReadableArray');
+      return wrapOptional('ReadableArray', isRequired);
     case 'FunctionTypeAnnotation':
       imports.add('com.facebook.react.bridge.Callback');
-      return wrapNullable('Callback');
+      return wrapOptional('Callback', isRequired);
     default:
       (realTypeAnnotation.type: 'MixedTypeAnnotation');
       throw new Error(createErrorMessage(realTypeAnnotation.type));
@@ -200,13 +196,11 @@ function translateFunctionReturnTypeToJavaType(
       nullableReturnTypeAnnotation,
     );
 
-  function wrapNullable(javaType: string, nullableType?: string) {
-    if (nullable) {
-      imports.add('javax.annotation.Nullable');
-      return `@Nullable ${nullableType ?? javaType}`;
-    }
-    return javaType;
+  if (nullable) {
+    imports.add('javax.annotation.Nullable');
   }
+
+  const isRequired = !nullable;
 
   // FIXME: support class alias for args
   let realTypeAnnotation = returnTypeAnnotation;
@@ -218,7 +212,7 @@ function translateFunctionReturnTypeToJavaType(
     case 'ReservedTypeAnnotation':
       switch (realTypeAnnotation.name) {
         case 'RootTag':
-          return wrapNullable('double', 'Double');
+          return wrapOptional('double', isRequired);
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(createErrorMessage(realTypeAnnotation.name));
@@ -228,35 +222,35 @@ function translateFunctionReturnTypeToJavaType(
     case 'PromiseTypeAnnotation':
       return 'void';
     case 'StringTypeAnnotation':
-      return wrapNullable('String');
+      return wrapOptional('String', isRequired);
     case 'NumberTypeAnnotation':
-      return wrapNullable('double', 'Double');
+      return wrapOptional('double', isRequired);
     case 'FloatTypeAnnotation':
-      return wrapNullable('double', 'Double');
+      return wrapOptional('double', isRequired);
     case 'DoubleTypeAnnotation':
-      return wrapNullable('double', 'Double');
+      return wrapOptional('double', isRequired);
     case 'Int32TypeAnnotation':
-      return wrapNullable('double', 'Double');
+      return wrapOptional('double', isRequired);
     case 'BooleanTypeAnnotation':
-      return wrapNullable('boolean', 'Boolean');
+      return wrapOptional('boolean', isRequired);
     case 'EnumDeclaration':
       switch (realTypeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
-          return wrapNullable('double', 'Double');
+          return wrapOptional('double', isRequired);
         case 'StringTypeAnnotation':
-          return wrapNullable('String');
+          return wrapOptional('String', isRequired);
         default:
           throw new Error(createErrorMessage(realTypeAnnotation.type));
       }
     case 'UnionTypeAnnotation':
       switch (realTypeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
-          return wrapNullable('double', 'Double');
+          return wrapOptional('double', isRequired);
         case 'ObjectTypeAnnotation':
           imports.add('com.facebook.react.bridge.WritableMap');
-          return wrapNullable('WritableMap');
+          return wrapOptional('WritableMap', isRequired);
         case 'StringTypeAnnotation':
-          return wrapNullable('String');
+          return wrapOptional('String', isRequired);
         default:
           throw new Error(
             `Unsupported union member returning value, found: ${realTypeAnnotation.memberType}"`,
@@ -264,13 +258,13 @@ function translateFunctionReturnTypeToJavaType(
       }
     case 'ObjectTypeAnnotation':
       imports.add('com.facebook.react.bridge.WritableMap');
-      return wrapNullable('WritableMap');
+      return wrapOptional('WritableMap', isRequired);
     case 'GenericObjectTypeAnnotation':
       imports.add('com.facebook.react.bridge.WritableMap');
-      return wrapNullable('WritableMap');
+      return wrapOptional('WritableMap', isRequired);
     case 'ArrayTypeAnnotation':
       imports.add('com.facebook.react.bridge.WritableArray');
-      return wrapNullable('WritableArray');
+      return wrapOptional('WritableArray', isRequired);
     default:
       (realTypeAnnotation.type: 'MixedTypeAnnotation');
       throw new Error(createErrorMessage(realTypeAnnotation.type));

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -136,11 +136,11 @@ function translateFunctionParamToJavaType(
     case 'NumberTypeAnnotation':
       return wrapOptional('double', isRequired);
     case 'FloatTypeAnnotation':
-      return wrapOptional('double', isRequired);
+      return wrapOptional('float', isRequired);
     case 'DoubleTypeAnnotation':
       return wrapOptional('double', isRequired);
     case 'Int32TypeAnnotation':
-      return wrapOptional('double', isRequired);
+      return wrapOptional('int', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapOptional('boolean', isRequired);
     case 'EnumDeclaration':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -334,9 +334,9 @@ function translateReturnTypeToJniType(
     case 'DoubleTypeAnnotation':
       return nullable ? 'Ljava/lang/Double;' : 'D';
     case 'FloatTypeAnnotation':
-      return nullable ? 'Ljava/lang/Double;' : 'D';
+      return nullable ? 'Ljava/lang/Float;' : 'F';
     case 'Int32TypeAnnotation':
-      return nullable ? 'Ljava/lang/Double;' : 'D';
+      return nullable ? 'Ljava/lang/Integer;' : 'I';
     case 'PromiseTypeAnnotation':
       return 'Lcom/facebook/react/bridge/Promise;';
     case 'GenericObjectTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
@@ -15,6 +15,10 @@ import type {RegularStruct, StructTypeAnnotation} from '../StructCollector';
 import type {StructSerilizationOutput} from './serializeStruct';
 
 const {unwrapNullable} = require('../../../../parsers/parsers-commons');
+const {wrapOptional: wrapCxxOptional} = require('../../../TypeUtils/Cxx');
+const {
+  wrapOptional: wrapObjCOptional,
+} = require('../../../TypeUtils/Objective-C');
 const {capitalize} = require('../../../Utils');
 const {getNamespacedStructName, getSafePropertyName} = require('../Utils');
 
@@ -69,15 +73,12 @@ function toObjCType(
 ): string {
   const [typeAnnotation, nullable] = unwrapNullable(nullableTypeAnnotation);
   const isRequired = !nullable && !isOptional;
-  const wrapOptional = (type: string) => {
-    return isRequired ? type : `std::optional<${type}>`;
-  };
 
   switch (typeAnnotation.type) {
     case 'ReservedTypeAnnotation':
       switch (typeAnnotation.name) {
         case 'RootTag':
-          return wrapOptional('double');
+          return wrapCxxOptional('double', isRequired);
         default:
           (typeAnnotation.name: empty);
           throw new Error(`Unknown prop type, found: ${typeAnnotation.name}"`);
@@ -85,19 +86,19 @@ function toObjCType(
     case 'StringTypeAnnotation':
       return 'NSString *';
     case 'NumberTypeAnnotation':
-      return wrapOptional('double');
+      return wrapCxxOptional('double', isRequired);
     case 'FloatTypeAnnotation':
-      return wrapOptional('double');
+      return wrapCxxOptional('double', isRequired);
     case 'Int32TypeAnnotation':
-      return wrapOptional('double');
+      return wrapCxxOptional('double', isRequired);
     case 'DoubleTypeAnnotation':
-      return wrapOptional('double');
+      return wrapCxxOptional('double', isRequired);
     case 'BooleanTypeAnnotation':
-      return wrapOptional('bool');
+      return wrapCxxOptional('bool', isRequired);
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
-          return wrapOptional('double');
+          return wrapCxxOptional('double', isRequired);
         case 'StringTypeAnnotation':
           return 'NSString *';
         default:
@@ -106,16 +107,17 @@ function toObjCType(
           );
       }
     case 'GenericObjectTypeAnnotation':
-      return isRequired ? 'id<NSObject> ' : 'id<NSObject> _Nullable';
+      return wrapObjCOptional('id<NSObject>', isRequired);
     case 'ArrayTypeAnnotation':
       if (typeAnnotation.elementType == null) {
-        return isRequired ? 'id<NSObject> ' : 'id<NSObject> _Nullable';
+        return wrapObjCOptional('id<NSObject>', isRequired);
       }
-      return wrapOptional(
+      return wrapCxxOptional(
         `facebook::react::LazyVector<${toObjCType(
           hasteModuleName,
           typeAnnotation.elementType,
         )}>`,
+        isRequired,
       );
     case 'TypeAliasTypeAnnotation':
       const structName = capitalize(typeAnnotation.name);
@@ -123,7 +125,7 @@ function toObjCType(
         hasteModuleName,
         structName,
       );
-      return wrapOptional(namespacedStructName);
+      return wrapCxxOptional(namespacedStructName, isRequired);
     default:
       (typeAnnotation.type: empty);
       throw new Error(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -24,6 +24,7 @@ const {
   unwrapNullable,
   wrapNullable,
 } = require('../../../parsers/parsers-commons');
+const {wrapOptional} = require('../../TypeUtils/Objective-C');
 const {capitalize} = require('../../Utils');
 const {getNamespacedStructName} = require('./Utils');
 const invariant = require('invariant');
@@ -188,11 +189,7 @@ function getParamObjCType(
 ): $ReadOnly<{objCType: string, isStruct: boolean}> {
   const {name: paramName, typeAnnotation: nullableTypeAnnotation} = param;
   const [typeAnnotation, nullable] = unwrapNullable(nullableTypeAnnotation);
-  const notRequired = param.optional || nullable;
-
-  function wrapIntoNullableIfNeeded(generatedType: string) {
-    return nullable ? `${generatedType} _Nullable` : generatedType;
-  }
+  const isRequired = !param.optional && !nullable;
 
   const isStruct = (objCType: string) => ({
     isStruct: true,
@@ -220,7 +217,7 @@ function getParamObjCType(
        *   type Animal = {};
        *   Array<Animal> => NSArray<JS::NativeSampleTurboModule::Animal *>, etc.
        */
-      return notStruct(wrapIntoNullableIfNeeded('NSArray *'));
+      return notStruct(wrapOptional('NSArray *', !nullable));
     }
   }
 
@@ -251,7 +248,7 @@ function getParamObjCType(
     case 'ReservedTypeAnnotation':
       switch (structTypeAnnotation.name) {
         case 'RootTag':
-          return notStruct(notRequired ? 'NSNumber *' : 'double');
+          return notStruct(isRequired ? 'double' : 'NSNumber *');
         default:
           (structTypeAnnotation.name: empty);
           throw new Error(
@@ -259,30 +256,30 @@ function getParamObjCType(
           );
       }
     case 'StringTypeAnnotation':
-      return notStruct(wrapIntoNullableIfNeeded('NSString *'));
+      return notStruct(wrapOptional('NSString *', !nullable));
     case 'NumberTypeAnnotation':
-      return notStruct(notRequired ? 'NSNumber *' : 'double');
+      return notStruct(isRequired ? 'double' : 'NSNumber *');
     case 'FloatTypeAnnotation':
-      return notStruct(notRequired ? 'NSNumber *' : 'double');
+      return notStruct(isRequired ? 'double' : 'NSNumber *');
     case 'DoubleTypeAnnotation':
-      return notStruct(notRequired ? 'NSNumber *' : 'double');
+      return notStruct(isRequired ? 'double' : 'NSNumber *');
     case 'Int32TypeAnnotation':
-      return notStruct(notRequired ? 'NSNumber *' : 'double');
+      return notStruct(isRequired ? 'double' : 'NSNumber *');
     case 'BooleanTypeAnnotation':
-      return notStruct(notRequired ? 'NSNumber *' : 'BOOL');
+      return notStruct(isRequired ? 'BOOL' : 'NSNumber *');
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
-          return notStruct(notRequired ? 'NSNumber *' : 'double');
+          return notStruct(isRequired ? 'double' : 'NSNumber *');
         case 'StringTypeAnnotation':
-          return notStruct(wrapIntoNullableIfNeeded('NSString *'));
+          return notStruct(wrapOptional('NSString *', !nullable));
         default:
           throw new Error(
             `Unsupported enum type for param "${paramName}" in ${methodName}. Found: ${typeAnnotation.type}`,
           );
       }
     case 'GenericObjectTypeAnnotation':
-      return notStruct(wrapIntoNullableIfNeeded('NSDictionary *'));
+      return notStruct(wrapOptional('NSDictionary *', !nullable));
     default:
       (structTypeAnnotation.type: empty);
       throw new Error(
@@ -296,10 +293,7 @@ function getReturnObjCType(
   nullableTypeAnnotation: Nullable<NativeModuleReturnTypeAnnotation>,
 ): string {
   const [typeAnnotation, nullable] = unwrapNullable(nullableTypeAnnotation);
-
-  function wrapIntoNullableIfNeeded(generatedType: string) {
-    return nullable ? `${generatedType} _Nullable` : generatedType;
-  }
+  const isRequired = !nullable;
 
   switch (typeAnnotation.type) {
     case 'VoidTypeAnnotation':
@@ -307,24 +301,25 @@ function getReturnObjCType(
     case 'PromiseTypeAnnotation':
       return 'void';
     case 'ObjectTypeAnnotation':
-      return wrapIntoNullableIfNeeded('NSDictionary *');
+      return wrapOptional('NSDictionary *', isRequired);
     case 'TypeAliasTypeAnnotation':
-      return wrapIntoNullableIfNeeded('NSDictionary *');
+      return wrapOptional('NSDictionary *', isRequired);
     case 'ArrayTypeAnnotation':
       if (typeAnnotation.elementType == null) {
-        return wrapIntoNullableIfNeeded('NSArray<id<NSObject>> *');
+        return wrapOptional('NSArray<id<NSObject>> *', isRequired);
       }
 
-      return wrapIntoNullableIfNeeded(
+      return wrapOptional(
         `NSArray<${getReturnObjCType(
           methodName,
           typeAnnotation.elementType,
         )}> *`,
+        isRequired,
       );
     case 'ReservedTypeAnnotation':
       switch (typeAnnotation.name) {
         case 'RootTag':
-          return wrapIntoNullableIfNeeded('NSNumber *');
+          return wrapOptional('NSNumber *', isRequired);
         default:
           (typeAnnotation.name: empty);
           throw new Error(
@@ -334,23 +329,23 @@ function getReturnObjCType(
     case 'StringTypeAnnotation':
       // TODO: Can NSString * returns not be _Nullable?
       // In the legacy codegen, we don't surround NSSTring * with _Nullable
-      return wrapIntoNullableIfNeeded('NSString *');
+      return wrapOptional('NSString *', isRequired);
     case 'NumberTypeAnnotation':
-      return wrapIntoNullableIfNeeded('NSNumber *');
+      return wrapOptional('NSNumber *', isRequired);
     case 'FloatTypeAnnotation':
-      return wrapIntoNullableIfNeeded('NSNumber *');
+      return wrapOptional('NSNumber *', isRequired);
     case 'DoubleTypeAnnotation':
-      return wrapIntoNullableIfNeeded('NSNumber *');
+      return wrapOptional('NSNumber *', isRequired);
     case 'Int32TypeAnnotation':
-      return wrapIntoNullableIfNeeded('NSNumber *');
+      return wrapOptional('NSNumber *', isRequired);
     case 'BooleanTypeAnnotation':
-      return wrapIntoNullableIfNeeded('NSNumber *');
+      return wrapOptional('NSNumber *', isRequired);
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
-          return wrapIntoNullableIfNeeded('NSNumber *');
+          return wrapOptional('NSNumber *', isRequired);
         case 'StringTypeAnnotation':
-          return wrapIntoNullableIfNeeded('NSString *');
+          return wrapOptional('NSString *', isRequired);
         default:
           throw new Error(
             `Unsupported enum return type for ${methodName}. Found: ${typeAnnotation.type}`,
@@ -359,20 +354,20 @@ function getReturnObjCType(
     case 'UnionTypeAnnotation':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
-          return wrapIntoNullableIfNeeded('NSNumber *');
+          return wrapOptional('NSNumber *', isRequired);
         case 'ObjectTypeAnnotation':
-          return wrapIntoNullableIfNeeded('NSDictionary *');
+          return wrapOptional('NSDictionary *', isRequired);
         case 'StringTypeAnnotation':
           // TODO: Can NSString * returns not be _Nullable?
           // In the legacy codegen, we don't surround NSSTring * with _Nullable
-          return wrapIntoNullableIfNeeded('NSString *');
+          return wrapOptional('NSString *', isRequired);
         default:
           throw new Error(
             `Unsupported union return type for ${methodName}, found: ${typeAnnotation.memberType}"`,
           );
       }
     case 'GenericObjectTypeAnnotation':
-      return wrapIntoNullableIfNeeded('NSDictionary *');
+      return wrapOptional('NSDictionary *', isRequired);
     default:
       (typeAnnotation.type: 'MixedTypeAnnotation');
       throw new Error(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -255,11 +255,11 @@ function getParamObjCType(
     case 'NumberTypeAnnotation':
       return isRequired ? 'double' : 'NSNumber *';
     case 'FloatTypeAnnotation':
-      return isRequired ? 'double' : 'NSNumber *';
+      return isRequired ? 'float' : 'NSNumber *';
     case 'DoubleTypeAnnotation':
       return isRequired ? 'double' : 'NSNumber *';
     case 'Int32TypeAnnotation':
-      return isRequired ? 'double' : 'NSNumber *';
+      return isRequired ? 'NSInteger' : 'NSNumber *';
     case 'BooleanTypeAnnotation':
       return isRequired ? 'BOOL' : 'NSNumber *';
     case 'EnumDeclaration':

--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/failures.js
@@ -405,35 +405,6 @@ export default (codegenNativeComponent<ModuleProps>(
 ): HostComponent<ModuleProps>);
 `;
 
-const PROP_NUMBER_TYPE = `
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
- * @flow strict-local
- */
-
-'use strict';
-
-import type {ViewProps} from 'ViewPropTypes';
-import type {HostComponent} from 'react-native';
-
-const codegenNativeComponent = require('codegenNativeComponent');
-
-export type ModuleProps = $ReadOnly<{|
-  ...ViewProps,
-
-  someProp: number
-|}>;
-
-export default (codegenNativeComponent<ModuleProps>(
-  'Module',
-): HostComponent<ModuleProps>);
-`;
-
 const PROP_MIXED_ENUM = `
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -591,7 +562,6 @@ module.exports = {
   PROPS_CONFLICT_NAMES,
   PROPS_CONFLICT_WITH_SPREAD_PROPS,
   PROPS_SPREAD_CONFLICTS_WITH_PROPS,
-  PROP_NUMBER_TYPE,
   PROP_MIXED_ENUM,
   PROP_ENUM_BOOLEAN,
   PROP_ARRAY_MIXED_ENUM,

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
@@ -26,8 +26,6 @@ exports[`RN Codegen Flow Parser Fails with error message PROP_ENUM_BOOLEAN 1`] =
 
 exports[`RN Codegen Flow Parser Fails with error message PROP_MIXED_ENUM 1`] = `"Mixed types are not supported (see \\"someProp\\")."`;
 
-exports[`RN Codegen Flow Parser Fails with error message PROP_NUMBER_TYPE 1`] = `"Cannot use \\"NumberTypeAnnotation\\" type annotation for \\"someProp\\": must use a specific numeric type like Int32, Double, or Float"`;
-
 exports[`RN Codegen Flow Parser Fails with error message PROPS_CONFLICT_NAMES 1`] = `"A prop was already defined with the name isEnabled"`;
 
 exports[`RN Codegen Flow Parser Fails with error message PROPS_CONFLICT_WITH_SPREAD_PROPS 1`] = `"A prop was already defined with the name isEnabled"`;

--- a/packages/react-native-codegen/src/parsers/flow/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/commands.js
@@ -80,6 +80,11 @@ function buildCommandSchema(
           type: 'BooleanTypeAnnotation',
         };
         break;
+      case 'NumberTypeAnnotation':
+        returnType = {
+          type: 'NumberTypeAnnotation',
+        };
+        break;
       case 'Int32':
         returnType = {
           type: 'Int32TypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -127,6 +127,10 @@ function getTypeAnnotationForArray<+T>(
       return {
         type: 'Int32TypeAnnotation',
       };
+    case 'NumberTypeAnnotation':
+      return {
+        type: 'NumberTypeAnnotation',
+      };
     case 'Double':
       return {
         type: 'DoubleTypeAnnotation',
@@ -303,6 +307,11 @@ function getTypeAnnotation<+T>(
         type: 'Int32TypeAnnotation',
         default: ((defaultValue ? defaultValue : 0): number),
       };
+    case 'NumberTypeAnnotation':
+      return {
+        type: 'NumberTypeAnnotation',
+        default: ((defaultValue ? defaultValue : 0): number),
+      };
     case 'Double':
       return {
         type: 'DoubleTypeAnnotation',
@@ -371,10 +380,6 @@ function getTypeAnnotation<+T>(
     case 'ObjectTypeAnnotation':
       throw new Error(
         `Cannot use "${type}" type annotation for "${name}": object types must be declared using $ReadOnly<>`,
-      );
-    case 'NumberTypeAnnotation':
-      throw new Error(
-        `Cannot use "${type}" type annotation for "${name}": must use a specific numeric type like Int32, Double, or Float`,
       );
     case 'UnsafeMixed':
       return {


### PR DESCRIPTION
Summary:
This diff adds support for `number` type annotation for components.
Before this diff:
|Codegen Type|Objective-C Type|Java Type|
| -- | -- |
|number|double|double|

Changelog: [General][Added] - Codegen: added support for `number` type annotation for components.

Differential Revision: D52481049


