### PR TITLE
Add desktop out-of-tree platform files to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,8 @@ docs/generatedComponentApiDocs.js
 packages/react-native/flow/
 packages/react-native/Libraries/Renderer/*
 packages/react-native/Libraries/vendor/**/*
+packages/react-native/Libraries/**/*.macos.js
+packages/react-native/Libraries/**/*.windows.js
 node_modules/
 packages/*/node_modules
 packages/*/dist


### PR DESCRIPTION
Summary:
In case anyone was to try linting the react-native repo with desktop out-of-tree platform files there, this makes things easier.

## Changelog
[Internal]

Differential Revision: D52746379


