### PR TITLE
Fix RCTAppSetupPrepareApp import error from .m

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -55,9 +55,10 @@ void RCTAppSetupPrepareApp(
 
 RCT_EXTERN_C_BEGIN
 
-[[deprecated("Use the 3-argument overload of RCTAppSetupPrepareApp instead")]] void RCTAppSetupPrepareApp(
+void RCTAppSetupPrepareApp(
     UIApplication *application,
-    BOOL turboModuleEnabled);
+    BOOL turboModuleEnabled)
+  __deprecated_msg("Use the 3-argument overload of RCTAppSetupPrepareApp instead");
 
 UIView *RCTAppSetupDefaultRootView(
     RCTBridge *bridge,


### PR DESCRIPTION
## Summary:

This PR tries to fix a build error when `import <React/RCTAppSetupUtils.h>` from *.m files. Since the `[[deprecated("")]]` syntax is a C++14 feature and it was placed inside the `RCT_EXTERN_C_BEGIN` block. If the file in imported from Objective-C *.m files or Swift files, it will have a syntax error. Instead of using the C++ syntax, this PR uses the `__deprecated_msg()` statement that is also used in other code in react-native and that is C supported syntax.

## Changelog:

[IOS] [FIXED] - Fix RCTAppSetupPrepareApp.h import error from Objective-C *.m files

## Test Plan:

- test building and importing **RCTAppSetupPrepareApp.h** from a *.m file
- test `RCTAppSetupPrepareApp(application, turboModuleEnabled)` will show a compile warning
