### PR TITLE
Don't inject synthetic Debugger.disable message in modern CDP backend

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -279,8 +279,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 - (void)didReceiveReloadCommand
 {
 #if RCT_ENABLE_INSPECTOR
-  // Disable debugger to resume the JsVM & avoid thread locks while reloading
-  [RCTInspectorDevServerHelper disableDebugger];
+  auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
+  if (!inspectorFlags.getEnableModernCDPRegistry()) {
+    // Disable debugger to resume the JsVM & avoid thread locks while reloading
+    [RCTInspectorDevServerHelper disableDebugger];
+  }
 #endif
 
   [[NSNotificationCenter defaultCenter] postNotificationName:RCTBridgeWillReloadNotification object:self userInfo:nil];

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -145,7 +145,10 @@ static void sendEventToAllConnections(NSString *event)
 
 + (void)disableDebugger
 {
-  sendEventToAllConnections(kDebuggerMsgDisable);
+  auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
+  if (!inspectorFlags.getEnableModernCDPRegistry()) {
+    sendEventToAllConnections(kDebuggerMsgDisable);
+  }
 }
 
 + (id<RCTInspectorPackagerConnectionProtocol>)connectWithBundleURL:(NSURL *)bundleURL


### PR DESCRIPTION
Summary:
Changelog: [Internal]

TSIA - iOS counterpart of D52040149 on Android.

The overarching principle is that nothing outside of an Agent should be doing anything with the CDP message stream. Here we have a case of `RCTInspectorDevServerHelper` basically impersonating the CDP frontend in order to paper over an apparent lifetime management bug in the old backend; this gets in the way of implementing reloads natively so we disable it under the new backend.

NOTE: I'm gating out both the call site in `RCTBridge` (to signal intent) *and* the actual body of `disableDebugger` (in case any out-of-tree code happens to be using this method).

Differential Revision: D50967799


