### PR TITLE
Clean up the function naming in `TextMeasureCache.h`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -141,7 +141,7 @@ inline bool areAttributedStringFragmentsEquivalentLayoutWise(
         rhs.parentShadowView.layoutMetrics));
 }
 
-inline size_t textAttributesHashLayoutWise(
+inline size_t attributedStringFragmentHashLayoutWise(
     const AttributedString::Fragment& fragment) {
   // Here we are not taking `isAttachment` and `layoutMetrics` into account
   // because they are logically interdependent and this can break an invariant
@@ -171,12 +171,12 @@ inline bool areAttributedStringsEquivalentLayoutWise(
   return true;
 }
 
-inline size_t textAttributedStringHashLayoutWise(
+inline size_t attributedStringHashLayoutWise(
     const AttributedString& attributedString) {
   auto seed = size_t{0};
 
   for (const auto& fragment : attributedString.getFragments()) {
-    facebook::react::hash_combine(seed, textAttributesHashLayoutWise(fragment));
+    facebook::react::hash_combine(seed, attributedStringFragmentHashLayoutWise(fragment));
   }
 
   return seed;
@@ -206,7 +206,7 @@ template <>
 struct hash<facebook::react::TextMeasureCacheKey> {
   size_t operator()(const facebook::react::TextMeasureCacheKey& key) const {
     return facebook::react::hash_combine(
-        textAttributedStringHashLayoutWise(key.attributedString),
+        attributedStringHashLayoutWise(key.attributedString),
         key.paragraphAttributes,
         key.layoutConstraints.maximumSize.width);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Clean up the function naming in `TextMeasureCache.h`. One name was clearly a human mistake. Make the naming consistent.

This is a minor improvement in the context of my multi-PR work on https://github.com/react-native-community/discussions-and-proposals/issues/695.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [CHANGE] - Clean up the function naming in `TextMeasureCache.h`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
