### PR TITLE
[Local][RN][General] 0.72 - migrate boost away from JFrog

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -243,7 +243,7 @@ task createNativeDepsDirectories {
 }
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
-    src("https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION.replace("_", ".")}/source/boost_${BOOST_VERSION}.tar.gz")
+    src("https://archives.boost.io/release/${BOOST_VERSION.replace("_", ".")}/source/boost_${BOOST_VERSION}.tar.gz")
     onlyIfModified(true)
     overwrite(false)
     retries(5)

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
-  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
+  spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',
                   :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
 
   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
## Summary:
JFrog is down and it's making all the iOS build fails. Reference: #42110

## Changelog:
[Internal] - Change url from where boost is downloaded

## Test Plan:
CI is green