### PR TITLE
'[skip ci] [RN][JS] Open source PopupMenuAndroid

### DIFF
--- a/packages/react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.android.js
+++ b/packages/react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.android.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {RefObject} from 'react';
+
+import PopupMenuAndroidNativeComponent, {
+  Commands,
+} from './PopupMenuAndroidNativeComponent';
+import nullthrows from 'nullthrows';
+import * as React from 'react';
+import {useCallback, useImperativeHandle, useRef} from 'react';
+
+type PopupMenuSelectionEvent = SyntheticEvent<
+  $ReadOnly<{
+    item: number,
+  }>,
+>;
+
+export type PopupMenuAndroidInstance = {
+  +show: () => void,
+};
+
+type Props = {
+  menuItems: $ReadOnlyArray<string>,
+  onSelectionChange: number => void,
+  children: React.Node,
+  instanceRef: RefObject<?PopupMenuAndroidInstance>,
+};
+
+export default function PopupMenuAndroid({
+  menuItems,
+  onSelectionChange,
+  children,
+  instanceRef,
+}: Props): React.Node {
+  const nativeRef = useRef<React.ElementRef<HostComponent<mixed>> | null>(null);
+  const _onSelectionChange = useCallback(
+    (event: PopupMenuSelectionEvent) => {
+      onSelectionChange(event.nativeEvent.item);
+    },
+    [onSelectionChange],
+  );
+
+  useImperativeHandle(instanceRef, ItemViewabilityInstance => {
+    return {
+      show() {
+        Commands.show(nullthrows(nativeRef.current));
+      },
+    };
+  });
+
+  return (
+    <PopupMenuAndroidNativeComponent
+      ref={nativeRef}
+      onSelectionChange={_onSelectionChange}
+      menuItems={menuItems}>
+      {children}
+    </PopupMenuAndroidNativeComponent>
+  );
+}

--- a/packages/react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.d.ts
+++ b/packages/react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type * as React from 'react';
+import {HostComponent} from '../../../types/public/ReactNativeTypes';
+
+type PopupMenuAndroidInstance = {
+  show: () => void;
+};
+
+type Props = {
+  menuItems: Array<string>;
+  onSelectionChange: (number) => void;
+  children: React.ReactNode | undefined;
+  instanceRef: React.ElementRef<HostComponent<PopupMenuAndroidInstance>>;
+};
+
+declare class PopupMenuAndroid extends React.Component<Props> {}

--- a/packages/react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.js
+++ b/packages/react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import type {RefObject} from 'react';
+import type {Node} from 'react';
+
+import * as React from 'react';
+
+const UnimplementedView = require('../UnimplementedViews/UnimplementedView');
+
+export type PopupMenuAndroidInstance = {
+  +show: () => void,
+};
+
+type Props = {
+  menuItems: $ReadOnlyArray<string>,
+  onSelectionChange: number => void,
+  children: Node,
+  instanceRef: RefObject<?PopupMenuAndroidInstance>,
+};
+
+function PopupMenuAndroid(props: Props): Node {
+  return <UnimplementedView />;
+}
+
+export default PopupMenuAndroid;

--- a/packages/react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroidNativeComponent.js
+++ b/packages/react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroidNativeComponent.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {DirectEventHandler, Int32} from '../../Types/CodegenTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+
+import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
+import codegenNativeComponent from '../../Utilities/codegenNativeComponent';
+import * as React from 'react';
+
+type PopupMenuSelectionEvent = $ReadOnly<{
+  item: Int32,
+}>;
+
+type NativeProps = $ReadOnly<{
+  ...ViewProps,
+
+  //Props
+  menuItems?: ?$ReadOnlyArray<string>,
+
+  onSelectionChange?: DirectEventHandler<PopupMenuSelectionEvent>,
+}>;
+
+type ComponentType = HostComponent<NativeProps>;
+
+interface NativeCommands {
+  +show: (viewRef: React.ElementRef<ComponentType>) => void;
+}
+
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ['show'],
+});
+
+export default (codegenNativeComponent<NativeProps>(
+  'AndroidPopupMenu',
+): HostComponent<NativeProps>);

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -41,7 +41,7 @@ const getUIManagerConstantsCached = (function () {
   };
 })();
 
-const getConstantsForViewManager: ?(viewManagerName: string) => Object =
+const getConstantsForViewManager: ?(viewManagerName: string) => ?Object =
   global.RN$LegacyInterop_UIManager_getConstantsForViewManager;
 
 const getDefaultEventTypes: ?() => Object =
@@ -157,7 +157,7 @@ const UIManagerJSUnusedAPIs = {
 
 const UIManagerJSPlatformAPIs = Platform.select({
   android: {
-    getConstantsForViewManager: (viewManagerName: string): Object => {
+    getConstantsForViewManager: (viewManagerName: string): ?Object => {
       if (getConstantsForViewManager) {
         return getConstantsForViewManager(viewManagerName);
       }

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -245,6 +245,11 @@ const UIManagerJSPlatformAPIs = Platform.select({
     },
   },
   ios: {
+    /**
+     * TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
+     *
+     * Leave this unimplemented until we implement lazy loading of legacy modules and view managers in the new architecture.
+     */
     lazilyLoadView: (name: string): Object => {
       raiseSoftError('lazilyLoadView');
       return {};

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -313,7 +313,45 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
       height: number,
     ) => void,
   ): void => {
-    raiseSoftError('findSubviewIn');
+    const FabricUIManager = nullthrows(getFabricUIManager());
+    const shadowNode = FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
+
+    if (!shadowNode) {
+      console.error(
+        `findSubviewIn() noop: Cannot find view with reactTag ${reactTag}`,
+      );
+      return;
+    }
+
+    FabricUIManager.findNodeAtPoint(
+      shadowNode,
+      point[0],
+      point[1],
+      function (internalInstanceHandle) {
+        if (internalInstanceHandle == null) {
+          console.error('findSubviewIn(): Cannot find node at point');
+          return;
+        }
+
+        let instanceHandle: Object = internalInstanceHandle;
+        let node = instanceHandle.stateNode.node;
+
+        if (!node) {
+          console.error('findSubviewIn(): Cannot find node at point');
+          return;
+        }
+
+        let nativeViewTag = (instanceHandle.stateNode.canonical
+          .nativeTag: number);
+
+        FabricUIManager.measure(
+          node,
+          function (x, y, width, height, pageX, pageY) {
+            callback(nativeViewTag, pageX, pageY, width, height);
+          },
+        );
+      },
+    );
   },
   viewIsDescendantOf: (
     reactTag: number,

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -65,7 +65,7 @@ const getDefaultEventTypesCached = (function () {
  */
 const UIManagerJSOverridenAPIs = {
   measure: (
-    reactTag: ?number,
+    reactTag: number,
     callback: (
       left: number,
       top: number,
@@ -78,14 +78,14 @@ const UIManagerJSOverridenAPIs = {
     raiseSoftError('measure');
   },
   measureInWindow: (
-    reactTag: ?number,
+    reactTag: number,
     callback: (x: number, y: number, width: number, height: number) => void,
   ): void => {
     raiseSoftError('measureInWindow');
   },
   measureLayout: (
-    reactTag: ?number,
-    ancestorReactTag: ?number,
+    reactTag: number,
+    ancestorReactTag: number,
     errorCallback: (error: Object) => void,
     callback: (
       left: number,
@@ -97,7 +97,7 @@ const UIManagerJSOverridenAPIs = {
     raiseSoftError('measureLayout');
   },
   measureLayoutRelativeToParent: (
-    reactTag: ?number,
+    reactTag: number,
     errorCallback: (error: Object) => void,
     callback: (
       left: number,
@@ -109,7 +109,7 @@ const UIManagerJSOverridenAPIs = {
     raiseSoftError('measureLayoutRelativeToParent');
   },
   dispatchViewManagerCommand: (
-    reactTag: ?number,
+    reactTag: number,
     commandID: number,
     commandArgs: ?Array<string | number | boolean>,
   ): void => {
@@ -124,7 +124,7 @@ const UIManagerJSOverridenAPIs = {
  */
 const UIManagerJSUnusedAPIs = {
   createView: (
-    reactTag: ?number,
+    reactTag: number,
     viewName: string,
     rootTag: RootTag,
     props: Object,
@@ -134,11 +134,11 @@ const UIManagerJSUnusedAPIs = {
   updateView: (reactTag: number, viewName: string, props: Object): void => {
     raiseSoftError('updateView');
   },
-  setChildren: (containerTag: ?number, reactTags: Array<number>): void => {
+  setChildren: (containerTag: number, reactTags: Array<number>): void => {
     raiseSoftError('setChildren');
   },
   manageChildren: (
-    containerTag: ?number,
+    containerTag: number,
     moveFromIndices: Array<number>,
     moveToIndices: Array<number>,
     addChildReactTags: Array<number>,
@@ -147,7 +147,7 @@ const UIManagerJSUnusedAPIs = {
   ): void => {
     raiseSoftError('manageChildren');
   },
-  setJSResponder: (reactTag: ?number, blockNativeResponder: boolean): void => {
+  setJSResponder: (reactTag: number, blockNativeResponder: boolean): void => {
     raiseSoftError('setJSResponder');
   },
   clearJSResponder: (): void => {
@@ -185,16 +185,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
         );
       }
     },
-    sendAccessibilityEvent: (reactTag: ?number, eventType: number): void => {
-      if (reactTag == null) {
-        console.error(
-          `sendAccessibilityEvent() dropping event: Cannot be called with ${String(
-            reactTag,
-          )} reactTag`,
-        );
-        return;
-      }
-
+    sendAccessibilityEvent: (reactTag: number, eventType: number): void => {
       // Keep this in sync with java:FabricUIManager.sendAccessibilityEventFromJS
       // and legacySendAccessibilityEvent.android.js
       const AccessibilityEvent = {
@@ -233,7 +224,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
       FabricUIManager.sendAccessibilityEvent(shadowNode, eventName);
     },
     showPopupMenu: (
-      reactTag: ?number,
+      reactTag: number,
       items: Array<string>,
       error: (error: Object) => void,
       success: (event: string, selected?: number) => void,
@@ -254,14 +245,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
       raiseSoftError('lazilyLoadView');
       return {};
     },
-    focus: (reactTag: ?number): void => {
-      if (reactTag == null) {
-        console.error(
-          `focus() noop: Cannot be called with ${String(reactTag)} reactTag`,
-        );
-        return;
-      }
-
+    focus: (reactTag: number): void => {
       const FabricUIManager = nullthrows(getFabricUIManager());
       const shadowNode =
         FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
@@ -271,14 +255,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
       }
       FabricUIManager.dispatchCommand(shadowNode, 'focus', []);
     },
-    blur: (reactTag: ?number): void => {
-      if (reactTag == null) {
-        console.error(
-          `blur() noop: Cannot be called with ${String(reactTag)} reactTag`,
-        );
-        return;
-      }
-
+    blur: (reactTag: number): void => {
       const FabricUIManager = nullthrows(getFabricUIManager());
       const shadowNode =
         FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
@@ -326,7 +303,7 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
     }
   },
   findSubviewIn: (
-    reactTag: ?number,
+    reactTag: number,
     point: Array<number>,
     callback: (
       nativeViewTag: number,
@@ -339,33 +316,15 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
     raiseSoftError('findSubviewIn');
   },
   viewIsDescendantOf: (
-    reactTag: ?number,
-    ancestorReactTag: ?number,
+    reactTag: number,
+    ancestorReactTag: number,
     callback: (result: Array<boolean>) => void,
   ): void => {
-    if (reactTag == null) {
-      console.error(
-        `viewIsDescendantOf() noop: Cannot be called with ${String(
-          reactTag,
-        )} reactTag`,
-      );
-      return;
-    }
-
     const FabricUIManager = nullthrows(getFabricUIManager());
     const shadowNode = FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
     if (!shadowNode) {
       console.error(
         `viewIsDescendantOf() noop: Cannot find view with reactTag ${reactTag}`,
-      );
-      return;
-    }
-
-    if (ancestorReactTag == null) {
-      console.error(
-        `viewIsDescendantOf() noop: Cannot be called with ${String(
-          ancestorReactTag,
-        )} ancestorReactTag`,
       );
       return;
     }

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -64,6 +64,12 @@ export interface Spec {
     commandName: string,
     args: Array<mixed>,
   ) => void;
+  +findNodeAtPoint: (
+    node: Node,
+    locationX: number,
+    locationY: number,
+    callback: (instanceHandle: ?InternalInstanceHandle) => void,
+  ) => void;
 
   /**
    * Support methods for the DOM-compatible APIs.

--- a/packages/react-native/Libraries/ReactNative/NativeUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/NativeUIManager.js
@@ -16,14 +16,14 @@ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 export interface Spec extends TurboModule {
   +getConstants: () => Object;
   +createView: (
-    reactTag: ?number,
+    reactTag: number,
     viewName: string,
     rootTag: RootTag,
     props: Object,
   ) => void;
   +updateView: (reactTag: number, viewName: string, props: Object) => void;
   +findSubviewIn: (
-    reactTag: ?number,
+    reactTag: number,
     point: Array<number>,
     callback: (
       nativeViewTag: number,
@@ -34,8 +34,8 @@ export interface Spec extends TurboModule {
     ) => void,
   ) => void;
   +dispatchViewManagerCommand: (
-    reactTag: ?number,
-    commandID: number,
+    reactTag: number,
+    commandID: number, // number || string
     commandArgs: ?Array<any>,
   ) => void;
   +measure: (
@@ -54,8 +54,8 @@ export interface Spec extends TurboModule {
     callback: (x: number, y: number, width: number, height: number) => void,
   ) => void;
   +viewIsDescendantOf: (
-    reactTag: ?number,
-    ancestorReactTag: ?number,
+    reactTag: number,
+    ancestorReactTag: number,
     callback: (result: Array<boolean>) => void,
   ) => void;
   +measureLayout: (
@@ -79,16 +79,16 @@ export interface Spec extends TurboModule {
       height: number,
     ) => void,
   ) => void;
-  +setJSResponder: (reactTag: ?number, blockNativeResponder: boolean) => void;
+  +setJSResponder: (reactTag: number, blockNativeResponder: boolean) => void;
   +clearJSResponder: () => void;
   +configureNextLayoutAnimation: (
     config: Object,
     callback: () => void, // check what is returned here
     errorCallback: (error: Object) => void,
   ) => void;
-  +setChildren: (containerTag: ?number, reactTags: Array<number>) => void;
+  +setChildren: (containerTag: number, reactTags: Array<number>) => void;
   +manageChildren: (
-    containerTag: ?number,
+    containerTag: number,
     moveFromIndices: Array<number>,
     moveToIndices: Array<number>,
     addChildReactTags: Array<number>,
@@ -100,9 +100,9 @@ export interface Spec extends TurboModule {
   +getConstantsForViewManager?: (viewManagerName: string) => Object;
   +getDefaultEventTypes?: () => Array<string>;
   +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
-  +sendAccessibilityEvent?: (reactTag: ?number, eventType: number) => void;
+  +sendAccessibilityEvent?: (reactTag: number, eventType: number) => void;
   +showPopupMenu?: (
-    reactTag: ?number,
+    reactTag: number,
     items: Array<string>,
     error: (error: Object) => void,
     success: (event: string, selected?: number) => void,
@@ -111,8 +111,8 @@ export interface Spec extends TurboModule {
 
   // ios only
   +lazilyLoadView?: (name: string) => Object; // revisit return
-  +focus?: (reactTag: ?number) => void;
-  +blur?: (reactTag: ?number) => void;
+  +focus?: (reactTag: number) => void;
+  +blur?: (reactTag: number) => void;
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>('UIManager'): Spec);

--- a/packages/react-native/Libraries/ReactNative/NativeUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/NativeUIManager.js
@@ -97,7 +97,7 @@ export interface Spec extends TurboModule {
   ) => void;
 
   // Android only
-  +getConstantsForViewManager?: (viewManagerName: string) => Object;
+  +getConstantsForViewManager?: (viewManagerName: string) => ?Object;
   +getDefaultEventTypes?: () => Array<string>;
   +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
   +sendAccessibilityEvent?: (reactTag: number, eventType: number) => void;

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -83,7 +83,7 @@ function getViewManagerConfig(viewManagerName: string): any {
 const UIManagerJS: UIManagerJSInterface = {
   ...NativeUIManager,
   createView(
-    reactTag: ?number,
+    reactTag: number,
     viewName: string,
     rootTag: RootTag,
     props: Object,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7788,14 +7788,14 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
 "export interface Spec extends TurboModule {
   +getConstants: () => Object;
   +createView: (
-    reactTag: ?number,
+    reactTag: number,
     viewName: string,
     rootTag: RootTag,
     props: Object
   ) => void;
   +updateView: (reactTag: number, viewName: string, props: Object) => void;
   +findSubviewIn: (
-    reactTag: ?number,
+    reactTag: number,
     point: Array<number>,
     callback: (
       nativeViewTag: number,
@@ -7806,7 +7806,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
     ) => void
   ) => void;
   +dispatchViewManagerCommand: (
-    reactTag: ?number,
+    reactTag: number,
     commandID: number,
     commandArgs: ?Array<any>
   ) => void;
@@ -7826,8 +7826,8 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
     callback: (x: number, y: number, width: number, height: number) => void
   ) => void;
   +viewIsDescendantOf: (
-    reactTag: ?number,
-    ancestorReactTag: ?number,
+    reactTag: number,
+    ancestorReactTag: number,
     callback: (result: Array<boolean>) => void
   ) => void;
   +measureLayout: (
@@ -7841,16 +7841,16 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
     errorCallback: (error: Object) => void,
     callback: (left: number, top: number, width: number, height: number) => void
   ) => void;
-  +setJSResponder: (reactTag: ?number, blockNativeResponder: boolean) => void;
+  +setJSResponder: (reactTag: number, blockNativeResponder: boolean) => void;
   +clearJSResponder: () => void;
   +configureNextLayoutAnimation: (
     config: Object,
     callback: () => void,
     errorCallback: (error: Object) => void
   ) => void;
-  +setChildren: (containerTag: ?number, reactTags: Array<number>) => void;
+  +setChildren: (containerTag: number, reactTags: Array<number>) => void;
   +manageChildren: (
-    containerTag: ?number,
+    containerTag: number,
     moveFromIndices: Array<number>,
     moveToIndices: Array<number>,
     addChildReactTags: Array<number>,
@@ -7860,17 +7860,17 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
   +getConstantsForViewManager?: (viewManagerName: string) => Object;
   +getDefaultEventTypes?: () => Array<string>;
   +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
-  +sendAccessibilityEvent?: (reactTag: ?number, eventType: number) => void;
+  +sendAccessibilityEvent?: (reactTag: number, eventType: number) => void;
   +showPopupMenu?: (
-    reactTag: ?number,
+    reactTag: number,
     items: Array<string>,
     error: (error: Object) => void,
     success: (event: string, selected?: number) => void
   ) => void;
   +dismissPopupMenu?: () => void;
   +lazilyLoadView?: (name: string) => Object;
-  +focus?: (reactTag: ?number) => void;
-  +blur?: (reactTag: ?number) => void;
+  +focus?: (reactTag: number) => void;
+  +blur?: (reactTag: number) => void;
 }
 declare export default Spec;
 "

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7857,7 +7857,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
     addAtIndices: Array<number>,
     removeAtIndices: Array<number>
   ) => void;
-  +getConstantsForViewManager?: (viewManagerName: string) => Object;
+  +getConstantsForViewManager?: (viewManagerName: string) => ?Object;
   +getDefaultEventTypes?: () => Array<string>;
   +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
   +sendAccessibilityEvent?: (reactTag: number, eventType: number) => void;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7719,6 +7719,12 @@ export interface Spec {
     commandName: string,
     args: Array<mixed>
   ) => void;
+  +findNodeAtPoint: (
+    node: Node,
+    locationX: number,
+    locationY: number,
+    callback: (instanceHandle: ?InternalInstanceHandle) => void
+  ) => void;
   +getParentNode: (node: Node) => ?InternalInstanceHandle;
   +getChildNodes: (node: Node) => $ReadOnlyArray<InternalInstanceHandle>;
   +isConnected: (node: Node) => boolean;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2051,6 +2051,53 @@ declare export default ?Spec;
 "
 `;
 
+exports[`public API should not change unintentionally Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.android.js 1`] = `
+"export type PopupMenuAndroidInstance = {
+  +show: () => void,
+};
+type Props = {
+  menuItems: $ReadOnlyArray<string>,
+  onSelectionChange: (number) => void,
+  children: React.Node,
+  instanceRef: RefObject<?PopupMenuAndroidInstance>,
+};
+declare export default function PopupMenuAndroid(Props): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.js 1`] = `
+"export type PopupMenuAndroidInstance = {
+  +show: () => void,
+};
+type Props = {
+  menuItems: $ReadOnlyArray<string>,
+  onSelectionChange: (number) => void,
+  children: Node,
+  instanceRef: RefObject<?PopupMenuAndroidInstance>,
+};
+declare function PopupMenuAndroid(props: Props): Node;
+declare export default typeof PopupMenuAndroid;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/PopupMenuAndroid/PopupMenuAndroidNativeComponent.js 1`] = `
+"type PopupMenuSelectionEvent = $ReadOnly<{
+  item: Int32,
+}>;
+type NativeProps = $ReadOnly<{
+  ...ViewProps,
+  menuItems?: ?$ReadOnlyArray<string>,
+  onSelectionChange?: DirectEventHandler<PopupMenuSelectionEvent>,
+}>;
+type ComponentType = HostComponent<NativeProps>;
+interface NativeCommands {
+  +show: (viewRef: React.ElementRef<ComponentType>) => void;
+}
+declare export const Commands: NativeCommands;
+declare export default HostComponent<NativeProps>;
+"
+`;
+
 exports[`public API should not change unintentionally Libraries/Components/Pressable/Pressable.js 1`] = `
 "type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, \\"style\\">;
 export type StateCallbackType = $ReadOnly<{|
@@ -10659,6 +10706,7 @@ declare module.exports: {
   get ImageBackground(): ImageBackground,
   get InputAccessoryView(): InputAccessoryView,
   get KeyboardAvoidingView(): KeyboardAvoidingView,
+  get PopupMenuAndroid(): PopupMenuAndroid,
   get Modal(): Modal,
   get Pressable(): Pressable,
   get ProgressBarAndroid(): ProgressBarAndroid,

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -130,6 +130,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   }
 
   // Step 3: check if the module has been registered
+  // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
   NSArray<Class> *registeredModules = RCTGetModuleClasses();
   NSMutableDictionary<NSString *, Class> *supportedLegacyViewComponents =
       [RCTLegacyViewManagerInteropComponentView _supportedLegacyViewComponents];

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -135,6 +135,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   }
 
   // Fallback 3: Try to use Paper Interop.
+  // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
   if (RCTFabricInteropLayerEnabled() && [RCTLegacyViewManagerInteropComponentView isSupported:componentNameString]) {
     RCTLogNewArchitectureValidation(
         RCTNotAllowedInBridgeless,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -47,6 +47,7 @@ import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.views.drawer.ReactDrawerLayoutManager;
 import com.facebook.react.views.image.ReactImageManager;
 import com.facebook.react.views.modal.ReactModalHostManager;
+import com.facebook.react.views.popupmenu.ReactPopupMenuManager;
 import com.facebook.react.views.progressbar.ReactProgressBarViewManager;
 import com.facebook.react.views.scroll.ReactHorizontalScrollContainerViewManager;
 import com.facebook.react.views.scroll.ReactHorizontalScrollViewManager;
@@ -170,6 +171,7 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
     viewManagers.add(new ReactScrollViewManager());
     viewManagers.add(new ReactSwitchManager());
     viewManagers.add(new SwipeRefreshLayoutManager());
+    viewManagers.add(new ReactPopupMenuManager());
 
     // Native equivalents
     viewManagers.add(new FrescoBasedReactTextInlineImageViewManager());
@@ -211,6 +213,7 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
       appendMap(viewManagers, ReactSwitchManager.REACT_CLASS, ReactSwitchManager::new);
       appendMap(
           viewManagers, SwipeRefreshLayoutManager.REACT_CLASS, SwipeRefreshLayoutManager::new);
+      appendMap(viewManagers, ReactPopupMenuManager.REACT_CLASS, ReactPopupMenuManager::new);
       appendMap(
           viewManagers,
           FrescoBasedReactTextInlineImageViewManager.REACT_CLASS,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -247,9 +247,8 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
-  public @Nullable WritableMap getConstantsForViewManager(@Nullable String viewManagerName) {
-    ViewManager targetView =
-        viewManagerName != null ? mUIImplementation.resolveViewManager(viewManagerName) : null;
+  public @Nullable WritableMap getConstantsForViewManager(String viewManagerName) {
+    ViewManager targetView = mUIImplementation.resolveViewManager(viewManagerName);
     if (targetView == null) {
       return null;
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/popupmenu/PopupMenuSelectionEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/popupmenu/PopupMenuSelectionEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.popupmenu;
+
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/** Event emitted by a ReactSliderManager when user changes slider position. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
+public class PopupMenuSelectionEvent extends Event<PopupMenuSelectionEvent> {
+
+  public static final String EVENT_NAME = "topSelectionChange";
+
+  private final int mItem;
+
+  public PopupMenuSelectionEvent(int surfaceId, int viewId, int item) {
+    super(surfaceId, viewId);
+    mItem = item;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  public int getItem() {
+    return mItem;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    eventData.putDouble("item", getItem());
+    return eventData;
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/popupmenu/ReactPopupMenuContainer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/popupmenu/ReactPopupMenuContainer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.popupmenu;
+
+import android.content.Context;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.PopupMenu;
+import androidx.annotation.Nullable;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.events.EventDispatcher;
+
+public class ReactPopupMenuContainer extends FrameLayout {
+
+  private @Nullable ReadableArray mMenuItems;
+
+  public ReactPopupMenuContainer(Context context) {
+    super(context);
+  }
+
+  public void setMenuItems(@Nullable ReadableArray menuItems) {
+    mMenuItems = menuItems;
+  }
+
+  public void showPopupMenu() {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
+      View view = this.getChildAt(0);
+
+      PopupMenu popupMenu = new PopupMenu(getContext(), view);
+      Menu menu = null;
+      menu = popupMenu.getMenu();
+      if (mMenuItems != null) {
+        for (int i = 0; i < mMenuItems.size(); i++) {
+          menu.add(Menu.NONE, Menu.NONE, i, mMenuItems.getString(i));
+        }
+      }
+
+      popupMenu.setOnMenuItemClickListener(
+          new PopupMenu.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem menuItem) {
+              ReactContext reactContext = (ReactContext) getContext();
+              EventDispatcher eventDispatcher =
+                  UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
+              if (eventDispatcher != null) {
+                eventDispatcher.dispatchEvent(
+                    new PopupMenuSelectionEvent(
+                        UIManagerHelper.getSurfaceId(reactContext), getId(), menuItem.getOrder()));
+              }
+              return true;
+            }
+          });
+
+      popupMenu.show();
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/popupmenu/ReactPopupMenuManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/popupmenu/ReactPopupMenuManager.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.popupmenu;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.viewmanagers.AndroidPopupMenuManagerInterface;
+
+@ReactModule(name = ReactPopupMenuManager.REACT_CLASS)
+public class ReactPopupMenuManager extends ViewGroupManager<ReactPopupMenuContainer>
+    implements AndroidPopupMenuManagerInterface<ReactPopupMenuContainer> {
+
+  public static final String REACT_CLASS = "AndroidPopupMenu";
+
+  public ReactPopupMenuManager() {}
+
+  @Override
+  public ReactPopupMenuContainer createViewInstance(ThemedReactContext context) {
+    return new ReactPopupMenuContainer(context);
+  }
+
+  @ReactProp(name = "menuItems")
+  public void setMenuItems(ReactPopupMenuContainer view, @Nullable ReadableArray items) {
+    view.setMenuItems(items);
+  }
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
+
+  @Override
+  public void receiveCommand(
+      @NonNull ReactPopupMenuContainer view, String commandId, @Nullable ReadableArray args) {
+    switch (commandId) {
+      case "show":
+        show(view);
+        break;
+    }
+  }
+
+  @Override
+  public void show(ReactPopupMenuContainer popupMenu) {
+    popupMenu.showPopupMenu();
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
@@ -67,6 +67,8 @@ CoreComponentsRegistry::sharedProviderRegistry() {
                           AndroidDrawerLayoutComponentDescriptor>());
     providerRegistry->add(concreteComponentDescriptorProvider<
                           DebuggingOverlayComponentDescriptor>());
+    providerRegistry->add(concreteComponentDescriptorProvider<
+                          AndroidPopupMenuComponentDescriptor>());
 
     return providerRegistry;
   }();

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -231,6 +231,7 @@ static Class getFallbackClassFromName(const char *name)
     }
 
     if (RCTTurboModuleInteropEnabled()) {
+      // TODO(T174674274): Implement lazy loading of legacy modules in the new architecture.
       NSMutableDictionary<NSString *, id<RCTBridgeModule>> *legacyInitializedModules = [NSMutableDictionary new];
 
       if ([_delegate respondsToSelector:@selector(extraModulesForBridge:)]) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -326,6 +326,12 @@ jsi::Value UIManagerBinding::get(
               arguments[3].getObject(runtime).getFunction(runtime);
           auto targetNode =
               uiManager->findNodeAtPoint(node, Point{locationX, locationY});
+
+          if (!targetNode) {
+            onSuccessFunction.call(runtime, jsi::Value::null());
+            return jsi::Value::undefined();
+          }
+
           auto& eventTarget = targetNode->getEventEmitter()->eventTarget_;
 
           EventEmitter::DispatchMutex().lock();

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -27,6 +27,7 @@ import typeof Clipboard from './Libraries/Components/Clipboard/Clipboard';
 import typeof DrawerLayoutAndroid from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
 import typeof Keyboard from './Libraries/Components/Keyboard/Keyboard';
 import typeof KeyboardAvoidingView from './Libraries/Components/Keyboard/KeyboardAvoidingView';
+import typeof PopupMenuAndroid from './Libraries/Components/PopupMenuAndroid/PopupMenuAndroid';
 import typeof Pressable from './Libraries/Components/Pressable/Pressable';
 import typeof ProgressBarAndroid from './Libraries/Components/ProgressBarAndroid/ProgressBarAndroid';
 import typeof RefreshControl from './Libraries/Components/RefreshControl/RefreshControl';
@@ -127,6 +128,10 @@ module.exports = {
   },
   get KeyboardAvoidingView(): KeyboardAvoidingView {
     return require('./Libraries/Components/Keyboard/KeyboardAvoidingView')
+      .default;
+  },
+  get PopupMenuAndroid(): PopupMenuAndroid {
+    return require('./Libraries/Components/PopupMenuAndroid/PopupMenuAndroid')
       .default;
   },
   get Modal(): Modal {

--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -12,6 +12,7 @@ import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 import ReactNative from '../../../react-native/Libraries/Renderer/shims/ReactNative';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {UIManager, requireNativeComponent} from 'react-native';
 
@@ -44,7 +45,7 @@ export function callNativeMethodToChangeBackgroundColor(
     return;
   }
   UIManager.dispatchViewManagerCommand(
-    ReactNative.findNodeHandle(viewRef),
+    nullthrows(ReactNative.findNodeHandle(viewRef)),
     UIManager.getViewManagerConfig(
       'RNTMyLegacyNativeView',
     ).Commands.changeBackgroundColor.toString(),
@@ -61,7 +62,7 @@ export function callNativeMethodToAddOverlays(
     return;
   }
   UIManager.dispatchViewManagerCommand(
-    ReactNative.findNodeHandle(viewRef),
+    nullthrows(ReactNative.findNodeHandle(viewRef)),
     UIManager.getViewManagerConfig(
       'RNTMyLegacyNativeView',
     ).Commands.addOverlays.toString(),
@@ -77,7 +78,7 @@ export function callNativeMethodToRemoveOverlays(
     return;
   }
   UIManager.dispatchViewManagerCommand(
-    ReactNative.findNodeHandle(viewRef),
+    nullthrows(ReactNative.findNodeHandle(viewRef)),
     UIManager.getViewManagerConfig(
       'RNTMyLegacyNativeView',
     ).Commands.removeOverlays.toString(),

--- a/packages/rn-tester/js/examples/PopupMenuAndroid/PopupMenuAndroidExample.js
+++ b/packages/rn-tester/js/examples/PopupMenuAndroid/PopupMenuAndroidExample.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import type {Node} from 'react';
+import type {PopupMenuAndroidInstance} from 'react-native/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid';
+
+import * as React from 'react';
+import {Button, PopupMenuAndroid, StyleSheet, Text, View} from 'react-native';
+
+type Fruit = 'Apple' | 'Pear' | 'Banana' | 'Orange' | 'Kiwi';
+
+const PopupMenu = () => {
+  const popupRef = React.useRef<?PopupMenuAndroidInstance>();
+  const [fruit, setFruit] = React.useState<?Fruit>();
+  const fruits: Array<Fruit> = ['Apple', 'Pear', 'Banana', 'Orange', 'Kiwi'];
+  const items = fruits.map(item => ({
+    label: item,
+    onPress: () => {
+      setFruit(item);
+    },
+  }));
+
+  return (
+    <View style={styles.container}>
+      {fruit ? <Text>Selected {fruit}</Text> : null}
+      <PopupMenuAndroid
+        instanceRef={popupRef}
+        menuItems={items.map(({label}) => label)}
+        onSelectionChange={selection => items[selection].onPress()}>
+        <Button
+          title="Show PopupMenu!"
+          onPress={() => {
+            popupRef.current?.show();
+          }}
+        />
+      </PopupMenuAndroid>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+});
+
+exports.title = 'PopupMenuAndroid';
+// TODO(T175446328): Publish oss documentation for PopupMenuAndroid
+exports.description = 'PopupMenuAndroid Example';
+exports.examples = [
+  {
+    title: 'PopupMenu Example',
+    render(): Node {
+      return <PopupMenu />;
+    },
+  },
+];

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -21,6 +21,11 @@ const Components: Array<RNTesterModuleInfo> = [
     module: require('../examples/DrawerLayoutAndroid/DrawerLayoutAndroidExample'),
   },
   {
+    key: 'PopupMenuAndroidExample',
+    category: 'UI',
+    module: require('../examples/PopupMenuAndroid/PopupMenuAndroidExample'),
+  },
+  {
     key: 'ActivityIndicatorExample',
     category: 'UI',
     module: require('../examples/ActivityIndicator/ActivityIndicatorExample'),


### PR DESCRIPTION
Summary:
In React Native 0.75, we will remove UIManager.showPopupMenu(), UIManager.dismissPopupMenu().

To replace that API, we are introducing this <PopupMenuAndroid> component. This component works in both Fabric and Paper!

For the usage, please see PopupMenuAndroidExample.js.

Changelog: [Android][Added] - Introduce PopupMenuAndroid to replace UIManager.showPopupMenu()

Reviewed By: mdvacca

Differential Revision: D52712758

