### PR TITLE
Inject log to easily identify modern CDP backend

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/CONCEPTS.md
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CONCEPTS.md
@@ -1,0 +1,15 @@
+# jsinspector-modern concepts
+
+## CDP object model
+
+### Target
+
+A debuggable entity that a debugger frontend can connect to.
+
+### Session
+
+A single connection between a debugger frontend and a target. There can be multiple active sessions connected to the same target.
+
+### Agent
+
+A handler for a subset of CDP messages for a specific target as part of a specific session.

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -129,4 +129,11 @@ extern IInspector& getInspectorInstance();
 /// should only be used in tests.
 extern std::unique_ptr<IInspector> makeTestInspectorInstance();
 
+/**
+ * A callback that can be used to send debugger messages (method responses and
+ * events) to the frontend. The message must be a JSON-encoded string.
+ * The callback may be called from any thread.
+ */
+using FrontendChannel = std::function<void(std::string_view messageJson)>;
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorUtilities.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorUtilities.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "InspectorUtilities.h"
+
+#include <cassert>
+
+namespace facebook::react::jsinspector_modern {
+
+CallbackLocalConnection::CallbackLocalConnection(
+    std::function<void(std::string)> handler)
+    : handler_(std::move(handler)) {}
+
+void CallbackLocalConnection::sendMessage(std::string message) {
+  assert(handler_ && "Handler has been disconnected");
+  handler_(std::move(message));
+}
+
+void CallbackLocalConnection::disconnect() {
+  handler_ = nullptr;
+}
+
+RAIIRemoteConnection::RAIIRemoteConnection(
+    std::unique_ptr<IRemoteConnection> remote)
+    : remote_(std::move(remote)) {}
+
+void RAIIRemoteConnection::onMessage(std::string message) {
+  remote_->onMessage(std::move(message));
+}
+
+RAIIRemoteConnection::~RAIIRemoteConnection() {
+  remote_->onDisconnect();
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorUtilities.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorUtilities.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "InspectorInterfaces.h"
+
+// Utilities that are useful when integrating with InspectorInterfaces.h but
+// do not need to be exported.
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Wraps a callback function in ILocalConnection.
+ */
+class CallbackLocalConnection : public ILocalConnection {
+ public:
+  /**
+   * Creates a new Connection that uses the given callback to send messages to
+   * the backend.
+   */
+  explicit CallbackLocalConnection(std::function<void(std::string)> handler);
+
+  void sendMessage(std::string message) override;
+
+  void disconnect() override;
+
+ private:
+  std::function<void(std::string)> handler_;
+};
+
+/**
+ * Wraps an IRemoteConnection in a simpler interface that calls `onDisconnect`
+ * implicitly upon destruction.
+ */
+class RAIIRemoteConnection {
+ public:
+  explicit RAIIRemoteConnection(std::unique_ptr<IRemoteConnection> remote);
+
+  void onMessage(std::string message);
+
+  ~RAIIRemoteConnection();
+
+ private:
+  std::unique_ptr<IRemoteConnection> remote_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.cpp
@@ -9,12 +9,48 @@
 #include <folly/json.h>
 #include <jsinspector-modern/PageAgent.h>
 
+#include <chrono>
+
+using namespace std::chrono;
+using namespace std::literals::string_view_literals;
+
 namespace facebook::react::jsinspector_modern {
+
+#define ANSI_WEIGHT_BOLD "\x1B[1m"
+#define ANSI_WEIGHT_RESET "\x1B[22m"
+#define ANSI_STYLE_ITALIC "\x1B[3m"
+#define ANSI_STYLE_RESET "\x1B[23m"
+#define ANSI_COLOR_BG_YELLOW "\x1B[48;2;253;247;231m"
+
+static constexpr auto kModernCDPBackendNotice =
+    ANSI_COLOR_BG_YELLOW ANSI_WEIGHT_BOLD
+    "NOTE:" ANSI_WEIGHT_RESET " You are using the " ANSI_STYLE_ITALIC
+    "modern" ANSI_STYLE_RESET " CDP backend for React Native (PageTarget)."sv;
 
 PageAgent::PageAgent(FrontendChannel frontendChannel)
     : frontendChannel_(frontendChannel) {}
 
 void PageAgent::handleRequest(const cdp::PreparsedRequest& req) {
+  if (req.method == "Log.enable") {
+    // Send an "OK" response.
+    frontendChannel_(
+        folly::toJson(folly::dynamic::object("id", req.id)("result", nullptr)));
+
+    // Send a log entry identifying the modern CDP backend.
+    frontendChannel_(
+        folly::toJson(folly::dynamic::object("method", "Log.entryAdded")(
+            "params",
+            folly::dynamic::object(
+                "entry",
+                folly::dynamic::object(
+                    "timestamp",
+                    duration_cast<milliseconds>(
+                        system_clock::now().time_since_epoch())
+                        .count())("source", "other")(
+                    "level", "info")("text", kModernCDPBackendNotice)))));
+
+    return;
+  }
   folly::dynamic res = folly::dynamic::object("id", req.id)(
       "error",
       folly::dynamic::object("code", -32601)(

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <jsinspector-modern/PageAgent.h>
+
+namespace facebook::react::jsinspector_modern {
+
+PageAgent::PageAgent(FrontendChannel frontendChannel)
+    : frontendChannel_(frontendChannel) {}
+
+void PageAgent::handleRequest(const cdp::PreparsedRequest& req) {
+  folly::dynamic res = folly::dynamic::object("id", req.id)(
+      "error",
+      folly::dynamic::object("code", -32601)(
+          "message", req.method + " not implemented yet"));
+  std::string json = folly::toJson(res);
+  frontendChannel_(json);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsinspector-modern/InspectorInterfaces.h>
+#include <jsinspector-modern/Parsing.h>
+#include <functional>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * An Agent that handles requests from the Chrome DevTools Protocol for the
+ * given page.
+ * The constructor, destructor and all public methods must be called on the
+ * same thread.
+ */
+class PageAgent {
+ public:
+  /**
+   * \param frontendChannel A channel used to send responses and events to the
+   * frontend.
+   */
+  explicit PageAgent(FrontendChannel frontendChannel);
+
+  /**
+   * Handle a CDP request. The response will be sent over the provided
+   * \c FrontendChannel synchronously or asynchronously.
+   * \param req The parsed request.
+   */
+  void handleRequest(const cdp::PreparsedRequest& req);
+
+ private:
+  FrontendChannel frontendChannel_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PageTarget.h"
+#include "InspectorUtilities.h"
+#include "PageAgent.h"
+#include "Parsing.h"
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+
+#include <memory>
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+/**
+ * A Session connected to a PageTarget, passing CDP messages to and from a
+ * PageAgent which it owns.
+ */
+class PageTargetSession {
+ public:
+  explicit PageTargetSession(std::unique_ptr<IRemoteConnection> remote)
+      : remote_(std::make_shared<RAIIRemoteConnection>(std::move(remote))),
+        frontendChannel_(
+            [remoteWeak = std::weak_ptr(remote_)](std::string_view message) {
+              if (auto remote = remoteWeak.lock()) {
+                remote->onMessage(std::string(message));
+              }
+            }),
+        pageAgent_(frontendChannel_) {}
+  /**
+   * Called by CallbackLocalConnection to send a message to this Session's
+   * Agent.
+   */
+  void operator()(std::string message) {
+    cdp::PreparsedRequest request;
+    // Messages may be invalid JSON, or have unexpected types.
+    try {
+      request = cdp::preparse(message);
+    } catch (const cdp::ParseError& e) {
+      frontendChannel_(folly::toJson(folly::dynamic::object("id", nullptr)(
+          "error",
+          folly::dynamic::object("code", -32700)("message", e.what()))));
+      return;
+    } catch (const cdp::TypeError& e) {
+      frontendChannel_(folly::toJson(folly::dynamic::object("id", nullptr)(
+          "error",
+          folly::dynamic::object("code", -32600)("message", e.what()))));
+      return;
+    }
+
+    // Catch exceptions that may arise from accessing dynamic params during
+    // request handling.
+    try {
+      pageAgent_.handleRequest(request);
+    } catch (const cdp::TypeError& e) {
+      frontendChannel_(folly::toJson(folly::dynamic::object("id", request.id)(
+          "error",
+          folly::dynamic::object("code", -32600)("message", e.what()))));
+      return;
+    }
+  }
+
+ private:
+  // Owned by this instance, but shared (weakly) with the frontend channel
+  std::shared_ptr<RAIIRemoteConnection> remote_;
+  FrontendChannel frontendChannel_;
+  PageAgent pageAgent_;
+};
+
+} // namespace
+
+std::unique_ptr<ILocalConnection> PageTarget::connect(
+    std::unique_ptr<IRemoteConnection> connectionToFrontend) {
+  return std::make_unique<CallbackLocalConnection>(
+      PageTargetSession(std::move(connectionToFrontend)));
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsinspector-modern/InspectorInterfaces.h>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * The top-level Target in a React Native app. This is equivalent to the
+ * "Host" in React Native's architecture - the entity that manages the
+ * lifecycle of a React Instance.
+ */
+class PageTarget {
+ public:
+  /**
+   * Creates a new Session connected to this PageTarget, wrapped in an
+   * interface which is compatible with \c IInspector::addPage.
+   * The caller is responsible for destroying the connection before PageTarget
+   * is destroyed, on the same thread where PageTarget's constructor and
+   * destructor execute.
+   */
+  std::unique_ptr<ILocalConnection> connect(
+      std::unique_ptr<IRemoteConnection> connectionToFrontend);
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/Parsing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/Parsing.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <jsinspector-modern/Parsing.h>
+
+namespace facebook::react::jsinspector_modern::cdp {
+
+PreparsedRequest preparse(std::string_view message) {
+  folly::dynamic parsed = folly::parseJson(message);
+  return PreparsedRequest{
+      .id = parsed["id"].getInt(),
+      .method = parsed["method"].getString(),
+      .params = parsed.count("params") ? parsed["params"] : nullptr};
+}
+
+} // namespace facebook::react::jsinspector_modern::cdp

--- a/packages/react-native/ReactCommon/jsinspector-modern/Parsing.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/Parsing.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <string>
+#include <string_view>
+
+namespace facebook::react::jsinspector_modern {
+
+namespace cdp {
+using RequestId = long long;
+
+/**
+ * An incoming CDP request that has been parsed into a more usable form.
+ */
+struct PreparsedRequest {
+ public:
+  /**
+   * The ID of the request.
+   */
+  RequestId id;
+
+  /**
+   * The name of the method being invoked.
+   */
+  std::string method;
+
+  /**
+   * The parameters passed to the method, if any.
+   */
+  folly::dynamic params;
+};
+
+/**
+ * Parse a JSON-encoded CDP request into its constituent parts.
+ * \throws ParseError If the input cannot be parsed.
+ * \throws TypeError If the input does not conform to the expected format.
+ */
+PreparsedRequest preparse(std::string_view message);
+
+/**
+ * A type error that may be thrown while preparsing a request, or while
+ * accessing dynamic params on a request.
+ */
+using TypeError = folly::TypeError;
+
+/**
+ * A parse error that may be thrown while preparsing a request.
+ */
+using ParseError = folly::json::parse_error;
+} // namespace cdp
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsinspector-modern/PageTarget.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -49,6 +49,15 @@ class MockWebSocket : public IWebSocket {
   MOCK_METHOD(void, send, (std::string_view message), (override));
 };
 
+class MockRemoteConnection : public IRemoteConnection {
+ public:
+  MockRemoteConnection() = default;
+
+  // IRemoteConnection methods
+  MOCK_METHOD(void, onMessage, (std::string message), (override));
+  MOCK_METHOD(void, onDisconnect, (), (override));
+};
+
 class MockLocalConnection : public ILocalConnection {
  public:
   explicit MockLocalConnection(

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/PageTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/PageTargetTest.cpp
@@ -102,4 +102,25 @@ TEST_F(PageTargetProtocolTest, MalformedJson) {
   toPage_->sendMessage("{");
 }
 
+TEST_F(PageTargetProtocolTest, InjectLogToIdentifyBackend) {
+  InSequence s;
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "id": 1,
+                                               "result": null
+                                             })")))
+      .RetiresOnSaturation();
+
+  EXPECT_CALL(
+      fromPage(),
+      onMessage(JsonParsed(AllOf(
+          AtJsonPtr("/method", "Log.entryAdded"),
+          AtJsonPtr("/params/entry", Not(IsEmpty()))))))
+      .RetiresOnSaturation();
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": "Log.enable"
+                         })");
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/PageTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/PageTargetTest.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <jsinspector-modern/InspectorInterfaces.h>
+#include <jsinspector-modern/PageTarget.h>
+
+#include <memory>
+
+#include "FollyDynamicMatchers.h"
+#include "InspectorMocks.h"
+#include "UniquePtrFactory.h"
+
+using namespace ::testing;
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+/**
+ * Simplified test harness focused on sending messages to and from a PageTarget.
+ */
+class PageTargetProtocolTest : public Test {
+ public:
+  PageTargetProtocolTest() {
+    toPage_ = page_.connect(remoteConnections_.make_unique());
+
+    // In protocol tests, we'll always get an onDisconnect call when we tear
+    // down the test. Expect it in order to satisfy the strict mock.
+    EXPECT_CALL(*remoteConnections_[0], onDisconnect());
+  }
+
+ protected:
+  std::unique_ptr<ILocalConnection> toPage_;
+
+  MockRemoteConnection& fromPage() {
+    return *remoteConnections_[0];
+  }
+
+ private:
+  PageTarget page_;
+  UniquePtrFactory<StrictMock<MockRemoteConnection>> remoteConnections_;
+};
+
+} // namespace
+
+TEST_F(PageTargetProtocolTest, UnrecognizedMethod) {
+  EXPECT_CALL(
+      fromPage(),
+      onMessage(JsonParsed(AllOf(
+          AtJsonPtr("/error/code", Eq(-32601)), AtJsonPtr("/id", Eq(1))))))
+      .RetiresOnSaturation();
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": "SomeUnrecognizedMethod",
+                           "params": [1, 2]
+                         })");
+}
+
+TEST_F(PageTargetProtocolTest, TypeErrorInMethodName) {
+  EXPECT_CALL(
+      fromPage(),
+      onMessage(JsonParsed(AllOf(
+          AtJsonPtr("/error/code", Eq(-32600)),
+          AtJsonPtr("/id", Eq(nullptr))))))
+      .RetiresOnSaturation();
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": 42,
+                           "params": [1, 2]
+                         })");
+}
+
+TEST_F(PageTargetProtocolTest, MissingId) {
+  EXPECT_CALL(
+      fromPage(),
+      onMessage(JsonParsed(AllOf(
+          AtJsonPtr("/error/code", Eq(-32600)),
+          AtJsonPtr("/id", Eq(nullptr))))))
+      .RetiresOnSaturation();
+  toPage_->sendMessage(R"({
+                           "method": "SomeUnrecognizedMethod",
+                           "params": [1, 2]
+                         })");
+}
+
+TEST_F(PageTargetProtocolTest, MalformedJson) {
+  EXPECT_CALL(
+      fromPage(),
+      onMessage(JsonParsed(AllOf(
+          AtJsonPtr("/error/code", Eq(-32700)),
+          AtJsonPtr("/id", Eq(nullptr))))))
+      .RetiresOnSaturation();
+  toPage_->sendMessage("{");
+}
+
+} // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Changelog: [Internal]

During development / experimental rollout of the modern CDP backend, it can be helpful to have a user-visible message that makes it clear that the new backend is in use. Here, we add one using the [`Log.entryAdded`](https://chromedevtools.github.io/devtools-protocol/tot/Log/#type-LogEntry) CDP event. We also add some styling using [ANSI escape sequences](https://developer.chrome.com/docs/devtools/console/format-style#style-ansi) to make the message stand out from normal application logs.

We could have used [`Runtime.consoleAPICalled`](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-consoleAPICalled) instead, but:

1. `Runtime.consoleAPICalled` requires an `executionContextId` which is not available at the `Page` level (it is a concept that's managed closer to the instance/VM), and it's slightly cleaner if we don't have to send a fake context ID.
2. It's slightly easier to follow the CDP dispatching logic / grep for relevant code if we use `Log` for "system logs" (from the Page) and reserve `Runtime` for real application logs from the instance/VM.

NOTE: We'll probably want to remove this before the stable release.

Differential Revision: D52894171


