### PR TITLE
Register RCTHost with modern CDP backend

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
@@ -12,6 +12,18 @@
 #include <optional>
 #include <string>
 
+#ifndef JSINSPECTOR_EXPORT
+#ifdef _MSC_VER
+#ifdef CREATE_SHARED_LIBRARY
+#define JSINSPECTOR_EXPORT __declspec(dllexport)
+#else
+#define JSINSPECTOR_EXPORT
+#endif // CREATE_SHARED_LIBRARY
+#else // _MSC_VER
+#define JSINSPECTOR_EXPORT __attribute__((visibility("default")))
+#endif // _MSC_VER
+#endif // !defined(JSINSPECTOR_EXPORT)
+
 namespace facebook::react::jsinspector_modern {
 
 /**
@@ -19,7 +31,7 @@ namespace facebook::react::jsinspector_modern {
  * "Host" in React Native's architecture - the entity that manages the
  * lifecycle of a React Instance.
  */
-class PageTarget {
+class JSINSPECTOR_EXPORT PageTarget {
  public:
   struct SessionMetadata {
     std::optional<std::string> integrationName;

--- a/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
@@ -35,4 +35,5 @@ target_link_libraries(
         jsi
         jsireact
         react_utils
+        jsinspector
 )

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -62,4 +62,5 @@ Pod::Spec.new do |s|
     s.dependency "React-jsc"
   end
 
+  s.dependency "React-jsinspector"
 end

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -65,6 +65,7 @@ Pod::Spec.new do |s|
   s.dependency "React-RuntimeCore"
   s.dependency "React-Mapbuffer"
   s.dependency "React-jserrorhandler"
+  s.dependency "React-jsinspector"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"


### PR DESCRIPTION
Summary:
Changelog: [Internal][iOS] - Enable stub modern CDP backend in Bridgeless behind a feature flag

Minimally integrates the stub native CDP backend implementation (D50936932) into iOS Bridgeless.

This integration registers itself as a "Modern" target (D50967794, D50967795) to instruct `inspector-proxy` to disable its CDP hacks related to source map fetching, reloads, etc. This gives us a mostly-clean slate on which to develop and test native CDP functionality.

Differential Revision: D50936931

