### PR TITLE
Create PageTarget{Delegate,Controller}, respond to Page.reload

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/CONCEPTS.md
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CONCEPTS.md
@@ -6,6 +6,14 @@
 
 A debuggable entity that a debugger frontend can connect to.
 
+### Target Delegate
+
+An interface between a Target class and the underlying debuggable entity. For example, PageTargetDelegate is used by PageTarget to send page-related events to the native platform implementation.
+
+### Target Controller
+
+A private interface exposed by a Target class to its Sessions/Agents. For example, PageTargetController is used by PageAgent to safely access the page's PageTargetDelegate, without exposing PageTarget's other private state.
+
 ### Session
 
 A single connection between a debugger frontend and a target. There can be multiple active sessions connected to the same target.

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
@@ -17,20 +17,27 @@
 
 namespace facebook::react::jsinspector_modern {
 
+class PageTarget;
+
 /**
  * An Agent that handles requests from the Chrome DevTools Protocol for the
  * given page.
  * The constructor, destructor and all public methods must be called on the
- * same thread.
+ * same thread, which is also the thread where the associated PageTarget is
+ * constructed and managed.
  */
 class PageAgent {
  public:
   /**
    * \param frontendChannel A channel used to send responses and events to the
    * frontend.
+   * \param targetController An interface to the PageTarget that this agent is
+   * attached to. The caller is responsible for ensuring that the
+   * PageTargetDelegate and underlying PageTarget both outlive the agent.
    */
   PageAgent(
       FrontendChannel frontendChannel,
+      PageTargetController& targetController,
       PageTarget::SessionMetadata sessionMetadata);
 
   /**
@@ -53,6 +60,7 @@ class PageAgent {
   void sendInfoLogEntry(std::string_view text);
 
   FrontendChannel frontendChannel_;
+  PageTargetController& targetController_;
   const PageTarget::SessionMetadata sessionMetadata_;
 };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
@@ -9,6 +9,7 @@
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 
+#include <list>
 #include <optional>
 #include <string>
 
@@ -26,6 +27,66 @@
 
 namespace facebook::react::jsinspector_modern {
 
+class PageTargetSession;
+class PageAgent;
+class PageTarget;
+
+/**
+ * Receives events from a PageTarget. This is a shared interface that each
+ * React Native platform needs to implement in order to integrate with the
+ * debugging stack.
+ */
+class PageTargetDelegate {
+ public:
+  PageTargetDelegate() = default;
+  PageTargetDelegate(const PageTargetDelegate&) = delete;
+  PageTargetDelegate(PageTargetDelegate&&) = default;
+  PageTargetDelegate& operator=(const PageTargetDelegate&) = delete;
+  PageTargetDelegate& operator=(PageTargetDelegate&&) = default;
+
+  // TODO(moti): This is 1:1 the shape of the corresponding CDP message -
+  // consider reusing typed/generated CDP interfaces when we have those.
+  struct PageReloadRequest {
+    // It isn't clear what the ignoreCache parameter of @cdp Page.reload should
+    // mean in React Native. We parse it, but don't do anything with it yet.
+    std::optional<bool> ignoreCache;
+
+    // TODO: Implement scriptToEvaluateOnLoad parameter of @cdp Page.reload.
+    std::optional<std::string> scriptToEvaluateOnLoad;
+
+    /**
+     * Equality operator, useful for unit tests
+     */
+    inline bool operator==(const PageReloadRequest& rhs) const {
+      return ignoreCache == rhs.ignoreCache &&
+          scriptToEvaluateOnLoad == rhs.scriptToEvaluateOnLoad;
+    }
+  };
+
+  virtual ~PageTargetDelegate();
+
+  /**
+   * Called when the debugger requests a reload of the page. This is called on
+   * the thread on which messages are dispatched to the session (that is, where
+   * ILocalConnection::sendMessage was called).
+   */
+  virtual void onReload(const PageReloadRequest& request) = 0;
+};
+
+/**
+ * The limited interface that PageTarget exposes to its associated
+ * sessions/agents.
+ */
+class PageTargetController {
+ public:
+  explicit PageTargetController(PageTarget& target);
+
+  PageTargetDelegate& getDelegate();
+
+ private:
+  PageTarget& target_;
+};
+
 /**
  * The top-level Target in a React Native app. This is equivalent to the
  * "Host" in React Native's architecture - the entity that manages the
@@ -38,6 +99,20 @@ class JSINSPECTOR_EXPORT PageTarget {
   };
 
   /**
+   * Constructs a new PageTarget.
+   * \param delegate The PageTargetDelegate that will receive events from
+   * this PageTarget. The caller is responsible for ensuring that the
+   * PageTargetDelegate outlives this object.
+   */
+  explicit PageTarget(PageTargetDelegate& delegate);
+
+  PageTarget(const PageTarget&) = delete;
+  PageTarget(PageTarget&&) = default;
+  PageTarget& operator=(const PageTarget&) = delete;
+  PageTarget& operator=(PageTarget&&) = delete;
+  ~PageTarget();
+
+  /**
    * Creates a new Session connected to this PageTarget, wrapped in an
    * interface which is compatible with \c IInspector::addPage.
    * The caller is responsible for destroying the connection before PageTarget
@@ -47,6 +122,39 @@ class JSINSPECTOR_EXPORT PageTarget {
   std::unique_ptr<ILocalConnection> connect(
       std::unique_ptr<IRemoteConnection> connectionToFrontend,
       SessionMetadata sessionMetadata = {});
+
+ private:
+  std::list<std::weak_ptr<PageTargetSession>> sessions_;
+
+  PageTargetDelegate& delegate_;
+  PageTargetController controller_{*this};
+
+  /**
+   * Call the given function for every active session, and clean up any
+   * references to inactive sessions.
+   */
+  template <typename Fn>
+  void forEachSession(Fn&& fn) {
+    for (auto it = sessions_.begin(); it != sessions_.end();) {
+      if (auto session = it->lock()) {
+        fn(*session);
+        ++it;
+      } else {
+        it = sessions_.erase(it);
+      }
+    }
+  }
+
+  void removeExpiredSessions();
+
+  inline PageTargetDelegate& getDelegate() {
+    return delegate_;
+  }
+
+  // Necessary to allow PageAgent to access PageTarget's internals in a
+  // controlled way (i.e. only PageTargetController gets friend access, while
+  // PageAgent itself doesn't).
+  friend class PageTargetController;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -39,4 +39,5 @@ Pod::Spec.new do |s|
   s.dependency "glog"
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-nativeconfig"
+  s.dependency "DoubleConversion"
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -12,6 +12,7 @@
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/InspectorPackagerConnection.h>
+#include <jsinspector-modern/ReactCdp.h>
 
 #include <chrono>
 #include <functional>
@@ -112,6 +113,12 @@ class MockInspectorPackagerConnectionDelegate
 
  private:
   folly::Executor& executor_;
+};
+
+class MockPageTargetDelegate : public PageTargetDelegate {
+ public:
+  // PageTargetDelegate methods
+  MOCK_METHOD(void, onReload, (const PageReloadRequest& request), (override));
 };
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Changelog: [Internal]

* Introduces the Target Delegate and Target Controller concepts (see `CONCEPTS.md`).
* Introduces the `PageTargetDelegate` interface and `PageTargetController` class (see doc comments).
* Uses the above infra to implement support for the `Page.reload` CDP command. Each integration provides its own `PageTargetDelegate` that knows how to trigger a reload in a platform- and architecture-specific way.
  * iOS Bridge/Bridgeless and `PageTargetTest` are the only integrations that exist as of this diff, and are all updated here; Android will follow later.

NOTE: `RCTBridge` = iOS Bridge, `RCTHost` = iOS Bridgeless.

Differential Revision: D51164125

