### PR TITLE
Disable expensive checks in OSS

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -979,7 +979,7 @@ void YogaLayoutableShadowNode::ensureConsistency() const {
 }
 
 void YogaLayoutableShadowNode::ensureYogaChildrenLookFine() const {
-#ifdef REACT_NATIVE_DEBUG
+#if defined(REACT_NATIVE_DEBUG) && defined(WITH_FBSYSTRACE)
   // Checking that the shapes of Yoga node children object look fine.
   // This is the only heuristic that might produce false-positive results
   // (really broken dangled nodes might look fine). This is useful as an early
@@ -997,7 +997,7 @@ void YogaLayoutableShadowNode::ensureYogaChildrenLookFine() const {
 }
 
 void YogaLayoutableShadowNode::ensureYogaChildrenAlignment() const {
-#ifdef REACT_NATIVE_DEBUG
+#if defined(REACT_NATIVE_DEBUG) && defined(WITH_FBSYSTRACE)
   // If the node is not a leaf node, checking that:
   // - All children are `YogaLayoutableShadowNode` subclasses.
   // - All Yoga children are owned/connected to corresponding children of

--- a/packages/react-native/ReactCommon/react/renderer/debug/flags.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/flags.h
@@ -26,7 +26,7 @@
 // Enables some Shadow Tree introspection features (maintains a StubViewTree,
 // and logs prev/next tree and mutations if there are any discrepancies). If you
 // define this, also define `RN_DEBUG_STRING_CONVERTIBLE`.
-#ifdef REACT_NATIVE_DEBUG
+#if (defined(REACT_NATIVE_DEBUG) && defined(WITH_FBSYSTRACE))
 #define RN_SHADOW_TREE_INTROSPECTION 1
 #endif
 
@@ -34,9 +34,7 @@
 // Enable if `RN_SHADOW_TREE_INTROSPECTION` is enabled.
 #ifdef RN_SHADOW_TREE_INTROSPECTION
 #define RN_DEBUG_STRING_CONVERTIBLE 1
-#endif
-
-#ifndef RN_DEBUG_STRING_CONVERTIBLE
+#else
 #define RN_DEBUG_STRING_CONVERTIBLE 0
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/debug/tests/DebugStringConvertibleTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/debug/tests/DebugStringConvertibleTest.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#if RN_DEBUG_STRING_CONVERTIBLE
 #include <memory>
 
 #include <gtest/gtest.h>
@@ -82,3 +83,4 @@ TEST(DebugStringConvertibleTest, handleNodeWithComplexProps) {
       item->getDebugDescription().c_str(),
       "<View=hello x=1(height=100 width=200)/>");
 }
+#endif


### PR DESCRIPTION
Summary:
Internally, we have some computationally expensive checks in Debug mode when running Fabric.
However, these are not very useful in OSS and they were the cause of some issues which generated noise.
With this change, we are enabling those checks only in the Meta specific builds and making sure that the OSS won't incur in that cost.

## Changelog
[Internal] - Disable expensive Fabric checks when running Fabric in OSS

Reviewed By: cortinico, sammy-SC

Differential Revision: D52543696


