### PR TITLE
Deprecate ReactFeatureFlags.reduceDeleteCreateMutationLayoutAnimation

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1911,7 +1911,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field enableViewRecycling Z
 	public static field excludeYogaFromRawProps Z
 	public static field fixStoppedSurfaceTagSetLeak Z
-	public static field reduceDeleteCreateMutationLayoutAnimation Z
 	public static field rejectTurboModulePromiseOnNativeError Z
 	public static field traceTurboModulePromiseRejections Z
 	public static field unstable_bridgelessArchitectureMemoryPressureHackyBoltsFix Z

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1911,7 +1911,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field enableViewRecycling Z
 	public static field excludeYogaFromRawProps Z
 	public static field fixStoppedSurfaceTagSetLeak Z
-	public static field reduceDeleteCreateMutation Z
 	public static field reduceDeleteCreateMutationLayoutAnimation Z
 	public static field rejectTurboModulePromiseOnNativeError Z
 	public static field traceTurboModulePromiseRejections Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -112,12 +112,6 @@ public class ReactFeatureFlags {
    */
   public static boolean reduceDeleteCreateMutationLayoutAnimation = true;
 
-  /**
-   * Allow fix to drop delete...create mutations which could cause missing view state in Fabric
-   * SurfaceMountingManager.
-   */
-  public static boolean reduceDeleteCreateMutation = false;
-
   /** Report mount operations from the host platform to notify mount hooks. */
   public static boolean enableMountHooks = false;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -106,12 +106,6 @@ public class ReactFeatureFlags {
    */
   public static boolean enableRemoveDeleteTreeInstruction = false;
 
-  /**
-   * Allow fix in layout animation to drop delete...create mutations which could cause missing view
-   * state in Fabric SurfaceMountingManager.
-   */
-  public static boolean reduceDeleteCreateMutationLayoutAnimation = true;
-
   /** Report mount operations from the host platform to notify mount hooks. */
   public static boolean enableMountHooks = false;
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -63,8 +63,6 @@ class FabricMountingManager final {
       allocatedViewRegistry_{};
   std::recursive_mutex allocatedViewsMutex_;
 
-  const bool reduceDeleteCreateMutation_{false};
-
   jni::local_ref<jobject> getProps(
       const ShadowView& oldShadowView,
       const ShadowView& newShadowView);

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -145,11 +145,6 @@ void LayoutAnimationKeyFrameManager::setComponentDescriptorRegistry(
   componentDescriptorRegistry_ = componentDescriptorRegistry;
 }
 
-void LayoutAnimationKeyFrameManager::setReduceDeleteCreateMutation(
-    const bool reduceDeleteCreateMutation) {
-  reduceDeleteCreateMutation_ = reduceDeleteCreateMutation;
-}
-
 bool LayoutAnimationKeyFrameManager::shouldAnimateFrame() const {
   std::scoped_lock lock(currentAnimationMutex_);
   return currentAnimation_ || !inflightAnimations_.empty();
@@ -734,40 +729,6 @@ LayoutAnimationKeyFrameManager::pullTransaction(
 
       auto finalConflictingMutations = ShadowViewMutationList{};
       for (auto& keyFrame : conflictingAnimations) {
-        // Special-case: if the next conflicting animation contain "delete",
-        // while the final mutation has the same tag with "create", we should
-        // remove both the delete and create as they have no effect when
-        // combined in the same frame. The Fabric mount layer assumes no such
-        // combinations in the final mutations either.
-        if (reduceDeleteCreateMutation_) {
-          for (auto itMutation = immediateMutations.begin();
-               itMutation != immediateMutations.end();) {
-            auto& mutation = *itMutation;
-            bool hasCreateMutationDeletedWithSameTag = false;
-            if (mutation.newChildShadowView.tag == keyFrame.tag &&
-                mutation.type == ShadowViewMutation::Create) {
-              for (auto itKeyFrame = keyFrame.finalMutationsForKeyFrame.begin();
-                   itKeyFrame != keyFrame.finalMutationsForKeyFrame.end();) {
-                auto& conflictFinalMutation = *itKeyFrame;
-                if (conflictFinalMutation.type == ShadowViewMutation::Delete) {
-                  itKeyFrame =
-                      keyFrame.finalMutationsForKeyFrame.erase(itKeyFrame);
-                  hasCreateMutationDeletedWithSameTag = true;
-                  break;
-                } else {
-                  itKeyFrame++;
-                }
-              }
-            }
-
-            if (hasCreateMutationDeletedWithSameTag) {
-              itMutation = immediateMutations.erase(itMutation);
-            } else {
-              itMutation++;
-            }
-          }
-        }
-
         // Special-case: if we have some (1) ongoing UPDATE animation,
         // (2) it conflicted with a new MOVE operation (REMOVE+INSERT)
         // without another corresponding UPDATE, we should re-queue the

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
@@ -55,8 +55,6 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
   void setComponentDescriptorRegistry(const SharedComponentDescriptorRegistry&
                                           componentDescriptorRegistry) override;
 
-  void setReduceDeleteCreateMutation(bool reduceDeleteCreateMutation) override;
-
   // TODO: add SurfaceId to this API as well
   bool shouldAnimateFrame() const override;
 
@@ -145,7 +143,6 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
   mutable LayoutAnimationStatusDelegate* layoutAnimationStatusDelegate_{};
   mutable std::mutex surfaceIdsToStopMutex_;
   mutable std::unordered_set<SurfaceId> surfaceIdsToStop_{};
-  bool reduceDeleteCreateMutation_{false};
 
   // Function that returns current time in milliseconds
   std::function<uint64_t()> now_;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -129,14 +129,17 @@ Scheduler::Scheduler(
     uiManager->registerCommitHook(*commitHook);
   }
 
+  if (animationDelegate != nullptr) {
+    animationDelegate->setComponentDescriptorRegistry(
+        componentDescriptorRegistry_);
+  }
+  uiManager_->setAnimationDelegate(animationDelegate);
+
 #ifdef ANDROID
   removeOutstandingSurfacesOnDestruction_ = true;
-  reduceDeleteCreateMutationLayoutAnimation_ = reactNativeConfig_->getBool(
-      "react_fabric:reduce_delete_create_mutation_layout_animation_android");
 #else
   removeOutstandingSurfacesOnDestruction_ = reactNativeConfig_->getBool(
       "react_fabric:remove_outstanding_surfaces_on_destruction_ios");
-  reduceDeleteCreateMutationLayoutAnimation_ = true;
 #endif
 
 #ifdef ANDROID
@@ -159,14 +162,6 @@ Scheduler::Scheduler(
 
   CoreFeatures::enableReportEventPaintTime = reactNativeConfig_->getBool(
       "rn_responsiveness_performance:enable_paint_time_reporting");
-
-  if (animationDelegate != nullptr) {
-    animationDelegate->setComponentDescriptorRegistry(
-        componentDescriptorRegistry_);
-    animationDelegate->setReduceDeleteCreateMutation(
-        reduceDeleteCreateMutationLayoutAnimation_);
-  }
-  uiManager_->setAnimationDelegate(animationDelegate);
 }
 
 Scheduler::~Scheduler() {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
@@ -37,14 +37,6 @@ class UIManagerAnimationDelegate {
       const SharedComponentDescriptorRegistry& componentDescriptorRegistry) = 0;
 
   /**
-   * Set Animation flags for dropping delete and create mutations
-   *
-   * @param reduceDeleteCreateMutation
-   */
-  virtual void setReduceDeleteCreateMutation(
-      bool reduceDeleteCreateMutation) = 0;
-
-  /**
    * Only needed on Android to drive animations.
    */
   virtual bool shouldAnimateFrame() const = 0;


### PR DESCRIPTION
Summary:
This diff cleans up the code added in D41895427 to run QE: https://fburl.com/qe2/0di6ipt6

More context: https://fb.workplace.com/groups/react.technologies.discussions/permalink/3479283292303384/

Changelog:
[Android][Internal] - Revert internal optimizations

Reviewed By: mdvacca

Differential Revision: D52751274

