### PR TITLE
Refactor InspectorImpl internal page data structure

### DIFF
--- a/packages/react-native/React/Inspector/RCTInspector.mm
+++ b/packages/react-native/React/Inspector/RCTInspector.mm
@@ -67,7 +67,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 + (NSArray<RCTInspectorPage *> *)pages
 {
-  std::vector<InspectorPage> pages = getInstance()->getPages();
+  std::vector<InspectorPageDescription> pages = getInstance()->getPages();
   NSMutableArray<RCTInspectorPage *> *array = [NSMutableArray arrayWithCapacity:pages.size()];
   for (size_t i = 0; i < pages.size(); i++) {
     RCTInspectorPage *pageWrapper = [[RCTInspectorPage alloc] initWithId:pages[i].id

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JInspector.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JInspector.cpp
@@ -81,7 +81,8 @@ jni::global_ref<JInspector::javaobject> JInspector::instance(
 }
 
 jni::local_ref<jni::JArrayClass<JPage::javaobject>> JInspector::getPages() {
-  std::vector<jsinspector_modern::InspectorPage> pages = inspector_->getPages();
+  std::vector<jsinspector_modern::InspectorPageDescription> pages =
+      inspector_->getPages();
   auto array = jni::JArrayClass<JPage::javaobject>::newArray(pages.size());
   for (size_t i = 0; i < pages.size(); i++) {
     (*array)[i] = JPage::create(pages[i].id, pages[i].title, pages[i].vm);

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/tests/ConnectionDemuxTests.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/tests/ConnectionDemuxTests.cpp
@@ -23,13 +23,13 @@ namespace inspector_modern {
 namespace chrome {
 
 using ::facebook::react::jsinspector_modern::IInspector;
-using ::facebook::react::jsinspector_modern::InspectorPage;
+using ::facebook::react::jsinspector_modern::InspectorPageDescription;
 using ::facebook::react::jsinspector_modern::IRemoteConnection;
 
 namespace {
 
 std::unordered_map<int, std::string> makePageMap(
-    const std::vector<InspectorPage>& pages) {
+    const std::vector<InspectorPageDescription>& pages) {
   std::unordered_map<int, std::string> pageMap;
 
   for (auto& page : pages) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -51,7 +51,10 @@ bool InspectorFlags::getEnableCxxInspectorPackagerConnection() const {
     LOG(WARNING)
         << "InspectorFlags::getEnableCxxInspectorPackagerConnection was called before init";
   }
-  return enableCxxInspectorPackagerConnection_.value_or(false);
+  return enableCxxInspectorPackagerConnection_.value_or(false) ||
+      // If we are using the modern CDP registry, then we must also use the C++
+      // InspectorPackagerConnection implementation.
+      getEnableModernCDPRegistry();
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -31,11 +31,14 @@ class IDestructible {
   virtual ~IDestructible() = 0;
 };
 
-struct InspectorPage {
+struct InspectorPageDescription {
   const int id;
   const std::string title;
   const std::string vm;
 };
+
+// Alias for backwards compatibility.
+using InspectorPage = InspectorPageDescription;
 
 /// IRemoteConnection allows the VM to send debugger messages to the client.
 class JSINSPECTOR_EXPORT IRemoteConnection : public IDestructible {
@@ -72,7 +75,7 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
   virtual void removePage(int pageId) = 0;
 
   /// getPages is called by the client to list all debuggable pages.
-  virtual std::vector<InspectorPage> getPages() const = 0;
+  virtual std::vector<InspectorPageDescription> getPages() const = 0;
 
   /// connect is called by the client to initiate a debugging session on the
   /// given page.


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Light refactor of `InspectorImpl`'s storage from two separate maps (one of them with tuples for values!) to a single map of objects.

Differential Revision: D52786335


