### PR TITLE
ipconfig returns error code 1 if interface not configured

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -14,6 +14,8 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
 # Enables iOS devices to get the IP address of the machine running Metro
 if [[ ! "$SKIP_BUNDLING_METRO_IP" && "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
+(
+  set +e
   for num in 0 1 2 3 4 5 6 7 8; do
     IP=$(ipconfig getifaddr en${num} || echo "")
     if [ ! -z "$IP" ]; then
@@ -25,6 +27,7 @@ if [[ ! "$SKIP_BUNDLING_METRO_IP" && "$CONFIGURATION" = *Debug* && ! "$PLATFORM_
   fi
 
   echo "$IP" > "$DEST/ip.txt"
+)
 fi
 
 if [[ "$SKIP_BUNDLING" ]]; then


### PR DESCRIPTION
## Summary:

I have only seen this happen in one of our Mac mini (M1). The interface en0 is not configured, and en1 is. When the script tries to find the IP address of the metro server, it cycles through interfaces 0 to 8. But, ipconfig on en0 returns with exit code 1 which causes the script to exit.

## Changelog:

[INTERNAL] [CHANGED] - Do not exit the script when extracting IP address of metro server. 

## Test Plan:

ipconfig successfully cycles through the list of interfaces when the first interfaces are not configured.


![Screenshot 2024-01-16 at 12 06 38 PM](https://github.com/facebook/react-native/assets/46905/50608708-7d3f-4c49-82ed-d4f2b4df2533)
