### PR TITLE
check for prefix in automatic interop layer

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -147,7 +147,8 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
       supportedLegacyViewComponents[moduleName] = moduleClass;
     }
 
-    if ([moduleName isEqualToString:componentName]) {
+    if ([moduleName isEqualToString:componentName] ||
+        [moduleName isEqualToString:[@"RCT" stringByAppendingString:componentName]]) {
       return YES;
     }
   }


### PR DESCRIPTION
Summary:
changelog: [internal]

This mimics what interop layer does in LegacyViewManagerInteropComponentDescriptor.

https://www.internalfb.com/code/fbsource/[f80a9affe2cc]/xplat/js/react-native-github/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm?lines=62

Reviewed By: cipolleschi

Differential Revision: D52627132


