### PR TITLE
Remove deprecated DefaultNewArchitectureEntryPoint.load overload

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.defaults
 
+import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.config.ReactFeatureFlags
 
 /**
@@ -28,6 +29,11 @@ object DefaultNewArchitectureEntryPoint {
       fabricEnabled: Boolean = true,
       bridgelessEnabled: Boolean = false
   ) {
+    val (isValid, errorMessage) =
+        isConfigurationValid(turboModulesEnabled, fabricEnabled, bridgelessEnabled)
+    if (!isValid) {
+      error(errorMessage)
+    }
     ReactFeatureFlags.useTurboModules = turboModulesEnabled
     ReactFeatureFlags.enableFabricRenderer = fabricEnabled
     ReactFeatureFlags.unstable_useFabricInterop = fabricEnabled
@@ -76,4 +82,20 @@ object DefaultNewArchitectureEntryPoint {
   @JvmStatic
   val bridgelessEnabled: Boolean
     get() = privateBridgelessEnabled
+
+  @VisibleForTesting
+  fun isConfigurationValid(
+      turboModulesEnabled: Boolean,
+      fabricEnabled: Boolean,
+      bridgelessEnabled: Boolean
+  ): Pair<Boolean, String> =
+      when {
+        fabricEnabled && !turboModulesEnabled ->
+            false to
+                "fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters."
+        bridgelessEnabled && (!turboModulesEnabled || !fabricEnabled) ->
+            false to
+                "bridgelessEnabled=true requires (turboModulesEnabled=true AND fabricEnabled=true) - Please update your DefaultNewArchitectureEntryPoint.load() parameters."
+        else -> true to ""
+      }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -49,20 +49,6 @@ object DefaultNewArchitectureEntryPoint {
     DefaultSoLoader.maybeLoadSoLibrary()
   }
 
-  @Deprecated(
-      message =
-          "Calling DefaultNewArchitectureEntryPoint.load() with different fabricEnabled and concurrentReactEnabled is deprecated. Please use a single flag for both Fabric and Concurrent React",
-      replaceWith = ReplaceWith("load(turboModulesEnabled, fabricEnabled, bridgelessEnabled)"),
-      level = DeprecationLevel.WARNING)
-  fun load(
-      turboModulesEnabled: Boolean = true,
-      fabricEnabled: Boolean = true,
-      bridgelessEnabled: Boolean = false,
-      @Suppress("UNUSED_PARAMETER") concurrentReactEnabled: Boolean = true,
-  ) {
-    load(turboModulesEnabled, fabricEnabled, bridgelessEnabled)
-  }
-
   private var privateFabricEnabled: Boolean = false
   @JvmStatic
   val fabricEnabled: Boolean

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.defaults
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DefaultNewArchitectureEntryPointTest {
+
+  @Test
+  fun isConfigurationValid_withEverythingOff_returnsTrue() {
+    val (isValid, _) =
+        DefaultNewArchitectureEntryPoint.isConfigurationValid(
+            turboModulesEnabled = false, fabricEnabled = false, bridgelessEnabled = false)
+    assertEquals(true, isValid)
+  }
+
+  @Test
+  fun isConfigurationValid_withNewArchOn_returnsTrue() {
+    val (isValid, _) =
+        DefaultNewArchitectureEntryPoint.isConfigurationValid(
+            turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = false)
+    assertEquals(true, isValid)
+  }
+
+  @Test
+  fun isConfigurationValid_withTurboModulesOnlyOn_returnsTrue() {
+    val (isValid, _) =
+        DefaultNewArchitectureEntryPoint.isConfigurationValid(
+            turboModulesEnabled = true, fabricEnabled = false, bridgelessEnabled = false)
+    assertEquals(true, isValid)
+  }
+
+  @Test
+  fun isConfigurationValid_withBridgelessOn_returnsTrue() {
+    val (isValid, _) =
+        DefaultNewArchitectureEntryPoint.isConfigurationValid(
+            turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = true)
+    assertEquals(true, isValid)
+  }
+
+  @Test
+  fun isConfigurationValid_withFabricWithoutTurboModules_returnsFalse() {
+    val (isValid, errorMessage) =
+        DefaultNewArchitectureEntryPoint.isConfigurationValid(
+            turboModulesEnabled = false, fabricEnabled = true, bridgelessEnabled = false)
+    assertEquals(false, isValid)
+    assertEquals(
+        "fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.",
+        errorMessage)
+  }
+
+  @Test
+  fun isConfigurationValid_withBridgelessWithoutTurboModules_returnsFalse() {
+    val (isValid, errorMessage) =
+        DefaultNewArchitectureEntryPoint.isConfigurationValid(
+            turboModulesEnabled = false, fabricEnabled = true, bridgelessEnabled = true)
+    assertEquals(false, isValid)
+    assertEquals(
+        "fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.",
+        errorMessage)
+  }
+
+  @Test
+  fun isConfigurationValid_withBridgelessWithoutFabric_returnsFalse() {
+    val (isValid, errorMessage) =
+        DefaultNewArchitectureEntryPoint.isConfigurationValid(
+            turboModulesEnabled = true, fabricEnabled = false, bridgelessEnabled = true)
+    assertEquals(false, isValid)
+    assertEquals(
+        "bridgelessEnabled=true requires (turboModulesEnabled=true AND fabricEnabled=true) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.",
+        errorMessage)
+  }
+}


### PR DESCRIPTION
Summary:
This method was deprecated in 0.72. We're going to remove it in 0.74
Technically a breaking change, but users should not be using this method at all at this point.

Changelog:
[Android] [Removed] - Remove deprecated DefaultNewArchitectureEntryPoint.load overload

Reviewed By: mdvacca

Differential Revision: D52802644


