### PR TITLE
Make the jsinspector-modern build with use_frameworks

### DIFF
--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
 
   add_dependency(s, "React-Codegen")
   add_dependency(s, "React-NativeModulesApple")
+  add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -95,8 +95,6 @@ Pod::Spec.new do |s|
     end
     ss.exclude_files = exclude_files
     ss.private_header_files   = "React/Cxx*/*.h"
-
-    ss.dependency "React-jsinspector", version
   end
 
   s.subspec "DevSupport" do |ss|
@@ -105,7 +103,6 @@ Pod::Spec.new do |s|
 
     ss.dependency "React-Core/Default", version
     ss.dependency "React-Core/RCTWebSocket", version
-    ss.dependency "React-jsinspector", version
     ss.private_header_files = "React/Inspector/RCTCxx*.h"
   end
 
@@ -134,6 +131,7 @@ Pod::Spec.new do |s|
   s.dependency "Yoga"
   s.dependency "glog"
 
+  add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "RCTDeprecation")
 
   if use_hermes

--- a/packages/react-native/React/Base/RCTBridge+Private.h
+++ b/packages/react-native/React/Base/RCTBridge+Private.h
@@ -6,6 +6,9 @@
  */
 
 #import <React/RCTBridge.h>
+#ifdef __cplusplus
+#import <jsinspector-modern/ReactCdp.h>
+#endif
 
 @class RCTModuleRegistry;
 @class RCTModuleData;
@@ -70,6 +73,17 @@ RCT_EXTERN void RCTRegisterModule(Class);
  */
 @property (nonatomic, strong, readonly) RCTModuleRegistry *moduleRegistry;
 
+/**
+ * The page target for this bridge, if one has been created. Exposed for RCTCxxBridge only.
+ */
+@property (nonatomic, assign, readonly)
+#ifdef __cplusplus
+    facebook::react::jsinspector_modern::PageTarget *
+#else
+    // The inspector infrastructure cannot be used in C code.
+    void *
+#endif
+        inspectorTarget;
 @end
 
 @interface RCTBridge (RCTCxxBridge)

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -519,4 +519,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   [self.batchedBridge registerSegmentWithId:segmentId path:path];
 }
 
+- (facebook::react::jsinspector_modern::PageTarget *)inspectorTarget
+{
+  return _inspectorTarget.get();
+}
 @end

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi", version
   s.dependency 'React-RCTBlob'
   s.dependency "SocketRocket", socket_rocket_version
+  add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
   add_dependency(s, "React-Codegen")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -87,6 +87,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-utils")
   add_dependency(s, "React-rendererdebug")
   add_dependency(s, "React-runtimescheduler")
+  add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.dependency "fmt", "9.1.0"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
-  add_dependency(s, "React-jsinspector")
+  add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   s.dependency "React-callinvoker", version
   s.dependency "React-runtimeexecutor", version
   s.dependency "React-perflogger", version

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.dependency "fmt", "9.1.0"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
-  s.dependency "React-jsinspector", version
+  add_dependency(s, "React-jsinspector")
   s.dependency "React-callinvoker", version
   s.dependency "React-runtimeexecutor", version
   s.dependency "React-perflogger", version

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <jsinspector-modern/InstanceAgent.h>
+
+namespace facebook::react::jsinspector_modern {
+
+InstanceAgent::InstanceAgent(
+    FrontendChannel frontendChannel,
+    InstanceTarget& target)
+    : frontendChannel_(frontendChannel), target_(target) {
+  (void)target_;
+}
+
+bool InstanceAgent::handleRequest(const cdp::PreparsedRequest& req) {
+  // NOTE: Our implementation of @cdp Runtime.getHeapUsage is a stub.
+  if (req.method == "Runtime.getHeapUsage") {
+    folly::dynamic res = folly::dynamic::object("id", req.id)(
+        "result", folly::dynamic::object("usedSize", 0)("totalSize", 0));
+    frontendChannel_(folly::toJson(res));
+    return true;
+  }
+  return false;
+}
+
+int InstanceAgent::getExecutionContextId() const {
+  return 1;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsinspector-modern/InspectorInterfaces.h>
+#include <jsinspector-modern/Parsing.h>
+#include <functional>
+
+namespace facebook::react::jsinspector_modern {
+
+class InstanceTarget;
+
+/**
+ * An Agent that handles requests from the Chrome DevTools Protocol for the
+ * given InstanceTarget.
+ */
+class InstanceAgent {
+ public:
+  /**
+   * \param frontendChannel A channel used to send responses and events to the
+   * frontend.
+   * \param target The InstanceTarget that this agent is attached to. The
+   * caller is responsible for ensuring that the InstanceTarget outlives this
+   * object.
+   */
+  explicit InstanceAgent(
+      FrontendChannel frontendChannel,
+      InstanceTarget& target);
+
+  /**
+   * Handle a CDP request. The response will be sent over the provided
+   * \c FrontendChannel synchronously or asynchronously.
+   * \param req The parsed request.
+   */
+  bool handleRequest(const cdp::PreparsedRequest& req);
+
+  /**
+   * Get the ID of the execution context that this agent is associated with.
+   * \see
+   * https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExecutionContextId
+   */
+  int getExecutionContextId() const;
+
+ private:
+  FrontendChannel frontendChannel_;
+  InstanceTarget& target_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "InstanceAgent.h"
+
+#include <jsinspector-modern/InstanceTarget.h>
+
+namespace facebook::react::jsinspector_modern {
+
+InstanceTarget::InstanceTarget(InstanceTargetDelegate& delegate)
+    : delegate_(delegate) {
+  (void)delegate_;
+}
+
+InstanceTargetDelegate::~InstanceTargetDelegate() {}
+
+std::unique_ptr<InstanceAgent> InstanceTarget::createAgent(
+    FrontendChannel channel) {
+  return std::make_unique<InstanceAgent>(channel, *this);
+}
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsinspector-modern/InspectorInterfaces.h>
+
+#include <list>
+#include <optional>
+
+namespace facebook::react::jsinspector_modern {
+
+class InstanceAgent;
+
+/**
+ * Receives events from an InstanceTarget. This is a shared interface that
+ * each React Native platform needs to implement in order to integrate with
+ * the debugging stack.
+ */
+class InstanceTargetDelegate {
+ public:
+  InstanceTargetDelegate() = default;
+  InstanceTargetDelegate(const InstanceTargetDelegate&) = delete;
+  InstanceTargetDelegate(InstanceTargetDelegate&&) = default;
+  InstanceTargetDelegate& operator=(const InstanceTargetDelegate&) = delete;
+  InstanceTargetDelegate& operator=(InstanceTargetDelegate&&) = default;
+
+  virtual ~InstanceTargetDelegate();
+};
+
+/**
+ * A Target that represents a single instance of React Native.
+ */
+class InstanceTarget {
+ public:
+  /**
+   * \param delegate The object that will receive events from this target.
+   * The caller is responsible for ensuring that the delegate outlives this
+   * object.
+   */
+  explicit InstanceTarget(InstanceTargetDelegate& delegate);
+
+  InstanceTarget(const InstanceTarget&) = delete;
+  InstanceTarget(InstanceTarget&&) = delete;
+  InstanceTarget& operator=(const InstanceTarget&) = delete;
+  InstanceTarget& operator=(InstanceTarget&&) = delete;
+
+  std::unique_ptr<InstanceAgent> createAgent(FrontendChannel channel);
+
+ private:
+  InstanceTargetDelegate& delegate_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
@@ -10,6 +10,7 @@
 #include "PageTarget.h"
 
 #include <jsinspector-modern/InspectorInterfaces.h>
+#include <jsinspector-modern/InstanceAgent.h>
 #include <jsinspector-modern/Parsing.h>
 
 #include <functional>
@@ -18,6 +19,8 @@
 namespace facebook::react::jsinspector_modern {
 
 class PageTarget;
+class InstanceAgent;
+class InstanceTarget;
 
 /**
  * An Agent that handles requests from the Chrome DevTools Protocol for the
@@ -47,6 +50,14 @@ class PageAgent {
    */
   void handleRequest(const cdp::PreparsedRequest& req);
 
+  /**
+   * Replace the current InstanceAgent with the given one and notify the
+   * frontend about the new instance.
+   * \param agent The new InstanceAgent. May be null to signify that there is
+   * currently no active instance.
+   */
+  void setCurrentInstanceAgent(std::unique_ptr<InstanceAgent> agent);
+
  private:
   /**
    * Send a simple Log.entryAdded notification with the given
@@ -62,6 +73,8 @@ class PageAgent {
   FrontendChannel frontendChannel_;
   PageTargetController& targetController_;
   const PageTarget::SessionMetadata sessionMetadata_;
+  std::unique_ptr<InstanceAgent> instanceAgent_;
+  bool runtimeEnabled_{false};
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -20,6 +20,10 @@ folly_config = get_folly_config()
 folly_compiler_flags = folly_config[:compiler_flags]
 folly_version = folly_config[:version]
 
+use_frameworks = ENV['USE_FRAMEWORKS'] != nil
+
+header_dir = 'jsinspector-modern'
+module_name = "jsinspector_modern"
 Pod::Spec.new do |s|
   s.name                   = "React-jsinspector"
   s.version                = version
@@ -35,7 +39,14 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = {
                                "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\"",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20"
-                             }
+  }.merge!(use_frameworks ? {
+    "PUBLIC_HEADERS_FOLDER_PATH" => "#{module_name}.framework/Headers/#{header_dir}"
+  } : {})
+
+  if use_frameworks
+    s.module_name = module_name
+  end
+
   s.dependency "glog"
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-nativeconfig"

--- a/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
@@ -7,4 +7,5 @@
 
 #pragma once
 
+#include <jsinspector-modern/InstanceTarget.h>
 #include <jsinspector-modern/PageTarget.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -121,4 +121,6 @@ class MockPageTargetDelegate : public PageTargetDelegate {
   MOCK_METHOD(void, onReload, (const PageReloadRequest& request), (override));
 };
 
+class MockInstanceTargetDelegate : public InstanceTargetDelegate {};
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/PageTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/PageTargetTest.cpp
@@ -25,35 +25,48 @@ namespace facebook::react::jsinspector_modern {
 
 namespace {
 
-/**
- * Simplified test harness focused on sending messages to and from a PageTarget.
- */
-class PageTargetProtocolTest : public Test {
- public:
-  PageTargetProtocolTest() {
+class PageTargetTest : public Test {
+ protected:
+  void connect() {
+    ASSERT_FALSE(toPage_) << "Can only connect once in a PageTargetTest.";
     toPage_ = page_.connect(
         remoteConnections_.make_unique(),
-        {.integrationName = "PageTargetProtocolTest"});
+        {.integrationName = "PageTargetTest"});
 
-    // In protocol tests, we'll always get an onDisconnect call when we tear
+    // We'll always get an onDisconnect call when we tear
     // down the test. Expect it in order to satisfy the strict mock.
     EXPECT_CALL(*remoteConnections_[0], onDisconnect());
   }
 
- protected:
   MockPageTargetDelegate pageTargetDelegate_;
 
   MockRemoteConnection& fromPage() {
+    assert(toPage_);
     return *remoteConnections_[0];
   }
 
- private:
   PageTarget page_{pageTargetDelegate_};
+
+ private:
   UniquePtrFactory<StrictMock<MockRemoteConnection>> remoteConnections_;
 
  protected:
   // NOTE: Needs to be destroyed before page_.
   std::unique_ptr<ILocalConnection> toPage_;
+};
+
+/**
+ * Simplified test harness focused on sending messages to and from a PageTarget.
+ */
+class PageTargetProtocolTest : public PageTargetTest {
+ public:
+  PageTargetProtocolTest() {
+    connect();
+  }
+
+ private:
+  // Protocol tests shouldn't manually call connect()
+  using PageTargetTest::connect;
 };
 
 } // namespace
@@ -166,6 +179,147 @@ TEST_F(PageTargetProtocolTest, PageReloadMethod) {
                              "ignoreCache": true,
                              "scriptToEvaluateOnLoad": "alert('hello');"
                            }
+                         })");
+}
+
+TEST_F(PageTargetProtocolTest, RegisterUnregisterInstanceWithoutEvents) {
+  MockInstanceTargetDelegate instanceTargetDelegate;
+
+  auto& instanceTarget = page_.registerInstance(instanceTargetDelegate);
+
+  page_.unregisterInstance(instanceTarget);
+}
+
+TEST_F(PageTargetTest, ConnectToAlreadyRegisteredInstanceWithoutEvents) {
+  MockInstanceTargetDelegate instanceTargetDelegate;
+
+  auto& instanceTarget = page_.registerInstance(instanceTargetDelegate);
+
+  connect();
+
+  page_.unregisterInstance(instanceTarget);
+}
+
+TEST_F(PageTargetProtocolTest, RegisterUnregisterInstanceWithEvents) {
+  InSequence s;
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "id": 1,
+                                               "result": {}
+                                             })")));
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": "Runtime.enable"
+                         })");
+
+  MockInstanceTargetDelegate instanceTargetDelegate;
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "method": "Runtime.executionContextCreated",
+                                               "params": {
+                                                 "context": {
+                                                   "id": 1,
+                                                   "origin": "",
+                                                   "name": "React Native"
+                                                 }
+                                               }
+                                             })")));
+  auto& instanceTarget = page_.registerInstance(instanceTargetDelegate);
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "method": "Runtime.executionContextDestroyed",
+                                               "params": {
+                                                 "executionContextId": 1
+                                               }
+                                             })")));
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "method": "Runtime.executionContextsCleared"
+                                             })")));
+  page_.unregisterInstance(instanceTarget);
+}
+
+TEST_F(PageTargetTest, ConnectToAlreadyRegisteredInstanceWithEvents) {
+  MockInstanceTargetDelegate instanceTargetDelegate;
+  auto& instanceTarget = page_.registerInstance(instanceTargetDelegate);
+
+  connect();
+
+  InSequence s;
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "id": 1,
+                                               "result": {}
+                                             })")));
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "method": "Runtime.executionContextCreated",
+                                               "params": {
+                                                 "context": {
+                                                   "id": 1,
+                                                   "origin": "",
+                                                   "name": "React Native"
+                                                 }
+                                               }
+                                             })")));
+
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": "Runtime.enable"
+                         })");
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "method": "Runtime.executionContextDestroyed",
+                                               "params": {
+                                                 "executionContextId": 1
+                                               }
+                                             })")));
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "method": "Runtime.executionContextsCleared"
+                                             })")));
+  page_.unregisterInstance(instanceTarget);
+}
+
+TEST_F(PageTargetProtocolTest, RespondToHeapUsageMethodWhileInstanceExists) {
+  // NOTE: This test will be deleted once we add some real CDP method
+  // implementations to InstanceAgent.
+
+  EXPECT_CALL(
+      fromPage(),
+      onMessage(JsonParsed(AllOf(
+          AtJsonPtr("/error/code", Eq(-32601)), AtJsonPtr("/id", Eq(1))))))
+      .RetiresOnSaturation();
+
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": "Runtime.getHeapUsage"
+                         })");
+
+  MockInstanceTargetDelegate instanceTargetDelegate;
+  auto& instanceTarget = page_.registerInstance(instanceTargetDelegate);
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "id": 2,
+                                               "result": {
+                                                 "usedSize": 0,
+                                                 "totalSize": 0
+                                               }
+                                             })")));
+
+  toPage_->sendMessage(R"({
+                           "id": 2,
+                           "method": "Runtime.getHeapUsage"
+                         })");
+
+  page_.unregisterInstance(instanceTarget);
+
+  EXPECT_CALL(
+      fromPage(),
+      onMessage(JsonParsed(AllOf(
+          AtJsonPtr("/error/code", Eq(-32601)), AtJsonPtr("/id", Eq(3))))))
+      .RetiresOnSaturation();
+
+  toPage_->sendMessage(R"({
+                           "id": 3,
+                           "method": "Runtime.getHeapUsage"
                          })");
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
     s.dependency "React-cxxreact"
     s.dependency "React-jsi"
     s.dependency "React-runtimeexecutor"
+    add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
     if using_hermes
       s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -198,7 +198,8 @@ class RCTHostPageTargetDelegate : public facebook::react::jsinspector_modern::Pa
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
-                                     moduleRegistry:_moduleRegistry];
+                                     moduleRegistry:_moduleRegistry
+                              parentInspectorTarget:_inspectorTarget.get()];
   [_hostDelegate hostDidStart:self];
 }
 
@@ -265,7 +266,8 @@ class RCTHostPageTargetDelegate : public facebook::react::jsinspector_modern::Pa
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
-                                     moduleRegistry:_moduleRegistry];
+                                     moduleRegistry:_moduleRegistry
+                              parentInspectorTarget:_inspectorTarget.get()];
   [_hostDelegate hostDidStart:self];
 
   for (RCTFabricSurface *surface in [self _getAttachedSurfaces]) {
@@ -275,12 +277,12 @@ class RCTHostPageTargetDelegate : public facebook::react::jsinspector_modern::Pa
 
 - (void)dealloc
 {
+  [_instance invalidate];
   if (_inspectorPageId.has_value()) {
     facebook::react::jsinspector_modern::getInspectorInstance().removePage(*_inspectorPageId);
     _inspectorPageId.reset();
     _inspectorTarget.reset();
   }
-  [_instance invalidate];
 }
 
 #pragma mark - RCTInstanceDelegate

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
@@ -8,6 +8,7 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTDefines.h>
+#import <jsinspector-modern/ReactCdp.h>
 #import <react/renderer/mapbuffer/MapBuffer.h>
 #import <react/runtime/JSRuntimeFactory.h>
 #import <react/runtime/ReactInstance.h>
@@ -72,7 +73,8 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
-                  moduleRegistry:(RCTModuleRegistry *)moduleRegistry;
+                  moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+           parentInspectorTarget:(facebook::react::jsinspector_modern::PageTarget *)parentInspectorTarget;
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -31,6 +31,7 @@
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <ReactCommon/RuntimeExecutor.h>
 #import <cxxreact/ReactMarker.h>
+#import <jsinspector-modern/ReactCdp.h>
 #import <jsireact/JSIExecutor.h>
 #import <react/runtime/BridgelessJSCallInvoker.h>
 #import <react/utils/ContextContainer.h>
@@ -81,6 +82,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
   // APIs supporting interop with native modules and view managers
   RCTBridgeModuleDecorator *_bridgeModuleDecorator;
+
+  jsinspector_modern::PageTarget *_parentInspectorTarget;
 }
 
 #pragma mark - Public
@@ -91,6 +94,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+           parentInspectorTarget:(jsinspector_modern::PageTarget *)parentInspectorTarget
 {
   if (self = [super init]) {
     _performanceLogger = [RCTPerformanceLogger new];
@@ -106,6 +110,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                                                                      moduleRegistry:moduleRegistry
                                                                       bundleManager:bundleManager
                                                                   callableJSModules:[RCTCallableJSModules new]];
+    _parentInspectorTarget = parentInspectorTarget;
     {
       __weak __typeof(self) weakSelf = self;
       [_bridgeModuleDecorator.callableJSModules
@@ -138,7 +143,9 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 {
   std::lock_guard<std::mutex> lock(_invalidationMutex);
   _valid = false;
-
+  if (self->_reactInstance) {
+    self->_reactInstance->unregisterFromInspector();
+  }
   [_surfacePresenter suspend];
   [_jsThreadManager dispatchToJSThread:^{
     /**
@@ -227,7 +234,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       _jsThreadManager.jsMessageThread,
       timerManager,
       jsErrorHandlingFunc,
-      useModernRuntimeScheduler);
+      useModernRuntimeScheduler,
+      _parentInspectorTarget);
   _valid = true;
 
   RuntimeExecutor bufferedRuntimeExecutor = _reactInstance->getBufferedRuntimeExecutor();

--- a/packages/react-native/ReactCommon/react/test_utils/ios/Shims/ShimRCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/test_utils/ios/Shims/ShimRCTInstance.mm
@@ -23,7 +23,8 @@ static __weak ShimRCTInstance *weakShim = nil;
         [RCTInstance class],
         [ShimRCTInstance class],
         @selector(initWithDelegate:
-                  jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry:));
+                  jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry
+                                  :parentInspectorTarget:));
     RCTSwizzleInstanceSelector([RCTInstance class], [ShimRCTInstance class], @selector(invalidate));
     RCTSwizzleInstanceSelector(
         [RCTInstance class], [ShimRCTInstance class], @selector(callFunctionOnJSModule:method:args:));
@@ -38,7 +39,8 @@ static __weak ShimRCTInstance *weakShim = nil;
       [RCTInstance class],
       [ShimRCTInstance class],
       @selector(initWithDelegate:
-                jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry:));
+                jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry
+                                :parentInspectorTarget:));
   RCTSwizzleInstanceSelector([RCTInstance class], [ShimRCTInstance class], @selector(invalidate));
   RCTSwizzleInstanceSelector(
       [RCTInstance class], [ShimRCTInstance class], @selector(callFunctionOnJSModule:method:args:));
@@ -52,6 +54,7 @@ static __weak ShimRCTInstance *weakShim = nil;
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+           parentInspectorTarget:(facebook::react::jsinspector_modern::PageTarget *)parentInspectorTarget
 {
   weakShim.initCount++;
   return self;


### PR DESCRIPTION
Summary:
This small commit makes sure that we can build the new jsinspector with `use_frameworks!`.

## Changelog:
[Internal] - Make jsinspector build with use_framework!

Differential Revision: D53092634

