### PR TITLE
[RN][iOS] Reintroduce OldArch Integration Tests

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -508,6 +508,11 @@ jobs:
         description: The dependency building and linking strategy to use. Must be one of "StaticLibraries", "DynamicFrameworks"
         type: enum
         enum: ["StaticLibraries", "DynamicFrameworks"]
+      architecture:
+        default: "NewArch"
+        description: "The React Native architecture to Test. RNTester has always Fabric enabled, but we want to run integration test with the old arch setup"
+        type: enum
+        enum: ["OldArch", "NewArch"]
       ruby_version:
         default: "2.6.10"
         description: The version of ruby that must be used
@@ -556,9 +561,12 @@ jobs:
                           export USE_FRAMEWORKS=dynamic
                         fi
 
-                        export RCT_NEW_ARCH_ENABLED=1
-                        cd packages/rn-tester
+                        if [[ << parameters.architecture >> == "NewArch" ]]; then
+                          export RCT_NEW_ARCH_ENABLED=1
+                        fi
                         
+                        cd packages/rn-tester
+
                         bundle install
                         bundle exec pod install
                   - when:

--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -107,3 +107,4 @@
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
+              architecture: ["NewArch", "OldArch"]

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -69,27 +69,19 @@
       - test_ios_rntester:
           requires:
             - build_hermes_macos
-          name: "Test RNTester with Ruby 3.2.0"
+          name: "RNTester on Ruby 3.2.0"
           ruby_version: "3.2.0"
           executor: reactnativeios-lts
       - test_ios_rntester:
+          name: "RNTester with Dynamic Frameworks"
+          use_frameworks: "DynamicFrameworks"
           requires:
             - build_hermes_macos
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
-              use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
-            exclude:
-              # Tested by test_ios-Hermes
-              - jsengine: "Hermes"
-                use_frameworks: "StaticLibraries"
-              # Tested by test_ios-JSC
-              - jsengine: "JSC"
-                use_frameworks: "StaticLibraries"
-              # Tested with Ruby 3.2.0, let's not double test this
-              - jsengine: "Hermes"
-                use_frameworks: "StaticLibraries"
       - test_ios_rntester:
+          name: "RNTester Integration Tests"
           run_unit_tests: true
           use_frameworks: "StaticLibraries"
           ruby_version: "2.6.10"
@@ -98,3 +90,4 @@
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
+              architecture: ["NewArch", "OldArch"]


### PR DESCRIPTION
Yesterday we landed a change that removed tests for the Old Architecture for RNTester.
That was the right call as there are no build differences in RNTester between the two architectures. But we do have runtime differences, and we had an integration test running on RNTester that we deleted with the previous PR.
This change restores that test, adding this only new job to run that test

## Changelog:
[Internal] - Add back an old arch integration test

## Test Plan:
CircleCI is green
