### PR TITLE
Fix RemoveDeleteTree and subview clipping compatibility

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewGroupManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewGroupManager.java
@@ -8,6 +8,7 @@
 package com.facebook.react.uimanager;
 
 import android.view.View;
+import com.facebook.react.bridge.UiThreadUtil;
 
 /** Interface providing children management API for view managers of classes extending ViewGroup. */
 public interface IViewGroupManager<T extends View> extends IViewManagerWithChildren {
@@ -20,6 +21,15 @@ public interface IViewGroupManager<T extends View> extends IViewManagerWithChild
 
   /** Removes View from the parent View at the index specified as a parameter. */
   void removeViewAt(T parent, int index);
+
+  /** Remove all child views from the parent View. */
+  default void removeAllViews(T parent) {
+    UiThreadUtil.assertOnUiThread();
+
+    for (int i = getChildCount(parent) - 1; i >= 0; i--) {
+      removeViewAt(parent, i);
+    }
+  }
 
   /** Return the amount of children contained by the view specified as a parameter. */
   int getChildCount(T parent);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
@@ -89,14 +89,6 @@ public abstract class ViewGroupManager<T extends ViewGroup>
     }
   }
 
-  public void removeAllViews(T parent) {
-    UiThreadUtil.assertOnUiThread();
-
-    for (int i = getChildCount(parent) - 1; i >= 0; i--) {
-      removeViewAt(parent, i);
-    }
-  }
-
   /**
    * Returns whether this View type needs to handle laying out its own children instead of deferring
    * to the standard css-layout algorithm. Returns true for the layout to *not* be automatically


### PR DESCRIPTION
Summary:
`RemoveDeleteTreeUIFrameCallback` operated directly on the view to clean up its children, which does not correctly account for subviews which have been clipped because they're outside the visible frame.

Changelog: [Android][Added] Added `removeAllViews` to IViewGroupManager.

Reviewed By: jehartzog, sammy-SC

Differential Revision: D52834835


