### PR TITLE
Fix Soloader call in DefaultComponentsRegistry

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultComponentsRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultComponentsRegistry.kt
@@ -23,15 +23,17 @@ class DefaultComponentsRegistry
 @DoNotStrip
 private constructor(componentFactory: ComponentFactory) {
 
-  @DoNotStrip private val hybridData: HybridData = initHybrid(componentFactory)
+  @DoNotStrip
+  @Suppress("NoHungarianNotation")
+  private val mHybridData: HybridData = initHybrid(componentFactory)
 
   @DoNotStrip private external fun initHybrid(componentFactory: ComponentFactory): HybridData
 
-  init {
-    DefaultSoLoader.maybeLoadSoLibrary()
-  }
-
   companion object {
+    init {
+      DefaultSoLoader.maybeLoadSoLibrary()
+    }
+
     @JvmStatic
     @DoNotStrip
     fun register(componentFactory: ComponentFactory) = DefaultComponentsRegistry(componentFactory)


### PR DESCRIPTION
Summary:
Calling `maybeLoadSoLibrary` from init is too late, as we call `initHybrid` before `init`. Instead use a static initializer.

Changelog: [Internal]

Differential Revision: D53048065


