### PR TITLE
Remove RCTAppSetupPrepareApp overload and InspectorFlags call

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -87,7 +87,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
   NSDictionary *initProps = updateInitialProps([self prepareInitialProps], fabricEnabled);
 
-  RCTAppSetupPrepareApp(application, enableTM, *_reactNativeConfig);
+  RCTAppSetupPrepareApp(application, enableTM);
 
   UIView *rootView;
   if (enableBridgeless) {

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -11,8 +11,6 @@
 
 #ifdef __cplusplus
 
-#import <react/config/ReactNativeConfig.h>
-
 #import <memory>
 
 #if USE_HERMES
@@ -43,21 +41,11 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactory
     RCTBridge *bridge,
     const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler);
 
-/**
- * Register features and experiments prior to app initialization.
- */
-void RCTAppSetupPrepareApp(
-    UIApplication *application,
-    BOOL turboModuleEnabled,
-    const facebook::react::ReactNativeConfig &reactNativeConfig);
-
 #endif // __cplusplus
 
 RCT_EXTERN_C_BEGIN
 
-void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
-    __deprecated_msg("Use the 3-argument overload of RCTAppSetupPrepareApp instead");
-
+void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled);
 UIView *RCTAppSetupDefaultRootView(
     RCTBridge *bridge,
     NSString *moduleName,

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -24,9 +24,6 @@
 #import <React/RCTFabricSurface.h>
 #import <React/RCTSurfaceHostingProxyRootView.h>
 
-// jsinspector-modern
-#import <jsinspector-modern/InspectorFlags.h>
-
 void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
 {
   RCTEnableTurboModule(turboModuleEnabled);
@@ -36,20 +33,6 @@ void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
   // Metro reconnection logic. Users only need this when running the application using our CLI tooling.
   application.idleTimerDisabled = YES;
 #endif
-}
-
-void RCTAppSetupPrepareApp(
-    UIApplication *application,
-    BOOL turboModuleEnabled,
-    const facebook::react::ReactNativeConfig &reactNativeConfig)
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  RCTAppSetupPrepareApp(application, turboModuleEnabled);
-#pragma clang diagnostic pop
-
-  auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
-  inspectorFlags.initFromConfig(reactNativeConfig);
 }
 
 UIView *

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -88,7 +88,6 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-utils")
   add_dependency(s, "React-debug")
   add_dependency(s, "React-rendererdebug")
-  add_dependency(s, "React-jsinspector")
 
   if use_hermes
     s.dependency "React-hermes"


### PR DESCRIPTION
Summary:
Removes call to `InspectorFlags::initFromConfig`, since this approach is being replaced with `ReactNativeFeatureFlags`. This change is separated out as it originally made a public API deprecation.

Changelog:
[iOS][Deprecated] - **Un-deprecates** `RCTAppSetupPrepareApp` (reverts #41976)

Differential Revision: D53048207


