### PR TITLE
Use default inequality operator for LayoutMetrics

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -67,9 +67,7 @@ struct LayoutMetrics {
 
   bool operator==(const LayoutMetrics& rhs) const = default;
 
-  bool operator!=(const LayoutMetrics& rhs) const {
-    return !(*this == rhs);
-  }
+  bool operator!=(const LayoutMetrics& rhs) const = default;
 };
 
 /*


### PR DESCRIPTION
Summary:
tsia, we had the equality op defaulted so might as well do this for inequality 

Changelog: [Internal]

Differential Revision: D52515802


