### PR TITLE
Automatically enable C++ InspectorPackagerConnection if using modern CDP backend

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -51,7 +51,10 @@ bool InspectorFlags::getEnableCxxInspectorPackagerConnection() const {
     LOG(WARNING)
         << "InspectorFlags::getEnableCxxInspectorPackagerConnection was called before init";
   }
-  return enableCxxInspectorPackagerConnection_.value_or(false);
+  return enableCxxInspectorPackagerConnection_.value_or(false) ||
+      // If we are using the modern CDP registry, then we must also use the C++
+      // InspectorPackagerConnection implementation.
+      getEnableModernCDPRegistry();
 }
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Changelog: [Internal]

To simplify testing and rolling out the modern CDP backend in React Native, let's require the use of the C++ version of `InspectorPackagerConnection` whenever the modern CDP backend is in use, regardless of the `InspectorPackagerConnection` rollout setting.

Differential Revision: D52786334


