### PR TITLE
Drop stale comment in VirtualizedList

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1135,7 +1135,6 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
               this.context == null &&
               this.props.scrollEnabled !== false
             ) {
-              // TODO (T46547044): use React.warn once 16.9 is sync'd: https://github.com/facebook/react/pull/15170
               console.error(
                 'VirtualizedLists should never be nested inside plain ScrollViews with the same ' +
                   'orientation because it can break windowing and other functionality - use another ' +


### PR DESCRIPTION
Summary:
T46547044 has been closed and apparently `React.warn` was removed in [#16126](https://github.com/facebook/react/pull/16126).

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D52907508


