### PR TITLE
Remove Content-Length header from proxy inspector response

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -167,7 +167,6 @@ export default class InspectorProxy implements InspectorProxyQueries {
     response.writeHead(200, {
       'Content-Type': 'application/json; charset=UTF-8',
       'Cache-Control': 'no-cache',
-      'Content-Length': data.length.toString(),
       Connection: 'close',
     });
     response.end(data);


### PR DESCRIPTION
## Summary:

This change removes Content-Length header from proxy inspector response.

The presence of this header was resulting in the response being cropped under some circumstances because of erroneously calculated length.

The `Content-Length` header value represents the number of bytes in the response. In the code, `string.length` was used to calculate that value, but in JavaScript it gives the number of characters in a string instead of its size in bytes. Specifically, if there are some UTF characters in the string that occupy more than byte, there would be a mismatch in this size. This mismatch resulted in the response being cropped. 

The easiest way to reproduce this problem is to set the simulator name to contain a two-byte UTF character.

This change works according to the HTTP spec, which states that when Content-Length is not present, the end of the response stream indicates the end of the response. Since in the code `response.end(data)` is use, it terminates the stream and hence there is no need to provide the length in the header.

## Changelog:

[GENERAL] [FIXED] - fix issue with debugger not working when device name contain two-byte UTF characters

## Test Plan:

1. Change your iOS simulator name to contain some two-byte UTF character (for example this one: "–")
2. Run metro and connect your app with it
3. Go to http://localhost:8081/json/list in your browser – see the response being marked invalid as it is cropped
4. Apply the change and see that the resulting JSON in the response is now correct
5. Open debugger workflow to confirm it sees the connected device
