### PR TITLE
feat: add `--custom-resolver-options` to `bundle` command

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -42,6 +42,7 @@ export type BundleCommandArgs = {
   verbose: boolean,
   unstableTransformProfile: string,
   indexedRamBundle?: boolean,
+  customResolverOptions?: Record<string, string>,
 };
 
 async function buildBundle(
@@ -99,6 +100,7 @@ async function buildBundleWithConfig(
     minify: args.minify !== undefined ? args.minify : !args.dev,
     platform: args.platform,
     unstable_transformProfile: args.unstableTransformProfile,
+    customResolverOptions: args.customResolverOptions,
   };
   const server = new Server(config);
 

--- a/packages/community-cli-plugin/src/commands/bundle/index.js
+++ b/packages/community-cli-plugin/src/commands/bundle/index.js
@@ -118,11 +118,12 @@ const bundleCommand: Command = {
       name: '--custom-resolver-options <string>',
       description: 'Custom resolver options, format: key=value,key2=value2.',
       parse: (val: string): Record<string, string> => {
-        return val.split(',').reduce((options, option) => {
-          const [key, value] = option.split('=');
-          options[key] = value;
-          return options;
-        }, {});
+        return Object.fromEntries(
+          val.split(',').map(option => {
+            const [key, value] = option.split('=');
+            return [key, value];
+          }),
+        );
       },
     },
   ],

--- a/packages/community-cli-plugin/src/commands/bundle/index.js
+++ b/packages/community-cli-plugin/src/commands/bundle/index.js
@@ -114,6 +114,17 @@ const bundleCommand: Command = {
       description: 'Path to the CLI configuration file',
       parse: (val: string): string => path.resolve(val),
     },
+    {
+      name: '--custom-resolver-options <string>',
+      description: 'Custom resolver options, format: key=value,key2=value2.',
+      parse: (val: string): Record<string, string> => {
+        return val.split(',').reduce((options, option) => {
+          const [key, value] = option.split('=');
+          options[key] = value;
+          return options;
+        }, {});
+      },
+    },
   ],
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Added `--custom-resolver-options` to `--bundle` command. This options is also [available](https://github.com/facebook/metro/blob/main/docs/CLI.md#options) in Metro's CLI.

## Changelog:


[INTERNAL] [ADDED] - Add `--resolver-options` to `bundle` command

## Test Plan:

1. Build all packages by running `yarn build` in the root
2. Go to `packages/rn-tester` and run `npx react-native bundle --custom-resolver-options key=value` and the options should be passed to the Config.