### PR TITLE
Fix inspector "disconnect" event type and add tests

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -41,6 +41,8 @@ struct InspectorPageDescription {
 using InspectorPage = InspectorPageDescription;
 
 /// IRemoteConnection allows the VM to send debugger messages to the client.
+/// IRemoteConnection's methods are safe to call from any thread *if*
+/// InspectorPackagerConnection.cpp is in use.
 class JSINSPECTOR_EXPORT IRemoteConnection : public IDestructible {
  public:
   virtual ~IRemoteConnection() = 0;

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
@@ -23,10 +23,6 @@ static constexpr const std::chrono::duration RECONNECT_DELAY =
     std::chrono::milliseconds{2000};
 static constexpr const char* INVALID = "<invalid>";
 
-static folly::dynamic makePageIdPayload(std::string_view pageId) {
-  return folly::dynamic::object("id", pageId);
-}
-
 // InspectorPackagerConnection::Impl method definitions
 
 std::shared_ptr<InspectorPackagerConnection::Impl>
@@ -319,7 +315,7 @@ void InspectorPackagerConnection::Impl::RemoteConnection::onDisconnect() {
   if (owningPackagerConnectionStrong) {
     owningPackagerConnectionStrong->scheduleSendToPackager(
         folly::dynamic::object("event", "disconnect")(
-            "payload", makePageIdPayload(pageId_)),
+            "payload", folly::dynamic::object("pageId", pageId_)),
         sessionId_,
         pageId_);
   }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
@@ -48,7 +48,6 @@ class InspectorPackagerConnection {
 
  private:
   class Impl;
-  class RemoteConnectionImpl;
 
   const std::shared_ptr<Impl> impl_;
 };
@@ -72,10 +71,11 @@ class InspectorPackagerConnectionDelegate {
   /**
    * Schedules a function to run after a delay. If the function is called
    * asynchronously, the implementer of InspectorPackagerConnectionDelegate
-   * is responsible for thread safety (e.g. scheduling the callback on the same
-   * thread that called scheduleCallback, or otherwise ensuring
-   * synchronization). The callback MAY be dropped and never called, e.g. if the
-   * application is terminating.
+   * is responsible for thread safety (e.g. scheduling the callback on a thread
+   * that has unique access to the InspectorPackagerConnection instance, or
+   * otherwise ensuring synchronization). The callback MAY be dropped and never
+   * called if no further callbacks are being accepted, e.g. if the application
+   * is terminating.
    */
   virtual void scheduleCallback(
       std::function<void(void)> callback,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -59,12 +59,16 @@ class MockLocalConnection : public ILocalConnection {
     return *remoteConnection_;
   }
 
+  std::unique_ptr<IRemoteConnection> dangerouslyReleaseRemoteConnection() {
+    return std::move(remoteConnection_);
+  }
+
   // ILocalConnection methods
   MOCK_METHOD(void, sendMessage, (std::string message), (override));
   MOCK_METHOD(void, disconnect, (), (override));
 
  private:
-  const std::unique_ptr<IRemoteConnection> remoteConnection_;
+  std::unique_ptr<IRemoteConnection> remoteConnection_;
 };
 
 class MockInspectorPackagerConnectionDelegate


### PR DESCRIPTION
Summary:
The experimental C++ implementation of `InspectorPackagerConnection` currently sends malformed `'disconnect'` events. This diff fixes that and adds tests. (See https://github.com/facebook/react-native/blob/dd5474f1e96e1c1e2f00ba3655ef86590d39b0fd/packages/dev-middleware/src/inspector-proxy/types.js#L40-L43 for the definition of the proxy protocol.)

Changelog: [Internal]

Differential Revision: D52842515

