### PR TITLE
resolve warning when trying to register a class again with the same name

### DIFF
--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -732,6 +732,9 @@ struct RCTInstanceCallback : public InstanceCallback {
       } else if ([moduleClass new] == nil) {
         // The new module returned nil from init, so use the old module
         continue;
+      } else if (moduleData.moduleClass == moduleClass) {
+        // Same class is already registered with the same name, so skip register again
+        continue;
       } else if ([moduleData.moduleClass new] != nil) {
         // Both modules were non-nil, so it's unclear which should take precedence
         RCTLogWarn(


### PR DESCRIPTION
Summary:
# Problem
During development, after manually reload the app, get the warning message.

```
WARN  Attempted to register RCTBridgeModule class RCTAxialGradientViewManager for the name 'AxialGradientViewManager', but name was already registered by class RCTAxialGradientViewManager
```
https://pxl.cl/4cH3d 

The warning is basically saying we are attempting to register a class again with the same name.


# Solution
Simply skip the second register attempt and warning log.

## Changelog:
[Internal] - resolve warning when trying to register a class again with the same name

Differential Revision: D52947797


