### PR TITLE
fix: [TS] Update `translateX` & `translateY` types to support `%`

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -155,11 +155,11 @@ interface ScaleYTransform {
 }
 
 interface TranslateXTransform {
-  translateX: AnimatableNumericValue;
+  translateX: AnimatableNumericValue | `${number}%`;
 }
 
 interface TranslateYTransform {
-  translateY: AnimatableNumericValue;
+  translateY: AnimatableNumericValue | `${number}%`;
 }
 
 interface SkewXTransform {


### PR DESCRIPTION
## Summary:

After update to the latest `react-native` version 
we discover that we are unable to use `number%` value for `translate*` props :

```tsx
StyleSheet.create({
  root: {
    transform: [
      { translateX: '-50%'  }, 
      // ^^^^^^ TS Error: Type string is not assignable to type AnimatableNumericValue | undefined
    ],
  }
});
```

---

percentage values are supported, demo: https://snack.expo.dev/@retyui/test-tstransform

## Changelog:

[GENERAL] [FIXED] - Update typescript definition of `translateX` & `translateX` to be able to use percentage values

## Test Plan:

`yarn tsc --noEmit`
