### PR TITLE
Register RCTDeviceInfo to invalidating and cleanup observer

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -75,11 +75,44 @@ RCT_EXPORT_MODULE()
                                            selector:@selector(interfaceFrameDidChange)
                                                name:RCTWindowFrameDidChangeNotification
                                              object:nil];
+
+  // TODO T175901725 - Registering the RCTDeviceInfo module to the notification is a short-term fix to unblock 0.73
+  // The actual behavior should be that the module is properly registered in the TurboModule/Bridge infrastructure
+  // and the infrastructure imperatively invoke the `invalidate` method, rather than listening to a notification.
+  // This is a temporary workaround until we can investigate the issue better as there might be other modules in a
+  // similar situation.
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(invalidate)
+                                               name:RCTBridgeWillInvalidateModulesNotification
+                                             object:nil];
 }
 
 - (void)invalidate
 {
   _invalidated = YES;
+  [self _cleanupObservers];
+}
+
+- (void)_cleanupObservers
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:RCTAccessibilityManagerDidUpdateMultiplierNotification
+                                                object:[_moduleRegistry moduleForName:"AccessibilityManager"]];
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:UIApplicationDidChangeStatusBarOrientationNotification
+                                                object:nil];
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTUserInterfaceStyleDidChangeNotification object:nil];
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTWindowFrameDidChangeNotification object:nil];
+
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(invalidate)
+                                               name:RCTBridgeWillInvalidateModulesNotification
+                                             object:nil];
 }
 
 static BOOL RCTIsIPhoneNotched()


### PR DESCRIPTION
Summary:
Cmmunity reported [#42120](https://github.com/facebook/react-native/issues/42120) where React Native was crashing if RCTDeviceInfo native module was receiving a notification while the bridge is invalidating.

Upon investigation, I realized that:
1. The RCTDeviceInfo module is never invalidated
2. Observers are still observing even when the Bridge is in an invalidated state and it is not back up.

This change makes sure that we invalidate the `RCTDeviceInfo.mm` module and that we unregister the observers.

## Changelog:
[iOS][Fixed] - Make `RCTDeviceInfo` listen to invalidate events and unregister observers while invalidating the bridge

Differential Revision: D52912604


