### PR TITLE
Fix rendering of textInput using lineHeight in android API level <28

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -273,7 +273,9 @@ public class ReactEditText extends AppCompatEditText {
   @Override
   public void setLineHeight(int lineHeight) {
     mTextAttributes.setLineHeight(lineHeight);
-    super.setLineHeight(lineHeight);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      super.setLineHeight(lineHeight);
+    }
   }
 
   @Override


### PR DESCRIPTION
Summary:
Fix rendering of textInput using lineHeight in android API level <28 by removing call to ReactEditText.setLineHeight.
ReactEditText.setLineHeight was introduced in API level 28 and we actually don't need to call this method (in any API level)

changelog: [Internal] internal

Differential Revision: D53105649


