### PR TITLE
[RN][iOS] Disable Bitcode for Hermes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ references:
     gems_cache_key: &gems_cache_key v1-gems-{{ checksum "Gemfile.lock" }}
     gradle_cache_key: &gradle_cache_key v1-gradle-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "packages/react-native/ReactAndroid/gradle.properties" }}
     hermes_workspace_cache_key: &hermes_workspace_cache_key v4-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
-    hermes_workspace_debug_cache_key: &hermes_workspace_debug_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    hermes_workspace_release_cache_key: &hermes_workspace_release_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
+    hermes_workspace_debug_cache_key: &hermes_workspace_debug_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
+    hermes_workspace_release_cache_key: &hermes_workspace_release_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_linux_cache_key: &hermes_linux_cache_key v1-hermes-{{ .Environment.CIRCLE_JOB }}-linux-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_windows_cache_key: &hermes_windows_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-windows-{{ checksum "/Users/circleci/project/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v4-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -52,13 +52,9 @@ function build_host_hermesc {
 
 # Utility function to configure an Apple framework
 function configure_apple_framework {
-  local build_cli_tools enable_bitcode enable_debugger cmake_build_type xcode_15_flags xcode_major_version
+  local build_cli_tools enable_debugger cmake_build_type xcode_15_flags xcode_major_version
 
-  if [[ $1 == iphoneos || $1 == catalyst ]]; then
-    enable_bitcode="true"
-  else
-    enable_bitcode="false"
-  fi
+
   if [[ $1 == macosx ]]; then
     build_cli_tools="true"
   else
@@ -94,7 +90,7 @@ function configure_apple_framework {
       -DHERMES_ENABLE_LIBFUZZER:BOOLEAN=false \
       -DHERMES_ENABLE_FUZZILLI:BOOLEAN=false \
       -DHERMES_ENABLE_TEST_SUITE:BOOLEAN=false \
-      -DHERMES_ENABLE_BITCODE:BOOLEAN="$enable_bitcode" \
+      -DHERMES_ENABLE_BITCODE:BOOLEAN=false \
       -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true \
       -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true \
       -DHERMES_ENABLE_TOOLS:BOOLEAN="$build_cli_tools" \


### PR DESCRIPTION
## Summary:
Backports the commit https://github.com/facebook/react-native/commit/de6bfec82a1cb4b387bfe8a87b1f597f39572764 to 0.72.

Disabling the Bitcode has several benefits:
1. Downloading artifacts while testing will take much less time
2. Creating a new app will take less time
3. The Space occupied on Dev's machine is sensibly smaller

Community testing reported that the tarball size get reduced from ~500 Mb to ~25 Mb, a x20 reduction

## Changelog:

[iOS][Changed] - Disabled bitcode for Hermes prebuilts

## Test Plan:
Wait for CircleCI...