### PR TITLE
Add test asserting shape of public JS API

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "flow-bin": "^0.226.0",
     "glob": "^7.1.1",
     "hermes-eslint": "0.18.2",
+    "hermes-transform": "0.18.2",
     "inquirer": "^7.1.0",
     "jest": "^29.6.3",
     "jest-junit": "^10.0.0",

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1,0 +1,10677 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`public API should not change unintentionally Libraries/ActionSheetIOS/ActionSheetIOS.js 1`] = `
+"declare const ActionSheetIOS: {
+  showActionSheetWithOptions(
+    options: {|
+      +title?: ?string,
+      +message?: ?string,
+      +options: Array<string>,
+      +destructiveButtonIndex?: ?number | ?Array<number>,
+      +cancelButtonIndex?: ?number,
+      +anchor?: ?number,
+      +tintColor?: ColorValue | ProcessedColorValue,
+      +cancelButtonTintColor?: ColorValue | ProcessedColorValue,
+      +userInterfaceStyle?: string,
+      +disabledButtonIndices?: Array<number>,
+    |},
+    callback: (buttonIndex: number) => void
+  ): void,
+  showShareActionSheetWithOptions(
+    options: Object,
+    failureCallback: Function,
+    successCallback: Function
+  ): void,
+  dismissActionSheet: () => void,
+};
+declare module.exports: ActionSheetIOS;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ActionSheetIOS/NativeActionSheetManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +showActionSheetWithOptions: (
+    options: {|
+      +title?: ?string,
+      +message?: ?string,
+      +options: ?Array<string>,
+      +destructiveButtonIndices?: ?Array<number>,
+      +cancelButtonIndex?: ?number,
+      +anchor?: ?number,
+      +tintColor?: ?number,
+      +cancelButtonTintColor?: ?number,
+      +userInterfaceStyle?: ?string,
+      +disabledButtonIndices?: Array<number>,
+    |},
+    callback: (buttonIndex: number) => void
+  ) => void;
+  +showShareActionSheetWithOptions: (
+    options: {|
+      +message?: ?string,
+      +url?: ?string,
+      +subject?: ?string,
+      +anchor?: ?number,
+      +tintColor?: ?number,
+      +cancelButtonTintColor?: ?number,
+      +excludedActivityTypes?: ?Array<string>,
+      +userInterfaceStyle?: ?string,
+    |},
+    failureCallback: (error: {|
+      +domain: string,
+      +code: string,
+      +userInfo?: ?Object,
+      +message: string,
+    |}) => void,
+    successCallback: (completed: boolean, activityType: ?string) => void
+  ) => void;
+  +dismissActionSheet?: () => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Alert/Alert.js 1`] = `
+"export type AlertType =
+  | \\"default\\"
+  | \\"plain-text\\"
+  | \\"secure-text\\"
+  | \\"login-password\\";
+export type AlertButtonStyle = \\"default\\" | \\"cancel\\" | \\"destructive\\";
+export type Buttons = Array<{
+  text?: string,
+  onPress?: ?Function,
+  isPreferred?: boolean,
+  style?: AlertButtonStyle,
+  ...
+}>;
+type Options = {
+  cancelable?: ?boolean,
+  userInterfaceStyle?: \\"unspecified\\" | \\"light\\" | \\"dark\\",
+  onDismiss?: ?() => void,
+  ...
+};
+declare class Alert {
+  static alert(
+    title: ?string,
+    message?: ?string,
+    buttons?: Buttons,
+    options?: Options
+  ): void;
+  static prompt(
+    title: ?string,
+    message?: ?string,
+    callbackOrButtons?: ?(((text: string) => void) | Buttons),
+    type?: ?AlertType,
+    defaultValue?: string,
+    keyboardType?: string,
+    options?: Options
+  ): void;
+}
+declare module.exports: Alert;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Alert/NativeAlertManager.js 1`] = `
+"export type Args = {|
+  title?: string,
+  message?: string,
+  buttons?: Array<Object>,
+  type?: string,
+  defaultValue?: string,
+  cancelButtonKey?: string,
+  destructiveButtonKey?: string,
+  preferredButtonKey?: string,
+  keyboardType?: string,
+  userInterfaceStyle?: string,
+|};
+export interface Spec extends TurboModule {
+  +alertWithArgs: (
+    args: Args,
+    callback: (id: number, value: string) => void
+  ) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Alert/RCTAlertManager.android.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Alert/RCTAlertManager.ios.js 1`] = `
+"declare module.exports: {
+  alertWithArgs(
+    args: Args,
+    callback: (id: number, value: string) => void
+  ): void,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Alert/RCTAlertManager.js.flow 1`] = `
+"declare module.exports: {
+  alertWithArgs(
+    args: Args,
+    callback: (id: number, value: string) => void
+  ): void,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/Animated.js 1`] = `
+"export type { CompositeAnimation, Numeric } from \\"./AnimatedImplementation\\";
+declare const Animated: typeof AnimatedImplementation;
+declare export default {
+  get FlatList(): AnimatedFlatList,
+  get Image(): AnimatedImage,
+  get ScrollView(): AnimatedScrollView,
+  get SectionList(): AnimatedSectionList,
+  get Text(): AnimatedText,
+  get View(): AnimatedView,
+  ...Animated,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/AnimatedEvent.js 1`] = `
+"export type Mapping =
+  | { [key: string]: Mapping, ... }
+  | AnimatedValue
+  | AnimatedValueXY;
+export type EventConfig = {
+  listener?: ?Function,
+  useNativeDriver: boolean,
+  platformConfig?: PlatformConfig,
+};
+declare export function attachNativeEvent(
+  viewRef: any,
+  eventName: string,
+  argMapping: $ReadOnlyArray<?Mapping>,
+  platformConfig: ?PlatformConfig
+): { detach: () => void };
+declare export class AnimatedEvent {
+  _argMapping: $ReadOnlyArray<?Mapping>;
+  _listeners: Array<Function>;
+  _attachedEvent: ?{ detach: () => void, ... };
+  __isNative: boolean;
+  __platformConfig: ?PlatformConfig;
+  constructor(argMapping: $ReadOnlyArray<?Mapping>, config: EventConfig): void;
+  __addListener(callback: Function): void;
+  __removeListener(callback: Function): void;
+  __attach(viewRef: any, eventName: string): void;
+  __detach(viewTag: any, eventName: string): void;
+  __getHandler(): any | ((...args: any) => void);
+  _callListeners: $FlowFixMe;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/AnimatedImplementation.js 1`] = `
+"export type CompositeAnimation = {
+  start: (callback?: ?EndCallback) => void,
+  stop: () => void,
+  reset: () => void,
+  _startNativeLoop: (iterations?: number) => void,
+  _isUsingNativeDriver: () => boolean,
+  ...
+};
+declare const add: (
+  a: AnimatedNode | number,
+  b: AnimatedNode | number
+) => AnimatedAddition;
+declare const subtract: (
+  a: AnimatedNode | number,
+  b: AnimatedNode | number
+) => AnimatedSubtraction;
+declare const divide: (
+  a: AnimatedNode | number,
+  b: AnimatedNode | number
+) => AnimatedDivision;
+declare const multiply: (
+  a: AnimatedNode | number,
+  b: AnimatedNode | number
+) => AnimatedMultiplication;
+declare const modulo: (a: AnimatedNode, modulus: number) => AnimatedModulo;
+declare const diffClamp: (
+  a: AnimatedNode,
+  min: number,
+  max: number
+) => AnimatedDiffClamp;
+declare const spring: (
+  value: AnimatedValue | AnimatedValueXY | AnimatedColor,
+  config: SpringAnimationConfig
+) => CompositeAnimation;
+declare const timing: (
+  value: AnimatedValue | AnimatedValueXY | AnimatedColor,
+  config: TimingAnimationConfig
+) => CompositeAnimation;
+declare const decay: (
+  value: AnimatedValue | AnimatedValueXY | AnimatedColor,
+  config: DecayAnimationConfig
+) => CompositeAnimation;
+declare const sequence: (
+  animations: Array<CompositeAnimation>
+) => CompositeAnimation;
+type ParallelConfig = {
+  stopTogether?: boolean,
+  ...
+};
+declare const parallel: (
+  animations: Array<CompositeAnimation>,
+  config?: ?ParallelConfig
+) => CompositeAnimation;
+declare const delay: (time: number) => CompositeAnimation;
+declare const stagger: (
+  time: number,
+  animations: Array<CompositeAnimation>
+) => CompositeAnimation;
+type LoopAnimationConfig = {
+  iterations: number,
+  resetBeforeIteration?: boolean,
+  ...
+};
+declare const loop: (
+  animation: CompositeAnimation,
+  LoopAnimationConfig
+) => CompositeAnimation;
+declare function forkEvent(
+  event: ?AnimatedEvent | ?Function,
+  listener: Function
+): AnimatedEvent | Function;
+declare function unforkEvent(
+  event: ?AnimatedEvent | ?Function,
+  listener: Function
+): void;
+declare const event: (
+  argMapping: $ReadOnlyArray<?Mapping>,
+  config: EventConfig
+) => any;
+type AnimatedNumeric =
+  | AnimatedAddition
+  | AnimatedDiffClamp
+  | AnimatedDivision
+  | AnimatedInterpolation<number>
+  | AnimatedModulo
+  | AnimatedMultiplication
+  | AnimatedSubtraction
+  | AnimatedValue;
+export type { AnimatedNumeric as Numeric };
+declare export default {
+  Value: AnimatedValue,
+  ValueXY: AnimatedValueXY,
+  Color: AnimatedColor,
+  Interpolation: AnimatedInterpolation,
+  Node: AnimatedNode,
+  decay: decay,
+  timing: timing,
+  spring: spring,
+  add: add,
+  subtract: subtract,
+  divide: divide,
+  multiply: multiply,
+  modulo: modulo,
+  diffClamp: diffClamp,
+  delay: delay,
+  sequence: sequence,
+  parallel: parallel,
+  stagger: stagger,
+  loop: loop,
+  event: event,
+  createAnimatedComponent: createAnimatedComponent,
+  attachNativeEvent: attachNativeEvent,
+  forkEvent: forkEvent,
+  unforkEvent: unforkEvent,
+  Event: AnimatedEvent,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/AnimatedMock.js 1`] = `
+"export type CompositeAnimation = {
+  start: (callback?: ?EndCallback) => void,
+  stop: () => void,
+  reset: () => void,
+  _startNativeLoop: (iterations?: number) => void,
+  _isUsingNativeDriver: () => boolean,
+  ...
+};
+declare const spring: (
+  value: AnimatedValue | AnimatedValueXY | AnimatedColor,
+  config: SpringAnimationConfig
+) => CompositeAnimation;
+declare const timing: (
+  value: AnimatedValue | AnimatedValueXY | AnimatedColor,
+  config: TimingAnimationConfig
+) => CompositeAnimation;
+declare const decay: (
+  value: AnimatedValue | AnimatedValueXY | AnimatedColor,
+  config: DecayAnimationConfig
+) => CompositeAnimation;
+declare const sequence: (
+  animations: Array<CompositeAnimation>
+) => CompositeAnimation;
+type ParallelConfig = { stopTogether?: boolean, ... };
+declare const parallel: (
+  animations: Array<CompositeAnimation>,
+  config?: ?ParallelConfig
+) => CompositeAnimation;
+declare const delay: (time: number) => CompositeAnimation;
+declare const stagger: (
+  time: number,
+  animations: Array<CompositeAnimation>
+) => CompositeAnimation;
+type LoopAnimationConfig = {
+  iterations: number,
+  resetBeforeIteration?: boolean,
+  ...
+};
+declare const loop: (
+  animation: CompositeAnimation,
+  LoopAnimationConfig
+) => CompositeAnimation;
+export type { AnimatedNumeric as Numeric };
+declare export default {
+  Value: AnimatedValue,
+  ValueXY: AnimatedValueXY,
+  Color: AnimatedColor,
+  Interpolation: AnimatedInterpolation,
+  Node: AnimatedNode,
+  decay: decay,
+  timing: timing,
+  spring: spring,
+  add: $FlowFixMe,
+  subtract: $FlowFixMe,
+  divide: $FlowFixMe,
+  multiply: $FlowFixMe,
+  modulo: $FlowFixMe,
+  diffClamp: $FlowFixMe,
+  delay: delay,
+  sequence: sequence,
+  parallel: parallel,
+  stagger: stagger,
+  loop: loop,
+  event: $FlowFixMe,
+  createAnimatedComponent: createAnimatedComponent,
+  attachNativeEvent: attachNativeEvent,
+  forkEvent: $FlowFixMe,
+  unforkEvent: $FlowFixMe,
+  Event: AnimatedEvent,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/AnimatedPlatformConfig.js 1`] = `
+"export type PlatformConfig = {};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/AnimatedWeb.js 1`] = `
+"declare export default {
+  ...AnimatedImplementation,
+  div: $FlowFixMe,
+  span: $FlowFixMe,
+  img: $FlowFixMe,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/Easing.js 1`] = `
+"declare const Easing: {
+  step0(n: number): number,
+  step1(n: number): number,
+  linear(t: number): number,
+  ease(t: number): number,
+  quad(t: number): number,
+  cubic(t: number): number,
+  poly(n: number): (t: number) => number,
+  sin(t: number): number,
+  circle(t: number): number,
+  exp(t: number): number,
+  elastic(bounciness: number): (t: number) => number,
+  back(s: number): (t: number) => number,
+  bounce(t: number): number,
+  bezier(x1: number, y1: number, x2: number, y2: number): (t: number) => number,
+  in(easing: (t: number) => number): (t: number) => number,
+  out(easing: (t: number) => number): (t: number) => number,
+  inOut(easing: (t: number) => number): (t: number) => number,
+};
+declare export default typeof Easing;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/NativeAnimatedHelper.js 1`] = `
+"declare const API: {
+  getValue: (tag: number, saveValueCallback: (value: number) => void) => void,
+  setWaitingForIdentifier: (id: string) => void,
+  unsetWaitingForIdentifier: (id: string) => void,
+  disableQueue: () => void,
+  flushQueue: () => void,
+  queueOperation: <Args: $ReadOnlyArray<mixed>, Fn: (...Args) => void>(
+    fn: Fn,
+    ...args: Args
+  ) => void,
+  createAnimatedNode: (tag: number, config: AnimatedNodeConfig) => void,
+  updateAnimatedNodeConfig: (tag: number, config: AnimatedNodeConfig) => void,
+  startListeningToAnimatedNodeValue: (tag: number) => void,
+  stopListeningToAnimatedNodeValue: (tag: number) => void,
+  connectAnimatedNodes: (parentTag: number, childTag: number) => void,
+  disconnectAnimatedNodes: (parentTag: number, childTag: number) => void,
+  startAnimatingNode: (
+    animationId: number,
+    nodeTag: number,
+    config: AnimatingNodeConfig,
+    endCallback: EndCallback
+  ) => void,
+  stopAnimation: (animationId: number) => void,
+  setAnimatedNodeValue: (nodeTag: number, value: number) => void,
+  setAnimatedNodeOffset: (nodeTag: number, offset: number) => void,
+  flattenAnimatedNodeOffset: (nodeTag: number) => void,
+  extractAnimatedNodeOffset: (nodeTag: number) => void,
+  connectAnimatedNodeToView: (nodeTag: number, viewTag: number) => void,
+  disconnectAnimatedNodeFromView: (nodeTag: number, viewTag: number) => void,
+  restoreDefaultValues: (nodeTag: number) => void,
+  dropAnimatedNode: (tag: number) => void,
+  addAnimatedEventToView: (
+    viewTag: number,
+    eventName: string,
+    eventMapping: EventMapping
+  ) => void,
+  removeAnimatedEventFromView(
+    viewTag: number,
+    eventName: string,
+    animatedNodeTag: number
+  ): void,
+};
+declare function addWhitelistedStyleProp(prop: string): void;
+declare function addWhitelistedTransformProp(prop: string): void;
+declare function addWhitelistedInterpolationParam(param: string): void;
+declare function isSupportedColorStyleProp(prop: string): boolean;
+declare function isSupportedStyleProp(prop: string): boolean;
+declare function isSupportedTransformProp(prop: string): boolean;
+declare function isSupportedInterpolationParam(param: string): boolean;
+declare function validateTransform(
+  configs: Array<
+    | {
+        type: \\"animated\\",
+        property: string,
+        nodeTag: ?number,
+        ...
+      }
+    | {
+        type: \\"static\\",
+        property: string,
+        value: number | string,
+        ...
+      },
+  >
+): void;
+declare function validateStyles(styles: { [key: string]: ?number, ... }): void;
+declare function validateInterpolation<OutputT: number | string>(
+  config: InterpolationConfigType<OutputT>
+): void;
+declare function generateNewNodeTag(): number;
+declare function generateNewAnimationId(): number;
+declare function assertNativeAnimatedModule(): void;
+declare function shouldUseNativeDriver(
+  config: $ReadOnly<{ ...AnimationConfig, ... }> | EventConfig
+): boolean;
+declare function transformDataType(value: number | string): number | string;
+declare export default {
+  API: API,
+  isSupportedColorStyleProp: isSupportedColorStyleProp,
+  isSupportedStyleProp: isSupportedStyleProp,
+  isSupportedTransformProp: isSupportedTransformProp,
+  isSupportedInterpolationParam: isSupportedInterpolationParam,
+  addWhitelistedStyleProp: addWhitelistedStyleProp,
+  addWhitelistedTransformProp: addWhitelistedTransformProp,
+  addWhitelistedInterpolationParam: addWhitelistedInterpolationParam,
+  validateStyles: validateStyles,
+  validateTransform: validateTransform,
+  validateInterpolation: validateInterpolation,
+  generateNewNodeTag: generateNewNodeTag,
+  generateNewAnimationId: generateNewAnimationId,
+  assertNativeAnimatedModule: assertNativeAnimatedModule,
+  shouldUseNativeDriver: shouldUseNativeDriver,
+  transformDataType: transformDataType,
+  get nativeEventEmitter(): NativeEventEmitter,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/NativeAnimatedModule.js 1`] = `
+"type EndResult = { finished: boolean, value?: number, ... };
+type EndCallback = (result: EndResult) => void;
+type SaveValueCallback = (value: number) => void;
+export type EventMapping = {|
+  nativeEventPath: Array<string>,
+  animatedValueTag: ?number,
+|};
+export type AnimatedNodeConfig = Object;
+export type AnimatingNodeConfig = Object;
+export interface Spec extends TurboModule {
+  +startOperationBatch: () => void;
+  +finishOperationBatch: () => void;
+  +createAnimatedNode: (tag: number, config: AnimatedNodeConfig) => void;
+  +updateAnimatedNodeConfig?: (tag: number, config: AnimatedNodeConfig) => void;
+  +getValue: (tag: number, saveValueCallback: SaveValueCallback) => void;
+  +startListeningToAnimatedNodeValue: (tag: number) => void;
+  +stopListeningToAnimatedNodeValue: (tag: number) => void;
+  +connectAnimatedNodes: (parentTag: number, childTag: number) => void;
+  +disconnectAnimatedNodes: (parentTag: number, childTag: number) => void;
+  +startAnimatingNode: (
+    animationId: number,
+    nodeTag: number,
+    config: AnimatingNodeConfig,
+    endCallback: EndCallback
+  ) => void;
+  +stopAnimation: (animationId: number) => void;
+  +setAnimatedNodeValue: (nodeTag: number, value: number) => void;
+  +setAnimatedNodeOffset: (nodeTag: number, offset: number) => void;
+  +flattenAnimatedNodeOffset: (nodeTag: number) => void;
+  +extractAnimatedNodeOffset: (nodeTag: number) => void;
+  +connectAnimatedNodeToView: (nodeTag: number, viewTag: number) => void;
+  +disconnectAnimatedNodeFromView: (nodeTag: number, viewTag: number) => void;
+  +restoreDefaultValues: (nodeTag: number) => void;
+  +dropAnimatedNode: (tag: number) => void;
+  +addAnimatedEventToView: (
+    viewTag: number,
+    eventName: string,
+    eventMapping: EventMapping
+  ) => void;
+  +removeAnimatedEventFromView: (
+    viewTag: number,
+    eventName: string,
+    animatedNodeTag: number
+  ) => void;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+  +queueAndExecuteBatchedOperations?: (operationsAndArgs: Array<any>) => void;
+}
+declare const NativeModule: ?Spec;
+declare export default typeof NativeModule;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/NativeAnimatedTurboModule.js 1`] = `
+"type EndResult = { finished: boolean, value?: number, ... };
+type EndCallback = (result: EndResult) => void;
+type SaveValueCallback = (value: number) => void;
+export type EventMapping = {|
+  nativeEventPath: Array<string>,
+  animatedValueTag: ?number,
+|};
+export type AnimatedNodeConfig = Object;
+export type AnimatingNodeConfig = Object;
+export interface Spec extends TurboModule {
+  +startOperationBatch: () => void;
+  +finishOperationBatch: () => void;
+  +createAnimatedNode: (tag: number, config: AnimatedNodeConfig) => void;
+  +updateAnimatedNodeConfig?: (tag: number, config: AnimatedNodeConfig) => void;
+  +getValue: (tag: number, saveValueCallback: SaveValueCallback) => void;
+  +startListeningToAnimatedNodeValue: (tag: number) => void;
+  +stopListeningToAnimatedNodeValue: (tag: number) => void;
+  +connectAnimatedNodes: (parentTag: number, childTag: number) => void;
+  +disconnectAnimatedNodes: (parentTag: number, childTag: number) => void;
+  +startAnimatingNode: (
+    animationId: number,
+    nodeTag: number,
+    config: AnimatingNodeConfig,
+    endCallback: EndCallback
+  ) => void;
+  +stopAnimation: (animationId: number) => void;
+  +setAnimatedNodeValue: (nodeTag: number, value: number) => void;
+  +setAnimatedNodeOffset: (nodeTag: number, offset: number) => void;
+  +flattenAnimatedNodeOffset: (nodeTag: number) => void;
+  +extractAnimatedNodeOffset: (nodeTag: number) => void;
+  +connectAnimatedNodeToView: (nodeTag: number, viewTag: number) => void;
+  +disconnectAnimatedNodeFromView: (nodeTag: number, viewTag: number) => void;
+  +restoreDefaultValues: (nodeTag: number) => void;
+  +dropAnimatedNode: (tag: number) => void;
+  +addAnimatedEventToView: (
+    viewTag: number,
+    eventName: string,
+    eventMapping: EventMapping
+  ) => void;
+  +removeAnimatedEventFromView: (
+    viewTag: number,
+    eventName: string,
+    animatedNodeTag: number
+  ) => void;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+  +queueAndExecuteBatchedOperations?: (operationsAndArgs: Array<any>) => void;
+}
+declare const NativeModule: ?Spec;
+declare export default typeof NativeModule;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/SpringConfig.js 1`] = `
+"type SpringConfigType = {
+  stiffness: number,
+  damping: number,
+  ...
+};
+declare export function fromOrigamiTensionAndFriction(
+  tension: number,
+  friction: number
+): SpringConfigType;
+declare export function fromBouncinessAndSpeed(
+  bounciness: number,
+  speed: number
+): SpringConfigType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/animations/Animation.js 1`] = `
+"export type EndResult = { finished: boolean, value?: number, ... };
+export type EndCallback = (result: EndResult) => void;
+export type AnimationConfig = {
+  isInteraction?: boolean,
+  useNativeDriver: boolean,
+  platformConfig?: PlatformConfig,
+  onComplete?: ?EndCallback,
+  iterations?: number,
+};
+declare export default class Animation {
+  __active: boolean;
+  __isInteraction: boolean;
+  __onEnd: ?EndCallback;
+  __iterations: number;
+  _nativeId: number;
+  start(
+    fromValue: number,
+    onUpdate: (value: number) => void,
+    onEnd: ?EndCallback,
+    previousAnimation: ?Animation,
+    animatedValue: AnimatedValue
+  ): void;
+  stop(): void;
+  __getNativeAnimationConfig(): any;
+  __debouncedOnEnd(result: EndResult): void;
+  __findAnimatedPropsNodes(node: AnimatedNode): Array<AnimatedProps>;
+  __startNativeAnimation(animatedValue: AnimatedValue): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/animations/DecayAnimation.js 1`] = `
+"export type DecayAnimationConfig = {
+  ...AnimationConfig,
+  velocity:
+    | number
+    | {
+        x: number,
+        y: number,
+        ...
+      },
+  deceleration?: number,
+};
+export type DecayAnimationConfigSingle = {
+  ...AnimationConfig,
+  velocity: number,
+  deceleration?: number,
+};
+declare export default class DecayAnimation extends Animation {
+  _startTime: number;
+  _lastValue: number;
+  _fromValue: number;
+  _deceleration: number;
+  _velocity: number;
+  _onUpdate: (value: number) => void;
+  _animationFrame: any;
+  _useNativeDriver: boolean;
+  _platformConfig: ?PlatformConfig;
+  constructor(config: DecayAnimationConfigSingle): void;
+  __getNativeAnimationConfig(): {|
+    deceleration: number,
+    iterations: number,
+    platformConfig: ?PlatformConfig,
+    type: $TEMPORARY$string<\\"decay\\">,
+    velocity: number,
+  |};
+  start(
+    fromValue: number,
+    onUpdate: (value: number) => void,
+    onEnd: ?EndCallback,
+    previousAnimation: ?Animation,
+    animatedValue: AnimatedValue
+  ): void;
+  onUpdate(): void;
+  stop(): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/animations/SpringAnimation.js 1`] = `
+"export type SpringAnimationConfig = {
+  ...AnimationConfig,
+  toValue:
+    | number
+    | AnimatedValue
+    | {
+        x: number,
+        y: number,
+        ...
+      }
+    | AnimatedValueXY
+    | {
+        r: number,
+        g: number,
+        b: number,
+        a: number,
+        ...
+      }
+    | AnimatedColor
+    | AnimatedInterpolation<number>,
+  overshootClamping?: boolean,
+  restDisplacementThreshold?: number,
+  restSpeedThreshold?: number,
+  velocity?:
+    | number
+    | {
+        x: number,
+        y: number,
+        ...
+      },
+  bounciness?: number,
+  speed?: number,
+  tension?: number,
+  friction?: number,
+  stiffness?: number,
+  damping?: number,
+  mass?: number,
+  delay?: number,
+};
+export type SpringAnimationConfigSingle = {
+  ...AnimationConfig,
+  toValue: number,
+  overshootClamping?: boolean,
+  restDisplacementThreshold?: number,
+  restSpeedThreshold?: number,
+  velocity?: number,
+  bounciness?: number,
+  speed?: number,
+  tension?: number,
+  friction?: number,
+  stiffness?: number,
+  damping?: number,
+  mass?: number,
+  delay?: number,
+};
+declare export default class SpringAnimation extends Animation {
+  _overshootClamping: boolean;
+  _restDisplacementThreshold: number;
+  _restSpeedThreshold: number;
+  _lastVelocity: number;
+  _startPosition: number;
+  _lastPosition: number;
+  _fromValue: number;
+  _toValue: number;
+  _stiffness: number;
+  _damping: number;
+  _mass: number;
+  _initialVelocity: number;
+  _delay: number;
+  _timeout: any;
+  _startTime: number;
+  _lastTime: number;
+  _frameTime: number;
+  _onUpdate: (value: number) => void;
+  _animationFrame: any;
+  _useNativeDriver: boolean;
+  _platformConfig: ?PlatformConfig;
+  constructor(config: SpringAnimationConfigSingle): void;
+  __getNativeAnimationConfig(): {|
+    damping: number,
+    initialVelocity: number,
+    iterations: number,
+    mass: number,
+    platformConfig: ?PlatformConfig,
+    overshootClamping: boolean,
+    restDisplacementThreshold: number,
+    restSpeedThreshold: number,
+    stiffness: number,
+    toValue: any,
+    type: $TEMPORARY$string<\\"spring\\">,
+  |};
+  start(
+    fromValue: number,
+    onUpdate: (value: number) => void,
+    onEnd: ?EndCallback,
+    previousAnimation: ?Animation,
+    animatedValue: AnimatedValue
+  ): void;
+  getInternalState(): Object;
+  onUpdate(): void;
+  stop(): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/animations/TimingAnimation.js 1`] = `
+"export type TimingAnimationConfig = $ReadOnly<{
+  ...AnimationConfig,
+  toValue:
+    | number
+    | AnimatedValue
+    | {
+        x: number,
+        y: number,
+        ...
+      }
+    | AnimatedValueXY
+    | RgbaValue
+    | AnimatedColor
+    | AnimatedInterpolation<number>,
+  easing?: (value: number) => number,
+  duration?: number,
+  delay?: number,
+}>;
+export type TimingAnimationConfigSingle = $ReadOnly<{
+  ...AnimationConfig,
+  toValue: number,
+  easing?: (value: number) => number,
+  duration?: number,
+  delay?: number,
+}>;
+declare export default class TimingAnimation extends Animation {
+  _startTime: number;
+  _fromValue: number;
+  _toValue: number;
+  _duration: number;
+  _delay: number;
+  _easing: (value: number) => number;
+  _onUpdate: (value: number) => void;
+  _animationFrame: any;
+  _timeout: any;
+  _useNativeDriver: boolean;
+  _platformConfig: ?PlatformConfig;
+  constructor(config: TimingAnimationConfigSingle): void;
+  __getNativeAnimationConfig(): any;
+  start(
+    fromValue: number,
+    onUpdate: (value: number) => void,
+    onEnd: ?EndCallback,
+    previousAnimation: ?Animation,
+    animatedValue: AnimatedValue
+  ): void;
+  onUpdate(): void;
+  stop(): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/bezier.js 1`] = `
+"declare export default function bezier(
+  mX1: number,
+  mY1: number,
+  mX2: number,
+  mY2: number
+): (x: number) => number;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/components/AnimatedFlatList.js 1`] = `
+"declare export default AnimatedComponentType<
+  React.ElementConfig<typeof FlatList>,
+  React.ElementRef<typeof FlatList>,
+>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/components/AnimatedImage.js 1`] = `
+"declare export default AnimatedComponentType<
+  React.ElementConfig<typeof Image>,
+  React.ElementRef<typeof Image>,
+>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/components/AnimatedScrollView.js 1`] = `
+"type Props = React.ElementConfig<typeof ScrollView>;
+type Instance = React.ElementRef<typeof ScrollView>;
+declare const AnimatedScrollView: AnimatedComponentType<Props, Instance>;
+declare export default typeof AnimatedScrollView;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/components/AnimatedSectionList.js 1`] = `
+"declare export default AnimatedComponentType<
+  React.ElementConfig<typeof SectionList>,
+  React.ElementRef<typeof SectionList>,
+>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/components/AnimatedText.js 1`] = `
+"declare export default AnimatedComponentType<
+  React.ElementConfig<typeof Text>,
+  React.ElementRef<typeof Text>,
+>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/components/AnimatedView.js 1`] = `
+"declare export default AnimatedComponentType<
+  React.ElementConfig<typeof View>,
+  React.ElementRef<typeof View>,
+>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/createAnimatedComponent.js 1`] = `
+"export type AnimatedProps<Props: { ... }> = $ObjMap<
+  Props &
+    $ReadOnly<{
+      passthroughAnimatedPropExplicitValues?: React.ElementConfig<typeof View>,
+    }>,
+  () => any,
+>;
+export type AnimatedComponentType<
+  Props: { ... },
+  +Instance = mixed,
+> = React.AbstractComponent<AnimatedProps<Props>, Instance>;
+declare export default function createAnimatedComponent<
+  TProps: { ... },
+  TInstance,
+>(
+  Component: React.AbstractComponent<TProps, TInstance>
+): AnimatedComponentType<TProps, TInstance>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedAddition.js 1`] = `
+"declare export default class AnimatedAddition extends AnimatedWithChildren {
+  _a: AnimatedNode;
+  _b: AnimatedNode;
+  constructor(a: AnimatedNode | number, b: AnimatedNode | number): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getValue(): number;
+  interpolate<OutputT: number | string>(
+    config: InterpolationConfigType<OutputT>
+  ): AnimatedInterpolation<OutputT>;
+  __attach(): void;
+  __detach(): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedColor.js 1`] = `
+"export type AnimatedColorConfig = $ReadOnly<{
+  useNativeDriver: boolean,
+}>;
+type ColorListenerCallback = (value: ColorValue) => mixed;
+export type RgbaValue = {
+  +r: number,
+  +g: number,
+  +b: number,
+  +a: number,
+  ...
+};
+type RgbaAnimatedValue = {
+  +r: AnimatedValue,
+  +g: AnimatedValue,
+  +b: AnimatedValue,
+  +a: AnimatedValue,
+  ...
+};
+export type InputValue = ?(RgbaValue | RgbaAnimatedValue | ColorValue);
+declare export default class AnimatedColor extends AnimatedWithChildren {
+  r: AnimatedValue;
+  g: AnimatedValue;
+  b: AnimatedValue;
+  a: AnimatedValue;
+  nativeColor: ?NativeColorValue;
+  _suspendCallbacks: number;
+  constructor(valueIn?: InputValue, config?: ?AnimatedColorConfig): void;
+  setValue(value: RgbaValue | ColorValue): void;
+  setOffset(offset: RgbaValue): void;
+  flattenOffset(): void;
+  extractOffset(): void;
+  stopAnimation(callback?: ColorListenerCallback): void;
+  resetAnimation(callback?: ColorListenerCallback): void;
+  __getValue(): ColorValue;
+  __attach(): void;
+  __detach(): void;
+  _withSuspendedCallbacks(callback: () => void): void;
+  __callListeners(value: number): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getNativeConfig(): { ... };
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedDiffClamp.js 1`] = `
+"declare export default class AnimatedDiffClamp extends AnimatedWithChildren {
+  _a: AnimatedNode;
+  _min: number;
+  _max: number;
+  _value: number;
+  _lastValue: number;
+  constructor(a: AnimatedNode, min: number, max: number): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  interpolate<OutputT: number | string>(
+    config: InterpolationConfigType<OutputT>
+  ): AnimatedInterpolation<OutputT>;
+  __getValue(): number;
+  __attach(): void;
+  __detach(): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedDivision.js 1`] = `
+"declare export default class AnimatedDivision extends AnimatedWithChildren {
+  _a: AnimatedNode;
+  _b: AnimatedNode;
+  _warnedAboutDivideByZero: boolean;
+  constructor(a: AnimatedNode | number, b: AnimatedNode | number): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getValue(): number;
+  interpolate<OutputT: number | string>(
+    config: InterpolationConfigType<OutputT>
+  ): AnimatedInterpolation<OutputT>;
+  __attach(): void;
+  __detach(): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedInterpolation.js 1`] = `
+"type ExtrapolateType = \\"extend\\" | \\"identity\\" | \\"clamp\\";
+export type InterpolationConfigType<OutputT: number | string> = $ReadOnly<{
+  inputRange: $ReadOnlyArray<number>,
+  outputRange: $ReadOnlyArray<OutputT>,
+  easing?: (input: number) => number,
+  extrapolate?: ExtrapolateType,
+  extrapolateLeft?: ExtrapolateType,
+  extrapolateRight?: ExtrapolateType,
+}>;
+declare export default class AnimatedInterpolation<OutputT: number | string>
+  extends AnimatedWithChildren
+{
+  _parent: AnimatedNode;
+  _config: InterpolationConfigType<OutputT>;
+  _interpolation: ?(input: number) => OutputT;
+  constructor(
+    parent: AnimatedNode,
+    config: InterpolationConfigType<OutputT>
+  ): void;
+  _getInterpolation(): (number) => OutputT;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getValue(): OutputT;
+  interpolate<NewOutputT: number | string>(
+    config: InterpolationConfigType<NewOutputT>
+  ): AnimatedInterpolation<NewOutputT>;
+  __attach(): void;
+  __detach(): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedModulo.js 1`] = `
+"declare export default class AnimatedModulo extends AnimatedWithChildren {
+  _a: AnimatedNode;
+  _modulus: number;
+  constructor(a: AnimatedNode, modulus: number): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getValue(): number;
+  interpolate<OutputT: number | string>(
+    config: InterpolationConfigType<OutputT>
+  ): AnimatedInterpolation<OutputT>;
+  __attach(): void;
+  __detach(): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedMultiplication.js 1`] = `
+"declare export default class AnimatedMultiplication
+  extends AnimatedWithChildren
+{
+  _a: AnimatedNode;
+  _b: AnimatedNode;
+  constructor(a: AnimatedNode | number, b: AnimatedNode | number): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getValue(): number;
+  interpolate<OutputT: number | string>(
+    config: InterpolationConfigType<OutputT>
+  ): AnimatedInterpolation<OutputT>;
+  __attach(): void;
+  __detach(): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedNode.js 1`] = `
+"type ValueListenerCallback = (state: { value: number, ... }) => mixed;
+declare export default class AnimatedNode {
+  _listeners: { [key: string]: ValueListenerCallback, ... };
+  _platformConfig: ?PlatformConfig;
+  __nativeAnimatedValueListener: ?any;
+  __attach(): void;
+  __detach(): void;
+  __getValue(): any;
+  __getAnimatedValue(): any;
+  __addChild(child: AnimatedNode): void;
+  __removeChild(child: AnimatedNode): void;
+  __getChildren(): $ReadOnlyArray<AnimatedNode>;
+  __isNative: boolean;
+  __nativeTag: ?number;
+  __shouldUpdateListenersForNewNativeTag: boolean;
+  constructor(): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  addListener(callback: (value: any) => mixed): string;
+  removeListener(id: string): void;
+  removeAllListeners(): void;
+  hasListeners(): boolean;
+  _startListeningToNativeValueUpdates(): void;
+  __onAnimatedValueUpdateReceived(value: number): void;
+  __callListeners(value: number): void;
+  _stopListeningForNativeValueUpdates(): void;
+  __getNativeTag(): number;
+  __getNativeConfig(): Object;
+  toJSON(): any;
+  __getPlatformConfig(): ?PlatformConfig;
+  __setPlatformConfig(platformConfig: ?PlatformConfig): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedObject.js 1`] = `
+"declare export function hasAnimatedNode(value: any, depth: number): boolean;
+declare export default class AnimatedObject extends AnimatedWithChildren {
+  _value: any;
+  constructor(value: any): void;
+  __getValue(): any;
+  __getAnimatedValue(): any;
+  __attach(): void;
+  __detach(): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedProps.js 1`] = `
+"declare export default class AnimatedProps extends AnimatedNode {
+  _props: Object;
+  _animatedView: any;
+  _callback: () => void;
+  constructor(props: Object, callback: () => void): void;
+  __getValue(): Object;
+  __getAnimatedValue(): Object;
+  __attach(): void;
+  __detach(): void;
+  update(): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  setNativeView(animatedView: any): void;
+  __connectAnimatedView(): void;
+  __disconnectAnimatedView(): void;
+  __restoreDefaultValues(): void;
+  __getNativeConfig(): Object;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedStyle.js 1`] = `
+"declare export default class AnimatedStyle extends AnimatedWithChildren {
+  _inputStyle: any;
+  _style: Object;
+  constructor(style: any): void;
+  __getValue(): Object | Array<Object>;
+  __getAnimatedValue(): Object;
+  __attach(): void;
+  __detach(): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getNativeConfig(): Object;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedSubtraction.js 1`] = `
+"declare export default class AnimatedSubtraction extends AnimatedWithChildren {
+  _a: AnimatedNode;
+  _b: AnimatedNode;
+  constructor(a: AnimatedNode | number, b: AnimatedNode | number): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getValue(): number;
+  interpolate<OutputT: number | string>(
+    config: InterpolationConfigType<OutputT>
+  ): AnimatedInterpolation<OutputT>;
+  __attach(): void;
+  __detach(): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedTracking.js 1`] = `
+"declare export default class AnimatedTracking extends AnimatedNode {
+  _value: AnimatedValue;
+  _parent: AnimatedNode;
+  _callback: ?EndCallback;
+  _animationConfig: Object;
+  _animationClass: any;
+  _useNativeDriver: boolean;
+  constructor(
+    value: AnimatedValue,
+    parent: AnimatedNode,
+    animationClass: any,
+    animationConfig: Object,
+    callback?: ?EndCallback
+  ): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getValue(): Object;
+  __attach(): void;
+  __detach(): void;
+  update(): void;
+  __getNativeConfig(): any;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedTransform.js 1`] = `
+"declare export default class AnimatedTransform extends AnimatedWithChildren {
+  _transforms: $ReadOnlyArray<Object>;
+  constructor(transforms: $ReadOnlyArray<Object>): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __getValue(): $ReadOnlyArray<Object>;
+  __getAnimatedValue(): $ReadOnlyArray<Object>;
+  __attach(): void;
+  __detach(): void;
+  __getNativeConfig(): any;
+  _get(getter: (AnimatedNode) => any): $ReadOnlyArray<Object>;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedValue.js 1`] = `
+"export type AnimatedValueConfig = $ReadOnly<{
+  useNativeDriver: boolean,
+}>;
+declare export function flushValue(rootNode: AnimatedNode): void;
+declare export default class AnimatedValue extends AnimatedWithChildren {
+  _value: number;
+  _startingValue: number;
+  _offset: number;
+  _animation: ?Animation;
+  _tracking: ?AnimatedTracking;
+  constructor(value: number, config?: ?AnimatedValueConfig): void;
+  __detach(): void;
+  __getValue(): number;
+  setValue(value: number): void;
+  setOffset(offset: number): void;
+  flattenOffset(): void;
+  extractOffset(): void;
+  stopAnimation(callback?: ?(value: number) => void): void;
+  resetAnimation(callback?: ?(value: number) => void): void;
+  __onAnimatedValueUpdateReceived(value: number): void;
+  interpolate<OutputT: number | string>(
+    config: InterpolationConfigType<OutputT>
+  ): AnimatedInterpolation<OutputT>;
+  animate(animation: Animation, callback: ?EndCallback): void;
+  stopTracking(): void;
+  track(tracking: AnimatedTracking): void;
+  _updateValue(value: number, flush: boolean): void;
+  __getNativeConfig(): Object;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedValueXY.js 1`] = `
+"export type AnimatedValueXYConfig = $ReadOnly<{
+  useNativeDriver: boolean,
+}>;
+type ValueXYListenerCallback = (value: { x: number, y: number, ... }) => mixed;
+declare export default class AnimatedValueXY extends AnimatedWithChildren {
+  x: AnimatedValue;
+  y: AnimatedValue;
+  _listeners: {
+    [key: string]: {
+      x: string,
+      y: string,
+      ...
+    },
+    ...
+  };
+  constructor(
+    valueIn?: ?{
+      +x: number | AnimatedValue,
+      +y: number | AnimatedValue,
+      ...
+    },
+    config?: ?AnimatedValueXYConfig
+  ): void;
+  setValue(value: { x: number, y: number, ... }): void;
+  setOffset(offset: { x: number, y: number, ... }): void;
+  flattenOffset(): void;
+  extractOffset(): void;
+  __getValue(): {
+    x: number,
+    y: number,
+    ...
+  };
+  resetAnimation(
+    callback?: (value: { x: number, y: number, ... }) => void
+  ): void;
+  stopAnimation(
+    callback?: (value: { x: number, y: number, ... }) => void
+  ): void;
+  addListener(callback: ValueXYListenerCallback): string;
+  removeListener(id: string): void;
+  removeAllListeners(): void;
+  getLayout(): { [key: string]: AnimatedValue, ... };
+  getTranslateTransform(): Array<{ [key: string]: AnimatedValue, ... }>;
+  __attach(): void;
+  __detach(): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedWithChildren.js 1`] = `
+"declare export default class AnimatedWithChildren extends AnimatedNode {
+  _children: Array<AnimatedNode>;
+  constructor(): void;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  __addChild(child: AnimatedNode): void;
+  __removeChild(child: AnimatedNode): void;
+  __getChildren(): $ReadOnlyArray<AnimatedNode>;
+  __callListeners(value: number): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/shouldUseTurboAnimatedModule.js 1`] = `
+"declare function shouldUseTurboAnimatedModule(): boolean;
+declare export default typeof shouldUseTurboAnimatedModule;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/useAnimatedProps.js 1`] = `
+"type ReducedProps<TProps> = {
+  ...TProps,
+  collapsable: boolean,
+  ...
+};
+type CallbackRef<T> = (T) => mixed;
+declare export default function useAnimatedProps<TProps: { ... }, TInstance>(
+  props: TProps
+): [ReducedProps<TProps>, CallbackRef<TInstance | null>];
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/useAnimatedValue.js 1`] = `
+"declare export default function useAnimatedValue(
+  initialValue: number,
+  config?: ?AnimatedValueConfig
+): Animated.Value;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/AppState/AppState.js 1`] = `
+"export type AppStateValues = \\"inactive\\" | \\"background\\" | \\"active\\";
+type AppStateEventDefinitions = {
+  change: [AppStateValues],
+  memoryWarning: [],
+  blur: [],
+  focus: [],
+};
+type NativeAppStateEventDefinitions = {
+  appStateDidChange: [{ app_state: AppStateValues }],
+  appStateFocusChange: [boolean],
+  memoryWarning: [],
+};
+declare class AppState {
+  currentState: ?string;
+  isAvailable: boolean;
+  _emitter: ?NativeEventEmitter<NativeAppStateEventDefinitions>;
+  constructor(): void;
+  addEventListener<K: $Keys<AppStateEventDefinitions>>(
+    type: K,
+    handler: (...$ElementType<AppStateEventDefinitions, K>) => void
+  ): EventSubscription;
+}
+declare module.exports: AppState;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/AppState/NativeAppState.js 1`] = `
+"export type AppStateConstants = {|
+  initialAppState: string,
+|};
+export type AppState = {| app_state: string |};
+export interface Spec extends TurboModule {
+  +getConstants: () => AppStateConstants;
+  +getCurrentAppState: (
+    success: (appState: AppState) => void,
+    error: (error: Object) => void
+  ) => void;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/BatchedBridge/BatchedBridge.js 1`] = `
+"declare const BatchedBridge: MessageQueue;
+declare module.exports: BatchedBridge;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/BatchedBridge/MessageQueue.js 1`] = `
+"export type SpyData = {
+  type: number,
+  module: ?string,
+  method: string | number,
+  args: mixed[],
+  ...
+};
+declare class MessageQueue {
+  _lazyCallableModules: { [key: string]: (void) => { ... }, ... };
+  _queue: [number[], number[], mixed[], number];
+  _successCallbacks: Map<number, ?(...mixed[]) => void>;
+  _failureCallbacks: Map<number, ?(...mixed[]) => void>;
+  _callID: number;
+  _lastFlush: number;
+  _eventLoopStartTime: number;
+  _reactNativeMicrotasksCallback: ?() => void;
+  _debugInfo: { [number]: [number, number], ... };
+  _remoteModuleTable: { [number]: string, ... };
+  _remoteMethodTable: { [number]: $ReadOnlyArray<string>, ... };
+  __spy: ?(data: SpyData) => void;
+  constructor(): void;
+  static spy(spyOrToggle: boolean | ((data: SpyData) => void)): void;
+  callFunctionReturnFlushedQueue(
+    module: string,
+    method: string,
+    args: mixed[]
+  ): null | [Array<number>, Array<number>, Array<mixed>, number];
+  invokeCallbackAndReturnFlushedQueue(
+    cbID: number,
+    args: mixed[]
+  ): null | [Array<number>, Array<number>, Array<mixed>, number];
+  flushedQueue(): null | [Array<number>, Array<number>, Array<mixed>, number];
+  getEventLoopRunningTime(): number;
+  registerCallableModule(name: string, module: { ... }): void;
+  registerLazyCallableModule(
+    name: string,
+    factory: (void) => interface {}
+  ): void;
+  getCallableModule(name: string): { ... } | null;
+  callNativeSyncHook(
+    moduleID: number,
+    methodID: number,
+    params: mixed[],
+    onFail: ?(...mixed[]) => void,
+    onSucc: ?(...mixed[]) => void
+  ): mixed;
+  processCallbacks(
+    moduleID: number,
+    methodID: number,
+    params: mixed[],
+    onFail: ?(...mixed[]) => void,
+    onSucc: ?(...mixed[]) => void
+  ): void;
+  enqueueNativeCall(
+    moduleID: number,
+    methodID: number,
+    params: mixed[],
+    onFail: ?(...mixed[]) => void,
+    onSucc: ?(...mixed[]) => void
+  ): void;
+  createDebugLookup(
+    moduleID: number,
+    name: string,
+    methods: ?$ReadOnlyArray<string>
+  ): void;
+  setReactNativeMicrotasksCallback(fn: () => void): void;
+  __guard(fn: () => void): void;
+  __shouldPauseOnThrow(): boolean;
+  __callReactNativeMicrotasks(): void;
+  __callFunction(module: string, method: string, args: mixed[]): void;
+  __invokeCallback(cbID: number, args: mixed[]): void;
+}
+declare module.exports: MessageQueue;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/BatchedBridge/NativeModules.js 1`] = `
+"export type ModuleConfig = [
+  string,
+  ?{ ... },
+  ?$ReadOnlyArray<string>,
+  ?$ReadOnlyArray<number>,
+  ?$ReadOnlyArray<number>,
+];
+export type MethodType = \\"async\\" | \\"promise\\" | \\"sync\\";
+declare let NativeModules: { [moduleName: string]: $FlowFixMe, ... };
+declare module.exports: NativeModules;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Blob/Blob.js 1`] = `
+"declare class Blob {
+  _data: ?BlobData;
+  constructor(parts: Array<Blob | string>, options?: BlobOptions): void;
+  set data(data: ?BlobData): void;
+  get data(): BlobData;
+  slice(start?: number, end?: number, contentType: string): Blob;
+  close(): void;
+  get size(): number;
+  get type(): string;
+}
+declare module.exports: Blob;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Blob/BlobManager.js 1`] = `
+"declare class BlobManager {
+  static isAvailable: boolean;
+  static createFromParts(
+    parts: Array<Blob | string>,
+    options?: BlobOptions
+  ): Blob;
+  static createFromOptions(options: BlobData): Blob;
+  static release(blobId: string): void;
+  static addNetworkingHandler(): void;
+  static addWebSocketHandler(socketId: number): void;
+  static removeWebSocketHandler(socketId: number): void;
+  static sendOverSocket(blob: Blob, socketId: number): void;
+}
+declare module.exports: BlobManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Blob/BlobRegistry.js 1`] = `
+"declare const register: (id: string) => void;
+declare const unregister: (id: string) => void;
+declare const has: (id: string) => number | boolean;
+declare module.exports: {
+  register: register,
+  unregister: unregister,
+  has: has,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Blob/BlobTypes.js 1`] = `
+"declare export opaque type BlobCollector;
+export type BlobData = {
+  blobId: string,
+  offset: number,
+  size: number,
+  name?: string,
+  type?: string,
+  lastModified?: number,
+  __collector?: ?BlobCollector,
+  ...
+};
+export type BlobOptions = {
+  type: string,
+  lastModified: number,
+  ...
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Blob/File.js 1`] = `
+"declare const Blob: $FlowFixMe;
+declare class File extends Blob {
+  constructor(
+    parts: Array<Blob | string>,
+    name: string,
+    options?: BlobOptions
+  ): void;
+  get name(): string;
+  get lastModified(): number;
+}
+declare module.exports: File;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Blob/NativeBlobModule.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {| BLOB_URI_SCHEME: ?string, BLOB_URI_HOST: ?string |};
+  +addNetworkingHandler: () => void;
+  +addWebSocketHandler: (id: number) => void;
+  +removeWebSocketHandler: (id: number) => void;
+  +sendOverSocket: (blob: Object, socketID: number) => void;
+  +createFromParts: (parts: Array<Object>, withId: string) => void;
+  +release: (blobId: string) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Blob/NativeFileReaderModule.js 1`] = `
+"export interface Spec extends TurboModule {
+  +readAsDataURL: (data: Object) => Promise<string>;
+  +readAsText: (data: Object, encoding: string) => Promise<string>;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/BugReporting/BugReporting.js 1`] = `
+"type ExtraData = { [key: string]: string, ... };
+type SourceCallback = () => string;
+type DebugData = {
+  extras: ExtraData,
+  files: ExtraData,
+  ...
+};
+declare class BugReporting {
+  static _extraSources: Map<string, SourceCallback>;
+  static _fileSources: Map<string, SourceCallback>;
+  static _subscription: ?EventSubscription;
+  static _redboxSubscription: ?EventSubscription;
+  static _maybeInit(): void;
+  static addSource(
+    key: string,
+    callback: SourceCallback
+  ): { remove: () => void, ... };
+  static addFileSource(
+    key: string,
+    callback: SourceCallback
+  ): { remove: () => void, ... };
+  static _addSource(
+    key: string,
+    callback: SourceCallback,
+    source: Map<string, SourceCallback>
+  ): { remove: () => void, ... };
+  static collectExtraData(): DebugData;
+}
+declare module.exports: BugReporting;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/BugReporting/NativeBugReporting.js 1`] = `
+"export interface Spec extends TurboModule {
+  +startReportAProblemFlow: () => void;
+  +setExtraData: (extraData: Object, extraFiles: Object) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/BugReporting/dumpReactTree.js 1`] = `
+"declare function dumpReactTree(): string;
+declare module.exports: dumpReactTree;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/BugReporting/getReactData.js 1`] = `
+"declare function getData(element: Object): Object;
+declare module.exports: getData;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/AccessibilityInfo/AccessibilityInfo.js 1`] = `
+"type AccessibilityEventDefinitionsAndroid = {
+  accessibilityServiceChanged: [boolean],
+};
+type AccessibilityEventDefinitionsIOS = {
+  announcementFinished: [{ announcement: string, success: boolean }],
+  boldTextChanged: [boolean],
+  grayscaleChanged: [boolean],
+  invertColorsChanged: [boolean],
+  reduceTransparencyChanged: [boolean],
+};
+type AccessibilityEventDefinitions = {
+  ...AccessibilityEventDefinitionsAndroid,
+  ...AccessibilityEventDefinitionsIOS,
+  change: [boolean],
+  reduceMotionChanged: [boolean],
+  screenReaderChanged: [boolean],
+};
+type AccessibilityEventTypes = \\"click\\" | \\"focus\\" | \\"viewHoverEnter\\";
+declare const AccessibilityInfo: {
+  isBoldTextEnabled(): Promise<boolean>,
+  isGrayscaleEnabled(): Promise<boolean>,
+  isInvertColorsEnabled(): Promise<boolean>,
+  isReduceMotionEnabled(): Promise<boolean>,
+  prefersCrossFadeTransitions(): Promise<boolean>,
+  isReduceTransparencyEnabled(): Promise<boolean>,
+  isScreenReaderEnabled(): Promise<boolean>,
+  isAccessibilityServiceEnabled(): Promise<boolean>,
+  addEventListener<K: $Keys<AccessibilityEventDefinitions>>(
+    eventName: K,
+    handler: (...$ElementType<AccessibilityEventDefinitions, K>) => void
+  ): EventSubscription,
+  setAccessibilityFocus(reactTag: number): void,
+  sendAccessibilityEvent(
+    handle: ElementRef<HostComponent<mixed>>,
+    eventType: AccessibilityEventTypes
+  ): void,
+  announceForAccessibility(announcement: string): void,
+  announceForAccessibilityWithOptions(
+    announcement: string,
+    options: { queue?: boolean }
+  ): void,
+  getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>,
+};
+declare export default typeof AccessibilityInfo;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js 1`] = `
+"export interface Spec extends TurboModule {
+  +isReduceMotionEnabled: (
+    onSuccess: (isReduceMotionEnabled: boolean) => void
+  ) => void;
+  +isTouchExplorationEnabled: (
+    onSuccess: (isScreenReaderEnabled: boolean) => void
+  ) => void;
+  +isAccessibilityServiceEnabled?: ?(
+    onSuccess: (isAccessibilityServiceEnabled: boolean) => void
+  ) => void;
+  +setAccessibilityFocus: (reactTag: number) => void;
+  +announceForAccessibility: (announcement: string) => void;
+  +getRecommendedTimeoutMillis?: (
+    mSec: number,
+    onSuccess: (recommendedTimeoutMillis: number) => void
+  ) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getCurrentBoldTextState: (
+    onSuccess: (isBoldTextEnabled: boolean) => void,
+    onError: (error: Object) => void
+  ) => void;
+  +getCurrentGrayscaleState: (
+    onSuccess: (isGrayscaleEnabled: boolean) => void,
+    onError: (error: Object) => void
+  ) => void;
+  +getCurrentInvertColorsState: (
+    onSuccess: (isInvertColorsEnabled: boolean) => void,
+    onError: (error: Object) => void
+  ) => void;
+  +getCurrentReduceMotionState: (
+    onSuccess: (isReduceMotionEnabled: boolean) => void,
+    onError: (error: Object) => void
+  ) => void;
+  +getCurrentPrefersCrossFadeTransitionsState?: (
+    onSuccess: (prefersCrossFadeTransitions: boolean) => void,
+    onError: (error: Object) => void
+  ) => void;
+  +getCurrentReduceTransparencyState: (
+    onSuccess: (isReduceTransparencyEnabled: boolean) => void,
+    onError: (error: Object) => void
+  ) => void;
+  +getCurrentVoiceOverState: (
+    onSuccess: (isScreenReaderEnabled: boolean) => void,
+    onError: (error: Object) => void
+  ) => void;
+  +setAccessibilityContentSizeMultipliers: (JSMultipliers: {|
+    +extraSmall?: ?number,
+    +small?: ?number,
+    +medium?: ?number,
+    +large?: ?number,
+    +extraLarge?: ?number,
+    +extraExtraLarge?: ?number,
+    +extraExtraExtraLarge?: ?number,
+    +accessibilityMedium?: ?number,
+    +accessibilityLarge?: ?number,
+    +accessibilityExtraLarge?: ?number,
+    +accessibilityExtraExtraLarge?: ?number,
+    +accessibilityExtraExtraExtraLarge?: ?number,
+  |}) => void;
+  +setAccessibilityFocus: (reactTag: number) => void;
+  +announceForAccessibility: (announcement: string) => void;
+  +announceForAccessibilityWithOptions?: (
+    announcement: string,
+    options: { queue?: boolean }
+  ) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.android.js 1`] = `
+"declare function legacySendAccessibilityEvent(
+  reactTag: number,
+  eventType: string
+): void;
+declare module.exports: legacySendAccessibilityEvent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.ios.js 1`] = `
+"declare function legacySendAccessibilityEvent(
+  reactTag: number,
+  eventType: string
+): void;
+declare module.exports: legacySendAccessibilityEvent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.js.flow 1`] = `
+"declare function legacySendAccessibilityEvent(
+  reactTag: number,
+  eventType: string
+): void;
+declare module.exports: legacySendAccessibilityEvent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ActivityIndicator/ActivityIndicator.js 1`] = `
+"type IndicatorSize = number | \\"small\\" | \\"large\\";
+type IOSProps = $ReadOnly<{|
+  hidesWhenStopped?: ?boolean,
+|}>;
+type Props = $ReadOnly<{|
+  ...ViewProps,
+  ...IOSProps,
+  animating?: ?boolean,
+  color?: ?ColorValue,
+  size?: ?IndicatorSize,
+|}>;
+declare const ActivityIndicatorWithRef: React.AbstractComponent<
+  Props,
+  HostComponent<mixed>,
+>;
+declare export default typeof ActivityIndicatorWithRef;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ActivityIndicator/ActivityIndicatorViewNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  hidesWhenStopped?: WithDefault<boolean, true>,
+  animating?: WithDefault<boolean, true>,
+  color?: ?ColorValue,
+  size?: WithDefault<\\"small\\" | \\"large\\", \\"small\\">,
+|}>;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Button.flow.js 1`] = `
+"type ButtonProps = $ReadOnly<{|
+  title: string,
+  onPress: (event?: PressEvent) => mixed,
+  touchSoundDisabled?: ?boolean,
+  color?: ?ColorValue,
+  hasTVPreferredFocus?: ?boolean,
+  nextFocusDown?: ?number,
+  nextFocusForward?: ?number,
+  nextFocusLeft?: ?number,
+  nextFocusRight?: ?number,
+  nextFocusUp?: ?number,
+  accessibilityLabel?: ?string,
+  \\"aria-label\\"?: ?string,
+  disabled?: ?boolean,
+  testID?: ?string,
+  accessible?: ?boolean,
+  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  accessibilityState?: ?AccessibilityState,
+  importantForAccessibility?: ?(\\"auto\\" | \\"yes\\" | \\"no\\" | \\"no-hide-descendants\\"),
+  accessibilityHint?: ?string,
+  accessibilityLanguage?: ?Stringish,
+|}>;
+export type Button = React.ComponentType<ButtonProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Button.js 1`] = `
+"declare module.exports: ButtonType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Clipboard/Clipboard.js 1`] = `
+"declare module.exports: {
+  getString(): Promise<string>,
+  setString(content: string): void,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Clipboard/NativeClipboard.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +getString: () => Promise<string>;
+  +setString: (content: string) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js 1`] = `
+"type DrawerStateEvent = $ReadOnly<{|
+  drawerState: Int32,
+|}>;
+type DrawerSlideEvent = $ReadOnly<{|
+  offset: Float,
+|}>;
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  keyboardDismissMode?: WithDefault<\\"none\\" | \\"on-drag\\", \\"none\\">,
+  drawerBackgroundColor: ColorValue,
+  drawerPosition?: WithDefault<\\"left\\" | \\"right\\", \\"left\\">,
+  drawerWidth?: WithDefault<Float, null>,
+  drawerLockMode?: WithDefault<
+    \\"unlocked\\" | \\"locked-closed\\" | \\"locked-open\\",
+    \\"unlocked\\",
+  >,
+  onDrawerSlide?: ?DirectEventHandler<DrawerSlideEvent>,
+  onDrawerStateChanged?: ?DirectEventHandler<DrawerStateEvent>,
+  onDrawerOpen?: ?DirectEventHandler<null>,
+  onDrawerClose?: ?DirectEventHandler<null>,
+  statusBarBackgroundColor?: ?ColorValue,
+|}>;
+type NativeType = HostComponent<NativeProps>;
+interface NativeCommands {
+  +openDrawer: (viewRef: React.ElementRef<NativeType>) => void;
+  +closeDrawer: (viewRef: React.ElementRef<NativeType>) => void;
+}
+declare export const Commands: NativeCommands;
+declare export default NativeType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Components/Keyboard/Keyboard.js 1`] = `
+"export type KeyboardEventName = $Keys<KeyboardEventDefinitions>;
+export type KeyboardEventEasing =
+  | \\"easeIn\\"
+  | \\"easeInEaseOut\\"
+  | \\"easeOut\\"
+  | \\"linear\\"
+  | \\"keyboard\\";
+export type KeyboardMetrics = $ReadOnly<{|
+  screenX: number,
+  screenY: number,
+  width: number,
+  height: number,
+|}>;
+export type KeyboardEvent = AndroidKeyboardEvent | IOSKeyboardEvent;
+type BaseKeyboardEvent = {|
+  duration: number,
+  easing: KeyboardEventEasing,
+  endCoordinates: KeyboardMetrics,
+|};
+export type AndroidKeyboardEvent = $ReadOnly<{|
+  ...BaseKeyboardEvent,
+  duration: 0,
+  easing: \\"keyboard\\",
+|}>;
+export type IOSKeyboardEvent = $ReadOnly<{|
+  ...BaseKeyboardEvent,
+  startCoordinates: KeyboardMetrics,
+  isEventFromThisApp: boolean,
+|}>;
+type KeyboardEventDefinitions = {
+  keyboardWillShow: [KeyboardEvent],
+  keyboardDidShow: [KeyboardEvent],
+  keyboardWillHide: [KeyboardEvent],
+  keyboardDidHide: [KeyboardEvent],
+  keyboardWillChangeFrame: [KeyboardEvent],
+  keyboardDidChangeFrame: [KeyboardEvent],
+};
+declare class Keyboard {
+  _currentlyShowing: ?KeyboardEvent;
+  _emitter: NativeEventEmitter<KeyboardEventDefinitions>;
+  constructor(): void;
+  addListener<K: $Keys<KeyboardEventDefinitions>>(
+    eventType: K,
+    listener: (...$ElementType<KeyboardEventDefinitions, K>) => mixed,
+    context?: mixed
+  ): EventSubscription;
+  removeAllListeners<K: $Keys<KeyboardEventDefinitions>>(eventType: ?K): void;
+  dismiss(): void;
+  isVisible(): boolean;
+  metrics(): ?KeyboardMetrics;
+  scheduleLayoutAnimation(event: KeyboardEvent): void;
+}
+declare module.exports: Keyboard;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Keyboard/NativeKeyboardObserver.js 1`] = `
+"export interface Spec extends TurboModule {
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Pressable/Pressable.js 1`] = `
+"type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, \\"style\\">;
+export type StateCallbackType = $ReadOnly<{|
+  pressed: boolean,
+|}>;
+type Props = $ReadOnly<{|
+  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+  accessibilityElementsHidden?: ?boolean,
+  accessibilityHint?: ?Stringish,
+  accessibilityLanguage?: ?Stringish,
+  accessibilityIgnoresInvertColors?: ?boolean,
+  accessibilityLabel?: ?Stringish,
+  accessibilityLiveRegion?: ?(\\"none\\" | \\"polite\\" | \\"assertive\\"),
+  accessibilityRole?: ?AccessibilityRole,
+  accessibilityState?: ?AccessibilityState,
+  accessibilityValue?: ?AccessibilityValue,
+  \\"aria-valuemax\\"?: AccessibilityValue[\\"max\\"],
+  \\"aria-valuemin\\"?: AccessibilityValue[\\"min\\"],
+  \\"aria-valuenow\\"?: AccessibilityValue[\\"now\\"],
+  \\"aria-valuetext\\"?: AccessibilityValue[\\"text\\"],
+  accessibilityViewIsModal?: ?boolean,
+  \\"aria-modal\\"?: ?boolean,
+  accessible?: ?boolean,
+  \\"aria-busy\\"?: ?boolean,
+  \\"aria-checked\\"?: ?boolean | \\"mixed\\",
+  \\"aria-disabled\\"?: ?boolean,
+  \\"aria-expanded\\"?: ?boolean,
+  \\"aria-selected\\"?: ?boolean,
+  \\"aria-hidden\\"?: ?boolean,
+  \\"aria-live\\"?: ?(\\"polite\\" | \\"assertive\\" | \\"off\\"),
+  focusable?: ?boolean,
+  importantForAccessibility?: ?(\\"auto\\" | \\"yes\\" | \\"no\\" | \\"no-hide-descendants\\"),
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  cancelable?: ?boolean,
+  children: React.Node | ((state: StateCallbackType) => React.Node),
+  delayHoverIn?: ?number,
+  delayHoverOut?: ?number,
+  delayLongPress?: ?number,
+  disabled?: ?boolean,
+  hitSlop?: ?RectOrSize,
+  pressRetentionOffset?: ?RectOrSize,
+  onLayout?: ?(event: LayoutEvent) => mixed,
+  onHoverIn?: ?(event: MouseEvent) => mixed,
+  onHoverOut?: ?(event: MouseEvent) => mixed,
+  onLongPress?: ?(event: PressEvent) => mixed,
+  onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
+  style?: ViewStyleProp | ((state: StateCallbackType) => ViewStyleProp),
+  testID?: ?string,
+  android_disableSound?: ?boolean,
+  android_ripple?: ?RippleConfig,
+  testOnly_pressed?: ?boolean,
+  unstable_pressDelay?: ?number,
+  \\"aria-label\\"?: ?string,
+|}>;
+declare export default React.AbstractComponent<
+  Props,
+  React.ElementRef<typeof View>,
+>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Pressable/useAndroidRippleForView.js 1`] = `
+"type NativeBackgroundProp = $ReadOnly<{|
+  type: \\"RippleAndroid\\",
+  color: ?number,
+  borderless: boolean,
+  rippleRadius: ?number,
+|}>;
+export type RippleConfig = {|
+  color?: ColorValue,
+  borderless?: boolean,
+  radius?: number,
+  foreground?: boolean,
+|};
+declare export default function useAndroidRippleForView(
+  rippleConfig: ?RippleConfig,
+  viewRef: {| current: null | React.ElementRef<typeof View> |}
+): ?$ReadOnly<{|
+  onPressIn: (event: PressEvent) => void,
+  onPressMove: (event: PressEvent) => void,
+  onPressOut: (event: PressEvent) => void,
+  viewProps:
+    | $ReadOnly<{| nativeBackgroundAndroid: NativeBackgroundProp |}>
+    | $ReadOnly<{| nativeForegroundAndroid: NativeBackgroundProp |}>,
+|}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js 1`] = `
+"export type ProgressBarAndroidProps = $ReadOnly<{|
+  ...ViewProps,
+  ...
+    | {|
+        styleAttr: \\"Horizontal\\",
+        indeterminate: false,
+        progress: number,
+      |}
+    | {|
+        typeAttr:
+          | \\"Horizontal\\"
+          | \\"Normal\\"
+          | \\"Small\\"
+          | \\"Large\\"
+          | \\"Inverse\\"
+          | \\"SmallInverse\\"
+          | \\"LargeInverse\\",
+        indeterminate: true,
+      |},
+  animating?: ?boolean,
+  color?: ?ColorValue,
+  testID?: ?string,
+|}>;
+declare module.exports: typeof ProgressBarAndroidNativeComponent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js 1`] = `
+"export type { ProgressBarAndroidProps } from \\"./ProgressBarAndroid.android\\";
+declare module.exports:
+  | UnimplementedViewType
+  | ProgressBarAndroidNativeComponentType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  styleAttr?: string,
+  typeAttr?: string,
+  indeterminate: boolean,
+  progress?: WithDefault<Double, 0>,
+  animating?: WithDefault<boolean, true>,
+  color?: ?ColorValue,
+  testID?: WithDefault<string, \\"\\">,
+|}>;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/RefreshControl/AndroidSwipeRefreshLayoutNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  enabled?: WithDefault<boolean, true>,
+  colors?: ?$ReadOnlyArray<ColorValue>,
+  progressBackgroundColor?: ?ColorValue,
+  size?: WithDefault<\\"default\\" | \\"large\\", \\"default\\">,
+  progressViewOffset?: WithDefault<Float, 0>,
+  onRefresh?: ?DirectEventHandler<null>,
+  refreshing: boolean,
+|}>;
+type NativeType = HostComponent<NativeProps>;
+interface NativeCommands {
+  +setNativeRefreshing: (
+    viewRef: React.ElementRef<NativeType>,
+    value: boolean
+  ) => void;
+}
+declare export const Commands: NativeCommands;
+declare export default NativeType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/RefreshControl/PullToRefreshViewNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  tintColor?: ?ColorValue,
+  titleColor?: ?ColorValue,
+  title?: WithDefault<string, null>,
+  progressViewOffset?: WithDefault<Float, 0>,
+  onRefresh?: ?DirectEventHandler<null>,
+  refreshing: boolean,
+|}>;
+type ComponentType = HostComponent<NativeProps>;
+interface NativeCommands {
+  +setNativeRefreshing: (
+    viewRef: React.ElementRef<ComponentType>,
+    refreshing: boolean
+  ) => void;
+}
+declare export const Commands: NativeCommands;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+|}>;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/SafeAreaView/SafeAreaView.js 1`] = `
+"declare const exported: React.AbstractComponent<
+  ViewProps,
+  React.ElementRef<typeof View>,
+>;
+declare export default typeof exported;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/AndroidHorizontalScrollContentViewNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  removeClippedSubviews?: ?boolean,
+|}>;
+type NativeType = HostComponent<NativeProps>;
+declare export default NativeType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js 1`] = `
+"declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare const AndroidHorizontalScrollViewNativeComponent: HostComponent<Props>;
+declare export default typeof AndroidHorizontalScrollViewNativeComponent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/ScrollContentViewNativeComponent.js 1`] = `
+"declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare const ScrollContentViewNativeComponent: HostComponent<Props>;
+declare export default typeof ScrollContentViewNativeComponent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/ScrollViewCommands.js 1`] = `
+"type ScrollViewNativeComponentType = HostComponent<mixed>;
+interface NativeCommands {
+  +flashScrollIndicators: (
+    viewRef: React.ElementRef<ScrollViewNativeComponentType>
+  ) => void;
+  +scrollTo: (
+    viewRef: React.ElementRef<ScrollViewNativeComponentType>,
+    x: Double,
+    y: Double,
+    animated: boolean
+  ) => void;
+  +scrollToEnd: (
+    viewRef: React.ElementRef<ScrollViewNativeComponentType>,
+    animated: boolean
+  ) => void;
+  +zoomToRect: (
+    viewRef: React.ElementRef<ScrollViewNativeComponentType>,
+    rect: {|
+      x: Double,
+      y: Double,
+      width: Double,
+      height: Double,
+      animated?: boolean,
+    |},
+    animated?: boolean
+  ) => void;
+}
+declare export default NativeCommands;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/ScrollViewContext.js 1`] = `
+"type Value = { horizontal: boolean } | null;
+declare const ScrollViewContext: React.Context<Value>;
+declare export default typeof ScrollViewContext;
+declare export const HORIZONTAL: Value;
+declare export const VERTICAL: Value;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/ScrollViewNativeComponent.js 1`] = `
+"declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare const ScrollViewNativeComponent: HostComponent<Props>;
+declare export default typeof ScrollViewNativeComponent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/ScrollViewNativeComponentType.js 1`] = `
+"export type ScrollViewNativeProps = $ReadOnly<{
+  ...ViewProps,
+  alwaysBounceHorizontal?: ?boolean,
+  alwaysBounceVertical?: ?boolean,
+  automaticallyAdjustContentInsets?: ?boolean,
+  automaticallyAdjustKeyboardInsets?: ?boolean,
+  automaticallyAdjustsScrollIndicatorInsets?: ?boolean,
+  bounces?: ?boolean,
+  bouncesZoom?: ?boolean,
+  canCancelContentTouches?: ?boolean,
+  centerContent?: ?boolean,
+  contentInset?: ?EdgeInsetsProp,
+  contentInsetAdjustmentBehavior?: ?(
+    | \\"automatic\\"
+    | \\"scrollableAxes\\"
+    | \\"never\\"
+    | \\"always\\"
+  ),
+  contentOffset?: ?PointProp,
+  decelerationRate?: ?(\\"fast\\" | \\"normal\\" | number),
+  directionalLockEnabled?: ?boolean,
+  disableIntervalMomentum?: ?boolean,
+  endFillColor?: ?ColorValue,
+  fadingEdgeLength?: ?number,
+  indicatorStyle?: ?(\\"default\\" | \\"black\\" | \\"white\\"),
+  isInvertedVirtualizedList?: ?boolean,
+  keyboardDismissMode?: ?(\\"none\\" | \\"on-drag\\" | \\"interactive\\"),
+  maintainVisibleContentPosition?: ?$ReadOnly<{
+    minIndexForVisible: number,
+    autoscrollToTopThreshold?: ?number,
+  }>,
+  maximumZoomScale?: ?number,
+  minimumZoomScale?: ?number,
+  nestedScrollEnabled?: ?boolean,
+  onMomentumScrollBegin?: ?(event: ScrollEvent) => void,
+  onMomentumScrollEnd?: ?(event: ScrollEvent) => void,
+  onScroll?: ?(event: ScrollEvent) => void,
+  onScrollBeginDrag?: ?(event: ScrollEvent) => void,
+  onScrollEndDrag?: ?(event: ScrollEvent) => void,
+  onScrollToTop?: (event: ScrollEvent) => void,
+  overScrollMode?: ?(\\"auto\\" | \\"always\\" | \\"never\\"),
+  pagingEnabled?: ?boolean,
+  persistentScrollbar?: ?boolean,
+  pinchGestureEnabled?: ?boolean,
+  scrollEnabled?: ?boolean,
+  scrollEventThrottle?: ?number,
+  scrollIndicatorInsets?: ?EdgeInsetsProp,
+  scrollPerfTag?: ?string,
+  scrollToOverflowEnabled?: ?boolean,
+  scrollsToTop?: ?boolean,
+  sendMomentumEvents?: ?boolean,
+  showsHorizontalScrollIndicator?: ?boolean,
+  showsVerticalScrollIndicator?: ?boolean,
+  snapToAlignment?: ?(\\"start\\" | \\"center\\" | \\"end\\"),
+  snapToEnd?: ?boolean,
+  snapToInterval?: ?number,
+  snapToOffsets?: ?$ReadOnlyArray<number>,
+  snapToStart?: ?boolean,
+  zoomScale?: ?number,
+  onResponderGrant?: ?(e: $FlowFixMe) => void | boolean,
+  ...
+}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/ScrollViewStickyHeader.js 1`] = `
+"export type Props = $ReadOnly<{
+  children?: React.Element<$FlowFixMe>,
+  nextHeaderLayoutY: ?number,
+  onLayout: (event: LayoutEvent) => void,
+  scrollAnimatedValue: Animated.Value,
+  inverted: ?boolean,
+  scrollViewHeight: ?number,
+  nativeID?: ?string,
+  hiddenOnScroll?: ?boolean,
+}>;
+type Instance = {
+  ...React.ElementRef<typeof Animated.View>,
+  setNextHeaderY: (number) => void,
+  ...
+};
+declare const ScrollViewStickyHeaderWithForwardedRef: React.AbstractComponent<
+  Props,
+  Instance,
+>;
+declare export default typeof ScrollViewStickyHeaderWithForwardedRef;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ScrollView/processDecelerationRate.js 1`] = `
+"declare function processDecelerationRate(
+  decelerationRate: number | \\"normal\\" | \\"fast\\"
+): number;
+declare module.exports: processDecelerationRate;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Sound/NativeSoundManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +playTouchSound: () => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Sound/SoundManager.js 1`] = `
+"declare const SoundManager: { playTouchSound: () => void };
+declare module.exports: SoundManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/StatusBar/NativeStatusBarManagerAndroid.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {|
+    +HEIGHT: number,
+    +DEFAULT_BACKGROUND_COLOR: number,
+  |};
+  +setColor: (color: number, animated: boolean) => void;
+  +setTranslucent: (translucent: boolean) => void;
+  +setStyle: (statusBarStyle?: ?string) => void;
+  +setHidden: (hidden: boolean) => void;
+}
+declare const NativeStatusBarManager: {
+  getConstants(): {|
+    +HEIGHT: number,
+    +DEFAULT_BACKGROUND_COLOR?: number,
+  |},
+  setColor(color: number, animated: boolean): void,
+  setTranslucent(translucent: boolean): void,
+  setStyle(statusBarStyle?: ?string): void,
+  setHidden(hidden: boolean): void,
+};
+declare export default typeof NativeStatusBarManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {|
+    +HEIGHT: number,
+    +DEFAULT_BACKGROUND_COLOR?: number,
+  |};
+  +getHeight: (callback: (result: {| height: number |}) => void) => void;
+  +setNetworkActivityIndicatorVisible: (visible: boolean) => void;
+  +addListener: (eventType: string) => void;
+  +removeListeners: (count: number) => void;
+  +setStyle: (statusBarStyle?: ?string, animated: boolean) => void;
+  +setHidden: (hidden: boolean, withAnimation: string) => void;
+}
+declare const NativeStatusBarManager: {
+  getConstants(): {|
+    +HEIGHT: number,
+    +DEFAULT_BACKGROUND_COLOR?: number,
+  |},
+  getHeight(callback: (result: {| height: number |}) => void): void,
+  setNetworkActivityIndicatorVisible(visible: boolean): void,
+  addListener(eventType: string): void,
+  removeListeners(count: number): void,
+  setStyle(statusBarStyle?: ?string, animated: boolean): void,
+  setHidden(hidden: boolean, withAnimation: string): void,
+};
+declare export default typeof NativeStatusBarManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Switch/AndroidSwitchNativeComponent.js 1`] = `
+"type SwitchChangeEvent = $ReadOnly<{|
+  value: boolean,
+  target: Int32,
+|}>;
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  disabled?: WithDefault<boolean, false>,
+  enabled?: WithDefault<boolean, true>,
+  thumbColor?: ?ColorValue,
+  trackColorForFalse?: ?ColorValue,
+  trackColorForTrue?: ?ColorValue,
+  value?: WithDefault<boolean, false>,
+  on?: WithDefault<boolean, false>,
+  thumbTintColor?: ?ColorValue,
+  trackTintColor?: ?ColorValue,
+  onChange?: BubblingEventHandler<SwitchChangeEvent>,
+|}>;
+type NativeType = HostComponent<NativeProps>;
+interface NativeCommands {
+  +setNativeValue: (
+    viewRef: React.ElementRef<NativeType>,
+    value: boolean
+  ) => void;
+}
+declare export const Commands: NativeCommands;
+declare export default NativeType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Switch/Switch.js 1`] = `
+"type SwitchChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    value: boolean,
+    target: number,
+  |}>,
+>;
+export type Props = $ReadOnly<{|
+  ...ViewProps,
+  disabled?: ?boolean,
+  value?: ?boolean,
+  thumbColor?: ?ColorValue,
+  trackColor?: ?$ReadOnly<{|
+    false?: ?ColorValue,
+    true?: ?ColorValue,
+  |}>,
+  ios_backgroundColor?: ?ColorValue,
+  onChange?: ?(event: SwitchChangeEvent) => Promise<void> | void,
+  onValueChange?: ?(value: boolean) => Promise<void> | void,
+|}>;
+declare const SwitchWithForwardedRef: React.AbstractComponent<
+  Props,
+  React.ElementRef<
+    typeof SwitchNativeComponent | typeof AndroidSwitchNativeComponent,
+  >,
+>;
+declare export default typeof SwitchWithForwardedRef;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Switch/SwitchNativeComponent.js 1`] = `
+"type SwitchChangeEvent = $ReadOnly<{|
+  value: boolean,
+  target: Int32,
+|}>;
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  disabled?: WithDefault<boolean, false>,
+  value?: WithDefault<boolean, false>,
+  tintColor?: ?ColorValue,
+  onTintColor?: ?ColorValue,
+  thumbTintColor?: ?ColorValue,
+  thumbColor?: ?ColorValue,
+  trackColorForFalse?: ?ColorValue,
+  trackColorForTrue?: ?ColorValue,
+  onChange?: ?BubblingEventHandler<SwitchChangeEvent>,
+|}>;
+type ComponentType = HostComponent<NativeProps>;
+interface NativeCommands {
+  +setValue: (viewRef: React.ElementRef<ComponentType>, value: boolean) => void;
+}
+declare export const Commands: NativeCommands;
+declare export default ComponentType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/AndroidTextInputNativeComponent.js 1`] = `
+"export type KeyboardType =
+  | \\"default\\"
+  | \\"email-address\\"
+  | \\"numeric\\"
+  | \\"phone-pad\\"
+  | \\"number-pad\\"
+  | \\"decimal-pad\\"
+  | \\"url\\"
+  | \\"ascii-capable\\"
+  | \\"numbers-and-punctuation\\"
+  | \\"name-phone-pad\\"
+  | \\"twitter\\"
+  | \\"web-search\\"
+  | \\"visible-password\\";
+export type ReturnKeyType =
+  | \\"done\\"
+  | \\"go\\"
+  | \\"next\\"
+  | \\"search\\"
+  | \\"send\\"
+  | \\"none\\"
+  | \\"previous\\"
+  | \\"default\\"
+  | \\"emergency-call\\"
+  | \\"google\\"
+  | \\"join\\"
+  | \\"route\\"
+  | \\"yahoo\\";
+export type SubmitBehavior = \\"submit\\" | \\"blurAndSubmit\\" | \\"newline\\";
+export type NativeProps = $ReadOnly<{|
+  ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
+  autoComplete?: WithDefault<
+    | \\"birthdate-day\\"
+    | \\"birthdate-full\\"
+    | \\"birthdate-month\\"
+    | \\"birthdate-year\\"
+    | \\"cc-csc\\"
+    | \\"cc-exp\\"
+    | \\"cc-exp-day\\"
+    | \\"cc-exp-month\\"
+    | \\"cc-exp-year\\"
+    | \\"cc-number\\"
+    | \\"email\\"
+    | \\"gender\\"
+    | \\"name\\"
+    | \\"name-family\\"
+    | \\"name-given\\"
+    | \\"name-middle\\"
+    | \\"name-middle-initial\\"
+    | \\"name-prefix\\"
+    | \\"name-suffix\\"
+    | \\"password\\"
+    | \\"password-new\\"
+    | \\"postal-address\\"
+    | \\"postal-address-country\\"
+    | \\"postal-address-extended\\"
+    | \\"postal-address-extended-postal-code\\"
+    | \\"postal-address-locality\\"
+    | \\"postal-address-region\\"
+    | \\"postal-code\\"
+    | \\"street-address\\"
+    | \\"sms-otp\\"
+    | \\"tel\\"
+    | \\"tel-country-code\\"
+    | \\"tel-national\\"
+    | \\"tel-device\\"
+    | \\"username\\"
+    | \\"username-new\\"
+    | \\"off\\",
+    \\"off\\",
+  >,
+  returnKeyLabel?: ?string,
+  numberOfLines?: ?Int32,
+  disableFullscreenUI?: ?boolean,
+  textBreakStrategy?: WithDefault<
+    \\"simple\\" | \\"highQuality\\" | \\"balanced\\",
+    \\"simple\\",
+  >,
+  underlineColorAndroid?: ?ColorValue,
+  inlineImageLeft?: ?string,
+  inlineImagePadding?: ?Int32,
+  importantForAutofill?: string,
+  showSoftInputOnFocus?: ?boolean,
+  autoCapitalize?: WithDefault<
+    \\"none\\" | \\"sentences\\" | \\"words\\" | \\"characters\\",
+    \\"none\\",
+  >,
+  autoCorrect?: ?boolean,
+  autoFocus?: ?boolean,
+  allowFontScaling?: ?boolean,
+  maxFontSizeMultiplier?: ?Float,
+  editable?: ?boolean,
+  keyboardType?: WithDefault<KeyboardType, \\"default\\">,
+  returnKeyType?: WithDefault<ReturnKeyType, \\"done\\">,
+  maxLength?: ?Int32,
+  multiline?: ?boolean,
+  onBlur?: ?BubblingEventHandler<$ReadOnly<{| target: Int32 |}>>,
+  onFocus?: ?BubblingEventHandler<$ReadOnly<{| target: Int32 |}>>,
+  onChange?: ?BubblingEventHandler<
+    $ReadOnly<{| target: Int32, eventCount: Int32, text: string |}>,
+  >,
+  onChangeText?: ?BubblingEventHandler<
+    $ReadOnly<{| target: Int32, eventCount: Int32, text: string |}>,
+  >,
+  onContentSizeChange?: ?DirectEventHandler<
+    $ReadOnly<{|
+      target: Int32,
+      contentSize: $ReadOnly<{| width: Double, height: Double |}>,
+    |}>,
+  >,
+  onTextInput?: ?BubblingEventHandler<
+    $ReadOnly<{|
+      target: Int32,
+      text: string,
+      previousText: string,
+      range: $ReadOnly<{| start: Double, end: Double |}>,
+    |}>,
+  >,
+  onEndEditing?: ?BubblingEventHandler<
+    $ReadOnly<{| target: Int32, text: string |}>,
+  >,
+  onSelectionChange?: ?DirectEventHandler<
+    $ReadOnly<{|
+      target: Int32,
+      selection: $ReadOnly<{| start: Double, end: Double |}>,
+    |}>,
+  >,
+  onSubmitEditing?: ?BubblingEventHandler<
+    $ReadOnly<{| target: Int32, text: string |}>,
+  >,
+  onKeyPress?: ?BubblingEventHandler<
+    $ReadOnly<{| target: Int32, key: string |}>,
+  >,
+  onScroll?: ?DirectEventHandler<
+    $ReadOnly<{|
+      target: Int32,
+      responderIgnoreScroll: boolean,
+      contentInset: $ReadOnly<{|
+        top: Double,
+        bottom: Double,
+        left: Double,
+        right: Double,
+      |}>,
+      contentOffset: $ReadOnly<{|
+        x: Double,
+        y: Double,
+      |}>,
+      contentSize: $ReadOnly<{|
+        width: Double,
+        height: Double,
+      |}>,
+      layoutMeasurement: $ReadOnly<{|
+        width: Double,
+        height: Double,
+      |}>,
+      velocity: $ReadOnly<{|
+        x: Double,
+        y: Double,
+      |}>,
+    |}>,
+  >,
+  placeholder?: ?Stringish,
+  placeholderTextColor?: ?ColorValue,
+  secureTextEntry?: ?boolean,
+  selectionColor?: ?ColorValue,
+  selectionHandleColor?: ?ColorValue,
+  selection?: ?$ReadOnly<{|
+    start: Int32,
+    end?: ?Int32,
+  |}>,
+  value?: ?string,
+  defaultValue?: ?string,
+  selectTextOnFocus?: ?boolean,
+  blurOnSubmit?: ?boolean,
+  submitBehavior?: ?SubmitBehavior,
+  style?: ?TextStyleProp,
+  caretHidden?: ?boolean,
+  contextMenuHidden?: ?boolean,
+  textShadowColor?: ?ColorValue,
+  textShadowRadius?: ?Float,
+  textDecorationLine?: ?string,
+  fontStyle?: ?string,
+  textShadowOffset?: ?$ReadOnly<{| width?: ?Double, height?: ?Double |}>,
+  lineHeight?: ?Float,
+  textTransform?: ?string,
+  color?: ?Int32,
+  letterSpacing?: ?Float,
+  fontSize?: ?Float,
+  textAlign?: ?string,
+  includeFontPadding?: ?boolean,
+  fontWeight?: ?string,
+  fontFamily?: ?string,
+  textAlignVertical?: ?string,
+  cursorColor?: ?ColorValue,
+  mostRecentEventCount: Int32,
+  text?: ?string,
+|}>;
+type NativeType = HostComponent<NativeProps>;
+type NativeCommands = TextInputNativeCommands<NativeType>;
+declare export const Commands: NativeCommands;
+declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/RCTInputAccessoryViewNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  backgroundColor?: ?ColorValue,
+|}>;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/RCTMultilineTextInputNativeComponent.js 1`] = `
+"type NativeType = HostComponent<mixed>;
+type NativeCommands = TextInputNativeCommands<NativeType>;
+declare export const Commands: NativeCommands;
+declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare export default HostComponent<mixed>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/RCTSingelineTextInputNativeComponent.js 1`] = `
+"type NativeType = HostComponent<mixed>;
+type NativeCommands = TextInputNativeCommands<NativeType>;
+declare export const Commands: NativeCommands;
+declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare export default HostComponent<mixed>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/RCTTextInputViewConfig.js 1`] = `
+"type PartialViewConfigWithoutName = $Rest<
+  PartialViewConfig,
+  { uiViewClassName: string },
+>;
+declare module.exports: PartialViewConfigWithoutName;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/TextInput.flow.js 1`] = `
+"type ComponentRef = React.ElementRef<HostComponent<mixed>>;
+type ReactRefSetter<T> =
+  | { current: null | T, ... }
+  | ((ref: null | T) => mixed);
+export type ChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    eventCount: number,
+    target: number,
+    text: string,
+  |}>,
+>;
+export type TextInputEvent = SyntheticEvent<
+  $ReadOnly<{|
+    eventCount: number,
+    previousText: string,
+    range: $ReadOnly<{|
+      start: number,
+      end: number,
+    |}>,
+    target: number,
+    text: string,
+  |}>,
+>;
+export type ContentSizeChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    target: number,
+    contentSize: $ReadOnly<{|
+      width: number,
+      height: number,
+    |}>,
+  |}>,
+>;
+type TargetEvent = SyntheticEvent<
+  $ReadOnly<{|
+    target: number,
+  |}>,
+>;
+export type BlurEvent = TargetEvent;
+export type FocusEvent = TargetEvent;
+type Selection = $ReadOnly<{|
+  start: number,
+  end: number,
+|}>;
+export type SelectionChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    selection: Selection,
+    target: number,
+  |}>,
+>;
+export type KeyPressEvent = SyntheticEvent<
+  $ReadOnly<{|
+    key: string,
+    target?: ?number,
+    eventCount?: ?number,
+  |}>,
+>;
+export type EditingEvent = SyntheticEvent<
+  $ReadOnly<{|
+    eventCount: number,
+    text: string,
+    target: number,
+  |}>,
+>;
+type DataDetectorTypesType =
+  | \\"phoneNumber\\"
+  | \\"link\\"
+  | \\"address\\"
+  | \\"calendarEvent\\"
+  | \\"trackingNumber\\"
+  | \\"flightNumber\\"
+  | \\"lookupSuggestion\\"
+  | \\"none\\"
+  | \\"all\\";
+export type KeyboardType =
+  | \\"default\\"
+  | \\"email-address\\"
+  | \\"numeric\\"
+  | \\"phone-pad\\"
+  | \\"number-pad\\"
+  | \\"decimal-pad\\"
+  | \\"url\\"
+  | \\"ascii-capable\\"
+  | \\"numbers-and-punctuation\\"
+  | \\"name-phone-pad\\"
+  | \\"twitter\\"
+  | \\"web-search\\"
+  | \\"ascii-capable-number-pad\\"
+  | \\"visible-password\\";
+export type InputMode =
+  | \\"none\\"
+  | \\"text\\"
+  | \\"decimal\\"
+  | \\"numeric\\"
+  | \\"tel\\"
+  | \\"search\\"
+  | \\"email\\"
+  | \\"url\\";
+export type ReturnKeyType =
+  | \\"done\\"
+  | \\"go\\"
+  | \\"next\\"
+  | \\"search\\"
+  | \\"send\\"
+  | \\"none\\"
+  | \\"previous\\"
+  | \\"default\\"
+  | \\"emergency-call\\"
+  | \\"google\\"
+  | \\"join\\"
+  | \\"route\\"
+  | \\"yahoo\\";
+export type SubmitBehavior = \\"submit\\" | \\"blurAndSubmit\\" | \\"newline\\";
+export type AutoCapitalize = \\"none\\" | \\"sentences\\" | \\"words\\" | \\"characters\\";
+export type TextContentType =
+  | \\"none\\"
+  | \\"URL\\"
+  | \\"addressCity\\"
+  | \\"addressCityAndState\\"
+  | \\"addressState\\"
+  | \\"countryName\\"
+  | \\"creditCardNumber\\"
+  | \\"creditCardExpiration\\"
+  | \\"creditCardExpirationMonth\\"
+  | \\"creditCardExpirationYear\\"
+  | \\"creditCardSecurityCode\\"
+  | \\"creditCardType\\"
+  | \\"creditCardName\\"
+  | \\"creditCardGivenName\\"
+  | \\"creditCardMiddleName\\"
+  | \\"creditCardFamilyName\\"
+  | \\"emailAddress\\"
+  | \\"familyName\\"
+  | \\"fullStreetAddress\\"
+  | \\"givenName\\"
+  | \\"jobTitle\\"
+  | \\"location\\"
+  | \\"middleName\\"
+  | \\"name\\"
+  | \\"namePrefix\\"
+  | \\"nameSuffix\\"
+  | \\"nickname\\"
+  | \\"organizationName\\"
+  | \\"postalCode\\"
+  | \\"streetAddressLine1\\"
+  | \\"streetAddressLine2\\"
+  | \\"sublocality\\"
+  | \\"telephoneNumber\\"
+  | \\"username\\"
+  | \\"password\\"
+  | \\"newPassword\\"
+  | \\"oneTimeCode\\"
+  | \\"birthdate\\"
+  | \\"birthdateDay\\"
+  | \\"birthdateMonth\\"
+  | \\"birthdateYear\\";
+export type enterKeyHintType =
+  | \\"enter\\"
+  | \\"done\\"
+  | \\"go\\"
+  | \\"next\\"
+  | \\"previous\\"
+  | \\"search\\"
+  | \\"send\\";
+type PasswordRules = string;
+type IOSProps = $ReadOnly<{|
+  clearButtonMode?: ?(\\"never\\" | \\"while-editing\\" | \\"unless-editing\\" | \\"always\\"),
+  clearTextOnFocus?: ?boolean,
+  dataDetectorTypes?:
+    | ?DataDetectorTypesType
+    | $ReadOnlyArray<DataDetectorTypesType>,
+  enablesReturnKeyAutomatically?: ?boolean,
+  inputAccessoryViewID?: ?string,
+  keyboardAppearance?: ?(\\"default\\" | \\"light\\" | \\"dark\\"),
+  passwordRules?: ?PasswordRules,
+  rejectResponderTermination?: ?boolean,
+  scrollEnabled?: ?boolean,
+  spellCheck?: ?boolean,
+  textContentType?: ?TextContentType,
+  lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
+  smartInsertDelete?: ?boolean,
+|}>;
+type AndroidProps = $ReadOnly<{|
+  cursorColor?: ?ColorValue,
+  selectionHandleColor?: ?ColorValue,
+  disableFullscreenUI?: ?boolean,
+  importantForAutofill?: ?(
+    | \\"auto\\"
+    | \\"no\\"
+    | \\"noExcludeDescendants\\"
+    | \\"yes\\"
+    | \\"yesExcludeDescendants\\"
+  ),
+  inlineImageLeft?: ?string,
+  inlineImagePadding?: ?number,
+  numberOfLines?: ?number,
+  returnKeyLabel?: ?string,
+  rows?: ?number,
+  showSoftInputOnFocus?: ?boolean,
+  textBreakStrategy?: ?(\\"simple\\" | \\"highQuality\\" | \\"balanced\\"),
+  underlineColorAndroid?: ?ColorValue,
+|}>;
+export type Props = $ReadOnly<{|
+  ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
+  ...IOSProps,
+  ...AndroidProps,
+  autoCapitalize?: ?AutoCapitalize,
+  autoComplete?: ?(
+    | \\"additional-name\\"
+    | \\"address-line1\\"
+    | \\"address-line2\\"
+    | \\"birthdate-day\\"
+    | \\"birthdate-full\\"
+    | \\"birthdate-month\\"
+    | \\"birthdate-year\\"
+    | \\"cc-csc\\"
+    | \\"cc-exp\\"
+    | \\"cc-exp-day\\"
+    | \\"cc-exp-month\\"
+    | \\"cc-exp-year\\"
+    | \\"cc-number\\"
+    | \\"cc-name\\"
+    | \\"cc-given-name\\"
+    | \\"cc-middle-name\\"
+    | \\"cc-family-name\\"
+    | \\"cc-type\\"
+    | \\"country\\"
+    | \\"current-password\\"
+    | \\"email\\"
+    | \\"family-name\\"
+    | \\"gender\\"
+    | \\"given-name\\"
+    | \\"honorific-prefix\\"
+    | \\"honorific-suffix\\"
+    | \\"name\\"
+    | \\"name-family\\"
+    | \\"name-given\\"
+    | \\"name-middle\\"
+    | \\"name-middle-initial\\"
+    | \\"name-prefix\\"
+    | \\"name-suffix\\"
+    | \\"new-password\\"
+    | \\"nickname\\"
+    | \\"one-time-code\\"
+    | \\"organization\\"
+    | \\"organization-title\\"
+    | \\"password\\"
+    | \\"password-new\\"
+    | \\"postal-address\\"
+    | \\"postal-address-country\\"
+    | \\"postal-address-extended\\"
+    | \\"postal-address-extended-postal-code\\"
+    | \\"postal-address-locality\\"
+    | \\"postal-address-region\\"
+    | \\"postal-code\\"
+    | \\"street-address\\"
+    | \\"sms-otp\\"
+    | \\"tel\\"
+    | \\"tel-country-code\\"
+    | \\"tel-national\\"
+    | \\"tel-device\\"
+    | \\"url\\"
+    | \\"username\\"
+    | \\"username-new\\"
+    | \\"off\\"
+  ),
+  autoCorrect?: ?boolean,
+  autoFocus?: ?boolean,
+  allowFontScaling?: ?boolean,
+  caretHidden?: ?boolean,
+  contextMenuHidden?: ?boolean,
+  defaultValue?: ?Stringish,
+  editable?: ?boolean,
+  forwardedRef?: ?ReactRefSetter<
+    React.ElementRef<HostComponent<mixed>> & ImperativeMethods,
+  >,
+  enterKeyHint?: ?enterKeyHintType,
+  inputMode?: ?InputMode,
+  keyboardType?: ?KeyboardType,
+  maxFontSizeMultiplier?: ?number,
+  maxLength?: ?number,
+  multiline?: ?boolean,
+  onBlur?: ?(e: BlurEvent) => mixed,
+  onChange?: ?(e: ChangeEvent) => mixed,
+  unstable_onChangeSync?: ?(e: ChangeEvent) => mixed,
+  onChangeText?: ?(text: string) => mixed,
+  unstable_onChangeTextSync?: ?(text: string) => mixed,
+  onContentSizeChange?: ?(e: ContentSizeChangeEvent) => mixed,
+  onEndEditing?: ?(e: EditingEvent) => mixed,
+  onFocus?: ?(e: FocusEvent) => mixed,
+  onKeyPress?: ?(e: KeyPressEvent) => mixed,
+  unstable_onKeyPressSync?: ?(e: KeyPressEvent) => mixed,
+  onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
+  onSelectionChange?: ?(e: SelectionChangeEvent) => mixed,
+  onSubmitEditing?: ?(e: EditingEvent) => mixed,
+  onScroll?: ?(e: ScrollEvent) => mixed,
+  placeholder?: ?Stringish,
+  placeholderTextColor?: ?ColorValue,
+  readOnly?: ?boolean,
+  returnKeyType?: ?ReturnKeyType,
+  secureTextEntry?: ?boolean,
+  selection?: ?$ReadOnly<{|
+    start: number,
+    end?: ?number,
+  |}>,
+  selectionColor?: ?ColorValue,
+  selectTextOnFocus?: ?boolean,
+  blurOnSubmit?: ?boolean,
+  submitBehavior?: ?SubmitBehavior,
+  style?: ?TextStyleProp,
+  value?: ?Stringish,
+|}>;
+type ImperativeMethods = $ReadOnly<{|
+  clear: () => void,
+  isFocused: () => boolean,
+  getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
+  setSelection: (start: number, end: number) => void,
+|}>;
+type InternalTextInput = (props: Props) => React.Node;
+export type TextInputComponentStatics = $ReadOnly<{|
+  State: $ReadOnly<{|
+    currentlyFocusedInput: () => ?ComponentRef,
+    currentlyFocusedField: () => ?number,
+    focusTextInput: (textField: ?ComponentRef) => void,
+    blurTextInput: (textField: ?ComponentRef) => void,
+  |}>,
+|}>;
+export type TextInputType = React.AbstractComponent<
+  React.ElementConfig<InternalTextInput>,
+  $ReadOnly<{|
+    ...React.ElementRef<HostComponent<mixed>>,
+    ...ImperativeMethods,
+  |}>,
+> &
+  TextInputComponentStatics;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/TextInput.js 1`] = `
+"type ReactRefSetter<T> =
+  | { current: null | T, ... }
+  | ((ref: null | T) => mixed);
+type TextInputInstance = React.ElementRef<HostComponent<mixed>> & {
+  +clear: () => void,
+  +isFocused: () => boolean,
+  +getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
+  +setSelection: (start: number, end: number) => void,
+};
+export type ChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    eventCount: number,
+    target: number,
+    text: string,
+  |}>,
+>;
+export type TextInputEvent = SyntheticEvent<
+  $ReadOnly<{|
+    eventCount: number,
+    previousText: string,
+    range: $ReadOnly<{|
+      start: number,
+      end: number,
+    |}>,
+    target: number,
+    text: string,
+  |}>,
+>;
+export type ContentSizeChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    target: number,
+    contentSize: $ReadOnly<{|
+      width: number,
+      height: number,
+    |}>,
+  |}>,
+>;
+type TargetEvent = SyntheticEvent<
+  $ReadOnly<{|
+    target: number,
+  |}>,
+>;
+export type BlurEvent = TargetEvent;
+export type FocusEvent = TargetEvent;
+type Selection = $ReadOnly<{|
+  start: number,
+  end: number,
+|}>;
+export type SelectionChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    selection: Selection,
+    target: number,
+  |}>,
+>;
+export type KeyPressEvent = SyntheticEvent<
+  $ReadOnly<{|
+    key: string,
+    target?: ?number,
+    eventCount?: ?number,
+  |}>,
+>;
+export type EditingEvent = SyntheticEvent<
+  $ReadOnly<{|
+    eventCount: number,
+    text: string,
+    target: number,
+  |}>,
+>;
+type DataDetectorTypesType =
+  | \\"phoneNumber\\"
+  | \\"link\\"
+  | \\"address\\"
+  | \\"calendarEvent\\"
+  | \\"trackingNumber\\"
+  | \\"flightNumber\\"
+  | \\"lookupSuggestion\\"
+  | \\"none\\"
+  | \\"all\\";
+export type KeyboardType =
+  | \\"default\\"
+  | \\"email-address\\"
+  | \\"numeric\\"
+  | \\"phone-pad\\"
+  | \\"number-pad\\"
+  | \\"decimal-pad\\"
+  | \\"url\\"
+  | \\"ascii-capable\\"
+  | \\"numbers-and-punctuation\\"
+  | \\"name-phone-pad\\"
+  | \\"twitter\\"
+  | \\"web-search\\"
+  | \\"ascii-capable-number-pad\\"
+  | \\"visible-password\\";
+export type InputMode =
+  | \\"none\\"
+  | \\"text\\"
+  | \\"decimal\\"
+  | \\"numeric\\"
+  | \\"tel\\"
+  | \\"search\\"
+  | \\"email\\"
+  | \\"url\\";
+export type ReturnKeyType =
+  | \\"done\\"
+  | \\"go\\"
+  | \\"next\\"
+  | \\"search\\"
+  | \\"send\\"
+  | \\"none\\"
+  | \\"previous\\"
+  | \\"default\\"
+  | \\"emergency-call\\"
+  | \\"google\\"
+  | \\"join\\"
+  | \\"route\\"
+  | \\"yahoo\\";
+export type SubmitBehavior = \\"submit\\" | \\"blurAndSubmit\\" | \\"newline\\";
+export type AutoCapitalize = \\"none\\" | \\"sentences\\" | \\"words\\" | \\"characters\\";
+export type TextContentType =
+  | \\"none\\"
+  | \\"URL\\"
+  | \\"addressCity\\"
+  | \\"addressCityAndState\\"
+  | \\"addressState\\"
+  | \\"countryName\\"
+  | \\"creditCardNumber\\"
+  | \\"creditCardExpiration\\"
+  | \\"creditCardExpirationMonth\\"
+  | \\"creditCardExpirationYear\\"
+  | \\"creditCardSecurityCode\\"
+  | \\"creditCardType\\"
+  | \\"creditCardName\\"
+  | \\"creditCardGivenName\\"
+  | \\"creditCardMiddleName\\"
+  | \\"creditCardFamilyName\\"
+  | \\"emailAddress\\"
+  | \\"familyName\\"
+  | \\"fullStreetAddress\\"
+  | \\"givenName\\"
+  | \\"jobTitle\\"
+  | \\"location\\"
+  | \\"middleName\\"
+  | \\"name\\"
+  | \\"namePrefix\\"
+  | \\"nameSuffix\\"
+  | \\"nickname\\"
+  | \\"organizationName\\"
+  | \\"postalCode\\"
+  | \\"streetAddressLine1\\"
+  | \\"streetAddressLine2\\"
+  | \\"sublocality\\"
+  | \\"telephoneNumber\\"
+  | \\"username\\"
+  | \\"password\\"
+  | \\"newPassword\\"
+  | \\"oneTimeCode\\"
+  | \\"birthdate\\"
+  | \\"birthdateDay\\"
+  | \\"birthdateMonth\\"
+  | \\"birthdateYear\\";
+export type enterKeyHintType =
+  | \\"done\\"
+  | \\"go\\"
+  | \\"next\\"
+  | \\"search\\"
+  | \\"send\\"
+  | \\"previous\\"
+  | \\"enter\\";
+type PasswordRules = string;
+type IOSProps = $ReadOnly<{|
+  clearButtonMode?: ?(\\"never\\" | \\"while-editing\\" | \\"unless-editing\\" | \\"always\\"),
+  clearTextOnFocus?: ?boolean,
+  dataDetectorTypes?:
+    | ?DataDetectorTypesType
+    | $ReadOnlyArray<DataDetectorTypesType>,
+  enablesReturnKeyAutomatically?: ?boolean,
+  inputAccessoryViewID?: ?string,
+  keyboardAppearance?: ?(\\"default\\" | \\"light\\" | \\"dark\\"),
+  passwordRules?: ?PasswordRules,
+  rejectResponderTermination?: ?boolean,
+  scrollEnabled?: ?boolean,
+  spellCheck?: ?boolean,
+  textContentType?: ?TextContentType,
+  lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
+  smartInsertDelete?: ?boolean,
+|}>;
+type AndroidProps = $ReadOnly<{|
+  cursorColor?: ?ColorValue,
+  disableFullscreenUI?: ?boolean,
+  importantForAutofill?: ?(
+    | \\"auto\\"
+    | \\"no\\"
+    | \\"noExcludeDescendants\\"
+    | \\"yes\\"
+    | \\"yesExcludeDescendants\\"
+  ),
+  inlineImageLeft?: ?string,
+  inlineImagePadding?: ?number,
+  numberOfLines?: ?number,
+  returnKeyLabel?: ?string,
+  rows?: ?number,
+  showSoftInputOnFocus?: ?boolean,
+  textBreakStrategy?: ?(\\"simple\\" | \\"highQuality\\" | \\"balanced\\"),
+  underlineColorAndroid?: ?ColorValue,
+|}>;
+export type Props = $ReadOnly<{|
+  ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
+  ...IOSProps,
+  ...AndroidProps,
+  autoCapitalize?: ?AutoCapitalize,
+  autoComplete?: ?(
+    | \\"additional-name\\"
+    | \\"address-line1\\"
+    | \\"address-line2\\"
+    | \\"birthdate-day\\"
+    | \\"birthdate-full\\"
+    | \\"birthdate-month\\"
+    | \\"birthdate-year\\"
+    | \\"cc-csc\\"
+    | \\"cc-exp\\"
+    | \\"cc-exp-day\\"
+    | \\"cc-exp-month\\"
+    | \\"cc-exp-year\\"
+    | \\"cc-number\\"
+    | \\"cc-name\\"
+    | \\"cc-given-name\\"
+    | \\"cc-middle-name\\"
+    | \\"cc-family-name\\"
+    | \\"cc-type\\"
+    | \\"country\\"
+    | \\"current-password\\"
+    | \\"email\\"
+    | \\"family-name\\"
+    | \\"gender\\"
+    | \\"given-name\\"
+    | \\"honorific-prefix\\"
+    | \\"honorific-suffix\\"
+    | \\"name\\"
+    | \\"name-family\\"
+    | \\"name-given\\"
+    | \\"name-middle\\"
+    | \\"name-middle-initial\\"
+    | \\"name-prefix\\"
+    | \\"name-suffix\\"
+    | \\"new-password\\"
+    | \\"nickname\\"
+    | \\"one-time-code\\"
+    | \\"organization\\"
+    | \\"organization-title\\"
+    | \\"password\\"
+    | \\"password-new\\"
+    | \\"postal-address\\"
+    | \\"postal-address-country\\"
+    | \\"postal-address-extended\\"
+    | \\"postal-address-extended-postal-code\\"
+    | \\"postal-address-locality\\"
+    | \\"postal-address-region\\"
+    | \\"postal-code\\"
+    | \\"street-address\\"
+    | \\"sms-otp\\"
+    | \\"tel\\"
+    | \\"tel-country-code\\"
+    | \\"tel-national\\"
+    | \\"tel-device\\"
+    | \\"url\\"
+    | \\"username\\"
+    | \\"username-new\\"
+    | \\"off\\"
+  ),
+  autoCorrect?: ?boolean,
+  autoFocus?: ?boolean,
+  allowFontScaling?: ?boolean,
+  caretHidden?: ?boolean,
+  contextMenuHidden?: ?boolean,
+  defaultValue?: ?Stringish,
+  editable?: ?boolean,
+  forwardedRef?: ?ReactRefSetter<TextInputInstance>,
+  enterKeyHint?: ?enterKeyHintType,
+  inputMode?: ?InputMode,
+  keyboardType?: ?KeyboardType,
+  maxFontSizeMultiplier?: ?number,
+  maxLength?: ?number,
+  multiline?: ?boolean,
+  onBlur?: ?(e: BlurEvent) => mixed,
+  onChange?: ?(e: ChangeEvent) => mixed,
+  unstable_onChangeSync?: ?(e: ChangeEvent) => mixed,
+  onChangeText?: ?(text: string) => mixed,
+  unstable_onChangeTextSync?: ?(text: string) => mixed,
+  onContentSizeChange?: ?(e: ContentSizeChangeEvent) => mixed,
+  onEndEditing?: ?(e: EditingEvent) => mixed,
+  onFocus?: ?(e: FocusEvent) => mixed,
+  onKeyPress?: ?(e: KeyPressEvent) => mixed,
+  unstable_onKeyPressSync?: ?(e: KeyPressEvent) => mixed,
+  onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
+  onSelectionChange?: ?(e: SelectionChangeEvent) => mixed,
+  onSubmitEditing?: ?(e: EditingEvent) => mixed,
+  onScroll?: ?(e: ScrollEvent) => mixed,
+  placeholder?: ?Stringish,
+  placeholderTextColor?: ?ColorValue,
+  readOnly?: ?boolean,
+  returnKeyType?: ?ReturnKeyType,
+  secureTextEntry?: ?boolean,
+  selection?: ?$ReadOnly<{|
+    start: number,
+    end?: ?number,
+  |}>,
+  selectionColor?: ?ColorValue,
+  selectionHandleColor?: ?ColorValue,
+  selectTextOnFocus?: ?boolean,
+  blurOnSubmit?: ?boolean,
+  submitBehavior?: ?SubmitBehavior,
+  style?: ?TextStyleProp,
+  value?: ?Stringish,
+|}>;
+export type TextInputComponentStatics = $ReadOnly<{|
+  State: $ReadOnly<{|
+    currentlyFocusedInput: typeof TextInputState.currentlyFocusedInput,
+    currentlyFocusedField: typeof TextInputState.currentlyFocusedField,
+    focusTextInput: typeof TextInputState.focusTextInput,
+    blurTextInput: typeof TextInputState.blurTextInput,
+  |}>,
+|}>;
+declare module.exports: TextInputType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/TextInputNativeCommands.js 1`] = `
+"export interface TextInputNativeCommands<T> {
+  +focus: (viewRef: React.ElementRef<T>) => void;
+  +blur: (viewRef: React.ElementRef<T>) => void;
+  +setTextAndSelection: (
+    viewRef: React.ElementRef<T>,
+    mostRecentEventCount: Int32,
+    value: ?string,
+    start: Int32,
+    end: Int32
+  ) => void;
+}
+declare const supportedCommands: $FlowFixMe;
+declare export default typeof supportedCommands;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TextInput/TextInputState.js 1`] = `
+"declare const React: $FlowFixMe;
+type ComponentRef = React.ElementRef<HostComponent<mixed>>;
+declare function currentlyFocusedInput(): ?ComponentRef;
+declare function currentlyFocusedField(): ?number;
+declare function focusInput(textField: ?ComponentRef): void;
+declare function blurInput(textField: ?ComponentRef): void;
+declare function focusField(textFieldID: ?number): void;
+declare function blurField(textFieldID: ?number): void;
+declare function focusTextInput(textField: ?ComponentRef): void;
+declare function blurTextInput(textField: ?ComponentRef): void;
+declare function registerInput(textField: ComponentRef): void;
+declare function unregisterInput(textField: ComponentRef): void;
+declare function isTextInput(textField: ComponentRef): boolean;
+declare module.exports: {
+  currentlyFocusedInput: currentlyFocusedInput,
+  focusInput: focusInput,
+  blurInput: blurInput,
+  currentlyFocusedField: currentlyFocusedField,
+  focusField: focusField,
+  blurField: blurField,
+  focusTextInput: focusTextInput,
+  blurTextInput: blurTextInput,
+  registerInput: registerInput,
+  unregisterInput: unregisterInput,
+  isTextInput: isTextInput,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ToastAndroid/NativeToastAndroid.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {|
+    SHORT: number,
+    LONG: number,
+    TOP: number,
+    BOTTOM: number,
+    CENTER: number,
+  |};
+  +show: (message: string, duration: number) => void;
+  +showWithGravity: (
+    message: string,
+    duration: number,
+    gravity: number
+  ) => void;
+  +showWithGravityAndOffset: (
+    message: string,
+    duration: number,
+    gravity: number,
+    xOffset: number,
+    yOffset: number
+  ) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ToastAndroid/ToastAndroid.android.js 1`] = `
+"declare const ToastAndroid: {
+  SHORT: number,
+  LONG: number,
+  TOP: number,
+  BOTTOM: number,
+  CENTER: number,
+  show: (message: string, duration: number) => void,
+  showWithGravity: (message: string, duration: number, gravity: number) => void,
+  showWithGravityAndOffset: (
+    message: string,
+    duration: number,
+    gravity: number,
+    xOffset: number,
+    yOffset: number
+  ) => void,
+};
+declare module.exports: ToastAndroid;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/ToastAndroid/ToastAndroid.js 1`] = `
+"declare const ToastAndroid: {
+  SHORT: number,
+  LONG: number,
+  TOP: number,
+  BOTTOM: number,
+  CENTER: number,
+  show: (message: string, duration: number) => void,
+  showWithGravity: (message: string, duration: number, gravity: number) => void,
+  showWithGravityAndOffset: (
+    message: string,
+    duration: number,
+    gravity: number,
+    xOffset: number,
+    yOffset: number
+  ) => void,
+};
+declare module.exports: ToastAndroid;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Touchable/BoundingDimensions.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Components/Touchable/PooledClass.js 1`] = `
+"type Pooler = any;
+declare const addPoolingTo: <T>(
+  CopyConstructor: Class<T>,
+  pooler: Pooler
+) => Class<T> & {
+  getPooled(...args: $ReadOnlyArray<mixed>): T,
+  release(instance: mixed): void,
+  ...
+};
+declare const PooledClass: {
+  addPoolingTo: addPoolingTo,
+  oneArgumentPooler: Pooler,
+  twoArgumentPooler: Pooler,
+  threeArgumentPooler: Pooler,
+  fourArgumentPooler: Pooler,
+};
+declare module.exports: PooledClass;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Touchable/Position.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Components/Touchable/Touchable.flow.js 1`] = `
+"declare const States: {
+  NOT_RESPONDER: \\"NOT_RESPONDER\\",
+  RESPONDER_INACTIVE_PRESS_IN: \\"RESPONDER_INACTIVE_PRESS_IN\\",
+  RESPONDER_INACTIVE_PRESS_OUT: \\"RESPONDER_INACTIVE_PRESS_OUT\\",
+  RESPONDER_ACTIVE_PRESS_IN: \\"RESPONDER_ACTIVE_PRESS_IN\\",
+  RESPONDER_ACTIVE_PRESS_OUT: \\"RESPONDER_ACTIVE_PRESS_OUT\\",
+  RESPONDER_ACTIVE_LONG_PRESS_IN: \\"RESPONDER_ACTIVE_LONG_PRESS_IN\\",
+  RESPONDER_ACTIVE_LONG_PRESS_OUT: \\"RESPONDER_ACTIVE_LONG_PRESS_OUT\\",
+  ERROR: \\"ERROR\\",
+};
+type State =
+  | typeof States.NOT_RESPONDER
+  | typeof States.RESPONDER_INACTIVE_PRESS_IN
+  | typeof States.RESPONDER_INACTIVE_PRESS_OUT
+  | typeof States.RESPONDER_ACTIVE_PRESS_IN
+  | typeof States.RESPONDER_ACTIVE_PRESS_OUT
+  | typeof States.RESPONDER_ACTIVE_LONG_PRESS_IN
+  | typeof States.RESPONDER_ACTIVE_LONG_PRESS_OUT
+  | typeof States.ERROR;
+interface TouchableMixinType {
+  touchableHandleFocus: (e: Event) => void;
+  touchableHandleBlur: (e: Event) => void;
+  componentDidMount: () => void;
+  componentWillUnmount: () => void;
+  touchableGetInitialState: () => {
+    touchable: {
+      touchState: ?State,
+      responderID: ?PressEvent[\\"currentTarget\\"],
+    },
+  };
+  touchableHandleResponderTerminationRequest: () => any;
+  touchableHandleStartShouldSetResponder: () => any;
+  touchableLongPressCancelsPress: () => boolean;
+  touchableHandleResponderGrant: (e: PressEvent) => void;
+  touchableHandleResponderRelease: (e: PressEvent) => void;
+  touchableHandleResponderTerminate: (e: PressEvent) => void;
+  touchableHandleResponderMove: (e: PressEvent) => void;
+  withoutDefaultFocusAndBlur: { ... };
+}
+export type TouchableType = {
+  Mixin: TouchableMixinType,
+  renderDebugView: ({
+    color: ColorValue,
+    hitSlop: EdgeInsetsProp,
+    ...
+  }) => null | React.Node,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Touchable/Touchable.js 1`] = `
+"declare const Touchable: TouchableType;
+declare module.exports: Touchable;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableBounce.js 1`] = `
+"type Props = $ReadOnly<{|
+  ...React.ElementConfig<TouchableWithoutFeedback>,
+  onPressAnimationComplete?: ?() => void,
+  onPressWithCompletion?: ?(callback: () => void) => void,
+  releaseBounciness?: ?number,
+  releaseVelocity?: ?number,
+  style?: ?ViewStyleProp,
+  hostRef: React.Ref<typeof Animated.View>,
+|}>;
+declare module.exports: React.AbstractComponent<
+  $ReadOnly<$Diff<Props, {| hostRef: mixed |}>>,
+>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableHighlight.js 1`] = `
+"type AndroidProps = $ReadOnly<{|
+  nextFocusDown?: ?number,
+  nextFocusForward?: ?number,
+  nextFocusLeft?: ?number,
+  nextFocusRight?: ?number,
+  nextFocusUp?: ?number,
+|}>;
+type IOSProps = $ReadOnly<{|
+  hasTVPreferredFocus?: ?boolean,
+|}>;
+type Props = $ReadOnly<{|
+  ...React.ElementConfig<TouchableWithoutFeedback>,
+  ...AndroidProps,
+  ...IOSProps,
+  activeOpacity?: ?number,
+  underlayColor?: ?ColorValue,
+  style?: ?ViewStyleProp,
+  onShowUnderlay?: ?() => void,
+  onHideUnderlay?: ?() => void,
+  testOnly_pressed?: ?boolean,
+  hostRef: React.Ref<typeof View>,
+|}>;
+declare const Touchable: React.AbstractComponent<
+  $ReadOnly<$Diff<Props, {| hostRef: React.Ref<typeof View> |}>>,
+  React.ElementRef<typeof View>,
+>;
+declare module.exports: Touchable;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableOpacity.js 1`] = `
+"type TVProps = $ReadOnly<{|
+  hasTVPreferredFocus?: ?boolean,
+  nextFocusDown?: ?number,
+  nextFocusForward?: ?number,
+  nextFocusLeft?: ?number,
+  nextFocusRight?: ?number,
+  nextFocusUp?: ?number,
+|}>;
+type Props = $ReadOnly<{|
+  ...React.ElementConfig<TouchableWithoutFeedback>,
+  ...TVProps,
+  activeOpacity?: ?number,
+  style?: ?ViewStyleProp,
+  hostRef?: ?React.Ref<typeof Animated.View>,
+|}>;
+declare const Touchable: React.AbstractComponent<
+  Props,
+  React.ElementRef<typeof Animated.View>,
+>;
+declare module.exports: Touchable;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/TraceUpdateOverlay/TraceUpdateOverlay.js 1`] = `
+"type Props = {
+  reactDevToolsAgent: ReactDevToolsAgent,
+};
+declare export default function TraceUpdateOverlay(Props): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/UnimplementedViews/UnimplementedNativeViewNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  name?: WithDefault<string, \\"\\">,
+|}>;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/View/ReactNativeStyleAttributes.js 1`] = `
+"declare const ReactNativeStyleAttributes: { [string]: AnyAttributeType, ... };
+declare module.exports: ReactNativeStyleAttributes;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/View/ReactNativeViewAttributes.js 1`] = `
+"declare const UIView: {
+  pointerEvents: true,
+  accessible: true,
+  accessibilityActions: true,
+  accessibilityLabel: true,
+  accessibilityLiveRegion: true,
+  accessibilityRole: true,
+  accessibilityState: true,
+  accessibilityValue: true,
+  accessibilityHint: true,
+  accessibilityLanguage: true,
+  importantForAccessibility: true,
+  nativeID: true,
+  testID: true,
+  renderToHardwareTextureAndroid: true,
+  shouldRasterizeIOS: true,
+  onLayout: true,
+  onAccessibilityAction: true,
+  onAccessibilityTap: true,
+  onMagicTap: true,
+  onAccessibilityEscape: true,
+  collapsable: true,
+  needsOffscreenAlphaCompositing: true,
+  style: ReactNativeStyleAttributes,
+  role: true,
+};
+declare const RCTView: { ...UIView, removeClippedSubviews: true };
+declare const ReactNativeViewAttributes: { UIView: UIView, RCTView: RCTView };
+declare module.exports: ReactNativeViewAttributes;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/View/View.js 1`] = `
+"export type Props = ViewProps;
+declare const View: React.AbstractComponent<
+  ViewProps,
+  React.ElementRef<typeof ViewNativeComponent>,
+>;
+declare module.exports: View;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/View/ViewAccessibility.js 1`] = `
+"export type AccessibilityRole =
+  | \\"none\\"
+  | \\"button\\"
+  | \\"dropdownlist\\"
+  | \\"togglebutton\\"
+  | \\"link\\"
+  | \\"search\\"
+  | \\"image\\"
+  | \\"keyboardkey\\"
+  | \\"text\\"
+  | \\"adjustable\\"
+  | \\"imagebutton\\"
+  | \\"header\\"
+  | \\"summary\\"
+  | \\"alert\\"
+  | \\"checkbox\\"
+  | \\"combobox\\"
+  | \\"menu\\"
+  | \\"menubar\\"
+  | \\"menuitem\\"
+  | \\"progressbar\\"
+  | \\"radio\\"
+  | \\"radiogroup\\"
+  | \\"scrollbar\\"
+  | \\"spinbutton\\"
+  | \\"switch\\"
+  | \\"tab\\"
+  | \\"tabbar\\"
+  | \\"tablist\\"
+  | \\"timer\\"
+  | \\"list\\"
+  | \\"toolbar\\"
+  | \\"grid\\"
+  | \\"pager\\"
+  | \\"scrollview\\"
+  | \\"horizontalscrollview\\"
+  | \\"viewgroup\\"
+  | \\"webview\\"
+  | \\"drawerlayout\\"
+  | \\"slidingdrawer\\"
+  | \\"iconmenu\\";
+export type Role =
+  | \\"alert\\"
+  | \\"alertdialog\\"
+  | \\"application\\"
+  | \\"article\\"
+  | \\"banner\\"
+  | \\"button\\"
+  | \\"cell\\"
+  | \\"checkbox\\"
+  | \\"columnheader\\"
+  | \\"combobox\\"
+  | \\"complementary\\"
+  | \\"contentinfo\\"
+  | \\"definition\\"
+  | \\"dialog\\"
+  | \\"directory\\"
+  | \\"document\\"
+  | \\"feed\\"
+  | \\"figure\\"
+  | \\"form\\"
+  | \\"grid\\"
+  | \\"group\\"
+  | \\"heading\\"
+  | \\"img\\"
+  | \\"link\\"
+  | \\"list\\"
+  | \\"listitem\\"
+  | \\"log\\"
+  | \\"main\\"
+  | \\"marquee\\"
+  | \\"math\\"
+  | \\"menu\\"
+  | \\"menubar\\"
+  | \\"menuitem\\"
+  | \\"meter\\"
+  | \\"navigation\\"
+  | \\"none\\"
+  | \\"note\\"
+  | \\"option\\"
+  | \\"presentation\\"
+  | \\"progressbar\\"
+  | \\"radio\\"
+  | \\"radiogroup\\"
+  | \\"region\\"
+  | \\"row\\"
+  | \\"rowgroup\\"
+  | \\"rowheader\\"
+  | \\"scrollbar\\"
+  | \\"searchbox\\"
+  | \\"separator\\"
+  | \\"slider\\"
+  | \\"spinbutton\\"
+  | \\"status\\"
+  | \\"summary\\"
+  | \\"switch\\"
+  | \\"tab\\"
+  | \\"table\\"
+  | \\"tablist\\"
+  | \\"tabpanel\\"
+  | \\"term\\"
+  | \\"timer\\"
+  | \\"toolbar\\"
+  | \\"tooltip\\"
+  | \\"tree\\"
+  | \\"treegrid\\"
+  | \\"treeitem\\";
+export type AccessibilityActionInfo = $ReadOnly<{
+  name: string,
+  label?: string,
+  ...
+}>;
+export type AccessibilityActionEvent = SyntheticEvent<
+  $ReadOnly<{ actionName: string, ... }>,
+>;
+export type AccessibilityState = {
+  disabled?: boolean,
+  selected?: boolean,
+  checked?: ?boolean | \\"mixed\\",
+  busy?: boolean,
+  expanded?: boolean,
+  ...
+};
+export type AccessibilityValue = $ReadOnly<{|
+  min?: number,
+  max?: number,
+  now?: number,
+  text?: Stringish,
+|}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/View/ViewNativeComponent.js 1`] = `
+"declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare const ViewNativeComponent: HostComponent<Props>;
+interface NativeCommands {
+  +hotspotUpdate: (
+    viewRef: React.ElementRef<HostComponent<mixed>>,
+    x: number,
+    y: number
+  ) => void;
+  +setPressed: (
+    viewRef: React.ElementRef<HostComponent<mixed>>,
+    pressed: boolean
+  ) => void;
+}
+declare export const Commands: NativeCommands;
+declare export default typeof ViewNativeComponent;
+export type ViewNativeComponentType = HostComponent<Props>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/View/ViewPropTypes.js 1`] = `
+"export type ViewLayout = Layout;
+export type ViewLayoutEvent = LayoutEvent;
+type DirectEventProps = $ReadOnly<{|
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  onAccessibilityTap?: ?() => mixed,
+  onLayout?: ?(event: LayoutEvent) => mixed,
+  onMagicTap?: ?() => mixed,
+  onAccessibilityEscape?: ?() => mixed,
+|}>;
+type MouseEventProps = $ReadOnly<{|
+  onMouseEnter?: ?(event: MouseEvent) => void,
+  onMouseLeave?: ?(event: MouseEvent) => void,
+|}>;
+type PointerEventProps = $ReadOnly<{|
+  onClick?: ?(event: PointerEvent) => void,
+  onClickCapture?: ?(event: PointerEvent) => void,
+  onPointerEnter?: ?(event: PointerEvent) => void,
+  onPointerEnterCapture?: ?(event: PointerEvent) => void,
+  onPointerLeave?: ?(event: PointerEvent) => void,
+  onPointerLeaveCapture?: ?(event: PointerEvent) => void,
+  onPointerMove?: ?(event: PointerEvent) => void,
+  onPointerMoveCapture?: ?(event: PointerEvent) => void,
+  onPointerCancel?: ?(e: PointerEvent) => void,
+  onPointerCancelCapture?: ?(e: PointerEvent) => void,
+  onPointerDown?: ?(e: PointerEvent) => void,
+  onPointerDownCapture?: ?(e: PointerEvent) => void,
+  onPointerUp?: ?(e: PointerEvent) => void,
+  onPointerUpCapture?: ?(e: PointerEvent) => void,
+  onPointerOver?: ?(e: PointerEvent) => void,
+  onPointerOverCapture?: ?(e: PointerEvent) => void,
+  onPointerOut?: ?(e: PointerEvent) => void,
+  onPointerOutCapture?: ?(e: PointerEvent) => void,
+  onGotPointerCapture?: ?(e: PointerEvent) => void,
+  onGotPointerCaptureCapture?: ?(e: PointerEvent) => void,
+  onLostPointerCapture?: ?(e: PointerEvent) => void,
+  onLostPointerCaptureCapture?: ?(e: PointerEvent) => void,
+|}>;
+type FocusEventProps = $ReadOnly<{|
+  onBlur?: ?(event: BlurEvent) => void,
+  onBlurCapture?: ?(event: BlurEvent) => void,
+  onFocus?: ?(event: FocusEvent) => void,
+  onFocusCapture?: ?(event: FocusEvent) => void,
+|}>;
+type TouchEventProps = $ReadOnly<{|
+  onTouchCancel?: ?(e: PressEvent) => void,
+  onTouchCancelCapture?: ?(e: PressEvent) => void,
+  onTouchEnd?: ?(e: PressEvent) => void,
+  onTouchEndCapture?: ?(e: PressEvent) => void,
+  onTouchMove?: ?(e: PressEvent) => void,
+  onTouchMoveCapture?: ?(e: PressEvent) => void,
+  onTouchStart?: ?(e: PressEvent) => void,
+  onTouchStartCapture?: ?(e: PressEvent) => void,
+|}>;
+type GestureResponderEventProps = $ReadOnly<{|
+  onMoveShouldSetResponder?: ?(e: PressEvent) => boolean,
+  onMoveShouldSetResponderCapture?: ?(e: PressEvent) => boolean,
+  onResponderGrant?: ?(e: PressEvent) => void | boolean,
+  onResponderMove?: ?(e: PressEvent) => void,
+  onResponderReject?: ?(e: PressEvent) => void,
+  onResponderRelease?: ?(e: PressEvent) => void,
+  onResponderStart?: ?(e: PressEvent) => void,
+  onResponderEnd?: ?(e: PressEvent) => void,
+  onResponderTerminate?: ?(e: PressEvent) => void,
+  onResponderTerminationRequest?: ?(e: PressEvent) => boolean,
+  onStartShouldSetResponder?: ?(e: PressEvent) => boolean,
+  onStartShouldSetResponderCapture?: ?(e: PressEvent) => boolean,
+|}>;
+type AndroidDrawableThemeAttr = $ReadOnly<{|
+  type: \\"ThemeAttrAndroid\\",
+  attribute: string,
+|}>;
+type AndroidDrawableRipple = $ReadOnly<{|
+  type: \\"RippleAndroid\\",
+  color?: ?number,
+  borderless?: ?boolean,
+  rippleRadius?: ?number,
+|}>;
+type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
+type AndroidViewProps = $ReadOnly<{|
+  accessibilityLabelledBy?: ?string | ?Array<string>,
+  \\"aria-labelledby\\"?: ?string,
+  accessibilityLiveRegion?: ?(\\"none\\" | \\"polite\\" | \\"assertive\\"),
+  \\"aria-live\\"?: ?(\\"polite\\" | \\"assertive\\" | \\"off\\"),
+  nativeBackgroundAndroid?: ?AndroidDrawable,
+  nativeForegroundAndroid?: ?AndroidDrawable,
+  renderToHardwareTextureAndroid?: ?boolean,
+  importantForAccessibility?: ?(\\"auto\\" | \\"yes\\" | \\"no\\" | \\"no-hide-descendants\\"),
+  hasTVPreferredFocus?: ?boolean,
+  nextFocusDown?: ?number,
+  nextFocusForward?: ?number,
+  nextFocusLeft?: ?number,
+  nextFocusRight?: ?number,
+  nextFocusUp?: ?number,
+  focusable?: boolean,
+  tabIndex?: 0 | -1,
+  onClick?: ?(event: PressEvent) => mixed,
+|}>;
+type IOSViewProps = $ReadOnly<{|
+  accessibilityIgnoresInvertColors?: ?boolean,
+  accessibilityViewIsModal?: ?boolean,
+  \\"aria-modal\\"?: ?boolean,
+  accessibilityElementsHidden?: ?boolean,
+  accessibilityLanguage?: ?Stringish,
+  shouldRasterizeIOS?: ?boolean,
+|}>;
+export type ViewProps = $ReadOnly<{|
+  ...DirectEventProps,
+  ...GestureResponderEventProps,
+  ...MouseEventProps,
+  ...PointerEventProps,
+  ...FocusEventProps,
+  ...TouchEventProps,
+  ...AndroidViewProps,
+  ...IOSViewProps,
+  children?: Node,
+  style?: ?ViewStyleProp,
+  accessible?: ?boolean,
+  accessibilityLabel?: ?Stringish,
+  accessibilityHint?: ?Stringish,
+  \\"aria-label\\"?: ?Stringish,
+  accessibilityRole?: ?AccessibilityRole,
+  role?: ?Role,
+  accessibilityState?: ?AccessibilityState,
+  accessibilityValue?: ?AccessibilityValue,
+  \\"aria-valuemax\\"?: ?AccessibilityValue[\\"max\\"],
+  \\"aria-valuemin\\"?: ?AccessibilityValue[\\"min\\"],
+  \\"aria-valuenow\\"?: ?AccessibilityValue[\\"now\\"],
+  \\"aria-valuetext\\"?: ?AccessibilityValue[\\"text\\"],
+  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+  \\"aria-busy\\"?: ?boolean,
+  \\"aria-checked\\"?: ?boolean | \\"mixed\\",
+  \\"aria-disabled\\"?: ?boolean,
+  \\"aria-expanded\\"?: ?boolean,
+  \\"aria-selected\\"?: ?boolean,
+  \\"aria-hidden\\"?: ?boolean,
+  collapsable?: ?boolean,
+  experimental_layoutConformance?: ?(\\"strict\\" | \\"classic\\"),
+  id?: string,
+  testID?: ?string,
+  nativeID?: ?string,
+  needsOffscreenAlphaCompositing?: ?boolean,
+  hitSlop?: ?EdgeInsetsOrSizeProp,
+  pointerEvents?: ?(\\"auto\\" | \\"box-none\\" | \\"box-only\\" | \\"none\\"),
+  removeClippedSubviews?: ?boolean,
+|}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Devtools/getDevServer.js 1`] = `
+"type DevServerInfo = {
+  url: string,
+  fullBundleUrl: ?string,
+  bundleLoadedFromServer: boolean,
+  ...
+};
+declare function getDevServer(): DevServerInfo;
+declare module.exports: getDevServer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Devtools/loadBundleFromServer.js 1`] = `
+"declare module.exports: (bundlePathAndQuery: string) => Promise<void>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Devtools/openFileInEditor.js 1`] = `
+"declare function openFileInEditor(file: string, lineNumber: number): void;
+declare module.exports: openFileInEditor;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Devtools/openURLInBrowser.js 1`] = `
+"declare function openURLInBrowser(url: string): void;
+declare module.exports: openURLInBrowser;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Devtools/parseErrorStack.js 1`] = `
+"declare function parseErrorStack(errorStack?: string): Array<StackFrame>;
+declare module.exports: parseErrorStack;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Devtools/parseHermesStack.js 1`] = `
+"type HermesStackLocationNative = $ReadOnly<{
+  type: \\"NATIVE\\",
+}>;
+type HermesStackLocationSource = $ReadOnly<{
+  type: \\"SOURCE\\",
+  sourceUrl: string,
+  line1Based: number,
+  column1Based: number,
+}>;
+type HermesStackLocationInternalBytecode = $ReadOnly<{
+  type: \\"INTERNAL_BYTECODE\\",
+  sourceUrl: string,
+  line1Based: number,
+  virtualOffset0Based: number,
+}>;
+type HermesStackLocationBytecode = $ReadOnly<{
+  type: \\"BYTECODE\\",
+  sourceUrl: string,
+  line1Based: number,
+  virtualOffset0Based: number,
+}>;
+type HermesStackLocation =
+  | HermesStackLocationNative
+  | HermesStackLocationSource
+  | HermesStackLocationInternalBytecode
+  | HermesStackLocationBytecode;
+type HermesStackEntryFrame = $ReadOnly<{
+  type: \\"FRAME\\",
+  location: HermesStackLocation,
+  functionName: string,
+}>;
+type HermesStackEntrySkipped = $ReadOnly<{
+  type: \\"SKIPPED\\",
+  count: number,
+}>;
+type HermesStackEntry = HermesStackEntryFrame | HermesStackEntrySkipped;
+export type HermesParsedStack = $ReadOnly<{
+  message: string,
+  entries: $ReadOnlyArray<HermesStackEntry>,
+}>;
+declare module.exports: (stack: string) => HermesParsedStack;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Devtools/symbolicateStackTrace.js 1`] = `
+"export type CodeFrame = $ReadOnly<{
+  content: string,
+  location: ?{
+    row: number,
+    column: number,
+    ...
+  },
+  fileName: string,
+}>;
+export type SymbolicatedStackTrace = $ReadOnly<{
+  stack: Array<StackFrame>,
+  codeFrame: ?CodeFrame,
+}>;
+declare function symbolicateStackTrace(
+  stack: Array<StackFrame>,
+  extraData?: mixed
+): Promise<SymbolicatedStackTrace>;
+declare module.exports: symbolicateStackTrace;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/ExceptionsManager.js 1`] = `
+"declare class SyntheticError extends Error {
+  name: string;
+}
+type ExceptionDecorator = (ExceptionData) => ExceptionData;
+declare const decoratedExtraDataKey: symbol;
+declare function unstable_setExceptionDecorator(
+  exceptionDecorator: ?ExceptionDecorator
+): void;
+declare function handleException(e: mixed, isFatal: boolean): void;
+declare function installConsoleErrorReporter(): void;
+declare module.exports: {
+  decoratedExtraDataKey: decoratedExtraDataKey,
+  handleException: handleException,
+  installConsoleErrorReporter: installConsoleErrorReporter,
+  SyntheticError: SyntheticError,
+  unstable_setExceptionDecorator: unstable_setExceptionDecorator,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/ExtendedError.js 1`] = `
+"export type ExtendedError = Error &
+  interface {
+    jsEngine?: string,
+    preventSymbolication?: boolean,
+    componentStack?: string,
+    isComponentError?: boolean,
+    type?: string,
+    cause?: {
+      name: string,
+      message: string,
+      stackElements?: $ReadOnlyArray<Object>,
+      stackSymbols?: $ReadOnlyArray<Object>,
+      stackReturnAddresses?: $ReadOnlyArray<Object>,
+    },
+  };
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/InitializeCore.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/NativeExceptionsManager.js 1`] = `
+"export type StackFrame = {|
+  column: ?number,
+  file: ?string,
+  lineNumber: ?number,
+  methodName: string,
+  collapse?: boolean,
+|};
+export type ExceptionData = {
+  message: string,
+  originalMessage: ?string,
+  name: ?string,
+  componentStack: ?string,
+  stack: Array<StackFrame>,
+  id: number,
+  isFatal: boolean,
+  extraData?: Object,
+  ...
+};
+export interface Spec extends TurboModule {
+  +reportFatalException: (
+    message: string,
+    stack: Array<StackFrame>,
+    exceptionId: number
+  ) => void;
+  +reportSoftException: (
+    message: string,
+    stack: Array<StackFrame>,
+    exceptionId: number
+  ) => void;
+  +reportException?: (data: ExceptionData) => void;
+  +updateExceptionMessage: (
+    message: string,
+    stack: Array<StackFrame>,
+    exceptionId: number
+  ) => void;
+  +dismissRedbox?: () => void;
+}
+declare const ExceptionsManager: {
+  reportFatalException(
+    message: string,
+    stack: Array<StackFrame>,
+    exceptionId: number
+  ): void,
+  reportSoftException(
+    message: string,
+    stack: Array<StackFrame>,
+    exceptionId: number
+  ): void,
+  updateExceptionMessage(
+    message: string,
+    stack: Array<StackFrame>,
+    exceptionId: number
+  ): void,
+  dismissRedbox(): void,
+  reportException(data: ExceptionData): void,
+};
+declare export default typeof ExceptionsManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/RawEventEmitter.js 1`] = `
+"export type RawEventEmitterEvent = $ReadOnly<{|
+  eventName: string,
+  nativeEvent: { [string]: mixed },
+|}>;
+type RawEventDefinitions = {
+  [eventChannel: string]: [RawEventEmitterEvent],
+};
+declare const RawEventEmitter: IEventEmitter<RawEventDefinitions>;
+declare export default typeof RawEventEmitter;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/ReactFiberErrorDialog.js 1`] = `
+"export type CapturedError = {
+  +componentStack: string,
+  +error: mixed,
+  +errorBoundary: ?{ ... },
+  ...
+};
+declare const ReactFiberErrorDialog: {
+  showErrorDialog(CapturedError): boolean,
+};
+declare export default typeof ReactFiberErrorDialog;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/SegmentFetcher/NativeSegmentFetcher.js 1`] = `
+"export interface Spec extends TurboModule {
+  +fetchSegment: (
+    segmentId: number,
+    options: Object,
+    callback: (error: ?Object) => void
+  ) => void;
+  +getSegment?: (
+    segmentId: number,
+    options: Object,
+    callback: (error: ?Object, path: ?string) => void
+  ) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Timers/JSTimers.js 1`] = `
+"export type JSTimerType =
+  | \\"setTimeout\\"
+  | \\"setInterval\\"
+  | \\"requestAnimationFrame\\"
+  | \\"queueReactNativeMicrotask\\"
+  | \\"requestIdleCallback\\";
+declare let ExportedJSTimers: {|
+  callIdleCallbacks: (frameTime: number) => any | void,
+  callReactNativeMicrotasks: () => void,
+  callTimers: (timersToCall: Array<number>) => any | void,
+  cancelAnimationFrame: (timerID: number) => void,
+  cancelIdleCallback: (timerID: number) => void,
+  clearReactNativeMicrotask: (timerID: number) => void,
+  clearInterval: (timerID: number) => void,
+  clearTimeout: (timerID: number) => void,
+  emitTimeDriftWarning: (warningMessage: string) => any | void,
+  requestAnimationFrame: (func: any) => any | number,
+  requestIdleCallback: (func: any, options: ?any) => any | number,
+  queueReactNativeMicrotask: (func: any, ...args: any) => number,
+  setInterval: (func: any, duration: number, ...args: any) => number,
+  setTimeout: (func: any, duration: number, ...args: any) => number,
+|};
+declare module.exports: ExportedJSTimers;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Timers/NativeTiming.js 1`] = `
+"export interface Spec extends TurboModule {
+  +createTimer: (
+    callbackID: number,
+    duration: number,
+    jsSchedulingTime: number,
+    repeats: boolean
+  ) => void;
+  +deleteTimer: (timerID: number) => void;
+  +setSendIdleEvents: (sendIdleEvents: boolean) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Timers/immediateShim.js 1`] = `
+"declare function setImmediate(callback: Function, ...args: any): number;
+declare function clearImmediate(immediateID: number): void;
+declare const immediateShim: {
+  setImmediate: setImmediate,
+  clearImmediate: clearImmediate,
+};
+declare module.exports: immediateShim;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/Timers/queueMicrotask.js 1`] = `
+"declare export default function queueMicrotask(callback: Function): void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/checkNativeVersion.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/polyfillPromise.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpAlert.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpBatchedBridge.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpDOM.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpDeveloperTools.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpErrorHandling.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpGlobals.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpIntersectionObserver.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpMutationObserver.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpNavigator.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpPerformance.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpPerformanceObserver.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpReactDevTools.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpReactRefresh.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpRegeneratorRuntime.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpSegmentFetcher.js 1`] = `
+"export type FetchSegmentFunction = typeof __fetchSegment;
+declare function __fetchSegment(
+  segmentId: number,
+  options: $ReadOnly<{
+    otaBuildNumber: ?string,
+    requestedModuleName: string,
+    segmentHash: string,
+  }>,
+  callback: (?Error) => void
+): void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpTimers.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/Core/setUpXHR.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/DOM/Geometry/DOMRect.js 1`] = `
+"declare export default class DOMRect extends DOMRectReadOnly {
+  get x(): number;
+  set x(x: ?number): void;
+  get y(): number;
+  set y(y: ?number): void;
+  get width(): number;
+  set width(width: ?number): void;
+  get height(): number;
+  set height(height: ?number): void;
+  static fromRect(rect?: ?DOMRectLike): DOMRect;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/Geometry/DOMRectReadOnly.js 1`] = `
+"export interface DOMRectLike {
+  x?: ?number;
+  y?: ?number;
+  width?: ?number;
+  height?: ?number;
+}
+declare export default class DOMRectReadOnly {
+  _x: number;
+  _y: number;
+  _width: number;
+  _height: number;
+  constructor(x: ?number, y: ?number, width: ?number, height: ?number): void;
+  get x(): number;
+  get y(): number;
+  get width(): number;
+  get height(): number;
+  get top(): number;
+  get right(): number;
+  get bottom(): number;
+  get left(): number;
+  toJSON(): {
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    top: number,
+    left: number,
+    bottom: number,
+    right: number,
+  };
+  static fromRect(rect?: ?DOMRectLike): DOMRectReadOnly;
+  __getInternalX(): number;
+  __getInternalY(): number;
+  __getInternalWidth(): number;
+  __getInternalHeight(): number;
+  __setInternalX(x: ?number): void;
+  __setInternalY(y: ?number): void;
+  __setInternalWidth(width: ?number): void;
+  __setInternalHeight(height: ?number): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/Nodes/ReactNativeElement.js 1`] = `
+"declare export default class ReactNativeElement
+  extends ReadOnlyElement
+  implements INativeMethods
+{
+  __nativeTag: number;
+  __internalInstanceHandle: InternalInstanceHandle;
+  _viewConfig: ViewConfig;
+  constructor(
+    tag: number,
+    viewConfig: ViewConfig,
+    internalInstanceHandle: InternalInstanceHandle
+  ): void;
+  get offsetHeight(): number;
+  get offsetLeft(): number;
+  get offsetParent(): ReadOnlyElement | null;
+  get offsetTop(): number;
+  get offsetWidth(): number;
+  blur(): void;
+  focus(): void;
+  measure(callback: MeasureOnSuccessCallback): void;
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void;
+  measureLayout(
+    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void
+  ): void;
+  setNativeProps(nativeProps: { ... }): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/Nodes/ReadOnlyCharacterData.js 1`] = `
+"declare export default class ReadOnlyCharacterData extends ReadOnlyNode {
+  get nextElementSibling(): ReadOnlyElement | null;
+  get previousElementSibling(): ReadOnlyElement | null;
+  get data(): string;
+  get length(): number;
+  get textContent(): string | null;
+  get nodeValue(): string;
+  substringData(offset: number, count: number): string;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/Nodes/ReadOnlyElement.js 1`] = `
+"declare export default class ReadOnlyElement extends ReadOnlyNode {
+  get childElementCount(): number;
+  get children(): HTMLCollection<ReadOnlyElement>;
+  get clientHeight(): number;
+  get clientLeft(): number;
+  get clientTop(): number;
+  get clientWidth(): number;
+  get firstElementChild(): ReadOnlyElement | null;
+  get id(): string;
+  get lastElementChild(): ReadOnlyElement | null;
+  get nextElementSibling(): ReadOnlyElement | null;
+  get nodeName(): string;
+  get nodeType(): number;
+  get nodeValue(): string | null;
+  set nodeValue(value: string): void;
+  get previousElementSibling(): ReadOnlyElement | null;
+  get scrollHeight(): number;
+  get scrollLeft(): number;
+  get scrollTop(): number;
+  get scrollWidth(): number;
+  get tagName(): string;
+  get textContent(): string | null;
+  getBoundingClientRect(): DOMRect;
+  hasPointerCapture(pointerId: number): boolean;
+  setPointerCapture(pointerId: number): void;
+  releasePointerCapture(pointerId: number): void;
+}
+declare export function getBoundingClientRect(
+  node: ReadOnlyElement,
+  { includeTransform: boolean }
+): DOMRect;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/Nodes/ReadOnlyNode.js 1`] = `
+"declare export default class ReadOnlyNode {
+  constructor(internalInstanceHandle: InternalInstanceHandle): void;
+  get childNodes(): NodeList<ReadOnlyNode>;
+  get firstChild(): ReadOnlyNode | null;
+  get isConnected(): boolean;
+  get lastChild(): ReadOnlyNode | null;
+  get nextSibling(): ReadOnlyNode | null;
+  get nodeName(): string;
+  get nodeType(): number;
+  get nodeValue(): string | null;
+  get parentElement(): ReadOnlyElement | null;
+  get parentNode(): ReadOnlyNode | null;
+  get previousSibling(): ReadOnlyNode | null;
+  get textContent(): string | null;
+  compareDocumentPosition(otherNode: ReadOnlyNode): number;
+  contains(otherNode: ReadOnlyNode): boolean;
+  getRootNode(): ReadOnlyNode;
+  hasChildNodes(): boolean;
+  static ELEMENT_NODE: number;
+  static ATTRIBUTE_NODE: number;
+  static TEXT_NODE: number;
+  static CDATA_SECTION_NODE: number;
+  static ENTITY_REFERENCE_NODE: number;
+  static ENTITY_NODE: number;
+  static PROCESSING_INSTRUCTION_NODE: number;
+  static COMMENT_NODE: number;
+  static DOCUMENT_NODE: number;
+  static DOCUMENT_TYPE_NODE: number;
+  static DOCUMENT_FRAGMENT_NODE: number;
+  static NOTATION_NODE: number;
+  static DOCUMENT_POSITION_DISCONNECTED: number;
+  static DOCUMENT_POSITION_PRECEDING: number;
+  static DOCUMENT_POSITION_FOLLOWING: number;
+  static DOCUMENT_POSITION_CONTAINS: number;
+  static DOCUMENT_POSITION_CONTAINED_BY: number;
+  static DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: number;
+}
+declare export function getInstanceHandle(
+  node: ReadOnlyNode
+): InternalInstanceHandle;
+declare export function getShadowNode(node: ReadOnlyNode): ?ShadowNode;
+declare export function getChildNodes(
+  node: ReadOnlyNode
+): $ReadOnlyArray<ReadOnlyNode>;
+declare export function getPublicInstanceFromInternalInstanceHandle(
+  instanceHandle: InternalInstanceHandle
+): ?ReadOnlyNode;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/Nodes/ReadOnlyText.js 1`] = `
+"declare export default class ReadOnlyText extends ReadOnlyCharacterData {
+  get nodeName(): string;
+  get nodeType(): number;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/Nodes/Utilities/Traversal.js 1`] = `
+"declare export function getElementSibling(
+  node: ReadOnlyNode,
+  direction: \\"next\\" | \\"previous\\"
+): ReadOnlyElement | null;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/OldStyleCollections/ArrayLikeUtils.js 1`] = `
+"export interface ArrayLike<T> extends Iterable<T> {
+  [indexer: number]: T;
+  +length: number;
+}
+declare export function createValueIterator<T>(
+  arrayLike: ArrayLike<T>
+): Iterator<T>;
+declare export function createKeyIterator<T>(
+  arrayLike: ArrayLike<T>
+): Iterator<number>;
+declare export function createEntriesIterator<T>(
+  arrayLike: ArrayLike<T>
+): Iterator<[number, T]>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/OldStyleCollections/DOMRectList.js.flow 1`] = `
+"declare export default class DOMRectList
+  implements Iterable<DOMRectReadOnly>, ArrayLike<DOMRectReadOnly>
+{
+  [index: number]: DOMRectReadOnly;
+  +length: number;
+  item(index: number): DOMRectReadOnly | null;
+  @@iterator(): Iterator<DOMRectReadOnly>;
+}
+declare export function createDOMRectList(
+  domRects: $ReadOnlyArray<DOMRectReadOnly>
+): DOMRectList;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/OldStyleCollections/HTMLCollection.js.flow 1`] = `
+"declare export default class HTMLCollection<+T>
+  implements Iterable<T>, ArrayLike<T>
+{
+  [index: number]: T;
+  +length: number;
+  item(index: number): T | null;
+  namedItem(name: string): T | null;
+  @@iterator(): Iterator<T>;
+}
+declare export function createHTMLCollection<T>(
+  elements: $ReadOnlyArray<T>
+): HTMLCollection<T>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DOM/OldStyleCollections/NodeList.js.flow 1`] = `
+"declare export default class NodeList<+T> implements Iterable<T>, ArrayLike<T> {
+  [index: number]: T;
+  +length: number;
+  item(index: number): T | null;
+  entries(): Iterator<[number, T]>;
+  forEach<ThisType>(
+    callbackFn: (value: T, index: number, array: NodeList<T>) => mixed,
+    thisArg?: ThisType
+  ): void;
+  keys(): Iterator<number>;
+  values(): Iterator<T>;
+  @@iterator(): Iterator<T>;
+}
+declare export function createNodeList<T>(
+  elements: $ReadOnlyArray<T>
+): NodeList<T>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Debugging/DebuggingOverlayNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+|}>;
+export type DebuggingOverlayNativeComponentType = HostComponent<NativeProps>;
+export type Overlay = {
+  rect: { left: number, top: number, width: number, height: number },
+  color: ?ProcessedColorValue,
+};
+interface NativeCommands {
+  +draw: (
+    viewRef: React.ElementRef<DebuggingOverlayNativeComponentType>,
+    overlays: string
+  ) => void;
+}
+declare export const Commands: NativeCommands;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DevToolsSettings/DevToolsSettingsManager.android.js 1`] = `
+"declare module.exports: {
+  setConsolePatchSettings(newSettings: string): void,
+  getConsolePatchSettings(): ?string,
+  setProfilingSettings(newSettings: string): void,
+  getProfilingSettings(): ?string,
+  reload(): void,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DevToolsSettings/DevToolsSettingsManager.ios.js 1`] = `
+"declare const DevToolsSettingsManager: {
+  setConsolePatchSettings(newConsolePatchSettings: string): void,
+  getConsolePatchSettings(): ?string,
+  setProfilingSettings(newProfilingSettings: string): void,
+  getProfilingSettings(): ?string,
+  reload(): void,
+};
+declare module.exports: DevToolsSettingsManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DevToolsSettings/DevToolsSettingsManager.js.flow 1`] = `
+"declare const DevToolsSettingsManager: {
+  setConsolePatchSettings(newConsolePatchSettings: string): void,
+  getConsolePatchSettings(): ?string,
+  setProfilingSettings(newProfilingSettings: string): void,
+  getProfilingSettings(): ?string,
+  reload(): void,
+};
+declare module.exports: DevToolsSettingsManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/DevToolsSettings/NativeDevToolsSettingsManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +setConsolePatchSettings: (newConsolePatchSettings: string) => void;
+  +getConsolePatchSettings: () => ?string;
+  +setProfilingSettings?: (newProfilingSettings: string) => void;
+  +getProfilingSettings?: () => ?string;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/EventEmitter/NativeEventEmitter.js 1`] = `
+"interface NativeModule {
+  addListener(eventType: string): void;
+  removeListeners(count: number): void;
+}
+export type { EventSubscription };
+declare export default class NativeEventEmitter<TEventToArgsMap: { ... }>
+  implements IEventEmitter<TEventToArgsMap>
+{
+  _nativeModule: ?NativeModule;
+  constructor(nativeModule: ?NativeModule): void;
+  addListener<TEvent: $Keys<TEventToArgsMap>>(
+    eventType: TEvent,
+    listener: (...args: $ElementType<TEventToArgsMap, TEvent>) => mixed,
+    context?: mixed
+  ): EventSubscription;
+  emit<TEvent: $Keys<TEventToArgsMap>>(
+    eventType: TEvent,
+    ...args: $ElementType<TEventToArgsMap, TEvent>
+  ): void;
+  removeAllListeners<TEvent: $Keys<TEventToArgsMap>>(eventType?: ?TEvent): void;
+  listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/EventEmitter/RCTDeviceEventEmitter.js 1`] = `
+"type RCTDeviceEventDefinitions = $FlowFixMe;
+declare export default IEventEmitter<RCTDeviceEventDefinitions>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/EventEmitter/RCTEventEmitter.js 1`] = `
+"declare const RCTEventEmitter: { register(eventEmitter: any): void };
+declare module.exports: RCTEventEmitter;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/EventEmitter/RCTNativeAppEventEmitter.js 1`] = `
+"declare const RCTNativeAppEventEmitter: typeof RCTDeviceEventEmitter;
+declare module.exports: RCTNativeAppEventEmitter;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Events/CustomEvent.js 1`] = `
+"type CustomEvent$Options = $ReadOnly<{|
+  bubbles?: boolean,
+  cancelable?: boolean,
+  composed?: boolean,
+  detail?: { ... },
+|}>;
+declare class CustomEvent extends EventPolyfill {
+  detail: ?{ ... };
+  constructor(typeArg: string, options: CustomEvent$Options): void;
+}
+declare export default typeof CustomEvent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Events/EventPolyfill.js 1`] = `
+"type Event$Init = {
+  bubbles?: boolean,
+  cancelable?: boolean,
+  composed?: boolean,
+  scoped?: boolean,
+  ...
+};
+interface IEvent {
+  constructor(type: string, eventInitDict?: Event$Init): void;
+  +type: string;
+  +target: EventTarget;
+  +srcElement: Element;
+  +currentTarget: EventTarget;
+  composedPath(): Array<EventTarget>;
+  +NONE: number;
+  +AT_TARGET: number;
+  +BUBBLING_PHASE: number;
+  +CAPTURING_PHASE: number;
+  +eventPhase: number;
+  stopPropagation(): void;
+  stopImmediatePropagation(): void;
+  +bubbles: boolean;
+  +cancelable: boolean;
+  preventDefault(): void;
+  +defaultPrevented: boolean;
+  +composed: boolean;
+  +isTrusted: boolean;
+  +timeStamp: number;
+  +deepPath?: () => EventTarget[];
+  +scoped: boolean;
+  initEvent(type: string, bubbles: boolean, cancelable: boolean): void;
+}
+declare class EventPolyfill implements IEvent {
+  type: string;
+  bubbles: boolean;
+  cancelable: boolean;
+  composed: boolean;
+  scoped: boolean;
+  isTrusted: boolean;
+  defaultPrevented: boolean;
+  timeStamp: number;
+  NONE: number;
+  AT_TARGET: number;
+  BUBBLING_PHASE: number;
+  CAPTURING_PHASE: number;
+  eventPhase: number;
+  currentTarget: EventTarget;
+  target: EventTarget;
+  srcElement: Element;
+  _syntheticEvent: mixed;
+  constructor(type: string, eventInitDict?: Event$Init): void;
+  composedPath(): Array<EventTarget>;
+  preventDefault(): void;
+  initEvent(type: string, bubbles: boolean, cancelable: boolean): void;
+  stopImmediatePropagation(): void;
+  stopPropagation(): void;
+  setSyntheticEvent(value: mixed): void;
+}
+declare export default typeof EventPolyfill;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/HeapCapture/HeapCapture.js 1`] = `
+"declare const HeapCapture: { captureHeap: (path: string) => void };
+declare module.exports: HeapCapture;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/HeapCapture/NativeJSCHeapCapture.js 1`] = `
+"export interface Spec extends TurboModule {
+  +captureComplete: (path: string, error: ?string) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/AssetRegistry.js 1`] = `
+"declare module.exports: $FlowFixMe;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/AssetSourceResolver.js 1`] = `
+"export type ResolvedAssetSource = {|
+  +__packager_asset: boolean,
+  +width: ?number,
+  +height: ?number,
+  +uri: string,
+  +scale: number,
+|};
+declare class AssetSourceResolver {
+  serverUrl: ?string;
+  jsbundleUrl: ?string;
+  asset: PackagerAsset;
+  constructor(
+    serverUrl: ?string,
+    jsbundleUrl: ?string,
+    asset: PackagerAsset
+  ): void;
+  isLoadedFromServer(): boolean;
+  isLoadedFromFileSystem(): boolean;
+  defaultAsset(): ResolvedAssetSource;
+  assetServerURL(): ResolvedAssetSource;
+  scaledAssetPath(): ResolvedAssetSource;
+  scaledAssetURLNearBundle(): ResolvedAssetSource;
+  resourceIdentifierWithoutScale(): ResolvedAssetSource;
+  drawableFolderInBundle(): ResolvedAssetSource;
+  fromSource(source: string): ResolvedAssetSource;
+  static pickScale: (scales: Array<number>, deviceScale?: number) => number;
+}
+declare module.exports: AssetSourceResolver;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/AssetUtils.js 1`] = `
+"declare export function pickScale(
+  scales: Array<number>,
+  deviceScale?: number
+): number;
+declare export function setUrlCacheBreaker(appendage: string): void;
+declare export function getUrlCacheBreaker(): string;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/Image.android.js 1`] = `
+"declare const Image: ImageAndroid;
+declare module.exports: Image;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/Image.ios.js 1`] = `
+"declare const Image: ImageIOS;
+declare module.exports: Image;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/Image.js.flow 1`] = `
+"declare module.exports: Image;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageAnalyticsTagContext.js 1`] = `
+"type ContextType = ?string;
+declare const Context: React.Context<ContextType>;
+declare export default typeof Context;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageInjection.js 1`] = `
+"type ImageComponentDecorator =
+  ((AbstractImageAndroid) => AbstractImageAndroid) &
+    ((AbstractImageIOS) => AbstractImageIOS);
+declare export function unstable_setImageComponentDecorator(
+  imageComponentDecorator: ?ImageComponentDecorator
+): void;
+declare export function unstable_getImageComponentDecorator(): ?ImageComponentDecorator;
+type ImageInstance = React.ElementRef<ImageComponent>;
+type ImageAttachedCallback = (
+  imageInstance: ImageInstance
+) => void | (() => void);
+declare export function unstable_registerImageAttachedCallback(
+  callback: ImageAttachedCallback
+): void;
+declare export function unstable_unregisterImageAttachedCallback(
+  callback: ImageAttachedCallback
+): void;
+declare export function useWrapRefWithImageAttachedCallbacks(
+  forwardedRef: React.RefSetter<ImageInstance>
+): React.RefSetter<ImageInstance>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageProps.js 1`] = `
+"export type ImageLoadEvent = SyntheticEvent<
+  $ReadOnly<{|
+    source: $ReadOnly<{|
+      width: number,
+      height: number,
+      uri: string,
+    |}>,
+  |}>,
+>;
+type IOSImageProps = $ReadOnly<{|
+  defaultSource?: ?ImageSource,
+  onPartialLoad?: ?() => void,
+  onProgress?: ?(
+    event: SyntheticEvent<$ReadOnly<{| loaded: number, total: number |}>>
+  ) => void,
+|}>;
+type AndroidImageProps = $ReadOnly<{|
+  loadingIndicatorSource?: ?(number | $ReadOnly<{| uri: string |}>),
+  progressiveRenderingEnabled?: ?boolean,
+  fadeDuration?: ?number,
+|}>;
+export type ImageProps = {|
+  ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
+  ...IOSImageProps,
+  ...AndroidImageProps,
+  accessible?: ?boolean,
+  internal_analyticTag?: ?string,
+  accessibilityLabel?: ?Stringish,
+  \\"aria-label\\"?: ?Stringish,
+  \\"aria-labelledby\\"?: ?string,
+  alt?: ?Stringish,
+  blurRadius?: ?number,
+  capInsets?: ?EdgeInsetsProp,
+  crossOrigin?: ?(\\"anonymous\\" | \\"use-credentials\\"),
+  height?: number,
+  width?: number,
+  onError?: ?(
+    event: SyntheticEvent<
+      $ReadOnly<{|
+        error: string,
+      |}>,
+    >
+  ) => void,
+  onLayout?: ?(event: LayoutEvent) => mixed,
+  onLoad?: ?(event: ImageLoadEvent) => void,
+  onLoadEnd?: ?() => void,
+  onLoadStart?: ?() => void,
+  resizeMethod?: ?(\\"auto\\" | \\"resize\\" | \\"scale\\"),
+  source?: ?ImageSource,
+  style?: ?ImageStyleProp,
+  referrerPolicy?: ?(
+    | \\"no-referrer\\"
+    | \\"no-referrer-when-downgrade\\"
+    | \\"origin\\"
+    | \\"origin-when-cross-origin\\"
+    | \\"same-origin\\"
+    | \\"strict-origin\\"
+    | \\"strict-origin-when-cross-origin\\"
+    | \\"unsafe-url\\"
+  ),
+  resizeMode?: ?(\\"cover\\" | \\"contain\\" | \\"stretch\\" | \\"repeat\\" | \\"center\\"),
+  testID?: ?string,
+  tintColor?: ColorValue,
+  src?: ?string,
+  srcSet?: ?string,
+  children?: empty,
+|};
+export type ImageBackgroundProps = $ReadOnly<{|
+  ...ImageProps,
+  children?: Node,
+  style?: ?ViewStyleProp,
+  imageStyle?: ?ImageStyleProp,
+  imageRef?: Ref<Image>,
+|}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageResizeMode.js 1`] = `
+"export type ImageResizeMode =
+  | \\"center\\"
+  | \\"contain\\"
+  | \\"cover\\"
+  | \\"repeat\\"
+  | \\"stretch\\";
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageSource.js 1`] = `
+"export interface ImageURISource {
+  +uri?: ?string;
+  +bundle?: ?string;
+  +method?: ?string;
+  +headers?: ?{ [string]: string };
+  +body?: ?string;
+  +cache?: ?(\\"default\\" | \\"reload\\" | \\"force-cache\\" | \\"only-if-cached\\");
+  +width?: ?number;
+  +height?: ?number;
+  +scale?: ?number;
+}
+export type ImageSource =
+  | number
+  | ImageURISource
+  | $ReadOnlyArray<ImageURISource>;
+type ImageSourceProperties = {
+  body?: ?string,
+  bundle?: ?string,
+  cache?: ?(\\"default\\" | \\"reload\\" | \\"force-cache\\" | \\"only-if-cached\\"),
+  headers?: ?{ [string]: string },
+  height?: ?number,
+  method?: ?string,
+  scale?: ?number,
+  uri?: ?string,
+  width?: ?number,
+  ...
+};
+declare export function getImageSourceProperties(
+  imageSource: ImageURISource
+): $ReadOnly<ImageSourceProperties>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageSourceUtils.js 1`] = `
+"declare export function getImageSourcesFromImageProps(
+  imageProps: ImageProps
+): ?ResolvedAssetSource | $ReadOnlyArray<{ uri: string, ... }>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageTypes.flow.js 1`] = `
+"type ImageComponentStaticsIOS = $ReadOnly<{
+  getSize: (
+    uri: string,
+    success: (width: number, height: number) => void,
+    failure?: (error: mixed) => void
+  ) => void,
+  getSizeWithHeaders(
+    uri: string,
+    headers: { [string]: string, ... },
+    success: (width: number, height: number) => void,
+    failure?: (error: mixed) => void
+  ): void,
+  prefetch(url: string): Promise<boolean>,
+  prefetchWithMetadata(
+    url: string,
+    queryRootName: string,
+    rootTag?: ?RootTag
+  ): Promise<boolean>,
+  queryCache(
+    urls: Array<string>
+  ): Promise<{ [string]: \\"memory\\" | \\"disk\\" | \\"disk/memory\\", ... }>,
+  resolveAssetSource(source: ImageSource): ?ResolvedAssetSource,
+}>;
+type ImageComponentStaticsAndroid = $ReadOnly<{
+  ...ImageComponentStaticsIOS,
+  abortPrefetch(requestId: number): void,
+}>;
+export type AbstractImageAndroid = React.AbstractComponent<
+  ImagePropsType,
+  | React.ElementRef<TextInlineImageNativeComponent>
+  | React.ElementRef<ImageViewNativeComponent>,
+>;
+export type ImageAndroid = AbstractImageAndroid & ImageComponentStaticsAndroid;
+export type AbstractImageIOS = React.AbstractComponent<
+  ImagePropsType,
+  React.ElementRef<ImageViewNativeComponent>,
+>;
+export type ImageIOS = AbstractImageIOS & ImageComponentStaticsIOS;
+export type Image = ImageIOS | ImageAndroid;
+export type { ImageProps } from \\"./ImageProps\\";
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageUtils.js 1`] = `
+"type ResizeMode = \\"cover\\" | \\"contain\\" | \\"stretch\\" | \\"repeat\\" | \\"center\\";
+declare export function convertObjectFitToResizeMode(
+  objectFit: string
+): ResizeMode;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/ImageViewNativeComponent.js 1`] = `
+"type Props = $ReadOnly<{
+  ...ImageProps,
+  ...ViewProps,
+  style?: ImageStyleProp | DangerouslyImpreciseStyle,
+  tintColor?: ColorValue,
+  shouldNotifyLoadEvents?: boolean,
+  src?:
+    | ?ResolvedAssetSource
+    | ?$ReadOnlyArray<?$ReadOnly<{ uri?: ?string, ... }>>,
+  headers?: ?{ [string]: string },
+  defaultSrc?: ?string,
+  loadingIndicatorSrc?: ?string,
+}>;
+interface NativeCommands {
+  +setIsVisible_EXPERIMENTAL: (
+    viewRef: ElementRef<HostComponent<mixed>>,
+    isVisible: boolean
+  ) => void;
+}
+declare export const Commands: NativeCommands;
+declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare const ImageViewNativeComponent: HostComponent<Props>;
+declare export default typeof ImageViewNativeComponent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/NativeImageEditor.js 1`] = `
+"type Options = {|
+  +offset: {|
+    +x: number,
+    +y: number,
+  |},
+  +size: {|
+    +width: number,
+    +height: number,
+  |},
+  +displaySize?: ?{|
+    +width: number,
+    +height: number,
+  |},
+  +resizeMode?: ?string,
+  +allowExternalStorage?: boolean,
+|};
+export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +cropImage: (
+    uri: string,
+    cropData: Options,
+    successCallback: (uri: string) => void,
+    errorCallback: (error: string) => void
+  ) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/NativeImageLoaderAndroid.js 1`] = `
+"export type ImageSize = {
+  width: number,
+  height: number,
+  ...
+};
+export interface Spec extends TurboModule {
+  +abortRequest: (requestId: number) => void;
+  +getConstants: () => {||};
+  +getSize: (uri: string) => Promise<ImageSize>;
+  +getSizeWithHeaders: (uri: string, headers: Object) => Promise<ImageSize>;
+  +prefetchImage: (uri: string, requestId: number) => Promise<boolean>;
+  +queryCache: (uris: Array<string>) => Promise<Object>;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/NativeImageLoaderIOS.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +getSize: (uri: string) => Promise<$ReadOnlyArray<number>>;
+  +getSizeWithHeaders: (
+    uri: string,
+    headers: Object
+  ) => Promise<{
+    width: number,
+    height: number,
+    ...
+  }>;
+  +prefetchImage: (uri: string) => Promise<boolean>;
+  +prefetchImageWithMetadata?: (
+    uri: string,
+    queryRootName: string,
+    rootTag: RootTag
+  ) => Promise<boolean>;
+  +queryCache: (uris: Array<string>) => Promise<Object>;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/NativeImageStoreAndroid.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +getBase64ForTag: (
+    uri: string,
+    successCallback: (base64ImageData: string) => void,
+    errorCallback: (error: string) => void
+  ) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/NativeImageStoreIOS.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +getBase64ForTag: (
+    uri: string,
+    successCallback: (base64ImageData: string) => void,
+    errorCallback: (error: {| message: string |}) => void
+  ) => void;
+  +hasImageForTag: (uri: string, callback: (hasImage: boolean) => void) => void;
+  +removeImageForTag: (uri: string) => void;
+  +addImageFromBase64: (
+    base64ImageData: string,
+    successCallback: (uri: string) => void,
+    errorCallback: (error: {| message: string |}) => void
+  ) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/RelativeImageStub.js 1`] = `
+"declare module.exports: number;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/TextInlineImageNativeComponent.js 1`] = `
+"type NativeProps = $ReadOnly<{
+  ...ViewProps,
+  resizeMode?: ?ImageResizeMode,
+  src?: ?$ReadOnlyArray<?$ReadOnly<{ uri?: ?string, ... }>>,
+  tintColor?: ?ColorValue,
+  headers?: ?{ [string]: string },
+}>;
+declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
+declare const TextInlineImage: HostComponent<NativeProps>;
+declare export default typeof TextInlineImage;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/nativeImageSource.js 1`] = `
+"type NativeImageSourceSpec = $ReadOnly<{|
+  android?: string,
+  ios?: string,
+  default?: string,
+  height: number,
+  width: number,
+|}>;
+declare function nativeImageSource(spec: NativeImageSourceSpec): ImageURISource;
+declare module.exports: nativeImageSource;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Image/resolveAssetSource.js 1`] = `
+"declare function resolveAssetSource(source: ?ImageSource): ?ResolvedAssetSource;
+declare module.exports: resolveAssetSource;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Inspector/Inspector.js 1`] = `
+"declare const View: $FlowFixMe;
+declare const React: $FlowFixMe;
+export type InspectedElementFrame = TouchedViewDataAtPoint[\\"frame\\"];
+export type InspectedElementSource = InspectorData[\\"source\\"];
+export type InspectedElement = $ReadOnly<{
+  frame: InspectedElementFrame,
+  source?: InspectedElementSource,
+  style?: ViewStyleProp,
+}>;
+export type ElementsHierarchy = InspectorData[\\"hierarchy\\"];
+type Props = {
+  inspectedViewRef: React.RefObject<React.ElementRef<typeof View> | null>,
+  onRequestRerenderApp: () => void,
+  reactDevToolsAgent?: ReactDevToolsAgent,
+};
+declare function Inspector(Props): React.Node;
+declare module.exports: Inspector;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Inspector/InspectorOverlay.js 1`] = `
+"declare const React: $FlowFixMe;
+type Props = $ReadOnly<{|
+  inspected?: ?InspectedElement,
+  onTouchPoint: (locationX: number, locationY: number) => void,
+|}>;
+declare function InspectorOverlay(Props): React.Node;
+declare module.exports: InspectorOverlay;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Inspector/ReactDevToolsOverlay.js 1`] = `
+"type Props = {
+  inspectedViewRef: React.RefObject<React.ElementRef<typeof View> | null>,
+  reactDevToolsAgent: ReactDevToolsAgent,
+};
+declare export default function ReactDevToolsOverlay(Props): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Inspector/getInspectorDataForViewAtPoint.js 1`] = `
+"declare const React: $FlowFixMe;
+export type HostRef = React.ElementRef<HostComponent<mixed>>;
+export type ReactRenderer = {
+  rendererConfig: {
+    getInspectorDataForViewAtPoint: (
+      inspectedView: ?HostRef,
+      locationX: number,
+      locationY: number,
+      callback: Function
+    ) => void,
+    ...
+  },
+};
+declare module.exports: (
+  inspectedView: ?HostRef,
+  locationX: number,
+  locationY: number,
+  callback: (viewData: TouchedViewDataAtPoint) => boolean
+) => void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Inspector/resolveBoxStyle.js 1`] = `
+"declare function resolveBoxStyle(
+  prefix: string,
+  style: Object
+): ?$ReadOnly<{|
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
+|}>;
+declare module.exports: resolveBoxStyle;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Interaction/FrameRateLogger.js 1`] = `
+"declare const FrameRateLogger: {
+  setGlobalOptions: (options: { debug?: boolean, ... }) => void,
+  setContext: (context: string) => void,
+  beginScroll(): void,
+  endScroll(): void,
+};
+declare module.exports: FrameRateLogger;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Interaction/InteractionManager.js 1`] = `
+"export type Handle = number;
+declare const InteractionManager: {
+  Events: {
+    interactionStart: \\"interactionStart\\",
+    interactionComplete: \\"interactionComplete\\",
+  },
+  runAfterInteractions(task: ?Task): {
+    then: <U>(
+      onFulfill?: ?(void) => ?(Promise<U> | U),
+      onReject?: ?(error: mixed) => ?(Promise<U> | U)
+    ) => Promise<U>,
+    cancel: () => void,
+    ...
+  },
+  createInteractionHandle(): Handle,
+  clearInteractionHandle(handle: Handle): void,
+  addListener: $FlowFixMe,
+  setDeadline(deadline: number): void,
+};
+declare module.exports: InteractionManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Interaction/JSEventLoopWatchdog.js 1`] = `
+"type Handler = {
+  onIterate?: () => void,
+  onStall: (params: { lastInterval: number, busyTime: number, ... }) => ?string,
+  ...
+};
+declare const JSEventLoopWatchdog: {
+  getStats: () => Object,
+  reset: () => void,
+  addHandler: (handler: Handler) => void,
+  install: ({ thresholdMS: number, ... }) => void,
+};
+declare module.exports: JSEventLoopWatchdog;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Interaction/NativeFrameRateLogger.js 1`] = `
+"export interface Spec extends TurboModule {
+  +setGlobalOptions: (options: {| +debug?: ?boolean |}) => void;
+  +setContext: (context: string) => void;
+  +beginScroll: () => void;
+  +endScroll: () => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Interaction/PanResponder.js 1`] = `
+"export type GestureState = {|
+  stateID: number,
+  moveX: number,
+  moveY: number,
+  x0: number,
+  y0: number,
+  dx: number,
+  dy: number,
+  vx: number,
+  vy: number,
+  numberActiveTouches: number,
+  _accountsForMovesUpTo: number,
+|};
+type ActiveCallback = (
+  event: PressEvent,
+  gestureState: GestureState
+) => boolean;
+type PassiveCallback = (event: PressEvent, gestureState: GestureState) => mixed;
+export type PanHandlers = {|
+  onMoveShouldSetResponder: (event: PressEvent) => boolean,
+  onMoveShouldSetResponderCapture: (event: PressEvent) => boolean,
+  onResponderEnd: (event: PressEvent) => void,
+  onResponderGrant: (event: PressEvent) => boolean,
+  onResponderMove: (event: PressEvent) => void,
+  onResponderReject: (event: PressEvent) => void,
+  onResponderRelease: (event: PressEvent) => void,
+  onResponderStart: (event: PressEvent) => void,
+  onResponderTerminate: (event: PressEvent) => void,
+  onResponderTerminationRequest: (event: PressEvent) => boolean,
+  onStartShouldSetResponder: (event: PressEvent) => boolean,
+  onStartShouldSetResponderCapture: (event: PressEvent) => boolean,
+|};
+type PanResponderConfig = $ReadOnly<{|
+  onMoveShouldSetPanResponder?: ?ActiveCallback,
+  onMoveShouldSetPanResponderCapture?: ?ActiveCallback,
+  onStartShouldSetPanResponder?: ?ActiveCallback,
+  onStartShouldSetPanResponderCapture?: ?ActiveCallback,
+  onPanResponderGrant?: ?(PassiveCallback | ActiveCallback),
+  onPanResponderReject?: ?PassiveCallback,
+  onPanResponderStart?: ?PassiveCallback,
+  onPanResponderEnd?: ?PassiveCallback,
+  onPanResponderRelease?: ?PassiveCallback,
+  onPanResponderMove?: ?PassiveCallback,
+  onPanResponderTerminate?: ?PassiveCallback,
+  onPanResponderTerminationRequest?: ?ActiveCallback,
+  onShouldBlockNativeResponder?: ?ActiveCallback,
+|}>;
+declare const PanResponder: {
+  _initializeGestureState(gestureState: GestureState): void,
+  _updateGestureStateOnMove(
+    gestureState: GestureState,
+    touchHistory: $PropertyType<PressEvent, \\"touchHistory\\">
+  ): void,
+  create(config: PanResponderConfig): {
+    getInteractionHandle: () => ?number,
+    panHandlers: PanHandlers,
+  },
+};
+export type PanResponderInstance = ReturnType<(typeof PanResponder)[\\"create\\"]>;
+declare export default typeof PanResponder;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Interaction/TaskQueue.js 1`] = `
+"type SimpleTask = {
+  name: string,
+  run: () => void,
+};
+type PromiseTask = {
+  name: string,
+  gen: () => Promise<void>,
+};
+export type Task = SimpleTask | PromiseTask | (() => void);
+declare class TaskQueue {
+  constructor({ onMoreTasks: () => void, ... }): void;
+  enqueue(task: Task): void;
+  enqueueTasks(tasks: Array<Task>): void;
+  cancelTasks(tasksToCancel: Array<Task>): void;
+  hasTasksToProcess(): boolean;
+  processNext(): void;
+  _queueStack: Array<{
+    tasks: Array<Task>,
+    popable: boolean,
+    ...
+  }>;
+  _onMoreTasks: () => void;
+  _getCurrentQueue(): Array<Task>;
+  _genPromise(task: PromiseTask): void;
+}
+declare module.exports: TaskQueue;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Interaction/TouchHistoryMath.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/IntersectionObserver/IntersectionObserver.js 1`] = `
+"export type IntersectionObserverCallback = (
+  entries: Array<IntersectionObserverEntry>,
+  observer: IntersectionObserver
+) => mixed;
+type IntersectionObserverInit = {
+  threshold?: number | $ReadOnlyArray<number>,
+};
+declare export default class IntersectionObserver {
+  _callback: IntersectionObserverCallback;
+  _thresholds: $ReadOnlyArray<number>;
+  _observationTargets: Set<ReactNativeElement>;
+  _intersectionObserverId: ?IntersectionObserverId;
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit
+  ): void;
+  get root(): ReactNativeElement | null;
+  get rootMargin(): string;
+  get thresholds(): $ReadOnlyArray<number>;
+  observe(target: ReactNativeElement): void;
+  unobserve(target: ReactNativeElement): void;
+  disconnect(): void;
+  _getOrCreateIntersectionObserverId(): IntersectionObserverId;
+  __getObserverID(): ?IntersectionObserverId;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/IntersectionObserver/IntersectionObserverEntry.js 1`] = `
+"declare export default class IntersectionObserverEntry {
+  _nativeEntry: NativeIntersectionObserverEntry;
+  _target: ReactNativeElement;
+  constructor(
+    nativeEntry: NativeIntersectionObserverEntry,
+    target: ReactNativeElement
+  ): void;
+  get boundingClientRect(): DOMRectReadOnly;
+  get intersectionRatio(): number;
+  get intersectionRect(): DOMRectReadOnly;
+  get isIntersecting(): boolean;
+  get rootBounds(): DOMRectReadOnly;
+  get target(): ReactNativeElement;
+  get time(): DOMHighResTimeStamp;
+}
+declare export function createIntersectionObserverEntry(
+  entry: NativeIntersectionObserverEntry,
+  target: ReactNativeElement
+): IntersectionObserverEntry;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/IntersectionObserver/IntersectionObserverManager.js 1`] = `
+"export type IntersectionObserverId = number;
+declare export function registerObserver(
+  observer: IntersectionObserver,
+  callback: IntersectionObserverCallback
+): IntersectionObserverId;
+declare export function unregisterObserver(
+  intersectionObserverId: IntersectionObserverId
+): void;
+declare export function observe({
+  intersectionObserverId: IntersectionObserverId,
+  target: ReactNativeElement,
+}): void;
+declare export function unobserve(
+  intersectionObserverId: number,
+  target: ReactNativeElement
+): void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/IntersectionObserver/NativeIntersectionObserver.js 1`] = `
+"export type NativeIntersectionObserverEntry = {
+  intersectionObserverId: number,
+  targetInstanceHandle: mixed,
+  targetRect: $ReadOnlyArray<number>,
+  rootRect: $ReadOnlyArray<number>,
+  intersectionRect: ?$ReadOnlyArray<number>,
+  isIntersectingAboveThresholds: boolean,
+  time: number,
+};
+export type NativeIntersectionObserverObserveOptions = {
+  intersectionObserverId: number,
+  targetShadowNode: mixed,
+  thresholds: $ReadOnlyArray<number>,
+};
+export interface Spec extends TurboModule {
+  +observe: (options: NativeIntersectionObserverObserveOptions) => void;
+  +unobserve: (intersectionObserverId: number, targetShadowNode: mixed) => void;
+  +connect: (notifyIntersectionObserversCallback: () => void) => void;
+  +disconnect: () => void;
+  +takeRecords: () => $ReadOnlyArray<NativeIntersectionObserverEntry>;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/JSInspector/InspectorAgent.js 1`] = `
+"export type EventSender = (name: string, params: mixed) => void;
+declare class InspectorAgent {
+  _eventSender: EventSender;
+  constructor(eventSender: EventSender): void;
+  sendEvent(name: string, params: mixed): void;
+}
+declare module.exports: InspectorAgent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/JSInspector/JSInspector.js 1`] = `
+"interface Agent {
+  constructor(eventSender: EventSender): void;
+}
+type AgentClass = Class<Agent> & { DOMAIN: string, ... };
+declare const JSInspector: {
+  registerAgent(type: AgentClass): void,
+  getTimestamp(): number,
+};
+declare module.exports: JSInspector;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/JSInspector/NetworkAgent.js 1`] = `
+"declare const InspectorAgent: $FlowFixMe;
+type RequestId = string;
+type Headers = { [string]: string };
+declare class Interceptor {
+  _agent: NetworkAgent;
+  _requests: Map<string, string>;
+  constructor(agent: NetworkAgent): void;
+  getData(requestId: string): ?string;
+  requestSent(id: number, url: string, method: string, headers: Headers): void;
+  responseReceived(
+    id: number,
+    url: string,
+    status: number,
+    headers: Headers
+  ): void;
+  dataReceived(id: number, data: string): void;
+  loadingFinished(id: number, encodedDataLength: number): void;
+  loadingFailed(id: number, error: string): void;
+  _getMimeType(headers: Headers): string;
+}
+type EnableArgs = {
+  maxResourceBufferSize?: number,
+  maxTotalBufferSize?: number,
+  ...
+};
+declare class NetworkAgent extends InspectorAgent {
+  static DOMAIN: $TEMPORARY$string<\\"Network\\">;
+  _sendEvent: EventSender;
+  _interceptor: ?Interceptor;
+  enable(EnableArgs): void;
+  disable(): void;
+  getResponseBody({ requestId: RequestId, ... }): {
+    body: ?string,
+    base64Encoded: boolean,
+    ...
+  };
+  interceptor(): Interceptor;
+}
+declare module.exports: NetworkAgent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LayoutAnimation/LayoutAnimation.js 1`] = `
+"export type LayoutAnimationConfig = LayoutAnimationConfig_;
+type OnAnimationDidEndCallback = () => void;
+type OnAnimationDidFailCallback = () => void;
+declare function setEnabled(value: boolean): void;
+declare function configureNext(
+  config: LayoutAnimationConfig,
+  onAnimationDidEnd?: OnAnimationDidEndCallback,
+  onAnimationDidFail?: OnAnimationDidFailCallback
+): void;
+declare function create(
+  duration: number,
+  type: LayoutAnimationType,
+  property: LayoutAnimationProperty
+): LayoutAnimationConfig;
+declare const Presets: {
+  easeInEaseOut: LayoutAnimationConfig,
+  linear: LayoutAnimationConfig,
+  spring: {
+    duration: 700,
+    create: { type: \\"linear\\", property: \\"opacity\\" },
+    update: { type: \\"spring\\", springDamping: 0.4 },
+    delete: { type: \\"linear\\", property: \\"opacity\\" },
+  },
+};
+declare const LayoutAnimation: {
+  configureNext: configureNext,
+  create: create,
+  Types: $FlowFixMe,
+  Properties: $FlowFixMe,
+  checkConfig(...args: Array<mixed>): void,
+  Presets: Presets,
+  easeInEaseOut: (onAnimationDidEnd?: OnAnimationDidEndCallback) => void,
+  linear: (onAnimationDidEnd?: OnAnimationDidEndCallback) => void,
+  spring: (onAnimationDidEnd?: OnAnimationDidEndCallback) => void,
+  setEnabled: setEnabled,
+};
+declare module.exports: LayoutAnimation;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Linking/Linking.js 1`] = `
+"type LinkingEventDefinitions = {
+  url: [{ url: string }],
+};
+declare class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
+  constructor(): void;
+  addEventListener<K: $Keys<LinkingEventDefinitions>>(
+    eventType: K,
+    listener: (...$ElementType<LinkingEventDefinitions, K>) => mixed,
+    context: $FlowFixMe
+  ): EventSubscription;
+  openURL(url: string): Promise<void>;
+  canOpenURL(url: string): Promise<boolean>;
+  openSettings(): Promise<void>;
+  getInitialURL(): Promise<?string>;
+  sendIntent(
+    action: string,
+    extras?: Array<{
+      key: string,
+      value: string | number | boolean,
+      ...
+    }>
+  ): Promise<void>;
+  _validateURL(url: string): void;
+}
+declare module.exports: Linking;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Linking/NativeIntentAndroid.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getInitialURL: () => Promise<string>;
+  +canOpenURL: (url: string) => Promise<boolean>;
+  +openURL: (url: string) => Promise<void>;
+  +openSettings: () => Promise<void>;
+  +sendIntent: (
+    action: string,
+    extras: ?Array<{
+      key: string,
+      value: string | number | boolean,
+      ...
+    }>
+  ) => Promise<void>;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Linking/NativeLinkingManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getInitialURL: () => Promise<string>;
+  +canOpenURL: (url: string) => Promise<boolean>;
+  +openURL: (url: string) => Promise<void>;
+  +openSettings: () => Promise<void>;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Lists/FillRateHelper.js 1`] = `
+"declare const FillRateHelper: FillRateHelperType;
+export type { FillRateInfo } from \\"@react-native/virtualized-lists\\";
+declare module.exports: FillRateHelper;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Lists/SectionListModern.js 1`] = `
+"type Item = any;
+export type SectionBase<SectionItemT> = _SectionBase<SectionItemT>;
+type RequiredProps<SectionT: SectionBase<any>> = {|
+  sections: $ReadOnlyArray<SectionT>,
+|};
+type OptionalProps<SectionT: SectionBase<any>> = {|
+  renderItem?: (info: {
+    item: Item,
+    index: number,
+    section: SectionT,
+    separators: {
+      highlight: () => void,
+      unhighlight: () => void,
+      updateProps: (select: \\"leading\\" | \\"trailing\\", newProps: Object) => void,
+      ...
+    },
+    ...
+  }) => null | Element<any>,
+  extraData?: any,
+  initialNumToRender?: ?number,
+  inverted?: ?boolean,
+  keyExtractor?: ?(item: Item, index: number) => string,
+  onEndReached?: ?(info: { distanceFromEnd: number, ... }) => void,
+  removeClippedSubviews?: boolean,
+|};
+export type Props<SectionT> = {|
+  ...$Diff<
+    VirtualizedSectionListProps<SectionT>,
+    {
+      getItem: $PropertyType<VirtualizedSectionListProps<SectionT>, \\"getItem\\">,
+      getItemCount: $PropertyType<
+        VirtualizedSectionListProps<SectionT>,
+        \\"getItemCount\\",
+      >,
+      renderItem: $PropertyType<
+        VirtualizedSectionListProps<SectionT>,
+        \\"renderItem\\",
+      >,
+      keyExtractor: $PropertyType<
+        VirtualizedSectionListProps<SectionT>,
+        \\"keyExtractor\\",
+      >,
+      ...
+    },
+  >,
+  ...RequiredProps<SectionT>,
+  ...OptionalProps<SectionT>,
+|};
+declare const SectionList: AbstractComponent<Props<SectionBase<any>>, any>;
+declare export default typeof SectionList;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Lists/ViewabilityHelper.js 1`] = `
+"export type {
+  ViewToken,
+  ViewabilityConfig,
+  ViewabilityConfigCallbackPair,
+} from \\"@react-native/virtualized-lists\\";
+declare const ViewabilityHelper: ViewabilityHelperType;
+declare module.exports: ViewabilityHelper;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Lists/VirtualizeUtils.js 1`] = `
+"declare const keyExtractor: KeyExtractorType;
+declare module.exports: { keyExtractor: keyExtractor };
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Lists/VirtualizedList.js 1`] = `
+"declare const VirtualizedList: VirtualizedListType;
+export type {
+  RenderItemProps,
+  RenderItemType,
+  Separators,
+} from \\"@react-native/virtualized-lists\\";
+declare module.exports: VirtualizedList;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Lists/VirtualizedListContext.js 1`] = `
+"declare const VirtualizedListContextResetter: VirtualizedListContextResetterType;
+declare module.exports: {
+  VirtualizedListContextResetter: VirtualizedListContextResetter,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Lists/VirtualizedSectionList.js 1`] = `
+"declare const VirtualizedSectionList: VirtualizedSectionListType;
+export type {
+  SectionBase,
+  ScrollToLocationParamsType,
+} from \\"@react-native/virtualized-lists\\";
+declare module.exports: VirtualizedSectionList;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/Data/LogBoxData.js 1`] = `
+"export type LogBoxLogs = Set<LogBoxLog>;
+export type LogData = $ReadOnly<{|
+  level: LogLevel,
+  message: Message,
+  category: Category,
+  componentStack: ComponentStack,
+  stack?: string,
+|}>;
+export type Observer = (
+  $ReadOnly<{|
+    logs: LogBoxLogs,
+    isDisabled: boolean,
+    selectedLogIndex: number,
+  |}>
+) => void;
+export type IgnorePattern = string | RegExp;
+export type Subscription = $ReadOnly<{|
+  unsubscribe: () => void,
+|}>;
+export type WarningInfo = {|
+  finalFormat: string,
+  forceDialogImmediately: boolean,
+  suppressDialog_LEGACY: boolean,
+  suppressCompletely: boolean,
+  monitorEvent: string | null,
+  monitorListVersion: number,
+  monitorSampleRate: number,
+|};
+export type WarningFilter = (format: string) => WarningInfo;
+type AppInfo = $ReadOnly<{|
+  appVersion: string,
+  engine: string,
+  onPress?: ?() => void,
+|}>;
+declare export function reportLogBoxError(
+  error: ExtendedError,
+  componentStack?: string
+): void;
+declare export function isLogBoxErrorMessage(message: string): boolean;
+declare export function isMessageIgnored(message: string): boolean;
+declare export function addLog(log: LogData): void;
+declare export function addException(error: ExtendedExceptionData): void;
+declare export function symbolicateLogNow(log: LogBoxLog): void;
+declare export function retrySymbolicateLogNow(log: LogBoxLog): void;
+declare export function symbolicateLogLazy(log: LogBoxLog): void;
+declare export function clear(): void;
+declare export function setSelectedLog(proposedNewIndex: number): void;
+declare export function clearWarnings(): void;
+declare export function clearErrors(): void;
+declare export function dismiss(log: LogBoxLog): void;
+declare export function setWarningFilter(filter: WarningFilter): void;
+declare export function setAppInfo(info: () => AppInfo): void;
+declare export function getAppInfo(): ?AppInfo;
+declare export function checkWarningFilter(format: string): WarningInfo;
+declare export function getIgnorePatterns(): $ReadOnlyArray<IgnorePattern>;
+declare export function addIgnorePatterns(
+  patterns: $ReadOnlyArray<IgnorePattern>
+): void;
+declare export function setDisabled(value: boolean): void;
+declare export function isDisabled(): boolean;
+declare export function observe(observer: Observer): Subscription;
+type SubscribedComponent = React.AbstractComponent<
+  $ReadOnly<{|
+    logs: $ReadOnlyArray<LogBoxLog>,
+    isDisabled: boolean,
+    selectedLogIndex: number,
+  |}>,
+>;
+declare export function withSubscription(
+  WrappedComponent: SubscribedComponent
+): React.AbstractComponent<{||}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/Data/LogBoxLog.js 1`] = `
+"type SymbolicationStatus = \\"NONE\\" | \\"PENDING\\" | \\"COMPLETE\\" | \\"FAILED\\";
+export type LogLevel = \\"warn\\" | \\"error\\" | \\"fatal\\" | \\"syntax\\";
+export type LogBoxLogData = $ReadOnly<{|
+  level: LogLevel,
+  type?: ?string,
+  message: Message,
+  stack: Stack,
+  category: string,
+  componentStack: ComponentStack,
+  codeFrame?: ?CodeFrame,
+  isComponentError: boolean,
+  extraData?: mixed,
+|}>;
+declare class LogBoxLog {
+  message: Message;
+  type: ?string;
+  category: Category;
+  componentStack: ComponentStack;
+  stack: Stack;
+  count: number;
+  level: LogLevel;
+  codeFrame: ?CodeFrame;
+  isComponentError: boolean;
+  extraData: mixed | void;
+  symbolicated:
+    | $ReadOnly<{| error: null, stack: null, status: \\"NONE\\" |}>
+    | $ReadOnly<{| error: null, stack: null, status: \\"PENDING\\" |}>
+    | $ReadOnly<{| error: null, stack: Stack, status: \\"COMPLETE\\" |}>
+    | $ReadOnly<{| error: Error, stack: null, status: \\"FAILED\\" |}>;
+  constructor(data: LogBoxLogData): void;
+  incrementCount(): void;
+  getAvailableStack(): Stack;
+  retrySymbolicate(callback?: (status: SymbolicationStatus) => void): void;
+  symbolicate(callback?: (status: SymbolicationStatus) => void): void;
+  handleSymbolicate(callback?: (status: SymbolicationStatus) => void): void;
+  updateStatus(
+    error: ?Error,
+    stack: ?Stack,
+    codeFrame: ?CodeFrame,
+    callback?: (status: SymbolicationStatus) => void
+  ): void;
+}
+declare export default typeof LogBoxLog;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/Data/LogBoxSymbolication.js 1`] = `
+"export type Stack = Array<StackFrame>;
+declare export function deleteStack(stack: Stack): void;
+declare export function symbolicate(
+  stack: Stack,
+  extraData?: mixed
+): Promise<SymbolicatedStackTrace>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/Data/parseLogBoxLog.js 1`] = `
+"export type ExtendedExceptionData = ExceptionData & {
+  isComponentError: boolean,
+  ...
+};
+export type Category = string;
+export type CodeFrame = $ReadOnly<{|
+  content: string,
+  location: ?{
+    row: number,
+    column: number,
+    ...
+  },
+  fileName: string,
+  collapse?: boolean,
+|}>;
+export type Message = $ReadOnly<{|
+  content: string,
+  substitutions: $ReadOnlyArray<
+    $ReadOnly<{|
+      length: number,
+      offset: number,
+    |}>,
+  >,
+|}>;
+export type ComponentStack = $ReadOnlyArray<CodeFrame>;
+declare export function parseInterpolation(
+  args: $ReadOnlyArray<mixed>
+): $ReadOnly<{|
+  category: Category,
+  message: Message,
+|}>;
+declare export function parseComponentStack(message: string): ComponentStack;
+declare export function parseLogBoxException(
+  error: ExtendedExceptionData
+): LogBoxLogData;
+declare export function parseLogBoxLog(args: $ReadOnlyArray<mixed>): {|
+  componentStack: ComponentStack,
+  category: Category,
+  message: Message,
+|};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/LogBox.js 1`] = `
+"export type { LogData, ExtendedExceptionData, IgnorePattern };
+interface ILogBox {
+  install(): void;
+  uninstall(): void;
+  isInstalled(): boolean;
+  ignoreLogs($ReadOnlyArray<IgnorePattern>): void;
+  ignoreAllLogs(?boolean): void;
+  clearAllLogs(): void;
+  addLog(log: LogData): void;
+  addException(error: ExtendedExceptionData): void;
+}
+declare export default ILogBox;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/LogBoxNotificationContainer.js 1`] = `
+"type Props = $ReadOnly<{|
+  logs: $ReadOnlyArray<LogBoxLog>,
+  selectedLogIndex: number,
+  isDisabled?: ?boolean,
+|}>;
+declare export function _LogBoxNotificationContainer(props: Props): React.Node;
+declare export default React.AbstractComponent<{||}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/AnsiHighlight.js 1`] = `
+"declare export default function Ansi({
+  text: string,
+  style: TextStyleProp,
+  ...
+}): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxButton.js 1`] = `
+"type Props = $ReadOnly<{|
+  backgroundColor: $ReadOnly<{|
+    default: string,
+    pressed: string,
+  |}>,
+  children?: React.Node,
+  hitSlop?: ?EdgeInsetsProp,
+  onPress?: ?(event: PressEvent) => void,
+  style?: ViewStyleProp,
+|}>;
+declare function LogBoxButton(props: Props): React.Node;
+declare export default typeof LogBoxButton;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspector.js 1`] = `
+"type Props = $ReadOnly<{|
+  onDismiss: () => void,
+  onChangeSelectedIndex: (index: number) => void,
+  onMinimize: () => void,
+  logs: $ReadOnlyArray<LogBoxLog>,
+  selectedIndex: number,
+  fatalType?: ?LogLevel,
+|}>;
+declare function LogBoxInspector(props: Props): React.Node;
+declare export default typeof LogBoxInspector;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js 1`] = `
+"type Props = $ReadOnly<{|
+  codeFrame: ?CodeFrame,
+|}>;
+declare function LogBoxInspectorCodeFrame(props: Props): React.Node;
+declare export default typeof LogBoxInspectorCodeFrame;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorFooter.js 1`] = `
+"type Props = $ReadOnly<{|
+  onDismiss: () => void,
+  onMinimize: () => void,
+  level?: ?LogLevel,
+|}>;
+declare function LogBoxInspectorFooter(props: Props): React.Node;
+declare export default typeof LogBoxInspectorFooter;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorHeader.js 1`] = `
+"type Props = $ReadOnly<{|
+  onSelectIndex: (selectedIndex: number) => void,
+  selectedIndex: number,
+  total: number,
+  level: LogLevel,
+|}>;
+declare function LogBoxInspectorHeader(props: Props): React.Node;
+declare export default typeof LogBoxInspectorHeader;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js 1`] = `
+"type Props = $ReadOnly<{|
+  collapsed: boolean,
+  message: Message,
+  level: LogLevel,
+  title: string,
+  onPress: () => void,
+|}>;
+declare function LogBoxInspectorMessageHeader(props: Props): React.Node;
+declare export default typeof LogBoxInspectorMessageHeader;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorReactFrames.js 1`] = `
+"type Props = $ReadOnly<{|
+  log: LogBoxLog,
+|}>;
+declare function LogBoxInspectorReactFrames(props: Props): React.Node;
+declare export default typeof LogBoxInspectorReactFrames;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorSection.js 1`] = `
+"type Props = $ReadOnly<{|
+  heading: string,
+  children: React.Node,
+  action?: ?React.Node,
+|}>;
+declare function LogBoxInspectorSection(props: Props): React.Node;
+declare export default typeof LogBoxInspectorSection;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorSourceMapStatus.js 1`] = `
+"type Props = $ReadOnly<{|
+  onPress?: ?(event: PressEvent) => void,
+  status: \\"COMPLETE\\" | \\"FAILED\\" | \\"NONE\\" | \\"PENDING\\",
+|}>;
+declare function LogBoxInspectorSourceMapStatus(props: Props): React.Node;
+declare export default typeof LogBoxInspectorSourceMapStatus;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorStackFrame.js 1`] = `
+"type Props = $ReadOnly<{
+  frame: StackFrame,
+  onPress?: ?(event: PressEvent) => void,
+}>;
+declare function LogBoxInspectorStackFrame(props: Props): React.Node;
+declare export default typeof LogBoxInspectorStackFrame;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorStackFrames.js 1`] = `
+"type Props = $ReadOnly<{|
+  log: LogBoxLog,
+  onRetry: () => void,
+|}>;
+declare export function getCollapseMessage(
+  stackFrames: Stack,
+  collapsed: boolean
+): string;
+declare function LogBoxInspectorStackFrames(props: Props): React.Node;
+declare export default typeof LogBoxInspectorStackFrames;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxMessage.js 1`] = `
+"type Props = {
+  message: Message,
+  style: TextStyleProp,
+  plaintext?: ?boolean,
+  maxLength?: ?number,
+  ...
+};
+declare function LogBoxMessage(props: Props): React.Node;
+declare export default typeof LogBoxMessage;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxNotification.js 1`] = `
+"type Props = $ReadOnly<{
+  log: LogBoxLog,
+  totalLogCount: number,
+  level: \\"warn\\" | \\"error\\",
+  onPressOpen: () => void,
+  onPressDismiss: () => void,
+}>;
+declare function LogBoxLogNotification(props: Props): React.Node;
+declare export default typeof LogBoxLogNotification;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxStyle.js 1`] = `
+"declare export function getBackgroundColor(opacity?: number): string;
+declare export function getBackgroundLightColor(opacity?: number): string;
+declare export function getBackgroundDarkColor(opacity?: number): string;
+declare export function getWarningColor(opacity?: number): string;
+declare export function getWarningDarkColor(opacity?: number): string;
+declare export function getFatalColor(opacity?: number): string;
+declare export function getFatalDarkColor(opacity?: number): string;
+declare export function getErrorColor(opacity?: number): string;
+declare export function getErrorDarkColor(opacity?: number): string;
+declare export function getLogColor(opacity?: number): string;
+declare export function getWarningHighlightColor(opacity?: number): string;
+declare export function getDividerColor(opacity?: number): string;
+declare export function getHighlightColor(opacity?: number): string;
+declare export function getTextColor(opacity?: number): string;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Modal/ModalInjection.js 1`] = `
+"declare export default { unstable_Modal: ?Modal };
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Modal/NativeModalManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Modal/RCTModalHostViewNativeComponent.js 1`] = `
+"type OrientationChangeEvent = $ReadOnly<{|
+  orientation: \\"portrait\\" | \\"landscape\\",
+|}>;
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  animationType?: WithDefault<\\"none\\" | \\"slide\\" | \\"fade\\", \\"none\\">,
+  presentationStyle?: WithDefault<
+    \\"fullScreen\\" | \\"pageSheet\\" | \\"formSheet\\" | \\"overFullScreen\\",
+    \\"fullScreen\\",
+  >,
+  transparent?: WithDefault<boolean, false>,
+  statusBarTranslucent?: WithDefault<boolean, false>,
+  hardwareAccelerated?: WithDefault<boolean, false>,
+  onRequestClose?: ?DirectEventHandler<null>,
+  onShow?: ?DirectEventHandler<null>,
+  onDismiss?: ?DirectEventHandler<null>,
+  visible?: WithDefault<boolean, false>,
+  animated?: WithDefault<boolean, false>,
+  supportedOrientations?: WithDefault<
+    $ReadOnlyArray<
+      | \\"portrait\\"
+      | \\"portrait-upside-down\\"
+      | \\"landscape\\"
+      | \\"landscape-left\\"
+      | \\"landscape-right\\",
+    >,
+    \\"portrait\\",
+  >,
+  onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
+  identifier?: WithDefault<Int32, 0>,
+|}>;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/MutationObserver/MutationObserver.js 1`] = `
+"export type MutationObserverCallback = (
+  mutationRecords: $ReadOnlyArray<MutationRecord>,
+  observer: MutationObserver
+) => mixed;
+type MutationObserverInit = $ReadOnly<{
+  subtree?: boolean,
+  childList: true,
+  attributes?: boolean,
+  attributeFilter?: $ReadOnlyArray<string>,
+  attributeOldValue?: boolean,
+  characterData?: boolean,
+  characterDataOldValue?: boolean,
+}>;
+declare export default class MutationObserver {
+  _callback: MutationObserverCallback;
+  _observationTargets: Set<ReactNativeElement>;
+  _mutationObserverId: ?MutationObserverId;
+  constructor(callback: MutationObserverCallback): void;
+  observe(target: ReactNativeElement, options?: MutationObserverInit): void;
+  _unobserve(target: ReactNativeElement): void;
+  disconnect(): void;
+  _getOrCreateMutationObserverId(): MutationObserverId;
+  __getObserverID(): ?MutationObserverId;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/MutationObserver/MutationObserverManager.js 1`] = `
+"export type MutationObserverId = number;
+declare export function registerObserver(
+  observer: MutationObserver,
+  callback: MutationObserverCallback
+): MutationObserverId;
+declare export function unregisterObserver(
+  mutationObserverId: MutationObserverId
+): void;
+declare export function observe({
+  mutationObserverId: MutationObserverId,
+  target: ReactNativeElement,
+  subtree: boolean,
+}): void;
+declare export function unobserve(
+  mutationObserverId: number,
+  target: ReactNativeElement
+): void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/MutationObserver/MutationRecord.js 1`] = `
+"export type MutationType = \\"attributes\\" | \\"characterData\\" | \\"childList\\";
+declare export default class MutationRecord {
+  _target: ReactNativeElement;
+  _addedNodes: NodeList<ReadOnlyNode>;
+  _removedNodes: NodeList<ReadOnlyNode>;
+  constructor(nativeRecord: NativeMutationRecord): void;
+  get addedNodes(): NodeList<ReadOnlyNode>;
+  get attributeName(): string | null;
+  get nextSibling(): ReadOnlyNode | null;
+  get oldValue(): mixed | null;
+  get previousSibling(): ReadOnlyNode | null;
+  get removedNodes(): NodeList<ReadOnlyNode>;
+  get target(): ReactNativeElement;
+  get type(): MutationType;
+}
+declare export function createMutationRecord(
+  entry: NativeMutationRecord
+): MutationRecord;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/MutationObserver/NativeMutationObserver.js 1`] = `
+"export type MutationObserverId = number;
+type ShadowNode = mixed;
+type InstanceHandle = mixed;
+type ReactNativeElement = mixed;
+type ReadOnlyNode = mixed;
+export type NativeMutationRecord = {
+  mutationObserverId: MutationObserverId,
+  target: ReactNativeElement,
+  addedNodes: $ReadOnlyArray<ReadOnlyNode>,
+  removedNodes: $ReadOnlyArray<ReadOnlyNode>,
+  ...
+};
+export type NativeMutationObserverObserveOptions = {
+  mutationObserverId: number,
+  targetShadowNode: ShadowNode,
+  subtree: boolean,
+};
+export interface Spec extends TurboModule {
+  +observe: (options: NativeMutationObserverObserveOptions) => void;
+  +unobserve: (
+    mutationObserverId: number,
+    targetShadowNode: ShadowNode
+  ) => void;
+  +connect: (
+    notifyMutationObservers: () => void,
+    getPublicInstanceFromInstanceHandle: (
+      instanceHandle: InstanceHandle
+    ) => ReadOnlyNode
+  ) => void;
+  +disconnect: () => void;
+  +takeRecords: () => $ReadOnlyArray<NativeMutationRecord>;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/BaseViewConfig.android.js 1`] = `
+"declare const PlatformBaseViewConfigAndroid: PartialViewConfigWithoutName;
+declare export default typeof PlatformBaseViewConfigAndroid;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/BaseViewConfig.ios.js 1`] = `
+"declare const PlatformBaseViewConfigIos: PartialViewConfigWithoutName;
+declare export default typeof PlatformBaseViewConfigIos;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/BaseViewConfig.js.flow 1`] = `
+"declare const PlatformBaseViewConfig: PartialViewConfigWithoutName;
+declare export default typeof PlatformBaseViewConfig;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/NativeComponentRegistry.js 1`] = `
+"declare export function setRuntimeConfigProvider(
+  runtimeConfigProvider: (name: string) => ?{
+    native: boolean,
+    strict: boolean,
+    verify: boolean,
+  }
+): void;
+declare export function get<Config>(
+  name: string,
+  viewConfigProvider: () => PartialViewConfig
+): HostComponent<Config>;
+declare export function getWithFallback_DEPRECATED<Config>(
+  name: string,
+  viewConfigProvider: () => PartialViewConfig
+): React.AbstractComponent<Config>;
+declare export function unstable_hasStaticViewConfig(name: string): boolean;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/NativeComponentRegistryUnstable.js 1`] = `
+"declare export function unstable_hasComponent(name: string): boolean;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/PlatformBaseViewConfig.js 1`] = `
+"export type PartialViewConfigWithoutName = $Rest<
+  PartialViewConfig,
+  { uiViewClassName: string },
+>;
+declare const PlatformBaseViewConfig: PartialViewConfigWithoutName;
+declare export default typeof PlatformBaseViewConfig;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/StaticViewConfigValidator.js 1`] = `
+"export type Difference =
+  | {
+      type: \\"missing\\",
+      path: Array<string>,
+      nativeValue: mixed,
+    }
+  | {
+      type: \\"unequal\\",
+      path: Array<string>,
+      nativeValue: mixed,
+      staticValue: mixed,
+    }
+  | {
+      type: \\"unexpected\\",
+      path: Array<string>,
+      staticValue: mixed,
+    };
+export type ValidationResult = ValidResult | InvalidResult;
+type ValidResult = {
+  type: \\"valid\\",
+};
+type InvalidResult = {
+  type: \\"invalid\\",
+  differences: Array<Difference>,
+};
+declare export function validate(
+  name: string,
+  nativeViewConfig: ViewConfig,
+  staticViewConfig: ViewConfig
+): ValidationResult;
+declare export function stringifyValidationResult(
+  name: string,
+  validationResult: InvalidResult
+): string;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/ViewConfig.js 1`] = `
+"declare export function createViewConfig(
+  partialViewConfig: PartialViewConfig
+): ViewConfig;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeComponent/ViewConfigIgnore.js 1`] = `
+"declare export function DynamicallyInjectedByGestureHandler<T: { ... }>(
+  object: T
+): T;
+declare export function ConditionallyIgnoredEventHandlers<
+  T: { [name: string]: true },
+>(
+  value: T
+): T | void;
+declare export function isIgnored(value: mixed): boolean;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeModules/specs/NativeAnimationsDebugModule.js 1`] = `
+"export interface Spec extends TurboModule {
+  +startRecordingFps: () => void;
+  +stopRecordingFps: (animationStopTimeMs: number) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeModules/specs/NativeDevMenu.js 1`] = `
+"export interface Spec extends TurboModule {
+  +show: () => void;
+  +reload: () => void;
+  +debugRemotely: (enableDebug: boolean) => void;
+  +setProfilingEnabled: (enabled: boolean) => void;
+  +setHotLoadingEnabled: (enabled: boolean) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeModules/specs/NativeDevSettings.js 1`] = `
+"export interface Spec extends TurboModule {
+  +reload: () => void;
+  +reloadWithReason?: (reason: string) => void;
+  +onFastRefresh?: () => void;
+  +setHotLoadingEnabled: (isHotLoadingEnabled: boolean) => void;
+  +setIsDebuggingRemotely: (isDebuggingRemotelyEnabled: boolean) => void;
+  +setProfilingEnabled: (isProfilingEnabled: boolean) => void;
+  +toggleElementInspector: () => void;
+  +addMenuItem: (title: string) => void;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+  +setIsShakeToShowDevMenuEnabled: (enabled: boolean) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeModules/specs/NativeDeviceEventManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +invokeDefaultBackPressHandler: () => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeModules/specs/NativeDialogManagerAndroid.js 1`] = `
+"type DialogAction = string;
+type DialogButtonKey = number;
+export type DialogOptions = {|
+  title?: string,
+  message?: string,
+  buttonPositive?: string,
+  buttonNegative?: string,
+  buttonNeutral?: string,
+  items?: Array<string>,
+  cancelable?: boolean,
+|};
+export interface Spec extends TurboModule {
+  +getConstants: () => {|
+    +buttonClicked: DialogAction,
+    +dismissed: DialogAction,
+    +buttonPositive: DialogButtonKey,
+    +buttonNegative: DialogButtonKey,
+    +buttonNeutral: DialogButtonKey,
+  |};
+  +showAlert: (
+    config: DialogOptions,
+    onError: (error: string) => void,
+    onAction: (action: DialogAction, buttonKey?: DialogButtonKey) => void
+  ) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeModules/specs/NativeLogBox.js 1`] = `
+"export interface Spec extends TurboModule {
+  +show: () => void;
+  +hide: () => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeModules/specs/NativeRedBox.js 1`] = `
+"export interface Spec extends TurboModule {
+  +setExtraData: (extraData: Object, forIdentifier: string) => void;
+  +dismiss: () => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NativeModules/specs/NativeSourceCode.js 1`] = `
+"export type SourceCodeConstants = {|
+  scriptURL: string,
+|};
+export interface Spec extends TurboModule {
+  +getConstants: () => SourceCodeConstants;
+}
+declare const NativeSourceCode: { getConstants(): SourceCodeConstants };
+declare export default typeof NativeSourceCode;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Network/FormData.js 1`] = `
+"type FormDataValue = string | { name?: string, type?: string, uri: string };
+type FormDataNameValuePair = [string, FormDataValue];
+type Headers = { [name: string]: string, ... };
+type FormDataPart =
+  | {
+      string: string,
+      headers: Headers,
+      ...
+    }
+  | {
+      uri: string,
+      headers: Headers,
+      name?: string,
+      type?: string,
+      ...
+    };
+declare class FormData {
+  _parts: Array<FormDataNameValuePair>;
+  constructor(): void;
+  append(key: string, value: FormDataValue): void;
+  getAll(key: string): Array<FormDataValue>;
+  getParts(): Array<FormDataPart>;
+}
+declare module.exports: FormData;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Network/NativeNetworkingAndroid.js 1`] = `
+"type Header = [string, string];
+export interface Spec extends TurboModule {
+  +sendRequest: (
+    method: string,
+    url: string,
+    requestId: number,
+    headers: Array<Header>,
+    data: Object,
+    responseType: string,
+    useIncrementalUpdates: boolean,
+    timeout: number,
+    withCredentials: boolean
+  ) => void;
+  +abortRequest: (requestId: number) => void;
+  +clearCookies: (callback: (result: boolean) => void) => void;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Network/NativeNetworkingIOS.js 1`] = `
+"export interface Spec extends TurboModule {
+  +sendRequest: (
+    query: {|
+      method: string,
+      url: string,
+      data: Object,
+      headers: Object,
+      responseType: string,
+      incrementalUpdates: boolean,
+      timeout: number,
+      withCredentials: boolean,
+    |},
+    callback: (requestId: number) => void
+  ) => void;
+  +abortRequest: (requestId: number) => void;
+  +clearCookies: (callback: (result: boolean) => void) => void;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Network/RCTNetworking.android.js 1`] = `
+"declare class RCTNetworking extends NativeEventEmitter<$FlowFixMe> {
+  constructor(): void;
+  sendRequest(
+    method: string,
+    trackingName: string,
+    url: string,
+    headers: Object,
+    data: RequestBody,
+    responseType: NativeResponseType,
+    incrementalUpdates: boolean,
+    timeout: number,
+    callback: (requestId: number) => mixed,
+    withCredentials: boolean
+  ): void;
+  abortRequest(requestId: number): void;
+  clearCookies(callback: (result: boolean) => any): void;
+}
+declare export default RCTNetworking;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Network/RCTNetworking.ios.js 1`] = `
+"type RCTNetworkingEventDefinitions = $ReadOnly<{
+  didSendNetworkData: [[number, number, number]],
+  didReceiveNetworkResponse: [[number, number, ?{ [string]: string }, ?string]],
+  didReceiveNetworkData: [[number, string]],
+  didReceiveNetworkIncrementalData: [[number, string, number, number]],
+  didReceiveNetworkDataProgress: [[number, number, number]],
+  didCompleteNetworkResponse: [[number, string, boolean]],
+}>;
+declare const RCTNetworking: {
+  addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
+    eventType: K,
+    listener: (...$ElementType<RCTNetworkingEventDefinitions, K>) => mixed,
+    context?: mixed
+  ): EventSubscription,
+  sendRequest(
+    method: string,
+    trackingName: string,
+    url: string,
+    headers: { ... },
+    data: RequestBody,
+    responseType: NativeResponseType,
+    incrementalUpdates: boolean,
+    timeout: number,
+    callback: (requestId: number) => void,
+    withCredentials: boolean
+  ): void,
+  abortRequest(requestId: number): void,
+  clearCookies(callback: (result: boolean) => void): void,
+};
+declare export default typeof RCTNetworking;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Network/RCTNetworking.js.flow 1`] = `
+"type RCTNetworkingEventDefinitions = $ReadOnly<{
+  didSendNetworkData: [[number, number, number]],
+  didReceiveNetworkResponse: [[number, number, ?{ [string]: string }, ?string]],
+  didReceiveNetworkData: [[number, string]],
+  didReceiveNetworkIncrementalData: [[number, string, number, number]],
+  didReceiveNetworkDataProgress: [[number, number, number]],
+  didCompleteNetworkResponse: [[number, string, boolean]],
+}>;
+declare const RCTNetworking: interface {
+  addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
+    eventType: K,
+    listener: (...$ElementType<RCTNetworkingEventDefinitions, K>) => mixed,
+    context?: mixed
+  ): EventSubscription,
+  sendRequest(
+    method: string,
+    trackingName: string,
+    url: string,
+    headers: { ... },
+    data: RequestBody,
+    responseType: NativeResponseType,
+    incrementalUpdates: boolean,
+    timeout: number,
+    callback: (requestId: number) => void,
+    withCredentials: boolean
+  ): void,
+  abortRequest(requestId: number): void,
+  clearCookies(callback: (result: boolean) => void): void,
+};
+declare export default typeof RCTNetworking;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Network/XHRInterceptor.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Network/convertRequestBody.js 1`] = `
+"export type RequestBody =
+  | string
+  | Blob
+  | FormData
+  | { uri: string, ... }
+  | ArrayBuffer
+  | $ArrayBufferView;
+declare function convertRequestBody(body: RequestBody): Object;
+declare module.exports: convertRequestBody;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Network/fetch.js 1`] = `
+"declare module.exports: {
+  fetch: fetch,
+  Headers: Headers,
+  Request: Request,
+  Response: Response,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NewAppScreen/components/Colors.js 1`] = `
+"declare export default {
+  primary: \\"#1292B4\\",
+  white: \\"#FFF\\",
+  lighter: \\"#F3F3F3\\",
+  light: \\"#DAE1E7\\",
+  dark: \\"#444\\",
+  darker: \\"#222\\",
+  black: \\"#000\\",
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NewAppScreen/components/DebugInstructions.js 1`] = `
+"declare const DebugInstructions: () => Node;
+declare export default typeof DebugInstructions;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NewAppScreen/components/Header.js 1`] = `
+"declare const Header: () => Node;
+declare export default typeof Header;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NewAppScreen/components/HermesBadge.js 1`] = `
+"declare const HermesBadge: () => Node;
+declare export default typeof HermesBadge;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NewAppScreen/components/LearnMoreLinks.js 1`] = `
+"declare const LinkList: () => Node;
+declare export default typeof LinkList;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NewAppScreen/components/ReloadInstructions.js 1`] = `
+"declare const ReloadInstructions: () => Node;
+declare export default typeof ReloadInstructions;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/NewAppScreen/index.js 1`] = `
+"export {
+  Colors,
+  Header,
+  HermesBadge,
+  LearnMoreLinks,
+  DebugInstructions,
+  ReloadInstructions,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Performance/NativeJSCSamplingProfiler.js 1`] = `
+"export interface Spec extends TurboModule {
+  +operationComplete: (token: number, result: ?string, error: ?string) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Performance/QuickPerformanceLogger.js 1`] = `
+"export type AnnotationsMap = Partial<{
+  string: ?{ [string]: string, ... },
+  int: ?{ [string]: number, ... },
+  double: ?{ [string]: number, ... },
+  bool: ?{ [string]: boolean, ... },
+  string_array: ?{ [string]: $ReadOnlyArray<string>, ... },
+  int_array: ?{ [string]: $ReadOnlyArray<number>, ... },
+  double_array: ?{ [string]: $ReadOnlyArray<number>, ... },
+  bool_array: ?{ [string]: $ReadOnlyArray<boolean>, ... },
+}>;
+declare const QuickPerformanceLogger: {
+  markerStart(markerId: number, instanceKey: number, timestamp: number): void,
+  markerEnd(
+    markerId: number,
+    actionId: number,
+    instanceKey: number,
+    timestamp: number
+  ): void,
+  markerTag(markerId: number, tag: string, instanceKey: number): void,
+  markerAnnotate(
+    markerId: number,
+    annotations: AnnotationsMap,
+    instanceKey: number
+  ): void,
+  markerCancel(markerId: number, instanceKey?: number): void,
+  markerPoint(
+    markerId: number,
+    name: string,
+    instanceKey: number,
+    timestamp: number,
+    data: ?string
+  ): void,
+  markerDrop(markerId: number, instanceKey?: number): void,
+  isMarkerOn(markerId: number, instanceKey?: number): boolean,
+  markEvent(markerId: number, type: string, annotations: ?AnnotationsMap): void,
+  currentTimestamp(): number,
+};
+declare module.exports: QuickPerformanceLogger;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Performance/SamplingProfiler.js 1`] = `
+"declare const SamplingProfiler: { poke: (token: number) => void };
+declare module.exports: SamplingProfiler;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Performance/Systrace.js 1`] = `
+"type EventName = string | (() => string);
+type EventArgs = ?{ [string]: string };
+declare export function isEnabled(): boolean;
+declare export function setEnabled(_doEnable: boolean): void;
+declare export function beginEvent(
+  eventName: EventName,
+  args?: EventArgs
+): void;
+declare export function endEvent(args?: EventArgs): void;
+declare export function beginAsyncEvent(
+  eventName: EventName,
+  args?: EventArgs
+): number;
+declare export function endAsyncEvent(
+  eventName: EventName,
+  cookie: number,
+  args?: EventArgs
+): void;
+declare export function counterEvent(eventName: EventName, value: number): void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/PermissionsAndroid/NativePermissionsAndroid.js 1`] = `
+"export type PermissionStatus = string;
+export type PermissionType = string;
+export interface Spec extends TurboModule {
+  +checkPermission: (permission: PermissionType) => Promise<boolean>;
+  +requestPermission: (permission: PermissionType) => Promise<PermissionStatus>;
+  +shouldShowRequestPermissionRationale: (
+    permission: string
+  ) => Promise<boolean>;
+  +requestMultiplePermissions: (
+    permissions: Array<PermissionType>
+  ) => Promise<{ [permission: PermissionType]: PermissionStatus, ... }>;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/PermissionsAndroid/PermissionsAndroid.js 1`] = `
+"export type Rationale = {
+  title: string,
+  message: string,
+  buttonPositive?: string,
+  buttonNegative?: string,
+  buttonNeutral?: string,
+  ...
+};
+declare class PermissionsAndroid {
+  PERMISSIONS: {|
+    ACCEPT_HANDOVER: string,
+    ACCESS_BACKGROUND_LOCATION: string,
+    ACCESS_COARSE_LOCATION: string,
+    ACCESS_FINE_LOCATION: string,
+    ACCESS_MEDIA_LOCATION: string,
+    ACTIVITY_RECOGNITION: string,
+    ADD_VOICEMAIL: string,
+    READ_VOICEMAIL: string,
+    WRITE_VOICEMAIL: string,
+    ANSWER_PHONE_CALLS: string,
+    BLUETOOTH_ADVERTISE: string,
+    BLUETOOTH_CONNECT: string,
+    BLUETOOTH_SCAN: string,
+    BODY_SENSORS: string,
+    BODY_SENSORS_BACKGROUND: string,
+    CALL_PHONE: string,
+    CAMERA: string,
+    GET_ACCOUNTS: string,
+    NEARBY_WIFI_DEVICES: string,
+    POST_NOTIFICATIONS: string,
+    PROCESS_OUTGOING_CALLS: string,
+    READ_CALENDAR: string,
+    READ_CALL_LOG: string,
+    READ_CONTACTS: string,
+    READ_EXTERNAL_STORAGE: string,
+    READ_MEDIA_IMAGES: string,
+    READ_MEDIA_VIDEO: string,
+    READ_MEDIA_AUDIO: string,
+    READ_MEDIA_VISUAL_USER_SELECTED: string,
+    READ_PHONE_NUMBERS: string,
+    READ_PHONE_STATE: string,
+    READ_SMS: string,
+    RECEIVE_MMS: string,
+    RECEIVE_SMS: string,
+    RECEIVE_WAP_PUSH: string,
+    RECORD_AUDIO: string,
+    SEND_SMS: string,
+    USE_SIP: string,
+    UWB_RANGING: string,
+    WRITE_CALENDAR: string,
+    WRITE_CALL_LOG: string,
+    WRITE_CONTACTS: string,
+    WRITE_EXTERNAL_STORAGE: string,
+  |};
+  RESULTS: {|
+    DENIED: \\"denied\\",
+    GRANTED: \\"granted\\",
+    NEVER_ASK_AGAIN: \\"never_ask_again\\",
+  |};
+  checkPermission(permission: PermissionType): Promise<boolean>;
+  check(permission: PermissionType): Promise<boolean>;
+  requestPermission(
+    permission: PermissionType,
+    rationale?: Rationale
+  ): Promise<boolean>;
+  request(
+    permission: PermissionType,
+    rationale?: Rationale
+  ): Promise<PermissionStatus>;
+  requestMultiple(
+    permissions: Array<PermissionType>
+  ): Promise<{ [permission: PermissionType]: PermissionStatus, ... }>;
+}
+declare const PermissionsAndroidInstance: PermissionsAndroid;
+declare module.exports: PermissionsAndroidInstance;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Pressability/HoverState.js 1`] = `
+"declare export function isHoverEnabled(): boolean;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Pressability/Pressability.js 1`] = `
+"export type PressabilityConfig = $ReadOnly<{|
+  cancelable?: ?boolean,
+  disabled?: ?boolean,
+  hitSlop?: ?RectOrSize,
+  pressRectOffset?: ?RectOrSize,
+  android_disableSound?: ?boolean,
+  delayHoverIn?: ?number,
+  delayHoverOut?: ?number,
+  delayLongPress?: ?number,
+  delayPressIn?: ?number,
+  delayPressOut?: ?number,
+  minPressDuration?: ?number,
+  onBlur?: ?(event: BlurEvent) => mixed,
+  onFocus?: ?(event: FocusEvent) => mixed,
+  onHoverIn?: ?(event: MouseEvent) => mixed,
+  onHoverOut?: ?(event: MouseEvent) => mixed,
+  onLongPress?: ?(event: PressEvent) => mixed,
+  onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressMove?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
+  blockNativeResponder?: ?boolean,
+  onLongPressShouldCancelPress_DEPRECATED?: ?() => boolean,
+  onResponderTerminationRequest_DEPRECATED?: ?() => boolean,
+  onStartShouldSetResponder_DEPRECATED?: ?() => boolean,
+|}>;
+export type EventHandlers = $ReadOnly<{|
+  onBlur: (event: BlurEvent) => void,
+  onClick: (event: PressEvent) => void,
+  onFocus: (event: FocusEvent) => void,
+  onMouseEnter?: (event: MouseEvent) => void,
+  onMouseLeave?: (event: MouseEvent) => void,
+  onPointerEnter?: (event: PointerEvent) => void,
+  onPointerLeave?: (event: PointerEvent) => void,
+  onResponderGrant: (event: PressEvent) => void | boolean,
+  onResponderMove: (event: PressEvent) => void,
+  onResponderRelease: (event: PressEvent) => void,
+  onResponderTerminate: (event: PressEvent) => void,
+  onResponderTerminationRequest: () => boolean,
+  onStartShouldSetResponder: () => boolean,
+|}>;
+type TouchState =
+  | \\"NOT_RESPONDER\\"
+  | \\"RESPONDER_INACTIVE_PRESS_IN\\"
+  | \\"RESPONDER_INACTIVE_PRESS_OUT\\"
+  | \\"RESPONDER_ACTIVE_PRESS_IN\\"
+  | \\"RESPONDER_ACTIVE_PRESS_OUT\\"
+  | \\"RESPONDER_ACTIVE_LONG_PRESS_IN\\"
+  | \\"RESPONDER_ACTIVE_LONG_PRESS_OUT\\"
+  | \\"ERROR\\";
+declare export default class Pressability {
+  _config: PressabilityConfig;
+  _eventHandlers: ?EventHandlers;
+  _hoverInDelayTimeout: ?TimeoutID;
+  _hoverOutDelayTimeout: ?TimeoutID;
+  _isHovered: boolean;
+  _longPressDelayTimeout: ?TimeoutID;
+  _pressDelayTimeout: ?TimeoutID;
+  _pressOutDelayTimeout: ?TimeoutID;
+  _responderID: ?number | React.ElementRef<HostComponent<mixed>>;
+  _responderRegion: ?$ReadOnly<{|
+    bottom: number,
+    left: number,
+    right: number,
+    top: number,
+  |}>;
+  _touchActivatePosition: ?$ReadOnly<{|
+    pageX: number,
+    pageY: number,
+  |}>;
+  _touchActivateTime: ?number;
+  _touchState: TouchState;
+  constructor(config: PressabilityConfig): void;
+  configure(config: PressabilityConfig): void;
+  reset(): void;
+  getEventHandlers(): EventHandlers;
+  static setLongPressDeactivationDistance(distance: number): void;
+  _createEventHandlers(): EventHandlers;
+  _receiveSignal(signal: TouchSignal, event: PressEvent): void;
+  _performTransitionSideEffects(
+    prevState: TouchState,
+    nextState: TouchState,
+    signal: TouchSignal,
+    event: PressEvent
+  ): void;
+  _activate(event: PressEvent): void;
+  _deactivate(event: PressEvent): void;
+  _measureResponderRegion(): void;
+  _measureCallback: $FlowFixMe;
+  _isTouchWithinResponderRegion(
+    touch: $PropertyType<PressEvent, \\"nativeEvent\\">,
+    responderRegion: $ReadOnly<{|
+      bottom: number,
+      left: number,
+      right: number,
+      top: number,
+    |}>
+  ): boolean;
+  _handleLongPress(event: PressEvent): void;
+  _shouldLongPressCancelPress(): boolean;
+  _cancelHoverInDelayTimeout(): void;
+  _cancelHoverOutDelayTimeout(): void;
+  _cancelLongPressDelayTimeout(): void;
+  _cancelPressDelayTimeout(): void;
+  _cancelPressOutDelayTimeout(): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Pressability/PressabilityDebug.js 1`] = `
+"type Props = $ReadOnly<{|
+  color: ColorValue,
+  hitSlop: ?RectOrSize,
+|}>;
+declare export function PressabilityDebugView(props: Props): React.Node;
+declare export function isEnabled(): boolean;
+declare export function setEnabled(value: boolean): void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Pressability/PressabilityPerformanceEventEmitter.js 1`] = `
+"export type PressabilityPerformanceEvent = $ReadOnly<{|
+  signal: TouchSignal,
+  nativeTimestamp: number,
+|}>;
+export type PressabilityPerformanceEventListener =
+  (PressabilityPerformanceEvent) => void;
+declare class PressabilityPerformanceEventEmitter {
+  _listeners: Array<PressabilityPerformanceEventListener>;
+  constructor(): void;
+  addListener(listener: PressabilityPerformanceEventListener): void;
+  removeListener(listener: PressabilityPerformanceEventListener): void;
+  emitEvent(constructEvent: () => PressabilityPerformanceEvent): void;
+}
+declare const PressabilityPerformanceEventEmitterSingleton: PressabilityPerformanceEventEmitter;
+declare export default typeof PressabilityPerformanceEventEmitterSingleton;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Pressability/PressabilityTypes.js 1`] = `
+"export type PressabilityTouchSignal =
+  | \\"DELAY\\"
+  | \\"RESPONDER_GRANT\\"
+  | \\"RESPONDER_RELEASE\\"
+  | \\"RESPONDER_TERMINATED\\"
+  | \\"ENTER_PRESS_RECT\\"
+  | \\"LEAVE_PRESS_RECT\\"
+  | \\"LONG_PRESS_DETECTED\\";
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Pressability/usePressability.js 1`] = `
+"declare export default function usePressability(
+  config: ?PressabilityConfig
+): ?EventHandlers;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Promise.js 1`] = `
+"declare const Promise: $FlowFixMe;
+declare module.exports: Promise;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/PushNotificationIOS/NativePushNotificationManagerIOS.js 1`] = `
+"type Permissions = {|
+  alert: boolean,
+  badge: boolean,
+  sound: boolean,
+|};
+type Notification = {|
+  +alertTitle?: ?string,
+  +alertBody?: ?string,
+  +userInfo?: ?Object,
+  +category?: ?string,
+  +fireDate?: ?number,
+  +fireIntervalSeconds?: ?number,
+  +applicationIconBadgeNumber?: ?number,
+  +isSilent?: ?boolean,
+  +soundName?: ?string,
+  +alertAction?: ?string,
+  +repeatInterval?: ?string,
+|};
+export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +onFinishRemoteNotification: (
+    notificationId: string,
+    fetchResult: string
+  ) => void;
+  +setApplicationIconBadgeNumber: (num: number) => void;
+  +getApplicationIconBadgeNumber: (callback: (num: number) => void) => void;
+  +requestPermissions: (permission: {|
+    +alert: boolean,
+    +badge: boolean,
+    +sound: boolean,
+  |}) => Promise<Permissions>;
+  +abandonPermissions: () => void;
+  +checkPermissions: (callback: (permissions: Permissions) => void) => void;
+  +presentLocalNotification: (notification: Notification) => void;
+  +scheduleLocalNotification: (notification: Notification) => void;
+  +cancelAllLocalNotifications: () => void;
+  +cancelLocalNotifications: (userInfo: Object) => void;
+  +getInitialNotification: () => Promise<?Notification>;
+  +getScheduledLocalNotifications: (
+    callback: (notification: Notification) => void
+  ) => void;
+  +removeAllDeliveredNotifications: () => void;
+  +removeDeliveredNotifications: (identifiers: Array<string>) => void;
+  +getDeliveredNotifications: (
+    callback: (notification: Array<Notification>) => void
+  ) => void;
+  +getAuthorizationStatus: (
+    callback: (authorizationStatus: number) => void
+  ) => void;
+  +addListener: (eventType: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/PushNotificationIOS/PushNotificationIOS.js 1`] = `
+"export type ContentAvailable = 1 | null | void;
+export type FetchResult = {
+  NewData: string,
+  NoData: string,
+  ResultFailed: string,
+  ...
+};
+export type PushNotificationEventName = $Keys<{
+  notification: string,
+  localNotification: string,
+  register: string,
+  registrationError: string,
+  ...
+}>;
+declare class PushNotificationIOS {
+  _data: Object;
+  _alert: string | Object;
+  _sound: string;
+  _category: string;
+  _contentAvailable: ContentAvailable;
+  _badgeCount: number;
+  _notificationId: string;
+  _isRemote: boolean;
+  _remoteNotificationCompleteCallbackCalled: boolean;
+  _threadID: string;
+  static FetchResult: FetchResult;
+  static presentLocalNotification(details: Object): void;
+  static scheduleLocalNotification(details: Object): void;
+  static cancelAllLocalNotifications(): void;
+  static removeAllDeliveredNotifications(): void;
+  static getDeliveredNotifications(
+    callback: (notifications: Array<Object>) => void
+  ): void;
+  static removeDeliveredNotifications(identifiers: Array<string>): void;
+  static setApplicationIconBadgeNumber(number: number): void;
+  static getApplicationIconBadgeNumber(callback: Function): void;
+  static cancelLocalNotifications(userInfo: Object): void;
+  static getScheduledLocalNotifications(callback: Function): void;
+  static addEventListener(
+    type: PushNotificationEventName,
+    handler: Function
+  ): void;
+  static removeEventListener(
+    type: PushNotificationEventName,
+    handler: Function
+  ): void;
+  static requestPermissions(permissions?: {
+    alert?: boolean,
+    badge?: boolean,
+    sound?: boolean,
+    ...
+  }): Promise<{
+    alert: boolean,
+    badge: boolean,
+    sound: boolean,
+    ...
+  }>;
+  static abandonPermissions(): void;
+  static checkPermissions(callback: Function): void;
+  static getInitialNotification(): Promise<?PushNotificationIOS>;
+  static getAuthorizationStatus(
+    callback: (authorizationStatus: number) => void
+  ): void;
+  constructor(nativeNotif: Object): void;
+  finish(fetchResult: string): void;
+  getMessage(): ?string | ?Object;
+  getSound(): ?string;
+  getCategory(): ?string;
+  getAlert(): ?string | ?Object;
+  getContentAvailable(): ContentAvailable;
+  getBadgeCount(): ?number;
+  getData(): ?Object;
+  getThreadID(): ?string;
+}
+declare module.exports: PushNotificationIOS;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/AppContainer.js 1`] = `
+"export type Props = $ReadOnly<{|
+  children?: React.Node,
+  fabric?: boolean,
+  rootTag: number | RootTag,
+  initialProps?: { ... },
+  showArchitectureIndicator?: boolean,
+  WrapperComponent?: ?React.ComponentType<any>,
+  internal_excludeLogBox?: boolean,
+  internal_excludeInspector?: boolean,
+|}>;
+declare const AppContainer: React.AbstractComponent<Props>;
+declare module.exports: AppContainer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/AppContainer-dev.js 1`] = `
+"declare const AppContainer: (Props) => React.Node;
+declare export default typeof AppContainer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/AppContainer-prod.js 1`] = `
+"declare const AppContainer: (Props) => React.Node;
+declare export default typeof AppContainer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/AppRegistry.js 1`] = `
+"type Task = (taskData: any) => Promise<void>;
+export type TaskProvider = () => Task;
+type TaskCanceller = () => void;
+type TaskCancelProvider = () => TaskCanceller;
+export type ComponentProvider = () => React$ComponentType<any>;
+export type ComponentProviderInstrumentationHook = (
+  component_: ComponentProvider,
+  scopedPerformanceLogger: IPerformanceLogger
+) => React$ComponentType<any>;
+export type AppConfig = {
+  appKey: string,
+  component?: ComponentProvider,
+  run?: Runnable,
+  section?: boolean,
+  ...
+};
+type AppParameters = {
+  initialProps: $ReadOnly<{ [string]: mixed, ... }>,
+  rootTag: RootTag,
+  fabric?: boolean,
+  concurrentRoot?: boolean,
+};
+export type Runnable = (
+  appParameters: AppParameters,
+  displayMode: DisplayModeType
+) => void;
+export type Runnables = { [appKey: string]: Runnable };
+export type Registry = {
+  sections: $ReadOnlyArray<string>,
+  runnables: Runnables,
+  ...
+};
+export type WrapperComponentProvider = (
+  appParameters: Object
+) => React$ComponentType<any>;
+declare const AppRegistry: {
+  setWrapperComponentProvider(provider: WrapperComponentProvider): void,
+  enableArchitectureIndicator(enabled: boolean): void,
+  registerConfig(config: Array<AppConfig>): void,
+  registerComponent(
+    appKey: string,
+    componentProvider: ComponentProvider,
+    section?: boolean
+  ): string,
+  registerRunnable(appKey: string, run: Runnable): string,
+  registerSection(appKey: string, component: ComponentProvider): void,
+  getAppKeys(): $ReadOnlyArray<string>,
+  getSectionKeys(): $ReadOnlyArray<string>,
+  getSections(): Runnables,
+  getRunnable(appKey: string): ?Runnable,
+  getRegistry(): Registry,
+  setComponentProviderInstrumentationHook(
+    hook: ComponentProviderInstrumentationHook
+  ): void,
+  runApplication(
+    appKey: string,
+    appParameters: AppParameters,
+    displayMode?: number
+  ): void,
+  setSurfaceProps(
+    appKey: string,
+    appParameters: Object,
+    displayMode?: number
+  ): void,
+  unmountApplicationComponentAtRootTag(rootTag: RootTag): void,
+  registerHeadlessTask(taskKey: string, taskProvider: TaskProvider): void,
+  registerCancellableHeadlessTask(
+    taskKey: string,
+    taskProvider: TaskProvider,
+    taskCancelProvider: TaskCancelProvider
+  ): void,
+  startHeadlessTask(taskId: number, taskKey: string, data: any): void,
+  cancelHeadlessTask(taskId: number, taskKey: string): void,
+};
+declare module.exports: AppRegistry;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/BridgelessUIManager.js 1`] = `
+"declare const UIManagerJS: UIManagerJSInterface & { [string]: any };
+declare module.exports: UIManagerJS;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/DisplayMode.js 1`] = `
+"declare export opaque type DisplayModeType;
+declare const DisplayMode: { [string]: DisplayModeType };
+declare export function coerceDisplayMode(value: ?number): DisplayModeType;
+declare export default typeof DisplayMode;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/FabricUIManager.js 1`] = `
+"export type NodeSet = Array<Node>;
+export type NodeProps = { ... };
+export interface Spec {
+  +createNode: (
+    reactTag: number,
+    viewName: string,
+    rootTag: RootTag,
+    props: NodeProps,
+    instanceHandle: InternalInstanceHandle
+  ) => Node;
+  +cloneNode: (node: Node) => Node;
+  +cloneNodeWithNewChildren: (node: Node) => Node;
+  +cloneNodeWithNewProps: (node: Node, newProps: NodeProps) => Node;
+  +cloneNodeWithNewChildrenAndProps: (node: Node, newProps: NodeProps) => Node;
+  +createChildSet: (rootTag: RootTag) => NodeSet;
+  +appendChild: (parentNode: Node, child: Node) => Node;
+  +appendChildToSet: (childSet: NodeSet, child: Node) => void;
+  +completeRoot: (rootTag: RootTag, childSet: NodeSet) => void;
+  +measure: (node: Node, callback: MeasureOnSuccessCallback) => void;
+  +measureInWindow: (
+    node: Node,
+    callback: MeasureInWindowOnSuccessCallback
+  ) => void;
+  +measureLayout: (
+    node: Node,
+    relativeNode: Node,
+    onFail: () => void,
+    onSuccess: MeasureLayoutOnSuccessCallback
+  ) => void;
+  +configureNextLayoutAnimation: (
+    config: LayoutAnimationConfig,
+    callback: () => void,
+    errorCallback: () => void
+  ) => void;
+  +sendAccessibilityEvent: (node: Node, eventType: string) => void;
+  +findShadowNodeByTag_DEPRECATED: (reactTag: number) => ?Node;
+  +setNativeProps: (node: Node, newProps: NodeProps) => void;
+  +dispatchCommand: (
+    node: Node,
+    commandName: string,
+    args: Array<mixed>
+  ) => void;
+  +getParentNode: (node: Node) => ?InternalInstanceHandle;
+  +getChildNodes: (node: Node) => $ReadOnlyArray<InternalInstanceHandle>;
+  +isConnected: (node: Node) => boolean;
+  +compareDocumentPosition: (node: Node, otherNode: Node) => number;
+  +getTextContent: (node: Node) => string;
+  +getBoundingClientRect: (
+    node: Node,
+    includeTransform: boolean
+  ) => ?[number, number, number, number];
+  +getOffset: (node: Node) => ?[InternalInstanceHandle, number, number];
+  +getScrollPosition: (node: Node) => ?[number, number];
+  +getScrollSize: (node: Node) => ?[number, number];
+  +getInnerSize: (node: Node) => ?[number, number];
+  +getBorderSize: (node: Node) => ?[number, number, number, number];
+  +getTagName: (node: Node) => string;
+  +hasPointerCapture: (node: Node, pointerId: number) => boolean;
+  +setPointerCapture: (node: Node, pointerId: number) => void;
+  +releasePointerCapture: (node: Node, pointerId: number) => void;
+}
+declare export function getFabricUIManager(): ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/HeadlessJsTaskError.js 1`] = `
+"declare export default class HeadlessJsTaskError extends Error {}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/I18nManager.js 1`] = `
+"declare module.exports: {
+  getConstants: () => I18nManagerConstants,
+  allowRTL: (shouldAllow: boolean) => void,
+  forceRTL: (shouldForce: boolean) => void,
+  swapLeftAndRightInRTL: (flipStyles: boolean) => void,
+  isRTL: $FlowFixMe,
+  doLeftAndRightSwapInRTL: $FlowFixMe,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/NativeHeadlessJsTaskSupport.js 1`] = `
+"export interface Spec extends TurboModule {
+  +notifyTaskFinished: (taskId: number) => void;
+  +notifyTaskRetry: (taskId: number) => Promise<boolean>;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/NativeI18nManager.js 1`] = `
+"export type I18nManagerConstants = {|
+  doLeftAndRightSwapInRTL: boolean,
+  isRTL: boolean,
+  localeIdentifier?: ?string,
+|};
+export interface Spec extends TurboModule {
+  +getConstants: () => I18nManagerConstants;
+  allowRTL: (allowRTL: boolean) => void;
+  forceRTL: (forceRTL: boolean) => void;
+  swapLeftAndRightInRTL: (flipStyles: boolean) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/NativeUIManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => Object;
+  +createView: (
+    reactTag: ?number,
+    viewName: string,
+    rootTag: RootTag,
+    props: Object
+  ) => void;
+  +updateView: (reactTag: number, viewName: string, props: Object) => void;
+  +findSubviewIn: (
+    reactTag: ?number,
+    point: Array<number>,
+    callback: (
+      nativeViewTag: number,
+      left: number,
+      top: number,
+      width: number,
+      height: number
+    ) => void
+  ) => void;
+  +dispatchViewManagerCommand: (
+    reactTag: ?number,
+    commandID: number,
+    commandArgs: ?Array<any>
+  ) => void;
+  +measure: (
+    reactTag: number,
+    callback: (
+      left: number,
+      top: number,
+      width: number,
+      height: number,
+      pageX: number,
+      pageY: number
+    ) => void
+  ) => void;
+  +measureInWindow: (
+    reactTag: number,
+    callback: (x: number, y: number, width: number, height: number) => void
+  ) => void;
+  +viewIsDescendantOf: (
+    reactTag: ?number,
+    ancestorReactTag: ?number,
+    callback: (result: Array<boolean>) => void
+  ) => void;
+  +measureLayout: (
+    reactTag: number,
+    ancestorReactTag: number,
+    errorCallback: (error: Object) => void,
+    callback: (left: number, top: number, width: number, height: number) => void
+  ) => void;
+  +measureLayoutRelativeToParent: (
+    reactTag: number,
+    errorCallback: (error: Object) => void,
+    callback: (left: number, top: number, width: number, height: number) => void
+  ) => void;
+  +setJSResponder: (reactTag: ?number, blockNativeResponder: boolean) => void;
+  +clearJSResponder: () => void;
+  +configureNextLayoutAnimation: (
+    config: Object,
+    callback: () => void,
+    errorCallback: (error: Object) => void
+  ) => void;
+  +setChildren: (containerTag: ?number, reactTags: Array<number>) => void;
+  +manageChildren: (
+    containerTag: ?number,
+    moveFromIndices: Array<number>,
+    moveToIndices: Array<number>,
+    addChildReactTags: Array<number>,
+    addAtIndices: Array<number>,
+    removeAtIndices: Array<number>
+  ) => void;
+  +getConstantsForViewManager?: (viewManagerName: string) => Object;
+  +getDefaultEventTypes?: () => Array<string>;
+  +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
+  +sendAccessibilityEvent?: (reactTag: ?number, eventType: number) => void;
+  +showPopupMenu?: (
+    reactTag: ?number,
+    items: Array<string>,
+    error: (error: Object) => void,
+    success: (event: string, selected?: number) => void
+  ) => void;
+  +dismissPopupMenu?: () => void;
+  +lazilyLoadView?: (name: string) => Object;
+  +focus?: (reactTag: ?number) => void;
+  +blur?: (reactTag: ?number) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/PaperUIManager.js 1`] = `
+"declare const UIManagerJS: UIManagerJSInterface;
+declare module.exports: UIManagerJS;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/ReactFabricInternals.js 1`] = `
+"declare const createReactNativeComponentClass: $FlowFixMe;
+declare module.exports: {
+  createReactNativeComponentClass: createReactNativeComponentClass,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js 1`] = `
+"declare export default class ReactFabricHostComponent
+  implements INativeMethods
+{
+  __nativeTag: number;
+  __internalInstanceHandle: InternalInstanceHandle;
+  _viewConfig: ViewConfig;
+  constructor(
+    tag: number,
+    viewConfig: ViewConfig,
+    internalInstanceHandle: InternalInstanceHandle
+  ): void;
+  blur(): void;
+  focus(): void;
+  measure(callback: MeasureOnSuccessCallback): void;
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void;
+  measureLayout(
+    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void
+  ): void;
+  unstable_getBoundingClientRect(): DOMRect;
+  setNativeProps(nativeProps: { ... }): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance.js 1`] = `
+"declare export function createPublicInstance(
+  tag: number,
+  viewConfig: ViewConfig,
+  internalInstanceHandle: InternalInstanceHandle
+): ReactFabricHostComponent | ReactNativeElement;
+declare export function createPublicTextInstance(
+  internalInstanceHandle: InternalInstanceHandle
+): ReadOnlyText;
+declare export function getNativeTagFromPublicInstance(
+  publicInstance: ReactFabricHostComponent | ReactNativeElement
+): number;
+declare export function getNodeFromPublicInstance(
+  publicInstance: ReactFabricHostComponent | ReactNativeElement
+): ?Node;
+declare export function getInternalInstanceHandleFromPublicInstance(
+  publicInstance: ReactFabricHostComponent | ReactNativeElement
+): InternalInstanceHandle;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstanceUtils.js 1`] = `
+"declare export function isPublicInstance(maybeInstance: mixed): boolean;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload.js 1`] = `
+"declare export function create(
+  props: Object,
+  validAttributes: AttributeConfiguration
+): null | Object;
+declare export function diff(
+  prevProps: Object,
+  nextProps: Object,
+  validAttributes: AttributeConfiguration
+): null | Object;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/ReactFabricPublicInstance/warnForStyleProps.js 1`] = `
+"declare export default function warnForStyleProps(
+  props: { ... },
+  validAttributes: AttributeConfiguration
+): void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/ReactNativeFeatureFlags.js 1`] = `
+"export type FeatureFlags = {|
+  isLayoutAnimationEnabled: () => boolean,
+  shouldEmitW3CPointerEvents: () => boolean,
+  shouldPressibilityUseW3CPointerEventsForHover: () => boolean,
+  animatedShouldDebounceQueueFlush: () => boolean,
+  animatedShouldUseSingleOp: () => boolean,
+  enableAccessToHostTreeInFabric: () => boolean,
+  shouldUseAnimatedObjectForTransform: () => boolean,
+  shouldUseSetNativePropsInFabric: () => boolean,
+|};
+declare const ReactNativeFeatureFlags: FeatureFlags;
+declare module.exports: ReactNativeFeatureFlags;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/ReactNativeRuntimeDiagnostics.js 1`] = `
+"export type RuntimeDiagnostics = {|
+  isEnabled: () => boolean,
+  simulateEarlyJavaScriptErrors: () => void,
+|};
+export type RuntimeDiagnosticFlag = \\"early_js_errors\\" | \\"all\\";
+declare const ReactNativeRuntimeDiagnostics: RuntimeDiagnostics;
+declare module.exports: ReactNativeRuntimeDiagnostics;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/RendererImplementation.js 1`] = `
+"declare export function renderElement({
+  element: Element<ElementType>,
+  rootTag: number,
+  useFabric: boolean,
+  useConcurrentRoot: boolean,
+}): void;
+declare export function findHostInstance_DEPRECATED<TElementType: ElementType>(
+  componentOrHandle: ?(ElementRef<TElementType> | number)
+): ?ElementRef<HostComponent<mixed>>;
+declare export function findNodeHandle<TElementType: ElementType>(
+  componentOrHandle: ?(ElementRef<TElementType> | number)
+): ?number;
+declare export function dispatchCommand(
+  handle: ElementRef<HostComponent<mixed>>,
+  command: string,
+  args: Array<mixed>
+): void;
+declare export function sendAccessibilityEvent(
+  handle: ElementRef<HostComponent<mixed>>,
+  eventType: string
+): void;
+declare export function unmountComponentAtNodeAndRemoveContainer(
+  rootTag: RootTag
+): void;
+declare export function unstable_batchedUpdates<T>(
+  fn: (T) => void,
+  bookkeeping: T
+): void;
+declare export function isProfilingRenderer(): boolean;
+declare export function isChildPublicInstance(
+  parentInstance: ReactFabricHostComponent | HostComponent<mixed>,
+  childInstance: ReactFabricHostComponent | HostComponent<mixed>
+): boolean;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/RendererProxy.js 1`] = `
+"export * from \\"./RendererImplementation\\";
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/RootTag.js 1`] = `
+"declare export opaque type RootTag;
+declare export const RootTagContext: React$Context<RootTag>;
+declare export function createRootTag(rootTag: number | RootTag): RootTag;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/UIManager.js 1`] = `
+"declare const UIManager: UIManagerJSInterface;
+declare module.exports: UIManager;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/UIManagerProperties.js 1`] = `
+"declare module.exports: $FlowFixMe;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/getCachedComponentWithDebugName.js 1`] = `
+"type NoopComponent = AbstractComponent<{ children: React.Node }>;
+declare export default function getCachedComponentWithDisplayName(
+  displayName: string
+): NoopComponent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/getNativeComponentAttributes.js 1`] = `
+"declare function getNativeComponentAttributes(uiViewClassName: string): any;
+declare module.exports: getNativeComponentAttributes;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/renderApplication.js 1`] = `
+"declare export default function renderApplication<Props: Object>(
+  RootComponent: React.ComponentType<Props>,
+  initialProps: Props,
+  rootTag: any,
+  WrapperComponent?: ?React.ComponentType<any>,
+  fabric?: boolean,
+  showArchitectureIndicator?: boolean,
+  scopedPerformanceLogger?: IPerformanceLogger,
+  isLogBox?: boolean,
+  debugName?: string,
+  displayMode?: ?DisplayModeType,
+  useConcurrentRoot?: boolean,
+  useOffscreen?: boolean
+): void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactNative/requireNativeComponent.js 1`] = `
+"declare const requireNativeComponent: <T>(
+  uiViewClassName: string
+) => HostComponent<T>;
+declare export default typeof requireNativeComponent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/ReactPrivate/ReactNativePrivateInitializeCore.js 1`] = `""`;
+
+exports[`public API should not change unintentionally Libraries/ReactPrivate/ReactNativePrivateInterface.js 1`] = `
+"declare module.exports: {
+  get BatchedBridge(): BatchedBridge,
+  get ExceptionsManager(): ExceptionsManager,
+  get Platform(): Platform,
+  get RCTEventEmitter(): RCTEventEmitter,
+  get ReactNativeViewConfigRegistry(): ReactNativeViewConfigRegistry,
+  get TextInputState(): TextInputState,
+  get UIManager(): UIManager,
+  get deepDiffer(): deepDiffer,
+  get deepFreezeAndThrowOnMutationInDev(): deepFreezeAndThrowOnMutationInDev<
+    { ... } | Array<mixed>,
+  >,
+  get flattenStyle(): flattenStyle<DangerouslyImpreciseStyleProp>,
+  get ReactFiberErrorDialog(): ReactFiberErrorDialog,
+  get legacySendAccessibilityEvent(): legacySendAccessibilityEvent,
+  get RawEventEmitter(): RawEventEmitter,
+  get CustomEvent(): CustomEvent,
+  get createAttributePayload(): createAttributePayload,
+  get diffAttributePayloads(): diffAttributePayloads,
+  get createPublicInstance(): createPublicInstance,
+  get createPublicTextInstance(): createPublicTextInstance,
+  get getNativeTagFromPublicInstance(): getNativeTagFromPublicInstance,
+  get getNodeFromPublicInstance(): getNodeFromPublicInstance,
+  get getInternalInstanceHandleFromPublicInstance(): getInternalInstanceHandleFromPublicInstance,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/implementations/ReactFabric-dev.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/implementations/ReactFabric-prod.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/implementations/ReactFabric-profiling.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/implementations/ReactNativeRenderer-dev.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/implementations/ReactNativeRenderer-prod.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/shims/ReactFabric.js 1`] = `
+"declare module.exports: ReactFabricType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/shims/ReactFeatureFlags.js 1`] = `
+"declare const ReactFeatureFlags: { debugRenderPhaseSideEffects: false };
+declare module.exports: ReactFeatureFlags;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/shims/ReactNative.js 1`] = `
+"declare module.exports: ReactNativeType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/shims/ReactNativeTypes.js 1`] = `
+"export type MeasureOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  pageX: number,
+  pageY: number
+) => void;
+export type MeasureInWindowOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number
+) => void;
+export type MeasureLayoutOnSuccessCallback = (
+  left: number,
+  top: number,
+  width: number,
+  height: number
+) => void;
+export type AttributeType<T, V> =
+  | true
+  | $ReadOnly<{
+      diff?: (arg1: T, arg2: T) => boolean,
+      process?: (arg1: V) => T,
+    }>;
+export type AnyAttributeType = AttributeType<$FlowFixMe, $FlowFixMe>;
+export type AttributeConfiguration = $ReadOnly<{
+  [propName: string]: AnyAttributeType,
+  style: $ReadOnly<{
+    [propName: string]: AnyAttributeType,
+    ...
+  }>,
+  ...
+}>;
+export type PartialAttributeConfiguration = $ReadOnly<{
+  [propName: string]: AnyAttributeType,
+  style?: $ReadOnly<{
+    [propName: string]: AnyAttributeType,
+    ...
+  }>,
+  ...
+}>;
+export type ViewConfig = $ReadOnly<{
+  Commands?: $ReadOnly<{ [commandName: string]: number, ... }>,
+  Constants?: $ReadOnly<{ [name: string]: mixed, ... }>,
+  Manager?: string,
+  NativeProps?: $ReadOnly<{ [propName: string]: string, ... }>,
+  baseModuleName?: ?string,
+  bubblingEventTypes?: $ReadOnly<{
+    [eventName: string]: $ReadOnly<{
+      phasedRegistrationNames: $ReadOnly<{
+        captured: string,
+        bubbled: string,
+        skipBubbling?: ?boolean,
+      }>,
+    }>,
+    ...
+  }>,
+  directEventTypes?: $ReadOnly<{
+    [eventName: string]: $ReadOnly<{
+      registrationName: string,
+    }>,
+    ...
+  }>,
+  uiViewClassName: string,
+  validAttributes: AttributeConfiguration,
+}>;
+export type PartialViewConfig = $ReadOnly<{
+  bubblingEventTypes?: $PropertyType<ViewConfig, \\"bubblingEventTypes\\">,
+  directEventTypes?: $PropertyType<ViewConfig, \\"directEventTypes\\">,
+  uiViewClassName: string,
+  validAttributes?: PartialAttributeConfiguration,
+}>;
+export interface INativeMethods {
+  blur(): void;
+  focus(): void;
+  measure(callback: MeasureOnSuccessCallback): void;
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void;
+  measureLayout(
+    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void
+  ): void;
+  setNativeProps(nativeProps: { ... }): void;
+}
+export type NativeMethods = $ReadOnly<{|
+  blur(): void,
+  focus(): void,
+  measure(callback: MeasureOnSuccessCallback): void,
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
+  measureLayout(
+    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void
+  ): void,
+  setNativeProps(nativeProps: { ... }): void,
+|}>;
+export type HostComponent<T> = AbstractComponent<T, $ReadOnly<NativeMethods>>;
+type SecretInternalsType = {
+  computeComponentStackForErrorReporting(tag: number): string,
+  ...
+};
+type InspectorDataProps = $ReadOnly<{
+  [propName: string]: string,
+  ...
+}>;
+type InspectorDataSource = $ReadOnly<{
+  fileName?: string,
+  lineNumber?: number,
+}>;
+type InspectorDataGetter = (
+  <TElementType: ElementType>(
+    componentOrHandle: ElementRef<TElementType> | number
+  ) => ?number
+) => $ReadOnly<{
+  measure: (callback: MeasureOnSuccessCallback) => void,
+  props: InspectorDataProps,
+  source: InspectorDataSource,
+}>;
+export type InspectorData = $ReadOnly<{
+  closestInstance?: mixed,
+  hierarchy: Array<{
+    name: ?string,
+    getInspectorData: InspectorDataGetter,
+  }>,
+  selectedIndex: ?number,
+  props: InspectorDataProps,
+  source: ?InspectorDataSource,
+}>;
+export type TouchedViewDataAtPoint = $ReadOnly<{
+  pointerY: number,
+  touchedViewTag?: number,
+  frame: $ReadOnly<{
+    top: number,
+    left: number,
+    width: number,
+    height: number,
+  }>,
+  ...InspectorData,
+}>;
+export type ReactNativeType = {
+  findHostInstance_DEPRECATED<TElementType: ElementType>(
+    componentOrHandle: ?(ElementRef<TElementType> | number)
+  ): ?ElementRef<HostComponent<mixed>>,
+  findNodeHandle<TElementType: ElementType>(
+    componentOrHandle: ?(ElementRef<TElementType> | number)
+  ): ?number,
+  isChildPublicInstance(
+    parent: PublicInstance | HostComponent<mixed>,
+    child: PublicInstance | HostComponent<mixed>
+  ): boolean,
+  dispatchCommand(
+    handle: ElementRef<HostComponent<mixed>>,
+    command: string,
+    args: Array<mixed>
+  ): void,
+  sendAccessibilityEvent(
+    handle: ElementRef<HostComponent<mixed>>,
+    eventType: string
+  ): void,
+  render(
+    element: Element<ElementType>,
+    containerTag: number,
+    callback: ?() => void
+  ): ?ElementRef<ElementType>,
+  unmountComponentAtNode(containerTag: number): void,
+  unmountComponentAtNodeAndRemoveContainer(containerTag: number): void,
+  unstable_batchedUpdates: <T>(fn: (T) => void, bookkeeping: T) => void,
+  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: SecretInternalsType,
+  ...
+};
+declare export opaque type Node;
+declare export opaque type InternalInstanceHandle;
+type PublicInstance = mixed;
+type PublicTextInstance = mixed;
+export type ReactFabricType = {
+  findHostInstance_DEPRECATED<TElementType: ElementType>(
+    componentOrHandle: ?(ElementRef<TElementType> | number)
+  ): ?ElementRef<HostComponent<mixed>>,
+  findNodeHandle<TElementType: ElementType>(
+    componentOrHandle: ?(ElementRef<TElementType> | number)
+  ): ?number,
+  dispatchCommand(
+    handle: ElementRef<HostComponent<mixed>>,
+    command: string,
+    args: Array<mixed>
+  ): void,
+  isChildPublicInstance(parent: PublicInstance, child: PublicInstance): boolean,
+  sendAccessibilityEvent(
+    handle: ElementRef<HostComponent<mixed>>,
+    eventType: string
+  ): void,
+  render(
+    element: Element<ElementType>,
+    containerTag: number,
+    callback: ?() => void,
+    concurrentRoot: ?boolean
+  ): ?ElementRef<ElementType>,
+  unmountComponentAtNode(containerTag: number): void,
+  getNodeFromInternalInstanceHandle(
+    internalInstanceHandle: InternalInstanceHandle
+  ): ?Node,
+  getPublicInstanceFromInternalInstanceHandle(
+    internalInstanceHandle: InternalInstanceHandle
+  ): PublicInstance | PublicTextInstance | null,
+  ...
+};
+export type ReactFabricEventTouch = {
+  identifier: number,
+  locationX: number,
+  locationY: number,
+  pageX: number,
+  pageY: number,
+  screenX: number,
+  screenY: number,
+  target: number,
+  timestamp: number,
+  force: number,
+  ...
+};
+export type ReactFabricEvent = {
+  touches: Array<ReactFabricEventTouch>,
+  changedTouches: Array<ReactFabricEventTouch>,
+  targetTouches: Array<ReactFabricEventTouch>,
+  target: number,
+  ...
+};
+export type LayoutAnimationType =
+  | \\"spring\\"
+  | \\"linear\\"
+  | \\"easeInEaseOut\\"
+  | \\"easeIn\\"
+  | \\"easeOut\\"
+  | \\"keyboard\\";
+export type LayoutAnimationProperty =
+  | \\"opacity\\"
+  | \\"scaleX\\"
+  | \\"scaleY\\"
+  | \\"scaleXY\\";
+export type LayoutAnimationAnimationConfig = $ReadOnly<{
+  duration?: number,
+  delay?: number,
+  springDamping?: number,
+  initialVelocity?: number,
+  type?: LayoutAnimationType,
+  property?: LayoutAnimationProperty,
+}>;
+export type LayoutAnimationConfig = $ReadOnly<{
+  duration: number,
+  create?: LayoutAnimationAnimationConfig,
+  update?: LayoutAnimationAnimationConfig,
+  delete?: LayoutAnimationAnimationConfig,
+}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js 1`] = `
+"declare export const customBubblingEventTypes: {
+  [eventName: string]: $ReadOnly<{
+    phasedRegistrationNames: $ReadOnly<{
+      captured: string,
+      bubbled: string,
+      skipBubbling?: ?boolean,
+    }>,
+  }>,
+};
+declare export const customDirectEventTypes: {
+  [eventName: string]: $ReadOnly<{
+    registrationName: string,
+  }>,
+};
+declare export function register(
+  name: string,
+  callback: () => ViewConfig
+): string;
+declare export function get(name: string): ViewConfig;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Renderer/shims/createReactNativeComponentClass.js 1`] = `
+"declare const createReactNativeComponentClass: (
+  name: string,
+  callback: () => ViewConfig
+) => string;
+declare module.exports: createReactNativeComponentClass;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Settings/NativeSettingsManager.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {|
+    settings: Object,
+  |};
+  +setValues: (values: Object) => void;
+  +deleteValues: (values: Array<string>) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Settings/Settings.ios.js 1`] = `
+"declare const Settings: {
+  _settings: any,
+  get(key: string): mixed,
+  set(settings: Object): void,
+  watchKeys(keys: string | Array<string>, callback: Function): number,
+  clearWatch(watchId: number): void,
+  _sendObservations(body: Object): void,
+};
+declare module.exports: Settings;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Settings/Settings.js 1`] = `
+"declare const Settings: {
+  get(key: string): mixed,
+  set(settings: Object): void,
+  watchKeys(keys: string | Array<string>, callback: Function): number,
+  clearWatch(watchId: number): void,
+};
+declare module.exports: Settings;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Share/NativeShareModule.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +share: (
+    content: {| title?: string, message?: string |},
+    dialogTitle?: string
+  ) => Promise<{| action: string |}>;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Share/Share.js 1`] = `
+"type Content =
+  | {
+      title?: string,
+      message: string,
+      ...
+    }
+  | {
+      title?: string,
+      url: string,
+      ...
+    };
+type Options = {
+  dialogTitle?: string,
+  excludedActivityTypes?: Array<string>,
+  tintColor?: string,
+  subject?: string,
+  anchor?: number,
+  ...
+};
+declare class Share {
+  static share(
+    content: Content,
+    options: Options
+  ): Promise<{ action: string, activityType: ?string }>;
+  static sharedAction: \\"sharedAction\\";
+  static dismissedAction: \\"dismissedAction\\";
+}
+declare module.exports: Share;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/EdgeInsetsPropType.js 1`] = `
+"export type EdgeInsetsProp = Rect;
+export type EdgeInsetsOrSizeProp = RectOrSize;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/PlatformColorValueTypes.android.js 1`] = `
+"declare export const PlatformColor: (...names: Array<string>) => ColorValue;
+declare export const normalizeColorObject: (
+  color: NativeColorValue
+) => ?ProcessedColorValue;
+declare export const processColorObject: (
+  color: NativeColorValue
+) => ?NativeColorValue;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/PlatformColorValueTypes.ios.js 1`] = `
+"declare export const PlatformColor: (...names: Array<string>) => ColorValue;
+export type DynamicColorIOSTuplePrivate = {
+  light: ColorValue,
+  dark: ColorValue,
+  highContrastLight?: ColorValue,
+  highContrastDark?: ColorValue,
+};
+declare export const DynamicColorIOSPrivate: (
+  tuple: DynamicColorIOSTuplePrivate
+) => ColorValue;
+declare export const normalizeColorObject: (
+  color: NativeColorValue
+) => ?ProcessedColorValue;
+declare export const processColorObject: (
+  color: NativeColorValue
+) => ?NativeColorValue;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/PlatformColorValueTypes.js.flow 1`] = `
+"declare export function PlatformColor(...names: Array<string>): ColorValue;
+declare export function normalizeColorObject(
+  color: NativeColorValue
+): ?ProcessedColorValue;
+declare export function processColorObject(
+  color: NativeColorValue
+): ?NativeColorValue;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/PlatformColorValueTypesIOS.ios.js 1`] = `
+"export type DynamicColorIOSTuple = {
+  light: ColorValue,
+  dark: ColorValue,
+  highContrastLight?: ColorValue,
+  highContrastDark?: ColorValue,
+};
+declare export const DynamicColorIOS: (
+  tuple: DynamicColorIOSTuple
+) => ColorValue;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/PlatformColorValueTypesIOS.js 1`] = `
+"export type DynamicColorIOSTuple = {
+  light: ColorValue,
+  dark: ColorValue,
+  highContrastLight?: ColorValue,
+  highContrastDark?: ColorValue,
+};
+declare export const DynamicColorIOS: (
+  tuple: DynamicColorIOSTuple
+) => ColorValue;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/PointPropType.js 1`] = `
+"export type PointProp = $ReadOnly<{
+  x: number,
+  y: number,
+  ...
+}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/Rect.js 1`] = `
+"export type Rect = $ReadOnly<{|
+  bottom?: ?number,
+  left?: ?number,
+  right?: ?number,
+  top?: ?number,
+|}>;
+export type RectOrSize = Rect | number;
+declare export function createSquare(size: number): Rect;
+declare export function normalizeRect(rectOrSize: ?RectOrSize): ?Rect;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/StyleSheet.js 1`] = `
+"declare const flatten: $FlowFixMe;
+export type { NativeColorValue } from \\"./StyleSheetTypes\\";
+export type ColorValue = ____ColorValue_Internal;
+export type ViewStyleProp = ____ViewStyleProp_Internal;
+export type TextStyleProp = ____TextStyleProp_Internal;
+export type ImageStyleProp = ____ImageStyleProp_Internal;
+export type DangerouslyImpreciseStyleProp =
+  ____DangerouslyImpreciseStyleProp_Internal;
+export type TypeForStyleKey<
+  +key: $Keys<____DangerouslyImpreciseStyle_Internal>,
+> = $ElementType<____DangerouslyImpreciseStyle_Internal, key>;
+export type ViewStyle = ____ViewStyle_Internal;
+export type TextStyle = ____TextStyle_Internal;
+export type ImageStyle = ____ImageStyle_Internal;
+export type DangerouslyImpreciseStyle = ____DangerouslyImpreciseStyle_Internal;
+declare let hairlineWidth: number;
+declare const absoluteFill: {
+  position: \\"absolute\\",
+  left: 0,
+  right: 0,
+  top: 0,
+  bottom: 0,
+};
+declare module.exports: {
+  hairlineWidth: hairlineWidth,
+  absoluteFill: any,
+  absoluteFillObject: absoluteFill,
+  compose<T: DangerouslyImpreciseStyleProp>(
+    style1: ?T,
+    style2: ?T
+  ): ?T | $ReadOnlyArray<T>,
+  flatten: flatten,
+  setStyleAttributePreprocessor(
+    property: string,
+    process: (nextProp: mixed) => mixed
+  ): void,
+  create<+S: ____Styles_Internal>(obj: S): $ReadOnly<S>,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/StyleSheetTypes.js 1`] = `
+"declare export opaque type NativeColorValue;
+export type ____ColorValue_Internal = null | string | number | NativeColorValue;
+export type ColorArrayValue = null | $ReadOnlyArray<____ColorValue_Internal>;
+export type PointValue = {
+  x: number,
+  y: number,
+};
+export type EdgeInsetsValue = {
+  top: number,
+  left: number,
+  right: number,
+  bottom: number,
+};
+export type DimensionValue = number | string | \\"auto\\" | AnimatedNode | null;
+export type AnimatableNumericValue = number | AnimatedNode;
+type ____LayoutStyle_Internal = $ReadOnly<{
+  display?: \\"none\\" | \\"flex\\",
+  width?: DimensionValue,
+  height?: DimensionValue,
+  bottom?: DimensionValue,
+  end?: DimensionValue,
+  left?: DimensionValue,
+  right?: DimensionValue,
+  start?: DimensionValue,
+  top?: DimensionValue,
+  inset?: DimensionValue,
+  insetBlock?: DimensionValue,
+  insetBlockEnd?: DimensionValue,
+  insetBlockStart?: DimensionValue,
+  insetInline?: DimensionValue,
+  insetInlineEnd?: DimensionValue,
+  insetInlineStart?: DimensionValue,
+  minWidth?: DimensionValue,
+  maxWidth?: DimensionValue,
+  minHeight?: DimensionValue,
+  maxHeight?: DimensionValue,
+  margin?: DimensionValue,
+  marginBlock?: DimensionValue,
+  marginBlockEnd?: DimensionValue,
+  marginBlockStart?: DimensionValue,
+  marginBottom?: DimensionValue,
+  marginEnd?: DimensionValue,
+  marginHorizontal?: DimensionValue,
+  marginInline?: DimensionValue,
+  marginInlineEnd?: DimensionValue,
+  marginInlineStart?: DimensionValue,
+  marginLeft?: DimensionValue,
+  marginRight?: DimensionValue,
+  marginStart?: DimensionValue,
+  marginTop?: DimensionValue,
+  marginVertical?: DimensionValue,
+  padding?: DimensionValue,
+  paddingBlock?: DimensionValue,
+  paddingBlockEnd?: DimensionValue,
+  paddingBlockStart?: DimensionValue,
+  paddingBottom?: DimensionValue,
+  paddingEnd?: DimensionValue,
+  paddingHorizontal?: DimensionValue,
+  paddingInline?: DimensionValue,
+  paddingInlineEnd?: DimensionValue,
+  paddingInlineStart?: DimensionValue,
+  paddingLeft?: DimensionValue,
+  paddingRight?: DimensionValue,
+  paddingStart?: DimensionValue,
+  paddingTop?: DimensionValue,
+  paddingVertical?: DimensionValue,
+  borderWidth?: number,
+  borderBottomWidth?: number,
+  borderEndWidth?: number,
+  borderLeftWidth?: number,
+  borderRightWidth?: number,
+  borderStartWidth?: number,
+  borderTopWidth?: number,
+  position?: \\"absolute\\" | \\"relative\\",
+  flexDirection?: \\"row\\" | \\"row-reverse\\" | \\"column\\" | \\"column-reverse\\",
+  flexWrap?: \\"wrap\\" | \\"nowrap\\" | \\"wrap-reverse\\",
+  justifyContent?:
+    | \\"flex-start\\"
+    | \\"flex-end\\"
+    | \\"center\\"
+    | \\"space-between\\"
+    | \\"space-around\\"
+    | \\"space-evenly\\",
+  alignItems?: \\"flex-start\\" | \\"flex-end\\" | \\"center\\" | \\"stretch\\" | \\"baseline\\",
+  alignSelf?:
+    | \\"auto\\"
+    | \\"flex-start\\"
+    | \\"flex-end\\"
+    | \\"center\\"
+    | \\"stretch\\"
+    | \\"baseline\\",
+  alignContent?:
+    | \\"flex-start\\"
+    | \\"flex-end\\"
+    | \\"center\\"
+    | \\"stretch\\"
+    | \\"space-between\\"
+    | \\"space-around\\"
+    | \\"space-evenly\\",
+  overflow?: \\"visible\\" | \\"hidden\\" | \\"scroll\\",
+  flex?: number,
+  flexGrow?: number,
+  flexShrink?: number,
+  flexBasis?: number | string,
+  aspectRatio?: number | string,
+  zIndex?: number,
+  direction?: \\"inherit\\" | \\"ltr\\" | \\"rtl\\",
+  rowGap?: number,
+  columnGap?: number,
+  gap?: number,
+}>;
+export type ____ShadowStyle_InternalCore = $ReadOnly<{
+  shadowColor?: ____ColorValue_Internal,
+  shadowOffset?: $ReadOnly<{
+    width?: number,
+    height?: number,
+  }>,
+  shadowOpacity?: AnimatableNumericValue,
+  shadowRadius?: number,
+}>;
+export type ____ShadowStyle_Internal = $ReadOnly<{
+  ...____ShadowStyle_InternalCore,
+  ...____ShadowStyle_InternalOverrides,
+}>;
+export type ____ViewStyle_InternalCore = $ReadOnly<{
+  ...$Exact<____LayoutStyle_Internal>,
+  ...$Exact<____ShadowStyle_Internal>,
+  ...$Exact<____TransformStyle_Internal>,
+  backfaceVisibility?: \\"visible\\" | \\"hidden\\",
+  backgroundColor?: ____ColorValue_Internal,
+  borderColor?: ____ColorValue_Internal,
+  borderCurve?: \\"circular\\" | \\"continuous\\",
+  borderBottomColor?: ____ColorValue_Internal,
+  borderEndColor?: ____ColorValue_Internal,
+  borderLeftColor?: ____ColorValue_Internal,
+  borderRightColor?: ____ColorValue_Internal,
+  borderStartColor?: ____ColorValue_Internal,
+  borderTopColor?: ____ColorValue_Internal,
+  borderBlockColor?: ____ColorValue_Internal,
+  borderBlockEndColor?: ____ColorValue_Internal,
+  borderBlockStartColor?: ____ColorValue_Internal,
+  borderRadius?: AnimatableNumericValue,
+  borderBottomEndRadius?: AnimatableNumericValue,
+  borderBottomLeftRadius?: AnimatableNumericValue,
+  borderBottomRightRadius?: AnimatableNumericValue,
+  borderBottomStartRadius?: AnimatableNumericValue,
+  borderEndEndRadius?: AnimatableNumericValue,
+  borderEndStartRadius?: AnimatableNumericValue,
+  borderStartEndRadius?: AnimatableNumericValue,
+  borderStartStartRadius?: AnimatableNumericValue,
+  borderTopEndRadius?: AnimatableNumericValue,
+  borderTopLeftRadius?: AnimatableNumericValue,
+  borderTopRightRadius?: AnimatableNumericValue,
+  borderTopStartRadius?: AnimatableNumericValue,
+  borderStyle?: \\"solid\\" | \\"dotted\\" | \\"dashed\\",
+  borderWidth?: AnimatableNumericValue,
+  borderBottomWidth?: AnimatableNumericValue,
+  borderEndWidth?: AnimatableNumericValue,
+  borderLeftWidth?: AnimatableNumericValue,
+  borderRightWidth?: AnimatableNumericValue,
+  borderStartWidth?: AnimatableNumericValue,
+  borderTopWidth?: AnimatableNumericValue,
+  opacity?: AnimatableNumericValue,
+  elevation?: number,
+  pointerEvents?: \\"auto\\" | \\"none\\" | \\"box-none\\" | \\"box-only\\",
+}>;
+export type ____ViewStyle_Internal = $ReadOnly<{
+  ...____ViewStyle_InternalCore,
+  ...____ViewStyle_InternalOverrides,
+}>;
+export type FontStyleType = {
+  fontFamily: string,
+  fontWeight: ____FontWeight_Internal,
+};
+export type FontStyleMap = {
+  ultraLight: FontStyleType,
+  thin: FontStyleType,
+  light: FontStyleType,
+  regular: FontStyleType,
+  medium: FontStyleType,
+  semibold: FontStyleType,
+  bold: FontStyleType,
+  heavy: FontStyleType,
+  black: FontStyleType,
+};
+export type ____FontWeight_Internal =
+  | \\"normal\\"
+  | \\"bold\\"
+  | \\"100\\"
+  | \\"200\\"
+  | \\"300\\"
+  | \\"400\\"
+  | \\"500\\"
+  | \\"600\\"
+  | \\"700\\"
+  | \\"800\\"
+  | \\"900\\"
+  | 100
+  | 200
+  | 300
+  | 400
+  | 500
+  | 600
+  | 700
+  | 800
+  | 900
+  | \\"ultralight\\"
+  | \\"thin\\"
+  | \\"light\\"
+  | \\"medium\\"
+  | \\"regular\\"
+  | \\"semibold\\"
+  | \\"condensedBold\\"
+  | \\"condensed\\"
+  | \\"heavy\\"
+  | \\"black\\";
+export type ____FontVariantArray_Internal = $ReadOnlyArray<
+  | \\"small-caps\\"
+  | \\"oldstyle-nums\\"
+  | \\"lining-nums\\"
+  | \\"tabular-nums\\"
+  | \\"common-ligatures\\"
+  | \\"no-common-ligatures\\"
+  | \\"discretionary-ligatures\\"
+  | \\"no-discretionary-ligatures\\"
+  | \\"historical-ligatures\\"
+  | \\"no-historical-ligatures\\"
+  | \\"contextual\\"
+  | \\"no-contextual\\"
+  | \\"proportional-nums\\"
+  | \\"stylistic-one\\"
+  | \\"stylistic-two\\"
+  | \\"stylistic-three\\"
+  | \\"stylistic-four\\"
+  | \\"stylistic-five\\"
+  | \\"stylistic-six\\"
+  | \\"stylistic-seven\\"
+  | \\"stylistic-eight\\"
+  | \\"stylistic-nine\\"
+  | \\"stylistic-ten\\"
+  | \\"stylistic-eleven\\"
+  | \\"stylistic-twelve\\"
+  | \\"stylistic-thirteen\\"
+  | \\"stylistic-fourteen\\"
+  | \\"stylistic-fifteen\\"
+  | \\"stylistic-sixteen\\"
+  | \\"stylistic-seventeen\\"
+  | \\"stylistic-eighteen\\"
+  | \\"stylistic-nineteen\\"
+  | \\"stylistic-twenty\\",
+>;
+export type ____TextStyle_InternalCore = $ReadOnly<{
+  ...$Exact<____ViewStyle_Internal>,
+  color?: ____ColorValue_Internal,
+  fontFamily?: string,
+  fontSize?: number,
+  fontStyle?: \\"normal\\" | \\"italic\\",
+  fontWeight?: ____FontWeight_Internal,
+  fontVariant?: ____FontVariantArray_Internal | string,
+  textShadowOffset?: $ReadOnly<{
+    width: number,
+    height: number,
+  }>,
+  textShadowRadius?: number,
+  textShadowColor?: ____ColorValue_Internal,
+  letterSpacing?: number,
+  lineHeight?: number,
+  textAlign?: \\"auto\\" | \\"left\\" | \\"right\\" | \\"center\\" | \\"justify\\",
+  textAlignVertical?: \\"auto\\" | \\"top\\" | \\"bottom\\" | \\"center\\",
+  includeFontPadding?: boolean,
+  textDecorationLine?:
+    | \\"none\\"
+    | \\"underline\\"
+    | \\"line-through\\"
+    | \\"underline line-through\\",
+  textDecorationStyle?: \\"solid\\" | \\"double\\" | \\"dotted\\" | \\"dashed\\",
+  textDecorationColor?: ____ColorValue_Internal,
+  textTransform?: \\"none\\" | \\"capitalize\\" | \\"uppercase\\" | \\"lowercase\\",
+  userSelect?: \\"auto\\" | \\"text\\" | \\"none\\" | \\"contain\\" | \\"all\\",
+  verticalAlign?: \\"auto\\" | \\"top\\" | \\"bottom\\" | \\"middle\\",
+  writingDirection?: \\"auto\\" | \\"ltr\\" | \\"rtl\\",
+}>;
+export type ____TextStyle_Internal = $ReadOnly<{
+  ...____TextStyle_InternalCore,
+  ...____TextStyle_InternalOverrides,
+}>;
+export type ____ImageStyle_InternalCore = $ReadOnly<{
+  ...$Exact<____ViewStyle_Internal>,
+  resizeMode?: \\"contain\\" | \\"cover\\" | \\"stretch\\" | \\"center\\" | \\"repeat\\",
+  objectFit?: \\"cover\\" | \\"contain\\" | \\"fill\\" | \\"scale-down\\",
+  tintColor?: ____ColorValue_Internal,
+  overlayColor?: string,
+}>;
+export type ____ImageStyle_Internal = $ReadOnly<{
+  ...____ImageStyle_InternalCore,
+  ...____ImageStyle_InternalOverrides,
+}>;
+export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
+  ...$Exact<____TextStyle_Internal>,
+  resizeMode?: \\"contain\\" | \\"cover\\" | \\"stretch\\" | \\"center\\" | \\"repeat\\",
+  objectFit?: \\"cover\\" | \\"contain\\" | \\"fill\\" | \\"scale-down\\",
+  tintColor?: ____ColorValue_Internal,
+  overlayColor?: string,
+}>;
+export type ____DangerouslyImpreciseStyle_Internal = $ReadOnly<{
+  ...____DangerouslyImpreciseStyle_InternalCore,
+  ...____DangerouslyImpreciseStyle_InternalOverrides,
+  ...
+}>;
+type GenericStyleProp<+T> =
+  | null
+  | void
+  | T
+  | false
+  | \\"\\"
+  | $ReadOnlyArray<GenericStyleProp<T>>;
+export type ____DangerouslyImpreciseStyleProp_Internal = GenericStyleProp<
+  Partial<____DangerouslyImpreciseStyle_Internal>,
+>;
+export type ____ViewStyleProp_Internal = GenericStyleProp<
+  $ReadOnly<Partial<____ViewStyle_Internal>>,
+>;
+export type ____TextStyleProp_Internal = GenericStyleProp<
+  $ReadOnly<Partial<____TextStyle_Internal>>,
+>;
+export type ____ImageStyleProp_Internal = GenericStyleProp<
+  $ReadOnly<Partial<____ImageStyle_Internal>>,
+>;
+export type ____Styles_Internal = {
+  +[key: string]: Partial<____DangerouslyImpreciseStyle_Internal>,
+  ...
+};
+export type ____FlattenStyleProp_Internal<
+  +TStyleProp: GenericStyleProp<mixed>,
+> = TStyleProp extends null | void | false | \\"\\"
+  ? empty
+  : TStyleProp extends $ReadOnlyArray<infer V>
+  ? ____FlattenStyleProp_Internal<V>
+  : TStyleProp;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/flattenStyle.js 1`] = `
+"declare function flattenStyle<TStyleProp: DangerouslyImpreciseStyleProp>(
+  style: ?TStyleProp
+): ?____FlattenStyleProp_Internal<TStyleProp>;
+declare module.exports: flattenStyle;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/normalizeColor.js 1`] = `
+"declare function normalizeColor(
+  color: ?(ColorValue | ProcessedColorValue)
+): ?ProcessedColorValue;
+declare module.exports: normalizeColor;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/private/_StyleSheetTypesOverrides.js 1`] = `
+"export type ____DangerouslyImpreciseStyle_InternalOverrides = $ReadOnly<{}>;
+export type ____ImageStyle_InternalOverrides = $ReadOnly<{}>;
+export type ____ShadowStyle_InternalOverrides = $ReadOnly<{}>;
+export type ____TextStyle_InternalOverrides = $ReadOnly<{}>;
+export type ____ViewStyle_InternalOverrides = $ReadOnly<{}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/private/_TransformStyle.js 1`] = `
+"export type ____TransformStyle_Internal = $ReadOnly<{|
+  transform?:
+    | $ReadOnlyArray<
+        | {| +perspective: number | AnimatedNode |}
+        | {| +rotate: string | AnimatedNode |}
+        | {| +rotateX: string | AnimatedNode |}
+        | {| +rotateY: string | AnimatedNode |}
+        | {| +rotateZ: string | AnimatedNode |}
+        | {| +scale: number | AnimatedNode |}
+        | {| +scaleX: number | AnimatedNode |}
+        | {| +scaleY: number | AnimatedNode |}
+        | {| +translateX: number | AnimatedNode |}
+        | {| +translateY: number | AnimatedNode |}
+        | {|
+            +translate:
+              | [number | AnimatedNode, number | AnimatedNode]
+              | AnimatedNode,
+          |}
+        | {| +skewX: string | AnimatedNode |}
+        | {| +skewY: string | AnimatedNode |}
+        | {|
+            +matrix: $ReadOnlyArray<number | AnimatedNode> | AnimatedNode,
+          |},
+      >
+    | string,
+  transformOrigin?:
+    | [string | number, string | number, string | number]
+    | string,
+|}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/processAspectRatio.js 1`] = `
+"declare function processAspectRatio(aspectRatio?: number | string): ?number;
+declare module.exports: processAspectRatio;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/processColor.js 1`] = `
+"export type ProcessedColorValue = number | NativeColorValue;
+declare function processColor(
+  color?: ?(number | ColorValue)
+): ?ProcessedColorValue;
+declare export default typeof processColor;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/processColorArray.js 1`] = `
+"declare function processColorArray(
+  colors: ?$ReadOnlyArray<ColorValue>
+): ?$ReadOnlyArray<ProcessedColorValue>;
+declare module.exports: processColorArray;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/processFontVariant.js 1`] = `
+"declare function processFontVariant(
+  fontVariant: ____FontVariantArray_Internal | string
+): ?____FontVariantArray_Internal;
+declare module.exports: processFontVariant;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/processTransform.js 1`] = `
+"declare function processTransform(
+  transform: Array<Object> | string
+): Array<Object> | Array<number>;
+declare module.exports: processTransform;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/processTransformOrigin.js 1`] = `
+"declare export default function processTransformOrigin(
+  transformOrigin: Array<string | number> | string
+): Array<string | number>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/setNormalizedColorAlpha.js 1`] = `
+"declare function setNormalizedColorAlpha(input: number, alpha: number): number;
+declare module.exports: setNormalizedColorAlpha;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/splitLayoutProps.js 1`] = `
+"declare export default function splitLayoutProps(
+  props: ?____ViewStyle_Internal
+): {
+  outer: ?____ViewStyle_Internal,
+  inner: ?____ViewStyle_Internal,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Text/Text.js 1`] = `
+"declare const Text: React.AbstractComponent<
+  TextProps,
+  React.ElementRef<typeof NativeText | typeof NativeVirtualText>,
+>;
+declare module.exports: Text;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Text/TextAncestor.js 1`] = `
+"declare const TextAncestorContext: React$Context<$FlowFixMe>;
+declare module.exports: TextAncestorContext;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Text/TextNativeComponent.js 1`] = `
+"type NativeTextProps = $ReadOnly<{
+  ...TextProps,
+  isHighlighted?: ?boolean,
+  selectionColor?: ?ProcessedColorValue,
+  onClick?: ?(event: PressEvent) => mixed,
+  isPressable?: ?boolean,
+}>;
+declare export const NativeText: HostComponent<NativeTextProps>;
+declare export const NativeVirtualText: HostComponent<NativeTextProps>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Text/TextProps.js 1`] = `
+"export type PressRetentionOffset = $ReadOnly<{|
+  top: number,
+  left: number,
+  bottom: number,
+  right: number,
+|}>;
+type PointerEventProps = $ReadOnly<{|
+  onPointerEnter?: (event: PointerEvent) => void,
+  onPointerLeave?: (event: PointerEvent) => void,
+  onPointerMove?: (event: PointerEvent) => void,
+|}>;
+export type TextProps = $ReadOnly<{|
+  ...PointerEventProps,
+  accessible?: ?boolean,
+  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  accessibilityHint?: ?Stringish,
+  accessibilityLanguage?: ?Stringish,
+  accessibilityLabel?: ?Stringish,
+  accessibilityRole?: ?AccessibilityRole,
+  accessibilityState?: ?AccessibilityState,
+  \\"aria-label\\"?: ?string,
+  adjustsFontSizeToFit?: ?boolean,
+  allowFontScaling?: ?boolean,
+  android_hyphenationFrequency?: ?(\\"normal\\" | \\"none\\" | \\"full\\"),
+  \\"aria-busy\\"?: ?boolean,
+  \\"aria-checked\\"?: ?boolean | \\"mixed\\",
+  \\"aria-disabled\\"?: ?boolean,
+  \\"aria-expanded\\"?: ?boolean,
+  \\"aria-selected\\"?: ?boolean,
+  \\"aria-labelledby\\"?: ?string,
+  children?: ?Node,
+  ellipsizeMode?: ?(\\"clip\\" | \\"head\\" | \\"middle\\" | \\"tail\\"),
+  id?: string,
+  maxFontSizeMultiplier?: ?number,
+  nativeID?: ?string,
+  numberOfLines?: ?number,
+  onLayout?: ?(event: LayoutEvent) => mixed,
+  onLongPress?: ?(event: PressEvent) => mixed,
+  onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
+  onResponderGrant?: ?(event: PressEvent) => void,
+  onResponderMove?: ?(event: PressEvent) => void,
+  onResponderRelease?: ?(event: PressEvent) => void,
+  onResponderTerminate?: ?(event: PressEvent) => void,
+  onResponderTerminationRequest?: ?() => boolean,
+  onStartShouldSetResponder?: ?() => boolean,
+  onMoveShouldSetResponder?: ?() => boolean,
+  onTextLayout?: ?(event: TextLayoutEvent) => mixed,
+  pressRetentionOffset?: ?PressRetentionOffset,
+  role?: ?Role,
+  selectable?: ?boolean,
+  style?: ?TextStyleProp,
+  testID?: ?string,
+  disabled?: ?boolean,
+  selectionColor?: ?string,
+  dataDetectorType?: ?(\\"phoneNumber\\" | \\"link\\" | \\"email\\" | \\"none\\" | \\"all\\"),
+  textBreakStrategy?: ?(\\"balanced\\" | \\"highQuality\\" | \\"simple\\"),
+  adjustsFontSizeToFit?: ?boolean,
+  dynamicTypeRamp?: ?(
+    | \\"caption2\\"
+    | \\"caption1\\"
+    | \\"footnote\\"
+    | \\"subheadline\\"
+    | \\"callout\\"
+    | \\"body\\"
+    | \\"headline\\"
+    | \\"title3\\"
+    | \\"title2\\"
+    | \\"title1\\"
+    | \\"largeTitle\\"
+  ),
+  minimumFontScale?: ?number,
+  suppressHighlighting?: ?boolean,
+  lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
+|}>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/TurboModule/RCTExport.js 1`] = `
+"export interface DEPRECATED_RCTExport<T: void = void> {
+  +getConstants?: () => { ... };
+}
+export interface TurboModule extends DEPRECATED_RCTExport<void> {}
+export type { RootTag } from \\"../Types/RootTagTypes.js\\";
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/TurboModule/TurboModuleRegistry.js 1`] = `
+"declare export function get<T: TurboModule>(name: string): ?T;
+declare export function getEnforcing<T: TurboModule>(name: string): T;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/TurboModule/samples/NativeSampleTurboModule.js 1`] = `
+"export enum EnumInt {
+  A = 23,
+  B = 42,
+}
+export interface Spec extends TurboModule {
+  +getConstants: () => {|
+    const1: boolean,
+    const2: number,
+    const3: string,
+  |};
+  +voidFunc: () => void;
+  +getBool: (arg: boolean) => boolean;
+  +getEnum?: (arg: EnumInt) => EnumInt;
+  +getNumber: (arg: number) => number;
+  +getString: (arg: string) => string;
+  +getArray: (arg: Array<any>) => Array<any>;
+  +getObject: (arg: Object) => Object;
+  +getUnsafeObject: (arg: UnsafeObject) => UnsafeObject;
+  +getRootTag: (arg: RootTag) => RootTag;
+  +getValue: (x: number, y: string, z: Object) => Object;
+  +getValueWithCallback: (callback: (value: string) => void) => void;
+  +getValueWithPromise: (error: boolean) => Promise<string>;
+  +voidFuncThrows?: () => void;
+  +getObjectThrows?: (arg: Object) => Object;
+  +promiseThrows?: () => Promise<void>;
+  +voidFuncAssert?: () => void;
+  +getObjectAssert?: (arg: Object) => Object;
+  +promiseAssert?: () => Promise<void>;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Types/CodegenTypes.js 1`] = `
+"export type BubblingEventHandler<T, PaperName: string | empty = empty> = (
+  event: SyntheticEvent<T>
+) => void | Promise<void>;
+export type DirectEventHandler<T, PaperName: string | empty = empty> = (
+  event: SyntheticEvent<T>
+) => void | Promise<void>;
+export type Double = number;
+export type Float = number;
+export type Int32 = number;
+export type UnsafeObject = $FlowFixMe;
+export type UnsafeMixed = mixed;
+type DefaultTypes = number | boolean | string | $ReadOnlyArray<string>;
+export type WithDefault<Type: DefaultTypes, Value: ?Type | string> = ?Type;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Types/CoreEventTypes.js 1`] = `
+"export type SyntheticEvent<+T> = $ReadOnly<{|
+  bubbles: ?boolean,
+  cancelable: ?boolean,
+  currentTarget: number | React.ElementRef<HostComponent<mixed>>,
+  defaultPrevented: ?boolean,
+  dispatchConfig: $ReadOnly<{|
+    registrationName: string,
+  |}>,
+  eventPhase: ?number,
+  preventDefault: () => void,
+  isDefaultPrevented: () => boolean,
+  stopPropagation: () => void,
+  isPropagationStopped: () => boolean,
+  isTrusted: ?boolean,
+  nativeEvent: T,
+  persist: () => void,
+  target: ?number | React.ElementRef<HostComponent<mixed>>,
+  timeStamp: number,
+  type: ?string,
+|}>;
+export type ResponderSyntheticEvent<T> = $ReadOnly<{|
+  ...SyntheticEvent<T>,
+  touchHistory: $ReadOnly<{|
+    indexOfSingleActiveTouch: number,
+    mostRecentTimeStamp: number,
+    numberActiveTouches: number,
+    touchBank: $ReadOnlyArray<
+      $ReadOnly<{|
+        touchActive: boolean,
+        startPageX: number,
+        startPageY: number,
+        startTimeStamp: number,
+        currentPageX: number,
+        currentPageY: number,
+        currentTimeStamp: number,
+        previousPageX: number,
+        previousPageY: number,
+        previousTimeStamp: number,
+      |}>,
+    >,
+  |}>,
+|}>;
+export type Layout = $ReadOnly<{|
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+|}>;
+export type TextLayout = $ReadOnly<{|
+  ...Layout,
+  ascender: number,
+  capHeight: number,
+  descender: number,
+  text: string,
+  xHeight: number,
+|}>;
+export type LayoutEvent = SyntheticEvent<
+  $ReadOnly<{|
+    layout: Layout,
+  |}>,
+>;
+export type TextLayoutEvent = SyntheticEvent<
+  $ReadOnly<{|
+    lines: Array<TextLayout>,
+  |}>,
+>;
+export interface NativeUIEvent {
+  +detail: number;
+}
+export interface NativeMouseEvent extends NativeUIEvent {
+  +screenX: number;
+  +screenY: number;
+  +pageX: number;
+  +pageY: number;
+  +clientX: number;
+  +clientY: number;
+  +x: number;
+  +y: number;
+  +ctrlKey: boolean;
+  +shiftKey: boolean;
+  +altKey: boolean;
+  +metaKey: boolean;
+  +button: number;
+  +buttons: number;
+  +relatedTarget: null | number | React.ElementRef<HostComponent<mixed>>;
+  +offsetX: number;
+  +offsetY: number;
+}
+export interface NativePointerEvent extends NativeMouseEvent {
+  +pointerId: number;
+  +width: number;
+  +height: number;
+  +pressure: number;
+  +tangentialPressure: number;
+  +tiltX: number;
+  +tiltY: number;
+  +twist: number;
+  +pointerType: string;
+  +isPrimary: boolean;
+}
+export type PointerEvent = SyntheticEvent<NativePointerEvent>;
+export type PressEvent = ResponderSyntheticEvent<
+  $ReadOnly<{|
+    changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, \\"nativeEvent\\">>,
+    force?: number,
+    identifier: number,
+    locationX: number,
+    locationY: number,
+    pageX: number,
+    pageY: number,
+    target: ?number,
+    timestamp: number,
+    touches: $ReadOnlyArray<$PropertyType<PressEvent, \\"nativeEvent\\">>,
+  |}>,
+>;
+export type ScrollEvent = SyntheticEvent<
+  $ReadOnly<{|
+    contentInset: $ReadOnly<{|
+      bottom: number,
+      left: number,
+      right: number,
+      top: number,
+    |}>,
+    contentOffset: $ReadOnly<{|
+      y: number,
+      x: number,
+    |}>,
+    contentSize: $ReadOnly<{|
+      height: number,
+      width: number,
+    |}>,
+    layoutMeasurement: $ReadOnly<{|
+      height: number,
+      width: number,
+    |}>,
+    targetContentOffset?: $ReadOnly<{|
+      y: number,
+      x: number,
+    |}>,
+    velocity?: $ReadOnly<{|
+      y: number,
+      x: number,
+    |}>,
+    zoomScale?: number,
+    responderIgnoreScroll?: boolean,
+  |}>,
+>;
+export type BlurEvent = SyntheticEvent<
+  $ReadOnly<{|
+    target: number,
+  |}>,
+>;
+export type FocusEvent = SyntheticEvent<
+  $ReadOnly<{|
+    target: number,
+  |}>,
+>;
+export type MouseEvent = SyntheticEvent<
+  $ReadOnly<{|
+    clientX: number,
+    clientY: number,
+    pageX: number,
+    pageY: number,
+    timestamp: number,
+  |}>,
+>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Types/ReactDevToolsTypes.js 1`] = `
+"type PublicInstance = {
+  ...NativeMethods,
+};
+export type InstanceFromReactDevTools =
+  | PublicInstance
+  | {
+      canonical?:
+        | PublicInstance
+        | {
+            publicInstance?: PublicInstance,
+          },
+    };
+export type ReactDevToolsAgentEvents = {
+  drawTraceUpdates: [Array<{ node: InstanceFromReactDevTools, color: string }>],
+  disableTraceUpdates: [],
+  showNativeHighlight: [node: InstanceFromReactDevTools],
+  hideNativeHighlight: [],
+  shutdown: [],
+  startInspectingNative: [],
+  stopInspectingNative: [],
+};
+export type ReactDevToolsAgent = {
+  selectNode(node: mixed): void,
+  stopInspectingNative(value: boolean): void,
+  addListener<Event: $Keys<ReactDevToolsAgentEvents>>(
+    event: Event,
+    listener: (...ReactDevToolsAgentEvents[Event]) => void
+  ): void,
+  removeListener(
+    event: $Keys<ReactDevToolsAgentEvents>,
+    listener: () => void
+  ): void,
+};
+export type ReactDevToolsGlobalHook = {
+  on: (eventName: string, (agent: ReactDevToolsAgent) => void) => void,
+  off: (eventName: string, (agent: ReactDevToolsAgent) => void) => void,
+  reactDevtoolsAgent?: ReactDevToolsAgent,
+  resolveRNStyle?: mixed,
+  nativeStyleEditorValidAttributes?: Array<string>,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Types/RootTagTypes.js 1`] = `
+"export type { RootTag } from \\"../ReactNative/RootTag\\";
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Types/UIManagerJSInterface.js 1`] = `
+"export interface UIManagerJSInterface extends Spec {
+  +getViewManagerConfig: (viewManagerName: string) => Object;
+  +hasViewManagerConfig: (viewManagerName: string) => boolean;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/UTFSequence.js 1`] = `
+"declare const UTFSequence: {|
+  BOM: string,
+  BULLET: string,
+  BULLET_SP: string,
+  MDASH: string,
+  MDASH_SP: string,
+  MIDDOT: string,
+  MIDDOT_KATAKANA: string,
+  MIDDOT_SP: string,
+  NBSP: string,
+  NDASH: string,
+  NDASH_SP: string,
+  NEWLINE: string,
+  PIZZA: string,
+  TRIANGLE_LEFT: string,
+  TRIANGLE_RIGHT: string,
+|};
+declare export default typeof UTFSequence;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/Appearance.js 1`] = `
+"type AppearanceListener = (preferences: AppearancePreferences) => void;
+declare module.exports: {
+  getColorScheme(): ?ColorSchemeName,
+  setColorScheme(colorScheme: ?ColorSchemeName): void,
+  addChangeListener(listener: AppearanceListener): EventSubscription,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/BackHandler.android.js 1`] = `
+"type BackPressEventName = \\"backPress\\" | \\"hardwareBackPress\\";
+type TBackHandler = {|
+  +exitApp: () => void,
+  +addEventListener: (
+    eventName: BackPressEventName,
+    handler: () => ?boolean
+  ) => { remove: () => void, ... },
+  +removeEventListener: (
+    eventName: BackPressEventName,
+    handler: () => ?boolean
+  ) => void,
+|};
+declare const BackHandler: TBackHandler;
+declare module.exports: BackHandler;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/BackHandler.ios.js 1`] = `
+"declare module.exports: $FlowFixMe;
+type BackPressEventName = \\"backPress\\" | \\"hardwareBackPress\\";
+type TBackHandler = {|
+  +exitApp: () => void,
+  +addEventListener: (
+    eventName: BackPressEventName,
+    handler: () => ?boolean
+  ) => { remove: () => void, ... },
+  +removeEventListener: (
+    eventName: BackPressEventName,
+    handler: () => ?boolean
+  ) => void,
+|};
+declare let BackHandler: TBackHandler;
+declare module.exports: BackHandler;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/BackHandler.js.flow 1`] = `
+"type BackPressEventName = \\"backPress\\" | \\"hardwareBackPress\\";
+type TBackHandler = {|
+  +exitApp: () => void,
+  +addEventListener: (
+    eventName: BackPressEventName,
+    handler: () => ?boolean
+  ) => { remove: () => void, ... },
+  +removeEventListener: (
+    eventName: BackPressEventName,
+    handler: () => ?boolean
+  ) => void,
+|};
+declare module.exports: TBackHandler;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/DebugEnvironment.js 1`] = `
+"declare export let isAsyncDebugging: boolean;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/DevSettings.js 1`] = `
+"declare let DevSettings: {
+  addMenuItem(title: string, handler: () => mixed): void,
+  reload(reason?: string): void,
+  onFastRefresh(): void,
+};
+declare module.exports: DevSettings;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/DeviceInfo.js 1`] = `
+"declare module.exports: NativeDeviceInfo;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/Dimensions.js 1`] = `
+"declare class Dimensions {
+  static get(dim: string): DisplayMetrics | DisplayMetricsAndroid;
+  static set(dims: $ReadOnly<DimensionsPayload>): void;
+  static addEventListener(type: \\"change\\", handler: Function): EventSubscription;
+}
+declare export default typeof Dimensions;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/FeatureDetection.js 1`] = `
+"declare function isNativeFunction(f: Function): boolean;
+declare function hasNativeConstructor(o: Object, expectedName: string): boolean;
+declare module.exports: {
+  isNativeFunction: isNativeFunction,
+  hasNativeConstructor: hasNativeConstructor,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/GlobalPerformanceLogger.js 1`] = `
+"declare const GlobalPerformanceLogger: IPerformanceLogger;
+declare module.exports: GlobalPerformanceLogger;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/HMRClient.js 1`] = `
+"type LogLevel =
+  | \\"trace\\"
+  | \\"info\\"
+  | \\"warn\\"
+  | \\"error\\"
+  | \\"log\\"
+  | \\"group\\"
+  | \\"groupCollapsed\\"
+  | \\"groupEnd\\"
+  | \\"debug\\";
+export type HMRClientNativeInterface = {|
+  enable(): void,
+  disable(): void,
+  registerBundle(requestUrl: string): void,
+  log(level: LogLevel, data: $ReadOnlyArray<mixed>): void,
+  setup(
+    platform: string,
+    bundleEntry: string,
+    host: string,
+    port: number | string,
+    isEnabled: boolean,
+    scheme?: string
+  ): void,
+|};
+declare const HMRClient: HMRClientNativeInterface;
+declare module.exports: HMRClient;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/HMRClientProdShim.js 1`] = `
+"declare const HMRClientProdShim: HMRClientNativeInterface;
+declare module.exports: HMRClientProdShim;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/IPerformanceLogger.js 1`] = `
+"export type Timespan = {
+  startTime: number,
+  endTime?: number,
+  totalTime?: number,
+  startExtras?: Extras,
+  endExtras?: Extras,
+};
+export type ExtraValue = number | string | boolean;
+export type Extras = { [key: string]: ExtraValue };
+export interface IPerformanceLogger {
+  addTimespan(
+    key: string,
+    startTime: number,
+    endTime: number,
+    startExtras?: Extras,
+    endExtras?: Extras
+  ): void;
+  append(logger: IPerformanceLogger): void;
+  clear(): void;
+  clearCompleted(): void;
+  close(): void;
+  currentTimestamp(): number;
+  getExtras(): $ReadOnly<{ [key: string]: ?ExtraValue, ... }>;
+  getPoints(): $ReadOnly<{ [key: string]: ?number, ... }>;
+  getPointExtras(): $ReadOnly<{ [key: string]: ?Extras, ... }>;
+  getTimespans(): $ReadOnly<{ [key: string]: ?Timespan, ... }>;
+  hasTimespan(key: string): boolean;
+  isClosed(): boolean;
+  logEverything(): void;
+  markPoint(key: string, timestamp?: number, extras?: Extras): void;
+  removeExtra(key: string): ?ExtraValue;
+  setExtra(key: string, value: ExtraValue): void;
+  startTimespan(key: string, timestamp?: number, extras?: Extras): void;
+  stopTimespan(key: string, timestamp?: number, extras?: Extras): void;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/LoadingView.android.js 1`] = `
+"declare module.exports: {
+  showMessage(message: string, type: \\"load\\" | \\"refresh\\"): void,
+  hide(): void,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/LoadingView.ios.js 1`] = `
+"declare module.exports: {
+  showMessage(message: string, type: \\"load\\" | \\"refresh\\"): void,
+  hide(): void,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/LoadingView.js 1`] = `
+"declare module.exports: {
+  showMessage(message: string, type: \\"load\\" | \\"refresh\\"): void,
+  hide(): void,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/NativeAppearance.js 1`] = `
+"export type ColorSchemeName = \\"light\\" | \\"dark\\";
+export type AppearancePreferences = {|
+  colorScheme?: ?string,
+|};
+export interface Spec extends TurboModule {
+  +getColorScheme: () => ?string;
+  +setColorScheme?: (colorScheme: string) => void;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/NativeDevLoadingView.js 1`] = `
+"export interface Spec extends TurboModule {
+  +showMessage: (
+    message: string,
+    withColor: ?number,
+    withBackgroundColor: ?number
+  ) => void;
+  +hide: () => void;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/NativeDeviceInfo.js 1`] = `
+"export type DisplayMetricsAndroid = {|
+  width: number,
+  height: number,
+  scale: number,
+  fontScale: number,
+  densityDpi: number,
+|};
+export type DisplayMetrics = {|
+  width: number,
+  height: number,
+  scale: number,
+  fontScale: number,
+|};
+export type DimensionsPayload = {|
+  window?: DisplayMetrics,
+  screen?: DisplayMetrics,
+  windowPhysicalPixels?: DisplayMetricsAndroid,
+  screenPhysicalPixels?: DisplayMetricsAndroid,
+|};
+export type DeviceInfoConstants = {|
+  +Dimensions: DimensionsPayload,
+  +isIPhoneX_deprecated?: boolean,
+|};
+export interface Spec extends TurboModule {
+  +getConstants: () => DeviceInfoConstants;
+}
+declare const NativeDeviceInfo: { getConstants(): DeviceInfoConstants };
+declare export default typeof NativeDeviceInfo;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/NativePlatformConstantsAndroid.js 1`] = `
+"export type ReactNativeVersionAndroid = {|
+  major: number,
+  minor: number,
+  patch: number,
+  prerelease: ?number,
+|};
+export type PlatformConstantsAndroid = {|
+  isTesting: boolean,
+  isDisableAnimations?: boolean,
+  reactNativeVersion: ReactNativeVersionAndroid,
+  Version: number,
+  Release: string,
+  Serial: string,
+  Fingerprint: string,
+  Model: string,
+  ServerHost?: string,
+  uiMode: string,
+  Brand: string,
+  Manufacturer: string,
+|};
+export interface Spec extends TurboModule {
+  +getConstants: () => PlatformConstantsAndroid;
+  +getAndroidID: () => string;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/NativePlatformConstantsIOS.js 1`] = `
+"export type PlatformConstantsIOS = {|
+  isTesting: boolean,
+  isDisableAnimations?: boolean,
+  reactNativeVersion: {|
+    major: number,
+    minor: number,
+    patch: number,
+    prerelease: ?number,
+  |},
+  forceTouchAvailable: boolean,
+  osVersion: string,
+  systemName: string,
+  interfaceIdiom: string,
+  isMacCatalyst?: boolean,
+|};
+export interface Spec extends TurboModule {
+  +getConstants: () => PlatformConstantsIOS;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/PerformanceLoggerContext.js 1`] = `
+"declare const PerformanceLoggerContext: React.Context<IPerformanceLogger>;
+declare export function usePerformanceLogger(): IPerformanceLogger;
+declare export default typeof PerformanceLoggerContext;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/PixelRatio.js 1`] = `
+"declare class PixelRatio {
+  static get(): number;
+  static getFontScale(): number;
+  static getPixelSizeForLayoutSize(layoutSize: number): number;
+  static roundToNearestPixel(layoutSize: number): number;
+  static startDetecting(): void;
+}
+declare export default typeof PixelRatio;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/Platform.android.js 1`] = `
+"declare const Platform: PlatformType;
+declare module.exports: Platform;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/Platform.flow.js 1`] = `
+"export type PlatformSelectSpec<T> = {
+  default?: T,
+  native?: T,
+  ios?: T,
+  android?: T,
+  ...
+};
+type IOSPlatform = {
+  __constants: null,
+  OS: $TEMPORARY$string<\\"ios\\">,
+  get Version(): string,
+  get constants(): {|
+    forceTouchAvailable: boolean,
+    interfaceIdiom: string,
+    isTesting: boolean,
+    isDisableAnimations?: boolean,
+    osVersion: string,
+    reactNativeVersion: {|
+      major: number,
+      minor: number,
+      patch: number,
+      prerelease: ?number,
+    |},
+    systemName: string,
+    isMacCatalyst?: boolean,
+  |},
+  get isPad(): boolean,
+  get isTV(): boolean,
+  get isTesting(): boolean,
+  get isDisableAnimations(): boolean,
+  get isMacCatalyst(): boolean,
+  select: <T>(spec: PlatformSelectSpec<T>) => T,
+};
+type AndroidPlatform = {
+  __constants: null,
+  OS: $TEMPORARY$string<\\"android\\">,
+  get Version(): number,
+  get constants(): {|
+    isTesting: boolean,
+    isDisableAnimations?: boolean,
+    reactNativeVersion: {|
+      major: number,
+      minor: number,
+      patch: number,
+      prerelease: ?number,
+    |},
+    Version: number,
+    Release: string,
+    Serial: string,
+    Fingerprint: string,
+    Model: string,
+    ServerHost?: string,
+    uiMode: string,
+    Brand: string,
+    Manufacturer: string,
+  |},
+  get isTV(): boolean,
+  get isTesting(): boolean,
+  get isDisableAnimations(): boolean,
+  select: <T>(spec: PlatformSelectSpec<T>) => T,
+};
+export type Platform = IOSPlatform | AndroidPlatform;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/Platform.ios.js 1`] = `
+"declare const Platform: PlatformType;
+declare module.exports: Platform;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/Platform.js.flow 1`] = `
+"declare module.exports: Platform;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/PolyfillFunctions.js 1`] = `
+"declare function polyfillObjectProperty<T>(
+  object: { ... },
+  name: string,
+  getValue: () => T
+): void;
+declare function polyfillGlobal<T>(name: string, getValue: () => T): void;
+declare module.exports: {
+  polyfillObjectProperty: polyfillObjectProperty,
+  polyfillGlobal: polyfillGlobal,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/RCTLog.js 1`] = `
+"declare let warningHandler: ?(...Array<mixed>) => void;
+declare const RCTLog: {
+  logIfNoNativeHook(level: string, ...args: Array<mixed>): void,
+  logToConsole(level: string, ...args: Array<mixed>): void,
+  setWarningHandler(handler: typeof warningHandler): void,
+};
+declare module.exports: RCTLog;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/ReactNativeTestTools.js 1`] = `
+"declare const React: $FlowFixMe;
+declare const ReactTestRenderer: $FlowFixMe;
+export type ReactTestInstance = $PropertyType<ReactTestRendererType, \\"root\\">;
+export type Predicate = (node: ReactTestInstance) => boolean;
+export type ReactTestRendererJSON = ReturnType<ReactTestRenderer.create.toJSON>;
+declare function byClickable(): Predicate;
+declare function byTestID(testID: string): Predicate;
+declare function byTextMatching(regex: RegExp): Predicate;
+declare function enter(instance: ReactTestInstance, text: string): void;
+declare function maximumDepthError(
+  tree: ReactTestRendererType,
+  maxDepthLimit: number
+): ?string;
+declare function expectNoConsoleWarn(): void;
+declare function expectNoConsoleError(): void;
+declare function expectRendersMatchingSnapshot(
+  name: string,
+  ComponentProvider: () => React.Element<any>,
+  unmockComponent: () => mixed
+): void;
+declare function maximumDepthOfJSON(node: ?ReactTestRendererJSON): number;
+declare function renderAndEnforceStrictMode(element: React.Node): any;
+declare function renderWithStrictMode(
+  element: React.Node
+): ReactTestRendererType;
+declare function tap(instance: ReactTestInstance): void;
+declare function scrollToBottom(instance: ReactTestInstance): void;
+declare function withMessage(fn: Predicate, message: string): Predicate;
+export { byClickable };
+export { byTestID };
+export { byTextMatching };
+export { enter };
+export { expectNoConsoleWarn };
+export { expectNoConsoleError };
+export { expectRendersMatchingSnapshot };
+export { maximumDepthError };
+export { maximumDepthOfJSON };
+export { renderAndEnforceStrictMode };
+export { renderWithStrictMode };
+export { scrollToBottom };
+export { tap };
+export { withMessage };
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/SceneTracker.js 1`] = `
+"export type Scene = { name: string, [string]: mixed, ... };
+declare const SceneTracker: {
+  setActiveScene(scene: Scene): void,
+  getActiveScene(): Scene,
+  addActiveSceneChangedListener(callback: (scene: Scene) => void): {
+    remove: () => void,
+    ...
+  },
+};
+declare module.exports: SceneTracker;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/binaryToBase64.js 1`] = `
+"declare function binaryToBase64(data: ArrayBuffer | $ArrayBufferView): string;
+declare module.exports: binaryToBase64;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/codegenNativeCommands.js 1`] = `
+"type Options<T = string> = $ReadOnly<{|
+  supportedCommands: $ReadOnlyArray<T>,
+|}>;
+declare function codegenNativeCommands<T: interface {}>(
+  options: Options<$Keys<T>>
+): T;
+declare export default typeof codegenNativeCommands;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/codegenNativeComponent.js 1`] = `
+"type Options = $ReadOnly<{|
+  interfaceOnly?: boolean,
+  paperComponentName?: string,
+  paperComponentNameDeprecated?: string,
+  excludedPlatforms?: $ReadOnlyArray<\\"iOS\\" | \\"android\\">,
+|}>;
+export type NativeComponentType<T> = HostComponent<T>;
+declare function codegenNativeComponent<Props>(
+  componentName: string,
+  options?: Options
+): NativeComponentType<Props>;
+declare export default typeof codegenNativeComponent;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/createPerformanceLogger.js 1`] = `
+"declare export const getCurrentTimestamp: () => number;
+export type { Extras, ExtraValue, IPerformanceLogger, Timespan };
+declare export default function createPerformanceLogger(): IPerformanceLogger;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js 1`] = `
+"declare function deepFreezeAndThrowOnMutationInDev<T: { ... } | Array<mixed>>(
+  object: T
+): T;
+declare module.exports: deepFreezeAndThrowOnMutationInDev;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/defineLazyObjectProperty.js 1`] = `
+"declare function defineLazyObjectProperty<T>(
+  object: interface {},
+  name: string,
+  descriptor: {
+    get: () => T,
+    enumerable?: boolean,
+    writable?: boolean,
+    ...
+  }
+): void;
+declare module.exports: defineLazyObjectProperty;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/differ/deepDiffer.js 1`] = `
+"type Options = {| +unsafelyIgnoreFunctions?: boolean |};
+declare const deepDiffer: (
+  one: any,
+  two: any,
+  maxDepthOrOptions: Options | number,
+  maybeOptions?: Options
+) => boolean;
+declare module.exports: deepDiffer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/differ/insetsDiffer.js 1`] = `
+"type Inset = {
+  top: ?number,
+  left: ?number,
+  right: ?number,
+  bottom: ?number,
+  ...
+};
+declare const insetsDiffer: (one: Inset, two: Inset) => boolean;
+declare module.exports: insetsDiffer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/differ/matricesDiffer.js 1`] = `
+"declare const matricesDiffer: (
+  one: ?Array<number>,
+  two: ?Array<number>
+) => boolean;
+declare module.exports: matricesDiffer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/differ/pointsDiffer.js 1`] = `
+"type Point = {
+  x: ?number,
+  y: ?number,
+  ...
+};
+declare const pointsDiffer: (one: ?Point, two: ?Point) => boolean;
+declare module.exports: pointsDiffer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/differ/sizesDiffer.js 1`] = `
+"type Size = { width: ?number, height: ?number };
+declare const sizesDiffer: (one: Size, two: Size) => boolean;
+declare module.exports: sizesDiffer;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/dismissKeyboard.js 1`] = `
+"declare function dismissKeyboard(): void;
+declare module.exports: dismissKeyboard;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/infoLog.js 1`] = `
+"declare function infoLog(...args: Array<mixed>): void;
+declare module.exports: infoLog;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/logError.js 1`] = `
+"declare const logError: (...args: $ReadOnlyArray<mixed>) => void;
+declare module.exports: logError;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/mapWithSeparator.js 1`] = `
+"declare function mapWithSeparator<TFrom, TTo>(
+  items: Array<TFrom>,
+  itemRenderer: (item: TFrom, index: number, items: Array<TFrom>) => TTo,
+  spacerRenderer: (index: number) => TTo
+): Array<TTo>;
+declare module.exports: mapWithSeparator;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/stringifySafe.js 1`] = `
+"declare export function createStringifySafeWithLimits(limits: {|
+  maxDepth?: number,
+  maxStringLimit?: number,
+  maxArrayLimit?: number,
+  maxObjectKeysLimit?: number,
+|}): (mixed) => string;
+declare const stringifySafe: (mixed) => string;
+declare export default typeof stringifySafe;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/useColorScheme.js 1`] = `
+"declare export default function useColorScheme(): ?ColorSchemeName;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/useMergeRefs.js 1`] = `
+"declare export default function useMergeRefs<Instance>(
+  ...refs: $ReadOnlyArray<?React.RefSetter<Instance>>
+): (Instance | null) => void;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/useRefEffect.js 1`] = `
+"type CallbackRef<T> = (T) => mixed;
+declare export default function useRefEffect<TInstance>(
+  effect: (TInstance) => (() => void) | void
+): CallbackRef<TInstance | null>;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/useWindowDimensions.js 1`] = `
+"declare export default function useWindowDimensions():
+  | DisplayMetrics
+  | DisplayMetricsAndroid;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/verifyComponentAttributeEquivalence.js 1`] = `
+"declare export default function verifyComponentAttributeEquivalence(
+  nativeViewConfig: ViewConfig,
+  staticViewConfig: ViewConfig
+): void;
+declare export function getConfigWithoutViewProps(
+  viewConfig: ViewConfig,
+  propName: string
+): { ... };
+declare export function stringifyViewConfig(viewConfig: any): string;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Utilities/warnOnce.js 1`] = `
+"declare function warnOnce(key: string, message: string): void;
+declare module.exports: warnOnce;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Vibration/NativeVibration.js 1`] = `
+"export interface Spec extends TurboModule {
+  +getConstants: () => {||};
+  +vibrate: (pattern: number) => void;
+  +vibrateByPattern: (pattern: Array<number>, repeat: number) => void;
+  +cancel: () => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Vibration/Vibration.js 1`] = `
+"declare const Vibration: {
+  vibrate: (pattern: number | Array<number>, repeat: boolean) => void,
+  cancel: () => void,
+};
+declare module.exports: Vibration;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/EventCounts.js 1`] = `
+"type EventCountsForEachCallbackType =
+  | (() => void)
+  | ((value: number) => void)
+  | ((value: number, key: string) => void)
+  | ((value: number, key: string, map: Map<string, number>) => void);
+declare export default class EventCounts {
+  get size(): number;
+  entries(): Iterator<[string, number]>;
+  forEach(callback: EventCountsForEachCallbackType): void;
+  get(key: string): ?number;
+  has(key: string): boolean;
+  keys(): Iterator<string>;
+  values(): Iterator<number>;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/MemoryInfo.js 1`] = `
+"type MemoryInfoLike = {
+  jsHeapSizeLimit: ?number,
+  totalJSHeapSize: ?number,
+  usedJSHeapSize: ?number,
+};
+declare export default class MemoryInfo {
+  _jsHeapSizeLimit: ?number;
+  _totalJSHeapSize: ?number;
+  _usedJSHeapSize: ?number;
+  constructor(memoryInfo: ?MemoryInfoLike): void;
+  get jsHeapSizeLimit(): ?number;
+  get totalJSHeapSize(): ?number;
+  get usedJSHeapSize(): ?number;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/NativePerformance.js 1`] = `
+"export type NativeMemoryInfo = { [key: string]: ?number };
+export type ReactNativeStartupTiming = { [key: string]: ?number };
+export interface Spec extends TurboModule {
+  +mark: (name: string, startTime: number) => void;
+  +measure: (
+    name: string,
+    startTime: number,
+    endTime: number,
+    duration?: number,
+    startMark?: string,
+    endMark?: string
+  ) => void;
+  +getSimpleMemoryInfo: () => NativeMemoryInfo;
+  +getReactNativeStartupTiming: () => ReactNativeStartupTiming;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/NativePerformanceObserver.js 1`] = `
+"export type RawPerformanceEntryType = number;
+export type RawPerformanceEntry = {|
+  name: string,
+  entryType: RawPerformanceEntryType,
+  startTime: number,
+  duration: number,
+  processingStart?: number,
+  processingEnd?: number,
+  interactionId?: number,
+|};
+export type GetPendingEntriesResult = {|
+  entries: $ReadOnlyArray<RawPerformanceEntry>,
+  droppedEntriesCount: number,
+|};
+export interface Spec extends TurboModule {
+  +startReporting: (entryType: RawPerformanceEntryType) => void;
+  +stopReporting: (entryType: RawPerformanceEntryType) => void;
+  +setIsBuffered: (
+    entryTypes: $ReadOnlyArray<RawPerformanceEntryType>,
+    isBuffered: boolean
+  ) => void;
+  +popPendingEntries: () => GetPendingEntriesResult;
+  +setOnPerformanceEntryCallback: (callback?: () => void) => void;
+  +logRawEntry: (entry: RawPerformanceEntry) => void;
+  +getEventCounts: () => $ReadOnlyArray<[string, number]>;
+  +setDurationThreshold: (
+    entryType: RawPerformanceEntryType,
+    durationThreshold: number
+  ) => void;
+  +clearEntries: (
+    entryType: RawPerformanceEntryType,
+    entryName?: string
+  ) => void;
+  +getEntries: (
+    entryType?: RawPerformanceEntryType,
+    entryName?: string
+  ) => $ReadOnlyArray<RawPerformanceEntry>;
+  +getSupportedPerformanceEntryTypes: () => $ReadOnlyArray<RawPerformanceEntryType>;
+}
+declare export default ?Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/Performance.js 1`] = `
+"type DetailType = mixed;
+export type PerformanceMarkOptions = {
+  detail?: DetailType,
+  startTime?: HighResTimeStamp,
+};
+declare export class PerformanceMark extends PerformanceEntry {
+  detail: DetailType;
+  constructor(markName: string, markOptions?: PerformanceMarkOptions): void;
+}
+export type TimeStampOrName = HighResTimeStamp | string;
+export type PerformanceMeasureOptions = {
+  detail?: DetailType,
+  start?: TimeStampOrName,
+  end?: TimeStampOrName,
+  duration?: HighResTimeStamp,
+};
+declare export class PerformanceMeasure extends PerformanceEntry {
+  detail: DetailType;
+  constructor(
+    measureName: string,
+    measureOptions?: PerformanceMeasureOptions
+  ): void;
+}
+declare export default class Performance {
+  eventCounts: EventCounts;
+  get memory(): MemoryInfo;
+  get reactNativeStartupTiming(): ReactNativeStartupTiming;
+  mark(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
+  clearMarks(markName?: string): void;
+  measure(
+    measureName: string,
+    startMarkOrOptions?: string | PerformanceMeasureOptions,
+    endMark?: string
+  ): PerformanceMeasure;
+  clearMeasures(measureName?: string): void;
+  now(): HighResTimeStamp;
+  getEntries(): PerformanceEntryList;
+  getEntriesByType(entryType: PerformanceEntryType): PerformanceEntryList;
+  getEntriesByName(
+    entryName: string,
+    entryType?: PerformanceEntryType
+  ): PerformanceEntryList;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/PerformanceEntry.js 1`] = `
+"export type HighResTimeStamp = number;
+export type PerformanceEntryType = \\"mark\\" | \\"measure\\" | \\"event\\";
+export type PerformanceEntryJSON = {
+  name: string,
+  entryType: PerformanceEntryType,
+  startTime: HighResTimeStamp,
+  duration: HighResTimeStamp,
+  ...
+};
+declare export const ALWAYS_LOGGED_ENTRY_TYPES: $ReadOnlyArray<PerformanceEntryType>;
+declare export class PerformanceEntry {
+  name: string;
+  entryType: PerformanceEntryType;
+  startTime: HighResTimeStamp;
+  duration: HighResTimeStamp;
+  constructor(init: {
+    name: string,
+    entryType: PerformanceEntryType,
+    startTime: HighResTimeStamp,
+    duration: HighResTimeStamp,
+  }): void;
+  toJSON(): PerformanceEntryJSON;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/PerformanceEventTiming.js 1`] = `
+"export type PerformanceEventTimingJSON = {
+  ...PerformanceEntryJSON,
+  processingStart: HighResTimeStamp,
+  processingEnd: HighResTimeStamp,
+  interactionId: number,
+  ...
+};
+declare export default class PerformanceEventTiming extends PerformanceEntry {
+  processingStart: HighResTimeStamp;
+  processingEnd: HighResTimeStamp;
+  interactionId: number;
+  constructor(init: {
+    name: string,
+    startTime?: HighResTimeStamp,
+    duration?: HighResTimeStamp,
+    processingStart?: HighResTimeStamp,
+    processingEnd?: HighResTimeStamp,
+    interactionId?: number,
+  }): void;
+  toJSON(): PerformanceEventTimingJSON;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/PerformanceObserver.js 1`] = `
+"export type PerformanceEntryList = $ReadOnlyArray<PerformanceEntry>;
+declare export class PerformanceObserverEntryList {
+  _entries: PerformanceEntryList;
+  constructor(entries: PerformanceEntryList): void;
+  getEntries(): PerformanceEntryList;
+  getEntriesByType(type: PerformanceEntryType): PerformanceEntryList;
+  getEntriesByName(
+    name: string,
+    type?: PerformanceEntryType
+  ): PerformanceEntryList;
+}
+export type PerformanceObserverCallback = (
+  list: PerformanceObserverEntryList,
+  observer: PerformanceObserver,
+  droppedEntryCount?: number
+) => void;
+export type PerformanceObserverInit =
+  | {
+      entryTypes: Array<PerformanceEntryType>,
+    }
+  | {
+      type: PerformanceEntryType,
+      durationThreshold?: HighResTimeStamp,
+    };
+declare export function warnNoNativePerformanceObserver(): void;
+declare export default class PerformanceObserver {
+  _callback: PerformanceObserverCallback;
+  _type: \\"single\\" | \\"multiple\\" | void;
+  constructor(callback: PerformanceObserverCallback): void;
+  observe(options: PerformanceObserverInit): void;
+  disconnect(): void;
+  _validateObserveOptions(options: PerformanceObserverInit): void;
+  static supportedEntryTypes: $ReadOnlyArray<PerformanceEntryType>;
+}
+export { PerformanceEventTiming };
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/RawPerformanceEntry.js 1`] = `
+"declare export const RawPerformanceEntryTypeValues: {
+  UNDEFINED: 0,
+  MARK: 1,
+  MEASURE: 2,
+  EVENT: 3,
+};
+declare export function rawToPerformanceEntry(
+  entry: RawPerformanceEntry
+): PerformanceEntry;
+declare export function rawToPerformanceEntryType(
+  type: RawPerformanceEntryType
+): PerformanceEntryType;
+declare export function performanceEntryTypeToRaw(
+  type: PerformanceEntryType
+): RawPerformanceEntryType;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebPerformance/ReactNativeStartupTiming.js 1`] = `
+"type ReactNativeStartupTimingLike = {
+  startTime: ?number,
+  endTime: ?number,
+  initializeRuntimeStart: ?number,
+  initializeRuntimeEnd: ?number,
+  executeJavaScriptBundleEntryPointStart: ?number,
+  executeJavaScriptBundleEntryPointEnd: ?number,
+};
+declare export default class ReactNativeStartupTiming {
+  _startTime: ?number;
+  _endTime: ?number;
+  _initializeRuntimeStart: ?number;
+  _initializeRuntimeEnd: ?number;
+  _executeJavaScriptBundleEntryPointStart: ?number;
+  _executeJavaScriptBundleEntryPointEnd: ?number;
+  constructor(startUpTiming: ?ReactNativeStartupTimingLike): void;
+  get startTime(): ?number;
+  get endTime(): ?number;
+  get initializeRuntimeStart(): ?number;
+  get initializeRuntimeEnd(): ?number;
+  get executeJavaScriptBundleEntryPointStart(): ?number;
+  get executeJavaScriptBundleEntryPointEnd(): ?number;
+}
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebSocket/NativeWebSocketModule.js 1`] = `
+"export interface Spec extends TurboModule {
+  +connect: (
+    url: string,
+    protocols: ?Array<string>,
+    options: {| headers?: Object |},
+    socketID: number
+  ) => void;
+  +send: (message: string, forSocketID: number) => void;
+  +sendBinary: (base64String: string, forSocketID: number) => void;
+  +ping: (socketID: number) => void;
+  +close: (code: number, reason: string, socketID: number) => void;
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+declare export default Spec;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/WebSocket/WebSocketEvent.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/WebSocket/WebSocketInterceptor.js 1`] = `"UNTYPED MODULE"`;
+
+exports[`public API should not change unintentionally Libraries/YellowBox/YellowBoxDeprecated.js 1`] = `
+"declare const React: $FlowFixMe;
+type Props = $ReadOnly<{||}>;
+declare module.exports: Class<React.Component<Props>> & {
+  ignoreWarnings($ReadOnlyArray<IgnorePattern>): void,
+  install(): void,
+  uninstall(): void,
+  ...
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/promiseRejectionTrackingOptions.js 1`] = `
+"declare let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]>;
+declare export default typeof rejectionTrackingOptions;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/vendor/core/ErrorUtils.js 1`] = `
+"declare module.exports: ErrorUtilsT;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/vendor/emitter/EventEmitter.js 1`] = `
+"export interface EventSubscription {
+  remove(): void;
+}
+export interface IEventEmitter<TEventToArgsMap: { ... }> {
+  addListener<TEvent: $Keys<TEventToArgsMap>>(
+    eventType: TEvent,
+    listener: (...args: TEventToArgsMap[TEvent]) => mixed,
+    context?: mixed
+  ): EventSubscription;
+  emit<TEvent: $Keys<TEventToArgsMap>>(
+    eventType: TEvent,
+    ...args: TEventToArgsMap[TEvent]
+  ): void;
+  removeAllListeners<TEvent: $Keys<TEventToArgsMap>>(eventType?: ?TEvent): void;
+  listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number;
+}
+declare export default class EventEmitter<TEventToArgsMap: { ... }>
+  implements IEventEmitter<TEventToArgsMap>
+{
+  addListener<TEvent: $Keys<TEventToArgsMap>>(
+    eventType: TEvent,
+    listener: (...args: TEventToArgsMap[TEvent]) => mixed,
+    context: mixed
+  ): EventSubscription;
+  emit<TEvent: $Keys<TEventToArgsMap>>(
+    eventType: TEvent,
+    ...args: TEventToArgsMap[TEvent]
+  ): void;
+  removeAllListeners<TEvent: $Keys<TEventToArgsMap>>(eventType?: ?TEvent): void;
+  listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number;
+}
+"
+`;
+
+exports[`public API should not change unintentionally index.js 1`] = `
+"export type HostComponent<T> = _HostComponentInternal<T>;
+declare module.exports: {
+  get AccessibilityInfo(): AccessibilityInfo,
+  get ActivityIndicator(): ActivityIndicator,
+  get Button(): Button,
+  get DrawerLayoutAndroid(): DrawerLayoutAndroid,
+  get FlatList(): FlatList,
+  get Image(): Image,
+  get ImageBackground(): ImageBackground,
+  get InputAccessoryView(): InputAccessoryView,
+  get KeyboardAvoidingView(): KeyboardAvoidingView,
+  get Modal(): Modal,
+  get Pressable(): Pressable,
+  get ProgressBarAndroid(): ProgressBarAndroid,
+  get RefreshControl(): RefreshControl,
+  get SafeAreaView(): SafeAreaView,
+  get ScrollView(): ScrollView,
+  get SectionList(): SectionList,
+  get StatusBar(): StatusBar,
+  get Switch(): Switch,
+  get Text(): Text,
+  get TextInput(): TextInput,
+  get Touchable(): Touchable,
+  get TouchableHighlight(): TouchableHighlight,
+  get TouchableNativeFeedback(): TouchableNativeFeedback,
+  get TouchableOpacity(): TouchableOpacity,
+  get TouchableWithoutFeedback(): TouchableWithoutFeedback,
+  get View(): View,
+  get VirtualizedList(): VirtualizedList,
+  get VirtualizedSectionList(): VirtualizedSectionList,
+  get ActionSheetIOS(): ActionSheetIOS,
+  get Alert(): Alert,
+  get Animated(): { ...$Diff<AnimatedModule, { default: any }>, ...Animated },
+  get Appearance(): Appearance,
+  get AppRegistry(): AppRegistry,
+  get AppState(): AppState,
+  get BackHandler(): BackHandler,
+  get Clipboard(): Clipboard,
+  get DeviceInfo(): DeviceInfo,
+  get DevSettings(): DevSettings,
+  get Dimensions(): Dimensions,
+  get Easing(): Easing,
+  get findNodeHandle(): $PropertyType<ReactNative, \\"findNodeHandle\\">,
+  get I18nManager(): I18nManager,
+  get InteractionManager(): InteractionManager,
+  get Keyboard(): Keyboard,
+  get LayoutAnimation(): LayoutAnimation,
+  get Linking(): Linking,
+  get LogBox(): LogBox,
+  get NativeDialogManagerAndroid(): NativeDialogManagerAndroid,
+  get NativeEventEmitter(): NativeEventEmitter,
+  get Networking(): Networking,
+  get PanResponder(): PanResponder,
+  get PermissionsAndroid(): PermissionsAndroid,
+  get PixelRatio(): PixelRatio,
+  get PushNotificationIOS(): PushNotificationIOS,
+  get Settings(): Settings,
+  get Share(): Share,
+  get StyleSheet(): StyleSheet,
+  get Systrace(): Systrace,
+  get ToastAndroid(): ToastAndroid,
+  get TurboModuleRegistry(): TurboModuleRegistry,
+  get UIManager(): UIManager,
+  get unstable_batchedUpdates(): $PropertyType<
+    ReactNative,
+    \\"unstable_batchedUpdates\\",
+  >,
+  get useAnimatedValue(): useAnimatedValue,
+  get useColorScheme(): useColorScheme,
+  get useWindowDimensions(): useWindowDimensions,
+  get UTFSequence(): UTFSequence,
+  get Vibration(): Vibration,
+  get YellowBox(): YellowBox,
+  get DeviceEventEmitter(): RCTDeviceEventEmitter,
+  get DynamicColorIOS(): DynamicColorIOS,
+  get NativeAppEventEmitter(): RCTNativeAppEventEmitter,
+  get NativeModules(): NativeModules,
+  get Platform(): Platform,
+  get PlatformColor(): PlatformColor,
+  get processColor(): processColor,
+  get requireNativeComponent(): <T>(
+    uiViewClassName: string
+  ) => HostComponent<T>,
+  get RootTagContext(): RootTagContext,
+  get unstable_enableLogBox(): () => void,
+};
+"
+`;

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+import type {TransformVisitor} from 'hermes-transform';
+
+const translate = require('flow-api-translator');
+const {promises: fs} = require('fs');
+const glob = require('glob');
+const {transform} = require('hermes-transform');
+const path = require('path');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '../../');
+const JS_FILES_PATTERN = 'Libraries/**/*.{js,flow}';
+const IGNORE_PATTERNS = [
+  '**/__{tests,mocks,fixtures,flowtests}__/**',
+  '**/*.fb.js',
+];
+
+// Exclude list for files that fail to parse under flow-api-translator. Please
+// review your changes before adding new entries.
+const FILES_WITH_KNOWN_ERRORS = new Set([
+  'Libraries/Blob/FileReader.js',
+  'Libraries/Blob/URL.js',
+  'Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js',
+  'Libraries/Components/Keyboard/KeyboardAvoidingView.js',
+  'Libraries/Components/RefreshControl/RefreshControl.js',
+  'Libraries/Components/ScrollView/ScrollView.js',
+  'Libraries/Components/StatusBar/StatusBar.js',
+  'Libraries/Components/TextInput/InputAccessoryView.js',
+  'Libraries/Components/StaticRenderer.js',
+  'Libraries/Components/Touchable/TouchableNativeFeedback.js',
+  'Libraries/Components/Touchable/TouchableWithoutFeedback.js',
+  'Libraries/Components/UnimplementedViews/UnimplementedView.js',
+  'Libraries/Core/ReactNativeVersion.js',
+  'Libraries/Core/ReactNativeVersionCheck.js',
+  'Libraries/DOM/OldStyleCollections/DOMRectList.js',
+  'Libraries/DOM/OldStyleCollections/HTMLCollection.js',
+  'Libraries/DOM/OldStyleCollections/NodeList.js',
+  'Libraries/Image/ImageBackground.js',
+  'Libraries/Inspector/ElementProperties.js',
+  'Libraries/Inspector/BorderBox.js',
+  'Libraries/Inspector/BoxInspector.js',
+  'Libraries/Inspector/InspectorPanel.js',
+  'Libraries/Inspector/NetworkOverlay.js',
+  'Libraries/Inspector/PerformanceOverlay.js',
+  'Libraries/Inspector/StyleInspector.js',
+  'Libraries/Inspector/ElementBox.js',
+  'Libraries/Lists/FlatList.js',
+  'Libraries/Lists/SectionList.js',
+  'Libraries/LogBox/LogBoxInspectorContainer.js',
+  'Libraries/Modal/Modal.js',
+  'Libraries/Network/XMLHttpRequest.js',
+  'Libraries/WebSocket/WebSocket.js',
+]);
+
+const sourceFiles = [
+  'index.js',
+  ...glob.sync(JS_FILES_PATTERN, {
+    cwd: PACKAGE_ROOT,
+    ignore: IGNORE_PATTERNS,
+    nodir: true,
+  }),
+];
+
+describe('public API', () => {
+  describe('should not change unintentionally', () => {
+    test.each(sourceFiles)('%s', async (file: string) => {
+      const source = await fs.readFile(path.join(PACKAGE_ROOT, file), 'utf-8');
+
+      if (/@flow/.test(source)) {
+        try {
+          expect(await translateFlowToExportedAPI(source)).toMatchSnapshot();
+
+          if (FILES_WITH_KNOWN_ERRORS.has(file)) {
+            console.error(
+              'Expected parse error, please remove file exclude from FILES_WITH_KNOWN_ERRORS:',
+              file,
+            );
+          }
+        } catch (e) {
+          if (!FILES_WITH_KNOWN_ERRORS.has(file)) {
+            console.error('Unable to parse file:', file, '\n' + e);
+          }
+        }
+      } else {
+        expect('UNTYPED MODULE').toMatchSnapshot();
+      }
+    });
+  });
+});
+
+async function translateFlowToExportedAPI(source: string): Promise<string> {
+  // Convert to Flow typedefs
+  const typeDefSource = await translate.translateFlowToFlowDef(source);
+
+  // Remove comments and import declarations
+  const visitors: TransformVisitor = context => ({
+    Program(node) {
+      // $FlowFixMe[cannot-write]
+      delete node.docblock;
+
+      for (const comment of node.comments) {
+        context.removeComments(comment);
+      }
+    },
+    ImportDeclaration(node) {
+      context.removeNode(node);
+    },
+  });
+
+  const result = await transform(typeDefSource, visitors);
+
+  // Remove empty lines (saves space, consistency fix on Windows)
+  return result.replaceAll('\n\n', '\n');
+}


### PR DESCRIPTION
Summary:
Adds a snapshot test against the `react-native` package which emits the shape of all Flow-typed modules under `Libraries/`, as an approximation of the public JS API.

This provides:
- Visibility for maintainers on any PR which changes the shape of the public API.
- An at-a-glance diff of changed APIs between React Native versions (useful for library integrators and the Release Crew).

Note — **workflow change**: Maintainers modifying public files/function signatures under Libraries/ will need to run `yarn jest -u` and commit the updated snapshot changes.

Changelog: [Internal]

Differential Revision: D52729777


