### PR TITLE
Make ReactNativeConfig a JNI Class

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/EmptyReactNativeConfig.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/EmptyReactNativeConfig.java
@@ -7,29 +7,40 @@
 
 package com.facebook.react.fabric;
 
+import androidx.annotation.NonNull;
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStrip;
+
 /**
- * An empty {@link ReactNativeConfig} that is returning empty responses and false for all the
- * requested keys.
+ * An empty {@link ReactNativeConfig} that is backed by the C++ implementation where the defaults
+ * are store.
  */
+@DoNotStrip
 public class EmptyReactNativeConfig implements ReactNativeConfig {
 
-  @Override
-  public boolean getBool(final String s) {
-    return false;
+  @NonNull @DoNotStrip private final HybridData mHybridData;
+
+  @DoNotStrip
+  private static native HybridData initHybrid();
+
+  @DoNotStrip
+  public EmptyReactNativeConfig() {
+    mHybridData = initHybrid();
   }
 
   @Override
-  public long getInt64(final String s) {
-    return 0;
-  }
+  @DoNotStrip
+  public native boolean getBool(final String param);
 
   @Override
-  public String getString(final String s) {
-    return "";
-  }
+  @DoNotStrip
+  public native long getInt64(final String param);
 
   @Override
-  public double getDouble(final String s) {
-    return 0;
-  }
+  @DoNotStrip
+  public native String getString(final String param);
+
+  @Override
+  @DoNotStrip
+  public native double getDouble(final String param);
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/OnLoad.cpp
@@ -12,6 +12,7 @@
 #include "CoreComponentsRegistry.h"
 #include "EventBeatManager.h"
 #include "EventEmitterWrapper.h"
+#include "ReactNativeConfigJni.h"
 #include "StateWrapperImpl.h"
 #include "SurfaceHandlerBinding.h"
 
@@ -24,5 +25,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
     facebook::react::ComponentFactory::registerNatives();
     facebook::react::CoreComponentsRegistry::registerNatives();
     facebook::react::SurfaceHandlerBinding::registerNatives();
+    facebook::react::ReactNativeConfigJni::registerNatives();
   });
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigHolder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigHolder.h
@@ -15,7 +15,7 @@
 namespace facebook::react {
 
 /**
- * Implementation of ReactNativeConfig that wraps a FabricMobileConfig Java
+ * Implementation of ReactNativeConfig that wraps a ReactNativeConfig Java
  * object.
  */
 class ReactNativeConfigHolder : public ReactNativeConfig {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigJni.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigJni.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ReactNativeConfigJni.h"
+#include <fbjni/fbjni.h>
+#include <react/config/ReactNativeConfig.h>
+
+namespace facebook::react {
+
+jni::local_ref<ReactNativeConfigJni::jhybriddata>
+ReactNativeConfigJni::initHybrid(jni::alias_ref<jclass>) {
+  return makeCxxInstance();
+}
+
+jboolean ReactNativeConfigJni::getBool(const jni::alias_ref<jstring> param) {
+  return reactNativeConfig_.getBool(param->toStdString());
+}
+
+jni::local_ref<jstring> ReactNativeConfigJni::getString(
+    const jni::alias_ref<jstring> param) {
+  return jni::make_jstring(reactNativeConfig_.getString(param->toStdString()));
+}
+
+jlong ReactNativeConfigJni::getInt64(const jni::alias_ref<jstring> param) {
+  return reactNativeConfig_.getInt64(param->toStdString());
+}
+
+jdouble ReactNativeConfigJni::getDouble(const jni::alias_ref<jstring> param) {
+  return reactNativeConfig_.getDouble(param->toStdString());
+}
+
+void ReactNativeConfigJni::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("initHybrid", ReactNativeConfigJni::initHybrid),
+      makeNativeMethod("getBool", ReactNativeConfigJni::getBool),
+      makeNativeMethod("getString", ReactNativeConfigJni::getString),
+      makeNativeMethod("getInt64", ReactNativeConfigJni::getInt64),
+      makeNativeMethod("getDouble", ReactNativeConfigJni::getDouble),
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigJni.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigJni.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <react/config/ReactNativeConfig.h>
+#include <react/jni/ReadableNativeMap.h>
+#include <memory>
+
+namespace facebook::react {
+
+class ReactNativeConfigJni : public jni::HybridClass<ReactNativeConfigJni> {
+ public:
+  constexpr static const char* const kJavaDescriptor =
+      "Lcom/facebook/react/fabric/EmptyReactNativeConfig;";
+
+  static void registerNatives();
+
+  jboolean getBool(const jni::alias_ref<jstring> param);
+
+  jni::local_ref<jstring> getString(const jni::alias_ref<jstring> param);
+
+  jlong getInt64(const jni::alias_ref<jstring> param);
+
+  jdouble getDouble(const jni::alias_ref<jstring> param);
+
+ private:
+  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jclass>);
+  const EmptyReactNativeConfig reactNativeConfig_ = EmptyReactNativeConfig();
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.h
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.h
@@ -27,7 +27,7 @@ class ReactNativeConfig {
 };
 
 /**
- * Empty configuration that will provide hardcoded values.
+ * Empty configuration that will provide hardcoded default values.
  */
 class EmptyReactNativeConfig : public ReactNativeConfig {
  public:


### PR DESCRIPTION
Summary:
With this change I make `ReactNativeConfig` a JNI class loaded at Fabric Loading time. 

This removes the default from `EmptyReactNativeConfig.java` and makes sure we do read the defaults from C++ `ReactNativeConfig.cpp` file.

Differential Revision: D52696653


