### PR TITLE
Allow non-static LongLivedObjectCollections in TurboModuleBinding

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
+++ b/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
@@ -28,7 +28,7 @@ namespace facebook::react {
  */
 class LongLivedObject {
  public:
-  void allowRelease();
+  virtual void allowRelease();
 
  protected:
   LongLivedObject() = default;
@@ -42,6 +42,7 @@ class LongLivedObjectCollection {
  public:
   static LongLivedObjectCollection& get();
 
+  LongLivedObjectCollection() = default;
   LongLivedObjectCollection(const LongLivedObjectCollection&) = delete;
   void operator=(const LongLivedObjectCollection&) = delete;
 
@@ -51,8 +52,6 @@ class LongLivedObjectCollection {
   size_t size() const;
 
  private:
-  LongLivedObjectCollection() = default;
-
   std::unordered_set<std::shared_ptr<LongLivedObject>> collection_;
   mutable std::mutex collectionMutex_;
 };

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -9,6 +9,7 @@
 
 #include <string>
 
+#include <ReactCommon/LongLivedObject.h>
 #include <ReactCommon/TurboModule.h>
 #include <jsi/jsi.h>
 
@@ -28,9 +29,14 @@ class TurboModuleBinding {
   static void install(
       jsi::Runtime& runtime,
       TurboModuleProviderFunctionType&& moduleProvider,
-      TurboModuleProviderFunctionType&& legacyModuleProvider = nullptr);
+      TurboModuleProviderFunctionType&& legacyModuleProvider = nullptr,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection =
+          nullptr);
 
-  TurboModuleBinding(TurboModuleProviderFunctionType&& moduleProvider);
+  TurboModuleBinding(
+      TurboModuleProviderFunctionType&& moduleProvider,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
+
   virtual ~TurboModuleBinding();
 
  private:
@@ -44,6 +50,7 @@ class TurboModuleBinding {
       const;
 
   TurboModuleProviderFunctionType moduleProvider_;
+  std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary: Apps that have multiple concurrently running React instances may suffer from issues where tearing down one instance affects the bindings / LongLivedObjectCollection instance of another due to the use of static getter for LongLivedObjectCollection. This should allow host platforms, e.g., react-native-windows (which still forks the TurboModuleBinding C++ files [here](https://github.com/microsoft/react-native-windows/tree/main/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/nativemodule/core/ReactCommon) for the reasons already mentioned) to manage per instance LongLivedObjectCollections.

Differential Revision: D52581170


