### PR TITLE
Introduce new notification callback in RCTPushNotificationManager

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -14,10 +14,34 @@ extern NSString *const RCTRemoteNotificationReceived;
 typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
-+ (void)didReceiveRemoteNotification:(NSDictionary *)notification;
++ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
+/**
+ * Triggers remoteNotificationReceived or localNotificationReceived events.
+ *
+ * Call this method from UNUserNotificationCenterDelegate's
+ * `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` in order to process a user tap on a
+ * notification.
+ *
+ * To process notifications received while the app is in the foreground, call this method from
+ * `userNotificationCenter:willPresentNotification:withCompletionHandler:`. Use the completion handler to determine if
+ * the push notification should be shown; to match prior behavior which does not show foreground notifications, use
+ * UNNotificationPresentationOptionNone.
+ *
+ * If you need to determine if the notification is remote, check that notification.request.trigger
+ * is an instance of UNPushNotificationTrigger.
+ */
++ (void)didReceiveNotification:(UNNotification *)notification;
+/**
+ * Call this from your app delegate's `application:didReceiveRemoteNotification:fetchCompletionHandler:`. If you
+ * implement both that method and `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:`, only
+ * the latter will be called.
+ */
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification
               fetchCompletionHandler:(RCTRemoteNotificationCallback)completionHandler;
-+ (void)didReceiveLocalNotification:(UILocalNotification *)notification;
-+ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
+
+/** DEPRECATED. Use didReceiveNotification instead. */
++ (void)didReceiveLocalNotification:(UILocalNotification *)notification RCT_DEPRECATED;
+/** DEPRECATED. Use didReceiveNotification instead. */
++ (void)didReceiveRemoteNotification:(NSDictionary *)notification RCT_DEPRECATED;
 
 @end

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -230,28 +230,47 @@ RCT_EXPORT_MODULE()
                                                     userInfo:@{@"error" : error}];
 }
 
++ (void)didReceiveNotification:(UNNotification *)notification
+{
+  BOOL const isRemoteNotification = [notification.request.trigger isKindOfClass:[UNPushNotificationTrigger class]];
+  if (isRemoteNotification) {
+    NSDictionary *userInfo = @{@"notification" : notification.request.content.userInfo};
+    [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
+                                                        object:self
+                                                      userInfo:userInfo];
+  } else {
+    [[NSNotificationCenter defaultCenter] postNotificationName:kLocalNotificationReceived
+                                                        object:self
+                                                      userInfo:RCTFormatUNNotification(notification)];
+  }
+}
+
++ (void)didReceiveRemoteNotification:(NSDictionary *)notification
+              fetchCompletionHandler:(RCTRemoteNotificationCallback)completionHandler
+{
+  NSDictionary *userInfo = completionHandler
+      ? @{@"notification" : notification, @"completionHandler" : completionHandler}
+      : @{@"notification" : notification};
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
+                                                      object:self
+                                                    userInfo:userInfo];
+}
+
+// Deprecated
++ (void)didReceiveLocalNotification:(UILocalNotification *)notification
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:kLocalNotificationReceived
+                                                      object:self
+                                                    userInfo:RCTFormatLocalNotification(notification)];
+}
+
+// Deprecated
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification
 {
   NSDictionary *userInfo = @{@"notification" : notification};
   [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
                                                       object:self
                                                     userInfo:userInfo];
-}
-
-+ (void)didReceiveRemoteNotification:(NSDictionary *)notification
-              fetchCompletionHandler:(RCTRemoteNotificationCallback)completionHandler
-{
-  NSDictionary *userInfo = @{@"notification" : notification, @"completionHandler" : completionHandler};
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
-                                                      object:self
-                                                    userInfo:userInfo];
-}
-
-+ (void)didReceiveLocalNotification:(UILocalNotification *)notification
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:kLocalNotificationReceived
-                                                      object:self
-                                                    userInfo:RCTFormatLocalNotification(notification)];
 }
 
 - (void)handleLocalNotificationReceived:(NSNotification *)notification


### PR DESCRIPTION
Summary:
## Changelog:

[iOS][Deprecated] Deprecating RCTPushNotificationManager's didReceiveLocalNotification: and didReceiveRemoteNotification:

Differential Revision: D52375779


