### PR TITLE
Remove suppressions for Wgnu-zero-variadic-macro-arguments

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JCallback.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JCallback.h
@@ -29,16 +29,9 @@ class JCxxCallbackImpl : public jni::HybridClass<JCxxCallbackImpl, JCallback> {
       "Lcom/facebook/react/bridge/CxxCallbackImpl;";
 
   static void registerNatives() {
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
     javaClassStatic()->registerNatives({
         makeNativeMethod("nativeInvoke", JCxxCallbackImpl::invoke),
     });
-#if __clang__
-#pragma clang diagnostic pop
-#endif
   }
 
  private:

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 folly_dep_name = 'RCT-Folly/Fabric'
 boost_compiler_flags = '-Wno-documentation'

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 folly_dep_name = 'RCT-Folly/Fabric'
 boost_compiler_flags = '-Wno-documentation'

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 boost_compiler_flags = '-Wno-documentation'
 using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"

--- a/packages/react-native/ReactCommon/butter/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/butter/CMakeLists.txt
@@ -12,8 +12,7 @@ add_compile_options(
         -frtti
         -std=c++20
         -Wall
-        -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments)
+        -Wpedantic)
 
 add_library(butter INTERFACE)
 

--- a/packages/react-native/ReactCommon/callinvoker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/callinvoker/CMakeLists.txt
@@ -11,8 +11,7 @@ add_compile_options(
         -frtti
         -std=c++20
         -Wall
-        -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments)
+        -Wpedantic)
 
 add_library(callinvoker INTERFACE)
 

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 folly_dep_name = 'RCT-Folly/Fabric'
 boost_compiler_flags = '-Wno-documentation'

--- a/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"ReactNative\")
 
 file(GLOB react_bridging_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/config/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/config/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_config_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"ReactNative\")
 
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 boost_compiler_flags = '-Wno-documentation'
 using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 boost_compiler_flags = '-Wno-documentation'
 using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DFOLLY_NO_CONFIG=1
         -DLOG_TAG=\"ReactNative\")
 

--- a/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_animations_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_attributedstring_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_componentregistry_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_native_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_image_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_legacyviewmanagerinterop_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_modal_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_progressbar_SRC CONFIGURE_DEPENDS android/react/renderer/components/progressbar/*.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_root_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_scrollview_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
@@ -42,5 +42,4 @@ target_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
 )

--- a/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_text_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS platform/android/react/renderer/components/androidtextinput/*.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_unimplementedview_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_view_SRC CONFIGURE_DEPENDS

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_core_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_debug_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_element_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_graphics_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_imagemanager_SRC CONFIGURE_DEPENDS

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_leakchecker_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_mounting_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_runtimescheduler_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_scheduler_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_telemetry_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_textlayourmanager_SRC CONFIGURE_DEPENDS

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_uimanager_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 folly_dep_name = 'RCT-Folly/Fabric'
 boost_compiler_flags = '-Wno-documentation'

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 folly_dep_name = 'RCT-Folly/Fabric'
 boost_compiler_flags = '-Wno-documentation'

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2023.08.07.00'
 folly_dep_name = 'RCT-Folly/Fabric'
 boost_compiler_flags = '-Wno-documentation'

--- a/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_utils_SRC CONFIGURE_DEPENDS *.cpp *.mm)

--- a/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
@@ -11,8 +11,7 @@ add_compile_options(
         -frtti
         -std=c++20
         -Wall
-        -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments)
+        -Wpedantic)
 
 file(GLOB reactperflogger_SRC CONFIGURE_DEPENDS reactperflogger/*.cpp)
 add_library(reactperflogger STATIC ${reactperflogger_SRC})

--- a/packages/react-native/ReactCommon/runtimeexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/runtimeexecutor/CMakeLists.txt
@@ -11,8 +11,7 @@ add_compile_options(
         -frtti
         -std=c++20
         -Wall
-        -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments)
+        -Wpedantic)
 
 file(GLOB_RECURSE runtimeexecutor_SRC CONFIGURE_DEPENDS *.cpp *.h)
 

--- a/packages/rn-tester/NativeCxxModuleExample/CMakeLists.txt
+++ b/packages/rn-tester/NativeCxxModuleExample/CMakeLists.txt
@@ -12,7 +12,6 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments
         -DFOLLY_NO_CONFIG=1
         -DLOG_TAG=\"ReactNative\")
 


### PR DESCRIPTION
Summary:
`Wpedantic` flags usage of variadic macros with zero arguments. This is widely supported by different compilers (including MSVC), but was previously forbidden by the standard.

C++ 20 explicitly allows them, so, theoretically Clang should know not to warn about these now. Let's try that.

Changelog: [Internal]

Differential Revision: D52534129

