### PR TITLE
Set InspectorFlags in ReactHostImpl (Bridgeless)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.devsupport;
 
+import androidx.annotation.NonNull;
 import com.facebook.proguard.annotations.DoNotStrip;
 
 /** JNI wrapper for `jsinspector_modern::InspectorFlags`. */
@@ -15,6 +16,9 @@ public class InspectorFlags {
   static {
     DevSupportSoLoader.staticInit();
   }
+
+  @DoNotStrip
+  public static native void initFromConfig(@NonNull Object reactNativeConfig);
 
   @DoNotStrip
   public static native boolean getEnableModernCDPRegistry();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -46,6 +46,7 @@ import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.DevSupportManagerBase;
 import com.facebook.react.devsupport.DisabledDevSupportManager;
+import com.facebook.react.devsupport.InspectorFlags;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.fabric.ComponentFactory;
 import com.facebook.react.fabric.FabricUIManager;
@@ -174,6 +175,8 @@ public class ReactHostImpl implements ReactHost {
                 "handleMemoryPressure(" + level + ")",
                 reactInstance -> reactInstance.handleMemoryPressure(level));
     mAllowPackagerServerAccess = allowPackagerServerAccess;
+    InspectorFlags.initFromConfig(mReactHostDelegate.getReactNativeConfig());
+
     if (DEV) {
       mDevSupportManager =
           new BridgelessDevSupportManager(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/CMakeLists.txt
@@ -15,5 +15,6 @@ add_library(react_devsupportjni SHARED ${react_devsupportjni_SRC})
 target_include_directories(react_devsupportjni PUBLIC .)
 
 target_link_libraries(react_devsupportjni
+        fabricjni
         fbjni
         jsinspector)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.cpp
@@ -8,8 +8,16 @@
 #include "JInspectorFlags.h"
 
 #include <jsinspector-modern/InspectorFlags.h>
+#include <react/fabric/ReactNativeConfigHolder.h>
 
 namespace facebook::react::jsinspector_modern {
+
+void JInspectorFlags::initFromConfig(
+    jni::alias_ref<jclass> /* unused */,
+    jni::alias_ref<jobject> reactNativeConfig) {
+  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+  inspectorFlags.initFromConfig(ReactNativeConfigHolder(reactNativeConfig));
+}
 
 bool JInspectorFlags::getEnableModernCDPRegistry(jni::alias_ref<jclass>) {
   auto& inspectorFlags = InspectorFlags::getInstance();
@@ -24,6 +32,7 @@ bool JInspectorFlags::getEnableCxxInspectorPackagerConnection(
 
 void JInspectorFlags::registerNatives() {
   javaClassLocal()->registerNatives({
+      makeNativeMethod("initFromConfig", JInspectorFlags::initFromConfig),
       makeNativeMethod(
           "getEnableModernCDPRegistry",
           JInspectorFlags::getEnableModernCDPRegistry),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <fbjni/fbjni.h>
+#include <react/config/ReactNativeConfig.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -18,6 +19,10 @@ class JInspectorFlags : public jni::JavaClass<JInspectorFlags> {
  public:
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/devsupport/InspectorFlags;";
+
+  static void initFromConfig(
+      jni::alias_ref<jclass> /* unused */,
+      jni::alias_ref<jobject> reactNativeConfig);
 
   static bool getEnableModernCDPRegistry(jni::alias_ref<jclass>);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -21,4 +21,5 @@ target_include_directories(jsinspector PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(jsinspector
         folly_runtime
         glog
+        react_config
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <glog/logging.h>
-#include <cassert>
-
 #include "InspectorFlags.h"
+
+#include <glog/logging.h>
+
+#include <cassert>
 
 namespace facebook::react::jsinspector_modern {
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <optional>
-
 #include <react/config/ReactNativeConfig.h>
+
+#include <optional>
 
 namespace facebook::react::jsinspector_modern {
 


### PR DESCRIPTION
Summary:
Progress towards an opt-in setup for our new CDP backend.

- Wires up D51563107 to conditionally disable the legacy Hermes debugger via `ReactNativeConfig`.
    - **Configuration covered**: Android, for the `ReactHostImpl` code path (Bridgeless).
- Exposes `InspectorFlags::initFromConfig` method via JNI.
- Stubs a `false` value for `react_native_devx:enable_modern_cdp_registry` in `EmptyReactNativeConfig.java` (documentation/convenience point for open source partners and integrators)

Changelog: [Internal]

Differential Revision: D52539671

