### PR TITLE
Add a workaround for text being measured incorrectly when ending with an empty line

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -355,6 +355,15 @@ public class TextLayoutManager {
       int hyphenationFrequency,
       Layout.Alignment alignment) {
     Layout layout;
+    // StaticLayout returns wrong metrics for the last line if it's empty, add something to the
+    // last line so it's measured correctly
+    if (text.toString().endsWith("\n")) {
+      SpannableStringBuilder sb = new SpannableStringBuilder(text);
+      sb.append("I");
+
+      text = sb;
+    }
+
     int spanLength = text.length();
     boolean unconstrainedWidth = widthYogaMeasureMode == YogaMeasureMode.UNDEFINED || width < 0;
     float desiredWidth =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

It looks like `StaticLayout` used for measuring multiline text on the new architecture returns wrong metrics for the last line if it's empty, however, if it contains anything, then the returned values are correct.

Similar approach with measuring `I` was already used in `ReactEditText`: https://github.com/facebook/react-native/blob/258d8e51b451b221e557dad4647cbd210fe37392/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java#L1203-L1213

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Fixed text being measured incorrectly when ending with an empty line on the new architecture

## Test Plan:

<details>
<summary>I tested the change on this simple code on React Native 0.73.2 (with the new arch enabled)</summary>

```jsx
import React from 'react';
import {useState} from 'react';
import {SafeAreaView, TextInput} from 'react-native';

export default function App() {
  const [text, setText] = useState('ABC\nDEF\nGHI\n');

  return (
    <SafeAreaView style={{flex: 1}}>
      <TextInput
        value={text}
        onChangeText={setText}
        style={{borderWidth: 1, margin: 20, padding: 30}}
        multiline
      />
    </SafeAreaView>
  );
}
```

</details>

Before:

https://github.com/facebook/react-native/assets/21055725/0787cc86-70c6-4238-b93a-87984e527a83

After:

https://github.com/facebook/react-native/assets/21055725/2acf619f-5cb4-4869-9576-cb8cc081c15b
