### PR TITLE
[#42164] Patches `with-environment.sh` script

### DIFF
--- a/packages/react-native/scripts/xcode/with-environment.sh
+++ b/packages/react-native/scripts/xcode/with-environment.sh
@@ -13,7 +13,7 @@
 # ./with-environment.sh command
 
 # Start with a default
-NODE_BINARY=$(command -v node)
+NODE_BINARY=$(command -v node || echo "")
 export NODE_BINARY
 
 # Override the default with the global environment


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Closes https://github.com/facebook/react-native/issues/42164

## Changelog:

[IOS] [FIXED] - Fixes `with-environment.sh` script for the case when Node can't be found prior to loading `.xcode.env`

## Test Plan:

This is a trivial update, no need for much testing.
