### PR TITLE
Add standards based lexer/tokenizer for CSS values

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSTokenizer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSTokenizer.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cmath>
+
+#include <react/debug/react_native_assert.h>
+#include <react/renderer/components/view/CSSTokenizer.h>
+
+namespace facebook::react {
+
+CSSTokenizer::CSSTokenizer(std::string_view tokenStream)
+    : remainingTokenStream_{tokenStream} {}
+
+CSSToken CSSTokenizer::next() {
+  // https://www.w3.org/TR/css-syntax-3/#token-diagrams
+  char nextChar = peek();
+  if (isWhitespace(nextChar)) {
+    return consumeWhitespace();
+  } else if (nextChar == '+') {
+    if (isDigit(peekNext())) {
+      return consumeNumeric();
+    } else {
+      return consumeDelim();
+    }
+  } else if (nextChar == '-') {
+    if (isDigit(peekNext())) {
+      return consumeNumeric();
+    } else {
+      return consumeDelim();
+    }
+  } else if (isDigit(nextChar)) {
+    return consumeNumeric();
+  } else if (isIdentStart(nextChar)) {
+    return consumeIdent();
+  } else if (nextChar == '\0') {
+    return {CSSTokenType::EndOfFile};
+  } else {
+    return consumeDelim();
+  }
+}
+
+char CSSTokenizer::peek() const {
+  auto index = position_;
+  return index >= remainingTokenStream_.size() ? '\0'
+                                               : remainingTokenStream_[index];
+}
+
+char CSSTokenizer::peekNext() const {
+  auto index = position_ + 1;
+  return index >= remainingTokenStream_.size() ? '\0'
+                                               : remainingTokenStream_[index];
+}
+
+void CSSTokenizer::advance() {
+  react_native_assert(remainingTokenStream_.size() > position_);
+  position_ += 1;
+}
+
+CSSToken CSSTokenizer::consumeDelim() {
+  advance();
+  return {CSSTokenType::Delim, consumeRunningValue()};
+}
+
+CSSToken CSSTokenizer::consumeWhitespace() {
+  while (isWhitespace(peek())) {
+    advance();
+  }
+
+  consumeRunningValue();
+  return {CSSTokenType::WhiteSpace};
+}
+
+CSSToken CSSTokenizer::consumeNumber() {
+  // https://www.w3.org/TR/css-syntax-3/#consume-number
+  // https://www.w3.org/TR/css-syntax-3/#convert-a-string-to-a-number
+  int32_t signPart = 1.0;
+  if (peek() == '+' || peek() == '-') {
+    if (peek() == '-') {
+      signPart = -1.0;
+    }
+    advance();
+  }
+
+  int32_t intPart = 0;
+  while (isDigit(peek())) {
+    intPart = intPart * 10 + (peek() - '0');
+    advance();
+  }
+
+  int32_t fractionalPart = 0;
+  int32_t fractionDigits = 0;
+  if (peek() == '.') {
+    advance();
+    while (isDigit(peek())) {
+      fractionalPart = fractionalPart * 10 + (peek() - '0');
+      fractionDigits++;
+      advance();
+    }
+  }
+
+  int32_t exponentSign = 1.0;
+  int32_t exponentPart = 0;
+  if (peek() == 'e' || peek() == 'E') {
+    advance();
+    if (peek() == '+' || peek() == '-') {
+      if (peek() == '-') {
+        exponentSign = -1.0;
+      }
+      advance();
+    }
+
+    while (isDigit(peek())) {
+      exponentPart = exponentPart * 10 + (peek() - '0');
+      advance();
+    }
+  }
+
+  float value = static_cast<float>(
+      signPart * (intPart + (fractionalPart * std::pow(10, -fractionDigits))) *
+      std::pow(10, exponentSign * exponentPart));
+
+  consumeRunningValue();
+  return {CSSTokenType::Number, value};
+}
+
+CSSToken CSSTokenizer::consumeNumeric() {
+  // https://www.w3.org/TR/css-syntax-3/#consume-numeric-token
+  auto number = consumeNumber();
+  auto nextChar = peek();
+
+  if (isIdent(nextChar)) {
+    auto ident = consumeIdent();
+    return {
+        CSSTokenType::Dimension, number.numericValue(), ident.stringValue()};
+  } else if (nextChar == '%') {
+    advance();
+    consumeRunningValue();
+    return {CSSTokenType::Percent, number.numericValue()};
+  } else {
+    return number;
+  }
+}
+
+CSSToken CSSTokenizer::consumeIdent() {
+  // https://www.w3.org/TR/css-syntax-3/#consume-an-ident-sequence
+  while (isIdent(peek())) {
+    advance();
+  }
+
+  return {CSSTokenType::Ident, consumeRunningValue()};
+}
+
+std::string_view CSSTokenizer::consumeRunningValue() {
+  auto next = remainingTokenStream_.substr(0, position_);
+  remainingTokenStream_ = remainingTokenStream_.substr(next.size());
+  position_ = 0;
+  return next;
+}
+
+/*static*/ bool CSSTokenizer::isDigit(char c) {
+  // https://www.w3.org/TR/css-syntax-3/#digit
+  return c >= '0' && c <= '9';
+}
+
+/*static*/ bool CSSTokenizer::isIdentStart(char c) {
+  // https://www.w3.org/TR/css-syntax-3/#ident-start-code-point
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' ||
+      static_cast<unsigned char>(c) > 0x80;
+}
+
+/*static*/ bool CSSTokenizer::isIdent(char c) {
+  // https://www.w3.org/TR/css-syntax-3/#ident-code-point
+  return isIdentStart(c) || isDigit(c) || c == '-';
+}
+
+/*static*/ bool CSSTokenizer::isWhitespace(char c) {
+  // https://www.w3.org/TR/css-syntax-3/#whitespace
+  return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSTokenizer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSTokenizer.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <limits>
+#include <string_view>
+#include <utility>
+
+namespace facebook::react {
+
+/**
+ * One of the tokens defined as part of
+ * https://www.w3.org/TR/css-syntax-3/#tokenizer-definitions
+ */
+enum class CSSTokenType {
+  Delim,
+  Dimension,
+  EndOfFile,
+  Ident,
+  Number,
+  Percent,
+  WhiteSpace,
+};
+
+struct CSSToken {
+  CSSToken(CSSTokenType type) : type_(type) {}
+  CSSToken(CSSTokenType type, std::string_view value)
+      : type_{type}, stringValue_{value} {}
+  CSSToken(CSSTokenType type, float value)
+      : type_{type}, numericValue_{value} {}
+  CSSToken(CSSTokenType type, float value, std::string_view unit)
+      : type_{type}, numericValue_{value}, unit_{unit} {}
+
+  CSSTokenType type() const {
+    return type_;
+  }
+
+  std::string_view stringValue() const {
+    return stringValue_;
+  }
+
+  float numericValue() const {
+    return numericValue_;
+  }
+
+  std::string_view unit() const {
+    return unit_;
+  }
+
+  bool operator==(const CSSToken& other) const = default;
+
+ private:
+  CSSTokenType type_;
+  std::string_view stringValue_;
+  float numericValue_{0.0f};
+  std::string_view unit_;
+};
+
+/**
+ * A minimal tokenizer for a subset of CSS "component values" (e.g. `10px`,
+ * `auto`).
+ *
+ * This is based on the W3C CSS Syntax specification, with simplifications made
+ * for syntax which React Native does not attempt to support.
+ * https://www.w3.org/TR/css-syntax-3/#tokenizing-and-parsing
+ */
+class CSSTokenizer {
+ public:
+  CSSTokenizer(std::string_view tokenStream);
+  CSSToken next();
+
+ private:
+  char peek() const;
+  char peekNext() const;
+  void advance();
+
+  CSSToken consumeDelim();
+  CSSToken consumeWhitespace();
+  CSSToken consumeNumber();
+  CSSToken consumeNumeric();
+  CSSToken consumeIdent();
+
+  std::string_view consumeRunningValue();
+
+  static bool isDigit(char c);
+  static bool isIdentStart(char c);
+  static bool isIdent(char c);
+  static bool isWhitespace(char c);
+
+  std::string_view remainingTokenStream_;
+  size_t position_{0};
+};
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/CSSTokenizerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/CSSTokenizerTest.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/components/view/CSSTokenizer.h>
+#include <deque>
+
+namespace facebook::react {
+
+static void expectTokens(
+    std::string_view tokenStream,
+    std::initializer_list<CSSToken> tokens) {
+  CSSTokenizer tokenizer{tokenStream};
+  std::deque tokenQueue(tokens.begin(), tokens.end());
+
+  while (!tokenQueue.empty()) {
+    auto nextToken = tokenizer.next();
+    auto nextExpectedToken = tokenQueue.front();
+    tokenQueue.pop_front();
+    EXPECT_EQ(nextToken.type(), nextExpectedToken.type());
+    EXPECT_EQ(nextToken.stringValue(), nextExpectedToken.stringValue());
+    EXPECT_EQ(nextToken.numericValue(), nextExpectedToken.numericValue());
+    EXPECT_EQ(nextToken.unit(), nextExpectedToken.unit());
+  }
+}
+
+TEST(CSSTokenizer, eof) {
+  expectTokens("", {{CSSTokenType::EndOfFile}});
+}
+
+TEST(CSSTokenizer, whitespace) {
+  expectTokens(" ", {{CSSTokenType::WhiteSpace}, {CSSTokenType::EndOfFile}});
+  expectTokens(" \t", {{CSSTokenType::WhiteSpace}, {CSSTokenType::EndOfFile}});
+  expectTokens(
+      "\n   \t", {{CSSTokenType::WhiteSpace}, {CSSTokenType::EndOfFile}});
+}
+
+TEST(CSSTokenizer, ident_value) {
+  expectTokens(
+      "auto", {{CSSTokenType::Ident, "auto"}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "inset auto left",
+      {{CSSTokenType::Ident, "inset"},
+       {CSSTokenType::WhiteSpace},
+       {CSSTokenType::Ident, "auto"},
+       {CSSTokenType::WhiteSpace},
+       {CSSTokenType::Ident, "left"},
+       {CSSTokenType::EndOfFile}});
+}
+
+TEST(CSSTokenizer, number_values) {
+  expectTokens(
+      "12", {{CSSTokenType::Number, 12.0f}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "-5", {{CSSTokenType::Number, -5.0f}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "123.0", {{CSSTokenType::Number, 123.0f}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "4.2E-1", {{CSSTokenType::Number, 4.2e-1}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "6e-10", {{CSSTokenType::Number, 6e-10f}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "+81.07e+0",
+      {{CSSTokenType::Number, +81.07e+0}, {CSSTokenType::EndOfFile}});
+}
+
+TEST(CSSTokenizer, dimension_values) {
+  expectTokens(
+      "12px",
+      {{CSSTokenType::Dimension, 12.0f, "px"}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "463.2abc",
+      {{CSSTokenType::Dimension, 463.2, "abc"}, {CSSTokenType::EndOfFile}});
+}
+
+TEST(CSSTokenizer, percent_values) {
+  expectTokens(
+      "12%", {{CSSTokenType::Percent, 12.0f}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "-28.5%", {{CSSTokenType::Percent, -28.5f}, {CSSTokenType::EndOfFile}});
+}
+
+TEST(CSSTokenizer, mixed_values) {
+  expectTokens(
+      "12px   -100vh",
+      {{CSSTokenType::Dimension, 12.0f, "px"},
+       {CSSTokenType::WhiteSpace},
+       {CSSTokenType::Dimension, -100.0f, "vh"},
+       {CSSTokenType::EndOfFile}});
+}
+
+TEST(CSSTokenizer, invalid_values) {
+  expectTokens(
+      "100*",
+      {{CSSTokenType::Number, 100.0f},
+       {CSSTokenType::Delim, "*"},
+       {CSSTokenType::EndOfFile}});
+
+  expectTokens("+", {{CSSTokenType::Delim, "+"}, {CSSTokenType::EndOfFile}});
+
+  expectTokens(
+      "(%",
+      {{CSSTokenType::Delim, "("},
+       {CSSTokenType::Delim, "%"},
+       {CSSTokenType::EndOfFile}});
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Right now this is done by some combination of string splitting, JS side regexing, etc. This will not scale for math expressions, and gets more and more annoying when we try to add more.

In preparation for adding more units, this adds a tokenizer/lexer for a subset of CSS grammar, based on the spec.

This is not hooked up to anything yet, and doesn't add a parser.

Changelog: [Internal]

Differential Revision: D53030661


