### PR TITLE
fix: patch public renderer implementations to include isChildPublicInstance

### DIFF
--- a/packages/react-native/Libraries/DOM/Nodes/ReadOnlyNode.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReadOnlyNode.js
@@ -18,7 +18,6 @@ import type NodeList from '../OldStyleCollections/NodeList';
 import type ReadOnlyElement from './ReadOnlyElement';
 
 import {getFabricUIManager} from '../../ReactNative/FabricUIManager';
-import ReactFabric from '../../Renderer/shims/ReactFabric';
 import {createNodeList} from '../OldStyleCollections/NodeList';
 import nullthrows from 'nullthrows';
 
@@ -309,6 +308,9 @@ function setInstanceHandle(
 }
 
 export function getShadowNode(node: ReadOnlyNode): ?ShadowNode {
+  // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
+  // With a static import we can't use these classes for Paper-only variants.
+  const ReactFabric = require('../../Renderer/shims/ReactFabric');
   return ReactFabric.getNodeFromInternalInstanceHandle(getInstanceHandle(node));
 }
 
@@ -353,6 +355,9 @@ function getNodeSiblingsAndPosition(
 export function getPublicInstanceFromInternalInstanceHandle(
   instanceHandle: InternalInstanceHandle,
 ): ?ReadOnlyNode {
+  // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
+  // With a static import we can't use these classes for Paper-only variants.
+  const ReactFabric = require('../../Renderer/shims/ReactFabric');
   const mixedPublicInstance =
     ReactFabric.getPublicInstanceFromInternalInstanceHandle(instanceHandle);
   // $FlowExpectedError[incompatible-return] React defines public instances as "mixed" because it can't access the definition from React Native.

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance.js
@@ -88,5 +88,12 @@ export function getNodeFromPublicInstance(
 export function getInternalInstanceHandleFromPublicInstance(
   publicInstance: ReactFabricHostComponent | ReactNativeElement,
 ): InternalInstanceHandle {
+  // TODO(T174762768): Remove this once OSS versions of renderers will be synced.
+  // $FlowExpectedError[prop-missing] Keeping this for backwards-compatibility with the renderers versions in open source.
+  if (publicInstance._internalInstanceHandle != null) {
+    // $FlowExpectedError[incompatible-return] Keeping this for backwards-compatibility with the renderers versions in open source.
+    return publicInstance._internalInstanceHandle;
+  }
+
   return publicInstance.__internalInstanceHandle;
 }

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -3388,6 +3388,20 @@ function findCurrentHostFiberImpl(node) {
 
   return null;
 }
+function doesFiberContain(parentFiber, childFiber) {
+  var node = childFiber;
+  var parentFiberAlternate = parentFiber.alternate;
+
+  while (node !== null) {
+    if (node === parentFiber || node === parentFiberAlternate) {
+      return true;
+    }
+
+    node = node.return;
+  }
+
+  return false;
+}
 
 /**
  * In the future, we should cleanup callbacks by cancelling them instead of
@@ -24331,6 +24345,46 @@ function sendAccessibilityEvent(handle, eventType) {
   }
 }
 
+function isChildPublicInstance(parentInstance, childInstance) {
+  {
+    // Paper
+    if (
+      // $FlowExpectedError[incompatible-type]
+      // $FlowExpectedError[prop-missing] Don't check via `instanceof ReactNativeFiberHostComponent`, so it won't be leaked to Fabric.
+      parentInstance._internalFiberInstanceHandleDEV && // $FlowExpectedError[incompatible-type]
+      // $FlowExpectedError[prop-missing] Don't check via `instanceof ReactNativeFiberHostComponent`, so it won't be leaked to Fabric.
+      childInstance._internalFiberInstanceHandleDEV
+    ) {
+      return doesFiberContain(
+        // $FlowExpectedError[incompatible-call]
+        parentInstance._internalFiberInstanceHandleDEV, // $FlowExpectedError[incompatible-call]
+        childInstance._internalFiberInstanceHandleDEV
+      );
+    }
+
+    var parentInternalInstanceHandle = // $FlowExpectedError[incompatible-call] Type for parentInstance should have been PublicInstance from ReactFiberConfigFabric.
+      ReactNativePrivateInterface.getInternalInstanceHandleFromPublicInstance(
+        parentInstance
+      );
+    var childInternalInstanceHandle = // $FlowExpectedError[incompatible-call] Type for childInstance should have been PublicInstance from ReactFiberConfigFabric.
+      ReactNativePrivateInterface.getInternalInstanceHandleFromPublicInstance(
+        childInstance
+      ); // Fabric
+
+    if (
+      parentInternalInstanceHandle != null &&
+      childInternalInstanceHandle != null
+    ) {
+      return doesFiberContain(
+        parentInternalInstanceHandle,
+        childInternalInstanceHandle
+      );
+    } // Means that one instance is from Fabric and other is from Paper.
+
+    return false;
+  }
+}
+
 function onRecoverableError(error$1) {
   // TODO: Expose onRecoverableError option to userspace
   // eslint-disable-next-line react-internal/no-production-logging, react-internal/warning-args
@@ -24401,6 +24455,7 @@ exports.createPortal = createPortal$1;
 exports.dispatchCommand = dispatchCommand;
 exports.findHostInstance_DEPRECATED = findHostInstance_DEPRECATED;
 exports.findNodeHandle = findNodeHandle;
+exports.isChildPublicInstance = isChildPublicInstance;
 exports.render = render;
 exports.sendAccessibilityEvent = sendAccessibilityEvent;
 exports.stopSurface = stopSurface;
@@ -24414,6 +24469,6 @@ if (
 ) {
   __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(new Error());
 }
-        
+
   })();
 }

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
@@ -8386,6 +8386,9 @@ exports.findHostInstance_DEPRECATED = function(componentOrHandle) {
 };
 exports.findNodeHandle = findNodeHandle;
 exports.getInspectorDataForInstance = void 0;
+exports.isChildPublicInstance = function () {
+  throw Error("isChildPublicInstance() is not available in production.");
+};
 exports.render = function(element, containerTag, callback, concurrentRoot) {
   var root = roots.get(containerTag);
   root ||

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
@@ -8863,6 +8863,9 @@ exports.findHostInstance_DEPRECATED = function(componentOrHandle) {
 };
 exports.findNodeHandle = findNodeHandle;
 exports.getInspectorDataForInstance = void 0;
+exports.isChildPublicInstance = function () {
+  throw Error("isChildPublicInstance() is not available in production.");
+};
 exports.render = function(element, containerTag, callback, concurrentRoot) {
   var root = roots.get(containerTag);
   root ||
@@ -8931,4 +8934,3 @@ if (
 ) {
   __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(new Error());
 }
-        

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -3676,6 +3676,20 @@ function findCurrentHostFiberImpl(node) {
 
   return null;
 }
+function doesFiberContain(parentFiber, childFiber) {
+  var node = childFiber;
+  var parentFiberAlternate = parentFiber.alternate;
+
+  while (node !== null) {
+    if (node === parentFiber || node === parentFiberAlternate) {
+      return true;
+    }
+
+    node = node.return;
+  }
+
+  return false;
+}
 
 // Modules provided by RN:
 var emptyObject = {};
@@ -24651,6 +24665,46 @@ function sendAccessibilityEvent(handle, eventType) {
   }
 }
 
+function isChildPublicInstance(parentInstance, childInstance) {
+  {
+    // Paper
+    if (
+      // $FlowExpectedError[incompatible-type]
+      // $FlowExpectedError[prop-missing] Don't check via `instanceof ReactNativeFiberHostComponent`, so it won't be leaked to Fabric.
+      parentInstance._internalFiberInstanceHandleDEV && // $FlowExpectedError[incompatible-type]
+      // $FlowExpectedError[prop-missing] Don't check via `instanceof ReactNativeFiberHostComponent`, so it won't be leaked to Fabric.
+      childInstance._internalFiberInstanceHandleDEV
+    ) {
+      return doesFiberContain(
+        // $FlowExpectedError[incompatible-call]
+        parentInstance._internalFiberInstanceHandleDEV, // $FlowExpectedError[incompatible-call]
+        childInstance._internalFiberInstanceHandleDEV
+      );
+    }
+
+    var parentInternalInstanceHandle = // $FlowExpectedError[incompatible-call] Type for parentInstance should have been PublicInstance from ReactFiberConfigFabric.
+      ReactNativePrivateInterface.getInternalInstanceHandleFromPublicInstance(
+        parentInstance
+      );
+    var childInternalInstanceHandle = // $FlowExpectedError[incompatible-call] Type for childInstance should have been PublicInstance from ReactFiberConfigFabric.
+      ReactNativePrivateInterface.getInternalInstanceHandleFromPublicInstance(
+        childInstance
+      ); // Fabric
+
+    if (
+      parentInternalInstanceHandle != null &&
+      childInternalInstanceHandle != null
+    ) {
+      return doesFiberContain(
+        parentInternalInstanceHandle,
+        childInternalInstanceHandle
+      );
+    } // Means that one instance is from Fabric and other is from Paper.
+
+    return false;
+  }
+}
+
 function onRecoverableError(error$1) {
   // TODO: Expose onRecoverableError option to userspace
   // eslint-disable-next-line react-internal/no-production-logging, react-internal/warning-args
@@ -24738,6 +24792,7 @@ exports.createPortal = createPortal$1;
 exports.dispatchCommand = dispatchCommand;
 exports.findHostInstance_DEPRECATED = findHostInstance_DEPRECATED;
 exports.findNodeHandle = findNodeHandle;
+exports.isChildPublicInstance = isChildPublicInstance;
 exports.render = render;
 exports.sendAccessibilityEvent = sendAccessibilityEvent;
 exports.unmountComponentAtNode = unmountComponentAtNode;
@@ -24752,6 +24807,6 @@ if (
 ) {
   __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(new Error());
 }
-        
+
   })();
 }

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
@@ -8564,6 +8564,9 @@ exports.findHostInstance_DEPRECATED = function(componentOrHandle) {
 };
 exports.findNodeHandle = findNodeHandle;
 exports.getInspectorDataForInstance = void 0;
+exports.isChildPublicInstance = function () {
+  throw Error("isChildPublicInstance() is not available in production.");
+};
 exports.render = function(element, containerTag, callback) {
   var root = roots.get(containerTag);
   if (!root) {

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
@@ -9040,6 +9040,9 @@ exports.findHostInstance_DEPRECATED = function(componentOrHandle) {
 };
 exports.findNodeHandle = findNodeHandle;
 exports.getInspectorDataForInstance = void 0;
+exports.isChildPublicInstance = function () {
+  throw Error("isChildPublicInstance() is not available in production.");
+};
 exports.render = function(element, containerTag, callback) {
   var root = roots.get(containerTag);
   if (!root) {
@@ -9102,4 +9105,3 @@ if (
 ) {
   __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(new Error());
 }
-        


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Manually patching public React renderers artifacts to include `isChildPublicInstance` method, which was added in https://github.com/facebook/react/pull/27783.

To identifly the required changes in code I've ran a diff for 2 commits:
1. The one with the changes
2. Its parent

FB implementation were synced in D51816108.

Differential Revision: D52697885


