### PR TITLE
Report Inspector page type to client

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -41,6 +41,8 @@ struct InspectorPageDescription {
 using InspectorPage = InspectorPageDescription;
 
 /// IRemoteConnection allows the VM to send debugger messages to the client.
+/// IRemoteConnection's methods are safe to call from any thread *if*
+/// InspectorPackagerConnection.cpp is in use.
 class JSINSPECTOR_EXPORT IRemoteConnection : public IDestructible {
  public:
   virtual ~IRemoteConnection() = 0;

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -31,10 +31,25 @@ class IDestructible {
   virtual ~IDestructible() = 0;
 };
 
+enum class InspectorPageType {
+  Legacy,
+  Modern,
+};
+
+inline const char* pageTypeToString(InspectorPageType type) {
+  switch (type) {
+    case InspectorPageType::Legacy:
+      return "Legacy";
+    case InspectorPageType::Modern:
+      return "Modern";
+  }
+}
+
 struct InspectorPageDescription {
   const int id;
   const std::string title;
   const std::string vm;
+  const InspectorPageType type;
 };
 
 // Alias for backwards compatibility.
@@ -82,7 +97,8 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
   virtual int addPage(
       const std::string& title,
       const std::string& vm,
-      ConnectFunc connectFunc) = 0;
+      ConnectFunc connectFunc,
+      InspectorPageType type = InspectorPageType::Legacy) = 0;
 
   /// removePage is called by the VM to remove a page from the list of
   /// debuggable pages.

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
@@ -23,10 +23,6 @@ static constexpr const std::chrono::duration RECONNECT_DELAY =
     std::chrono::milliseconds{2000};
 static constexpr const char* INVALID = "<invalid>";
 
-static folly::dynamic makePageIdPayload(std::string_view pageId) {
-  return folly::dynamic::object("id", pageId);
-}
-
 // InspectorPackagerConnection::Impl method definitions
 
 std::shared_ptr<InspectorPackagerConnection::Impl>
@@ -319,7 +315,7 @@ void InspectorPackagerConnection::Impl::RemoteConnection::onDisconnect() {
   if (owningPackagerConnectionStrong) {
     owningPackagerConnectionStrong->scheduleSendToPackager(
         folly::dynamic::object("event", "disconnect")(
-            "payload", makePageIdPayload(pageId_)),
+            "payload", folly::dynamic::object("pageId", pageId_)),
         sessionId_,
         pageId_);
   }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
@@ -148,7 +148,8 @@ folly::dynamic InspectorPackagerConnection::Impl::pages() {
 
   for (const auto& page : pages) {
     array.push_back(folly::dynamic::object("id", std::to_string(page.id))(
-        "title", page.title + " [C++ connection]")("app", app_)("vm", page.vm));
+        "title", page.title + " [C++ connection]")(
+        "app", app_)("vm", page.vm)("type", pageTypeToString(page.type)));
   }
   return array;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
@@ -48,7 +48,6 @@ class InspectorPackagerConnection {
 
  private:
   class Impl;
-  class RemoteConnectionImpl;
 
   const std::shared_ptr<Impl> impl_;
 };
@@ -72,10 +71,11 @@ class InspectorPackagerConnectionDelegate {
   /**
    * Schedules a function to run after a delay. If the function is called
    * asynchronously, the implementer of InspectorPackagerConnectionDelegate
-   * is responsible for thread safety (e.g. scheduling the callback on the same
-   * thread that called scheduleCallback, or otherwise ensuring
-   * synchronization). The callback MAY be dropped and never called, e.g. if the
-   * application is terminating.
+   * is responsible for thread safety (e.g. scheduling the callback on a thread
+   * that has unique access to the InspectorPackagerConnection instance, or
+   * otherwise ensuring synchronization). The callback MAY be dropped and never
+   * called if no further callbacks are being accepted, e.g. if the application
+   * is terminating.
    */
   virtual void scheduleCallback(
       std::function<void(void)> callback,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -59,12 +59,16 @@ class MockLocalConnection : public ILocalConnection {
     return *remoteConnection_;
   }
 
+  std::unique_ptr<IRemoteConnection> dangerouslyReleaseRemoteConnection() {
+    return std::move(remoteConnection_);
+  }
+
   // ILocalConnection methods
   MOCK_METHOD(void, sendMessage, (std::string message), (override));
   MOCK_METHOD(void, disconnect, (), (override));
 
  private:
-  const std::unique_ptr<IRemoteConnection> remoteConnection_;
+  std::unique_ptr<IRemoteConnection> remoteConnection_;
 };
 
 class MockInspectorPackagerConnectionDelegate

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
@@ -216,7 +216,8 @@ TEST_F(InspectorPackagerConnectionTest, TestGetPages) {
                   AtJsonPtr("/app", Eq("my-app")),
                   AtJsonPtr("/title", Eq("mock-title [C++ connection]")),
                   AtJsonPtr("/vm", Eq("mock-vm")),
-                  AtJsonPtr("/id", Eq(std::to_string(pageId))))}))))))
+                  AtJsonPtr("/id", Eq(std::to_string(pageId))),
+                  AtJsonPtr("/type", Eq("Legacy")))}))))))
       .RetiresOnSaturation();
   webSockets_[0]->getDelegate().didReceiveMessage(R"({
       "event": "getPages"


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Add an optional mechanism for inspector pages to be registered with the "modern" or "legacy" type (defaulting to legacy). This is aligned with the inspector-proxy implementation of the `type` property in D50967795.

NOTE: This mechanism is experimental, only takes effect if `InspectorPackagerConnection.cpp` is in use, and will likely evolve before the RN 0.74 branch cut.

Reviewed By: huntie

Differential Revision: D50967794


