### PR TITLE
Ability to recreate yoga trees from JSON captures

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.cpp
@@ -33,7 +33,7 @@ static void appendNumberIfNotUndefined(
     const Style::Length& number) {
   if (number.unit() != Unit::Undefined) {
     if (number.unit() == Unit::Auto) {
-      j["style"][key]["unit"] = "auto";
+      j["style"][key] = "auto";
     } else {
       std::string unit = number.unit() == Unit::Point ? "px" : "%%";
       j["style"][key]["value"] = number.value().unwrap();
@@ -106,7 +106,7 @@ nodeToStringImpl(json& j, const yoga::Node* node, PrintOptions options) {
       j["style"]["display"] = toString(style.display());
     }
     if (style.positionType() != yoga::Style{}.positionType()) {
-      j["style"]["position"] = toString(style.positionType());
+      j["style"]["position-type"] = toString(style.positionType());
     }
 
     appendFloatOptionalIfDefined(j, "flex-grow", style.flexGrow());

--- a/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/NodeToString.h
@@ -19,8 +19,7 @@ namespace facebook::yoga {
 void nodeToString(
     std::string& str,
     const yoga::Node* node,
-    PrintOptions options,
-    uint32_t level);
+    PrintOptions options);
 
 void print(const yoga::Node* node, PrintOptions options);
 


### PR DESCRIPTION
Summary:
In the previous diffs we serialized the in-memory representation of a node into json. This diff exposes a `generateBenchmark` method that reads from that json executes the proper public Yoga API functions to recreate the same tree. It then calls calculate layout so that we can time that in the next diff.

This diff is really only focusing on the core aspects of a yoga tree like style, children, and calculating layout; there are still more things to add coming up:

* Support for configs, experiments, and errata
* Support for measure functions
* Support for general node state that is not style (like always forming a containing block)
* Actually running all of these benchmarks together
* Tests

Differential Revision: D52987588


