### PR TITLE
Change NodeToString.cpp to output JSON not html

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.h
@@ -19,8 +19,7 @@ namespace facebook::yoga {
 void nodeToString(
     std::string& str,
     const yoga::Node* node,
-    PrintOptions options,
-    uint32_t level);
+    PrintOptions options);
 
 void print(const yoga::Node* node, PrintOptions options);
 


### PR DESCRIPTION
Summary: We want to be able to capture Yoga trees in production. To do this we need to serialize and deserialize the in-memory representation of a tree. We have a way to turn a tree into html using NodeToString.cpp but that outputs html, which is going to be hard to deserialize. So, I added the [nlohmann json library](https://github.com/nlohmann/json/tree/develop?tab=readme-ov-file) so that we can serialize into JSON instead. Then we need to change the inner workings of NodeToString.cpp to use this library instead of its html.

Differential Revision: D52929268


