### PR TITLE
remove old architecture pipeline for RNTester

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -503,11 +503,6 @@ jobs:
         description: Which JavaScript engine to use. Must be one of "Hermes", "JSC".
         type: enum
         enum: ["Hermes", "JSC"]
-      architecture:
-        default: "OldArch"
-        description: Which React Native architecture to use. Must be one of "OldArch", "NewArch".
-        type: enum
-        enum: ["NewArch", "OldArch"]
       use_frameworks:
         default: "StaticLibraries"
         description: The dependency building and linking strategy to use. Must be one of "StaticLibraries", "DynamicFrameworks"
@@ -550,11 +545,8 @@ jobs:
             - with_xcodebuild_cache:
                 steps:
                   - run:
-                      name: Install CocoaPods dependencies - Architecture << parameters.architecture >>
+                      name: Install CocoaPods dependencies
                       command: |
-                        if [[ << parameters.architecture >> == "NewArch" ]]; then
-                          export RCT_NEW_ARCH_ENABLED=1
-                        fi
 
                         if [[ << parameters.jsengine >> == "JSC" ]]; then
                           export USE_HERMES=0
@@ -564,8 +556,9 @@ jobs:
                           export USE_FRAMEWORKS=dynamic
                         fi
 
+                        export RCT_NEW_ARCH_ENABLED=1
                         cd packages/rn-tester
-
+                        
                         bundle install
                         bundle exec pod install
                   - when:

--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -80,10 +80,8 @@
             - build_hermes_macos
           name: "Test RNTester with Ruby 3.2.0"
           ruby_version: "3.2.0"
-          architecture: "NewArch"
           executor: reactnativeios-lts
       - test_ios_rntester:
-          architecture: "NewArch"
           requires:
             - build_hermes_macos
           matrix:
@@ -108,5 +106,4 @@
             - build_hermes_macos
           matrix:
             parameters:
-              architecture: ["OldArch", "NewArch"]
               jsengine: ["Hermes", "JSC"]

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -71,10 +71,8 @@
             - build_hermes_macos
           name: "Test RNTester with Ruby 3.2.0"
           ruby_version: "3.2.0"
-          architecture: "NewArch"
           executor: reactnativeios-lts
       - test_ios_rntester:
-          architecture: "NewArch"
           requires:
             - build_hermes_macos
           matrix:
@@ -99,5 +97,4 @@
             - build_hermes_macos
           matrix:
             parameters:
-              architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]


### PR DESCRIPTION
## Summary:

As discussed with @cipolleschi, RNTester shouldn't be tested for Old Arch. This PR removes those unnecessary pipeline runs

## Changelog:

[INTERNAL] [REMOVED] - remove old architecture pipeline for RNTester

## Test Plan:

CI Green
