### PR TITLE
update ReactAndroid.api for D52802644

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1947,8 +1947,6 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun load (Z)V
 	public static final fun load (ZZ)V
 	public static final fun load (ZZZ)V
-	public final fun load (ZZZZ)V
-	public static synthetic fun load$default (Lcom/facebook/react/defaults/DefaultNewArchitectureEntryPoint;ZZZZILjava/lang/Object;)V
 	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
 }
 


### PR DESCRIPTION
Summary:
D52802644 land raced with D52800160

Changelog:
[Android] [Removed] - Remove deprecated DefaultNewArchitectureEntryPoint.load overload

Differential Revision: D52836926


