### PR TITLE
Replace ranges views with iterators

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
@@ -7,8 +7,6 @@
 
 #include "PointerEventsProcessor.h"
 
-#include <ranges>
-
 namespace facebook::react {
 
 ShadowNode::Shared PointerEventsProcessor::getShadowNodeFromEventTarget(
@@ -74,8 +72,8 @@ static bool isAnyViewInPathToRootListeningToEvents(
   auto ancestors = nodeFamily.getAncestors(*owningRootShadowNode);
 
   // Check for listeners from the target's parent to the root
-  for (auto& ancestor : std::ranges::reverse_view(ancestors)) {
-    auto& currentNode = ancestor.first.get();
+  for (auto it = ancestors.rbegin(); it != ancestors.rend(); it++) {
+    auto& currentNode = it->first.get();
     if (isViewListeningToEvents(currentNode, eventTypes)) {
       return true;
     }
@@ -481,8 +479,11 @@ void PointerEventsProcessor::handleIncomingPointerEventOnNode(
   }
 
   // Actually emit the leave events (in order from target to root)
-  for (auto it : std::ranges::reverse_view(targetsToEmitLeaveTo)) {
-    eventDispatcher(it, "topPointerLeave", ReactEventPriority::Discrete, event);
+  for (auto it = targetsToEmitLeaveTo.rbegin();
+       it != targetsToEmitLeaveTo.rend();
+       it++) {
+    eventDispatcher(
+        *it, "topPointerLeave", ReactEventPriority::Discrete, event);
   }
 
   // Over

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
@@ -91,17 +91,16 @@ std::tuple<EventPath, EventPath> PointerHoverTracker::diffEventPath(
   }
 
   EventPath removed;
-  for (const auto& node : std::ranges::subrange{myIt, myEventPath.rend()}) {
-    const auto& latestNode = getLatestNode(node, uiManager);
+  for (auto nodeIt = myIt; nodeIt != myEventPath.rend(); nodeIt++) {
+    const auto& latestNode = getLatestNode(*nodeIt, uiManager);
     if (latestNode != nullptr) {
       removed.push_back(*latestNode);
     }
   }
 
   EventPath added;
-  for (const auto& node :
-       std::ranges::subrange{otherIt, otherEventPath.rend()}) {
-    const auto& latestNode = other.getLatestNode(node, uiManager);
+  for (auto nodeIt = otherIt; nodeIt != otherEventPath.rend(); nodeIt++) {
+    const auto& latestNode = other.getLatestNode(*nodeIt, uiManager);
     if (latestNode != nullptr) {
       added.push_back(*latestNode);
     }
@@ -141,8 +140,8 @@ EventPath PointerHoverTracker::getEventPathTargets() const {
   auto ancestors = target_->getFamily().getAncestors(*root_);
 
   result.emplace_back(*target_);
-  for (const auto& ancestor : std::ranges::reverse_view(ancestors)) {
-    result.push_back(ancestor.first);
+  for (auto it = ancestors.rbegin(); it != ancestors.rend(); it++) {
+    result.push_back(it->first);
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/runtime/.clang-tidy
+++ b/packages/react-native/ReactCommon/react/runtime/.clang-tidy
@@ -14,4 +14,8 @@ Checks: '
 -modernize-use-trailing-return-type,
 -performance-unnecessary-value-param,
 '
+CheckOptions:
+  # clang 15 does not support reverse_view
+  - key:    modernize-loop-convert.UseCxx20ReverseRanges
+    value:  false
 ...


### PR DESCRIPTION
Summary:
Some std::ranges functions don't work well (or at all) when using
clang, eg see
https://fb.workplace.com/groups/474291069286180/posts/9724112847637243

This works in clang 16, but not clang 15 which fbcode is on. Note that more complicated parts of ranges work, but not these simpler helpers, funnily enough :).

As I'm trying to make RN compile in fbcode, I need clang to work. 

Moving them back to iterators, but using rbegin/rend making it fairly readable still.

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D52481786


