### PR TITLE
Fix AndroidManifest.xml for RN-Tester in OSS

### DIFF
--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-  package="com.facebook.react.uiapp"
-  xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-feature
     android:name="android.software.leanback"
@@ -15,10 +13,6 @@
   <uses-feature
     android:name="android.hardware.camera"
     android:required="false" />
-
-  <uses-sdk
-      android:minSdkVersion="23"
-      android:targetSdkVersion="34" />
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>


### PR DESCRIPTION
Summary:
I'm duplicating the AndroidManifest.xml file internally/externally as Gradle is really unhappy with it (and gets really noisy):
- It contains a package declaration which should be removed
- It contains a uses-sdk which should also be removed

Changelog:
[Internal] [Changed] - Fix AndroidManifest.xml for RN-Tester in OSS

Differential Revision: D52694108


