### PR TITLE
Bump NDK to 26.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ version =
 group = "com.facebook.react"
 
 val ndkPath by extra(System.getenv("ANDROID_NDK"))
-val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION") ?: "26.0.10792818")
+val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION") ?: libs.versions.ndkVersion.get())
 val sonatypeUsername = findProperty("SONATYPE_USERNAME")?.toString()
 val sonatypePassword = findProperty("SONATYPE_PASSWORD")?.toString()
 

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ minSdk = "23"
 targetSdk = "34"
 compileSdk = "34"
 buildTools = "34.0.0"
+ndkVersion = "26.1.10909125"
 # Dependencies versions
 agp = "8.2.1"
 androidx-annotation = "1.6.0"

--- a/packages/react-native/template/android/build.gradle
+++ b/packages/react-native/template/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         minSdkVersion = 23
         compileSdkVersion = 34
         targetSdkVersion = 34
-        ndkVersion = "26.0.10792818"
+        ndkVersion = "26.1.10909125"
         kotlinVersion = "1.8.0"
     }
     repositories {


### PR DESCRIPTION
Summary:
I'm bumping the NDK to 26.1. As we already have a bump lined up to 26.0 on main,
it makes sense to go to .1 as it's declared the LTS:
https://github.com/android/ndk/wiki

Changelog:
[Android] [Changed] - Android NDK to 26.1

Differential Revision: D53083606


