### PR TITLE
Build Android on Ubuntu 22.04

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -25,7 +25,7 @@ references:
   android-defaults: &android-defaults
     working_directory: ~/react-native
     docker:
-      - image: reactnativecommunity/react-native-android:v12.0
+      - image: reactnativecommunity/react-native-android:v13.0
     environment:
       - TERM: "dumb"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false'


### PR DESCRIPTION
## Summary:

Bumping the Docker image we use to build Android from Ubuntu 20.04 to 22.04

## Changelog:

[INTERNAL] - Build Android on Ubuntu 22.04

## Test Plan:

CI