### PR TITLE
fix: isVision return false for Platform.android.js

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -69,6 +69,10 @@ const Platform: PlatformType = {
     // $FlowFixMe[object-this-reference]
     return this.constants.uiMode === 'tv';
   },
+  // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean {
+    return false;
+  },
   select: <T>(spec: PlatformSelectSpec<T>): T =>
     'android' in spec
       ? // $FlowFixMe[incompatible-return]

--- a/packages/react-native/Libraries/Utilities/Platform.flow.js
+++ b/packages/react-native/Libraries/Utilities/Platform.flow.js
@@ -80,6 +80,8 @@ type AndroidPlatform = {
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean,
+  // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
   get isDisableAnimations(): boolean,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9940,6 +9940,7 @@ type AndroidPlatform = {
     Manufacturer: string,
   |},
   get isTV(): boolean,
+  get isVision(): boolean,
   get isTesting(): boolean,
   get isDisableAnimations(): boolean,
   select: <T>(spec: PlatformSelectSpec<T>) => T,


### PR DESCRIPTION
## Summary:

This PR is a follow up for #42243 it looks like we need to return `false` for the Platform.android.js to make flow happy.

This is the error we were getting in `react-native-visionos` CI/CD: 
![CleanShot 2024-01-19 at 13 01 19@2x](https://github.com/facebook/react-native/assets/52801365/218078b3-44d4-4dc0-bee7-f5d2e08eca50)


## Changelog:

[INTERNAL] [FIXED] - Add `isVision` interface idiom for Platform.android.js 


## Test Plan:

CI Green
