### PR TITLE
Assert `DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint` is set

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
@@ -8,6 +8,7 @@
 #include "DefaultComponentsRegistry.h"
 
 #include <CoreComponentsRegistry.h>
+#include <fb/assert.h>
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/rncore/ComponentDescriptors.h>
@@ -23,6 +24,10 @@ DefaultComponentsRegistry::DefaultComponentsRegistry(ComponentFactory* delegate)
 std::shared_ptr<const ComponentDescriptorProviderRegistry>
 DefaultComponentsRegistry::sharedProviderRegistry() {
   auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
+
+  FBASSERTMSGF(
+      DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint,
+      "'registerComponentDescriptorsFromEntryPoint' was not initialized in 'JNI_OnLoad'");
 
   (DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint)(
       providerRegistry);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
@@ -8,8 +8,8 @@
 #include "DefaultComponentsRegistry.h"
 
 #include <CoreComponentsRegistry.h>
-#include <fb/assert.h>
 #include <fbjni/fbjni.h>
+#include <react/debug/react_native_assert.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/rncore/ComponentDescriptors.h>
 
@@ -25,8 +25,8 @@ std::shared_ptr<const ComponentDescriptorProviderRegistry>
 DefaultComponentsRegistry::sharedProviderRegistry() {
   auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
 
-  FBASSERTMSGF(
-      DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint,
+  react_native_assert(
+      DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint &&
       "'registerComponentDescriptorsFromEntryPoint' was not initialized in 'JNI_OnLoad'");
 
   (DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint)(


### PR DESCRIPTION
## Summary:

Assert `DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint` is set. For full context, see #42244.

## Changelog:

[ANDROID] [FIXED] - Assert `DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint` is set

## Test Plan:

n/a