### PR TITLE
iOS Add React-debug to ReactCommon.podspec

### DIFF
--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -71,6 +71,8 @@ Pod::Spec.new do |s|
 
     ss.subspec "core" do |sss|
       sss.source_files = "react/nativemodule/core/ReactCommon/**/*.{cpp,h}"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\"" }
+      sss.dependency "React-debug", version
     end
   end
 end


### PR DESCRIPTION
Summary:
Changelog: [Fixed]

Fixes the CocoaPod build broken due to: https://github.com/facebook/react-native/commit/dd5474f1e96e1c1e2f00ba3655ef86590d39b0fd

Differential Revision: D52899067


