### PR TITLE
Call super.onRequestPermissionsResult in ReactActivity

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -114,6 +114,7 @@ public abstract class ReactActivity extends AppCompatActivity
   @Override
   public void onRequestPermissionsResult(
       int requestCode, @NotNull String[] permissions, @NotNull int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     mDelegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 


### PR DESCRIPTION
## Summary:

This change allows activities to handle onRequestPermissionsResult callbacks (eg: registerForActivityResult)

## Changelog:

[Android][Changed] - Call super.onRequestPermissionsResult in ReactActivity's onRequestPermissionsResult()

## Test Plan:

**Without super.onRequestPermissionsResult() call**

![before](https://github.com/facebook/react-native/assets/8672580/553ff597-c077-4831-a4d3-51846a253536)

**With super.onRequestPermissionsResult() call**

![after](https://github.com/facebook/react-native/assets/8672580/c7d588d2-5846-4083-a02f-59b5f915442c)
