### PR TITLE
Use Objective-C nullability to provide better Swift types in RCTAppDelegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -14,6 +14,8 @@
 @class RCTRootView;
 @class RCTSurfacePresenterBridgeAdapter;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The RCTAppDelegate is an utility class that implements some base configurations for all the React Native apps.
  * It is not mandatory to use it, but it could simplify your AppDelegate code.
@@ -55,10 +57,10 @@
 @interface RCTAppDelegate : UIResponder <UIApplicationDelegate, UISceneDelegate, RCTBridgeDelegate>
 
 /// The window object, used to render the UViewControllers
-@property (nonatomic, strong) UIWindow *window;
-@property (nonatomic, strong) RCTBridge *bridge;
-@property (nonatomic, strong) NSString *moduleName;
-@property (nonatomic, strong) NSDictionary *initialProps;
+@property (nonatomic, strong, nonnull) UIWindow *window;
+@property (nonatomic, strong, nullable) RCTBridge *bridge;
+@property (nonatomic, strong, nullable) NSString *moduleName;
+@property (nonatomic, strong, nullable) NSDictionary *initialProps;
 
 /**
  * It creates a `RCTBridge` using a delegate and some launch options.
@@ -160,3 +162,5 @@
 - (NSURL *)bundleURL;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/RCTBridgeDelegate.h
+++ b/packages/react-native/React/Base/RCTBridgeDelegate.h
@@ -10,6 +10,8 @@
 @class RCTBridge;
 @protocol RCTBridgeModule;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol RCTBridgeDelegate <NSObject>
 
 /**
@@ -77,3 +79,5 @@
 - (NSDictionary<NSString *, Class> *)extraLazyModuleClassesForBridge:(RCTBridge *)bridge;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary:

This PR adds nullable type annotations + nullability audit regions (`NS_ASSUME_NONNULL_BEGIN`/`NS_ASSUME_NONNULL_END`) to provide better Swift types. 


Before: 

```swift
class AppDelegate: RCTAppDelegate {
  override func sourceURL(for bridge: RCTBridge!) -> URL! {
    self.bundleURL()
  }
  
  override func bundleURL() -> URL! {
    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "js/RNTesterApp.ios")
  }
  
  override func customize(_ rootView: RCTRootView!) {
    rootView.backgroundColor = .red
  }
}
```

After:

```swift
class AppDelegate: RCTAppDelegate {
  override func sourceURL(for bridge: RCTBridge) -> URL {
    self.bundleURL()
  }
  
  override func bundleURL() -> URL {
    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "js/RNTesterApp.ios")
  }
  
  override func customize(_ rootView: RCTRootView) {
    rootView.backgroundColor = .red
  }
}
```


## Changelog:

[IOS] [ADDED] - Provide better Swift types for RCTAppDelegate and RCTBridgeDelegate

## Test Plan:

In Xcode click the top left square button and look up the generated interface:
![CleanShot 2024-01-10 at 16 40 51@2x](https://github.com/facebook/react-native/assets/52801365/ad2ac9ed-9d9a-4c5e-a200-1d7a2802e701)


