### PR TITLE
Cleanup srcSet for java and res

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -593,17 +593,12 @@ android {
       ":packages:react-native:ReactAndroid:hermes-engine:preBuild")
 
   sourceSets.getByName("main") {
-    res.srcDirs(
+    res.setSrcDirs(
         listOf(
             "src/main/res/devsupport",
             "src/main/res/shell",
             "src/main/res/views/modal",
             "src/main/res/views/uimanager"))
-    java.srcDirs(
-        listOf(
-            "src/main/java",
-            "src/main/libraries/soloader/java",
-            "src/main/jni/first-party/fb/jni/java"))
     java.exclude("com/facebook/annotationprocessors")
     java.exclude("com/facebook/react/processing")
     java.exclude("com/facebook/react/module/processing")


### PR DESCRIPTION
Summary:
Those folders for Java don't exist anymore, I'm removing this as it's unnecessary and will default to only src/main/java.
For resources instead, I'm using `setSrcDirs` as it will replace the default, while `srcDirs()` will add those folders.
We need to replace the default res folder as we need to follow the resource folder structure of BUCK

Changelog:
[Internal] [Changed] - Cleanup srcSet for java and res

Differential Revision: D53083677


