### PR TITLE
Enable DEFINES_MODULE for DoubleConversion

### DIFF
--- a/packages/react-native/third-party-podspecs/DoubleConversion.podspec
+++ b/packages/react-native/third-party-podspecs/DoubleConversion.podspec
@@ -20,6 +20,10 @@ Pod::Spec.new do |spec|
 
   spec.user_target_xcconfig = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/DoubleConversion\"" }
 
+  spec.pod_target_xcconfig = {
+    "DEFINES_MODULE" => "YES",
+  }
+
   # Pinning to the same version as React.podspec.
   spec.platforms = min_supported_versions
 


### PR DESCRIPTION
## Summary:

since https://github.com/facebook/react-native/commit/32dab7a63fd0795c3aaefa766aa9f818428ed2de, `DoubleConversion` is now added as an implicit dependency for 3rd party module and it breaks swift integration. this pr tries to add the `DEFINES_MODULE` to DoubleConversion.

## Changelog:

[IOS] [FIXED] - Fixed `DoubleConversion` build error from Swift integration

## Test Plan:

i'll need to test this on expo latest and react-native nightly build

```sh
# pull latest expo repo and get template tarball
$ git clone --depth 1 https://github.com/expo/expo.git 
$ cd expo
$ yarn install
$ cd templates/expo-template-bare-minimum
$ npx pack --pack-destination ../../

# now create an expo app
$ yarn create expo -t blank@sdk-50 sdk50
$ cd sdk50
$ yarn add react-native@nightly
$ jq '.expo.runtimeVersion = { "policy": "appVersion" }' app.json > app.json.tmp && mv app.json.tmp app.json
$ npx expo prebuild -p ios --template /path/to/expo/expo-template-bare-minimum-50.0.17.tgz
$ cd ios
$ pod install
```

then it will show the error message:
```
[!] The following Swift pods cannot yet be integrated as static libraries:

The Swift pod `ExpoModulesCore` depends upon `DoubleConversion`, which does not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
```