### PR TITLE
CocoaPods: simplify iOS build directory cleanup

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -391,11 +391,10 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Arrange
         CodegenUtils.set_cleanup_done(true)
         codegen_dir = "build/generated/ios"
-        ios_folder = '.'
         rn_path = '../node_modules/react-native'
 
         # Act
-        CodegenUtils.clean_up_build_folder(rn_path, @base_path, ios_folder, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
+        CodegenUtils.clean_up_build_folder(rn_path, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(FileUtils::FileUtilsStorage.rmrf_invocation_count, 0)
@@ -407,11 +406,10 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Arrange
         CodegenUtils.set_cleanup_done(false)
         codegen_dir = "build/generated/ios"
-        ios_folder = '.'
         rn_path = '../node_modules/react-native'
 
         # Act
-        CodegenUtils.clean_up_build_folder(rn_path, @base_path, ios_folder, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
+        CodegenUtils.clean_up_build_folder(rn_path, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(FileUtils::FileUtilsStorage.rmrf_invocation_count, 0)
@@ -424,8 +422,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Arrange
         CodegenUtils.set_cleanup_done(false)
         codegen_dir = "build/generated/ios"
-        ios_folder = '.'
-        codegen_path = "#{@base_path}/./#{codegen_dir}"
+        codegen_path = "#{@base_path}/#{codegen_dir}"
         globs = [
             "/MyModuleSpecs/MyModule.h",
             "#{codegen_path}/MyModuleSpecs/MyModule.mm",
@@ -438,7 +435,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         DirMock.mocked_existing_globs(globs, "#{codegen_path}/*")
 
         # Act
-        CodegenUtils.clean_up_build_folder(rn_path, @base_path, ios_folder, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
+        CodegenUtils.clean_up_build_folder(rn_path, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(DirMock.exist_invocation_params, [codegen_path, codegen_path])
@@ -460,10 +457,9 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Arrange
         codegen_dir = "build/generated/ios"
         codegen_path = "#{@base_path}/./#{codegen_dir}"
-        ios_folder = '.'
 
         # Act
-        CodegenUtils.assert_codegen_folder_is_empty(@base_path, ios_folder, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
+        CodegenUtils.assert_codegen_folder_is_empty(codegen_path, dir_manager: DirMock)
 
         # Assert
         assert_equal(Pod::UI.collected_warns, [])
@@ -473,12 +469,11 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Arrange
         codegen_dir = "build/generated/ios"
         codegen_path = "#{@base_path}/./#{codegen_dir}"
-        ios_folder = '.'
         DirMock.mocked_existing_dirs(codegen_path)
         DirMock.mocked_existing_globs([], "#{codegen_path}/*")
 
         # Act
-        CodegenUtils.assert_codegen_folder_is_empty(@base_path, ios_folder, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
+        CodegenUtils.assert_codegen_folder_is_empty(codegen_path, dir_manager: DirMock)
 
         # Assert
         assert_equal(Pod::UI.collected_warns, [])
@@ -488,13 +483,12 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Arrange
         codegen_dir = "build/generated/ios"
         codegen_path = "#{@base_path}/./#{codegen_dir}"
-        ios_folder = '.'
         DirMock.mocked_existing_dirs(codegen_path)
         DirMock.mocked_existing_globs(["#{codegen_path}/MyModuleSpecs/MyModule.mm",], "#{codegen_path}/*")
 
         # Act
         assert_raises() {
-            CodegenUtils.assert_codegen_folder_is_empty(@base_path, ios_folder, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
+            CodegenUtils.assert_codegen_folder_is_empty(codegen_path, dir_manager: DirMock)
         }
 
         # Assert

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -336,25 +336,25 @@ class CodegenUtils
       return @@CLEANUP_DONE
     end
 
-    def self.clean_up_build_folder(rn_path, app_path, ios_folder, codegen_dir, dir_manager: Dir, file_manager: File)
+    def self.clean_up_build_folder(rn_path, codegen_dir, dir_manager: Dir, file_manager: File)
       return if CodegenUtils.cleanup_done()
       CodegenUtils.set_cleanup_done(true)
 
-      codegen_path = file_manager.join(app_path, ios_folder, codegen_dir)
+      ios_folder = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
+      codegen_path = file_manager.join(ios_folder, codegen_dir)
       return if !dir_manager.exist?(codegen_path)
 
       FileUtils.rm_rf(dir_manager.glob("#{codegen_path}/*"))
       base_provider_path = file_manager.join(rn_path, 'React', 'Fabric', 'RCTThirdPartyFabricComponentsProvider')
       FileUtils.rm_rf("#{base_provider_path}.h")
       FileUtils.rm_rf("#{base_provider_path}.mm")
-      CodegenUtils.assert_codegen_folder_is_empty(app_path, ios_folder, codegen_dir, dir_manager: dir_manager, file_manager: file_manager)
+      CodegenUtils.assert_codegen_folder_is_empty(codegen_path, dir_manager: dir_manager)
     end
 
     # Need to split this function from the previous one to be able to test it properly.
-    def self.assert_codegen_folder_is_empty(app_path, ios_folder, codegen_dir, dir_manager: Dir, file_manager: File)
+    def self.assert_codegen_folder_is_empty(codegen_path, dir_manager: Dir)
       # double check that the files have actually been deleted.
       # Emit an error message if not.
-      codegen_path = file_manager.join(app_path, ios_folder, codegen_dir)
       if dir_manager.exist?(codegen_path) && dir_manager.glob("#{codegen_path}/*").length() != 0
         Pod::UI.warn "Unable to remove the content of #{codegen_path} folder. Please run rm -rf #{codegen_path} and try again."
         abort

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -66,7 +66,6 @@ end
 # - hermes_enabled: whether Hermes should be enabled or not.
 # - app_path: path to the React Native app. Required by the New Architecture.
 # - config_file_dir: directory of the `package.json` file, required by the New Architecture.
-# - ios_folder: the folder where the iOS code base lives. For a template app, it is `ios`, the default. For RNTester, it is `.`.
 def use_react_native! (
   path: "../node_modules/react-native",
   fabric_enabled: false,
@@ -74,8 +73,7 @@ def use_react_native! (
   production: false, # deprecated
   hermes_enabled: ENV['USE_HERMES'] && ENV['USE_HERMES'] == '0' ? false : true,
   app_path: '..',
-  config_file_dir: '',
-  ios_folder: 'ios'
+  config_file_dir: ''
 )
 
   # Set the app_path as env variable so the podspecs can access it.
@@ -86,7 +84,7 @@ def use_react_native! (
   # that has invoked the `use_react_native!` function.
   ReactNativePodsUtils.detect_use_frameworks(current_target_definition)
 
-  CodegenUtils.clean_up_build_folder(path, app_path, ios_folder, $CODEGEN_OUTPUT_DIR)
+  CodegenUtils.clean_up_build_folder(path, $CODEGEN_OUTPUT_DIR)
 
   # We are relying on this flag also in third parties libraries to proper install dependencies.
   # Better to rely and enable this environment flag if the new architecture is turned on using flags.

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -49,7 +49,6 @@ def pods(target_name, options = {})
     app_path: "#{Dir.pwd}",
     config_file_dir: "#{Dir.pwd}/node_modules",
     production: false, #deprecated
-    ios_folder: '.',
   )
   pod 'ReactCommon-Samples', :path => "#{@prefix_path}/ReactCommon/react/nativemodule/samples"
 

--- a/scripts/releases/__tests__/__fixtures__/remove-new-arch-flags-fixture.js
+++ b/scripts/releases/__tests__/__fixtures__/remove-new-arch-flags-fixture.js
@@ -18,7 +18,6 @@ def use_react_native! (
   flipper_configuration: FlipperConfiguration.disabled,
   app_path: '..',
   config_file_dir: '',
-  ios_folder: 'ios'
 )
 end
 `;
@@ -32,7 +31,6 @@ def use_react_native! (
   flipper_configuration: FlipperConfiguration.disabled,
   app_path: '..',
   config_file_dir: '',
-  ios_folder: 'ios'
 )
 end
 `;
@@ -45,7 +43,6 @@ def use_react_native! (
   flipper_configuration: FlipperConfiguration.disabled,
   app_path: '..',
   config_file_dir: '',
-  ios_folder: 'ios'
 )
 end
 `;


### PR DESCRIPTION
This diff removes the need for providing the `ios_folder` argument to `use_react_native`. We no longer do any manual path tranformations to get the iOS project root.
Instead we use `Pod::Config.instance.installation_root` which always points to the correct directory.

Changelog: [iOS][Breaking] - CocoaPods: remove the `ios_folder` argument from the `use_react_native` function.

Differential Revision: D52659429


