### PR TITLE
Bugfix RefreshControl.d.ts type error in RefreshControlPropsAndroid

### DIFF
--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.d.ts
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.d.ts
@@ -49,7 +49,7 @@ export interface RefreshControlPropsAndroid extends ViewProps {
   /**
    * Size of the refresh indicator, see RefreshControl.SIZE.
    */
-  size?: number | undefined;
+  size?: "default" | "large" | undefined;
 }
 
 export interface RefreshControlProps


### PR DESCRIPTION
Hi,
I ran into a complier type error when using a number for the  refresh indicator size on Android which resolved when following the [reference of RefreshControlPropsAndroid.size](https://reactnative.dev/docs/refreshcontrol#size-android) which requires `enum("default", "large")`...

Bugfix of type size in RefreshControlPropsAndroid.size to prevent type error and comply with references `enum("default", "large")`, compare https://reactnative.dev/docs/scrollview#scrollenabled

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog: [Android] [Fixed] - RefreshControlPropsAndroid.size type fixed from "number | undefined" to ""default" | "large" | undefined"

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
