### PR TITLE
Support specifying dist-tags for monorepo package bumps

### DIFF
--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -111,6 +111,29 @@ describe('npm-utils', () => {
         {cwd: 'path/to/my-package'},
       );
     });
+
+    it('should handle multiple tags', () => {
+      publishPackage('path/to/my-package', {
+        tags: ['next', '0.72-stable'],
+        otp: 'otp',
+      });
+      expect(execMock).toHaveBeenCalledWith(
+        'npm publish --tag next --tag 0.72-stable --otp otp',
+        {cwd: 'path/to/my-package'},
+      );
+    });
+
+    it('should be able to handle tag and tags, although shouldnt be encouraged', () => {
+      publishPackage('path/to/my-package', {
+        tags: ['next', '0.72-stable'],
+        tag: 'latest',
+        otp: 'otp',
+      });
+      expect(execMock).toHaveBeenCalledWith(
+        'npm publish --tag latest --tag next --tag 0.72-stable --otp otp',
+        {cwd: 'path/to/my-package'},
+      );
+    });
   });
 
   describe('getNpmInfo', () => {

--- a/scripts/monorepo/__tests__/find-and-publish-all-bumped-packages-test.js
+++ b/scripts/monorepo/__tests__/find-and-publish-all-bumped-packages-test.js
@@ -8,7 +8,10 @@
  */
 
 const {PUBLISH_PACKAGES_TAG} = require('../constants');
-const findAndPublishAllBumpedPackages = require('../find-and-publish-all-bumped-packages');
+const {
+  findAndPublishAllBumpedPackages,
+  getTagsFromCommitMessage,
+} = require('../find-and-publish-all-bumped-packages');
 const forEachPackage = require('../for-each-package');
 const {spawnSync} = require('child_process');
 
@@ -21,6 +24,7 @@ describe('findAndPublishAllBumpedPackages', () => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
   });
   it('throws an error if updated version is not 0.x.y', () => {
+    console.log('we setting up the mocks');
     const mockedPackageNewVersion = '1.0.0';
 
     forEachPackage.mockImplementationOnce(callback => {
@@ -40,5 +44,16 @@ describe('findAndPublishAllBumpedPackages', () => {
     expect(() => findAndPublishAllBumpedPackages()).toThrow(
       `Package version expected to be 0.x.y, but received ${mockedPackageNewVersion}`,
     );
+  });
+});
+
+describe('getTagsFromCommitMessage', () => {
+  it('should parse tags out', () => {
+    const commitMsg = `This may be any commit message before it like tag a \n\n${PUBLISH_PACKAGES_TAG}&tagA&tagB&tagA\n`;
+    expect(getTagsFromCommitMessage(commitMsg)).toEqual([
+      'tagA',
+      'tagB',
+      'tagA',
+    ]);
   });
 });

--- a/scripts/monorepo/find-and-publish-all-bumped-packages.js
+++ b/scripts/monorepo/find-and-publish-all-bumped-packages.js
@@ -16,6 +16,16 @@ const path = require('path');
 const ROOT_LOCATION = path.join(__dirname, '..', '..');
 const NPM_CONFIG_OTP = process.env.NPM_CONFIG_OTP;
 
+function getTagsFromCommitMessage(msg) {
+  // ex message we're trying to parse tags out of
+  // `_some_message_here_${PUBLISH_PACKAGES_TAG}&tagA&tagB\n`;
+  return msg
+    .substring(msg.indexOf(PUBLISH_PACKAGES_TAG))
+    .trim()
+    .split('&')
+    .slice(1);
+}
+
 const findAndPublishAllBumpedPackages = () => {
   console.log('Traversing all packages inside /packages...');
 
@@ -101,7 +111,12 @@ const findAndPublishAllBumpedPackages = () => {
         );
       }
 
-      const result = publishPackage(packageAbsolutePath, {otp: NPM_CONFIG_OTP});
+      const tags = getTagsFromCommitMessage(commitMessage);
+
+      const result = publishPackage(packageAbsolutePath, {
+        tags,
+        otp: NPM_CONFIG_OTP,
+      });
       if (result.code !== 0) {
         console.log(
           `\u274c Failed to publish version ${nextVersion} of ${packageManifest.name}. npm publish exited with code ${result.code}:`,
@@ -120,4 +135,11 @@ const findAndPublishAllBumpedPackages = () => {
   process.exit(0);
 };
 
-findAndPublishAllBumpedPackages();
+if (require.main === module) {
+  findAndPublishAllBumpedPackages();
+}
+
+module.exports = {
+  findAndPublishAllBumpedPackages,
+  getTagsFromCommitMessage,
+};

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -91,14 +91,15 @@ function getNpmInfo(buildType) {
 }
 
 function publishPackage(packagePath, packageOptions, execOptions) {
-  const {tag, otp} = packageOptions;
+  const {tag, otp, tags} = packageOptions;
+  const tagsFlag = tags ? tags.map(t => ` --tag ${t}`).join('') : '';
   const tagFlag = tag ? ` --tag ${tag}` : '';
   const otpFlag = otp ? ` --otp ${otp}` : '';
   const options = execOptions
     ? {...execOptions, cwd: packagePath}
     : {cwd: packagePath};
 
-  return exec(`npm publish${tagFlag}${otpFlag}`, options);
+  return exec(`npm publish${tagFlag}${tagsFlag}${otpFlag}`, options);
 }
 
 function diffPackages(packageSpecA, packageSpecB, options) {


### PR DESCRIPTION
## Summary:

Currently our CI will auto-tag any `npm publish` as `latest` for the monorepo packages. `react-native` is published in different flow and is unaffected. 

yarn and npm will resolve `*` dependencies using `latest`. This will be a problem for any React Native version that uses `*` deps. We have actively tried to remove these `*` versions but older patches may still contain them. 

When we do a monorepo package bump, it may be for a version 0.71 and for a user who is initializing a 0.72 version project (that still has * deps), they will receive monorepo packages of version `0.71.x`.

This change allows us to specify what tags to use. It will default to the release branch name ex. `0.72-stable` like we do for `react-native`: https://www.npmjs.com/package/react-native?activeTab=versions

```
? Select what npm tags to use for *ALL* packages being published. The default will be 0.72-stable (Press <space> to select, <a> to toggle
 all, <i> to invert selection)
 ◯ "latest" - Only use if you are targetting the latest stable React Native version, not RC.
❯◉ "0.72-stable"
 ◯ "nightly"
 ◯ "experimental"
✨  Done in 25.31s.
```

If we are bumping monorepo packages off `main`, it will ask the user what minor they are targetting.


## Changelog:

[INTERNAL|CHANGED] - Support dist-tags in publishing monorepo packages to avoid default "latest" tag. 


## Test Plan:

`yarn test scripts/`
