### PR TITLE
Fix `compose-source-maps.js` not outputting composed source map

### DIFF
--- a/packages/react-native/scripts/compose-source-maps.js
+++ b/packages/react-native/scripts/compose-source-maps.js
@@ -61,6 +61,6 @@ if (!argv.length) {
   if (outputPath) {
     fs.writeFileSync(outputPath, composedMapJSON, 'utf8');
   } else {
-    process.stdout.write();
+    process.stdout.write(composedMapJSON);
   }
 }


### PR DESCRIPTION
## Summary:

`compose-source-maps.js` fails if `-o` is not specified when it should output the composed source map.

## Changelog:

[GENERAL] [FIXED] - Fix `compose-source-maps.js` failing if `-o` is not specified when it should output the composed source map

## Test Plan:

Tested this in an internal repo. This was the output before this fix:

```
% node node_modules/react-native/scripts/compose-source-maps.js dist/main.jsbundle.map dist/main.jsbundle.hbc.map
node:internal/streams/writable:472
      throw new ERR_INVALID_ARG_TYPE(
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received undefined
    at _write (node:internal/streams/writable:472:13)
    at Writable.write (node:internal/streams/writable:494:10)
    at Object.<anonymous> (/~/node_modules/.store/react-native-virtual-c8e66dddc1/node_modules/react-native/scripts/compose-source-maps.js:64:20)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v20.10.0
```