### PR TITLE
[RN] Add support for src directory in react-native

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,7 +60,10 @@ module.exports = {
       },
     },
     {
-      files: ['packages/react-native/Libraries/**/*.js'],
+      files: [
+        'packages/react-native/Libraries/**/*.js',
+        'packages/react-native/src/**/*.js',
+      ],
       rules: {
         '@react-native/platform-colors': 2,
         '@react-native/specs/react-native-modules': 2,

--- a/jest.config.js
+++ b/jest.config.js
@@ -56,7 +56,10 @@ module.exports = {
     'denodeify',
   ],
   testEnvironment: 'node',
-  collectCoverageFrom: ['packages/react-native/Libraries/**/*.js'],
+  collectCoverageFrom: [
+    'packages/react-native/Libraries/**/*.js',
+    'packages/react-native/src/**/*.js',
+  ],
   coveragePathIgnorePatterns: [
     '/__tests__/',
     '/vendor/',

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -79,6 +79,7 @@
     "sdks/hermes-engine",
     "sdks/hermesc",
     "settings.gradle.kts",
+    "src",
     "template.config.js",
     "template",
     "!template/node_modules",


### PR DESCRIPTION
Summary:
This adds support for having JS files in a  directory within the  package. The plan is to have 2 subdirectories there:
*  for private modules, with any nested directories (e.g.: ).
*  for public modules, without nested directories. The plan is that the individual modules created in this directory will be public through the index module or directly via something like  (mapped to , or a  directory in the published npm package—details TBD).

The enforcement of private modules being inaccessible from outside the  package will be added soon by huntie.

Changelog: [internal]

Differential Revision: D52875999

