### PR TITLE
Update API docs for scrollEventThrottle

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -481,12 +481,12 @@ export interface ScrollViewPropsIOS {
   pinchGestureEnabled?: boolean | undefined;
 
   /**
-   * This controls how often the scroll event will be fired while scrolling (as a time interval in ms).
-   * A lower number yields better accuracy for code that is tracking the scroll position,
-   * but can lead to scroll performance problems due to the volume of information being sent over the bridge.
-   * The default value is zero, which means the scroll event will be sent only once each time the view is scrolled.
+   * Limits how often scroll events will be fired while scrolling, specified as
+   * a time interval in ms. This may be useful when expensive work is performed
+   * in response to scrolling. Values <= `16` will disable throttling,
+   * regardless of the refresh rate of the device.
    */
-  scrollEventThrottle?: number | undefined; // null
+  scrollEventThrottle?: number | undefined;
 
   /**
    * The amount by which the scroll view indicators are inset from the edges of the scroll view.
@@ -663,7 +663,6 @@ export interface ScrollViewProps
 
   /**
    * Fires at most once per frame during scrolling.
-   * The frequency of the events can be contolled using the scrollEventThrottle prop.
    */
   onScroll?:
     | ((event: NativeSyntheticEvent<NativeScrollEvent>) => void)

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -515,8 +515,7 @@ export type Props = $ReadOnly<{|
   onMomentumScrollEnd?: ?(event: ScrollEvent) => void,
 
   /**
-   * Fires at most once per frame during scrolling. The frequency of the
-   * events can be controlled using the `scrollEventThrottle` prop.
+   * Fires at most once per frame during scrolling.
    */
   onScroll?: ?(event: ScrollEvent) => void,
   /**
@@ -556,19 +555,10 @@ export type Props = $ReadOnly<{|
    */
   scrollEnabled?: ?boolean,
   /**
-   * This controls how often the scroll event will be fired while scrolling
-   * (as a time interval in ms). A lower number yields better accuracy for code
-   * that is tracking the scroll position, but can lead to scroll performance
-   * problems due to the volume of information being send over the bridge.
-   *
-   * Values between 0 and 17ms indicate 60fps updates are needed and throttling
-   * will be disabled.
-   *
-   * If you do not need precise scroll position tracking, set this value higher
-   * to limit the information being sent across the bridge.
-   *
-   * The default value is zero, which results in the scroll event being sent only
-   * once each time the view is scrolled.
+   * Limits how often scroll events will be fired while scrolling, specified as
+   * a time interval in ms. This may be useful when expensive work is performed
+   * in response to scrolling. Values <= `16` will disable throttling,
+   * regardless of the refresh rate of the device.
    */
   scrollEventThrottle?: ?number,
   /**


### PR DESCRIPTION
Summary:
We've rolled out some changes to the behavior here, mainly that throttling no longer happens by default on iOS.

This updates the documentation, in concert with https://github.com/facebook/react-native-website/pull/3971

Changelog:
[General][Changed] - Update API docs for scrollEventThrottle

Reviewed By: javache

Differential Revision: D52516092


