### PR TITLE
Do not apply public API tests to desktop out-of-tree platform files

### DIFF
--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -23,6 +23,8 @@ const JS_FILES_PATTERN = 'Libraries/**/*.{js,flow}';
 const IGNORE_PATTERNS = [
   '**/__{tests,mocks,fixtures,flowtests}__/**',
   '**/*.fb.js',
+  '**/*.macos.js',
+  '**/*.windows.js',
 ];
 
 // Exclude list for files that fail to parse under flow-api-translator. Please


### PR DESCRIPTION
Summary:
In case someone tries to inline out-of-tree platform files with react-native JS Libraries files, it's useful to suppress issues with public API tests, as the public APIs are not intended to match yet.

## Changelog

[Internal]

Differential Revision: D52790636


