### PR TITLE
Cherry-picking 'Call super.onRequestPermissionsResult in ReactActivity (#42478)' onto 0.71

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -113,6 +113,7 @@ public abstract class ReactActivity extends AppCompatActivity
   @Override
   public void onRequestPermissionsResult(
       int requestCode, String[] permissions, int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     mDelegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 


### PR DESCRIPTION
## Summary:

I'm cherry-picking 96ed1190c624869af96e464b009e0c0234076893 on the release branch for 0.71.

This change allows activities to handle onRequestPermissionsResult callbacks (eg: registerForActivityResult)

Fixes #42403

## Changelog:

[Android][Changed] - Call super.onRequestPermissionsResult in ReactActivity's onRequestPermissionsResult()

Pull Request resolved: https://github.com/facebook/react-native/pull/42478

Test Plan:
**Without super.onRequestPermissionsResult() call**

![before](https://github.com/facebook/react-native/assets/8672580/553ff597-c077-4831-a4d3-51846a253536)

**With super.onRequestPermissionsResult() call**

![after](https://github.com/facebook/react-native/assets/8672580/c7d588d2-5846-4083-a02f-59b5f915442c)