### PR TITLE
fix: singletonMap for module events

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -191,6 +191,11 @@ public class UIManagerModuleConstantsHelper {
         }
       }
     }
+    // When providing one event in Kotlin, it will create a SingletonMap by default
+    // which will throw on trying to add new element to it
+    if (events.getClass().getSimpleName().equals("SingletonMap")) {
+      events = new HashMap(events);
+    }
     for (String oldKey : keysToNormalize) {
       Object value = events.get(oldKey);
       String newKey = "top" + oldKey.substring(0, 1).toUpperCase() + oldKey.substring(1);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -193,7 +193,7 @@ public class UIManagerModuleConstantsHelper {
     }
     // When providing one event in Kotlin, it will create a SingletonMap by default
     // which will throw on trying to add new element to it
-    if (events.getClass().getSimpleName().equals("SingletonMap")) {
+    if (!(events instanceof HashMap)) {
       events = new HashMap(events);
     }
     for (String oldKey : keysToNormalize) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Sometimes the events map can be a of type `SingletonMap` which will cause this code to throw exception when adding keys to it, so we change it to normal `HashMap`. Creating `SingletonMap` can especially happen in Kotlin when there is only one event added to a map, see:
https://github.com/plaid/react-native-plaid-link-sdk/blob/5ffab5eef576163528f0da504181162da3bef08b/android/src/main/java/com/plaid/PLKEmbeddedViewManager.kt#L21
## Changelog:

[ANDROID] [FIXED] - Cover SingletonMap when parsing events exported by module

## Test Plan:

Create `getExportedCustomBubblingEventTypeConstants` as `SingletonMap` in some example module and see that the code does not throw.
