### PR TITLE
Skip unsupported Flow syntax in public-api-test

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1488,6 +1488,8 @@ declare export default typeof NativeFileReaderModule;
 "
 `;
 
+exports[`public API should not change unintentionally Libraries/Blob/URL.js 1`] = `"UNTYPED MODULE (unsupported-syntax suppression)"`;
+
 exports[`public API should not change unintentionally Libraries/BugReporting/BugReporting.js 1`] = `
 "type ExtraData = { [key: string]: string, ... };
 type SourceCallback = () => string;

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -31,7 +31,6 @@ const IGNORE_PATTERNS = [
 // review your changes before adding new entries.
 const FILES_WITH_KNOWN_ERRORS = new Set([
   'Libraries/Blob/FileReader.js',
-  'Libraries/Blob/URL.js',
   'Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js',
   'Libraries/Components/Keyboard/KeyboardAvoidingView.js',
   'Libraries/Components/RefreshControl/RefreshControl.js',
@@ -82,6 +81,13 @@ describe('public API', () => {
       const source = await fs.readFile(path.join(PACKAGE_ROOT, file), 'utf-8');
 
       if (/@flow/.test(source)) {
+        if (source.includes('// $FlowFixMe[unsupported-syntax]')) {
+          expect(
+            'UNTYPED MODULE (unsupported-syntax suppression)',
+          ).toMatchSnapshot();
+          return;
+        }
+
         try {
           expect(await translateFlowToExportedAPI(source)).toMatchSnapshot();
 


### PR DESCRIPTION
Summary: Changelog: [Internal]

Differential Revision: D53091943


