### PR TITLE
Fail run-ci-e2e-tests on package build errors

### DIFF
--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -88,7 +88,10 @@ try {
   VERDACCIO_PID = setupVerdaccio(ROOT, VERDACCIO_CONFIG_PATH);
 
   describe('Build and publish packages');
-  exec('node ./scripts/build/build.js', {cwd: ROOT});
+  if (exec('node ./scripts/build/build.js', {cwd: ROOT}).code) {
+    exitCode = 1;
+    throw Error(exitCode);
+  }
   forEachPackage(
     (packageAbsolutePath, packageRelativePathFromRoot, packageManifest) => {
       if (packageManifest.private) {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

`run-ci-e2e-tests.js` currently skips past package build errors and tries to keep going. At best, this fails somewhere downstream of a build error (without any clear diagnostics as to why). At worst, this can miss errors entirely.

Here we extend the script's existing error handling behaviour to cover errors during the build script. It's probably worth following up to make sure all unexpected failures bubble up and stop the script, as opposed to the current error-swallowing default.

Reviewed By: hoxyq

Differential Revision: D52785131


