### PR TITLE
fix: declare missing dependency `chalk`

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -109,6 +109,7 @@
     "anser": "^1.4.9",
     "ansi-regex": "^5.0.0",
     "base64-js": "^1.5.1",
+    "chalk": "^4.0.0",
     "event-target-shim": "^5.0.1",
     "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",


### PR DESCRIPTION
## Summary:

Dependency on `chalk` was introduced in https://github.com/facebook/react-native/pull/37510, but was never declared. In pnpm setups, the CLI fails to run because of this.

This needs to be picked to 0.73.

## Changelog:

[GENERAL] [FIXED] - Declare missing dependency `chalk`

## Test Plan:

n/a