### PR TITLE
[RN][iOS] Fix min ios version regression and update podfile.lock

### DIFF
--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -38,7 +38,7 @@ end
 module Helpers
     class Constants
         def self.min_ios_version_supported
-            return '13.4'
+            return '12.4'
         end
     end
 end

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.72.8)
-  - FBReactNativeSpec (0.72.8):
+  - FBLazyVector (0.72.9)
+  - FBReactNativeSpec (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
-    - React-Core (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
+    - React-Core (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
   - Flipper (0.182.0):
     - Flipper-Folly (~> 2.6)
   - Flipper-Boost-iOSX (1.76.0.1.11)
@@ -70,9 +70,9 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.72.8):
-    - hermes-engine/Pre-built (= 0.72.8)
-  - hermes-engine/Pre-built (0.72.8)
+  - hermes-engine (0.72.9):
+    - hermes-engine/Pre-built (= 0.72.9)
+  - hermes-engine/Pre-built (0.72.9)
   - libevent (2.1.12)
   - OCMock (3.9.1)
   - OpenSSL-Universal (1.1.1100)
@@ -98,26 +98,26 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.72.8)
-  - RCTTypeSafety (0.72.8):
-    - FBLazyVector (= 0.72.8)
-    - RCTRequired (= 0.72.8)
-    - React-Core (= 0.72.8)
-  - React (0.72.8):
-    - React-Core (= 0.72.8)
-    - React-Core/DevSupport (= 0.72.8)
-    - React-Core/RCTWebSocket (= 0.72.8)
-    - React-RCTActionSheet (= 0.72.8)
-    - React-RCTAnimation (= 0.72.8)
-    - React-RCTBlob (= 0.72.8)
-    - React-RCTImage (= 0.72.8)
-    - React-RCTLinking (= 0.72.8)
-    - React-RCTNetwork (= 0.72.8)
-    - React-RCTSettings (= 0.72.8)
-    - React-RCTText (= 0.72.8)
-    - React-RCTVibration (= 0.72.8)
-  - React-callinvoker (0.72.8)
-  - React-Codegen (0.72.8):
+  - RCTRequired (0.72.9)
+  - RCTTypeSafety (0.72.9):
+    - FBLazyVector (= 0.72.9)
+    - RCTRequired (= 0.72.9)
+    - React-Core (= 0.72.9)
+  - React (0.72.9):
+    - React-Core (= 0.72.9)
+    - React-Core/DevSupport (= 0.72.9)
+    - React-Core/RCTWebSocket (= 0.72.9)
+    - React-RCTActionSheet (= 0.72.9)
+    - React-RCTAnimation (= 0.72.9)
+    - React-RCTBlob (= 0.72.9)
+    - React-RCTImage (= 0.72.9)
+    - React-RCTLinking (= 0.72.9)
+    - React-RCTNetwork (= 0.72.9)
+    - React-RCTSettings (= 0.72.9)
+    - React-RCTText (= 0.72.9)
+    - React-RCTVibration (= 0.72.9)
+  - React-callinvoker (0.72.9)
+  - React-Codegen (0.72.9):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -136,11 +136,11 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.72.8):
+  - React-Core (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.8)
+    - React-Core/Default (= 0.72.9)
     - React-cxxreact
     - React-hermes
     - React-jsi
@@ -150,50 +150,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.72.8):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/Default (0.72.8):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/DevSupport (0.72.8):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.8)
-    - React-Core/RCTWebSocket (= 0.72.8)
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.72.8)
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.72.8):
+  - React-Core/CoreModulesHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -207,7 +164,36 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.72.8):
+  - React-Core/Default (0.72.9):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/DevSupport (0.72.9):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.72.9)
+    - React-Core/RCTWebSocket (= 0.72.9)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.72.9)
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -221,7 +207,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.72.8):
+  - React-Core/RCTAnimationHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -235,7 +221,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.72.8):
+  - React-Core/RCTBlobHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -249,7 +235,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.72.8):
+  - React-Core/RCTImageHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -263,7 +249,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.72.8):
+  - React-Core/RCTLinkingHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -277,7 +263,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.72.8):
+  - React-Core/RCTNetworkHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -291,7 +277,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.72.8):
+  - React-Core/RCTPushNotificationHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -305,7 +291,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.72.8):
+  - React-Core/RCTSettingsHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -319,7 +305,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.72.8):
+  - React-Core/RCTTextHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -333,11 +319,11 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.72.8):
+  - React-Core/RCTVibrationHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.8)
+    - React-Core/Default
     - React-cxxreact
     - React-hermes
     - React-jsi
@@ -347,591 +333,605 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-CoreModules (0.72.8):
+  - React-Core/RCTWebSocket (0.72.9):
+    - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.8)
-    - React-Codegen (= 0.72.8)
-    - React-Core/CoreModulesHeaders (= 0.72.8)
-    - React-jsi (= 0.72.8)
+    - React-Core/Default (= 0.72.9)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-CoreModules (0.72.9):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/CoreModulesHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
     - React-RCTBlob
-    - React-RCTImage (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
+    - React-RCTImage (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
     - SocketRocket (= 0.6.1)
-  - React-cxxreact (0.72.8):
+  - React-cxxreact (0.72.9):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.8)
-    - React-debug (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsinspector (= 0.72.8)
-    - React-logger (= 0.72.8)
-    - React-perflogger (= 0.72.8)
-    - React-runtimeexecutor (= 0.72.8)
-  - React-debug (0.72.8)
-  - React-Fabric (0.72.8):
+    - React-callinvoker (= 0.72.9)
+    - React-debug (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsinspector (= 0.72.9)
+    - React-logger (= 0.72.9)
+    - React-perflogger (= 0.72.9)
+    - React-runtimeexecutor (= 0.72.9)
+  - React-debug (0.72.9)
+  - React-Fabric (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-Fabric/animations (= 0.72.8)
-    - React-Fabric/attributedstring (= 0.72.8)
-    - React-Fabric/butter (= 0.72.8)
-    - React-Fabric/componentregistry (= 0.72.8)
-    - React-Fabric/componentregistrynative (= 0.72.8)
-    - React-Fabric/components (= 0.72.8)
-    - React-Fabric/config (= 0.72.8)
-    - React-Fabric/core (= 0.72.8)
-    - React-Fabric/debug_renderer (= 0.72.8)
-    - React-Fabric/imagemanager (= 0.72.8)
-    - React-Fabric/leakchecker (= 0.72.8)
-    - React-Fabric/mapbuffer (= 0.72.8)
-    - React-Fabric/mounting (= 0.72.8)
-    - React-Fabric/scheduler (= 0.72.8)
-    - React-Fabric/telemetry (= 0.72.8)
-    - React-Fabric/templateprocessor (= 0.72.8)
-    - React-Fabric/textlayoutmanager (= 0.72.8)
-    - React-Fabric/uimanager (= 0.72.8)
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-Fabric/animations (= 0.72.9)
+    - React-Fabric/attributedstring (= 0.72.9)
+    - React-Fabric/butter (= 0.72.9)
+    - React-Fabric/componentregistry (= 0.72.9)
+    - React-Fabric/componentregistrynative (= 0.72.9)
+    - React-Fabric/components (= 0.72.9)
+    - React-Fabric/config (= 0.72.9)
+    - React-Fabric/core (= 0.72.9)
+    - React-Fabric/debug_renderer (= 0.72.9)
+    - React-Fabric/imagemanager (= 0.72.9)
+    - React-Fabric/leakchecker (= 0.72.9)
+    - React-Fabric/mapbuffer (= 0.72.9)
+    - React-Fabric/mounting (= 0.72.9)
+    - React-Fabric/scheduler (= 0.72.9)
+    - React-Fabric/telemetry (= 0.72.9)
+    - React-Fabric/templateprocessor (= 0.72.9)
+    - React-Fabric/textlayoutmanager (= 0.72.9)
+    - React-Fabric/uimanager (= 0.72.9)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/animations (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/animations (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/attributedstring (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/attributedstring (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/butter (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/butter (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/componentregistry (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/componentregistry (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/componentregistrynative (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/componentregistrynative (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-Fabric/components/activityindicator (= 0.72.8)
-    - React-Fabric/components/image (= 0.72.8)
-    - React-Fabric/components/inputaccessory (= 0.72.8)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.72.8)
-    - React-Fabric/components/modal (= 0.72.8)
-    - React-Fabric/components/rncore (= 0.72.8)
-    - React-Fabric/components/root (= 0.72.8)
-    - React-Fabric/components/safeareaview (= 0.72.8)
-    - React-Fabric/components/scrollview (= 0.72.8)
-    - React-Fabric/components/text (= 0.72.8)
-    - React-Fabric/components/textinput (= 0.72.8)
-    - React-Fabric/components/unimplementedview (= 0.72.8)
-    - React-Fabric/components/view (= 0.72.8)
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-Fabric/components/activityindicator (= 0.72.9)
+    - React-Fabric/components/image (= 0.72.9)
+    - React-Fabric/components/inputaccessory (= 0.72.9)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.72.9)
+    - React-Fabric/components/modal (= 0.72.9)
+    - React-Fabric/components/rncore (= 0.72.9)
+    - React-Fabric/components/root (= 0.72.9)
+    - React-Fabric/components/safeareaview (= 0.72.9)
+    - React-Fabric/components/scrollview (= 0.72.9)
+    - React-Fabric/components/text (= 0.72.9)
+    - React-Fabric/components/textinput (= 0.72.9)
+    - React-Fabric/components/unimplementedview (= 0.72.9)
+    - React-Fabric/components/view (= 0.72.9)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/activityindicator (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/activityindicator (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/image (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/image (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/inputaccessory (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/inputaccessory (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/legacyviewmanagerinterop (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/legacyviewmanagerinterop (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/modal (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/modal (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/rncore (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/rncore (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/root (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/root (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/safeareaview (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/safeareaview (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/scrollview (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/scrollview (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/text (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/text (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/textinput (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/textinput (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/unimplementedview (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/unimplementedview (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/components/view (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/components/view (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
+    - ReactCommon/turbomodule/core (= 0.72.9)
     - Yoga
-  - React-Fabric/config (0.72.8):
+  - React-Fabric/config (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/core (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/core (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/debug_renderer (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/debug_renderer (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/imagemanager (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/imagemanager (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/leakchecker (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/leakchecker (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/mapbuffer (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/mapbuffer (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/mounting (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/mounting (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/scheduler (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/scheduler (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/telemetry (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/telemetry (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/templateprocessor (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/templateprocessor (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/textlayoutmanager (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/textlayoutmanager (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
     - React-Fabric/uimanager
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-Fabric/uimanager (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-Fabric/uimanager (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.72.8)
-    - RCTTypeSafety (= 0.72.8)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
     - React-Core
     - React-debug
-    - React-graphics (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-jsiexecutor (= 0.72.8)
+    - React-graphics (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsiexecutor (= 0.72.9)
     - React-logger
     - React-runtimescheduler
     - React-utils
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-graphics (0.72.8):
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-graphics (0.72.9):
     - glog
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.8)
-  - React-hermes (0.72.8):
+    - React-Core/Default (= 0.72.9)
+  - React-hermes (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - RCT-Folly/Futures (= 2021.07.22.00)
-    - React-cxxreact (= 0.72.8)
+    - React-cxxreact (= 0.72.9)
     - React-jsi
-    - React-jsiexecutor (= 0.72.8)
-    - React-jsinspector (= 0.72.8)
-    - React-perflogger (= 0.72.8)
-  - React-ImageManager (0.72.8):
+    - React-jsiexecutor (= 0.72.9)
+    - React-jsinspector (= 0.72.9)
+    - React-perflogger (= 0.72.9)
+  - React-ImageManager (0.72.9):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -939,24 +939,24 @@ PODS:
     - React-Fabric
     - React-RCTImage
     - React-utils
-  - React-jsi (0.72.8):
+  - React-jsi (0.72.9):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.72.8):
+  - React-jsiexecutor (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-perflogger (= 0.72.8)
-  - React-jsinspector (0.72.8)
-  - React-logger (0.72.8):
+    - React-cxxreact (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-perflogger (= 0.72.9)
+  - React-jsinspector (0.72.9)
+  - React-logger (0.72.9):
     - glog
-  - React-NativeModulesApple (0.72.8):
+  - React-NativeModulesApple (0.72.9):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -965,17 +965,17 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.72.8)
-  - React-RCTActionSheet (0.72.8):
-    - React-Core/RCTActionSheetHeaders (= 0.72.8)
-  - React-RCTAnimation (0.72.8):
+  - React-perflogger (0.72.9)
+  - React-RCTActionSheet (0.72.9):
+    - React-Core/RCTActionSheetHeaders (= 0.72.9)
+  - React-RCTAnimation (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.8)
-    - React-Codegen (= 0.72.8)
-    - React-Core/RCTAnimationHeaders (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-RCTAppDelegate (0.72.8):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTAnimationHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTAppDelegate (0.72.9):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -987,78 +987,78 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-RCTBlob (0.72.8):
+  - React-RCTBlob (0.72.9):
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.72.8)
-    - React-Core/RCTBlobHeaders (= 0.72.8)
-    - React-Core/RCTWebSocket (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-RCTNetwork (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-RCTFabric (0.72.8):
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTBlobHeaders (= 0.72.9)
+    - React-Core/RCTWebSocket (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-RCTNetwork (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTFabric (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core (= 0.72.8)
-    - React-Fabric (= 0.72.8)
+    - React-Core (= 0.72.9)
+    - React-Fabric (= 0.72.9)
     - React-ImageManager
-    - React-RCTImage (= 0.72.8)
+    - React-RCTImage (= 0.72.9)
     - React-RCTText
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.72.8):
+  - React-RCTImage (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.8)
-    - React-Codegen (= 0.72.8)
-    - React-Core/RCTImageHeaders (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-RCTNetwork (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-RCTLinking (0.72.8):
-    - React-Codegen (= 0.72.8)
-    - React-Core/RCTLinkingHeaders (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-RCTNetwork (0.72.8):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTImageHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-RCTNetwork (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTLinking (0.72.9):
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTLinkingHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTNetwork (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.8)
-    - React-Codegen (= 0.72.8)
-    - React-Core/RCTNetworkHeaders (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-RCTPushNotification (0.72.8):
-    - RCTTypeSafety (= 0.72.8)
-    - React-Codegen (= 0.72.8)
-    - React-Core/RCTPushNotificationHeaders (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-RCTSettings (0.72.8):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTNetworkHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTPushNotification (0.72.9):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTPushNotificationHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTSettings (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.8)
-    - React-Codegen (= 0.72.8)
-    - React-Core/RCTSettingsHeaders (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-RCTTest (0.72.8):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTSettingsHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTTest (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core (= 0.72.8)
-    - React-CoreModules (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-RCTText (0.72.8):
-    - React-Core/RCTTextHeaders (= 0.72.8)
-  - React-RCTVibration (0.72.8):
+    - React-Core (= 0.72.9)
+    - React-CoreModules (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTText (0.72.9):
+    - React-Core/RCTTextHeaders (= 0.72.9)
+  - React-RCTVibration (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.72.8)
-    - React-Core/RCTVibrationHeaders (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - ReactCommon/turbomodule/core (= 0.72.8)
-  - React-rncore (0.72.8)
-  - React-runtimeexecutor (0.72.8):
-    - React-jsi (= 0.72.8)
-  - React-runtimescheduler (0.72.8):
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTVibrationHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-rncore (0.72.9)
+  - React-runtimeexecutor (0.72.9):
+    - React-jsi (= 0.72.9)
+  - React-runtimescheduler (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -1066,11 +1066,11 @@ PODS:
     - React-debug
     - React-jsi
     - React-runtimeexecutor
-  - React-utils (0.72.8):
+  - React-utils (0.72.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-debug
-  - ReactCommon-Samples (0.72.8):
+  - ReactCommon-Samples (0.72.9):
     - DoubleConversion
     - hermes-engine
     - RCT-Folly
@@ -1079,26 +1079,26 @@ PODS:
     - React-cxxreact
     - React-NativeModulesApple
     - ReactCommon/turbomodule/core
-  - ReactCommon/turbomodule/bridging (0.72.8):
+  - ReactCommon/turbomodule/bridging (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.8)
-    - React-cxxreact (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-logger (= 0.72.8)
-    - React-perflogger (= 0.72.8)
-  - ReactCommon/turbomodule/core (0.72.8):
+    - React-callinvoker (= 0.72.9)
+    - React-cxxreact (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-logger (= 0.72.9)
+    - React-perflogger (= 0.72.9)
+  - ReactCommon/turbomodule/core (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.8)
-    - React-cxxreact (= 0.72.8)
-    - React-jsi (= 0.72.8)
-    - React-logger (= 0.72.8)
-    - React-perflogger (= 0.72.8)
+    - React-callinvoker (= 0.72.9)
+    - React-cxxreact (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-logger (= 0.72.9)
+    - React-perflogger (= 0.72.9)
   - ScreenshotManager (0.0.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -1297,11 +1297,11 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  FBLazyVector: df077ae30c8148bcfdc8f886450eb2eefb94a5be
-  FBReactNativeSpec: fa09eb09ebbd245add3536993cbca983f21e04af
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  FBLazyVector: dc178b8748748c036ef9493a5d59d6d1f91a36ce
+  FBReactNativeSpec: e661d6442e3c64baeab8da73e8eed47adf26e08b
   Flipper: 6edb735e6c3e332975d1b17956bcc584eccf5818
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -1311,53 +1311,53 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 32c50dea8bf400d1414d26cb22a5e8a1ceb66a5e
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  hermes-engine: 9b9bb14184a11b8ceb4131b09abf634880f0f46d
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
-  RCTRequired: 182d3e71f3ee4edfa87d4bf82eeea61510922b2a
-  RCTTypeSafety: 61b90f18bbc961c01ae4cfcb80830953eca73573
-  React: 1beea0f4f564f96b94159811340b6c09dc61530b
-  React-callinvoker: 2e055aa95f8169c20fade24f82c49a190ab7de45
-  React-Codegen: 11292133dfe7a90bb9b282dc38f731c52dc96bc6
-  React-Core: 1d8665e11f7ea4f0cd82aea8eab6a5c53e597cbd
-  React-CoreModules: 6e57bbb2ac83e5dd4c960ce3218f4fb3ac923bb9
-  React-cxxreact: d0ef80b5be65c1aad01e9413539315b5ddd26b15
-  React-debug: 535f01caed56dbf6fd2271b05a315384bda49174
-  React-Fabric: 7f8540a8e802179afab5193485dde2244d5e7bbc
-  React-graphics: cb8402699e45ce28962b77ef726286842ffae9b6
-  React-hermes: ab440bb0114ffb24fcb83f1f7d4a0b183e33bd27
-  React-ImageManager: c7b877ac75d6e003acf000cb6931592802bdaf5a
-  React-jsi: 0921d5fe8094d75d472b146137bb5f46102d7974
-  React-jsiexecutor: 03baea362e7475543e7cd091cb4fcf2bd78e041e
-  React-jsinspector: fdf0a09bddecf9ce8da830bcb89a9814230c04a4
-  React-logger: c2e7bb772d6e9fc3d0109d1243b81546a9c93c0f
-  React-NativeModulesApple: f6153767facad322a10b07fa2dbd747abbe10302
-  React-perflogger: 2a7d221549cd5b69e95c5afa2e8d336f0465e1ec
-  React-RCTActionSheet: 449042d31545790748a97d9b35d4acb683e2ad00
-  React-RCTAnimation: 1f4c8ce38087dbbb7f11159d8ba4eacd4fa6f06a
-  React-RCTAppDelegate: 6e095f409ff43b9065249d569e3f6bb5807be08b
-  React-RCTBlob: b63c4ddf33347557a4adaba553b02a23f4b49e44
-  React-RCTFabric: c60cfe97d03d0b232658432b68bd771fdb900f2e
-  React-RCTImage: 62a897828f129e2220d27b51ce9d965efed547ab
-  React-RCTLinking: 465ad65daf762d5b336973c988bdea0e51697467
-  React-RCTNetwork: 33b47ffe3b4192097e787a23cbbb1b5f495337ff
-  React-RCTPushNotification: 4b96a5a210735decc681ecb6c044424c4a7ae056
-  React-RCTSettings: 37d04a01ef8806ceeb281d7b90c85d8600a0642f
-  React-RCTTest: 0a78a8f1cdbc39cc5a0c16070a5bd37f25ef8d95
-  React-RCTText: 9a811835f8888d34aa9377333ca5d33ea46b3006
-  React-RCTVibration: 9f4d7f480b79141e1bb16ad76d46068e5ac4d378
-  React-rncore: ad6b370e43070487204ac69133fd56a77e211acd
-  React-runtimeexecutor: 4e97887d9cf661def3ffdb0f48c41d4e2afb31d0
-  React-runtimescheduler: ef4d39689a1e46020b2070233c283a1df318ea54
-  React-utils: 763133a48463476c429d1f99723f5a0ec467f9f9
-  ReactCommon: c111aa0c8006650d77a651e155f4112f97761dfd
-  ReactCommon-Samples: eeee60f521eb7db2ff076fbd7820f92fb7e0feb3
+  RCTRequired: f30c3213569b1dc43659ecc549a6536e1e11139e
+  RCTTypeSafety: e1ed3137728804fa98bce30b70e3da0b8e23054e
+  React: 54070abee263d5773486987f1cf3a3616710ed52
+  React-callinvoker: 794ea19cc4d8ce25921893141e131b9d6b7d02eb
+  React-Codegen: 56417b3402a3b85386470a72c338224d0b689998
+  React-Core: 7e2a9c4594083ecc68b91fc4a3f4d567e8c8b3b3
+  React-CoreModules: 87cc386c2200862672b76bb02c4574b4b1d11b3c
+  React-cxxreact: 1100498800597e812f0ce4ec365f4ea47ac39719
+  React-debug: 7af2049f3848bde3696276d4858ffea1274d8458
+  React-Fabric: 955c896c324f7112e2da198647ff7d107b4ca63f
+  React-graphics: 34b8df3af86c85fddb2bd1eb28bab4dad9fc6a25
+  React-hermes: b871a77ba1c427ca00f075759dc0cc9670484c94
+  React-ImageManager: 86776b5c7280cce657c94a2621b0e46ab999f581
+  React-jsi: 1f8d073a00264c6a701c4b7b4f4ef9946f9b2455
+  React-jsiexecutor: 5a169b1dd1abad06bed40ab7e1aca883c657d865
+  React-jsinspector: 54205b269da20c51417e0fc02c4cde9f29a4bf1a
+  React-logger: f42d2f2bc4cbb5d19d7c0ce84b8741b1e54e88c8
+  React-NativeModulesApple: 9f72feb8a04020b32417f768a7e1e40eec91fef4
+  React-perflogger: cb433f318c6667060fc1f62e26eb58d6eb30a627
+  React-RCTActionSheet: 0af3f8ac067e8a1dde902810b7ad169d0a0ec31e
+  React-RCTAnimation: 453a88e76ba6cb49819686acd8b21ce4d9ee4232
+  React-RCTAppDelegate: b9fb07959f227ddd2c458c42ed5ceacbd1e1e367
+  React-RCTBlob: fa513d56cdc2b7ad84a7758afc4863c1edd6a8b1
+  React-RCTFabric: 5247c6adba1c3379ecf851a8ebe1559f0ed00086
+  React-RCTImage: 8e059fbdfab18b86127424dc3742532aab960760
+  React-RCTLinking: 05ae2aa525b21a7f1c5069c14330700f470efd97
+  React-RCTNetwork: 7ed9d99d028c53e9a23e318f65937f499ba8a6fd
+  React-RCTPushNotification: c129613896ce15b15e1c566c34747a122d8cb5ad
+  React-RCTSettings: 8b12ebf04d4baa0e259017fcef6cf7abd7d8ac51
+  React-RCTTest: 49839e4d6bd2882086f84709a3d51d33c98dadf6
+  React-RCTText: a062ade9ff1591c46bcb6c5055fd4f96c154b8aa
+  React-RCTVibration: 87c490b6f01746ab8f9b4e555f514cc030c06731
+  React-rncore: c07cdca94018ebd0eb62d2b576c40094dec8bd93
+  React-runtimeexecutor: 226ebef5f625878d3028b196cbecbbdeb6f208e4
+  React-runtimescheduler: 3a5ce2c31eda2f04394aa843cbe2816912ef2ae0
+  React-utils: d3f806d3658bec0360aab46000d251872689340b
+  ReactCommon: 180205f326d59f52e12fa724f5278fcf8fb6afc3
+  ReactCommon-Samples: b8bad7c14a16b074adcf1005d811f9c60b5df44b
   ScreenshotManager: 4e5729bfcd19014d277e57eb60e8e75db64b2953
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 11d7931afb89721f39cf553a78767b81c7fbea1f
+  Yoga: eddf2bbe4a896454c248a8f23b4355891eb720a6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 9fa6f105e2187b680e978d57b28e2f700c8bd295


### PR DESCRIPTION
## Summary:
Fixes #42199 and updates podfile.lock

## Changelog:
[iOS][Fixed] - Revert the regression of iOS min version and updates Podfile.lock for Releases

## Test Plan:
Tested locally