### PR TITLE
(iOS) Add `RCTUIStatusBarManager` and properly retrieve StatusBar style and height

### DIFF
--- a/packages/react-native/Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js
+++ b/packages/react-native/Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js
@@ -18,8 +18,6 @@ export interface Spec extends TurboModule {
     +DEFAULT_BACKGROUND_COLOR?: number,
   |};
 
-  // TODO(T47754272) Can we remove this method?
-  +getHeight: (callback: (result: {|height: number|}) => void) => void;
   +setNetworkActivityIndicatorVisible: (visible: boolean) => void;
   +addListener: (eventType: string) => void;
   +removeListeners: (count: number) => void;
@@ -49,11 +47,6 @@ const NativeStatusBarManager = {
       constants = NativeModule.getConstants();
     }
     return constants;
-  },
-
-  // TODO(T47754272) Can we remove this method?
-  getHeight(callback: (result: {|height: number|}) => void): void {
-    NativeModule.getHeight(callback);
   },
 
   setNetworkActivityIndicatorVisible(visible: boolean): void {

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -99,6 +99,9 @@ RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
 // e.g. to present a modal view controller or alert over it
 RCT_EXTERN UIViewController *__nullable RCTPresentedViewController(void);
 
+// Retrieve current window UIStatusBarManager
+RCT_EXTERN UIStatusBarManager *__nullable RCTUIStatusBarManager(void);
+
 // Does this device support force touch (aka 3D Touch)?
 RCT_EXTERN BOOL RCTForceTouchAvailable(void);
 

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -579,6 +579,10 @@ UIWindow *__nullable RCTKeyWindow(void)
   return nil;
 }
 
+UIStatusBarManager *__nullable RCTUIStatusBarManager(void) {
+    return RCTKeyWindow().windowScene.statusBarManager;
+}
+
 UIViewController *__nullable RCTPresentedViewController(void)
 {
   if ([RCTUtilsUIOverride hasPresentedViewController]) {

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -116,13 +116,6 @@ RCT_EXPORT_MODULE()
   [self emitEvent:@"statusBarFrameWillChange" forNotification:notification];
 }
 
-RCT_EXPORT_METHOD(getHeight : (RCTResponseSenderBlock)callback)
-{
-  callback(@[ @{
-    @"height" : @(RCTSharedApplication().statusBarFrame.size.height),
-  } ]);
-}
-
 RCT_EXPORT_METHOD(setStyle : (NSString *)style animated : (BOOL)animated)
 {
   dispatch_async(dispatch_get_main_queue(), ^{

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -167,7 +167,7 @@ RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
   __block facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants> constants;
   RCTUnsafeExecuteOnMainQueueSync(^{
     constants = facebook::react::typedConstants<JS::NativeStatusBarManagerIOS::Constants>({
-        .HEIGHT = RCTSharedApplication().statusBarFrame.size.height,
+        .HEIGHT = RCTUIStatusBarManager().statusBarFrame.size.height,
         .DEFAULT_BACKGROUND_COLOR = std::nullopt,
     });
   });

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -14,6 +14,10 @@
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 
+static NSString *const statusBarFrameDidChange = @"statusBarFrameDidChange";
+static NSString *const statusBarFrameWillChange = @"statusBarFrameWillChange";
+
+
 @implementation RCTConvert (UIStatusBar)
 
 + (UIStatusBarStyle)UIStatusBarStyle:(id)json RCT_DYNAMIC
@@ -71,7 +75,7 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[ @"statusBarFrameDidChange", @"statusBarFrameWillChange" ];
+  return @[ statusBarFrameDidChange, statusBarFrameWillChange ];
 }
 
 - (void)startObserving
@@ -108,12 +112,12 @@ RCT_EXPORT_MODULE()
 
 - (void)applicationDidChangeStatusBarFrame:(NSNotification *)notification
 {
-  [self emitEvent:@"statusBarFrameDidChange" forNotification:notification];
+  [self emitEvent:statusBarFrameDidChange forNotification:notification];
 }
 
 - (void)applicationWillChangeStatusBarFrame:(NSNotification *)notification
 {
-  [self emitEvent:@"statusBarFrameWillChange" forNotification:notification];
+  [self emitEvent:statusBarFrameWillChange forNotification:notification];
 }
 
 RCT_EXPORT_METHOD(setStyle : (NSString *)style animated : (BOOL)animated)

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -44,7 +44,7 @@
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-  return [RCTSharedApplication() statusBarStyle];
+  return [RCTUIStatusBarManager() statusBarStyle];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
@@ -55,7 +55,7 @@
 
 - (BOOL)prefersStatusBarHidden
 {
-  return [RCTSharedApplication() isStatusBarHidden];
+  return [RCTUIStatusBarManager() isStatusBarHidden];
 }
 
 #if RCT_DEV

--- a/packages/react-native/React/Views/RCTModalHostViewController.m
+++ b/packages/react-native/React/Views/RCTModalHostViewController.m
@@ -24,8 +24,8 @@
 
   self.modalInPresentation = YES;
 
-  _preferredStatusBarStyle = [RCTSharedApplication() statusBarStyle];
-  _preferredStatusBarHidden = [RCTSharedApplication() isStatusBarHidden];
+  _preferredStatusBarStyle = [RCTUIStatusBarManager() statusBarStyle];
+  _preferredStatusBarHidden = [RCTUIStatusBarManager() isStatusBarHidden];
 
   return self;
 }


### PR DESCRIPTION
## Summary:

This PR migrates from the deprecated way of retrieving the status bar info. It introduces a helper method `RCTUIStatusBarManager` which gets the `UIStatusBarManager` from the KeyWindow. 

It also removes the unused `getHeight` method. 

## Changelog:

[IOS] [ADDED] - Add `RCTUIStatusBarManager` and properly retrieve StatusBar style and height
[IOS] [REMOVED] - Remove unused getHeight method from StatusBar

## Test Plan:

CI Green, Ensure that preferredStatusBarStyle and preferredStatusBarHidden is properly retrieved for Modals
