### PR TITLE
Update InspectorFlags to source from ReactNativeFeatureFlags

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -87,7 +87,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
   NSDictionary *initProps = updateInitialProps([self prepareInitialProps], fabricEnabled);
 
-  RCTAppSetupPrepareApp(application, enableTM, *_reactNativeConfig);
+  RCTAppSetupPrepareApp(application, enableTM);
 
   UIView *rootView;
   if (enableBridgeless) {

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -11,8 +11,6 @@
 
 #ifdef __cplusplus
 
-#import <react/config/ReactNativeConfig.h>
-
 #import <memory>
 
 #if USE_HERMES
@@ -43,21 +41,11 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactory
     RCTBridge *bridge,
     const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler);
 
-/**
- * Register features and experiments prior to app initialization.
- */
-void RCTAppSetupPrepareApp(
-    UIApplication *application,
-    BOOL turboModuleEnabled,
-    const facebook::react::ReactNativeConfig &reactNativeConfig);
-
 #endif // __cplusplus
 
 RCT_EXTERN_C_BEGIN
 
-void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
-    __deprecated_msg("Use the 3-argument overload of RCTAppSetupPrepareApp instead");
-
+void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled);
 UIView *RCTAppSetupDefaultRootView(
     RCTBridge *bridge,
     NSString *moduleName,

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -24,9 +24,6 @@
 #import <React/RCTFabricSurface.h>
 #import <React/RCTSurfaceHostingProxyRootView.h>
 
-// jsinspector-modern
-#import <jsinspector-modern/InspectorFlags.h>
-
 void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
 {
   RCTEnableTurboModule(turboModuleEnabled);
@@ -36,20 +33,6 @@ void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
   // Metro reconnection logic. Users only need this when running the application using our CLI tooling.
   application.idleTimerDisabled = YES;
 #endif
-}
-
-void RCTAppSetupPrepareApp(
-    UIApplication *application,
-    BOOL turboModuleEnabled,
-    const facebook::react::ReactNativeConfig &reactNativeConfig)
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  RCTAppSetupPrepareApp(application, turboModuleEnabled);
-#pragma clang diagnostic pop
-
-  auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
-  inspectorFlags.initFromConfig(reactNativeConfig);
 }
 
 UIView *

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -88,7 +88,6 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-utils")
   add_dependency(s, "React-debug")
   add_dependency(s, "React-rendererdebug")
-  add_dependency(s, "React-jsinspector")
 
   if use_hermes
     s.dependency "React-hermes"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<52367278b4d0fdf7f436bd8c511d4ffe>>
+ * @generated SignedSource<<b66dc0136c3b11f580bf86f4510e5f2d>>
  */
 
 /**
@@ -47,6 +47,16 @@ object ReactNativeFeatureFlags {
    * When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.
    */
   fun batchRenderingUpdatesInEventLoop() = accessor.batchRenderingUpdatesInEventLoop()
+
+  /**
+   * Flag determining if the C++ implementation of InspectorPackagerConnection should be used instead of the per-platform one. This flag is global and should not be changed across React Host lifetimes.
+   */
+  fun inspectorEnableCXXInspectorPackagerConnection() = accessor.inspectorEnableCXXInspectorPackagerConnection()
+
+  /**
+   * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
+   */
+  fun inspectorEnableModernCDPRegistry() = accessor.inspectorEnableModernCDPRegistry()
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<920bb26d238f935f63a77943df7ef6e2>>
+ * @generated SignedSource<<b231ef3cc360490588d342a4b329db74>>
  */
 
 /**
@@ -24,6 +24,8 @@ class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccessor {
   private var useModernRuntimeSchedulerCache: Boolean? = null
   private var enableMicrotasksCache: Boolean? = null
   private var batchRenderingUpdatesInEventLoopCache: Boolean? = null
+  private var inspectorEnableCXXInspectorPackagerConnectionCache: Boolean? = null
+  private var inspectorEnableModernCDPRegistryCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -57,6 +59,24 @@ class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccessor {
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.batchRenderingUpdatesInEventLoop()
       batchRenderingUpdatesInEventLoopCache = cached
+    }
+    return cached
+  }
+
+  override fun inspectorEnableCXXInspectorPackagerConnection(): Boolean {
+    var cached = inspectorEnableCXXInspectorPackagerConnectionCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.inspectorEnableCXXInspectorPackagerConnection()
+      inspectorEnableCXXInspectorPackagerConnectionCache = cached
+    }
+    return cached
+  }
+
+  override fun inspectorEnableModernCDPRegistry(): Boolean {
+    var cached = inspectorEnableModernCDPRegistryCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.inspectorEnableModernCDPRegistry()
+      inspectorEnableModernCDPRegistryCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<19d0606854e3e34efe67acf9dc1d26b4>>
+ * @generated SignedSource<<a8a49da74efc0fda9917204f155e5fdf>>
  */
 
 /**
@@ -35,6 +35,10 @@ object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic external fun enableMicrotasks(): Boolean
 
   @DoNotStrip @JvmStatic external fun batchRenderingUpdatesInEventLoop(): Boolean
+
+  @DoNotStrip @JvmStatic external fun inspectorEnableCXXInspectorPackagerConnection(): Boolean
+
+  @DoNotStrip @JvmStatic external fun inspectorEnableModernCDPRegistry(): Boolean
 
   @DoNotStrip @JvmStatic external fun override(provider: Any)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<932fd2768c81d5a5f49929c89d6659ff>>
+ * @generated SignedSource<<abf6ada278b17086001495e8c20beb94>>
  */
 
 /**
@@ -30,4 +30,8 @@ open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvider {
   override fun enableMicrotasks(): Boolean = false
 
   override fun batchRenderingUpdatesInEventLoop(): Boolean = false
+
+  override fun inspectorEnableCXXInspectorPackagerConnection(): Boolean = false
+
+  override fun inspectorEnableModernCDPRegistry(): Boolean = false
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6254686d99a8bfd0531ed629655cf673>>
+ * @generated SignedSource<<396ff5e588c70a75231cd28ef7372509>>
  */
 
 /**
@@ -28,6 +28,8 @@ class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAccessor {
   private var useModernRuntimeSchedulerCache: Boolean? = null
   private var enableMicrotasksCache: Boolean? = null
   private var batchRenderingUpdatesInEventLoopCache: Boolean? = null
+  private var inspectorEnableCXXInspectorPackagerConnectionCache: Boolean? = null
+  private var inspectorEnableModernCDPRegistryCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -65,6 +67,26 @@ class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAccessor {
       cached = currentProvider.batchRenderingUpdatesInEventLoop()
       accessedFeatureFlags.add("batchRenderingUpdatesInEventLoop")
       batchRenderingUpdatesInEventLoopCache = cached
+    }
+    return cached
+  }
+
+  override fun inspectorEnableCXXInspectorPackagerConnection(): Boolean {
+    var cached = inspectorEnableCXXInspectorPackagerConnectionCache
+    if (cached == null) {
+      cached = currentProvider.inspectorEnableCXXInspectorPackagerConnection()
+      accessedFeatureFlags.add("inspectorEnableCXXInspectorPackagerConnection")
+      inspectorEnableCXXInspectorPackagerConnectionCache = cached
+    }
+    return cached
+  }
+
+  override fun inspectorEnableModernCDPRegistry(): Boolean {
+    var cached = inspectorEnableModernCDPRegistryCache
+    if (cached == null) {
+      cached = currentProvider.inspectorEnableModernCDPRegistry()
+      accessedFeatureFlags.add("inspectorEnableModernCDPRegistry")
+      inspectorEnableModernCDPRegistryCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c5c87368aae4df966b4b7971aadb79f2>>
+ * @generated SignedSource<<82eaefcdbe1f6d10a8f23515a1d4da4f>>
  */
 
 /**
@@ -30,4 +30,8 @@ interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip fun enableMicrotasks(): Boolean
 
   @DoNotStrip fun batchRenderingUpdatesInEventLoop(): Boolean
+
+  @DoNotStrip fun inspectorEnableCXXInspectorPackagerConnection(): Boolean
+
+  @DoNotStrip fun inspectorEnableModernCDPRegistry(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bd4482119f1c4963aa4ad1e354f9107d>>
+ * @generated SignedSource<<c3f4d38c7536ac061a31f4120d74962a>>
  */
 
 /**
@@ -43,6 +43,16 @@ bool JReactNativeFeatureFlagsCxxInterop::batchRenderingUpdatesInEventLoop(
   return ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::inspectorEnableCXXInspectorPackagerConnection(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::inspectorEnableCXXInspectorPackagerConnection();
+}
+
+bool JReactNativeFeatureFlagsCxxInterop::inspectorEnableModernCDPRegistry(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry();
+}
+
 void JReactNativeFeatureFlagsCxxInterop::override(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/,
     jni::alias_ref<jobject> provider) {
@@ -72,6 +82,12 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "batchRenderingUpdatesInEventLoop",
         JReactNativeFeatureFlagsCxxInterop::batchRenderingUpdatesInEventLoop),
+      makeNativeMethod(
+        "inspectorEnableCXXInspectorPackagerConnection",
+        JReactNativeFeatureFlagsCxxInterop::inspectorEnableCXXInspectorPackagerConnection),
+      makeNativeMethod(
+        "inspectorEnableModernCDPRegistry",
+        JReactNativeFeatureFlagsCxxInterop::inspectorEnableModernCDPRegistry),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b7304c29a002ce5a8a612d7a08d798ff>>
+ * @generated SignedSource<<45db007305596a2948feb77bed43d821>>
  */
 
 /**
@@ -40,6 +40,12 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool batchRenderingUpdatesInEventLoop(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool inspectorEnableCXXInspectorPackagerConnection(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool inspectorEnableModernCDPRegistry(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static void override(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<91f988022fbff7eba632f2ba46056025>>
+ * @generated SignedSource<<e0169d9369bd97de137aceed244736ba>>
  */
 
 /**
@@ -48,6 +48,18 @@ bool ReactNativeFeatureFlagsProviderHolder::enableMicrotasks() {
 bool ReactNativeFeatureFlagsProviderHolder::batchRenderingUpdatesInEventLoop() {
   static const auto method =
       getJClass()->getMethod<jboolean()>("batchRenderingUpdatesInEventLoop");
+  return method(javaProvider_);
+}
+
+bool ReactNativeFeatureFlagsProviderHolder::inspectorEnableCXXInspectorPackagerConnection() {
+  static const auto method =
+      getJClass()->getMethod<jboolean()>("inspectorEnableCXXInspectorPackagerConnection");
+  return method(javaProvider_);
+}
+
+bool ReactNativeFeatureFlagsProviderHolder::inspectorEnableModernCDPRegistry() {
+  static const auto method =
+      getJClass()->getMethod<jboolean()>("inspectorEnableModernCDPRegistry");
   return method(javaProvider_);
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3550f7ee28a53a4024a48301ee38ce7e>>
+ * @generated SignedSource<<18e3302413a4b725f23c972728f109c5>>
  */
 
 /**
@@ -39,6 +39,8 @@ class ReactNativeFeatureFlagsProviderHolder
   bool useModernRuntimeScheduler() override;
   bool enableMicrotasks() override;
   bool batchRenderingUpdatesInEventLoop() override;
+  bool inspectorEnableCXXInspectorPackagerConnection() override;
+  bool inspectorEnableModernCDPRegistry() override;
 
  private:
   jni::global_ref<jobject> javaProvider_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -21,4 +21,5 @@ target_include_directories(jsinspector PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(jsinspector
         folly_runtime
         glog
+        react_featureflags
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <glog/logging.h>
-#include <cassert>
-
 #include "InspectorFlags.h"
+
+#include <glog/logging.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -17,44 +17,42 @@ InspectorFlags& InspectorFlags::getInstance() {
   return instance;
 }
 
-void InspectorFlags::initFromConfig(
-    const ReactNativeConfig& reactNativeConfig) {
-  bool enableModernCDPRegistry =
-      reactNativeConfig.getBool("react_native_devx:enable_modern_cdp_registry");
-  if (enableModernCDPRegistry_.has_value()) {
-    assert(
-        *enableModernCDPRegistry_ == enableModernCDPRegistry &&
-        "Flag value was changed after init");
-  }
-  enableModernCDPRegistry_ = enableModernCDPRegistry;
-  bool enableCxxInspectorPackagerConnection = reactNativeConfig.getBool(
-      "react_native_devx:enable_cxx_inspector_packager_connection");
-  if (enableCxxInspectorPackagerConnection_.has_value()) {
-    assert(
-        *enableCxxInspectorPackagerConnection_ ==
-            enableCxxInspectorPackagerConnection &&
-        "Flag value was changed after init");
-  }
-  enableCxxInspectorPackagerConnection_ = enableCxxInspectorPackagerConnection;
-}
+InspectorFlags::InspectorFlags()
+    : enableModernCDPRegistry_(
+          ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry()),
+      enableCxxInspectorPackagerConnection_(
+          ReactNativeFeatureFlags::
+              inspectorEnableCXXInspectorPackagerConnection()) {}
 
 bool InspectorFlags::getEnableModernCDPRegistry() const {
-  if (!enableModernCDPRegistry_.has_value()) {
-    LOG(WARNING)
-        << "InspectorFlags::getEnableModernCDPRegistry was called before init";
-  }
-  return enableModernCDPRegistry_.value_or(false);
+  assertFlagsMatchUpstream();
+  return enableModernCDPRegistry_;
 }
 
 bool InspectorFlags::getEnableCxxInspectorPackagerConnection() const {
-  if (!enableCxxInspectorPackagerConnection_.has_value()) {
-    LOG(WARNING)
-        << "InspectorFlags::getEnableCxxInspectorPackagerConnection was called before init";
-  }
-  return enableCxxInspectorPackagerConnection_.value_or(false) ||
+  assertFlagsMatchUpstream();
+  return enableCxxInspectorPackagerConnection_ ||
       // If we are using the modern CDP registry, then we must also use the C++
       // InspectorPackagerConnection implementation.
-      getEnableModernCDPRegistry();
+      enableModernCDPRegistry_;
+}
+
+void InspectorFlags::assertFlagsMatchUpstream() const {
+  if (inconsistentFlagsStateLogged_) {
+    return;
+  }
+
+  if (enableModernCDPRegistry_ !=
+          ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry() ||
+      enableCxxInspectorPackagerConnection_ !=
+          ReactNativeFeatureFlags::
+              inspectorEnableCXXInspectorPackagerConnection()) {
+    LOG(ERROR)
+        << "[InspectorFlags] Error: One or more ReactNativeFeatureFlags values "
+        << "have changed during the global app lifetime. This may lead to "
+        << "inconsistent inspector behaviour. Please quit and restart the app.";
+    inconsistentFlagsStateLogged_ = true;
+  }
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -9,24 +9,15 @@
 
 #include <optional>
 
-#include <react/config/ReactNativeConfig.h>
-
 namespace facebook::react::jsinspector_modern {
 
 /**
  * A container for all inspector related feature flags (Meyers singleton
- * pattern). Flags must be set before they are accessed and are static for the
- * lifetime of the app.
+ * pattern). Enforces that flag values are static for the lifetime of the app.
  */
 class InspectorFlags {
  public:
   static InspectorFlags& getInstance();
-
-  /**
-   * Initialize flags from a `ReactNativeConfig` instance. Validates that flag
-   * values are not changed across multiple calls.
-   */
-  void initFromConfig(const ReactNativeConfig& reactNativeConfig);
 
   /**
    * Flag determining if the modern CDP backend should be enabled.
@@ -40,13 +31,16 @@ class InspectorFlags {
   bool getEnableCxxInspectorPackagerConnection() const;
 
  private:
-  InspectorFlags() = default;
+  InspectorFlags();
   InspectorFlags(const InspectorFlags&) = delete;
   InspectorFlags& operator=(const InspectorFlags&) = delete;
   ~InspectorFlags() = default;
 
-  std::optional<bool> enableModernCDPRegistry_;
-  std::optional<bool> enableCxxInspectorPackagerConnection_;
+  const bool enableModernCDPRegistry_;
+  const bool enableCxxInspectorPackagerConnection_;
+
+  mutable bool inconsistentFlagsStateLogged_;
+  void assertFlagsMatchUpstream() const;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -38,6 +38,6 @@ Pod::Spec.new do |s|
                              }
   s.dependency "glog"
   s.dependency "RCT-Folly", folly_version
-  s.dependency "React-nativeconfig"
+  s.dependency "React-featureflags"
   s.dependency "DoubleConversion"
 end

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
@@ -16,12 +16,6 @@ bool EmptyReactNativeConfig::getBool(const std::string& param) const {
   if (param == "react_fabric:enabled_automatic_interop_android") {
     return true;
   }
-  if (param == "react_native_devx:enable_modern_cdp_registry") {
-    return false;
-  }
-  if (param == "react_native_devx:enable_cxx_inspector_packager_connection") {
-    return false;
-  }
   return false;
 }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<eb9bb346a84321197849de2dd8bf7dc3>>
+ * @generated SignedSource<<ae3f44dfb0e5672a8e47ce6ef32ba81e>>
  */
 
 /**
@@ -35,6 +35,14 @@ bool ReactNativeFeatureFlags::enableMicrotasks() {
 
 bool ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop() {
   return getAccessor().batchRenderingUpdatesInEventLoop();
+}
+
+bool ReactNativeFeatureFlags::inspectorEnableCXXInspectorPackagerConnection() {
+  return getAccessor().inspectorEnableCXXInspectorPackagerConnection();
+}
+
+bool ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry() {
+  return getAccessor().inspectorEnableModernCDPRegistry();
 }
 
 void ReactNativeFeatureFlags::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<be203871f94ca134f75b803b7d79a5ab>>
+ * @generated SignedSource<<a265fa2a1d703ca35b280bd56b76fffc>>
  */
 
 /**
@@ -51,6 +51,16 @@ class ReactNativeFeatureFlags {
    * When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.
    */
   static bool batchRenderingUpdatesInEventLoop();
+
+  /**
+   * Flag determining if the C++ implementation of InspectorPackagerConnection should be used instead of the per-platform one. This flag is global and should not be changed across React Host lifetimes.
+   */
+  static bool inspectorEnableCXXInspectorPackagerConnection();
+
+  /**
+   * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
+   */
+  static bool inspectorEnableModernCDPRegistry();
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5df50987338c0541436b11cd5433013c>>
+ * @generated SignedSource<<8701d8d90755e965553f71ccb179083d>>
  */
 
 /**
@@ -94,6 +94,40 @@ bool ReactNativeFeatureFlagsAccessor::batchRenderingUpdatesInEventLoop() {
   }
 
   return batchRenderingUpdatesInEventLoop_.value();
+}
+
+bool ReactNativeFeatureFlagsAccessor::inspectorEnableCXXInspectorPackagerConnection() {
+  if (!inspectorEnableCXXInspectorPackagerConnection_.has_value()) {
+    // Mark the flag as accessed.
+    static const char* flagName = "inspectorEnableCXXInspectorPackagerConnection";
+    if (std::find(
+            accessedFeatureFlags_.begin(),
+            accessedFeatureFlags_.end(),
+            flagName) == accessedFeatureFlags_.end()) {
+      accessedFeatureFlags_.push_back(flagName);
+    }
+
+    inspectorEnableCXXInspectorPackagerConnection_.emplace(currentProvider_->inspectorEnableCXXInspectorPackagerConnection());
+  }
+
+  return inspectorEnableCXXInspectorPackagerConnection_.value();
+}
+
+bool ReactNativeFeatureFlagsAccessor::inspectorEnableModernCDPRegistry() {
+  if (!inspectorEnableModernCDPRegistry_.has_value()) {
+    // Mark the flag as accessed.
+    static const char* flagName = "inspectorEnableModernCDPRegistry";
+    if (std::find(
+            accessedFeatureFlags_.begin(),
+            accessedFeatureFlags_.end(),
+            flagName) == accessedFeatureFlags_.end()) {
+      accessedFeatureFlags_.push_back(flagName);
+    }
+
+    inspectorEnableModernCDPRegistry_.emplace(currentProvider_->inspectorEnableModernCDPRegistry());
+  }
+
+  return inspectorEnableModernCDPRegistry_.value();
 }
 
 void ReactNativeFeatureFlagsAccessor::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<11335a9c0d793a3a5a0dfdb01cd43efd>>
+ * @generated SignedSource<<fc7f2d01aea3bc0332120d444cbb13ab>>
  */
 
 /**
@@ -34,6 +34,8 @@ class ReactNativeFeatureFlagsAccessor {
   bool useModernRuntimeScheduler();
   bool enableMicrotasks();
   bool batchRenderingUpdatesInEventLoop();
+  bool inspectorEnableCXXInspectorPackagerConnection();
+  bool inspectorEnableModernCDPRegistry();
 
   void override(std::unique_ptr<ReactNativeFeatureFlagsProvider> provider);
 
@@ -45,6 +47,8 @@ class ReactNativeFeatureFlagsAccessor {
   std::optional<bool> useModernRuntimeScheduler_;
   std::optional<bool> enableMicrotasks_;
   std::optional<bool> batchRenderingUpdatesInEventLoop_;
+  std::optional<bool> inspectorEnableCXXInspectorPackagerConnection_;
+  std::optional<bool> inspectorEnableModernCDPRegistry_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b354cb54b822e2dfa3e093d39fb4da4e>>
+ * @generated SignedSource<<d7fbc685429c4fd2b335454821d00ba4>>
  */
 
 /**
@@ -40,6 +40,14 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool batchRenderingUpdatesInEventLoop() override {
+    return false;
+  }
+
+  bool inspectorEnableCXXInspectorPackagerConnection() override {
+    return false;
+  }
+
+  bool inspectorEnableModernCDPRegistry() override {
     return false;
   }
 };

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6bf1fc0d7b32a36041c2371fe191792b>>
+ * @generated SignedSource<<c412e8bec6fb2757dea0861ebe072668>>
  */
 
 /**
@@ -29,6 +29,8 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useModernRuntimeScheduler() = 0;
   virtual bool enableMicrotasks() = 0;
   virtual bool batchRenderingUpdatesInEventLoop() = 0;
+  virtual bool inspectorEnableCXXInspectorPackagerConnection() = 0;
+  virtual bool inspectorEnableModernCDPRegistry() = 0;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<01b940f6716765f9359c42180db497c0>>
+ * @generated SignedSource<<078335ed4836a610f4898ceac4f09acc>>
  */
 
 /**
@@ -53,6 +53,16 @@ bool NativeReactNativeFeatureFlags::enableMicrotasks(
 bool NativeReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop();
+}
+
+bool NativeReactNativeFeatureFlags::inspectorEnableCXXInspectorPackagerConnection(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::inspectorEnableCXXInspectorPackagerConnection();
+}
+
+bool NativeReactNativeFeatureFlags::inspectorEnableModernCDPRegistry(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry();
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<200fe2cf84a044164c60f6dd3c5569dd>>
+ * @generated SignedSource<<0d9f67bdf91897c7b99f103c080392e5>>
  */
 
 /**
@@ -37,6 +37,10 @@ class NativeReactNativeFeatureFlags
   bool enableMicrotasks(jsi::Runtime& runtime);
 
   bool batchRenderingUpdatesInEventLoop(jsi::Runtime& runtime);
+
+  bool inspectorEnableCXXInspectorPackagerConnection(jsi::Runtime& runtime);
+
+  bool inspectorEnableModernCDPRegistry(jsi::Runtime& runtime);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.json
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.json
@@ -15,6 +15,14 @@
     "batchRenderingUpdatesInEventLoop": {
       "description": "When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.",
       "defaultValue": false
+    },
+    "inspectorEnableCXXInspectorPackagerConnection": {
+      "description": "Flag determining if the C++ implementation of InspectorPackagerConnection should be used instead of the per-platform one. This flag is global and should not be changed across React Host lifetimes.",
+      "defaultValue": false
+    },
+    "inspectorEnableModernCDPRegistry": {
+      "description": "Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.",
+      "defaultValue": false
     }
   },
   "jsOnly": {

--- a/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<564159837241d197ebc3084ff9e72b7c>>
+ * @generated SignedSource<<ce880c1d60db08be66dacaee38db634a>>
  * @flow strict-local
  */
 
@@ -27,6 +27,8 @@ export interface Spec extends TurboModule {
   +useModernRuntimeScheduler?: () => boolean;
   +enableMicrotasks?: () => boolean;
   +batchRenderingUpdatesInEventLoop?: () => boolean;
+  +inspectorEnableCXXInspectorPackagerConnection?: () => boolean;
+  +inspectorEnableModernCDPRegistry?: () => boolean;
 }
 
 const NativeReactNativeFeatureFlags: ?Spec = TurboModuleRegistry.get<Spec>(

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4e4ce58c1ce1a95355bba0dfe099e26e>>
+ * @generated SignedSource<<b0c3c8e7de4b85260fc80fe064634d15>>
  * @flow strict-local
  */
 
@@ -37,6 +37,8 @@ export type ReactNativeFeatureFlags = {
   useModernRuntimeScheduler: Getter<boolean>,
   enableMicrotasks: Getter<boolean>,
   batchRenderingUpdatesInEventLoop: Getter<boolean>,
+  inspectorEnableCXXInspectorPackagerConnection: Getter<boolean>,
+  inspectorEnableModernCDPRegistry: Getter<boolean>,
 }
 
 /**
@@ -60,6 +62,14 @@ export const enableMicrotasks: Getter<boolean> = createNativeFlagGetter('enableM
  * When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.
  */
 export const batchRenderingUpdatesInEventLoop: Getter<boolean> = createNativeFlagGetter('batchRenderingUpdatesInEventLoop', false);
+/**
+ * Flag determining if the C++ implementation of InspectorPackagerConnection should be used instead of the per-platform one. This flag is global and should not be changed across React Host lifetimes.
+ */
+export const inspectorEnableCXXInspectorPackagerConnection: Getter<boolean> = createNativeFlagGetter('inspectorEnableCXXInspectorPackagerConnection', false);
+/**
+ * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
+ */
+export const inspectorEnableModernCDPRegistry: Getter<boolean> = createNativeFlagGetter('inspectorEnableModernCDPRegistry', false);
 
 /**
  * Overrides the feature flags with the provided methods.

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -970,7 +970,7 @@ PODS:
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
-    - React-nativeconfig
+    - React-featureflags
   - React-jsitracing (1000.0.0):
     - React-jsi
   - React-logger (1000.0.0):
@@ -1010,7 +1010,6 @@ PODS:
     - React-Fabric
     - React-graphics
     - React-hermes
-    - React-jsinspector
     - React-nativeconfig
     - React-NativeModulesApple
     - React-RCTFabric
@@ -1439,67 +1438,67 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
-  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  FBLazyVector: 80d85e38b737304c573a42c3ed69ec51a74ebee4
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
+  FBLazyVector: f4492a543c5a8fa1502d3a5867e3f7252497cfe8
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 6f7d1a2fb590269119d19d963a6e2b62dcdd1721
+  hermes-engine: 1fb67b716710a0556ae5e77b87b952754f2b7dd8
   MyNativeView: dd2b0ad0ea90d05a1776b18c7d3470aa8b69f9d1
   NativeCxxModuleExample: 31e3c8426cf9ca356c76d253e6fc7e98921a7f4d
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: a14916570a9ef52b93dad473600f5d656832507a
-  RCTTypeSafety: 4769d6550d055cea198971df638b28f61e86072b
-  React: 194d13ea4a90032457b6e92099ac51cccda898d2
-  React-callinvoker: 215bd34db74ea2831bb627e2572b5b831746b6e1
+  RCTRequired: 82c56a03b3efd524bfdb581a906add903f78f978
+  RCTTypeSafety: 5f57d4ae5dfafc85a0f575d756c909b584722c52
+  React: cb6dc75e09f32aeddb4d8fb58a394a67219a92fe
+  React-callinvoker: bae59cbd6affd712bbfc703839dad868ff35069d
   React-Codegen: 25f5198c8c8158ec8ba01ee189d3a1d6b63379d5
-  React-Core: 5de238e24aaf3dd16aff743523df6dcceaaa49e0
-  React-CoreModules: f9170698af1e3a113c99ca381c756cba1482078f
-  React-cxxreact: f589d552b41c4c9c97257f5fdde5a7049775f8e4
-  React-debug: 48bb1735d8caac8e22e4f8d6d5683b98aab61044
-  React-Fabric: a5e0e4a4d143841ac4ee4201cb205dcd6834d342
-  React-FabricImage: 65a764914dd48a85cde02380d8740cf0af7d5300
-  React-featureflags: 0a56b28b4b3247f452a16b4664864becb781aad5
-  React-graphics: 251a50eff3719bd409a8cc26a2dc7ef2682dffb0
-  React-hermes: 99f5526d0782ad16fca84afb1b1ab193df978262
-  React-ImageManager: 47407334aa23bbe74c792b7ff5696bf8a9d7566a
-  React-jserrorhandler: 538730411d4bda2dcbf9987b6557271d8e47673a
-  React-jsi: 5a51a91a5ac30fc38af9987b1ac4c050a3f0dac9
-  React-jsiexecutor: e581070857be6eae34e146164c62592a132e7aa6
-  React-jsinspector: 74602660223d5080305b5b04c8c94174b058879c
-  React-jsitracing: 438dcae95d4567557f2574075b3d4612a8c302a5
-  React-logger: 50345fa50855797bd9fccebfec0d61e0df4337cf
-  React-Mapbuffer: d7960d378a9d7714367d9ed7200f1b0f8444a4b0
-  React-nativeconfig: 2528aeb80bd822750edd6e6877a95a4d89b20e9b
-  React-NativeModulesApple: 43ce497b0245c2487eae7fe45e5f51e32f3cca40
-  React-perflogger: e072f55f808309a3e55e1c08aa7bdd799fdb9c67
-  React-RCTActionSheet: 5ce53e5ecd88baa5b079ab1c55f54c347c4d154d
-  React-RCTAnimation: 7e9a4a00b0fb2667a0e9d7ebf8f77356d7102c03
-  React-RCTAppDelegate: 2eeadf179d3e0805ebdc1ab6ec6ca6956d4dc6b2
-  React-RCTBlob: a77a8de4e6f240000ba6181e7df9f53d83a6c775
-  React-RCTFabric: d6887c5192e2d74a50874af966b70d1aef6a9975
-  React-RCTImage: 830ed417aa58842a135bf8317b29f5fad2a20a6c
-  React-RCTLinking: 4dff6eba8be6a4e4c6aba3f7f7507c6bfbbb6bc1
-  React-RCTNetwork: fb0b6bb4bf5b23395ce813e48c57d4ace8bec6c0
-  React-RCTPushNotification: fff5dd9330358074441b12003be1466d410a33c2
-  React-RCTSettings: 2bd6189c94e7dac61469f2ec79a525221933f9d2
-  React-RCTTest: 6d1ce419123399227c8e8d4f4530038529432989
-  React-RCTText: 4250ed4719be5b0346678cea2fa0eb182eca0858
-  React-RCTVibration: 2f998bcecc8f78c75d448cb59552e6596e239959
-  React-rendererdebug: 515a2d5746c4cb5511e72ee11d8c2fb5cb4058d1
-  React-rncore: a4a0a2142eb23ddabfbeb6d05734ec01ac28426b
-  React-RuntimeApple: ad10b4ff896ef9f58f4a5b8cc2f8f79b4d6797c9
-  React-RuntimeCore: dcbb3e3f5d5d308a699850e0ec6b36570be0f735
-  React-runtimeexecutor: c5971b3b195b8999e830c9f3c76b958421fc6bbe
-  React-RuntimeHermes: e1c8a39e0d181f75f0c00bd9cd350b081ca6edc0
-  React-runtimescheduler: b442ef34ab06abfe0a6f809ac5a778efb25d6fbc
-  React-utils: 05b58bfc3aa4bfa5b478fbcfb4f24d0f5f5f6da7
-  ReactCommon: ba33f2bd19399b4d9085bc7455ebe2fbff04af1a
-  ReactCommon-Samples: 32452a708abecbd1f7694205ad87ef371af91ec6
+  React-Core: f36333c59576ea93c31573bc71fe29893fbc4484
+  React-CoreModules: 04058009e696161fd7a9f55b43e04819c41f12e3
+  React-cxxreact: d7e2b4279e31dee6ec2af7fd8fdd42b1fd0e655c
+  React-debug: 296b501a90c41f83961f58c6d96a01330d499da5
+  React-Fabric: 2a9b753ed7595c5357f3043fb57fa0055d2f4301
+  React-FabricImage: da62cc5089fe6bdaa6ec0ab6ccca75c7d679065d
+  React-featureflags: 23f83a12963770bf3cff300e8990678192436b36
+  React-graphics: da82f771ed590fffcfdad572f07ffde01937f11d
+  React-hermes: 14e7007ebbfcc9f674c9c4f3ac768aa587b6da79
+  React-ImageManager: 716592dcbe11a4960e1eb3d82adb264ee15b5f6d
+  React-jserrorhandler: 13a0cce4e1e445d2ace089dc6122fb85411a11b3
+  React-jsi: b7645527d3f77afdea4365488e47dbc5b293177f
+  React-jsiexecutor: 6baaff1e509ce9269b0457d3a9e442e3ae895c33
+  React-jsinspector: 29198b43732015a487296e995af9a3add2f0f122
+  React-jsitracing: dd08057dd5b74119cb406beb42028da85ed5b8a5
+  React-logger: 8486d7a1d32b972414b1d34a93470ee2562c6ee2
+  React-Mapbuffer: fd0d0306c1c4326be5f18a61e978d32a66b20a85
+  React-nativeconfig: 40a2c848083ef4065c163c854e1c82b5f9e9db84
+  React-NativeModulesApple: 67ee4e22f916aceaa8ccfc9c849d3e7de5d55b0b
+  React-perflogger: 70d009f755dd10002183454cdf5ad9b22de4a1d7
+  React-RCTActionSheet: 943bd5f540f3af1e5a149c13c4de81858edf718a
+  React-RCTAnimation: 07583f0ebfa7154f0e696a75c32a8f8b180fc8c5
+  React-RCTAppDelegate: caf6d5ee49620e032fb253308d143794bfe3d2b1
+  React-RCTBlob: da87f794f188db6539a05b8e13cbc5a198c94848
+  React-RCTFabric: d28cb914dbf28c6316d5863d8e6e11ab66704d8f
+  React-RCTImage: 8f46d82257827c2332bc4108fddef1a840f440a7
+  React-RCTLinking: efa67827466e50e07c5471447c12e474cbc5e336
+  React-RCTNetwork: a80529d2d90f79caa5e31d49e840735a10d6d91a
+  React-RCTPushNotification: c34ef3969207da3ddc777f36a252f99754b89e2d
+  React-RCTSettings: 39ca10f68da0ec88a63c33152d43c222c8c38119
+  React-RCTTest: 3b9f62c66c3814ccace402441597160aefc9e812
+  React-RCTText: d9925903524a7b179cf7803162a98038e0bfb4fd
+  React-RCTVibration: 33bef249bc4a637ed91bf1cf0d94d9329381dc7b
+  React-rendererdebug: 0abbd75e947eeae23542f3bf7491b048ae063141
+  React-rncore: e903b3d2819a25674403c548ec103f34bf02ba2b
+  React-RuntimeApple: b43ad6a5d60157f37ff3139e4dfb0cd6340e9be6
+  React-RuntimeCore: 7cfdac312222d7260d8ba9604686fbb4aa4f8a13
+  React-runtimeexecutor: e1c32bc249dd3cf3919cb4664fd8dc84ef70cff7
+  React-RuntimeHermes: e1d75303b20b761391be4b9443a0181d0ffe4d97
+  React-runtimescheduler: d5fecf52a345c1e557499ee86c864089c2a01fb8
+  React-utils: d468de964db1cfd301b450755ba00518777704c4
+  ReactCommon: 9e0640c274b0b7d1d46fd9e4b0d2e518be4898d5
+  ReactCommon-Samples: ca3ac1e08ee7f73d2b3b4a77946cfb44204d09ca
   ScreenshotManager: 5cdc3d3097325172021474d2741a0852ba712e05
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: a78992b37395702cd47e6787626b55d4583900a9
+  Yoga: 53e99e2a727b8498ea9e8aed8d917b808c9ff2ea
 
 PODFILE CHECKSUM: 60b84dd598fc04e9ed84dbc82e2cb3b99b1d7adf
 

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -941,8 +941,6 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
-					"-Wl",
-					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;
@@ -1033,8 +1031,6 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
-					"-Wl",
-					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Summary:
- Replace the internals of `InspectorFlags` to use the new `ReactNativeFeatureFlags` setup.
- Remove call sites to `InspectorFlags::initFromConfig`.

After this diff, all `InspectorFlags` are configured from `ReactNativeFeatureFlags.json`.

Changelog: [Internal]

Differential Revision: D53049790

