### PR TITLE
fix: RNTester new arch flag

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -35,7 +35,7 @@ end
 def pods(target_name, options = {})
   project 'RNTesterPods.xcodeproj'
 
-  fabric_enabled = true
+  new_arch_enabled = true
 
   # Hermes is now enabled by default.
   # The following line will only disable Hermes if the USE_HERMES envvar is SET to a value other than 1 (e.g. USE_HERMES=0).
@@ -44,7 +44,7 @@ def pods(target_name, options = {})
 
   use_react_native!(
     path: @prefix_path,
-    fabric_enabled: fabric_enabled,
+    new_arch_enabled: new_arch_enabled,
     hermes_enabled: hermes_enabled,
     app_path: "#{Dir.pwd}",
     config_file_dir: "#{Dir.pwd}/node_modules",


### PR DESCRIPTION
## Summary:

This PR fixes flag passed to RNTester podfile. After this change: #42259 passing `fabric_enabled` is not enough to set `RCT_NEW_ARCH_ENABLED` to true

## Changelog:

[INTERNAL] [CHANGED] - Pass new_arch_enabled to RNTester podfile


## Test Plan:

Check if `RCT_NEW_ARCH_ENABLED` is set correctly.
