### PR TITLE
Migrate RNTester onto new RN notification callbacks

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -7,6 +7,8 @@
 
 #import "AppDelegate.h"
 
+#import <UserNotifications/UserNotifications.h>
+
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTDefines.h>
 #import <React/RCTLinkingManager.h>
@@ -22,6 +24,9 @@
 
 static NSString *kBundlePath = @"js/RNTesterApp.ios";
 
+@interface AppDelegate () <UNUserNotificationCenterDelegate>
+@end
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -30,6 +35,8 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = [self prepareInitialProps];
+
+  [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
@@ -96,17 +103,26 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   [RCTPushNotificationManager didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
-// Required for the remoteNotificationReceived event.
-- (void)application:(__unused UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
+#pragma mark - UNUserNotificationCenterDelegate
+
+// Required for the remoteNotificationReceived and localNotificationReceived events
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  [RCTPushNotificationManager didReceiveRemoteNotification:notification];
+  [RCTPushNotificationManager didReceiveNotification:notification];
+  completionHandler(UNNotificationPresentationOptionNone);
 }
 
-// Required for the localNotificationReceived event.
-- (void)application:(__unused UIApplication *)application
-    didReceiveLocalNotification:(UILocalNotification *)notification
+// Required for the remoteNotificationReceived and localNotificationReceived events
+// Called when a notification is tapped from background. (Foreground notification will not be shown per
+// the presentation option selected above.)
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+    didReceiveNotificationResponse:(UNNotificationResponse *)response
+             withCompletionHandler:(void (^)(void))completionHandler
 {
-  [RCTPushNotificationManager didReceiveLocalNotification:notification];
+  [RCTPushNotificationManager didReceiveNotification:response.notification];
+  completionHandler();
 }
 
 #pragma mark - New Arch Enabled settings


### PR DESCRIPTION
Summary:
## Changelog:

[iOS][Changed] Migrated RNTester/AppDelegate to the new notification callback

Differential Revision: D52883367


