### PR TITLE
C++ InspectorPackagerConnection: Reconnect on socket failures

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
@@ -81,6 +81,9 @@ class InspectorPackagerConnection::Impl
   std::unique_ptr<IWebSocket> webSocket_;
   bool closed_{false};
   bool suppressConnectionErrors_{false};
+
+  // Whether a reconnection is currently pending.
+  bool reconnectPending_{false};
 };
 
 class InspectorPackagerConnection::RemoteConnectionImpl

--- a/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h
@@ -53,7 +53,8 @@ class IWebSocketDelegate {
   virtual void didReceiveMessage(std::string_view message) = 0;
 
   /**
-   * Called when the socket has been closed.
+   * Called when the socket has been closed. The call is not required if
+   * didFailWithError was called instead.
    */
   virtual void didClose() = 0;
 };


### PR DESCRIPTION
Summary:
Changelog: [Internal]

* Ports an existing Java/ObjC InspectorPackagerConnection behaviour to the C++ implementation: socket errors should trigger a reconnection. This was a simple omission in D52134592.
* Clarifies the relationship between the `didFailWithError` and `didClose` methods on `IWebSocketDelegate`: calling either one will terminate the connection (and trigger a reconnection), and it's legal to call `didClose` after `didFailWithError`.
  * I'm also adding logic to ensure we don't double-schedule reconnections if both methods are called.
* Cleans up the scaffolding comments from D52134592

Differential Revision: D52576727


