### PR TITLE
Remove ineffective excludes from typescript-config

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -36,11 +36,5 @@
       "skipLibCheck": true,
       // Causes issues with package.json "exports"
       "forceConsistentCasingInFileNames": false
-    },
-    "exclude": [
-      "node_modules",
-      "babel.config.js",
-      "metro.config.js",
-      "jest.config.js"
-    ]
+    }
   }


### PR DESCRIPTION
## Summary:

This removes the 4 ineffective and redundant entries from the `exclude` list in `tsconfig.json` (`typescript-config` package).

These entries have no effect as they are relative to the typescript-config package. Explained in detail here: https://github.com/tsconfig/bases/issues/207

A newly generated RN app shows this config:

```
$ yarn tsc --showConfig | grep -A 5 exclude
    "exclude": [
        "node_modules/@tsconfig/react-native/node_modules",
        "node_modules/@tsconfig/react-native/babel.config.js",
        "node_modules/@tsconfig/react-native/metro.config.js",
        "node_modules/@tsconfig/react-native/jest.config.js"
    ]
```

Clearly, none of these files exist, therefore to remove ambiguity and reduce the complexity of the config, they should be removed.

## Changelog:

[GENERAL] [REMOVED] - Remove ineffective excludes from typescript-config

## Test Plan:

- Create new RN app (`npx react-native init`), install dependencies, run `yarn tsc`
- It works
- Recreate config, but _without_ the `exclude` section
- Everything works exactly the same