### PR TITLE
feat: set Swift active compilation conditions build setting to DEBUG 

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -626,10 +626,10 @@ class UtilsTests < Test::Unit::TestCase
     end
 
     # ==================================== #
-    # Test - Set USE_HERMES Build Setting #
+    # Test - Set build setting             #
     # ==================================== #
 
-    def test_setUseHermesBuildSetting_addTheUserSetting
+    def test_setBuildSetting_addTheUserSetting
         # Arrange
         react_native_path = "react_native/node_modules"
         user_project_mock = prepare_empty_user_project_mock()
@@ -639,23 +639,23 @@ class UtilsTests < Test::Unit::TestCase
         ])
 
         # Act
-        ReactNativePodsUtils.set_use_hermes_build_setting(installer, false)
+        ReactNativePodsUtils.set_build_setting(installer, build_setting: "TEST_SETTING", value: ["Test"])
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal(config.build_settings["USE_HERMES"], false)
+            assert_equal(config.build_settings["TEST_SETTING"], ["Test"])
         end
 
         assert_equal(user_project_mock.save_invocation_count, 1)
         assert_equal(pods_projects_mock.save_invocation_count, 1)
-        assert_equal(Pod::UI.collected_messages, ["Setting USE_HERMES build settings"])
+        assert_equal(Pod::UI.collected_messages, ["Setting TEST_SETTING build settings"])
     end
 
     # ==================================== #
-    # Test - Set Node_Modules User Setting #
+    # Test - Set build setting (Debug)     #
     # ==================================== #
 
-    def test_setNodeModulesUserSettings_addTheUserSetting
+    def test_setBuildSettingDebug_addTheUserSetting
         # Arrange
         react_native_path = "react_native/node_modules"
         user_project_mock = prepare_empty_user_project_mock()
@@ -665,16 +665,18 @@ class UtilsTests < Test::Unit::TestCase
         ])
 
         # Act
-        ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
+        ReactNativePodsUtils.set_build_setting(installer, build_setting: "TEST_SETTING", value: ["Test"], config_name: "Debug")
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal(config.build_settings["REACT_NATIVE_PATH"], "${PODS_ROOT}/../#{react_native_path}")
+            if config.name == "Debug" then 
+                assert_equal(config.build_settings["TEST_SETTING"], ["Test"])
+            end
         end
 
         assert_equal(user_project_mock.save_invocation_count, 1)
         assert_equal(pods_projects_mock.save_invocation_count, 1)
-        assert_equal(Pod::UI.collected_messages, ["Setting REACT_NATIVE build settings"])
+        assert_equal(Pod::UI.collected_messages, ["Setting TEST_SETTING build settings"])
     end
 
     # =================================== #

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -60,26 +60,15 @@ class ReactNativePodsUtils
         end
     end
 
-    def self.set_use_hermes_build_setting(installer, hermes_enabled)
-        Pod::UI.puts("Setting USE_HERMES build settings")
+    def self.set_build_setting(installer, build_setting:, value:, config_name: nil)
+        Pod::UI.puts("Setting #{build_setting} build settings")
         projects = self.extract_projects(installer)
 
         projects.each do |project|
             project.build_configurations.each do |config|
-                config.build_settings["USE_HERMES"] = hermes_enabled
-            end
-
-            project.save()
-        end
-    end
-
-    def self.set_node_modules_user_settings(installer, react_native_path)
-        Pod::UI.puts("Setting REACT_NATIVE build settings")
-        projects = self.extract_projects(installer)
-
-        projects.each do |project|
-            project.build_configurations.each do |config|
-                config.build_settings["REACT_NATIVE_PATH"] = File.join("${PODS_ROOT}", "..", react_native_path)
+                if config_name == nil || config.name == config_name
+                    config.build_settings[build_setting] = value
+                end
             end
 
             project.save()

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -282,8 +282,10 @@ def react_native_post_install(
 
   ReactNativePodsUtils.fix_library_search_paths(installer)
   ReactNativePodsUtils.update_search_paths(installer)
-  ReactNativePodsUtils.set_use_hermes_build_setting(installer, hermes_enabled)
-  ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
+  ReactNativePodsUtils.set_build_setting(installer, build_setting: "USE_HERMES", value: hermes_enabled)
+  ReactNativePodsUtils.set_build_setting(installer, build_setting: "REACT_NATIVE_PATH", value: File.join("${PODS_ROOT}", "..", react_native_path))
+  ReactNativePodsUtils.set_build_setting(installer, build_setting: "SWIFT_ACTIVE_COMPILATION_CONDITIONS", value: ['$(inherited)', 'DEBUG'], config_name: "Debug")
+
   ReactNativePodsUtils.set_ccache_compiler_and_linker_build_settings(installer, react_native_path, ccache_enabled)
   ReactNativePodsUtils.apply_xcode_15_patch(installer)
   ReactNativePodsUtils.apply_ats_config(installer)

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -946,6 +946,7 @@
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				USE_HERMES = true;
 				WARNING_CFLAGS = (
 					"-Wextra",


### PR DESCRIPTION
## Summary:

This PR adds cocoapods utility to set `SWIFT_ACTIVE_COMPILATION_CONDITIONS` to DEBUG, which is set to this value by default (when generating a new native Xcode project). 

This allows to use the `#if DEBUG` compilator directive in Swift to work out of the box, without any changes on user's side: 

```swift
override func bundleURL() -> URL? {
#if DEBUG
    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
#else
    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
#endif
  }
``` 

## Changelog:

[IOS] [ADDED] - Set SWIFT_ACTIVE_COMPILATION_CONDITIONS to DEBUG 

## Test Plan:

Run `bundle exec pod install` and check if the active compilation flags are populated: 

![CleanShot 2024-01-17 at 13 11 03@2x](https://github.com/facebook/react-native/assets/52801365/68f119a6-af47-41bc-a1f1-9085fe4df6a0)

