### PR TITLE
enable setNativeProps in animations on by default

### DIFF
--- a/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
@@ -58,7 +58,7 @@ const ReactNativeFeatureFlags: FeatureFlags = {
   animatedShouldUseSingleOp: () => false,
   enableAccessToHostTreeInFabric: () => false,
   shouldUseAnimatedObjectForTransform: () => false,
-  shouldUseSetNativePropsInFabric: () => false,
+  shouldUseSetNativePropsInFabric: () => true,
 };
 
 module.exports = ReactNativeFeatureFlags;


### PR DESCRIPTION
Summary:
changelog: [newarch] Enable setNativeProps in animations

Enabling setNativeProps in animations on by default.

Differential Revision: D52962882


