### PR TITLE
fix: use real_path to find plist files is update_ats Cocoapod util

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -134,10 +134,12 @@ end
 class PBXFileRefMock
     attr_reader :name
     attr_reader :path
+    attr_reader :real_path
 
     def initialize(name)
         @name = name
         @path = name
+        @real_path = name
     end
 end
 

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -564,10 +564,9 @@ class ReactNativePodsUtils
         return info_plists
       end
 
-    def self.update_ats_in_plist(plistPaths, parent)
-        plistPaths.each do |plistPath|
-            fullPlistPath = File.join(parent, plistPath.path)
-            plist = Xcodeproj::Plist.read_from_path(fullPlistPath)
+    def self.update_ats_in_plist(plistFiles)
+        plistFiles.each do |plistFile|
+            plist = Xcodeproj::Plist.read_from_path(plistFile.real_path)
             ats_configs = {
                 "NSAllowsArbitraryLoads" => false,
                 "NSAllowsLocalNetworking" => true,
@@ -580,7 +579,7 @@ class ReactNativePodsUtils
                 plist["NSAppTransportSecurity"] ||= {}
                 plist["NSAppTransportSecurity"] = plist["NSAppTransportSecurity"].merge(ats_configs)
             end
-            Xcodeproj::Plist.write_to_path(plist, fullPlistPath)
+            Xcodeproj::Plist.write_to_path(plist, plistFile.real_path)
         end
     end
 
@@ -588,8 +587,8 @@ class ReactNativePodsUtils
         user_project = installer.aggregate_targets
                     .map{ |t| t.user_project }
                     .first
-        plistPaths = self.get_plist_paths_from(user_project)
-        self.update_ats_in_plist(plistPaths, user_project.path.parent)
+        plistFiles = self.get_plist_paths_from(user_project)
+        self.update_ats_in_plist(plistFiles)
     end
 
     def self.react_native_pods


### PR DESCRIPTION
## Summary:

This PR fixes a pod install failure detailed in #42239 which can occur when the `update_ats_in_plist` utility method in a Cocoapod script fails to find an Info.plist in the target folder. It does so by calling the Cocoapods `real_path` method instead of just `path` on the file reference, which correctly adds the target folder to the path.

## Changelog:

[iOS] [Fixed] - Fix pod install error when update_ats unable to find Info.plist in targets

## Test Plan:

Tested using patch-package against my reproduction branch in: https://github.com/chriszs/reproducer-react-native/pull/2

To test, clone the branch, `cd ReproducerApp`, `yarn`, `npx pod-install`. CI fails with "error Cannot start server in new window because no terminal app was specified" on the build step, but I believe that's unrelated.