### PR TITLE
Make bridgeless the default when the New Arch is enabled

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -251,7 +251,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (BOOL)bridgelessEnabled
 {
-  return NO;
+  return [self newArchEnabled];
 }
 
 #pragma mark - RCTComponentViewFactoryComponentProvider


### PR DESCRIPTION
Summary:
For 0.74, we would like to have Bridgeless as the default when the New Architecture is enabled.

## Changelog:
[iOS][Breaking] - Make bridgeless the default when the New Arch is enabled

Differential Revision: D52598104


