### PR TITLE
fix: use get_folly_config() in RCTAppDelegate podspec

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -16,8 +16,9 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_flags = ' -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1'
-folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
+folly_config = get_folly_config()
+folly_compiler_flags = folly_config[:compiler_flags]
+folly_version = folly_config[:version]
 
 is_new_arch_enabled = ENV["USE_NEW_ARCH"] == "1"
 use_hermes =  ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
@@ -25,7 +26,7 @@ use_hermes =  ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DUSE_NEW_ARCH" : "")
 is_fabric_enabled = is_new_arch_enabled || ENV["RCT_FABRIC_ENABLED"]
 hermes_flag = (use_hermes ? " -DUSE_HERMES" : "")
-other_cflags = "$(inherited)" + folly_flags + new_arch_enabled_flag + hermes_flag
+other_cflags = "$(inherited)" + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
 
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/../../ReactCommon",
@@ -68,7 +69,7 @@ Pod::Spec.new do |s|
   use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
 
   s.dependency "React-Core"
-  s.dependency "RCT-Folly"
+  s.dependency "RCT-Folly", folly_version
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "React-RCTNetwork"

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -980,7 +980,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
   - React-RCTAppDelegate (1000.0.0):
-    - RCT-Folly
+    - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Core


### PR DESCRIPTION
## Summary:

This PR adds `get_folly_config()` to RCTAppDelegate, it was recently introduced here: #42153

## Changelog:

[INTERNAL] [CHANGED] - Unify folly version and compiler flags for RCTAppDelegate

## Test Plan:

CI Green
