### PR TITLE
Make RemoteConnectionImpl thread-safe

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -41,6 +41,8 @@ struct InspectorPageDescription {
 using InspectorPage = InspectorPageDescription;
 
 /// IRemoteConnection allows the VM to send debugger messages to the client.
+/// IRemoteConnection's methods are safe to call from any thread *if*
+/// InspectorPackagerConnection.cpp is in use.
 class JSINSPECTOR_EXPORT IRemoteConnection : public IDestructible {
  public:
   virtual ~IRemoteConnection() = 0;

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
@@ -48,7 +48,6 @@ class InspectorPackagerConnection {
 
  private:
   class Impl;
-  class RemoteConnectionImpl;
 
   const std::shared_ptr<Impl> impl_;
 };
@@ -72,10 +71,11 @@ class InspectorPackagerConnectionDelegate {
   /**
    * Schedules a function to run after a delay. If the function is called
    * asynchronously, the implementer of InspectorPackagerConnectionDelegate
-   * is responsible for thread safety (e.g. scheduling the callback on the same
-   * thread that called scheduleCallback, or otherwise ensuring
-   * synchronization). The callback MAY be dropped and never called, e.g. if the
-   * application is terminating.
+   * is responsible for thread safety (e.g. scheduling the callback on a thread
+   * that has unique access to the InspectorPackagerConnection instance, or
+   * otherwise ensuring synchronization). The callback MAY be dropped and never
+   * called if no further callbacks are being accepted, e.g. if the application
+   * is terminating.
    */
   virtual void scheduleCallback(
       std::function<void(void)> callback,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -59,12 +59,16 @@ class MockLocalConnection : public ILocalConnection {
     return *remoteConnection_;
   }
 
+  std::unique_ptr<IRemoteConnection> dangerouslyReleaseRemoteConnection() {
+    return std::move(remoteConnection_);
+  }
+
   // ILocalConnection methods
   MOCK_METHOD(void, sendMessage, (std::string message), (override));
   MOCK_METHOD(void, disconnect, (), (override));
 
  private:
-  const std::unique_ptr<IRemoteConnection> remoteConnection_;
+  std::unique_ptr<IRemoteConnection> remoteConnection_;
 };
 
 class MockInspectorPackagerConnectionDelegate


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Makes it explicitly legal to call `IRemoteConnection`'s methods from any thread when used as part of the C++ implementation of `InspectorPackagerConnection`.

Implementation details:

* This relies on `InspectorPackagerConnectionDelegate::scheduleCallback` being thread-safe and handling any necessary synchronisation (which is already required for the existing `reconnect()` use case).
* We add *very basic* tracking of *sessions* within `InspectorPackagerConnection` to make sure events don't leak from one `RemoteConnection` instance to the next.
  * In the future we'll want to build on this to properly allow multiple concurrent sessions to a single page. That's not the primary goal here though.

Differential Revision: D52807388


