### PR TITLE
Improve types, fix translator compatibility for version-related modules

### DIFF
--- a/packages/react-native/Libraries/Core/ReactNativeVersion.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersion.js
@@ -9,9 +9,16 @@
  * @flow strict
  */
 
-exports.version = {
+const version: $ReadOnly<{
+  major: number,
+  minor: number,
+  patch: number,
+  prerelease: string | null,
+}> = {
   major: 1000,
   minor: 0,
   patch: 0,
   prerelease: null,
 };
+
+module.exports = {version};

--- a/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
@@ -21,7 +21,7 @@ const ReactNativeVersion = require('./ReactNativeVersion');
  * implementations for other platforms (ex: Windows) may override this module
  * and rely on its existence as a separate module.
  */
-exports.checkVersions = function checkVersions(): void {
+const checkVersions = function checkVersions(): void {
   const nativeVersion = Platform.constants.reactNativeVersion;
   if (
     ReactNativeVersion.version.major !== nativeVersion.major ||
@@ -29,7 +29,7 @@ exports.checkVersions = function checkVersions(): void {
   ) {
     console.error(
       `React Native version mismatch.\n\nJavaScript version: ${_formatVersion(
-        ReactNativeVersion.version,
+        (ReactNativeVersion.version: $FlowFixMe),
       )}\n` +
         `Native version: ${_formatVersion(nativeVersion)}\n\n` +
         'Make sure that you have rebuilt the native code. If the problem ' +
@@ -48,3 +48,5 @@ function _formatVersion(
     (version.prerelease != undefined ? `-${version.prerelease}` : '')
   );
 }
+
+module.exports = {checkVersions};

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3851,6 +3851,23 @@ declare export default typeof ReactFiberErrorDialog;
 "
 `;
 
+exports[`public API should not change unintentionally Libraries/Core/ReactNativeVersion.js 1`] = `
+"declare const version: $ReadOnly<{
+  major: number,
+  minor: number,
+  patch: number,
+  prerelease: string | null,
+}>;
+declare module.exports: { version: version };
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Core/ReactNativeVersionCheck.js 1`] = `
+"declare const checkVersions: () => void;
+declare module.exports: { checkVersions: checkVersions };
+"
+`;
+
 exports[`public API should not change unintentionally Libraries/Core/SegmentFetcher/NativeSegmentFetcher.js 1`] = `
 "export * from \\"../../../src/private/specs/modules/NativeSegmentFetcher\\";
 declare export default typeof NativeSegmentFetcher;

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -42,8 +42,6 @@ const FILES_WITH_KNOWN_ERRORS = new Set([
   'Libraries/Components/Touchable/TouchableNativeFeedback.js',
   'Libraries/Components/Touchable/TouchableWithoutFeedback.js',
   'Libraries/Components/UnimplementedViews/UnimplementedView.js',
-  'Libraries/Core/ReactNativeVersion.js',
-  'Libraries/Core/ReactNativeVersionCheck.js',
   'Libraries/Image/ImageBackground.js',
   'Libraries/Inspector/ElementProperties.js',
   'Libraries/Inspector/BorderBox.js',

--- a/scripts/versiontemplates/ReactNativeVersion.js.template
+++ b/scripts/versiontemplates/ReactNativeVersion.js.template
@@ -9,9 +9,16 @@
  * @flow strict
  */
 
-exports.version = {
+const version: $ReadOnly<{
+  major: number,
+  minor: number,
+  patch: number,
+  prerelease: string | null,
+}> = {
   major: ${major},
   minor: ${minor},
   patch: ${patch},
   prerelease: ${prerelease},
 };
+
+module.exports = {version};


### PR DESCRIPTION
Summary:
Enables these modules to be covered by `public-api-test`.

- Standardise as CommonJS modules, fixing compatibility with [`flow-api-translator`](https://www.npmjs.com/package/flow-api-translator).
- Use explicit object type in generated file template.

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D52963967


