### PR TITLE
Fix New Arch build failing with `-std=c++20`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.h
@@ -17,6 +17,11 @@ namespace react {
 // It should be used as infrequently as possible - most props can and should
 // be parsed without any context.
 struct PropsParserContext {
+  PropsParserContext(
+      SurfaceId const surfaceId,
+      ContextContainer const &contextContainer)
+      : surfaceId(surfaceId), contextContainer(contextContainer) {}
+
   // Non-copyable
   PropsParserContext(const PropsParserContext &) = delete;
   PropsParserContext &operator=(const PropsParserContext &) = delete;


### PR DESCRIPTION
## Summary:

`React-Fabric` fails to build because implicit constructors are no longer generated.

```
❌ /~/example/ios/Pods/Headers/Public/React-Fabric/react/renderer/core/RawPropsParser.h:50:24: no matching constructor for initialization of 'PropsParserContext'
    PropsParserContext parserContext{-1, contextContainer};
                       ^            ~~~~~~~~~~~~~~~~~~~~~~
```

This was fixed in 0.73 here: https://github.com/facebook/react-native/commit/e1876af923647ff8c10057414cf502e40feafdc6#diff-696b8d801910a87b0ba34645cfefcf01238c3f670d0e956a274091a6c950cc12

## Changelog:

[IOS] [FIXED] - `React-Fabric` fails to build with `-std=c++20` because implicit constructors are no longer generated

## Test Plan:

n/a