### PR TITLE
Fabric Automatic Interop for Android

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
@@ -27,4 +27,5 @@ target_link_libraries(react_render_componentregistry
         react_render_core
         react_render_debug
         react_utils
+        rrc_legacyviewmanagerinterop
 )

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
@@ -11,9 +11,10 @@
 
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+#include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h>
+#include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/ShadowNodeFragment.h>
-
 #include <utility>
 
 namespace facebook::react {
@@ -82,12 +83,11 @@ const ComponentDescriptor& ComponentDescriptorRegistry::at(
   }
 
   if (it == _registryByName.end()) {
-    if (_fallbackComponentDescriptor == nullptr) {
-      throw std::invalid_argument(
-          ("Unable to find componentDescriptor for " + unifiedComponentName)
-              .c_str());
-    }
-    return *_fallbackComponentDescriptor.get();
+    auto componentDescriptor = std::make_shared<
+        const UnstableLegacyViewManagerAutomaticComponentDescriptor>(
+        parameters_, unifiedComponentName);
+    registerComponentDescriptor(componentDescriptor);
+    return *_registryByName.find(unifiedComponentName)->second;
   }
 
   return *it->second;

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "UnstableLegacyViewManagerAutomaticComponentDescriptor.h"
+#include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <react/renderer/core/ReactPrimitives.h>
+#include <string>
+
+namespace facebook::react {
+ComponentName
+UnstableLegacyViewManagerAutomaticComponentDescriptor::getComponentName()
+    const {
+  return _legacyComponentName.c_str();
+}
+
+ComponentHandle
+UnstableLegacyViewManagerAutomaticComponentDescriptor::getComponentHandle()
+    const {
+  return reinterpret_cast<ComponentHandle>(getComponentName());
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <react/renderer/core/ReactPrimitives.h>
+#include <string>
+
+namespace facebook::react {
+
+class UnstableLegacyViewManagerAutomaticComponentDescriptor final
+    : public ConcreteComponentDescriptor<
+          LegacyViewManagerAndroidInteropShadowNode> {
+ public:
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
+
+  UnstableLegacyViewManagerAutomaticComponentDescriptor(
+      const ComponentDescriptorParameters& parameters,
+      std::string legacyComponentName)
+      : ConcreteComponentDescriptor(parameters),
+        _legacyComponentName(std::move(legacyComponentName)) {}
+
+  ComponentHandle getComponentHandle() const override;
+  ComponentName getComponentName() const override;
+
+ private:
+  std::string _legacyComponentName;
+};
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+namespace facebook::react {
+
+extern const char LegacyViewManagerAndroidInteropComponentName[] =
+    "LegacyViewManagerInterop";
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.h>
+#include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+
+namespace facebook::react {
+
+extern const char LegacyViewManagerAndroidInteropComponentName[];
+
+using LegacyViewManagerAndroidInteropShadowNode = ConcreteViewShadowNode<
+    LegacyViewManagerAndroidInteropComponentName,
+    LegacyViewManagerInteropViewProps>;
+
+} // namespace facebook::react

--- a/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
+++ b/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
@@ -13,7 +13,6 @@
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/AppSpecs/ComponentDescriptors.h>
-#include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h>
 
 namespace facebook {
 namespace react {
@@ -24,9 +23,6 @@ void registerComponents(
     std::shared_ptr<const ComponentDescriptorProviderRegistry> registry) {
   registry->add(concreteComponentDescriptorProvider<
                 RNTMyNativeViewComponentDescriptor>());
-  registry->add(concreteComponentDescriptorProvider<
-                UnstableLegacyViewManagerInteropComponentDescriptor<
-                    RNTMyNativeViewName>>());
 }
 
 std::shared_ptr<TurboModule> cxxModuleProvider(


### PR DESCRIPTION
Summary:
This changes enables the Fabric Intrerop Layer automatically for all the users.

Practically I'm removing the fallback `ComponentDescriptor` inside the `ComponentDescriptorRegistry` so that if a component hasn't been automatically registered by a user, instead of showing the UnimplementedView, it loads a `UnstableLegacyViewManagerAutomaticComponentDescriptor`.

This ComponentDescriptor is built starting from the legacy component name, and responds with correct `ComponentName` and `ComponentHandle` (similarly to the `UnstableLegacyViewManagerInteropComponentDescriptor` but without using C++ templates).

Changelog:
[Internal] [Changed] - Fabric Automatic Interop for Android

Differential Revision: D52663244


