### PR TITLE
Constify InspectorPackagerConnection members that are immutable

### DIFF
--- a/packages/react-native/React/Inspector/RCTCxxInspectorPackagerConnectionDelegate.h
+++ b/packages/react-native/React/Inspector/RCTCxxInspectorPackagerConnectionDelegate.h
@@ -26,7 +26,7 @@ class RCTCxxInspectorPackagerConnectionDelegate
     virtual ~WebSocket() override;
 
    private:
-    RCTCxxInspectorWebSocketAdapter* _adapter;
+    RCTCxxInspectorWebSocketAdapter* const _adapter;
   };
 
  public:

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnectionWebSocketDelegate.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnectionWebSocketDelegate.h
@@ -43,7 +43,7 @@ class JCxxInspectorPackagerConnectionWebSocketDelegate
 
  private:
   friend HybridBase;
-  std::weak_ptr<IWebSocketDelegate> cxxDelegate_;
+  const std::weak_ptr<IWebSocketDelegate> cxxDelegate_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -53,7 +53,19 @@ class JSINSPECTOR_EXPORT ILocalConnection : public IDestructible {
  public:
   virtual ~ILocalConnection() = 0;
   virtual void sendMessage(std::string message) = 0;
+
+  /**
+   * Called by the inspector singleton to notify that the connection has been
+   * closed, either by the remote party or because the local page/VM is no
+   * longer registered with the inspector.
+   */
   virtual void disconnect() = 0;
+};
+
+class JSINSPECTOR_EXPORT IPageStatusListener : public IDestructible {
+ public:
+  virtual ~IPageStatusListener() = 0;
+  virtual void onPageRemoved(int pageId) = 0;
 };
 
 /// IInspector tracks debuggable JavaScript targets (pages).
@@ -82,6 +94,13 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
   virtual std::unique_ptr<ILocalConnection> connect(
       int pageId,
       std::unique_ptr<IRemoteConnection> remote) = 0;
+
+  /**
+   * registerPageStatusListener registers a listener that will receive events
+   * when pages are removed.
+   */
+  virtual void registerPageStatusListener(
+      std::weak_ptr<IPageStatusListener> listener) = 0;
 };
 
 /// getInspectorInstance retrieves the singleton inspector that tracks all

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
@@ -33,8 +33,10 @@ InspectorPackagerConnection::Impl::create(
     std::string app,
     std::unique_ptr<InspectorPackagerConnectionDelegate> delegate) {
   // No make_shared because the constructor is private
-  return std::shared_ptr<InspectorPackagerConnection::Impl>(
+  std::shared_ptr<InspectorPackagerConnection::Impl> impl(
       new InspectorPackagerConnection::Impl(url, app, std::move(delegate)));
+  getInspectorInstance().registerPageStatusListener(impl);
+  return impl;
 }
 
 InspectorPackagerConnection::Impl::Impl(
@@ -192,6 +194,13 @@ void InspectorPackagerConnection::Impl::didClose() {
   closeAllConnections();
   if (!closed_) {
     reconnect();
+  }
+}
+
+void InspectorPackagerConnection::Impl::onPageRemoved(int pageId) {
+  auto connection = removeConnectionForPage(std::to_string(pageId));
+  if (connection) {
+    connection->disconnect();
   }
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
@@ -50,7 +50,7 @@ class InspectorPackagerConnection {
   class Impl;
   class RemoteConnectionImpl;
 
-  std::shared_ptr<Impl> impl_;
+  const std::shared_ptr<Impl> impl_;
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
@@ -76,9 +76,9 @@ class InspectorPackagerConnection::Impl
   // IPageStatusListener methods
   virtual void onPageRemoved(int pageId) override;
 
-  std::string url_;
-  std::string app_;
-  std::unique_ptr<InspectorPackagerConnectionDelegate> delegate_;
+  const std::string url_;
+  const std::string app_;
+  const std::unique_ptr<InspectorPackagerConnectionDelegate> delegate_;
 
   std::unordered_map<std::string, std::unique_ptr<ILocalConnection>>
       inspectorConnections_;
@@ -102,8 +102,9 @@ class InspectorPackagerConnection::RemoteConnectionImpl
   void onDisconnect() override;
 
  private:
-  std::weak_ptr<InspectorPackagerConnection::Impl> owningPackagerConnection_;
-  std::string pageId_;
+  const std::weak_ptr<InspectorPackagerConnection::Impl>
+      owningPackagerConnection_;
+  const std::string pageId_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
@@ -20,6 +20,7 @@ namespace facebook::react::jsinspector_modern {
  */
 class InspectorPackagerConnection::Impl
     : public IWebSocketDelegate,
+      public IPageStatusListener,
       // Used to generate `weak_ptr`s we can pass around.
       public std::enable_shared_from_this<InspectorPackagerConnection::Impl> {
  public:
@@ -71,6 +72,9 @@ class InspectorPackagerConnection::Impl
       override;
   virtual void didReceiveMessage(std::string_view message) override;
   virtual void didClose() override;
+
+  // IPageStatusListener methods
+  virtual void onPageRemoved(int pageId) override;
 
   std::string url_;
   std::string app_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -63,7 +63,7 @@ class MockLocalConnection : public ILocalConnection {
   MOCK_METHOD(void, disconnect, (), (override));
 
  private:
-  std::unique_ptr<IRemoteConnection> remoteConnection_;
+  const std::unique_ptr<IRemoteConnection> remoteConnection_;
 };
 
 class MockInspectorPackagerConnectionDelegate


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Just codifying the constness of some members.

Reviewed By: hoxyq

Differential Revision: D52786333


