### PR TITLE
Make Modal's `onDismiss` work on Fabric.

### DIFF
--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -173,7 +173,13 @@ function confirmProps(props: Props) {
   }
 }
 
-class Modal extends React.Component<Props> {
+// Create a state to track whether the Modal is rendering or not.
+// This is the only prop that controls whether the modal is rendered or not.
+type State = {
+  isRendered: boolean,
+};
+
+class Modal extends React.Component<Props, State> {
   static defaultProps: {|hardwareAccelerated: boolean, visible: boolean|} = {
     visible: true,
     hardwareAccelerated: false,
@@ -190,6 +196,9 @@ class Modal extends React.Component<Props> {
       confirmProps(props);
     }
     this._identifier = uniqueModalIdentifier++;
+    this.state = {
+      isRendered: props.visible === true,
+    };
   }
 
   componentDidMount() {
@@ -199,7 +208,11 @@ class Modal extends React.Component<Props> {
         'modalDismissed',
         event => {
           if (event.modalID === this._identifier && this.props.onDismiss) {
-            this.props.onDismiss();
+            this.setState({isRendered: false}, () => {
+              if (this.props.onDismiss) {
+                this.props.onDismiss();
+              }
+            });
           }
         },
       );
@@ -212,14 +225,27 @@ class Modal extends React.Component<Props> {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.visible === false && this.props.visible === true) {
+      this.setState({isRendered: true});
+    }
+
     if (__DEV__) {
       confirmProps(this.props);
     }
   }
 
+  // Helper function to encapsulate platform specific logic to show or not the Modal.
+  _shouldShowModal(): boolean {
+    if (Platform.OS === 'ios') {
+      return this.props.visible === true || this.state.isRendered === true;
+    }
+
+    return this.props.visible === true;
+  }
+
   render(): React.Node {
-    if (this.props.visible !== true) {
+    if (!this._shouldShowModal()) {
       return null;
     }
 
@@ -244,6 +270,17 @@ class Modal extends React.Component<Props> {
       this.props.children
     );
 
+    const onDismiss = () => {
+      // OnDismiss is implemented on iOS only.
+      if (Platform.OS === 'ios') {
+        this.setState({isRendered: false}, () => {
+          if (this.props.onDismiss) {
+            this.props.onDismiss();
+          }
+        });
+      }
+    };
+
     return (
       <RCTModalHostView
         animationType={animationType}
@@ -252,11 +289,7 @@ class Modal extends React.Component<Props> {
         hardwareAccelerated={this.props.hardwareAccelerated}
         onRequestClose={this.props.onRequestClose}
         onShow={this.props.onShow}
-        onDismiss={() => {
-          if (this.props.onDismiss) {
-            this.props.onDismiss();
-          }
-        }}
+        onDismiss={onDismiss}
         visible={this.props.visible}
         statusBarTranslucent={this.props.statusBarTranslucent}
         identifier={this._identifier}


### PR DESCRIPTION
Summary:
After S390064, the OnDismiss event for Modal from D52445670 was reverted.
The diff was too big and caused the SEV, so we are trying to reimplement it gradually to make sure we don't brake anything.

The most important thing for our short term goal is to make the `OnDismiss` work only for iOS (following the official docs, Android never supported it) for Fabric (Bridge and Bridgeless).

We also want to minimize the changes t the JS infrastructure, so we are trying not to alter the JS APIs.

## The Problem:
The reason why the onDismiss event does not work is because, as soon as the `visible` property is turned to `false`, the component is removed by the React tree.
When this happens, Fabric deallocate the ShadowNode and the EventEmitter. Therefore, the event is not fired.

## The Solution:
We made this work by "delaying" when the component need to be removed from the reacat Tree.

Rather then rendering or node or not based on the `visible` props, we are introducing a `State` object that keeps track when the Modal is rendered or not.

The `state.isRendering` property is set to `true` when the `visible` prop is set to `true`.
For iOS, when `visible` prop is set to `false`, instead, we wait for the Native side to actually dismiss the View and to invoke the event. When the event is fired, we manually set the `state.isRendering` property to false and the Modal can be considered dismissed.

Notice that this makes also useless to have the Modal Native's snapshot to simulate that the modal is still presented.

## Changelog:
[iOS][Fixed] - `onDismiss` now work on iOS with Fabric, in both Bridge and Bridgeless mode.

Differential Revision: D52959996


