### PR TITLE
Support transforms forming containing blocks

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -383,6 +383,11 @@ void YogaLayoutableShadowNode::updateYogaProps() {
   }
 
   yogaNode_.setStyle(styleResult);
+  if (getTraits().check(ShadowNodeTraits::ViewKind)) {
+    auto& viewProps = static_cast<const ViewProps&>(*props_);
+    YGNodeSetAlwaysFormsContainingBlock(
+        &yogaNode_, viewProps.transform != Transform::Identity());
+  }
 }
 
 /*static*/ yoga::Style YogaLayoutableShadowNode::applyAliasedProps(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -35,11 +35,6 @@ YogaStylableProps::YogaStylableProps(
   }
 };
 
-/*static*/ const yoga::Style& YogaStylableProps::defaultStyle() {
-  static const auto defaultStyle = []() { return yoga::Style{}; }();
-  return defaultStyle;
-}
-
 template <typename T>
 static inline T const getFieldValue(
     const PropsParserContext& context,
@@ -54,10 +49,10 @@ static inline T const getFieldValue(
   return defaultValue;
 }
 
-#define REBUILD_FIELD_SWITCH_CASE2(field, setter, fieldName)                 \
-  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                            \
-    yogaStyle.setter(getFieldValue(context, value, defaultStyle().field())); \
-    return;                                                                  \
+#define REBUILD_FIELD_SWITCH_CASE2(field, setter, fieldName)             \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                        \
+    yogaStyle.setter(getFieldValue(context, value, ygDefaults.field())); \
+    return;                                                              \
   }
 
 #define REBUILD_FIELD_SWITCH_CASE_YSP(field, setter) \
@@ -66,7 +61,7 @@ static inline T const getFieldValue(
 #define REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(field, setter, index, fieldName) \
   case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                             \
     yogaStyle.setter(                                                         \
-        index, getFieldValue(context, value, defaultStyle().field(index)));   \
+        index, getFieldValue(context, value, ygDefaults.field(index)));       \
     return;                                                                   \
   }
 
@@ -130,6 +125,7 @@ void YogaStylableProps::setProp(
     RawPropsPropNameHash hash,
     const char* propName,
     const RawValue& value) {
+  static const auto ygDefaults = yoga::Style{};
   static const auto defaults = YogaStylableProps{};
 
   Props::setProp(context, hash, propName, value);
@@ -185,225 +181,228 @@ void YogaStylableProps::setProp(
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 SharedDebugStringConvertibleList YogaStylableProps::getDebugProps() const {
+  const auto defaultYogaStyle = yoga::Style{};
   return {
       debugStringConvertibleItem(
-          "direction", yogaStyle.direction(), defaultStyle().direction()),
+          "direction", yogaStyle.direction(), defaultYogaStyle.direction()),
       debugStringConvertibleItem(
           "flexDirection",
           yogaStyle.flexDirection(),
-          defaultStyle().flexDirection()),
+          defaultYogaStyle.flexDirection()),
       debugStringConvertibleItem(
           "justifyContent",
           yogaStyle.justifyContent(),
-          defaultStyle().justifyContent()),
+          defaultYogaStyle.justifyContent()),
       debugStringConvertibleItem(
           "alignContent",
           yogaStyle.alignContent(),
-          defaultStyle().alignContent()),
+          defaultYogaStyle.alignContent()),
       debugStringConvertibleItem(
-          "alignItems", yogaStyle.alignItems(), defaultStyle().alignItems()),
+          "alignItems", yogaStyle.alignItems(), defaultYogaStyle.alignItems()),
       debugStringConvertibleItem(
-          "alignSelf", yogaStyle.alignSelf(), defaultStyle().alignSelf()),
+          "alignSelf", yogaStyle.alignSelf(), defaultYogaStyle.alignSelf()),
       debugStringConvertibleItem(
           "positionType",
           yogaStyle.positionType(),
-          defaultStyle().positionType()),
+          defaultYogaStyle.positionType()),
       debugStringConvertibleItem(
-          "flexWrap", yogaStyle.flexWrap(), defaultStyle().flexWrap()),
+          "flexWrap", yogaStyle.flexWrap(), defaultYogaStyle.flexWrap()),
       debugStringConvertibleItem(
-          "overflow", yogaStyle.overflow(), defaultStyle().overflow()),
+          "overflow", yogaStyle.overflow(), defaultYogaStyle.overflow()),
       debugStringConvertibleItem(
-          "display", yogaStyle.display(), defaultStyle().display()),
+          "display", yogaStyle.display(), defaultYogaStyle.display()),
       debugStringConvertibleItem(
-          "flex", yogaStyle.flex(), defaultStyle().flex()),
+          "flex", yogaStyle.flex(), defaultYogaStyle.flex()),
       debugStringConvertibleItem(
-          "flexGrow", yogaStyle.flexGrow(), defaultStyle().flexGrow()),
+          "flexGrow", yogaStyle.flexGrow(), defaultYogaStyle.flexGrow()),
       debugStringConvertibleItem(
           "rowGap",
           yogaStyle.gap(yoga::Gutter::Row),
-          defaultStyle().gap(yoga::Gutter::Row)),
+          defaultYogaStyle.gap(yoga::Gutter::Row)),
       debugStringConvertibleItem(
           "columnGap",
           yogaStyle.gap(yoga::Gutter::Column),
-          defaultStyle().gap(yoga::Gutter::Column)),
+          defaultYogaStyle.gap(yoga::Gutter::Column)),
       debugStringConvertibleItem(
           "gap",
           yogaStyle.gap(yoga::Gutter::All),
-          defaultStyle().gap(yoga::Gutter::All)),
+          defaultYogaStyle.gap(yoga::Gutter::All)),
       debugStringConvertibleItem(
-          "flexShrink", yogaStyle.flexShrink(), defaultStyle().flexShrink()),
+          "flexShrink", yogaStyle.flexShrink(), defaultYogaStyle.flexShrink()),
       debugStringConvertibleItem(
-          "flexBasis", yogaStyle.flexBasis(), defaultStyle().flexBasis()),
+          "flexBasis", yogaStyle.flexBasis(), defaultYogaStyle.flexBasis()),
       debugStringConvertibleItem(
           "marginLeft",
           yogaStyle.margin(yoga::Edge::Left),
-          defaultStyle().margin(yoga::Edge::Left)),
+          defaultYogaStyle.margin(yoga::Edge::Left)),
       debugStringConvertibleItem(
           "marginTop",
           yogaStyle.margin(yoga::Edge::Top),
-          defaultStyle().margin(yoga::Edge::Top)),
+          defaultYogaStyle.margin(yoga::Edge::Top)),
       debugStringConvertibleItem(
           "marginRight",
           yogaStyle.margin(yoga::Edge::Right),
-          defaultStyle().margin(yoga::Edge::Right)),
+          defaultYogaStyle.margin(yoga::Edge::Right)),
       debugStringConvertibleItem(
           "marginBottom",
           yogaStyle.margin(yoga::Edge::Bottom),
-          defaultStyle().margin(yoga::Edge::Bottom)),
+          defaultYogaStyle.margin(yoga::Edge::Bottom)),
       debugStringConvertibleItem(
           "marginStart",
           yogaStyle.margin(yoga::Edge::Start),
-          defaultStyle().margin(yoga::Edge::Start)),
+          defaultYogaStyle.margin(yoga::Edge::Start)),
       debugStringConvertibleItem(
           "marginEnd",
           yogaStyle.margin(yoga::Edge::End),
-          defaultStyle().margin(yoga::Edge::End)),
+          defaultYogaStyle.margin(yoga::Edge::End)),
       debugStringConvertibleItem(
           "marginHorizontal",
           yogaStyle.margin(yoga::Edge::Horizontal),
-          defaultStyle().margin(yoga::Edge::Horizontal)),
+          defaultYogaStyle.margin(yoga::Edge::Horizontal)),
       debugStringConvertibleItem(
           "marginVertical",
           yogaStyle.margin(yoga::Edge::Vertical),
-          defaultStyle().margin(yoga::Edge::Vertical)),
+          defaultYogaStyle.margin(yoga::Edge::Vertical)),
       debugStringConvertibleItem(
           "margin",
           yogaStyle.margin(yoga::Edge::All),
-          defaultStyle().margin(yoga::Edge::All)),
+          defaultYogaStyle.margin(yoga::Edge::All)),
       debugStringConvertibleItem(
           "left",
           yogaStyle.position(yoga::Edge::Left),
-          defaultStyle().position(yoga::Edge::Left)),
+          defaultYogaStyle.position(yoga::Edge::Left)),
       debugStringConvertibleItem(
           "top",
           yogaStyle.position(yoga::Edge::Top),
-          defaultStyle().position(yoga::Edge::Top)),
+          defaultYogaStyle.position(yoga::Edge::Top)),
       debugStringConvertibleItem(
           "right",
           yogaStyle.position(yoga::Edge::Right),
-          defaultStyle().position(yoga::Edge::Right)),
+          defaultYogaStyle.position(yoga::Edge::Right)),
       debugStringConvertibleItem(
           "bottom",
           yogaStyle.position(yoga::Edge::Bottom),
-          defaultStyle().position(yoga::Edge::Bottom)),
+          defaultYogaStyle.position(yoga::Edge::Bottom)),
       debugStringConvertibleItem(
           "start",
           yogaStyle.position(yoga::Edge::Start),
-          defaultStyle().position(yoga::Edge::Start)),
+          defaultYogaStyle.position(yoga::Edge::Start)),
       debugStringConvertibleItem(
           "end",
           yogaStyle.position(yoga::Edge::End),
-          defaultStyle().position(yoga::Edge::End)),
+          defaultYogaStyle.position(yoga::Edge::End)),
       debugStringConvertibleItem(
           "inseInline",
           yogaStyle.position(yoga::Edge::Horizontal),
-          defaultStyle().position(yoga::Edge::Horizontal)),
+          defaultYogaStyle.position(yoga::Edge::Horizontal)),
       debugStringConvertibleItem(
           "insetBlock",
           yogaStyle.position(yoga::Edge::Vertical),
-          defaultStyle().position(yoga::Edge::Vertical)),
+          defaultYogaStyle.position(yoga::Edge::Vertical)),
       debugStringConvertibleItem(
           "inset",
           yogaStyle.position(yoga::Edge::All),
-          defaultStyle().position(yoga::Edge::All)),
+          defaultYogaStyle.position(yoga::Edge::All)),
       debugStringConvertibleItem(
           "paddingLeft",
           yogaStyle.padding(yoga::Edge::Left),
-          defaultStyle().padding(yoga::Edge::Left)),
+          defaultYogaStyle.padding(yoga::Edge::Left)),
       debugStringConvertibleItem(
           "paddingTop",
           yogaStyle.padding(yoga::Edge::Top),
-          defaultStyle().padding(yoga::Edge::Top)),
+          defaultYogaStyle.padding(yoga::Edge::Top)),
       debugStringConvertibleItem(
           "paddingRight",
           yogaStyle.padding(yoga::Edge::Right),
-          defaultStyle().padding(yoga::Edge::Right)),
+          defaultYogaStyle.padding(yoga::Edge::Right)),
       debugStringConvertibleItem(
           "paddingBottom",
           yogaStyle.padding(yoga::Edge::Bottom),
-          defaultStyle().padding(yoga::Edge::Bottom)),
+          defaultYogaStyle.padding(yoga::Edge::Bottom)),
       debugStringConvertibleItem(
           "paddingStart",
           yogaStyle.padding(yoga::Edge::Start),
-          defaultStyle().padding(yoga::Edge::Start)),
+          defaultYogaStyle.padding(yoga::Edge::Start)),
       debugStringConvertibleItem(
           "paddingEnd",
           yogaStyle.padding(yoga::Edge::End),
-          defaultStyle().padding(yoga::Edge::End)),
+          defaultYogaStyle.padding(yoga::Edge::End)),
       debugStringConvertibleItem(
           "paddingHorizontal",
           yogaStyle.padding(yoga::Edge::Horizontal),
-          defaultStyle().padding(yoga::Edge::Horizontal)),
+          defaultYogaStyle.padding(yoga::Edge::Horizontal)),
       debugStringConvertibleItem(
           "paddingVertical",
           yogaStyle.padding(yoga::Edge::Vertical),
-          defaultStyle().padding(yoga::Edge::Vertical)),
+          defaultYogaStyle.padding(yoga::Edge::Vertical)),
       debugStringConvertibleItem(
           "padding",
           yogaStyle.padding(yoga::Edge::All),
-          defaultStyle().padding(yoga::Edge::All)),
+          defaultYogaStyle.padding(yoga::Edge::All)),
       debugStringConvertibleItem(
           "borderLeftWidth",
           yogaStyle.border(yoga::Edge::Left),
-          defaultStyle().border(yoga::Edge::Left)),
+          defaultYogaStyle.border(yoga::Edge::Left)),
       debugStringConvertibleItem(
           "borderTopWidth",
           yogaStyle.border(yoga::Edge::Top),
-          defaultStyle().border(yoga::Edge::Top)),
+          defaultYogaStyle.border(yoga::Edge::Top)),
       debugStringConvertibleItem(
           "borderRightWidth",
           yogaStyle.border(yoga::Edge::Right),
-          defaultStyle().border(yoga::Edge::Right)),
+          defaultYogaStyle.border(yoga::Edge::Right)),
       debugStringConvertibleItem(
           "borderBottomWidth",
           yogaStyle.border(yoga::Edge::Bottom),
-          defaultStyle().border(yoga::Edge::Bottom)),
+          defaultYogaStyle.border(yoga::Edge::Bottom)),
       debugStringConvertibleItem(
           "borderStartWidth",
           yogaStyle.border(yoga::Edge::Start),
-          defaultStyle().border(yoga::Edge::Start)),
+          defaultYogaStyle.border(yoga::Edge::Start)),
       debugStringConvertibleItem(
           "borderEndWidth",
           yogaStyle.border(yoga::Edge::End),
-          defaultStyle().border(yoga::Edge::End)),
+          defaultYogaStyle.border(yoga::Edge::End)),
       debugStringConvertibleItem(
           "borderHorizontalWidth",
           yogaStyle.border(yoga::Edge::Horizontal),
-          defaultStyle().border(yoga::Edge::Horizontal)),
+          defaultYogaStyle.border(yoga::Edge::Horizontal)),
       debugStringConvertibleItem(
           "borderVerticalWidth",
           yogaStyle.border(yoga::Edge::Vertical),
-          defaultStyle().border(yoga::Edge::Vertical)),
+          defaultYogaStyle.border(yoga::Edge::Vertical)),
       debugStringConvertibleItem(
           "bordeWidth",
           yogaStyle.border(yoga::Edge::All),
-          defaultStyle().border(yoga::Edge::All)),
+          defaultYogaStyle.border(yoga::Edge::All)),
       debugStringConvertibleItem(
           "width",
           yogaStyle.dimension(yoga::Dimension::Width),
-          defaultStyle().dimension(yoga::Dimension::Width)),
+          defaultYogaStyle.dimension(yoga::Dimension::Width)),
       debugStringConvertibleItem(
           "height",
           yogaStyle.dimension(yoga::Dimension::Height),
-          defaultStyle().dimension(yoga::Dimension::Height)),
+          defaultYogaStyle.dimension(yoga::Dimension::Height)),
       debugStringConvertibleItem(
           "minWidth",
           yogaStyle.minDimension(yoga::Dimension::Width),
-          defaultStyle().minDimension(yoga::Dimension::Width)),
+          defaultYogaStyle.minDimension(yoga::Dimension::Width)),
       debugStringConvertibleItem(
           "minHeight",
           yogaStyle.minDimension(yoga::Dimension::Height),
-          defaultStyle().minDimension(yoga::Dimension::Height)),
+          defaultYogaStyle.minDimension(yoga::Dimension::Height)),
       debugStringConvertibleItem(
           "maxWidth",
           yogaStyle.maxDimension(yoga::Dimension::Width),
-          defaultStyle().maxDimension(yoga::Dimension::Width)),
+          defaultYogaStyle.maxDimension(yoga::Dimension::Width)),
       debugStringConvertibleItem(
           "maxHeight",
           yogaStyle.maxDimension(yoga::Dimension::Height),
-          defaultStyle().maxDimension(yoga::Dimension::Height)),
+          defaultYogaStyle.maxDimension(yoga::Dimension::Height)),
       debugStringConvertibleItem(
-          "aspectRatio", yogaStyle.aspectRatio(), defaultStyle().aspectRatio()),
+          "aspectRatio",
+          yogaStyle.aspectRatio(),
+          defaultYogaStyle.aspectRatio()),
   };
 }
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
@@ -23,8 +23,6 @@ class YogaStylableProps : public Props {
       const YogaStylableProps& sourceProps,
       const RawProps& rawProps);
 
-  static const yoga::Style& defaultStyle();
-
   void setProp(
       const PropsParserContext& context,
       RawPropsPropNameHash hash,
@@ -37,7 +35,7 @@ class YogaStylableProps : public Props {
 #endif
 
 #pragma mark - Props
-  yoga::Style yogaStyle{defaultStyle()};
+  yoga::Style yogaStyle{};
 
   // Duplicates of existing properties with different names, taking
   // precedence. E.g. "marginBlock" instead of "marginVertical"

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <react/renderer/components/view/YogaStylableProps.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
@@ -23,7 +22,7 @@ static inline yoga::Style convertRawProp(
     const PropsParserContext& context,
     const RawProps& rawProps,
     const yoga::Style& sourceValue) {
-  auto yogaStyle = YogaStylableProps::defaultStyle();
+  yoga::Style yogaStyle{};
 
   yogaStyle.setDirection(convertRawProp(
       context,

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -67,9 +67,7 @@ struct LayoutMetrics {
 
   bool operator==(const LayoutMetrics& rhs) const = default;
 
-  bool operator!=(const LayoutMetrics& rhs) const {
-    return !(*this == rhs);
-  }
+  bool operator!=(const LayoutMetrics& rhs) const = default;
 };
 
 /*

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -328,6 +328,12 @@ void YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc) {
   resolveRef(node)->setPrintFunc(printFunc);
 }
 
+void YGNodeSetAlwaysFormsContainingBlock(
+    YGNodeRef node,
+    bool alwaysFormsContainingBlock) {
+  resolveRef(node)->setAlwaysFormsContainingBlock(alwaysFormsContainingBlock);
+}
+
 #ifdef DEBUG
 void YGNodePrint(const YGNodeConstRef node, const YGPrintOptions options) {
   yoga::print(resolveRef(node), scopedEnum(options));

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -271,6 +271,17 @@ typedef void (*YGPrintFunc)(YGNodeConstRef node);
 YG_EXPORT void YGNodeSetPrintFunc(YGNodeRef node, YGPrintFunc printFunc);
 
 /**
+ * Make it so that this node will always form a containing block for any
+ * descendant nodes. This is useful for when a node has a property outside of
+ * of Yoga that will form a containing block. For example, transforms or some of
+ * the others listed in
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block
+ */
+YG_EXPORT void YGNodeSetAlwaysFormsContainingBlock(
+    YGNodeRef node,
+    bool alwaysFormsContainingBlock);
+
+/**
  * Print a node to log output.
  */
 YG_EXPORT void YGNodePrint(YGNodeConstRef node, YGPrintOptions options);

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -528,7 +528,9 @@ void layoutAbsoluteDescendants(
       if (needsTrailingPosition(crossAxis)) {
         setChildTrailingPosition(currentNode, child, crossAxis);
       }
-    } else if (child->getStyle().positionType() == PositionType::Static) {
+    } else if (
+        child->getStyle().positionType() == PositionType::Static &&
+        !child->alwaysFormsContainingBlock()) {
       const Direction childDirection =
           child->resolveDirection(currentNodeDirection);
       const float childMainOffsetFromContainingBlock =

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -2034,7 +2034,7 @@ static void calculateLayoutImpl(
       // Let the containing block layout its absolute descendants. By definition
       // the containing block will not be static unless we are at the root.
       if (node->getStyle().positionType() != PositionType::Static ||
-          depth == 1) {
+          node->alwaysFormsContainingBlock() || depth == 1) {
         layoutAbsoluteDescendants(
             node,
             node,

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -48,6 +48,10 @@ class YG_EXPORT Node : public ::YGNode {
     return context_;
   }
 
+  bool alwaysFormsContainingBlock() const {
+    return alwaysFormsContainingBlock_;
+  }
+
   void print();
 
   bool getHasNewLayout() const {
@@ -242,6 +246,10 @@ class YG_EXPORT Node : public ::YGNode {
     context_ = context;
   }
 
+  void setAlwaysFormsContainingBlock(bool alwaysFormsContainingBlock) {
+    alwaysFormsContainingBlock_ = alwaysFormsContainingBlock;
+  }
+
   void setPrintFunc(YGPrintFunc printFunc) {
     printFunc_ = printFunc;
   }
@@ -369,6 +377,7 @@ class YG_EXPORT Node : public ::YGNode {
   bool hasNewLayout_ : 1 = true;
   bool isReferenceBaseline_ : 1 = false;
   bool isDirty_ : 1 = false;
+  bool alwaysFormsContainingBlock_ : 1 = false;
   NodeType nodeType_ : bitCount<NodeType>() = NodeType::Default;
   void* context_ = nullptr;
   YGMeasureFunc measureFunc_ = {nullptr};


### PR DESCRIPTION
Summary:
React native supports transforms and if a node has a transform it will [form a containing block for absolute descendants regardless of position type](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block). So we need to pass that information into Yoga to ensure this happens.

The verbiage for the field "alwaysFormsContainingBlock" is very specific. In a vacuum a node cannot simply "form a containing block". It only forms a containing block in reference to a different node. This can be illustrated in a scenario where we have a static node that is a flex container which has 1 absolute child and 1 relative child. This static node will form a containing block for the relative child but not the absolute one. We could just pass the information on rather something has a transform or not but Yoga is not supposed to know about transforms in general. As a result we have a notion of "always" forming a containing block. Since Yoga is a flexbox spec, non-absolute nodes' containing blocks will ways be their parent. If we add something like a transform to a node then that will also apply to absolute nodes - hence we can say the node will **always** form a CB, no matter who is the descendant.

Changelog: [Internal]

Differential Revision: D52521160


