### PR TITLE
Mark CallInvokerHolder APIs as FrameworkAPI only

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/CallInvokerHolderImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/CallInvokerHolderImpl.java
@@ -9,6 +9,7 @@ package com.facebook.react.turbomodule.core;
 
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.internal.turbomodule.core.NativeModuleSoLoader;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 
@@ -17,6 +18,7 @@ import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
  * TurboModuleManager. Therefore, we need to wrap JSCallInvoker within a hybrid class so that we may
  * pass it from CatalystInstance, through Java, to TurboModuleManager::initHybrid.
  */
+@FrameworkAPI
 public class CallInvokerHolderImpl implements CallInvokerHolder {
 
   @DoNotStrip private final HybridData mHybridData;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl.java
@@ -9,6 +9,7 @@ package com.facebook.react.turbomodule.core;
 
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.internal.turbomodule.core.NativeModuleSoLoader;
 import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder;
 
@@ -18,6 +19,7 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
  * class so that we may pass it from CatalystInstance, through Java, to
  * TurboModuleManager::initHybrid.
  */
+@FrameworkAPI
 public class NativeMethodCallInvokerHolderImpl implements NativeMethodCallInvokerHolder {
 
   @DoNotStrip private final HybridData mHybridData;


### PR DESCRIPTION
Summary:
Mark CallInvokerHolder APIs as FrameworkAPI only, these APIs are meant to be used only for partner frameworks

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D52913739


