### PR TITLE
Rename AbsolutePositioning errata

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -102,7 +102,7 @@ export interface FlexStyle {
   paddingStart?: DimensionValue | undefined;
   paddingTop?: DimensionValue | undefined;
   paddingVertical?: DimensionValue | undefined;
-  position?: 'absolute' | 'relative' | undefined;
+  position?: 'absolute' | 'relative' | 'static' | undefined;
   right?: DimensionValue | undefined;
   start?: DimensionValue | undefined;
   top?: DimensionValue | undefined;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -469,22 +469,23 @@ type ____LayoutStyle_Internal = $ReadOnly<{
   borderTopWidth?: number,
 
   /** `position` in React Native is similar to regular CSS, but
-   *  everything is set to `relative` by default, so `absolute`
-   *  positioning is always just relative to the parent.
+   *  everything is set to `relative` by default.
    *
    *  If you want to position a child using specific numbers of logical
    *  pixels relative to its parent, set the child to have `absolute`
    *  position.
    *
    *  If you want to position a child relative to something
-   *  that is not its parent, just don't use styles for that. Use the
-   *  component tree.
+   *  that is not its parent, set the child to have `absolute` position and the
+   *  nodes between to have `static` position.
+   *
+   *  Note that `static` is only available on the new renderer.
    *
    *  See https://github.com/facebook/yoga
    *  for more details on how `position` differs between React Native
    *  and CSS.
    */
-  position?: 'absolute' | 'relative',
+  position?: 'absolute' | 'relative' | 'static',
 
   /** `flexDirection` controls which directions children of a container go.
    *  `row` goes left to right, `column` goes top to bottom, and you may

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8722,7 +8722,7 @@ type ____LayoutStyle_Internal = $ReadOnly<{
   borderRightWidth?: number,
   borderStartWidth?: number,
   borderTopWidth?: number,
-  position?: \\"absolute\\" | \\"relative\\",
+  position?: \\"absolute\\" | \\"relative\\" | \\"static\\",
   flexDirection?: \\"row\\" | \\"row-reverse\\" | \\"column\\" | \\"column-reverse\\",
   flexWrap?: \\"wrap\\" | \\"nowrap\\" | \\"wrap-reverse\\",
   justifyContent?:

--- a/packages/react-native/React/Base/RCTConvert.m
+++ b/packages/react-native/React/Base/RCTConvert.m
@@ -1190,11 +1190,7 @@ RCT_ENUM_CONVERTER(
 
 RCT_ENUM_CONVERTER(
     YGPositionType,
-    (@{
-      @"static" : @(YGPositionTypeStatic),
-      @"absolute" : @(YGPositionTypeAbsolute),
-      @"relative" : @(YGPositionTypeRelative)
-    }),
+    (@{@"absolute" : @(YGPositionTypeAbsolute), @"relative" : @(YGPositionTypeRelative)}),
     YGPositionTypeRelative,
     intValue)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -823,11 +823,6 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
     }
 
     switch (position) {
-      case "static":
-        {
-          setPositionType(YogaPositionType.STATIC);
-          break;
-        }
       case "relative":
         {
           setPositionType(YogaPositionType.RELATIVE);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.java
@@ -12,7 +12,7 @@ package com.facebook.yoga;
 public enum YogaErrata {
   NONE(0),
   STRETCH_FLEX_BASIS(1),
-  ABSOLUTE_POSITIONING(2),
+  ABSOLUTE_POSITIONING_INCORRECT(2),
   ABSOLUTE_PERCENT_AGAINST_INNER_SIZE(4),
   ALL(2147483647),
   CLASSIC(2147483646);
@@ -31,7 +31,7 @@ public enum YogaErrata {
     switch (value) {
       case 0: return NONE;
       case 1: return STRETCH_FLEX_BASIS;
-      case 2: return ABSOLUTE_POSITIONING;
+      case 2: return ABSOLUTE_POSITIONING_INCORRECT;
       case 4: return ABSOLUTE_PERCENT_AGAINST_INNER_SIZE;
       case 2147483647: return ALL;
       case 2147483646: return CLASSIC;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaErrata.java
@@ -12,8 +12,8 @@ package com.facebook.yoga;
 public enum YogaErrata {
   NONE(0),
   STRETCH_FLEX_BASIS(1),
-  POSITION_STATIC_BEHAVES_LIKE_RELATIVE(2),
-  ABSOLUTE_POSITIONING(4),
+  ABSOLUTE_POSITIONING(2),
+  ABSOLUTE_PERCENT_AGAINST_INNER_SIZE(4),
   ALL(2147483647),
   CLASSIC(2147483646);
 
@@ -31,8 +31,8 @@ public enum YogaErrata {
     switch (value) {
       case 0: return NONE;
       case 1: return STRETCH_FLEX_BASIS;
-      case 2: return POSITION_STATIC_BEHAVES_LIKE_RELATIVE;
-      case 4: return ABSOLUTE_POSITIONING;
+      case 2: return ABSOLUTE_POSITIONING;
+      case 4: return ABSOLUTE_PERCENT_AGAINST_INNER_SIZE;
       case 2147483647: return ALL;
       case 2147483646: return CLASSIC;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaExperimentalFeature.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaExperimentalFeature.java
@@ -10,8 +10,7 @@
 package com.facebook.yoga;
 
 public enum YogaExperimentalFeature {
-  WEB_FLEX_BASIS(0),
-  ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE(1);
+  WEB_FLEX_BASIS(0);
 
   private final int mIntValue;
 
@@ -26,7 +25,6 @@ public enum YogaExperimentalFeature {
   public static YogaExperimentalFeature fromInt(int value) {
     switch (value) {
       case 0: return WEB_FLEX_BASIS;
-      case 1: return ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGConfig.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGConfig.h
@@ -81,7 +81,7 @@ YG_EXPORT float YGConfigGetPointScaleFactor(YGConfigConstRef config);
  *
  * By deafult Yoga will prioritize W3C conformance. `Errata` may be set to ask
  * Yoga to produce specific incorrect behaviors. E.g. `YGConfigSetErrata(config,
- * YGErrataPositionStaticBehavesLikeRelative)`.
+ * YGErrataStretchFlexBasis)`.
  *
  * YGErrata is a bitmask, and multiple errata may be set at once. Predfined
  * constants exist for convenience:

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -111,8 +111,6 @@ const char* YGExperimentalFeatureToString(const YGExperimentalFeature value) {
   switch (value) {
     case YGExperimentalFeatureWebFlexBasis:
       return "web-flex-basis";
-    case YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge:
-      return "absolute-percentage-against-padding-edge";
   }
   return "unknown";
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -95,8 +95,8 @@ const char* YGErrataToString(const YGErrata value) {
       return "none";
     case YGErrataStretchFlexBasis:
       return "stretch-flex-basis";
-    case YGErrataAbsolutePositioning:
-      return "absolute-positioning";
+    case YGErrataAbsolutePositioningIncorrect:
+      return "absolute-positioning-incorrect";
     case YGErrataAbsolutePercentAgainstInnerSize:
       return "absolute-percent-against-inner-size";
     case YGErrataAll:

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -95,10 +95,10 @@ const char* YGErrataToString(const YGErrata value) {
       return "none";
     case YGErrataStretchFlexBasis:
       return "stretch-flex-basis";
-    case YGErrataPositionStaticBehavesLikeRelative:
-      return "position-static-behaves-like-relative";
     case YGErrataAbsolutePositioning:
       return "absolute-positioning";
+    case YGErrataAbsolutePercentAgainstInnerSize:
+      return "absolute-percent-against-inner-size";
     case YGErrataAll:
       return "all";
     case YGErrataClassic:

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -64,8 +64,7 @@ YG_DEFINE_ENUM_FLAG_OPERATORS(YGErrata)
 
 YG_ENUM_DECL(
     YGExperimentalFeature,
-    YGExperimentalFeatureWebFlexBasis,
-    YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge)
+    YGExperimentalFeatureWebFlexBasis)
 
 YG_ENUM_DECL(
     YGFlexDirection,

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -56,8 +56,8 @@ YG_ENUM_DECL(
     YGErrata,
     YGErrataNone = 0,
     YGErrataStretchFlexBasis = 1,
-    YGErrataPositionStaticBehavesLikeRelative = 2,
-    YGErrataAbsolutePositioning = 4,
+    YGErrataAbsolutePositioning = 2,
+    YGErrataAbsolutePercentAgainstInnerSize = 4,
     YGErrataAll = 2147483647,
     YGErrataClassic = 2147483646)
 YG_DEFINE_ENUM_FLAG_OPERATORS(YGErrata)

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -56,7 +56,7 @@ YG_ENUM_DECL(
     YGErrata,
     YGErrataNone = 0,
     YGErrataStretchFlexBasis = 1,
-    YGErrataAbsolutePositioning = 2,
+    YGErrataAbsolutePositioningIncorrect = 2,
     YGErrataAbsolutePercentAgainstInnerSize = 4,
     YGErrataAll = 2147483647,
     YGErrataClassic = 2147483646)

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -462,7 +462,9 @@ void layoutAbsoluteDescendants(
     uint32_t currentDepth,
     uint32_t generationCount,
     float currentNodeMainOffsetFromContainingBlock,
-    float currentNodeCrossOffsetFromContainingBlock) {
+    float currentNodeCrossOffsetFromContainingBlock,
+    float containingNodeAvailableInnerWidth,
+    float containingNodeAvailableInnerHeight) {
   const FlexDirection mainAxis = resolveDirection(
       currentNode->getStyle().flexDirection(), currentNodeDirection);
   const FlexDirection crossAxis =
@@ -471,14 +473,23 @@ void layoutAbsoluteDescendants(
     if (child->getStyle().display() == Display::None) {
       continue;
     } else if (child->getStyle().positionType() == PositionType::Absolute) {
+      const bool absoluteErrata =
+          currentNode->hasErrata(Errata::AbsolutePercentAgainstInnerSize);
+      const float containingBlockWidth = absoluteErrata
+          ? containingNodeAvailableInnerWidth
+          : containingNode->getLayout().measuredDimension(Dimension::Width) -
+              containingNode->getBorderForAxis(FlexDirection::Row);
+      const float containingBlockHeight = absoluteErrata
+          ? containingNodeAvailableInnerHeight
+          : containingNode->getLayout().measuredDimension(Dimension::Height) -
+              containingNode->getBorderForAxis(FlexDirection::Column);
+
       layoutAbsoluteChild(
           containingNode,
           currentNode,
           child,
-          containingNode->getLayout().measuredDimension(Dimension::Width) -
-              containingNode->getBorderForAxis(FlexDirection::Row),
-          containingNode->getLayout().measuredDimension(Dimension::Height) -
-              containingNode->getBorderForAxis(FlexDirection::Column),
+          containingBlockWidth,
+          containingBlockHeight,
           widthSizingMode,
           currentNodeDirection,
           layoutMarkerData,
@@ -534,7 +545,9 @@ void layoutAbsoluteDescendants(
           currentDepth + 1,
           generationCount,
           childMainOffsetFromContainingBlock,
-          childCrossOffsetFromContainingBlock);
+          childCrossOffsetFromContainingBlock,
+          containingNodeAvailableInnerWidth,
+          containingNodeAvailableInnerHeight);
     }
   }
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -261,24 +261,25 @@ static void positionAbsoluteChild(
     const bool isMainAxis,
     const float containingBlockWidth,
     const float containingBlockHeight) {
-  child->hasErrata(Errata::AbsolutePositioning) ? positionAbsoluteChildLegacy(
-                                                      containingNode,
-                                                      parent,
-                                                      child,
-                                                      direction,
-                                                      axis,
-                                                      isMainAxis,
-                                                      containingBlockWidth,
-                                                      containingBlockHeight)
-                                                : positionAbsoluteChildImpl(
-                                                      containingNode,
-                                                      parent,
-                                                      child,
-                                                      direction,
-                                                      axis,
-                                                      isMainAxis,
-                                                      containingBlockWidth,
-                                                      containingBlockHeight);
+  child->hasErrata(Errata::AbsolutePositioningIncorrect)
+      ? positionAbsoluteChildLegacy(
+            containingNode,
+            parent,
+            child,
+            direction,
+            axis,
+            isMainAxis,
+            containingBlockWidth,
+            containingBlockHeight)
+      : positionAbsoluteChildImpl(
+            containingNode,
+            parent,
+            child,
+            direction,
+            axis,
+            isMainAxis,
+            containingBlockWidth,
+            containingBlockHeight);
 }
 
 void layoutAbsoluteChild(

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -178,21 +178,6 @@ static void positionAbsoluteChildLegacy(
         (parent->getLayout().measuredDimension(dimension(axis)) -
          child->getLayout().measuredDimension(dimension(axis))),
         flexStartEdge(axis));
-  } else if (
-      parent->getConfig()->isExperimentalFeatureEnabled(
-          ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge) &&
-      child->isFlexStartPositionDefined(axis, direction)) {
-    child->setLayoutPosition(
-        child->getFlexStartPosition(
-            axis,
-            direction,
-            containingNode->getLayout().measuredDimension(dimension(axis))) +
-            containingNode->getFlexStartBorder(axis, direction) +
-            child->getFlexStartMargin(
-                axis,
-                direction,
-                isAxisRow ? containingBlockWidth : containingBlockHeight),
-        flexStartEdge(axis));
   }
 }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.h
@@ -33,6 +33,8 @@ void layoutAbsoluteDescendants(
     uint32_t currentDepth,
     uint32_t generationCount,
     float currentNodeMainOffsetFromContainingBlock,
-    float currentNodeCrossOffsetFromContainingBlock);
+    float currentNodeCrossOffsetFromContainingBlock,
+    float containingNodeAvailableInnerWidth,
+    float containingNodeAvailableInnerHeight);
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -2026,41 +2026,22 @@ static void calculateLayoutImpl(
 
   if (performLayout) {
     // STEP 10: SIZING AND POSITIONING ABSOLUTE CHILDREN
-    if (!node->hasErrata(Errata::PositionStaticBehavesLikeRelative)) {
-      // Let the containing block layout its absolute descendants. By definition
-      // the containing block will not be static unless we are at the root.
-      if (node->getStyle().positionType() != PositionType::Static ||
-          node->alwaysFormsContainingBlock() || depth == 1) {
-        layoutAbsoluteDescendants(
-            node,
-            node,
-            isMainAxisRow ? sizingModeMainDim : sizingModeCrossDim,
-            direction,
-            layoutMarkerData,
-            depth,
-            generationCount,
-            0.0f,
-            0.0f);
-      }
-    } else {
-      for (auto child : node->getChildren()) {
-        if (child->getStyle().display() == Display::None ||
-            child->getStyle().positionType() != PositionType::Absolute) {
-          continue;
-        }
-
-        layoutAbsoluteChild(
-            node,
-            node,
-            child,
-            availableInnerWidth,
-            availableInnerHeight,
-            isMainAxisRow ? sizingModeMainDim : sizingModeCrossDim,
-            direction,
-            layoutMarkerData,
-            depth,
-            generationCount);
-      }
+    // Let the containing block layout its absolute descendants. By definition
+    // the containing block will not be static unless we are at the root.
+    if (node->getStyle().positionType() != PositionType::Static ||
+        node->alwaysFormsContainingBlock() || depth == 1) {
+      layoutAbsoluteDescendants(
+          node,
+          node,
+          isMainAxisRow ? sizingModeMainDim : sizingModeCrossDim,
+          direction,
+          layoutMarkerData,
+          depth,
+          generationCount,
+          0.0f,
+          0.0f,
+          availableInnerWidth,
+          availableInnerHeight);
     }
 
     // STEP 11: SETTING TRAILING POSITIONS FOR CHILDREN
@@ -2074,8 +2055,7 @@ static void calculateLayoutImpl(
         // cannot guarantee that their positions are set when their parents are
         // done with layout.
         if (child->getStyle().display() == Display::None ||
-            (!node->hasErrata(Errata::PositionStaticBehavesLikeRelative) &&
-             child->getStyle().positionType() == PositionType::Absolute)) {
+            child->getStyle().positionType() == PositionType::Absolute) {
           continue;
         }
         if (needsMainTrailingPos) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -2048,20 +2048,13 @@ static void calculateLayoutImpl(
             child->getStyle().positionType() != PositionType::Absolute) {
           continue;
         }
-        const bool absolutePercentageAgainstPaddingEdge =
-            node->getConfig()->isExperimentalFeatureEnabled(
-                ExperimentalFeature::AbsolutePercentageAgainstPaddingEdge);
 
         layoutAbsoluteChild(
             node,
             node,
             child,
-            absolutePercentageAgainstPaddingEdge
-                ? node->getLayout().measuredDimension(Dimension::Width)
-                : availableInnerWidth,
-            absolutePercentageAgainstPaddingEdge
-                ? node->getLayout().measuredDimension(Dimension::Height)
-                : availableInnerHeight,
+            availableInnerWidth,
+            availableInnerHeight,
             isMainAxisRow ? sizingModeMainDim : sizingModeCrossDim,
             direction,
             layoutMarkerData,

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
@@ -18,7 +18,7 @@ namespace facebook::yoga {
 enum class Errata : uint32_t {
   None = YGErrataNone,
   StretchFlexBasis = YGErrataStretchFlexBasis,
-  AbsolutePositioning = YGErrataAbsolutePositioning,
+  AbsolutePositioningIncorrect = YGErrataAbsolutePositioningIncorrect,
   AbsolutePercentAgainstInnerSize = YGErrataAbsolutePercentAgainstInnerSize,
   All = YGErrataAll,
   Classic = YGErrataClassic,

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/Errata.h
@@ -18,8 +18,8 @@ namespace facebook::yoga {
 enum class Errata : uint32_t {
   None = YGErrataNone,
   StretchFlexBasis = YGErrataStretchFlexBasis,
-  PositionStaticBehavesLikeRelative = YGErrataPositionStaticBehavesLikeRelative,
   AbsolutePositioning = YGErrataAbsolutePositioning,
+  AbsolutePercentAgainstInnerSize = YGErrataAbsolutePercentAgainstInnerSize,
   All = YGErrataAll,
   Classic = YGErrataClassic,
 };

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/ExperimentalFeature.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/ExperimentalFeature.h
@@ -17,12 +17,11 @@ namespace facebook::yoga {
 
 enum class ExperimentalFeature : uint8_t {
   WebFlexBasis = YGExperimentalFeatureWebFlexBasis,
-  AbsolutePercentageAgainstPaddingEdge = YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge,
 };
 
 template <>
 constexpr int32_t ordinalCount<ExperimentalFeature>() {
-  return 2;
+  return 1;
 }
 
 constexpr ExperimentalFeature scopedEnum(YGExperimentalFeature unscoped) {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -519,8 +519,7 @@ float Node::relativePosition(
     FlexDirection axis,
     Direction direction,
     float axisSize) const {
-  if (style_.positionType() == PositionType::Static &&
-      !hasErrata(Errata::PositionStaticBehavesLikeRelative)) {
+  if (style_.positionType() == PositionType::Static) {
     return 0;
   }
   if (isInlineStartPositionDefined(axis, direction)) {

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -230,6 +230,78 @@ class ZIndexExample extends React.Component<
   };
 }
 
+function PositionStaticZIndexExample(): React.Node {
+  return (
+    <View
+      testID="view-test-zindex-with-static"
+      style={{backgroundColor: 'yellow', flexDirection: 'row'}}>
+      <View
+        style={{
+          backgroundColor: 'red',
+          width: 100,
+          height: 100,
+          position: 'relative',
+          left: 10,
+        }}>
+        <View
+          style={{
+            backgroundColor: 'purple',
+            width: 50,
+            height: 50,
+            top: 30,
+            left: 65,
+            position: 'relative',
+          }}
+        />
+      </View>
+      <View
+        style={{
+          backgroundColor: 'blue',
+          width: 100,
+          height: 100,
+          zIndex: 100,
+          position: 'static',
+        }}>
+        <View
+          style={{
+            backgroundColor: 'orange',
+            width: 50,
+            height: 50,
+            top: 10,
+            position: 'relative',
+          }}
+        />
+        <View
+          style={{
+            backgroundColor: 'brown',
+            width: 50,
+            height: 50,
+            position: 'static',
+          }}>
+          <View
+            style={{
+              backgroundColor: 'black',
+              width: 25,
+              height: 25,
+              top: -10,
+              position: 'relative',
+            }}
+          />
+        </View>
+      </View>
+      <View
+        style={{
+          backgroundColor: 'green',
+          width: 100,
+          height: 100,
+          position: 'relative',
+          left: -20,
+        }}
+      />
+    </View>
+  );
+}
+
 class DisplayNoneStyle extends React.Component<
   $ReadOnly<{||}>,
   {|
@@ -662,6 +734,11 @@ export default ({
       render(): React.Node {
         return <ZIndexExample />;
       },
+    },
+    {
+      title: 'ZIndex With Static',
+      name: 'zindex-with-static',
+      render: PositionStaticZIndexExample,
     },
     {
       title: '`display: none` style',


### PR DESCRIPTION
Summary:
AbsolutePositioning -> AbsolutePositioningCatchAll

A bit more clear. This errata is for various issues with positioning absolute nodes. There really isn't a clear description as to what specifically this enables/disables, so I just opted to say "catch all" to indicate that this controls various bugs

Differential Revision: D52820117


