### PR TITLE
react-native: Bridging. Add conversion functions to std::array<T, N> and std::pair<T1, T2>

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/Array.h
+++ b/packages/react-native/ReactCommon/react/bridging/Array.h
@@ -64,11 +64,35 @@ struct BridgingDynamic {
 
 template <typename T, size_t N>
 struct Bridging<std::array<T, N>>
-    : array_detail::BridgingStatic<std::array<T, N>, N> {};
+    : array_detail::BridgingStatic<std::array<T, N>, N> {
+  static std::array<T, N> fromJs(
+      facebook::jsi::Runtime& rt,
+      const jsi::Array& array,
+      const std::shared_ptr<CallInvoker>& jsInvoker) {
+    size_t length = array.length(rt);
+
+    std::array<T, N> result;
+    for (size_t i = 0; i < length; i++) {
+      result[i] =
+          bridging::fromJs<T>(rt, array.getValueAtIndex(rt, i), jsInvoker);
+    }
+
+    return result;
+  }
+};
 
 template <typename T1, typename T2>
 struct Bridging<std::pair<T1, T2>>
-    : array_detail::BridgingStatic<std::pair<T1, T2>, 2> {};
+    : array_detail::BridgingStatic<std::pair<T1, T2>, 2> {
+  static std::pair<T1, T1> fromJs(
+      facebook::jsi::Runtime& rt,
+      const jsi::Array& array,
+      const std::shared_ptr<CallInvoker>& jsInvoker) {
+    return std::make_pair(
+        bridging::fromJs<T1>(rt, array.getValueAtIndex(rt, 0), jsInvoker),
+        bridging::fromJs<T2>(rt, array.getValueAtIndex(rt, 1), jsInvoker));
+  }
+};
 
 template <typename... Types>
 struct Bridging<std::tuple<Types...>>

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -158,6 +158,13 @@ TEST_F(BridgingTest, arrayTest) {
 
   EXPECT_EQ(
       vec, bridging::fromJs<std::vector<std::string>>(rt, array, invoker));
+  auto arr = bridging::fromJs<std::array<std::string, 2>>(rt, array, invoker);
+  EXPECT_EQ(vec[0], arr[0]);
+  EXPECT_EQ(vec[1], arr[1]);
+  auto pair =
+      bridging::fromJs<std::pair<std::string, std::string>>(rt, array, invoker);
+  EXPECT_EQ(vec[0], pair.first);
+  EXPECT_EQ(vec[1], pair.second);
 
   EXPECT_EQ(vec.size(), bridging::toJs(rt, vec, invoker).size(rt));
   for (size_t i = 0; i < vec.size(); i++) {
@@ -172,11 +179,20 @@ TEST_F(BridgingTest, arrayTest) {
   EXPECT_EQ(2, bridging::toJs(rt, std::make_pair(1, "2"), invoker).size(rt));
   EXPECT_EQ(2, bridging::toJs(rt, std::make_tuple(1, "2"), invoker).size(rt));
   EXPECT_EQ(2, bridging::toJs(rt, std::array<int, 2>{1, 2}, invoker).size(rt));
+  EXPECT_EQ(
+      2,
+      bridging::toJs(rt, std::array<std::string, 2>{"1", "2"}, invoker)
+          .size(rt));
   EXPECT_EQ(2, bridging::toJs(rt, std::deque<int>{1, 2}, invoker).size(rt));
   EXPECT_EQ(2, bridging::toJs(rt, std::list<int>{1, 2}, invoker).size(rt));
   EXPECT_EQ(
       2,
       bridging::toJs(rt, std::initializer_list<int>{1, 2}, invoker).size(rt));
+
+  std::vector<std::array<std::string, 2>> headers{
+      {"foo", "bar"}, {"baz", "qux"}};
+  auto jsiHeaders = bridging::toJs(rt, headers, invoker);
+  EXPECT_EQ(headers.size(), jsiHeaders.size(rt));
 }
 
 TEST_F(BridgingTest, functionTest) {
@@ -468,6 +484,12 @@ TEST_F(BridgingTest, supportTest) {
   EXPECT_TRUE((bridging::supportsFromJs<std::set<int>, jsi::Array&>));
   EXPECT_TRUE((bridging::supportsFromJs<std::vector<int>, jsi::Array>));
   EXPECT_TRUE((bridging::supportsFromJs<std::vector<int>, jsi::Array&>));
+  EXPECT_TRUE((
+      bridging::
+          supportsFromJs<std::vector<std::array<std::string, 2>>, jsi::Array>));
+  EXPECT_TRUE((bridging::supportsFromJs<
+               std::vector<std::array<std::string, 2>>,
+               jsi::Array&>));
   EXPECT_TRUE(
       (bridging::supportsFromJs<std::map<std::string, int>, jsi::Object>));
   EXPECT_TRUE(


### PR DESCRIPTION
Summary:
Changelog: [Internal]

These are currently missing.
They are convinient to e.g. turn an array of JS arrays such as `[["key", "value"]]` into a
- std::vector<std::array<T, N>> or
- std::vector<std::pair<T1, T2>>

Differential Revision: D52943602


