### PR TITLE
refactor: use less verbose API for RCTRedBox constraints

### DIFF
--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -142,19 +142,19 @@
                      accessibilityIdentifier:@"redbox-extra"
                                     selector:@selector(showExtraDataViewController)
                                        block:nil];
-
-  [dismissButton.heightAnchor constraintEqualToConstant:buttonHeight].active = YES;
-  [reloadButton.heightAnchor constraintEqualToConstant:buttonHeight].active = YES;
-  [copyButton.heightAnchor constraintEqualToConstant:buttonHeight].active = YES;
-  [extraButton.heightAnchor constraintEqualToConstant:buttonHeight].active = YES;
+  
+  [NSLayoutConstraint activateConstraints:@[
+    [dismissButton.heightAnchor constraintEqualToConstant:buttonHeight],
+    [reloadButton.heightAnchor constraintEqualToConstant:buttonHeight],
+    [copyButton.heightAnchor constraintEqualToConstant:buttonHeight],
+    [extraButton.heightAnchor constraintEqualToConstant:buttonHeight]
+  ]];
 
   UIStackView *buttonStackView = [[UIStackView alloc] init];
   buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
   buttonStackView.axis = UILayoutConstraintAxisHorizontal;
   buttonStackView.distribution = UIStackViewDistributionFillEqually;
   buttonStackView.alignment = UIStackViewAlignmentTop;
-
-  [buttonStackView.heightAnchor constraintEqualToConstant:buttonHeight + [self bottomSafeViewHeight]].active = YES;
   buttonStackView.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
 
   [buttonStackView addArrangedSubview:dismissButton];
@@ -163,30 +163,14 @@
   [buttonStackView addArrangedSubview:extraButton];
 
   [self.view addSubview:buttonStackView];
-
-  [self.view addConstraint:[NSLayoutConstraint constraintWithItem:buttonStackView
-                                                        attribute:NSLayoutAttributeLeading
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:self.view
-                                                        attribute:NSLayoutAttributeLeading
-                                                       multiplier:1.0
-                                                         constant:0]];
-
-  [self.view addConstraint:[NSLayoutConstraint constraintWithItem:buttonStackView
-                                                        attribute:NSLayoutAttributeTrailing
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:self.view
-                                                        attribute:NSLayoutAttributeTrailing
-                                                       multiplier:1.0
-                                                         constant:0]];
-
-  [self.view addConstraint:[NSLayoutConstraint constraintWithItem:buttonStackView
-                                                        attribute:NSLayoutAttributeBottom
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:self.view
-                                                        attribute:NSLayoutAttributeBottom
-                                                       multiplier:1.0
-                                                         constant:0]];
+    
+  [NSLayoutConstraint activateConstraints:@[
+    [buttonStackView.heightAnchor constraintEqualToConstant:buttonHeight + [self bottomSafeViewHeight]],
+    [buttonStackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [buttonStackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [buttonStackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+  ]];
+    
 
   for (NSUInteger i = 0; i < [_customButtonTitles count]; i++) {
     UIButton *button = [self redBoxButton:_customButtonTitles[i]
@@ -203,30 +187,12 @@
   [topBorder.heightAnchor constraintEqualToConstant:1].active = YES;
 
   [self.view addSubview:topBorder];
-
-  [self.view addConstraint:[NSLayoutConstraint constraintWithItem:topBorder
-                                                        attribute:NSLayoutAttributeLeading
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:self.view
-                                                        attribute:NSLayoutAttributeLeading
-                                                       multiplier:1.0
-                                                         constant:0]];
-
-  [self.view addConstraint:[NSLayoutConstraint constraintWithItem:topBorder
-                                                        attribute:NSLayoutAttributeTrailing
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:self.view
-                                                        attribute:NSLayoutAttributeTrailing
-                                                       multiplier:1.0
-                                                         constant:0]];
-
-  [self.view addConstraint:[NSLayoutConstraint constraintWithItem:topBorder
-                                                        attribute:NSLayoutAttributeBottom
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:buttonStackView
-                                                        attribute:NSLayoutAttributeTop
-                                                       multiplier:1.0
-                                                         constant:0]];
+    
+  [NSLayoutConstraint activateConstraints:@[
+    [topBorder.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [topBorder.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [topBorder.bottomAnchor constraintEqualToAnchor:buttonStackView.topAnchor],
+  ]];
 }
 
 - (UIButton *)redBoxButton:(NSString *)title


### PR DESCRIPTION
## Summary:

This PR is a continuation of my previous PR where I refactored RCTRedBox to use Auto Layout (#41217). This PR uses less verbose API for defining constraints. 

## Changelog:

[IOS] [CHANGED] - use less verbose Auto Layout API for RCTRedBox constraints

## Test Plan:

Launch the app without metro enabled to see the RCTRedBox

![CleanShot 2024-01-12 at 14 54 20@2x](https://github.com/facebook/react-native/assets/52801365/32ee9916-3e32-46c3-9f6b-c313631aa1e5)
![CleanShot 2024-01-12 at 14 54 16@2x](https://github.com/facebook/react-native/assets/52801365/c625b9b9-b462-4e67-831f-0192427bbe93)

