### PR TITLE
Update Yoga.podspec: fixes archiving for macos catalyst on react-native 0.73.1 in xcode

### DIFF
--- a/packages/react-native/ReactCommon/yoga/Yoga.podspec
+++ b/packages/react-native/ReactCommon/yoga/Yoga.podspec
@@ -31,7 +31,8 @@ Pod::Spec.new do |spec|
   spec.header_dir = 'yoga'
   spec.requires_arc = false
   spec.pod_target_xcconfig = {
-      'DEFINES_MODULE' => 'YES'
+      'DEFINES_MODULE' => 'YES',
+      'HEADER_SEARCH_PATHS' => ['$(inherited)', '${PODS_ROOT}/../../node_modules/react-native/ReactCommon/yoga']
   }
   spec.compiler_flags = [
       '-fno-omit-frame-pointer',


### PR DESCRIPTION
Hi

## Summary:

When I tried to archive macos catalyst app in Xcode I got error:

<img width="994" alt="Screenshot 2024-01-06 at 18 02 07" src="https://github.com/facebook/react-native/assets/11584712/5b334c79-c795-4c29-a6b5-65a024926cb7">
<img width="910" alt="Screenshot 2024-01-06 at 18 02 40" src="https://github.com/facebook/react-native/assets/11584712/dba51fc7-8b1e-4a00-b507-ea773c5b5fdf">

This PR fixes archiving

## Changelog:

[IOS] [FIXED] - fixed archiving for macos catalyst on react-native 0.73.1 in xcode

## Test Plan:

Try archive react-native tester app for macos catalyst in Xcode