### PR TITLE
Fix retrieving current appearance in multi-window apps

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAlertController.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertController.mm
@@ -35,8 +35,8 @@
 {
   UIUserInterfaceStyle style = self.overrideUserInterfaceStyle;
   if (style == UIUserInterfaceStyleUnspecified) {
-      UIUserInterfaceStyle overridenStyle = RCTSharedApplication().delegate.window.overrideUserInterfaceStyle;
-      style = overridenStyle ? overridenStyle : UIUserInterfaceStyleUnspecified;
+    UIUserInterfaceStyle overriddenStyle = RCTKeyWindow().overrideUserInterfaceStyle;
+    style = overriddenStyle ? overriddenStyle : UIUserInterfaceStyleUnspecified;
   }
 
   self.overrideUserInterfaceStyle = style;

--- a/packages/react-native/React/CoreModules/RCTAlertController.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertController.mm
@@ -35,9 +35,8 @@
 {
   UIUserInterfaceStyle style = self.overrideUserInterfaceStyle;
   if (style == UIUserInterfaceStyleUnspecified) {
-    style = RCTSharedApplication().delegate.window.overrideUserInterfaceStyle
-        ? RCTSharedApplication().delegate.window.overrideUserInterfaceStyle
-        : UIUserInterfaceStyleUnspecified;
+      UIUserInterfaceStyle overridenStyle = RCTSharedApplication().delegate.window.overrideUserInterfaceStyle;
+      style = overridenStyle ? overridenStyle : UIUserInterfaceStyleUnspecified;
   }
 
   self.overrideUserInterfaceStyle = style;

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -70,7 +70,7 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
 - (instancetype)init
 {
   if ((self = [super init])) {
-    UITraitCollection *traitCollection = RCTSharedApplication().delegate.window.traitCollection;
+    UITraitCollection *traitCollection = RCTKeyWindow().traitCollection;
     _currentColorScheme = RCTColorSchemePreference(traitCollection);
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appearanceChanged:)


### PR DESCRIPTION
## Summary:

This PR resolves issues with retrieving appearance in multi-window apps by calling `RCTKeyWindow()` instead of retrieving the AppDelegate window property. It also does small optimization in the RCTAlertController.

## Changelog:

[IOS] [FIXED] - Fix retrieving current appearance in multi-window apps

## Test Plan:

CI Green, it should work the same as before
