### PR TITLE
`yoga::Node::getStyle()` to `yoga::Node::style()`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -360,7 +360,7 @@ void YogaLayoutableShadowNode::updateYogaChildren() {
             yogaLayoutableChildren_.at(yogaChildIndex)->yogaNode_;
 
         isClean = isClean && !newYogaChildNode.isDirty() &&
-            (newYogaChildNode.getStyle() == oldYogaChildNode.getStyle());
+            (newYogaChildNode.style() == oldYogaChildNode.style());
       }
     }
   }
@@ -378,7 +378,7 @@ void YogaLayoutableShadowNode::updateYogaProps() {
   auto styleResult = applyAliasedProps(props.yogaStyle, props);
 
   // Resetting `dirty` flag only if `yogaStyle` portion of `Props` was changed.
-  if (!yogaNode_.isDirty() && (styleResult != yogaNode_.getStyle())) {
+  if (!yogaNode_.isDirty() && (styleResult != yogaNode_.style())) {
     yogaNode_.setDirty(true);
   }
 
@@ -532,7 +532,7 @@ YogaLayoutableShadowNode& YogaLayoutableShadowNode::cloneChildInPlace(
 void YogaLayoutableShadowNode::setSize(Size size) const {
   ensureUnsealed();
 
-  auto style = yogaNode_.getStyle();
+  auto style = yogaNode_.style();
   style.setDimension(yoga::Dimension::Width, yoga::value::points(size.width));
   style.setDimension(yoga::Dimension::Height, yoga::value::points(size.height));
   yogaNode_.setStyle(style);
@@ -542,7 +542,7 @@ void YogaLayoutableShadowNode::setSize(Size size) const {
 void YogaLayoutableShadowNode::setPadding(RectangleEdges<Float> padding) const {
   ensureUnsealed();
 
-  auto style = yogaNode_.getStyle();
+  auto style = yogaNode_.style();
 
   auto leftPadding = yoga::value::points(padding.left);
   auto topPadding = yoga::value::points(padding.top);
@@ -566,7 +566,7 @@ void YogaLayoutableShadowNode::setPositionType(
     YGPositionType positionType) const {
   ensureUnsealed();
 
-  auto style = yogaNode_.getStyle();
+  auto style = yogaNode_.style();
   style.setPositionType(yoga::scopedEnum(positionType));
   yogaNode_.setStyle(style);
   yogaNode_.setDirty(true);
@@ -617,7 +617,7 @@ void YogaLayoutableShadowNode::layoutTree(
   // `ownerHeight` to allow proper calculation of relative (e.g. specified in
   // percents) style values.
 
-  auto& yogaStyle = yogaNode_.getStyle();
+  auto& yogaStyle = yogaNode_.style();
 
   auto ownerWidth = yogaFloatFromFloat(maximumSize.width);
   auto ownerHeight = yogaFloatFromFloat(maximumSize.height);
@@ -717,7 +717,7 @@ void YogaLayoutableShadowNode::layout(LayoutContext layoutContext) {
     }
   }
 
-  if (yogaNode_.getStyle().overflow() == yoga::Overflow::Visible) {
+  if (yogaNode_.style().overflow() == yoga::Overflow::Visible) {
     // Note that the parent node's overflow layout is NOT affected by its
     // transform matrix. That transform matrix is applied on the parent node as
     // well as all of its child nodes, which won't cause changes on the
@@ -869,7 +869,7 @@ void YogaLayoutableShadowNode::swapStyleLeftAndRight() {
 
 void YogaLayoutableShadowNode::swapLeftAndRightInYogaStyleProps(
     const YogaLayoutableShadowNode& shadowNode) {
-  auto yogaStyle = shadowNode.yogaNode_.getStyle();
+  auto yogaStyle = shadowNode.yogaNode_.style();
 
   // Swap Yoga node values, position, padding and margin.
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -138,12 +138,12 @@ inline LayoutMetrics layoutMetricsFromYogaNode(yoga::Node& yogaNode) {
       layoutMetrics.borderWidth.bottom +
           floatFromYogaFloat(YGNodeLayoutGetPadding(&yogaNode, YGEdgeBottom))};
 
-  layoutMetrics.displayType =
-      yogaNode.getStyle().display() == yoga::Display::None ? DisplayType::None
-                                                           : DisplayType::Flex;
+  layoutMetrics.displayType = yogaNode.style().display() == yoga::Display::None
+      ? DisplayType::None
+      : DisplayType::Flex;
 
   layoutMetrics.positionType =
-      positionTypeFromYogaPositionType(yogaNode.getStyle().positionType());
+      positionTypeFromYogaPositionType(yogaNode.style().positionType());
 
   layoutMetrics.layoutDirection =
       YGNodeLayoutGetDirection(&yogaNode) == YGDirectionRTL

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
@@ -16,7 +16,7 @@ namespace {
 
 template <auto GetterT, auto SetterT, typename ValueT>
 void updateStyle(YGNodeRef node, ValueT value) {
-  auto& style = resolveRef(node)->getStyle();
+  auto& style = resolveRef(node)->style();
   if ((style.*GetterT)() != value) {
     (style.*SetterT)(value);
     resolveRef(node)->markDirtyAndPropagate();
@@ -25,7 +25,7 @@ void updateStyle(YGNodeRef node, ValueT value) {
 
 template <auto GetterT, auto SetterT, typename IdxT, typename ValueT>
 void updateStyle(YGNodeRef node, IdxT idx, ValueT value) {
-  auto& style = resolveRef(node)->getStyle();
+  auto& style = resolveRef(node)->style();
   if ((style.*GetterT)(idx) != value) {
     (style.*SetterT)(idx, value);
     resolveRef(node)->markDirtyAndPropagate();
@@ -40,8 +40,8 @@ void YGNodeCopyStyle(
   auto dstNode = resolveRef(dstNodeRef);
   auto srcNode = resolveRef(srcNodeRef);
 
-  if (!(dstNode->getStyle() == srcNode->getStyle())) {
-    dstNode->setStyle(srcNode->getStyle());
+  if (!(dstNode->style() == srcNode->style())) {
+    dstNode->setStyle(srcNode->style());
     dstNode->markDirtyAndPropagate();
   }
 }
@@ -51,7 +51,7 @@ void YGNodeStyleSetDirection(const YGNodeRef node, const YGDirection value) {
 }
 
 YGDirection YGNodeStyleGetDirection(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().direction());
+  return unscopedEnum(resolveRef(node)->style().direction());
 }
 
 void YGNodeStyleSetFlexDirection(
@@ -62,7 +62,7 @@ void YGNodeStyleSetFlexDirection(
 }
 
 YGFlexDirection YGNodeStyleGetFlexDirection(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().flexDirection());
+  return unscopedEnum(resolveRef(node)->style().flexDirection());
 }
 
 void YGNodeStyleSetJustifyContent(
@@ -73,7 +73,7 @@ void YGNodeStyleSetJustifyContent(
 }
 
 YGJustify YGNodeStyleGetJustifyContent(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().justifyContent());
+  return unscopedEnum(resolveRef(node)->style().justifyContent());
 }
 
 void YGNodeStyleSetAlignContent(
@@ -84,7 +84,7 @@ void YGNodeStyleSetAlignContent(
 }
 
 YGAlign YGNodeStyleGetAlignContent(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().alignContent());
+  return unscopedEnum(resolveRef(node)->style().alignContent());
 }
 
 void YGNodeStyleSetAlignItems(const YGNodeRef node, const YGAlign alignItems) {
@@ -93,7 +93,7 @@ void YGNodeStyleSetAlignItems(const YGNodeRef node, const YGAlign alignItems) {
 }
 
 YGAlign YGNodeStyleGetAlignItems(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().alignItems());
+  return unscopedEnum(resolveRef(node)->style().alignItems());
 }
 
 void YGNodeStyleSetAlignSelf(const YGNodeRef node, const YGAlign alignSelf) {
@@ -102,7 +102,7 @@ void YGNodeStyleSetAlignSelf(const YGNodeRef node, const YGAlign alignSelf) {
 }
 
 YGAlign YGNodeStyleGetAlignSelf(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().alignSelf());
+  return unscopedEnum(resolveRef(node)->style().alignSelf());
 }
 
 void YGNodeStyleSetPositionType(
@@ -113,7 +113,7 @@ void YGNodeStyleSetPositionType(
 }
 
 YGPositionType YGNodeStyleGetPositionType(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().positionType());
+  return unscopedEnum(resolveRef(node)->style().positionType());
 }
 
 void YGNodeStyleSetFlexWrap(const YGNodeRef node, const YGWrap flexWrap) {
@@ -122,7 +122,7 @@ void YGNodeStyleSetFlexWrap(const YGNodeRef node, const YGWrap flexWrap) {
 }
 
 YGWrap YGNodeStyleGetFlexWrap(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().flexWrap());
+  return unscopedEnum(resolveRef(node)->style().flexWrap());
 }
 
 void YGNodeStyleSetOverflow(const YGNodeRef node, const YGOverflow overflow) {
@@ -131,7 +131,7 @@ void YGNodeStyleSetOverflow(const YGNodeRef node, const YGOverflow overflow) {
 }
 
 YGOverflow YGNodeStyleGetOverflow(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().overflow());
+  return unscopedEnum(resolveRef(node)->style().overflow());
 }
 
 void YGNodeStyleSetDisplay(const YGNodeRef node, const YGDisplay display) {
@@ -139,7 +139,7 @@ void YGNodeStyleSetDisplay(const YGNodeRef node, const YGDisplay display) {
 }
 
 YGDisplay YGNodeStyleGetDisplay(const YGNodeConstRef node) {
-  return unscopedEnum(resolveRef(node)->getStyle().display());
+  return unscopedEnum(resolveRef(node)->style().display());
 }
 
 void YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
@@ -148,9 +148,8 @@ void YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
 
 float YGNodeStyleGetFlex(const YGNodeConstRef nodeRef) {
   const auto node = resolveRef(nodeRef);
-  return node->getStyle().flex().isUndefined()
-      ? YGUndefined
-      : node->getStyle().flex().unwrap();
+  return node->style().flex().isUndefined() ? YGUndefined
+                                            : node->style().flex().unwrap();
 }
 
 void YGNodeStyleSetFlexGrow(const YGNodeRef node, const float flexGrow) {
@@ -160,9 +159,9 @@ void YGNodeStyleSetFlexGrow(const YGNodeRef node, const float flexGrow) {
 
 float YGNodeStyleGetFlexGrow(const YGNodeConstRef nodeRef) {
   const auto node = resolveRef(nodeRef);
-  return node->getStyle().flexGrow().isUndefined()
+  return node->style().flexGrow().isUndefined()
       ? Style::DefaultFlexGrow
-      : node->getStyle().flexGrow().unwrap();
+      : node->style().flexGrow().unwrap();
 }
 
 void YGNodeStyleSetFlexShrink(const YGNodeRef node, const float flexShrink) {
@@ -172,10 +171,10 @@ void YGNodeStyleSetFlexShrink(const YGNodeRef node, const float flexShrink) {
 
 float YGNodeStyleGetFlexShrink(const YGNodeConstRef nodeRef) {
   const auto node = resolveRef(nodeRef);
-  return node->getStyle().flexShrink().isUndefined()
+  return node->style().flexShrink().isUndefined()
       ? (node->getConfig()->useWebDefaults() ? Style::WebDefaultFlexShrink
                                              : Style::DefaultFlexShrink)
-      : node->getStyle().flexShrink().unwrap();
+      : node->style().flexShrink().unwrap();
 }
 
 void YGNodeStyleSetFlexBasis(const YGNodeRef node, const float flexBasis) {
@@ -195,7 +194,7 @@ void YGNodeStyleSetFlexBasisAuto(const YGNodeRef node) {
 }
 
 YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
-  return (YGValue)resolveRef(node)->getStyle().flexBasis();
+  return (YGValue)resolveRef(node)->style().flexBasis();
 }
 
 void YGNodeStyleSetPosition(YGNodeRef node, YGEdge edge, float points) {
@@ -209,7 +208,7 @@ void YGNodeStyleSetPositionPercent(YGNodeRef node, YGEdge edge, float percent) {
 }
 
 YGValue YGNodeStyleGetPosition(YGNodeConstRef node, YGEdge edge) {
-  return (YGValue)resolveRef(node)->getStyle().position(scopedEnum(edge));
+  return (YGValue)resolveRef(node)->style().position(scopedEnum(edge));
 }
 
 void YGNodeStyleSetMargin(YGNodeRef node, YGEdge edge, float points) {
@@ -228,7 +227,7 @@ void YGNodeStyleSetMarginAuto(YGNodeRef node, YGEdge edge) {
 }
 
 YGValue YGNodeStyleGetMargin(YGNodeConstRef node, YGEdge edge) {
-  return (YGValue)resolveRef(node)->getStyle().margin(scopedEnum(edge));
+  return (YGValue)resolveRef(node)->style().margin(scopedEnum(edge));
 }
 
 void YGNodeStyleSetPadding(YGNodeRef node, YGEdge edge, float points) {
@@ -242,7 +241,7 @@ void YGNodeStyleSetPaddingPercent(YGNodeRef node, YGEdge edge, float percent) {
 }
 
 YGValue YGNodeStyleGetPadding(YGNodeConstRef node, YGEdge edge) {
-  return (YGValue)resolveRef(node)->getStyle().padding(scopedEnum(edge));
+  return (YGValue)resolveRef(node)->style().padding(scopedEnum(edge));
 }
 
 void YGNodeStyleSetBorder(
@@ -254,7 +253,7 @@ void YGNodeStyleSetBorder(
 }
 
 float YGNodeStyleGetBorder(const YGNodeConstRef node, const YGEdge edge) {
-  auto border = resolveRef(node)->getStyle().border(scopedEnum(edge));
+  auto border = resolveRef(node)->style().border(scopedEnum(edge));
   if (border.isUndefined() || border.isAuto()) {
     return YGUndefined;
   }
@@ -271,7 +270,7 @@ void YGNodeStyleSetGap(
 }
 
 float YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
-  auto gapLength = resolveRef(node)->getStyle().gap(scopedEnum(gutter));
+  auto gapLength = resolveRef(node)->style().gap(scopedEnum(gutter));
   if (gapLength.isUndefined() || gapLength.isAuto()) {
     return YGUndefined;
   }
@@ -285,7 +284,7 @@ void YGNodeStyleSetAspectRatio(const YGNodeRef node, const float aspectRatio) {
 }
 
 float YGNodeStyleGetAspectRatio(const YGNodeConstRef node) {
-  const FloatOptional op = resolveRef(node)->getStyle().aspectRatio();
+  const FloatOptional op = resolveRef(node)->style().aspectRatio();
   return op.isUndefined() ? YGUndefined : op.unwrap();
 }
 
@@ -305,7 +304,7 @@ void YGNodeStyleSetWidthAuto(YGNodeRef node) {
 }
 
 YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
-  return (YGValue)resolveRef(node)->getStyle().dimension(Dimension::Width);
+  return (YGValue)resolveRef(node)->style().dimension(Dimension::Width);
 }
 
 void YGNodeStyleSetHeight(YGNodeRef node, float points) {
@@ -324,7 +323,7 @@ void YGNodeStyleSetHeightAuto(YGNodeRef node) {
 }
 
 YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
-  return (YGValue)resolveRef(node)->getStyle().dimension(Dimension::Height);
+  return (YGValue)resolveRef(node)->style().dimension(Dimension::Height);
 }
 
 void YGNodeStyleSetMinWidth(const YGNodeRef node, const float minWidth) {
@@ -338,7 +337,7 @@ void YGNodeStyleSetMinWidthPercent(const YGNodeRef node, const float minWidth) {
 }
 
 YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
-  return (YGValue)resolveRef(node)->getStyle().minDimension(Dimension::Width);
+  return (YGValue)resolveRef(node)->style().minDimension(Dimension::Width);
 }
 
 void YGNodeStyleSetMinHeight(const YGNodeRef node, const float minHeight) {
@@ -354,7 +353,7 @@ void YGNodeStyleSetMinHeightPercent(
 }
 
 YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
-  return (YGValue)resolveRef(node)->getStyle().minDimension(Dimension::Height);
+  return (YGValue)resolveRef(node)->style().minDimension(Dimension::Height);
 }
 
 void YGNodeStyleSetMaxWidth(const YGNodeRef node, const float maxWidth) {
@@ -368,7 +367,7 @@ void YGNodeStyleSetMaxWidthPercent(const YGNodeRef node, const float maxWidth) {
 }
 
 YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
-  return (YGValue)resolveRef(node)->getStyle().maxDimension(Dimension::Width);
+  return (YGValue)resolveRef(node)->style().maxDimension(Dimension::Width);
 }
 
 void YGNodeStyleSetMaxHeight(const YGNodeRef node, const float maxHeight) {
@@ -384,5 +383,5 @@ void YGNodeStyleSetMaxHeightPercent(
 }
 
 YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
-  return (YGValue)resolveRef(node)->getStyle().maxDimension(Dimension::Height);
+  return (YGValue)resolveRef(node)->style().maxDimension(Dimension::Height);
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -72,7 +72,7 @@ static void justifyAbsoluteChild(
     const Direction direction,
     const FlexDirection mainAxis,
     const float containingBlockWidth) {
-  const Justify parentJustifyContent = parent->getStyle().justifyContent();
+  const Justify parentJustifyContent = parent->style().justifyContent();
   switch (parentJustifyContent) {
     case Justify::FlexStart:
     case Justify::SpaceBetween:
@@ -99,7 +99,7 @@ static void alignAbsoluteChild(
     const FlexDirection crossAxis,
     const float containingBlockWidth) {
   Align itemAlign = resolveChildAlignment(parent, child);
-  const Wrap parentWrap = parent->getStyle().flexWrap();
+  const Wrap parentWrap = parent->style().flexWrap();
   if (parentWrap == Wrap::WrapReverse) {
     if (itemAlign == Align::FlexEnd) {
       itemAlign = Align::FlexStart;
@@ -143,12 +143,12 @@ static void positionAbsoluteChildLegacy(
     const float containingBlockHeight) {
   const bool isAxisRow = isRow(axis);
   const bool shouldCenter = isMainAxis
-      ? parent->getStyle().justifyContent() == Justify::Center
+      ? parent->style().justifyContent() == Justify::Center
       : resolveChildAlignment(parent, child) == Align::Center;
   const bool shouldFlexEnd = isMainAxis
-      ? parent->getStyle().justifyContent() == Justify::FlexEnd
+      ? parent->style().justifyContent() == Justify::FlexEnd
       : ((resolveChildAlignment(parent, child) == Align::FlexEnd) ^
-         (parent->getStyle().flexWrap() == Wrap::WrapReverse));
+         (parent->style().flexWrap() == Wrap::WrapReverse));
 
   if (child->isFlexEndPositionDefined(axis, direction) &&
       !child->isFlexStartPositionDefined(axis, direction)) {
@@ -294,7 +294,7 @@ void layoutAbsoluteChild(
     const uint32_t depth,
     const uint32_t generationCount) {
   const FlexDirection mainAxis =
-      resolveDirection(node->getStyle().flexDirection(), direction);
+      resolveDirection(node->style().flexDirection(), direction);
   const FlexDirection crossAxis = resolveCrossDirection(mainAxis, direction);
   const bool isMainAxisRow = isRow(mainAxis);
 
@@ -366,7 +366,7 @@ void layoutAbsoluteChild(
   // Exactly one dimension needs to be defined for us to be able to do aspect
   // ratio calculation. One dimension being the anchor and the other being
   // flexible.
-  const auto& childStyle = child->getStyle();
+  const auto& childStyle = child->style();
   if (yoga::isUndefined(childWidth) ^ yoga::isUndefined(childHeight)) {
     if (childStyle.aspectRatio().isDefined()) {
       if (yoga::isUndefined(childWidth)) {
@@ -467,13 +467,13 @@ void layoutAbsoluteDescendants(
     float containingNodeAvailableInnerWidth,
     float containingNodeAvailableInnerHeight) {
   const FlexDirection mainAxis = resolveDirection(
-      currentNode->getStyle().flexDirection(), currentNodeDirection);
+      currentNode->style().flexDirection(), currentNodeDirection);
   const FlexDirection crossAxis =
       resolveCrossDirection(mainAxis, currentNodeDirection);
   for (auto child : currentNode->getChildren()) {
-    if (child->getStyle().display() == Display::None) {
+    if (child->style().display() == Display::None) {
       continue;
-    } else if (child->getStyle().positionType() == PositionType::Absolute) {
+    } else if (child->style().positionType() == PositionType::Absolute) {
       const bool absoluteErrata =
           currentNode->hasErrata(Errata::AbsolutePercentAgainstInnerSize);
       const float containingBlockWidth = absoluteErrata
@@ -499,11 +499,11 @@ void layoutAbsoluteDescendants(
 
       const bool isMainAxisRow = isRow(mainAxis);
       const bool mainInsetsDefined = isMainAxisRow
-          ? child->getStyle().horizontalInsetsDefined()
-          : child->getStyle().verticalInsetsDefined();
+          ? child->style().horizontalInsetsDefined()
+          : child->style().verticalInsetsDefined();
       const bool crossInsetsDefined = isMainAxisRow
-          ? child->getStyle().verticalInsetsDefined()
-          : child->getStyle().horizontalInsetsDefined();
+          ? child->style().verticalInsetsDefined()
+          : child->style().horizontalInsetsDefined();
 
       const float childMainOffsetFromParent = mainInsetsDefined
           ? (child->getLayout().position(flexStartEdge(mainAxis)) -
@@ -526,7 +526,7 @@ void layoutAbsoluteDescendants(
         setChildTrailingPosition(currentNode, child, crossAxis);
       }
     } else if (
-        child->getStyle().positionType() == PositionType::Static &&
+        child->style().positionType() == PositionType::Static &&
         !child->alwaysFormsContainingBlock()) {
       const Direction childDirection =
           child->resolveDirection(currentNodeDirection);

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/Align.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/Align.h
@@ -17,10 +17,10 @@ namespace facebook::yoga {
 inline Align resolveChildAlignment(
     const yoga::Node* node,
     const yoga::Node* child) {
-  const Align align = child->getStyle().alignSelf() == Align::Auto
-      ? node->getStyle().alignItems()
-      : child->getStyle().alignSelf();
-  if (align == Align::Baseline && isColumn(node->getStyle().flexDirection())) {
+  const Align align = child->style().alignSelf() == Align::Auto
+      ? node->style().alignItems()
+      : child->style().alignSelf();
+  if (align == Align::Baseline && isColumn(node->style().flexDirection())) {
     return Align::FlexStart;
   }
   return align;

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
@@ -38,7 +38,7 @@ float calculateBaseline(const yoga::Node* node) {
     if (child->getLineIndex() > 0) {
       break;
     }
-    if (child->getStyle().positionType() == PositionType::Absolute) {
+    if (child->style().positionType() == PositionType::Absolute) {
       continue;
     }
     if (resolveChildAlignment(node, child) == Align::Baseline ||
@@ -61,17 +61,17 @@ float calculateBaseline(const yoga::Node* node) {
 }
 
 bool isBaselineLayout(const yoga::Node* node) {
-  if (isColumn(node->getStyle().flexDirection())) {
+  if (isColumn(node->style().flexDirection())) {
     return false;
   }
-  if (node->getStyle().alignItems() == Align::Baseline) {
+  if (node->style().alignItems() == Align::Baseline) {
     return true;
   }
   const auto childCount = node->getChildCount();
   for (size_t i = 0; i < childCount; i++) {
     auto child = node->getChild(i);
-    if (child->getStyle().positionType() != PositionType::Absolute &&
-        child->getStyle().alignSelf() == Align::Baseline) {
+    if (child->style().positionType() != PositionType::Absolute &&
+        child->style().alignSelf() == Align::Baseline) {
       return true;
     }
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
@@ -35,11 +35,11 @@ inline FloatOptional boundAxisWithinMinAndMax(
   FloatOptional max;
 
   if (isColumn(axis)) {
-    min = node->getStyle().minDimension(Dimension::Height).resolve(axisSize);
-    max = node->getStyle().maxDimension(Dimension::Height).resolve(axisSize);
+    min = node->style().minDimension(Dimension::Height).resolve(axisSize);
+    max = node->style().maxDimension(Dimension::Height).resolve(axisSize);
   } else if (isRow(axis)) {
-    min = node->getStyle().minDimension(Dimension::Width).resolve(axisSize);
-    max = node->getStyle().maxDimension(Dimension::Width).resolve(axisSize);
+    min = node->style().minDimension(Dimension::Width).resolve(axisSize);
+    max = node->style().maxDimension(Dimension::Width).resolve(axisSize);
   }
 
   if (max >= FloatOptional{0} && value > max) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -44,7 +44,7 @@ static void constrainMaxSizeForMode(
     /*in_out*/ SizingMode* mode,
     /*in_out*/ float* size) {
   const FloatOptional maxSize =
-      node->getStyle().maxDimension(dimension(axis)).resolve(ownerAxisSize) +
+      node->style().maxDimension(dimension(axis)).resolve(ownerAxisSize) +
       FloatOptional(node->getMarginForAxis(axis, ownerWidth));
   switch (*mode) {
     case SizingMode::StretchFit:
@@ -76,7 +76,7 @@ static void computeFlexBasisForChild(
     const uint32_t depth,
     const uint32_t generationCount) {
   const FlexDirection mainAxis =
-      resolveDirection(node->getStyle().flexDirection(), direction);
+      resolveDirection(node->style().flexDirection(), direction);
   const bool isMainAxisRow = isRow(mainAxis);
   const float mainAxisSize = isMainAxisRow ? width : height;
   const float mainAxisownerSize = isMainAxisRow ? ownerWidth : ownerHeight;
@@ -147,23 +147,23 @@ static void computeFlexBasisForChild(
 
     // The W3C spec doesn't say anything about the 'overflow' property, but all
     // major browsers appear to implement the following logic.
-    if ((!isMainAxisRow && node->getStyle().overflow() == Overflow::Scroll) ||
-        node->getStyle().overflow() != Overflow::Scroll) {
+    if ((!isMainAxisRow && node->style().overflow() == Overflow::Scroll) ||
+        node->style().overflow() != Overflow::Scroll) {
       if (yoga::isUndefined(childWidth) && yoga::isDefined(width)) {
         childWidth = width;
         childWidthSizingMode = SizingMode::FitContent;
       }
     }
 
-    if ((isMainAxisRow && node->getStyle().overflow() == Overflow::Scroll) ||
-        node->getStyle().overflow() != Overflow::Scroll) {
+    if ((isMainAxisRow && node->style().overflow() == Overflow::Scroll) ||
+        node->style().overflow() != Overflow::Scroll) {
       if (yoga::isUndefined(childHeight) && yoga::isDefined(height)) {
         childHeight = height;
         childHeightSizingMode = SizingMode::FitContent;
       }
     }
 
-    const auto& childStyle = child->getStyle();
+    const auto& childStyle = child->style();
     if (childStyle.aspectRatio().isDefined()) {
       if (!isMainAxisRow && childWidthSizingMode == SizingMode::StretchFit) {
         childHeight = marginColumn +
@@ -457,13 +457,13 @@ static float calculateAvailableInnerDimension(
     // We want to make sure our available height does not violate min and max
     // constraints
     const FloatOptional minDimensionOptional =
-        node->getStyle().minDimension(dimension).resolve(ownerDim);
+        node->style().minDimension(dimension).resolve(ownerDim);
     const float minInnerDim = minDimensionOptional.isUndefined()
         ? 0.0f
         : minDimensionOptional.unwrap() - paddingAndBorder;
 
     const FloatOptional maxDimensionOptional =
-        node->getStyle().maxDimension(dimension).resolve(ownerDim);
+        node->style().maxDimension(dimension).resolve(ownerDim);
 
     const float maxInnerDim = maxDimensionOptional.isUndefined()
         ? FLT_MAX
@@ -514,7 +514,7 @@ static float computeFlexBasisForChildren(
 
   for (auto child : children) {
     child->resolveDimension();
-    if (child->getStyle().display() == Display::None) {
+    if (child->style().display() == Display::None) {
       zeroOutLayoutRecursively(child);
       child->setHasNewLayout(true);
       child->setDirty(false);
@@ -531,7 +531,7 @@ static float computeFlexBasisForChildren(
           childDirection, mainDim, crossDim, availableInnerWidth);
     }
 
-    if (child->getStyle().positionType() == PositionType::Absolute) {
+    if (child->style().positionType() == PositionType::Absolute) {
       continue;
     }
     if (child == singleFlexChild) {
@@ -586,7 +586,7 @@ static float distributeFreeSpaceSecondPass(
   float flexGrowFactor = 0;
   float deltaFreeSpace = 0;
   const bool isMainAxisRow = isRow(mainAxis);
-  const bool isNodeFlexWrap = node->getStyle().flexWrap() != Wrap::NoWrap;
+  const bool isNodeFlexWrap = node->style().flexWrap() != Wrap::NoWrap;
 
   for (auto currentLineChild : flexLine.itemsInFlow) {
     childFlexBasis = boundAxisWithinMinAndMax(
@@ -652,7 +652,7 @@ static float distributeFreeSpaceSecondPass(
     SizingMode childCrossSizingMode;
     SizingMode childMainSizingMode = SizingMode::StretchFit;
 
-    const auto& childStyle = currentLineChild->getStyle();
+    const auto& childStyle = currentLineChild->style();
     if (childStyle.aspectRatio().isDefined()) {
       childCrossSize = isMainAxisRow
           ? (childMainSize - marginMain) / childStyle.aspectRatio().unwrap()
@@ -917,7 +917,7 @@ static void justifyMainAxis(
     const float availableInnerCrossDim,
     const float availableInnerWidth,
     const bool performLayout) {
-  const auto& style = node->getStyle();
+  const auto& style = node->style();
 
   const float leadingPaddingAndBorderMain =
       node->getFlexStartPaddingAndBorder(mainAxis, direction, ownerWidth);
@@ -956,7 +956,7 @@ static void justifyMainAxis(
   int numberOfAutoMarginsOnCurrentLine = 0;
   for (size_t i = startOfLineIndex; i < flexLine.endOfLineIndex; i++) {
     auto child = node->getChild(i);
-    if (child->getStyle().positionType() != PositionType::Absolute) {
+    if (child->style().positionType() != PositionType::Absolute) {
       if (child->getFlexStartMarginValue(mainAxis).unit() == Unit::Auto) {
         numberOfAutoMarginsOnCurrentLine++;
       }
@@ -971,7 +971,7 @@ static void justifyMainAxis(
   // each two elements.
   float leadingMainDim = 0;
   float betweenMainDim = gap;
-  const Justify justifyContent = node->getStyle().justifyContent();
+  const Justify justifyContent = node->style().justifyContent();
 
   if (numberOfAutoMarginsOnCurrentLine == 0) {
     switch (justifyContent) {
@@ -1013,7 +1013,7 @@ static void justifyMainAxis(
   bool isNodeBaselineLayout = isBaselineLayout(node);
   for (size_t i = startOfLineIndex; i < flexLine.endOfLineIndex; i++) {
     const auto child = node->getChild(i);
-    const Style& childStyle = child->getStyle();
+    const Style& childStyle = child->style();
     const LayoutResults& childLayout = child->getLayout();
     if (childStyle.display() == Display::None) {
       continue;
@@ -1301,10 +1301,10 @@ static void calculateLayoutImpl(
 
   // STEP 1: CALCULATE VALUES FOR REMAINDER OF ALGORITHM
   const FlexDirection mainAxis =
-      resolveDirection(node->getStyle().flexDirection(), direction);
+      resolveDirection(node->style().flexDirection(), direction);
   const FlexDirection crossAxis = resolveCrossDirection(mainAxis, direction);
   const bool isMainAxisRow = isRow(mainAxis);
-  const bool isNodeFlexWrap = node->getStyle().flexWrap() != Wrap::NoWrap;
+  const bool isNodeFlexWrap = node->style().flexWrap() != Wrap::NoWrap;
 
   const float mainAxisownerSize = isMainAxisRow ? ownerWidth : ownerHeight;
   const float crossAxisownerSize = isMainAxisRow ? ownerHeight : ownerWidth;
@@ -1419,7 +1419,7 @@ static void calculateLayoutImpl(
     // If we don't measure with exact main dimension we want to ensure we don't
     // violate min and max
     if (sizingModeMainDim != SizingMode::StretchFit) {
-      const auto& style = node->getStyle();
+      const auto& style = node->style();
       const float minInnerWidth =
           style.minDimension(Dimension::Width).resolve(ownerWidth).unwrap() -
           paddingAndBorderAxisRow;
@@ -1560,10 +1560,10 @@ static void calculateLayoutImpl(
     if (performLayout) {
       for (size_t i = startOfLineIndex; i < endOfLineIndex; i++) {
         const auto child = node->getChild(i);
-        if (child->getStyle().display() == Display::None) {
+        if (child->style().display() == Display::None) {
           continue;
         }
-        if (child->getStyle().positionType() == PositionType::Absolute) {
+        if (child->style().positionType() == PositionType::Absolute) {
           // If the child is absolutely positioned and has a
           // top/left/bottom/right set, override all the previously computed
           // positions to set it correctly.
@@ -1609,7 +1609,7 @@ static void calculateLayoutImpl(
                     dimension(crossAxis), availableInnerCrossDim)) {
               float childMainSize =
                   child->getLayout().measuredDimension(dimension(mainAxis));
-              const auto& childStyle = child->getStyle();
+              const auto& childStyle = child->style();
               float childCrossSize = childStyle.aspectRatio().isDefined()
                   ? child->getMarginForAxis(crossAxis, availableInnerWidth) +
                       (isMainAxisRow
@@ -1642,7 +1642,7 @@ static void calculateLayoutImpl(
               const float childHeight =
                   !isMainAxisRow ? childMainSize : childCrossSize;
 
-              auto alignContent = node->getStyle().alignContent();
+              auto alignContent = node->style().alignContent();
               auto crossAxisDoesNotGrow =
                   alignContent != Align::Stretch && isNodeFlexWrap;
               const SizingMode childWidthSizingMode =
@@ -1729,7 +1729,7 @@ static void calculateLayoutImpl(
         paddingAndBorderAxisCross;
 
     const float remainingAlignContentDim = innerCrossDim - totalLineCrossDim;
-    switch (node->getStyle().alignContent()) {
+    switch (node->style().alignContent()) {
       case Align::FlexEnd:
         currentLead += remainingAlignContentDim;
         break;
@@ -1784,10 +1784,10 @@ static void calculateLayoutImpl(
       float maxDescentForCurrentLine = 0;
       for (ii = startIndex; ii < childCount; ii++) {
         const auto child = node->getChild(ii);
-        if (child->getStyle().display() == Display::None) {
+        if (child->style().display() == Display::None) {
           continue;
         }
-        if (child->getStyle().positionType() != PositionType::Absolute) {
+        if (child->style().positionType() != PositionType::Absolute) {
           if (child->getLineIndex() != i) {
             break;
           }
@@ -1821,10 +1821,10 @@ static void calculateLayoutImpl(
       if (performLayout) {
         for (ii = startIndex; ii < endIndex; ii++) {
           const auto child = node->getChild(ii);
-          if (child->getStyle().display() == Display::None) {
+          if (child->style().display() == Display::None) {
             continue;
           }
-          if (child->getStyle().positionType() != PositionType::Absolute) {
+          if (child->style().positionType() != PositionType::Absolute) {
             switch (resolveChildAlignment(node, child)) {
               case Align::FlexStart: {
                 child->setLayoutPosition(
@@ -1951,7 +1951,7 @@ static void calculateLayoutImpl(
   // If the user didn't specify a width or height for the node, set the
   // dimensions based on the children.
   if (sizingModeMainDim == SizingMode::MaxContent ||
-      (node->getStyle().overflow() != Overflow::Scroll &&
+      (node->style().overflow() != Overflow::Scroll &&
        sizingModeMainDim == SizingMode::FitContent)) {
     // Clamp the size to the min/max size, if specified, and make sure it
     // doesn't go below the padding and border amount.
@@ -1962,7 +1962,7 @@ static void calculateLayoutImpl(
 
   } else if (
       sizingModeMainDim == SizingMode::FitContent &&
-      node->getStyle().overflow() == Overflow::Scroll) {
+      node->style().overflow() == Overflow::Scroll) {
     node->setLayoutMeasuredDimension(
         yoga::maxOrDefined(
             yoga::minOrDefined(
@@ -1978,7 +1978,7 @@ static void calculateLayoutImpl(
   }
 
   if (sizingModeCrossDim == SizingMode::MaxContent ||
-      (node->getStyle().overflow() != Overflow::Scroll &&
+      (node->style().overflow() != Overflow::Scroll &&
        sizingModeCrossDim == SizingMode::FitContent)) {
     // Clamp the size to the min/max size, if specified, and make sure it
     // doesn't go below the padding and border amount.
@@ -1993,7 +1993,7 @@ static void calculateLayoutImpl(
 
   } else if (
       sizingModeCrossDim == SizingMode::FitContent &&
-      node->getStyle().overflow() == Overflow::Scroll) {
+      node->style().overflow() == Overflow::Scroll) {
     node->setLayoutMeasuredDimension(
         yoga::maxOrDefined(
             yoga::minOrDefined(
@@ -2011,10 +2011,10 @@ static void calculateLayoutImpl(
 
   // As we only wrapped in normal direction yet, we need to reverse the
   // positions on wrap-reverse.
-  if (performLayout && node->getStyle().flexWrap() == Wrap::WrapReverse) {
+  if (performLayout && node->style().flexWrap() == Wrap::WrapReverse) {
     for (size_t i = 0; i < childCount; i++) {
       const auto child = node->getChild(i);
-      if (child->getStyle().positionType() != PositionType::Absolute) {
+      if (child->style().positionType() != PositionType::Absolute) {
         child->setLayoutPosition(
             node->getLayout().measuredDimension(dimension(crossAxis)) -
                 child->getLayout().position(flexStartEdge(crossAxis)) -
@@ -2028,7 +2028,7 @@ static void calculateLayoutImpl(
     // STEP 10: SIZING AND POSITIONING ABSOLUTE CHILDREN
     // Let the containing block layout its absolute descendants. By definition
     // the containing block will not be static unless we are at the root.
-    if (node->getStyle().positionType() != PositionType::Static ||
+    if (node->style().positionType() != PositionType::Static ||
         node->alwaysFormsContainingBlock() || depth == 1) {
       layoutAbsoluteDescendants(
           node,
@@ -2054,8 +2054,8 @@ static void calculateLayoutImpl(
         // Absolute children will be handled by their containing block since we
         // cannot guarantee that their positions are set when their parents are
         // done with layout.
-        if (child->getStyle().display() == Display::None ||
-            child->getStyle().positionType() == PositionType::Absolute) {
+        if (child->style().display() == Display::None ||
+            child->style().positionType() == PositionType::Absolute) {
           continue;
         }
         if (needsMainTrailingPos) {
@@ -2289,7 +2289,7 @@ void calculateLayout(
   node->resolveDimension();
   float width = YGUndefined;
   SizingMode widthSizingMode = SizingMode::MaxContent;
-  const auto& style = node->getStyle();
+  const auto& style = node->style();
   if (node->hasDefiniteLength(Dimension::Width, ownerWidth)) {
     width =
         (node->getResolvedDimension(dimension(FlexDirection::Row))

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
@@ -32,15 +32,15 @@ FlexLine calculateFlexLine(
 
   float sizeConsumedIncludingMinConstraint = 0;
   const FlexDirection mainAxis = resolveDirection(
-      node->getStyle().flexDirection(), node->resolveDirection(ownerDirection));
-  const bool isNodeFlexWrap = node->getStyle().flexWrap() != Wrap::NoWrap;
+      node->style().flexDirection(), node->resolveDirection(ownerDirection));
+  const bool isNodeFlexWrap = node->style().flexWrap() != Wrap::NoWrap;
   const float gap = node->getGapForAxis(mainAxis);
 
   // Add items to the current line until it's full or we run out of items.
   for (; endOfLineIndex < node->getChildren().size(); endOfLineIndex++) {
     auto child = node->getChild(endOfLineIndex);
-    if (child->getStyle().display() == Display::None ||
-        child->getStyle().positionType() == PositionType::Absolute) {
+    if (child->style().display() == Display::None ||
+        child->style().positionType() == PositionType::Absolute) {
       if (firstElementInLineIndex == endOfLineIndex) {
         // We haven't found the first contributing element in the line yet.
         firstElementInLineIndex++;

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -114,24 +114,24 @@ void nodeToString(
 
   if ((options & PrintOptions::Style) == PrintOptions::Style) {
     appendFormattedString(str, "style=\"");
-    const auto& style = node->getStyle();
-    if (style.flexDirection() != yoga::Node{}.getStyle().flexDirection()) {
+    const auto& style = node->style();
+    if (style.flexDirection() != yoga::Style{}.flexDirection()) {
       appendFormattedString(
           str, "flex-direction: %s; ", toString(style.flexDirection()));
     }
-    if (style.justifyContent() != yoga::Node{}.getStyle().justifyContent()) {
+    if (style.justifyContent() != yoga::Style{}.justifyContent()) {
       appendFormattedString(
           str, "justify-content: %s; ", toString(style.justifyContent()));
     }
-    if (style.alignItems() != yoga::Node{}.getStyle().alignItems()) {
+    if (style.alignItems() != yoga::Style{}.alignItems()) {
       appendFormattedString(
           str, "align-items: %s; ", toString(style.alignItems()));
     }
-    if (style.alignContent() != yoga::Node{}.getStyle().alignContent()) {
+    if (style.alignContent() != yoga::Style{}.alignContent()) {
       appendFormattedString(
           str, "align-content: %s; ", toString(style.alignContent()));
     }
-    if (style.alignSelf() != yoga::Node{}.getStyle().alignSelf()) {
+    if (style.alignSelf() != yoga::Style{}.alignSelf()) {
       appendFormattedString(
           str, "align-self: %s; ", toString(style.alignSelf()));
     }
@@ -140,15 +140,15 @@ void nodeToString(
     appendNumberIfNotAuto(str, "flex-basis", style.flexBasis());
     appendFloatOptionalIfDefined(str, "flex", style.flex());
 
-    if (style.flexWrap() != yoga::Node{}.getStyle().flexWrap()) {
+    if (style.flexWrap() != yoga::Style{}.flexWrap()) {
       appendFormattedString(str, "flex-wrap: %s; ", toString(style.flexWrap()));
     }
 
-    if (style.overflow() != yoga::Node{}.getStyle().overflow()) {
+    if (style.overflow() != yoga::Style{}.overflow()) {
       appendFormattedString(str, "overflow: %s; ", toString(style.overflow()));
     }
 
-    if (style.display() != yoga::Node{}.getStyle().display()) {
+    if (style.display() != yoga::Style{}.display()) {
       appendFormattedString(str, "display: %s; ", toString(style.display()));
     }
     appendEdges<&Style::margin>(str, "margin", style);
@@ -173,7 +173,7 @@ void nodeToString(
     appendNumberIfNotAuto(
         str, "min-height", style.minDimension(Dimension::Height));
 
-    if (style.positionType() != yoga::Node{}.getStyle().positionType()) {
+    if (style.positionType() != yoga::Style{}.positionType()) {
       appendFormattedString(
           str, "position: %s; ", toString(style.positionType()));
     }

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -602,13 +602,13 @@ Style::Length Node::resolveFlexBasisPtr() const {
 }
 
 void Node::resolveDimension() {
-  const Style& style = getStyle();
   for (auto dim : {Dimension::Width, Dimension::Height}) {
-    if (style.maxDimension(dim).isDefined() &&
-        yoga::inexactEquals(style.maxDimension(dim), style.minDimension(dim))) {
-      resolvedDimensions_[yoga::to_underlying(dim)] = style.maxDimension(dim);
+    if (style_.maxDimension(dim).isDefined() &&
+        yoga::inexactEquals(
+            style_.maxDimension(dim), style_.minDimension(dim))) {
+      resolvedDimensions_[yoga::to_underlying(dim)] = style_.maxDimension(dim);
     } else {
-      resolvedDimensions_[yoga::to_underlying(dim)] = style.dimension(dim);
+      resolvedDimensions_[yoga::to_underlying(dim)] = style_.dimension(dim);
     }
   }
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -94,11 +94,11 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   // For Performance reasons passing as reference.
-  Style& getStyle() {
+  Style& style() {
     return style_;
   }
 
-  const Style& getStyle() const {
+  const Style& style() const {
     return style_;
   }
 


### PR DESCRIPTION
Summary:
The next diff moves a bunch of methods to `yoga::Style`. This renames the function to be a tad bit shorter, for more readable callsites. It also makes it more consistent with style property getters.

Changelog: [Internal]

Reviewed By: rozele

Differential Revision: D52803393


