### PR TITLE
prevent scroll event in nested scroll when scrollEnabled={false}

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -394,6 +394,15 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
    */
   @Override
   public void requestChildFocus(View child, View focused) {
+    /**
+     * This issue arises in a ScrollView containing a FlatList. The method now checks `mScrollEnabled`
+     * before handling focus requests to prevent unintended scroll behavior, ensuring proper functioning
+     * of nested scrolling components. when scrollEnabled={false}
+     */
+    if(!mScrollEnabled){
+      return;
+    }
+
     if (focused != null && !mPagingEnabled) {
       scrollToChild(focused);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -343,6 +343,15 @@ public class ReactScrollView extends ScrollView
    */
   @Override
   public void requestChildFocus(View child, View focused) {
+    /**
+     * This issue arises in a ScrollView containing a FlatList. The method now checks `mScrollEnabled`
+     * before handling focus requests to prevent unintended scroll behavior, ensuring proper functioning
+     * of nested scrolling components. when scrollEnabled={false}
+     */
+    if(!mScrollEnabled){
+      return;
+    }
+
     if (focused != null) {
       scrollToChild(focused);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When a FlatList is in side a scroll view (think Netflix style navigation), the DPAD up/down fires on the scroll view, despite scrollEnabled={false} being set. This additiontially conflicts with any custom scroll event that has been created.

## Changelog:

[Android] [Fixed] - fix: prevent scroll event in nested scroll when scrollEnabled={false}

## Test Plan

I tested this by making a ScrollView with FlatList of opposite scrolling direction inside with basic card layouts.

Both had scrollEnabled={false}

I scrolled the ScrollView myself as it has multiple rows using:

```
  const scrollToItem = React.useCallback(
    (itemIndex: number): void => {
      const targetScrollY = itemIndex * height
      scrollViewRef.current?.scrollTo({ y: targetScrollY, animated: true })
    },
    [height]
  )

  React.useEffect(() => {
    // Row 0, is global nav, but it's also the first row of cards
    // when we scroll to "1" what we mean is global nav is hidden
    // we should still be showing the first row of items.
    scrollToItem(rowIndex <= 1 ? 0 : rowIndex - 1)
  }, [rowIndex, scrollToItem])
```