### PR TITLE
'[skip ci] [Venice][Android] Make getViewManagerNames() return eager view manager names

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -187,23 +187,6 @@ final class ReactInstance {
             isProfiling,
             useModernRuntimeScheduler);
 
-    RuntimeExecutor unbufferedRuntimeExecutor = getUnbufferedRuntimeExecutor();
-
-    // Initialize function for JS's UIManager.hasViewManagerConfig()
-    mComponentNameResolverManager =
-        new ComponentNameResolverManager(
-            // Use unbuffered RuntimeExecutor to install binding
-            unbufferedRuntimeExecutor,
-            (ComponentNameResolver)
-                () -> {
-                  Collection<String> viewManagerNames = getViewManagerNames();
-                  if (viewManagerNames.size() < 1) {
-                    FLog.e(TAG, "No ViewManager names found");
-                    return new String[0];
-                  }
-                  return viewManagerNames.toArray(new String[0]);
-                });
-
     // Set up TurboModules
     Systrace.beginSection(
         Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.initialize#initTurboModules");
@@ -222,6 +205,7 @@ final class ReactInstance {
             .setReactApplicationContext(mBridgelessReactContext)
             .build();
 
+    RuntimeExecutor unbufferedRuntimeExecutor = getUnbufferedRuntimeExecutor();
     mTurboModuleManager =
         new TurboModuleManager(
             // Use unbuffered RuntimeExecutor to install binding
@@ -236,6 +220,25 @@ final class ReactInstance {
     }
 
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+
+    // Set up Fabric
+    Systrace.beginSection(
+        Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.initialize#initFabric");
+
+    // Initialize function for JS's UIManager.hasViewManagerConfig()
+    mComponentNameResolverManager =
+        new ComponentNameResolverManager(
+            // Use unbuffered RuntimeExecutor to install binding
+            unbufferedRuntimeExecutor,
+            (ComponentNameResolver)
+                () -> {
+                  Collection<String> viewManagerNames = getViewManagerNames();
+                  if (viewManagerNames.size() < 1) {
+                    FLog.e(TAG, "No ViewManager names found");
+                    return new String[0];
+                  }
+                  return viewManagerNames.toArray(new String[0]);
+                });
 
     // Initialize function for JS's UIManager.getViewManagerConfig()
     // It should come after getTurboModuleManagerDelegate as it relies on react packages being
@@ -257,10 +260,6 @@ final class ReactInstance {
                     return getUIManagerConstants();
                   });
     }
-
-    // Set up Fabric
-    Systrace.beginSection(
-        Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.initialize#initFabric");
 
     ViewManagerRegistry viewManagerRegistry =
         new ViewManagerRegistry(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -232,7 +232,8 @@ final class ReactInstance {
             unbufferedRuntimeExecutor,
             (ComponentNameResolver)
                 () -> {
-                  Collection<String> viewManagerNames = mViewManagerResolver.getViewManagerNames();
+                  Collection<String> viewManagerNames =
+                      mViewManagerResolver.getLazyViewManagerNames();
                   if (viewManagerNames.size() < 1) {
                     FLog.e(TAG, "No ViewManager names found");
                     return new String[0];
@@ -269,7 +270,8 @@ final class ReactInstance {
                     }
                     // 1, Retrive view managers via on demand loading
                     if (canLoadViewManagersLazily) {
-                      for (String viewManagerName : mViewManagerResolver.getViewManagerNames()) {
+                      for (String viewManagerName :
+                          mViewManagerResolver.getLazyViewManagerNames()) {
                         viewManagers.add(mViewManagerResolver.getViewManager(viewManagerName));
                       }
                     } else {
@@ -539,7 +541,10 @@ final class ReactInstance {
 
     @Override
     public synchronized Collection<String> getViewManagerNames() {
-      return getLazyViewManagerNames();
+      Set<String> allViewManagerNames = new HashSet<>();
+      allViewManagerNames.addAll(getLazyViewManagerNames());
+      allViewManagerNames.addAll(getEagerViewManagerMap().keySet());
+      return allViewManagerNames;
     }
 
     private Map<String, ViewManager> getEagerViewManagerMap() {
@@ -588,7 +593,7 @@ final class ReactInstance {
       return null;
     }
 
-    private Collection<String> getLazyViewManagerNames() {
+    public synchronized Collection<String> getLazyViewManagerNames() {
       Set<String> uniqueNames = new HashSet<>();
       for (ReactPackage reactPackage : mReactPackages) {
         if (reactPackage instanceof ViewManagerOnDemandReactPackage) {


### PR DESCRIPTION
Summary:
Make ViewManagerResolver.getViewManagerNames() also return eager ViewManager names

I think the only impact is [this exception message](https://github.com/facebook/react-native/blob/192a88d522befa3b5cc073d441210f8148e8ac69/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerRegistry.java#L63-L67) in ViewManagerRegistry:

https://www.internalfb.com/code/fbsource/[897438be9e04]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerRegistry.java?lines=63-67

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D52399005

