### PR TITLE
Revert QE for ReactFeatureFlags.reduceDeleteCreateMutation

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1911,7 +1911,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field enableViewRecycling Z
 	public static field excludeYogaFromRawProps Z
 	public static field fixStoppedSurfaceTagSetLeak Z
-	public static field reduceDeleteCreateMutation Z
 	public static field reduceDeleteCreateMutationLayoutAnimation Z
 	public static field rejectTurboModulePromiseOnNativeError Z
 	public static field traceTurboModulePromiseRejections Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -112,12 +112,6 @@ public class ReactFeatureFlags {
    */
   public static boolean reduceDeleteCreateMutationLayoutAnimation = true;
 
-  /**
-   * Allow fix to drop delete...create mutations which could cause missing view state in Fabric
-   * SurfaceMountingManager.
-   */
-  public static boolean reduceDeleteCreateMutation = false;
-
   /** Report mount operations from the host platform to notify mount hooks. */
   public static boolean enableMountHooks = false;
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -63,8 +63,6 @@ class FabricMountingManager final {
       allocatedViewRegistry_{};
   std::recursive_mutex allocatedViewsMutex_;
 
-  const bool reduceDeleteCreateMutation_{false};
-
   jni::local_ref<jobject> getProps(
       const ShadowView& oldShadowView,
       const ShadowView& newShadowView);


### PR DESCRIPTION
Summary:
This diff cleans up the code added in D41900201 to run QE: https://fburl.com/qe2/ovgxlayy

More context: https://fb.workplace.com/groups/react.technologies.discussions/permalink/3479283292303384/

Changelog:
[Android][Internal] - Revert internal optimizations

Reviewed By: mdvacca

Differential Revision: D52750975

