### PR TITLE
iOS: Introduce `vision` interfaceIdiom

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.d.ts
+++ b/packages/react-native/Libraries/Utilities/Platform.d.ts
@@ -55,6 +55,7 @@ interface PlatformIOSStatic extends PlatformStatic {
   OS: 'ios';
   isPad: boolean;
   isTV: boolean;
+  isVision: boolean;
   isMacCatalyst?: boolean | undefined;
   Version: string;
 }

--- a/packages/react-native/Libraries/Utilities/Platform.flow.js
+++ b/packages/react-native/Libraries/Utilities/Platform.flow.js
@@ -42,6 +42,8 @@ type IOSPlatform = {
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean,
+  // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
   get isDisableAnimations(): boolean,

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -58,6 +58,11 @@ const Platform: PlatformType = {
     return this.constants.interfaceIdiom === 'tv';
   },
   // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean {
+    // $FlowFixMe[object-this-reference]
+    return this.constants.interfaceIdiom === 'vision';
+  },
+  // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean {
     if (__DEV__) {
       // $FlowFixMe[object-this-reference]

--- a/packages/react-native/React/CoreModules/RCTPlatform.mm
+++ b/packages/react-native/React/CoreModules/RCTPlatform.mm
@@ -30,6 +30,8 @@ static NSString *interfaceIdiom(UIUserInterfaceIdiom idiom)
       return @"tv";
     case UIUserInterfaceIdiomCarPlay:
       return @"carplay";
+    case UIUserInterfaceIdiomVision:
+      return @"vision";
     default:
       return @"unknown";
   }


### PR DESCRIPTION
## Summary:

This PR introduces the `vision` interfaceIdiom to check if the app runs on visionOS.

An update to the documentation should follow this change.

## Changelog:

[IOS] [ADDED] - Introduce `vision` interfaceIdiom

## Test Plan:

This change has been used in `react-native-visionos` and the interfaceIdiom changes **only** when running in the non-compatibility mode. But it's still useful to have this upstream if at some point React native would compile to visionOS natively  
