### PR TITLE
Simplify Edge Resolution

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.java
@@ -12,9 +12,8 @@ package com.facebook.yoga;
 public enum YogaErrata {
   NONE(0),
   STRETCH_FLEX_BASIS(1),
-  STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION(2),
-  POSITION_STATIC_BEHAVES_LIKE_RELATIVE(4),
-  ABSOLUTE_POSITIONING(8),
+  POSITION_STATIC_BEHAVES_LIKE_RELATIVE(2),
+  ABSOLUTE_POSITIONING(4),
   ALL(2147483647),
   CLASSIC(2147483646);
 
@@ -32,9 +31,8 @@ public enum YogaErrata {
     switch (value) {
       case 0: return NONE;
       case 1: return STRETCH_FLEX_BASIS;
-      case 2: return STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION;
-      case 4: return POSITION_STATIC_BEHAVES_LIKE_RELATIVE;
-      case 8: return ABSOLUTE_POSITIONING;
+      case 2: return POSITION_STATIC_BEHAVES_LIKE_RELATIVE;
+      case 4: return ABSOLUTE_POSITIONING;
       case 2147483647: return ALL;
       case 2147483646: return CLASSIC;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -95,8 +95,6 @@ const char* YGErrataToString(const YGErrata value) {
       return "none";
     case YGErrataStretchFlexBasis:
       return "stretch-flex-basis";
-    case YGErrataStartingEndingEdgeFromFlexDirection:
-      return "starting-ending-edge-from-flex-direction";
     case YGErrataPositionStaticBehavesLikeRelative:
       return "position-static-behaves-like-relative";
     case YGErrataAbsolutePositioning:

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -56,9 +56,8 @@ YG_ENUM_DECL(
     YGErrata,
     YGErrataNone = 0,
     YGErrataStretchFlexBasis = 1,
-    YGErrataStartingEndingEdgeFromFlexDirection = 2,
-    YGErrataPositionStaticBehavesLikeRelative = 4,
-    YGErrataAbsolutePositioning = 8,
+    YGErrataPositionStaticBehavesLikeRelative = 2,
+    YGErrataAbsolutePositioning = 4,
     YGErrataAll = 2147483647,
     YGErrataClassic = 2147483646)
 YG_DEFINE_ENUM_FLAG_OPERATORS(YGErrata)

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -920,13 +920,9 @@ static void justifyMainAxis(
   const auto& style = node->getStyle();
 
   const float leadingPaddingAndBorderMain =
-      node->hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
-      ? node->getInlineStartPaddingAndBorder(mainAxis, direction, ownerWidth)
-      : node->getFlexStartPaddingAndBorder(mainAxis, direction, ownerWidth);
+      node->getFlexStartPaddingAndBorder(mainAxis, direction, ownerWidth);
   const float trailingPaddingAndBorderMain =
-      node->hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
-      ? node->getInlineEndPaddingAndBorder(mainAxis, direction, ownerWidth)
-      : node->getFlexEndPaddingAndBorder(mainAxis, direction, ownerWidth);
+      node->getFlexEndPaddingAndBorder(mainAxis, direction, ownerWidth);
 
   const float gap = node->getGapForAxis(mainAxis);
   // If we are using "at most" rules in the main axis, make sure that

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexDirection.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexDirection.h
@@ -99,32 +99,6 @@ inline Edge inlineEndEdge(
   return Edge::Bottom;
 }
 
-/**
- * The physical edges that Edge::Start and Edge::End correspond to (e.g.
- * left/right) are soley dependent on the direction. However, there are cases
- * where we want the flex start/end edge (i.e. which edge is the start/end
- * for laying out flex items), which can be distinct from the corresponding
- * inline edge. In these cases we need to know which "relative edge"
- * (Edge::Start/Edge::End) corresponds to the said flex start/end edge as these
- * relative edges can be used instead of physical ones when defining certain
- * attributes like border or padding.
- */
-inline Edge flexStartRelativeEdge(
-    FlexDirection flexDirection,
-    Direction direction) {
-  const Edge leadLayoutEdge = inlineStartEdge(flexDirection, direction);
-  const Edge leadFlexItemEdge = flexStartEdge(flexDirection);
-  return leadLayoutEdge == leadFlexItemEdge ? Edge::Start : Edge::End;
-}
-
-inline Edge flexEndRelativeEdge(
-    FlexDirection flexDirection,
-    Direction direction) {
-  const Edge trailLayoutEdge = inlineEndEdge(flexDirection, direction);
-  const Edge trailFlexItemEdge = flexEndEdge(flexDirection);
-  return trailLayoutEdge == trailFlexItemEdge ? Edge::End : Edge::Start;
-}
-
 inline Dimension dimension(const FlexDirection flexDirection) {
   switch (flexDirection) {
     case FlexDirection::Column:

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
@@ -18,7 +18,6 @@ namespace facebook::yoga {
 enum class Errata : uint32_t {
   None = YGErrataNone,
   StretchFlexBasis = YGErrataStretchFlexBasis,
-  StartingEndingEdgeFromFlexDirection = YGErrataStartingEndingEdgeFromFlexDirection,
   PositionStaticBehavesLikeRelative = YGErrataPositionStaticBehavesLikeRelative,
   AbsolutePositioning = YGErrataAbsolutePositioning,
   All = YGErrataAll,

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -84,33 +84,25 @@ Style::Length Node::computeEdgeValueForColumn(Edge edge) const {
 Edge Node::getInlineStartEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
-  return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
-      ? flexStartEdge(flexDirection)
-      : inlineStartEdge(flexDirection, direction);
+  return inlineStartEdge(flexDirection, direction);
 }
 
 Edge Node::getInlineEndEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
-  return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
-      ? flexEndEdge(flexDirection)
-      : inlineEndEdge(flexDirection, direction);
+  return inlineEndEdge(flexDirection, direction);
 }
 
 Edge Node::getFlexStartRelativeEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
-  return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
-      ? Edge::Start
-      : flexStartRelativeEdge(flexDirection, direction);
+  return flexStartRelativeEdge(flexDirection, direction);
 }
 
 Edge Node::getFlexEndRelativeEdgeUsingErrata(
     FlexDirection flexDirection,
     Direction direction) const {
-  return hasErrata(Errata::StartingEndingEdgeFromFlexDirection)
-      ? Edge::End
-      : flexEndRelativeEdge(flexDirection, direction);
+  return flexEndRelativeEdge(flexDirection, direction);
 }
 
 bool Node::isFlexStartPositionDefined(FlexDirection axis, Direction direction)

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -9,7 +9,6 @@
 #include <cstddef>
 #include <iostream>
 
-#include <yoga/algorithm/FlexDirection.h>
 #include <yoga/debug/AssertFatal.h>
 #include <yoga/node/Node.h>
 #include <yoga/numeric/Comparison.h>
@@ -55,285 +54,64 @@ void Node::print() {
   }
 }
 
-// TODO: Edge value resolution should be moved to `yoga::Style`
-template <auto Field>
-Style::Length Node::computeEdgeValueForRow(Edge rowEdge, Edge edge) const {
-  if ((style_.*Field)(rowEdge).isDefined()) {
-    return (style_.*Field)(rowEdge);
-  } else if ((style_.*Field)(edge).isDefined()) {
-    return (style_.*Field)(edge);
-  } else if ((style_.*Field)(Edge::Horizontal).isDefined()) {
-    return (style_.*Field)(Edge::Horizontal);
-  } else {
-    return (style_.*Field)(Edge::All);
+Style::Length Node::resolvePositionEdge(Edge edge, Direction direction) const {
+  switch (edge) {
+    case Edge::Left:
+      return getStyle().resolveLeft(direction);
+    case Edge::Top:
+      return getStyle().resolveTop();
+    case Edge::Right:
+      return getStyle().resolveRight(direction);
+    case Edge::Bottom:
+      return getStyle().resolveBottom();
+    default:
+      return {};
   }
 }
 
-// TODO: Edge value resolution should be moved to `yoga::Style`
-template <auto Field>
-Style::Length Node::computeEdgeValueForColumn(Edge edge) const {
-  if ((style_.*Field)(edge).isDefined()) {
-    return (style_.*Field)(edge);
-  } else if ((style_.*Field)(Edge::Vertical).isDefined()) {
-    return (style_.*Field)(Edge::Vertical);
-  } else {
-    return (style_.*Field)(Edge::All);
+Style::Length Node::resolveMarginEdge(Edge edge, Direction direction) const {
+  switch (edge) {
+    case Edge::Left:
+      return getStyle().resolveMarginLeft(direction);
+    case Edge::Top:
+      return getStyle().resolveMarginTop();
+    case Edge::Right:
+      return getStyle().resolveMarginRight(direction);
+    case Edge::Bottom:
+      return getStyle().resolveMarginBottom();
+    default:
+      return {};
   }
 }
 
-Edge Node::getInlineStartEdgeUsingErrata(
-    FlexDirection flexDirection,
-    Direction direction) const {
-  return inlineStartEdge(flexDirection, direction);
+Style::Length Node::resolvePaddingEdge(Edge edge, Direction direction) const {
+  switch (edge) {
+    case Edge::Left:
+      return getStyle().resolvePaddingLeft(direction);
+    case Edge::Top:
+      return getStyle().resolvePaddingTop();
+    case Edge::Right:
+      return getStyle().resolvePaddingRight(direction);
+    case Edge::Bottom:
+      return getStyle().resolvePaddingBottom();
+    default:
+      return {};
+  }
 }
 
-Edge Node::getInlineEndEdgeUsingErrata(
-    FlexDirection flexDirection,
-    Direction direction) const {
-  return inlineEndEdge(flexDirection, direction);
-}
-
-Edge Node::getFlexStartRelativeEdgeUsingErrata(
-    FlexDirection flexDirection,
-    Direction direction) const {
-  return flexStartRelativeEdge(flexDirection, direction);
-}
-
-Edge Node::getFlexEndRelativeEdgeUsingErrata(
-    FlexDirection flexDirection,
-    Direction direction) const {
-  return flexEndRelativeEdge(flexDirection, direction);
-}
-
-bool Node::isFlexStartPositionDefined(FlexDirection axis, Direction direction)
-    const {
-  auto leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(
-            getFlexStartRelativeEdgeUsingErrata(axis, direction),
-            flexStartEdge(axis))
-      : computeEdgeValueForColumn<&Style::position>(flexStartEdge(axis));
-
-  return leadingPosition.isDefined();
-}
-
-bool Node::isInlineStartPositionDefined(FlexDirection axis, Direction direction)
-    const {
-  Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
-  Style::Length leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(Edge::Start, startEdge)
-      : computeEdgeValueForColumn<&Style::position>(startEdge);
-
-  return leadingPosition.isDefined();
-}
-
-bool Node::isFlexEndPositionDefined(FlexDirection axis, Direction direction)
-    const {
-  auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(
-            getFlexEndRelativeEdgeUsingErrata(axis, direction),
-            flexEndEdge(axis))
-      : computeEdgeValueForColumn<&Style::position>(flexEndEdge(axis));
-
-  return !trailingPosition.isUndefined();
-}
-
-bool Node::isInlineEndPositionDefined(FlexDirection axis, Direction direction)
-    const {
-  Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
-  Style::Length trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(Edge::End, endEdge)
-      : computeEdgeValueForColumn<&Style::position>(endEdge);
-
-  return trailingPosition.isDefined();
-}
-
-float Node::getFlexStartPosition(
-    FlexDirection axis,
-    Direction direction,
-    float axisSize) const {
-  auto leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(
-            getFlexStartRelativeEdgeUsingErrata(axis, direction),
-            flexStartEdge(axis))
-      : computeEdgeValueForColumn<&Style::position>(flexStartEdge(axis));
-
-  return leadingPosition.resolve(axisSize).unwrapOrDefault(0.0f);
-}
-
-float Node::getInlineStartPosition(
-    FlexDirection axis,
-    Direction direction,
-    float axisSize) const {
-  Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
-  Style::Length leadingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(Edge::Start, startEdge)
-      : computeEdgeValueForColumn<&Style::position>(startEdge);
-
-  return leadingPosition.resolve(axisSize).unwrapOrDefault(0.0f);
-}
-
-float Node::getFlexEndPosition(
-    FlexDirection axis,
-    Direction direction,
-    float axisSize) const {
-  auto trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(
-            getFlexEndRelativeEdgeUsingErrata(axis, direction),
-            flexEndEdge(axis))
-      : computeEdgeValueForColumn<&Style::position>(flexEndEdge(axis));
-
-  return trailingPosition.resolve(axisSize).unwrapOrDefault(0.0f);
-}
-
-float Node::getInlineEndPosition(
-    FlexDirection axis,
-    Direction direction,
-    float axisSize) const {
-  Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
-  Style::Length trailingPosition = isRow(axis)
-      ? computeEdgeValueForRow<&Style::position>(Edge::End, endEdge)
-      : computeEdgeValueForColumn<&Style::position>(endEdge);
-
-  return trailingPosition.resolve(axisSize).unwrapOrDefault(0.0f);
-}
-
-float Node::getFlexStartMargin(
-    FlexDirection axis,
-    Direction direction,
-    float widthSize) const {
-  auto leadingMargin = isRow(axis)
-      ? computeEdgeValueForRow<&Style::margin>(
-            getFlexStartRelativeEdgeUsingErrata(axis, direction),
-            flexStartEdge(axis))
-      : computeEdgeValueForColumn<&Style::margin>(flexStartEdge(axis));
-
-  return leadingMargin.resolve(widthSize).unwrapOrDefault(0.0f);
-}
-
-float Node::getInlineStartMargin(
-    FlexDirection axis,
-    Direction direction,
-    float widthSize) const {
-  Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
-  Style::Length leadingMargin = isRow(axis)
-      ? computeEdgeValueForRow<&Style::margin>(Edge::Start, startEdge)
-      : computeEdgeValueForColumn<&Style::margin>(startEdge);
-
-  return leadingMargin.resolve(widthSize).unwrapOrDefault(0.0f);
-}
-
-float Node::getFlexEndMargin(
-    FlexDirection axis,
-    Direction direction,
-    float widthSize) const {
-  auto trailingMargin = isRow(axis)
-      ? computeEdgeValueForRow<&Style::margin>(
-            getFlexEndRelativeEdgeUsingErrata(axis, direction),
-            flexEndEdge(axis))
-      : computeEdgeValueForColumn<&Style::margin>(flexEndEdge(axis));
-
-  return trailingMargin.resolve(widthSize).unwrapOrDefault(0.0f);
-}
-
-float Node::getInlineEndMargin(
-    FlexDirection axis,
-    Direction direction,
-    float widthSize) const {
-  Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
-  Style::Length trailingMargin = isRow(axis)
-      ? computeEdgeValueForRow<&Style::margin>(Edge::End, endEdge)
-      : computeEdgeValueForColumn<&Style::margin>(endEdge);
-
-  return trailingMargin.resolve(widthSize).unwrapOrDefault(0.0f);
-}
-
-float Node::getInlineStartBorder(FlexDirection axis, Direction direction)
-    const {
-  Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
-  Style::Length leadingBorder = isRow(axis)
-      ? computeEdgeValueForRow<&Style::border>(Edge::Start, startEdge)
-      : computeEdgeValueForColumn<&Style::border>(startEdge);
-
-  return maxOrDefined(leadingBorder.value().unwrap(), 0.0f);
-}
-
-float Node::getFlexStartBorder(FlexDirection axis, Direction direction) const {
-  Style::Length leadingBorder = isRow(axis)
-      ? computeEdgeValueForRow<&Style::border>(
-            getFlexStartRelativeEdgeUsingErrata(axis, direction),
-            flexStartEdge(axis))
-      : computeEdgeValueForColumn<&Style::border>(flexStartEdge(axis));
-
-  return maxOrDefined(leadingBorder.value().unwrap(), 0.0f);
-}
-
-float Node::getInlineEndBorder(FlexDirection axis, Direction direction) const {
-  Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
-  Style::Length trailingBorder = isRow(axis)
-      ? computeEdgeValueForRow<&Style::border>(Edge::End, endEdge)
-      : computeEdgeValueForColumn<&Style::border>(endEdge);
-
-  return maxOrDefined(trailingBorder.value().unwrap(), 0.0f);
-}
-
-float Node::getFlexEndBorder(FlexDirection axis, Direction direction) const {
-  Style::Length trailingBorder = isRow(axis)
-      ? computeEdgeValueForRow<&Style::border>(
-            getFlexEndRelativeEdgeUsingErrata(axis, direction),
-            flexEndEdge(axis))
-      : computeEdgeValueForColumn<&Style::border>(flexEndEdge(axis));
-
-  return maxOrDefined(trailingBorder.value().unwrap(), 0.0f);
-}
-
-float Node::getInlineStartPadding(
-    FlexDirection axis,
-    Direction direction,
-    float widthSize) const {
-  Edge startEdge = getInlineStartEdgeUsingErrata(axis, direction);
-  Style::Length leadingPadding = isRow(axis)
-      ? computeEdgeValueForRow<&Style::padding>(Edge::Start, startEdge)
-      : computeEdgeValueForColumn<&Style::padding>(startEdge);
-
-  return maxOrDefined(leadingPadding.resolve(widthSize).unwrap(), 0.0f);
-}
-
-float Node::getFlexStartPadding(
-    FlexDirection axis,
-    Direction direction,
-    float widthSize) const {
-  auto leadingPadding = isRow(axis)
-      ? computeEdgeValueForRow<&Style::padding>(
-            getFlexStartRelativeEdgeUsingErrata(axis, direction),
-            flexStartEdge(axis))
-      : computeEdgeValueForColumn<&Style::padding>(flexStartEdge(axis));
-
-  return maxOrDefined(leadingPadding.resolve(widthSize).unwrap(), 0.0f);
-}
-
-float Node::getInlineEndPadding(
-    FlexDirection axis,
-    Direction direction,
-    float widthSize) const {
-  Edge endEdge = getInlineEndEdgeUsingErrata(axis, direction);
-  Style::Length trailingPadding = isRow(axis)
-      ? computeEdgeValueForRow<&Style::padding>(Edge::End, endEdge)
-      : computeEdgeValueForColumn<&Style::padding>(endEdge);
-
-  return maxOrDefined(trailingPadding.resolve(widthSize).unwrap(), 0.0f);
-}
-
-float Node::getFlexEndPadding(
-    FlexDirection axis,
-    Direction direction,
-    float widthSize) const {
-  auto trailingPadding = isRow(axis)
-      ? computeEdgeValueForRow<&Style::padding>(
-            getFlexEndRelativeEdgeUsingErrata(axis, direction),
-            flexEndEdge(axis))
-      : computeEdgeValueForColumn<&Style::padding>(flexEndEdge(axis));
-
-  return maxOrDefined(trailingPadding.resolve(widthSize).unwrap(), 0.0f);
+Style::Length Node::resolveBorderEdge(Edge edge, Direction direction) const {
+  switch (edge) {
+    case Edge::Left:
+      return getStyle().resolveBorderLeft(direction);
+    case Edge::Top:
+      return getStyle().resolveBorderTop();
+    case Edge::Right:
+      return getStyle().resolveBorderRight(direction);
+    case Edge::Bottom:
+      return getStyle().resolveBorderBottom();
+    default:
+      return {};
+  }
 }
 
 float Node::getInlineStartPaddingAndBorder(
@@ -570,14 +348,10 @@ void Node::setPosition(
   const float relativePositionCross =
       relativePosition(crossAxis, directionRespectingRoot, crossSize);
 
-  const Edge mainAxisLeadingEdge =
-      getInlineStartEdgeUsingErrata(mainAxis, direction);
-  const Edge mainAxisTrailingEdge =
-      getInlineEndEdgeUsingErrata(mainAxis, direction);
-  const Edge crossAxisLeadingEdge =
-      getInlineStartEdgeUsingErrata(crossAxis, direction);
-  const Edge crossAxisTrailingEdge =
-      getInlineEndEdgeUsingErrata(crossAxis, direction);
+  const Edge mainAxisLeadingEdge = inlineStartEdge(mainAxis, direction);
+  const Edge mainAxisTrailingEdge = inlineEndEdge(mainAxis, direction);
+  const Edge crossAxisLeadingEdge = inlineStartEdge(crossAxis, direction);
+  const Edge crossAxisTrailingEdge = inlineEndEdge(crossAxis, direction);
 
   setLayoutPosition(
       (getInlineStartMargin(mainAxis, direction, ownerWidth) +

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -13,6 +13,7 @@
 
 #include <yoga/Yoga.h>
 
+#include <yoga/algorithm/FlexDirection.h>
 #include <yoga/config/Config.h>
 #include <yoga/enums/Dimension.h>
 #include <yoga/enums/Direction.h>
@@ -158,69 +159,154 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   // Methods related to positions, margin, padding and border
-  bool isFlexStartPositionDefined(FlexDirection axis, Direction direction)
-      const;
-  bool isInlineStartPositionDefined(FlexDirection axis, Direction direction)
-      const;
-  bool isFlexEndPositionDefined(FlexDirection axis, Direction direction) const;
-  bool isInlineEndPositionDefined(FlexDirection axis, Direction direction)
-      const;
-  float getFlexStartPosition(
+  inline bool isFlexStartPositionDefined(
+      FlexDirection axis,
+      Direction direction) const {
+    return resolvePositionEdge(flexStartEdge(axis), direction).isDefined();
+  }
+  inline bool isInlineStartPositionDefined(
+      FlexDirection axis,
+      Direction direction) const {
+    return resolvePositionEdge(inlineStartEdge(axis, direction), direction)
+        .isDefined();
+  }
+  inline bool isFlexEndPositionDefined(FlexDirection axis, Direction direction)
+      const {
+    return resolvePositionEdge(flexEndEdge(axis), direction).isDefined();
+  }
+  inline bool isInlineEndPositionDefined(
+      FlexDirection axis,
+      Direction direction) const {
+    return resolvePositionEdge(inlineEndEdge(axis, direction), direction)
+        .isDefined();
+  }
+  inline float getFlexStartPosition(
       FlexDirection axis,
       Direction direction,
-      float axisSize) const;
-  float getInlineStartPosition(
+      float axisSize) const {
+    return resolvePositionEdge(flexStartEdge(axis), direction)
+        .resolve(axisSize)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getInlineStartPosition(
       FlexDirection axis,
       Direction direction,
-      float axisSize) const;
-  float getFlexEndPosition(
+      float axisSize) const {
+    return resolvePositionEdge(inlineStartEdge(axis, direction), direction)
+        .resolve(axisSize)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getFlexEndPosition(
       FlexDirection axis,
       Direction direction,
-      float axisSize) const;
-  float getInlineEndPosition(
+      float axisSize) const {
+    return resolvePositionEdge(flexEndEdge(axis), direction)
+        .resolve(axisSize)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getInlineEndPosition(
       FlexDirection axis,
       Direction direction,
-      float axisSize) const;
-  float getFlexStartMargin(
+      float axisSize) const {
+    return resolvePositionEdge(inlineEndEdge(axis, direction), direction)
+        .resolve(axisSize)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getFlexStartMargin(
       FlexDirection axis,
       Direction direction,
-      float widthSize) const;
-  float getInlineStartMargin(
+      float widthSize) const {
+    return resolveMarginEdge(flexStartEdge(axis), direction)
+        .resolve(widthSize)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getInlineStartMargin(
       FlexDirection axis,
       Direction direction,
-      float widthSize) const;
-  float getFlexEndMargin(
+      float widthSize) const {
+    return resolveMarginEdge(inlineStartEdge(axis, direction), direction)
+        .resolve(widthSize)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getFlexEndMargin(
       FlexDirection axis,
       Direction direction,
-      float widthSize) const;
-  float getInlineEndMargin(
+      float widthSize) const {
+    return resolveMarginEdge(flexEndEdge(axis), direction)
+        .resolve(widthSize)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getInlineEndMargin(
       FlexDirection axis,
       Direction direction,
-      float widthSize) const;
-  float getFlexStartBorder(FlexDirection flexDirection, Direction direction)
-      const;
-  float getInlineStartBorder(FlexDirection flexDirection, Direction direction)
-      const;
-  float getFlexEndBorder(FlexDirection flexDirection, Direction direction)
-      const;
-  float getInlineEndBorder(FlexDirection flexDirection, Direction direction)
-      const;
-  float getFlexStartPadding(
+      float widthSize) const {
+    return resolveMarginEdge(inlineEndEdge(axis, direction), direction)
+        .resolve(widthSize)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getFlexStartBorder(FlexDirection axis, Direction direction)
+      const {
+    return resolveBorderEdge(flexStartEdge(axis), direction)
+        .resolve(0.0f)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getInlineStartBorder(FlexDirection axis, Direction direction)
+      const {
+    return resolveBorderEdge(inlineStartEdge(axis, direction), direction)
+        .resolve(0.0f)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getFlexEndBorder(FlexDirection axis, Direction direction) const {
+    return resolveBorderEdge(flexEndEdge(axis), direction)
+        .resolve(0.0f)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getInlineEndBorder(FlexDirection axis, Direction direction)
+      const {
+    return resolveBorderEdge(inlineEndEdge(axis, direction), direction)
+        .resolve(0.0f)
+        .unwrapOrDefault(0.0f);
+  }
+  inline float getFlexStartPadding(
       FlexDirection axis,
       Direction direction,
-      float widthSize) const;
-  float getInlineStartPadding(
+      float widthSize) const {
+    return maxOrDefined(
+        resolvePaddingEdge(flexStartEdge(axis), direction)
+            .resolve(widthSize)
+            .unwrap(),
+        0.0f);
+  }
+  inline float getInlineStartPadding(
       FlexDirection axis,
       Direction direction,
-      float widthSize) const;
-  float getFlexEndPadding(
+      float widthSize) const {
+    return maxOrDefined(
+        resolvePaddingEdge(inlineStartEdge(axis, direction), direction)
+            .resolve(widthSize)
+            .unwrap(),
+        0.0f);
+  }
+  inline float getFlexEndPadding(
       FlexDirection axis,
       Direction direction,
-      float widthSize) const;
-  float getInlineEndPadding(
+      float widthSize) const {
+    return maxOrDefined(
+        resolvePaddingEdge(flexEndEdge(axis), direction)
+            .resolve(widthSize)
+            .unwrap(),
+        0.0f);
+  }
+  inline float getInlineEndPadding(
       FlexDirection axis,
       Direction direction,
-      float widthSize) const;
+      float widthSize) const {
+    return maxOrDefined(
+        resolvePaddingEdge(inlineEndEdge(axis, direction), direction)
+            .resolve(widthSize)
+            .unwrap(),
+        0.0f);
+  }
   float getFlexStartPaddingAndBorder(
       FlexDirection axis,
       Direction direction,
@@ -350,29 +436,15 @@ class YG_EXPORT Node : public ::YGNode {
       Direction direction,
       const float axisSize) const;
 
-  Edge getInlineStartEdgeUsingErrata(
-      FlexDirection flexDirection,
-      Direction direction) const;
-  Edge getInlineEndEdgeUsingErrata(
-      FlexDirection flexDirection,
-      Direction direction) const;
-  Edge getFlexStartRelativeEdgeUsingErrata(
-      FlexDirection flexDirection,
-      Direction direction) const;
-  Edge getFlexEndRelativeEdgeUsingErrata(
-      FlexDirection flexDirection,
-      Direction direction) const;
+  Style::Length resolvePositionEdge(Edge edge, Direction direction) const;
+  Style::Length resolveMarginEdge(Edge edge, Direction direction) const;
+  Style::Length resolvePaddingEdge(Edge edge, Direction direction) const;
+  Style::Length resolveBorderEdge(Edge edge, Direction direction) const;
 
   void useWebDefaults() {
     style_.setFlexDirection(FlexDirection::Row);
     style_.setAlignContent(Align::Stretch);
   }
-
-  template <auto Field>
-  Style::Length computeEdgeValueForColumn(Edge edge) const;
-
-  template <auto Field>
-  Style::Length computeEdgeValueForRow(Edge rowEdge, Edge edge) const;
 
   bool hasNewLayout_ : 1 = true;
   bool isReferenceBaseline_ : 1 = false;

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -217,6 +217,70 @@ class YG_EXPORT Style {
     }
   }
 
+  Style::Length resolveLeft(Direction layoutDirection) const {
+    return resolveLeftEdge(position_, layoutDirection);
+  }
+
+  Style::Length resolveTop() const {
+    return resolveTopEdge(position_);
+  }
+
+  Style::Length resolveRight(Direction layoutDirection) const {
+    return resolveRightEdge(position_, layoutDirection);
+  }
+
+  Style::Length resolveBottom() const {
+    return resolveBottomEdge(position_);
+  }
+
+  Style::Length resolveMarginLeft(Direction layoutDirection) const {
+    return resolveLeftEdge(margin_, layoutDirection);
+  }
+
+  Style::Length resolveMarginTop() const {
+    return resolveTopEdge(margin_);
+  }
+
+  Style::Length resolveMarginRight(Direction layoutDirection) const {
+    return resolveRightEdge(margin_, layoutDirection);
+  }
+
+  Style::Length resolveMarginBottom() const {
+    return resolveBottomEdge(margin_);
+  }
+
+  Style::Length resolvePaddingLeft(Direction layoutDirection) const {
+    return resolveLeftEdge(padding_, layoutDirection);
+  }
+
+  Style::Length resolvePaddingTop() const {
+    return resolveTopEdge(padding_);
+  }
+
+  Style::Length resolvePaddingRight(Direction layoutDirection) const {
+    return resolveRightEdge(padding_, layoutDirection);
+  }
+
+  Style::Length resolvePaddingBottom() const {
+    return resolveBottomEdge(padding_);
+  }
+
+  Style::Length resolveBorderLeft(Direction layoutDirection) const {
+    return resolveLeftEdge(border_, layoutDirection);
+  }
+
+  Style::Length resolveBorderTop() const {
+    return resolveTopEdge(border_);
+  }
+
+  Style::Length resolveBorderRight(Direction layoutDirection) const {
+    return resolveRightEdge(border_, layoutDirection);
+  }
+
+  Style::Length resolveBorderBottom() const {
+    return resolveBottomEdge(border_);
+  }
+
   bool horizontalInsetsDefined() const {
     return position_[YGEdge::YGEdgeLeft].isDefined() ||
         position_[YGEdge::YGEdgeRight].isDefined() ||
@@ -264,6 +328,62 @@ class YG_EXPORT Style {
   using Dimensions = std::array<CompactValue, ordinalCount<Dimension>()>;
   using Edges = std::array<CompactValue, ordinalCount<Edge>()>;
   using Gutters = std::array<CompactValue, ordinalCount<Gutter>()>;
+
+  Style::Length resolveLeftEdge(const Edges& edges, Direction layoutDirection)
+      const {
+    if (layoutDirection == Direction::LTR &&
+        edges[yoga::to_underlying(Edge::Start)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Start)];
+    } else if (
+        layoutDirection == Direction::RTL &&
+        edges[yoga::to_underlying(Edge::End)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::End)];
+    } else if (edges[yoga::to_underlying(Edge::Left)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Left)];
+    } else if (edges[yoga::to_underlying(Edge::Horizontal)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Horizontal)];
+    } else {
+      return (Style::Length)edges[yoga::to_underlying(Edge::All)];
+    }
+  }
+
+  Style::Length resolveTopEdge(const Edges& edges) const {
+    if (edges[yoga::to_underlying(Edge::Top)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Top)];
+    } else if (edges[yoga::to_underlying(Edge::Vertical)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Vertical)];
+    } else {
+      return (Style::Length)edges[yoga::to_underlying(Edge::All)];
+    }
+  }
+
+  Style::Length resolveRightEdge(const Edges& edges, Direction layoutDirection)
+      const {
+    if (layoutDirection == Direction::LTR &&
+        edges[yoga::to_underlying(Edge::End)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::End)];
+    } else if (
+        layoutDirection == Direction::RTL &&
+        edges[yoga::to_underlying(Edge::Start)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Start)];
+    } else if (edges[yoga::to_underlying(Edge::Right)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Right)];
+    } else if (edges[yoga::to_underlying(Edge::Horizontal)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Horizontal)];
+    } else {
+      return (Style::Length)edges[yoga::to_underlying(Edge::All)];
+    }
+  }
+
+  Style::Length resolveBottomEdge(const Edges& edges) const {
+    if (edges[yoga::to_underlying(Edge::Bottom)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Bottom)];
+    } else if (edges[yoga::to_underlying(Edge::Vertical)].isDefined()) {
+      return (Style::Length)edges[yoga::to_underlying(Edge::Vertical)];
+    } else {
+      return (Style::Length)edges[yoga::to_underlying(Edge::All)];
+    }
+  }
 
   Direction direction_ : bitCount<Direction>() = Direction::Inherit;
   FlexDirection flexDirection_


### PR DESCRIPTION
Summary:
This change aims to simplify how we resolve edges. This operation happens many, many times, and has gotten complex and slow when paired with StyleValuePool.

This starts reshaping so that `yoga::Style` can resolve a style prop for a given edge. This is closer to the ideal computed style API to avoid recalcing this so many times, but it is also a good amount cheaper than

This relies on removing the errata related to row-reverse, and cleans up the removal started in the last change.

This has no measurable perf effect under CompactValue, but has a >10% uplift in perf when using StyleValueHandle, where we can trivially check if a handle points to a defined value without resolving it, but only within `yoga::Style` since we don't expose the handle outside of it.

More quantifiably, we go from 2.35 million StyleValuePool reads to 1.05m.

Differential Revision: D52605596

