### PR TITLE
Ignore TM specs with out-of-tree platform suffix

### DIFF
--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -85,6 +85,12 @@ function verifyPlatforms(
       return;
     }
 
+    if (name.endsWith('Windows')) {
+      excludedPlatforms.add('iOS');
+      excludedPlatforms.add('android');
+      return;
+    }
+
     if (name.endsWith('Cxx')) {
       cxxOnly = true;
       excludedPlatforms.add('iOS');


### PR DESCRIPTION
Summary:
In cases where you merge out-of-tree platforms like react-native-windows with react-native mobile JS files, codegen awareness of the Windows suffix is useful. This helps prevent the creation of generated code for iOS and Android in mixed out-of-tree platform folders.

## Changelog

[Internal]

Differential Revision: D52873212


