### PR TITLE
Adds back __apply_Xcode_12_5_M1_post_install_workaround

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -297,3 +297,31 @@ def react_native_post_install(
 
   Pod::UI.puts "Pod install took #{Time.now.to_i - $START_TIME} [s] to run".green
 end
+
+# This provides a post_install workaround for build issues related Xcode 12.5 and Apple Silicon (M1) machines.
+# Call this in the app's main Podfile's post_install hook.
+# See https://github.com/facebook/react-native/issues/31480#issuecomment-902912841 for more context.
+# Actual fix was authored by https://github.com/mikehardy.
+# New app template will call this for now until the underlying issue is resolved.
+def __apply_Xcode_12_5_M1_post_install_workaround(installer)
+  # Flipper podspecs are still targeting an older iOS deployment target, and may cause an error like:
+  #   "error: thread-local storage is not supported for the current target"
+  # The most reliable known workaround is to bump iOS deployment target to match react-native (iOS 11 now).
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      # ensure IPHONEOS_DEPLOYMENT_TARGET is at least 11.0
+      deployment_target = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'].to_f
+      should_upgrade = deployment_target < 11.0 && deployment_target != 0.0
+      if should_upgrade
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+      end
+    end
+  end
+
+  # But... doing so caused another issue in Flipper:
+  #   "Time.h:52:17: error: typedef redefinition with different types"
+  # We need to make a patch to RCT-Folly - remove the `__IPHONE_OS_VERSION_MIN_REQUIRED` check.
+  # See https://github.com/facebook/flipper/issues/834 for more details.
+  time_header = "#{Pod::Config.instance.installation_root.to_s}/Pods/RCT-Folly/folly/portability/Time.h"
+  `sed -i -e  $'s/ && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)//' '#{time_header}'`
+end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This adds back `__apply_Xcode_12_5_M1_post_install_workaround`, which when removed has cause cocoapods to fail on M1 machines. Why was this removed???

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Try to run `npx pod-install` and you should no longer get a `__apply_Xcode_12_5_M1_post_install_workaround is undefiend` error.