### PR TITLE
fix[getInternalInstanceHandleFromPublicInstance]: make it backwards compatible with previous Fabric implementation

### DIFF
--- a/packages/react-native/Libraries/DOM/Nodes/ReadOnlyNode.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReadOnlyNode.js
@@ -18,7 +18,6 @@ import type NodeList from '../OldStyleCollections/NodeList';
 import type ReadOnlyElement from './ReadOnlyElement';
 
 import {getFabricUIManager} from '../../ReactNative/FabricUIManager';
-import ReactFabric from '../../Renderer/shims/ReactFabric';
 import {createNodeList} from '../OldStyleCollections/NodeList';
 import nullthrows from 'nullthrows';
 
@@ -309,6 +308,9 @@ function setInstanceHandle(
 }
 
 export function getShadowNode(node: ReadOnlyNode): ?ShadowNode {
+  // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
+  // With a static import we can't use these classes for Paper-only variants.
+  const ReactFabric = require('../../Renderer/shims/ReactFabric');
   return ReactFabric.getNodeFromInternalInstanceHandle(getInstanceHandle(node));
 }
 
@@ -353,6 +355,9 @@ function getNodeSiblingsAndPosition(
 export function getPublicInstanceFromInternalInstanceHandle(
   instanceHandle: InternalInstanceHandle,
 ): ?ReadOnlyNode {
+  // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
+  // With a static import we can't use these classes for Paper-only variants.
+  const ReactFabric = require('../../Renderer/shims/ReactFabric');
   const mixedPublicInstance =
     ReactFabric.getPublicInstanceFromInternalInstanceHandle(instanceHandle);
   // $FlowExpectedError[incompatible-return] React defines public instances as "mixed" because it can't access the definition from React Native.

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance.js
@@ -88,5 +88,12 @@ export function getNodeFromPublicInstance(
 export function getInternalInstanceHandleFromPublicInstance(
   publicInstance: ReactFabricHostComponent | ReactNativeElement,
 ): InternalInstanceHandle {
+  // TODO(T174762768): Remove this once OSS versions of renderers will be synced.
+  // $FlowExpectedError[prop-missing] Keeping this for backwards-compatibility with the renderers versions in open source.
+  if (publicInstance._internalInstanceHandle != null) {
+    // $FlowExpectedError[incompatible-return] Keeping this for backwards-compatibility with the renderers versions in open source.
+    return publicInstance._internalInstanceHandle;
+  }
+
   return publicInstance.__internalInstanceHandle;
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Currently, OSS versions ofReactFabric and ReactNativeRenderer artifacts are ~2 years behind the FB version.

Fabric host components store internal instance in __internalInstanceHandle field,  previously they have been storing it in the field with the same name, but with one underscore in prefix:
https://www.internalfb.com/code/fbsource/[79c52d10beb6]/xplat/js/react-native-github/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js?lines=5151

Once these artifacts will be synced, the implementation will use __internalInstanceHandle field, so we can safely remove the branch with a single underscore prefix.

Differential Revision: D52697886


