### PR TITLE
fix: UpdatePropertiesExampleView mutate existing appProperties instead of overwriting

### DIFF
--- a/packages/rn-tester/RNTester/NativeExampleViews/UpdatePropertiesExampleView.mm
+++ b/packages/rn-tester/RNTester/NativeExampleViews/UpdatePropertiesExampleView.mm
@@ -72,7 +72,11 @@ RCT_EXPORT_MODULE();
 - (void)changeColor
 {
   _beige = !_beige;
-  [_rootView setAppProperties:@{@"color" : _beige ? @"beige" : @"purple"}];
+  
+  NSMutableDictionary *newProperties = [_rootView.appProperties mutableCopy];
+  newProperties[@"color"] = _beige ? @"beige" : @"purple";
+  
+  [_rootView setAppProperties:newProperties];
 }
 
 - (NSArray<UIView<RCTComponent> *> *)reactSubviews


### PR DESCRIPTION
## Summary:

For Bridgeless mode we set `fabric` and `concurrentRoot` property for newly initialized views. This example overwrites those properties. I think we should Instead copy previous dictionary and only overwrite `color` key.

This issue results in a warning: "Using Fabric without concurrent root is deprecated. Please enable concurrent root for this application."

Note: This Example crashes on Bridgeless but my other PR #42263 fixes it.

## Changelog:

[INTERNAL] [FIXED] - UpdatePropertiesExampleView to mutate existing `appProperties` instead of overwriting

## Test Plan:

1. Wait for this example to get fixed for Bridgeless
2. Click the button to update props 
3. Check if there is no warning
