### PR TITLE
[iOS] Remove an early return to suppress a deprecated API warning for `UIMenuController`

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -246,19 +246,15 @@
     if (_editMenuInteraction) {
       [_editMenuInteraction presentEditMenuWithConfiguration:config];
     }
-    return;
-  }
-  UIMenuController *menuController = [UIMenuController sharedMenuController];
+  } else {
+    UIMenuController *menuController = [UIMenuController sharedMenuController];
 
-  if (menuController.isMenuVisible) {
-    return;
-  }
+    if (menuController.isMenuVisible) {
+      return;
+    }
 
-  if (!self.isFirstResponder) {
-    [self becomeFirstResponder];
+    [menuController showMenuFromView:self rect:self.bounds];
   }
-
-  [menuController showMenuFromView:self rect:self.bounds];
 }
 
 - (BOOL)canBecomeFirstResponder

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -236,25 +236,21 @@ using namespace facebook::react;
 
 - (void)handleLongPress:(UILongPressGestureRecognizer *)gesture
 {
-  if (@available(iOS 16.0, *)) {
+  if (@available(iOS 16.0, macCatalyst 16.0, *)) {
     CGPoint location = [gesture locationInView:self];
     UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
     if (_editMenuInteraction) {
       [_editMenuInteraction presentEditMenuWithConfiguration:config];
     }
-    return;
-  }
-  UIMenuController *menuController = [UIMenuController sharedMenuController];
+  } else {
+    UIMenuController *menuController = [UIMenuController sharedMenuController];
 
-  if (menuController.isMenuVisible) {
-    return;
-  }
+    if (menuController.isMenuVisible) {
+      return;
+    }
 
-  if (!self.isFirstResponder) {
-    [self becomeFirstResponder];
+    [menuController showMenuFromView:self rect:self.bounds];
   }
-
-  [menuController showMenuFromView:self rect:self.bounds];
 }
 
 - (BOOL)canBecomeFirstResponder


### PR DESCRIPTION
## Summary:

`UIMenuController` is deprecated as of iOS 16. https://github.com/facebook/react-native/commit/e08a1973f67d85acc157111c749c43572469e4c2 migrated a usage into an `@available` check. However, it does not properly fall back to the deprecated API in the "else" block of the availability check, instead it uses an early return. It seems this means Xcode still sees the API as used, and spits out a deprecated warning. Let's just refactor the code so we don't have that anymore.

## Changelog:

[IOS] [FIXED] -  Remove an early return to suppress a deprecated API warning for `UIMenuController`

## Test Plan:

CI should pass. 
