### PR TITLE
Enable the DevMenu in bridgeless mode

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -258,6 +258,16 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                    delegate:self
                   jsInvoker:std::make_shared<BridgelessJSCallInvoker>(bufferedRuntimeExecutor)];
 
+#if RCT_DEV
+  /**
+   * Instantiating DevMenu has the side-effect of registering
+   * shortcuts for CMD + d, CMD + i,  and CMD + n via RCTDevMenu.
+   * Therefore, when TurboModules are enabled, we must manually create this
+   * NativeModule.
+   */
+  [_turboModuleManager moduleForName:"RCTDevMenu"];
+#endif // end RCT_DEV
+
   // Initialize RCTModuleRegistry so that TurboModules can require other TurboModules.
   [_bridgeModuleDecorator.moduleRegistry setTurboModuleRegistry:_turboModuleManager];
 


### PR DESCRIPTION
Summary:
When the RCT_DEV flag is turned on, we force the eager initialization of the DevMenu at startup.
The initialization was happening in a method of the `CxxBridgeDelegate` protocol.
In bridgeless mode, we don't have the bridge, hence we don't call this method.

I need to put the initialization code in the `RCTIntance` because the only way I found to eagerly initialize a module was to tap into the `RCTTurboModuleManager` and, in Bridgeless mode, that's seemed to be the only way.
I'm open to move the code to a better place, anyway!

## Changelog:
[Internal] - Enable the DevMenu eagerly in Bridgeless mode

Reviewed By: sammy-SC

Differential Revision: D53083637


