### PR TITLE
'[skip ci] [RN][JS] BridgelessUIManager: Finish findSubviewIn

### DIFF
--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -41,7 +41,7 @@ const getUIManagerConstantsCached = (function () {
   };
 })();
 
-const getConstantsForViewManager: ?(viewManagerName: string) => Object =
+const getConstantsForViewManager: ?(viewManagerName: string) => ?Object =
   global.RN$LegacyInterop_UIManager_getConstantsForViewManager;
 
 const getDefaultEventTypes: ?() => Object =
@@ -157,7 +157,7 @@ const UIManagerJSUnusedAPIs = {
 
 const UIManagerJSPlatformAPIs = Platform.select({
   android: {
-    getConstantsForViewManager: (viewManagerName: string): Object => {
+    getConstantsForViewManager: (viewManagerName: string): ?Object => {
       if (getConstantsForViewManager) {
         return getConstantsForViewManager(viewManagerName);
       }

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -245,6 +245,11 @@ const UIManagerJSPlatformAPIs = Platform.select({
     },
   },
   ios: {
+    /**
+     * TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
+     *
+     * Leave this unimplemented until we implement lazy loading of legacy modules and view managers in the new architecture.
+     */
     lazilyLoadView: (name: string): Object => {
       raiseSoftError('lazilyLoadView');
       return {};

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -313,7 +313,45 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
       height: number,
     ) => void,
   ): void => {
-    raiseSoftError('findSubviewIn');
+    const FabricUIManager = nullthrows(getFabricUIManager());
+    const shadowNode = FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
+
+    if (!shadowNode) {
+      console.error(
+        `findSubviewIn() noop: Cannot find view with reactTag ${reactTag}`,
+      );
+      return;
+    }
+
+    FabricUIManager.findNodeAtPoint(
+      shadowNode,
+      point[0],
+      point[1],
+      function (internalInstanceHandle) {
+        if (internalInstanceHandle == null) {
+          console.error('findSubviewIn(): Cannot find node at point');
+          return;
+        }
+
+        let instanceHandle: Object = internalInstanceHandle;
+        let node = instanceHandle.stateNode.node;
+
+        if (!node) {
+          console.error('findSubviewIn(): Cannot find node at point');
+          return;
+        }
+
+        let nativeViewTag = (instanceHandle.stateNode.canonical
+          .nativeTag: number);
+
+        FabricUIManager.measure(
+          node,
+          function (x, y, width, height, pageX, pageY) {
+            callback(nativeViewTag, pageX, pageY, width, height);
+          },
+        );
+      },
+    );
   },
   viewIsDescendantOf: (
     reactTag: number,

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -65,7 +65,7 @@ const getDefaultEventTypesCached = (function () {
  */
 const UIManagerJSOverridenAPIs = {
   measure: (
-    reactTag: ?number,
+    reactTag: number,
     callback: (
       left: number,
       top: number,
@@ -78,14 +78,14 @@ const UIManagerJSOverridenAPIs = {
     raiseSoftError('measure');
   },
   measureInWindow: (
-    reactTag: ?number,
+    reactTag: number,
     callback: (x: number, y: number, width: number, height: number) => void,
   ): void => {
     raiseSoftError('measureInWindow');
   },
   measureLayout: (
-    reactTag: ?number,
-    ancestorReactTag: ?number,
+    reactTag: number,
+    ancestorReactTag: number,
     errorCallback: (error: Object) => void,
     callback: (
       left: number,
@@ -97,7 +97,7 @@ const UIManagerJSOverridenAPIs = {
     raiseSoftError('measureLayout');
   },
   measureLayoutRelativeToParent: (
-    reactTag: ?number,
+    reactTag: number,
     errorCallback: (error: Object) => void,
     callback: (
       left: number,
@@ -109,7 +109,7 @@ const UIManagerJSOverridenAPIs = {
     raiseSoftError('measureLayoutRelativeToParent');
   },
   dispatchViewManagerCommand: (
-    reactTag: ?number,
+    reactTag: number,
     commandID: number,
     commandArgs: ?Array<string | number | boolean>,
   ): void => {
@@ -124,7 +124,7 @@ const UIManagerJSOverridenAPIs = {
  */
 const UIManagerJSUnusedAPIs = {
   createView: (
-    reactTag: ?number,
+    reactTag: number,
     viewName: string,
     rootTag: RootTag,
     props: Object,
@@ -134,11 +134,11 @@ const UIManagerJSUnusedAPIs = {
   updateView: (reactTag: number, viewName: string, props: Object): void => {
     raiseSoftError('updateView');
   },
-  setChildren: (containerTag: ?number, reactTags: Array<number>): void => {
+  setChildren: (containerTag: number, reactTags: Array<number>): void => {
     raiseSoftError('setChildren');
   },
   manageChildren: (
-    containerTag: ?number,
+    containerTag: number,
     moveFromIndices: Array<number>,
     moveToIndices: Array<number>,
     addChildReactTags: Array<number>,
@@ -147,7 +147,7 @@ const UIManagerJSUnusedAPIs = {
   ): void => {
     raiseSoftError('manageChildren');
   },
-  setJSResponder: (reactTag: ?number, blockNativeResponder: boolean): void => {
+  setJSResponder: (reactTag: number, blockNativeResponder: boolean): void => {
     raiseSoftError('setJSResponder');
   },
   clearJSResponder: (): void => {
@@ -185,16 +185,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
         );
       }
     },
-    sendAccessibilityEvent: (reactTag: ?number, eventType: number): void => {
-      if (reactTag == null) {
-        console.error(
-          `sendAccessibilityEvent() dropping event: Cannot be called with ${String(
-            reactTag,
-          )} reactTag`,
-        );
-        return;
-      }
-
+    sendAccessibilityEvent: (reactTag: number, eventType: number): void => {
       // Keep this in sync with java:FabricUIManager.sendAccessibilityEventFromJS
       // and legacySendAccessibilityEvent.android.js
       const AccessibilityEvent = {
@@ -233,7 +224,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
       FabricUIManager.sendAccessibilityEvent(shadowNode, eventName);
     },
     showPopupMenu: (
-      reactTag: ?number,
+      reactTag: number,
       items: Array<string>,
       error: (error: Object) => void,
       success: (event: string, selected?: number) => void,
@@ -254,14 +245,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
       raiseSoftError('lazilyLoadView');
       return {};
     },
-    focus: (reactTag: ?number): void => {
-      if (reactTag == null) {
-        console.error(
-          `focus() noop: Cannot be called with ${String(reactTag)} reactTag`,
-        );
-        return;
-      }
-
+    focus: (reactTag: number): void => {
       const FabricUIManager = nullthrows(getFabricUIManager());
       const shadowNode =
         FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
@@ -271,14 +255,7 @@ const UIManagerJSPlatformAPIs = Platform.select({
       }
       FabricUIManager.dispatchCommand(shadowNode, 'focus', []);
     },
-    blur: (reactTag: ?number): void => {
-      if (reactTag == null) {
-        console.error(
-          `blur() noop: Cannot be called with ${String(reactTag)} reactTag`,
-        );
-        return;
-      }
-
+    blur: (reactTag: number): void => {
       const FabricUIManager = nullthrows(getFabricUIManager());
       const shadowNode =
         FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
@@ -326,7 +303,7 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
     }
   },
   findSubviewIn: (
-    reactTag: ?number,
+    reactTag: number,
     point: Array<number>,
     callback: (
       nativeViewTag: number,
@@ -339,33 +316,15 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
     raiseSoftError('findSubviewIn');
   },
   viewIsDescendantOf: (
-    reactTag: ?number,
-    ancestorReactTag: ?number,
+    reactTag: number,
+    ancestorReactTag: number,
     callback: (result: Array<boolean>) => void,
   ): void => {
-    if (reactTag == null) {
-      console.error(
-        `viewIsDescendantOf() noop: Cannot be called with ${String(
-          reactTag,
-        )} reactTag`,
-      );
-      return;
-    }
-
     const FabricUIManager = nullthrows(getFabricUIManager());
     const shadowNode = FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
     if (!shadowNode) {
       console.error(
         `viewIsDescendantOf() noop: Cannot find view with reactTag ${reactTag}`,
-      );
-      return;
-    }
-
-    if (ancestorReactTag == null) {
-      console.error(
-        `viewIsDescendantOf() noop: Cannot be called with ${String(
-          ancestorReactTag,
-        )} ancestorReactTag`,
       );
       return;
     }

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -64,6 +64,12 @@ export interface Spec {
     commandName: string,
     args: Array<mixed>,
   ) => void;
+  +findNodeAtPoint: (
+    node: Node,
+    locationX: number,
+    locationY: number,
+    callback: (instanceHandle: ?InternalInstanceHandle) => void,
+  ) => void;
 
   /**
    * Support methods for the DOM-compatible APIs.

--- a/packages/react-native/Libraries/ReactNative/NativeUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/NativeUIManager.js
@@ -16,14 +16,14 @@ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 export interface Spec extends TurboModule {
   +getConstants: () => Object;
   +createView: (
-    reactTag: ?number,
+    reactTag: number,
     viewName: string,
     rootTag: RootTag,
     props: Object,
   ) => void;
   +updateView: (reactTag: number, viewName: string, props: Object) => void;
   +findSubviewIn: (
-    reactTag: ?number,
+    reactTag: number,
     point: Array<number>,
     callback: (
       nativeViewTag: number,
@@ -34,8 +34,8 @@ export interface Spec extends TurboModule {
     ) => void,
   ) => void;
   +dispatchViewManagerCommand: (
-    reactTag: ?number,
-    commandID: number,
+    reactTag: number,
+    commandID: number, // number || string
     commandArgs: ?Array<any>,
   ) => void;
   +measure: (
@@ -54,8 +54,8 @@ export interface Spec extends TurboModule {
     callback: (x: number, y: number, width: number, height: number) => void,
   ) => void;
   +viewIsDescendantOf: (
-    reactTag: ?number,
-    ancestorReactTag: ?number,
+    reactTag: number,
+    ancestorReactTag: number,
     callback: (result: Array<boolean>) => void,
   ) => void;
   +measureLayout: (
@@ -79,16 +79,16 @@ export interface Spec extends TurboModule {
       height: number,
     ) => void,
   ) => void;
-  +setJSResponder: (reactTag: ?number, blockNativeResponder: boolean) => void;
+  +setJSResponder: (reactTag: number, blockNativeResponder: boolean) => void;
   +clearJSResponder: () => void;
   +configureNextLayoutAnimation: (
     config: Object,
     callback: () => void, // check what is returned here
     errorCallback: (error: Object) => void,
   ) => void;
-  +setChildren: (containerTag: ?number, reactTags: Array<number>) => void;
+  +setChildren: (containerTag: number, reactTags: Array<number>) => void;
   +manageChildren: (
-    containerTag: ?number,
+    containerTag: number,
     moveFromIndices: Array<number>,
     moveToIndices: Array<number>,
     addChildReactTags: Array<number>,
@@ -100,9 +100,9 @@ export interface Spec extends TurboModule {
   +getConstantsForViewManager?: (viewManagerName: string) => Object;
   +getDefaultEventTypes?: () => Array<string>;
   +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
-  +sendAccessibilityEvent?: (reactTag: ?number, eventType: number) => void;
+  +sendAccessibilityEvent?: (reactTag: number, eventType: number) => void;
   +showPopupMenu?: (
-    reactTag: ?number,
+    reactTag: number,
     items: Array<string>,
     error: (error: Object) => void,
     success: (event: string, selected?: number) => void,
@@ -111,8 +111,8 @@ export interface Spec extends TurboModule {
 
   // ios only
   +lazilyLoadView?: (name: string) => Object; // revisit return
-  +focus?: (reactTag: ?number) => void;
-  +blur?: (reactTag: ?number) => void;
+  +focus?: (reactTag: number) => void;
+  +blur?: (reactTag: number) => void;
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>('UIManager'): Spec);

--- a/packages/react-native/Libraries/ReactNative/NativeUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/NativeUIManager.js
@@ -97,7 +97,7 @@ export interface Spec extends TurboModule {
   ) => void;
 
   // Android only
-  +getConstantsForViewManager?: (viewManagerName: string) => Object;
+  +getConstantsForViewManager?: (viewManagerName: string) => ?Object;
   +getDefaultEventTypes?: () => Array<string>;
   +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
   +sendAccessibilityEvent?: (reactTag: number, eventType: number) => void;

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -83,7 +83,7 @@ function getViewManagerConfig(viewManagerName: string): any {
 const UIManagerJS: UIManagerJSInterface = {
   ...NativeUIManager,
   createView(
-    reactTag: ?number,
+    reactTag: number,
     viewName: string,
     rootTag: RootTag,
     props: Object,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7788,14 +7788,14 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
 "export interface Spec extends TurboModule {
   +getConstants: () => Object;
   +createView: (
-    reactTag: ?number,
+    reactTag: number,
     viewName: string,
     rootTag: RootTag,
     props: Object
   ) => void;
   +updateView: (reactTag: number, viewName: string, props: Object) => void;
   +findSubviewIn: (
-    reactTag: ?number,
+    reactTag: number,
     point: Array<number>,
     callback: (
       nativeViewTag: number,
@@ -7806,7 +7806,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
     ) => void
   ) => void;
   +dispatchViewManagerCommand: (
-    reactTag: ?number,
+    reactTag: number,
     commandID: number,
     commandArgs: ?Array<any>
   ) => void;
@@ -7826,8 +7826,8 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
     callback: (x: number, y: number, width: number, height: number) => void
   ) => void;
   +viewIsDescendantOf: (
-    reactTag: ?number,
-    ancestorReactTag: ?number,
+    reactTag: number,
+    ancestorReactTag: number,
     callback: (result: Array<boolean>) => void
   ) => void;
   +measureLayout: (
@@ -7841,16 +7841,16 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
     errorCallback: (error: Object) => void,
     callback: (left: number, top: number, width: number, height: number) => void
   ) => void;
-  +setJSResponder: (reactTag: ?number, blockNativeResponder: boolean) => void;
+  +setJSResponder: (reactTag: number, blockNativeResponder: boolean) => void;
   +clearJSResponder: () => void;
   +configureNextLayoutAnimation: (
     config: Object,
     callback: () => void,
     errorCallback: (error: Object) => void
   ) => void;
-  +setChildren: (containerTag: ?number, reactTags: Array<number>) => void;
+  +setChildren: (containerTag: number, reactTags: Array<number>) => void;
   +manageChildren: (
-    containerTag: ?number,
+    containerTag: number,
     moveFromIndices: Array<number>,
     moveToIndices: Array<number>,
     addChildReactTags: Array<number>,
@@ -7860,17 +7860,17 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
   +getConstantsForViewManager?: (viewManagerName: string) => Object;
   +getDefaultEventTypes?: () => Array<string>;
   +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
-  +sendAccessibilityEvent?: (reactTag: ?number, eventType: number) => void;
+  +sendAccessibilityEvent?: (reactTag: number, eventType: number) => void;
   +showPopupMenu?: (
-    reactTag: ?number,
+    reactTag: number,
     items: Array<string>,
     error: (error: Object) => void,
     success: (event: string, selected?: number) => void
   ) => void;
   +dismissPopupMenu?: () => void;
   +lazilyLoadView?: (name: string) => Object;
-  +focus?: (reactTag: ?number) => void;
-  +blur?: (reactTag: ?number) => void;
+  +focus?: (reactTag: number) => void;
+  +blur?: (reactTag: number) => void;
 }
 declare export default Spec;
 "

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7857,7 +7857,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Nati
     addAtIndices: Array<number>,
     removeAtIndices: Array<number>
   ) => void;
-  +getConstantsForViewManager?: (viewManagerName: string) => Object;
+  +getConstantsForViewManager?: (viewManagerName: string) => ?Object;
   +getDefaultEventTypes?: () => Array<string>;
   +setLayoutAnimationEnabledExperimental?: (enabled: boolean) => void;
   +sendAccessibilityEvent?: (reactTag: number, eventType: number) => void;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7719,6 +7719,12 @@ export interface Spec {
     commandName: string,
     args: Array<mixed>
   ) => void;
+  +findNodeAtPoint: (
+    node: Node,
+    locationX: number,
+    locationY: number,
+    callback: (instanceHandle: ?InternalInstanceHandle) => void
+  ) => void;
   +getParentNode: (node: Node) => ?InternalInstanceHandle;
   +getChildNodes: (node: Node) => $ReadOnlyArray<InternalInstanceHandle>;
   +isConnected: (node: Node) => boolean;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -130,6 +130,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   }
 
   // Step 3: check if the module has been registered
+  // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
   NSArray<Class> *registeredModules = RCTGetModuleClasses();
   NSMutableDictionary<NSString *, Class> *supportedLegacyViewComponents =
       [RCTLegacyViewManagerInteropComponentView _supportedLegacyViewComponents];

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -135,6 +135,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   }
 
   // Fallback 3: Try to use Paper Interop.
+  // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
   if (RCTFabricInteropLayerEnabled() && [RCTLegacyViewManagerInteropComponentView isSupported:componentNameString]) {
     RCTLogNewArchitectureValidation(
         RCTNotAllowedInBridgeless,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -247,9 +247,8 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
-  public @Nullable WritableMap getConstantsForViewManager(@Nullable String viewManagerName) {
-    ViewManager targetView =
-        viewManagerName != null ? mUIImplementation.resolveViewManager(viewManagerName) : null;
+  public @Nullable WritableMap getConstantsForViewManager(String viewManagerName) {
+    ViewManager targetView = mUIImplementation.resolveViewManager(viewManagerName);
     if (targetView == null) {
       return null;
     }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -231,6 +231,7 @@ static Class getFallbackClassFromName(const char *name)
     }
 
     if (RCTTurboModuleInteropEnabled()) {
+      // TODO(T174674274): Implement lazy loading of legacy modules in the new architecture.
       NSMutableDictionary<NSString *, id<RCTBridgeModule>> *legacyInitializedModules = [NSMutableDictionary new];
 
       if ([_delegate respondsToSelector:@selector(extraModulesForBridge:)]) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -326,6 +326,12 @@ jsi::Value UIManagerBinding::get(
               arguments[3].getObject(runtime).getFunction(runtime);
           auto targetNode =
               uiManager->findNodeAtPoint(node, Point{locationX, locationY});
+
+          if (!targetNode) {
+            onSuccessFunction.call(runtime, jsi::Value::null());
+            return jsi::Value::undefined();
+          }
+
           auto& eventTarget = targetNode->getEventEmitter()->eventTarget_;
 
           EventEmitter::DispatchMutex().lock();

--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -12,6 +12,7 @@ import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 import ReactNative from '../../../react-native/Libraries/Renderer/shims/ReactNative';
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {UIManager, requireNativeComponent} from 'react-native';
 
@@ -44,7 +45,7 @@ export function callNativeMethodToChangeBackgroundColor(
     return;
   }
   UIManager.dispatchViewManagerCommand(
-    ReactNative.findNodeHandle(viewRef),
+    nullthrows(ReactNative.findNodeHandle(viewRef)),
     UIManager.getViewManagerConfig(
       'RNTMyLegacyNativeView',
     ).Commands.changeBackgroundColor.toString(),
@@ -61,7 +62,7 @@ export function callNativeMethodToAddOverlays(
     return;
   }
   UIManager.dispatchViewManagerCommand(
-    ReactNative.findNodeHandle(viewRef),
+    nullthrows(ReactNative.findNodeHandle(viewRef)),
     UIManager.getViewManagerConfig(
       'RNTMyLegacyNativeView',
     ).Commands.addOverlays.toString(),
@@ -77,7 +78,7 @@ export function callNativeMethodToRemoveOverlays(
     return;
   }
   UIManager.dispatchViewManagerCommand(
-    ReactNative.findNodeHandle(viewRef),
+    nullthrows(ReactNative.findNodeHandle(viewRef)),
     UIManager.getViewManagerConfig(
       'RNTMyLegacyNativeView',
     ).Commands.removeOverlays.toString(),


### PR DESCRIPTION
Summary:
This is an implementation of UIManagerModule.findSubviewIn, based on the [Fabric renderer](https://github.com/facebook/react-fbsource-import/blob/772935f7320f37a14ef06a9616dd43fa090d54a3/compiled-rn/facebook-fbsource/xplat/js/react-native-github/Libraries/Renderer/implementations/ReactFabric-dev.fb.js#L28899-L28953).

UIManager.findSubviewIn(viewTag, point, callback)

The point is relative to viewTag'\''s parent'\''s (0, 0).

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D52642884

