### PR TITLE
🚑 hotfix Flatlist bug Cannot read property 'getItem' of undefined

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -420,6 +420,7 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
 
   constructor(props: Props<ItemT>) {
     super(props);
+    this.props = props;
     this._checkProps(this.props);
     if (this.props.viewabilityConfigCallbackPairs) {
       this._virtualizedListPairs =


### PR DESCRIPTION
fixes the issue https://github.com/facebook/react-native/issues/36828

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

There's a bug that shows up with RN 0.73 FlatList component `Cannot read property 'getItem' of undefined`

## Changelog:

Attaching the props to the class fixes the issue

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Fix FlatList props setting

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
