### PR TITLE
Remove linting step from dangerfile

### DIFF
--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -15,7 +15,6 @@
 
 const {danger, fail, /*message,*/ warn} = require('danger');
 const includes = require('lodash.includes');
-const eslint = require('@seadub/danger-plugin-eslint');
 const fetch = require('node-fetch');
 const {validate: validateChangelog} =
   require('@rnx-kit/rn-changelog-generator').default;
@@ -102,10 +101,6 @@ if (isMergeRefStable) {
     labels: ['Pick Request'],
   });
 }
-
-// Ensures that eslint is run from root folder and that it can find .eslintrc
-process.chdir('../../');
-eslint.default();
 
 // Wait for statuses and post a message if there are failures.
 async function handleStatuses() {

--- a/packages/react-native-bots/package.json
+++ b/packages/react-native-bots/package.json
@@ -15,9 +15,7 @@
   },
   "devDependencies": {
     "@rnx-kit/rn-changelog-generator": "^0.4.0",
-    "@seadub/danger-plugin-eslint": "^3.0.2",
     "danger": "^11.2.1",
-    "eslint": "^8.19.0",
     "lodash.includes": "^4.3.0",
     "minimatch": "^3.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2554,11 +2554,6 @@
   resolved "https://registry.yarnpkg.com/@rnx-kit/rn-changelog-generator/-/rn-changelog-generator-0.4.0.tgz#637d87bcf8de6e87599930ed88d9375010277660"
   integrity sha512-Igq/5lA6/bYSAdxfk43nbMXIt4yKIspds2fsv5eqgeg4elLeWfzHSEM3tU0wPDnOk4m3qzVEyO9fbtu616Dyhw==
 
-"@seadub/danger-plugin-eslint@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@seadub/danger-plugin-eslint/-/danger-plugin-eslint-3.0.2.tgz#9a51d9f1a103a274264c30212234001de0b417c1"
-  integrity sha512-W+efX4mP04A8wMuLV0nV+iOj892Vrbyik+FyDZcGgpzkJFXX0UfDhOPZ0FonbSV0xM47DI5a8go88U/pBdGM2A==
-
 "@sideway/address@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.0.tgz#0b301ada10ac4e0e3fa525c90615e0b61a72b78d"


### PR DESCRIPTION
Differential Revision: D52834693

Pull Request resolved: https://github.com/facebook/react-native/pull/42332

Changelog: [Internal]

TSIA - the Danger ESLint plugin we use is outdated and there have been issues with its reliability. We already have [linting jobs on CircleCI](https://github.com/facebook/react-native/blob/6c8dfc89566d27c36f9ca3828bcf3a63dfcb6942/.circleci/configurations/jobs.yml#L5-L74) that overlap with this functionality.