### PR TITLE
Move InspectorFlags JNI wrapper into devsupport library

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -14,7 +14,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.react.bridge.InspectorFlags;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -33,7 +33,6 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.R;
 import com.facebook.react.bridge.DefaultJSExceptionHandler;
-import com.facebook.react.bridge.InspectorFlags;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactMarker;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.java
@@ -5,15 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.bridge;
+package com.facebook.react.devsupport;
 
 import com.facebook.proguard.annotations.DoNotStrip;
 
-/** fbjni interface for reading `jsinspector_modern::InspectorFlags`. */
+/** JNI wrapper for `jsinspector_modern::InspectorFlags`. */
 @DoNotStrip
 public class InspectorFlags {
   static {
-    ReactBridge.staticInit();
+    DevSupportSoLoader.staticInit();
   }
 
   @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.cpp
@@ -9,16 +9,16 @@
 
 #include <jsinspector-modern/InspectorFlags.h>
 
-namespace facebook::react {
+namespace facebook::react::jsinspector_modern {
 
 bool JInspectorFlags::getEnableModernCDPRegistry(jni::alias_ref<jclass>) {
-  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+  auto& inspectorFlags = InspectorFlags::getInstance();
   return inspectorFlags.getEnableModernCDPRegistry();
 }
 
 bool JInspectorFlags::getEnableCxxInspectorPackagerConnection(
     jni::alias_ref<jclass>) {
-  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+  auto& inspectorFlags = InspectorFlags::getInstance();
   return inspectorFlags.getEnableCxxInspectorPackagerConnection();
 }
 
@@ -33,4 +33,4 @@ void JInspectorFlags::registerNatives() {
   });
 }
 
-} // namespace facebook::react
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.h
@@ -9,15 +9,15 @@
 
 #include <fbjni/fbjni.h>
 
-namespace facebook::react {
+namespace facebook::react::jsinspector_modern {
 
 /**
- * fbjni interface for reading `jsinspector_modern::InspectorFlags`.
+ * JNI wrapper for `jsinspector_modern::InspectorFlags`.
  */
 class JInspectorFlags : public jni::JavaClass<JInspectorFlags> {
  public:
   static constexpr auto kJavaDescriptor =
-      "Lcom/facebook/react/bridge/InspectorFlags;";
+      "Lcom/facebook/react/devsupport/InspectorFlags;";
 
   static bool getEnableModernCDPRegistry(jni::alias_ref<jclass>);
 
@@ -29,4 +29,4 @@ class JInspectorFlags : public jni::JavaClass<JInspectorFlags> {
   JInspectorFlags();
 };
 
-} // namespace facebook::react
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/OnLoad.cpp
@@ -7,6 +7,7 @@
 
 #include "JCxxInspectorPackagerConnection.h"
 #include "JCxxInspectorPackagerConnectionWebSocketDelegate.h"
+#include "JInspectorFlags.h"
 
 #include <fbjni/fbjni.h>
 
@@ -16,5 +17,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
         registerNatives();
     facebook::react::jsinspector_modern::
         JCxxInspectorPackagerConnectionWebSocketDelegate::registerNatives();
+    facebook::react::jsinspector_modern::JInspectorFlags::registerNatives();
   });
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -17,7 +17,6 @@
 #include "CxxModuleWrapperBase.h"
 #include "JCallback.h"
 #include "JInspector.h"
-#include "JInspectorFlags.h"
 #include "JReactMarker.h"
 #include "JavaScriptExecutorHolder.h"
 #include "ProxyExecutor.h"
@@ -85,7 +84,6 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     WritableNativeMap::registerNatives();
     JReactMarker::registerNatives();
     JInspector::registerNatives();
-    JInspectorFlags::registerNatives();
   });
 }
 


### PR DESCRIPTION
Summary:
As titled, also moving `InspectorFlags.java` across packages.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D52367642

