### PR TITLE
[RN][iOS] Fix symbol not found _jump_fcontext with use_frameworks!

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -137,7 +137,7 @@ class ReactNativePodsUtils
 
                 # fix for weak linking
                 self.safe_init(config, other_ld_flags_key)
-                if self.is_using_xcode15_or_greter(:xcodebuild_manager => xcodebuild_manager)
+                if self.is_using_xcode15_0(:xcodebuild_manager => xcodebuild_manager)
                     self.add_value_to_setting_if_missing(config, other_ld_flags_key, xcode15_compatibility_flags)
                 else
                     self.remove_value_from_setting_if_present(config, other_ld_flags_key, xcode15_compatibility_flags)
@@ -321,7 +321,7 @@ class ReactNativePodsUtils
         end
     end
 
-    def self.is_using_xcode15_or_greter(xcodebuild_manager: Xcodebuild)
+    def self.is_using_xcode15_0(xcodebuild_manager: Xcodebuild)
         xcodebuild_version = xcodebuild_manager.version
 
         # The output of xcodebuild -version is something like
@@ -332,7 +332,8 @@ class ReactNativePodsUtils
         regex = /(\d+)\.(\d+)(?:\.(\d+))?/
         if match_data = xcodebuild_version.match(regex)
             major = match_data[1].to_i
-            return major >= 15
+            minor = match_data[2].to_i
+            return major == 15 && minor == 0
         end
 
         return false


### PR DESCRIPTION
## Summary:
While developing Xcode 15, Apple reimplemented the linker. 
In Xcode 15.0, the linker was making old iOS (< 15) crash when they were built using Xcode 15.

To fix that, we make Apple create new compiler flags (`-ld_classic`) to have a backward compatible linker.

In Xcode 15.1, Apple fixed that behavior, so the flags should not be required anymore. 
But now, if we pass `-ld_classic` to the linker and we have an app that is using `use_framworks!`, that app crashes at startup.

This change remove the flags if the Xcode that is used is 15.1 or greater.

*Note:* The previous change added the flags to Hermes as well. I tested this fix in a configuration where Hermes has the flags and React Native does not, and it works. So we are removing the flags only from React Native. 

## Changelog:
[Internal] - Do not add the `-ld_classic` flag if the app is built with Xcode 15.1 or greater.

## Test Plan:
Tested locally that a new app with `use_frameworks!` is not crashing.
Tested on Firebase Testlab that a new app built with Xcode 15.2 and running on iOS <15 is not crashing at startup.