### PR TITLE
Disable keyword-spacing lint rule

### DIFF
--- a/packages/eslint-config-react-native/index.js
+++ b/packages/eslint-config-react-native/index.js
@@ -255,7 +255,6 @@ module.exports = {
     // These rules are purely matters of style and are quite subjective.
 
     'key-spacing': 0,
-    'keyword-spacing': 1, // enforce spacing before and after keywords
     'jsx-quotes': [1, 'prefer-double'], // enforces the usage of double quotes for all JSX attribute values which doesn’t contain a double quote
     'comma-spacing': 0,
     'no-multi-spaces': 0,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The version of the `keyword-spacing` lint rule we have installed is apparently buggy. Either way it's unnecessary since we use Prettier.

Differential Revision: D52799550


