### PR TITLE
Support launching experimental debugger for modern CDP targets

### DIFF
--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -29,6 +29,7 @@
     "connect": "^3.6.5",
     "debug": "^2.2.0",
     "node-fetch": "^2.2.0",
+    "nullthrows": "^1.1.1",
     "open": "^7.0.3",
     "selfsigned": "^2.4.1",
     "serve-static": "^1.13.1",

--- a/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
@@ -11,8 +11,8 @@
 
 import type {
   JSONSerializable,
-  Page,
   PageDescription,
+  PageFromDevice,
 } from '../inspector-proxy/types';
 import type {DebuggerMock} from './InspectorDebuggerUtils';
 import type {DeviceMock} from './InspectorDeviceUtils';
@@ -125,7 +125,7 @@ export async function createAndConnectTarget(
     ...
   }>,
   signal: AbortSignal,
-  page: Page,
+  page: PageFromDevice,
 ): Promise<{device: DeviceMock, debugger_: DebuggerMock}> {
   let device;
   let debugger_;

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -193,6 +193,7 @@ xdescribe('inspector proxy HTTP API', () => {
             id: 'device1-page1',
             reactNative: {
               logicalDeviceId: 'device1',
+              type: 'Legacy',
             },
             title: 'bar-title',
             type: 'node',
@@ -207,6 +208,7 @@ xdescribe('inspector proxy HTTP API', () => {
             id: 'device2-page1',
             reactNative: {
               logicalDeviceId: 'device2',
+              type: 'Legacy',
             },
             title: 'bar-title',
             type: 'node',

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -20,6 +20,7 @@ import type {
 import type {IncomingMessage, ServerResponse} from 'http';
 
 import Device from './Device';
+import nullthrows from 'nullthrows';
 import url from 'url';
 import WS from 'ws';
 
@@ -151,6 +152,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
       deviceName: device.getName(),
       reactNative: {
         logicalDeviceId: deviceId,
+        type: nullthrows(page.type),
       },
     };
   }

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -12,12 +12,16 @@
 // Page information received from the device. New page is created for
 // each new instance of VM and can appear when user reloads React Native
 // application.
-export type Page = $ReadOnly<{
+
+export type PageFromDevice = $ReadOnly<{
   id: string,
   title: string,
   vm: string,
   app: string,
+  type?: 'Legacy' | 'Modern',
 }>;
+
+export type Page = Required<PageFromDevice>;
 
 // Chrome Debugger Protocol message/event passed between device and debugger.
 export type WrappedEvent = $ReadOnly<{
@@ -48,7 +52,7 @@ export type GetPagesRequest = {event: 'getPages'};
 // Response to GetPagesRequest containing a list of page infos.
 export type GetPagesResponse = {
   event: 'getPages',
-  payload: $ReadOnlyArray<Page>,
+  payload: $ReadOnlyArray<PageFromDevice>,
 };
 
 // Union type for all possible messages sent from device to Inspector Proxy.
@@ -78,10 +82,11 @@ export type PageDescription = $ReadOnly<{
   // Metadata specific to React Native
   reactNative: $ReadOnly<{
     logicalDeviceId: string,
+    type: $NonMaybeType<Page['type']>,
   }>,
 }>;
 
-export type JsonPagesListResponse = $ReadOnlyArray<PageDescription>;
+export type JsonPagesListResponse = Array<PageDescription>;
 
 // Response to /json/version HTTP request from the debugger specifying browser type and
 // Chrome protocol version.

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -62,7 +62,8 @@ export default function openDebuggerMiddleware({
       const targets = inspectorProxy.getPageDescriptions().filter(
         // Only use targets with better reloading support
         app =>
-          app.title === 'React Native Experimental (Improved Chrome Reloads)',
+          app.title === 'React Native Experimental (Improved Chrome Reloads)' ||
+          app.reactNative.type === 'Modern',
       );
 
       let target;


### PR DESCRIPTION
Summary:
Changelog: [Internal][Added] Support launching experimental debugger frontend for CDP targets marked as "modern"

See the definition of "modern" targets in D50967795.

Differential Revision: D52786332


