### PR TITLE
Re-enable InspectorProxy* Jest tests

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -38,6 +38,16 @@ const {only: _, ...nodeBabelOptions} = metroBabelRegister.config([]);
 require('../scripts/build/babel-register').registerForMonorepo();
 const transformer = require('@react-native/metro-babel-transformer');
 
+// Set BUILD_EXCLUDE_BABEL_REGISTER (see ../scripts/build/babel-register.js) to
+// prevent inline Babel registration in code under test, normally required when
+// running from source, but not in combination with the Jest transformer.
+const babelPluginPreventBabelRegister = [
+  require.resolve('babel-plugin-transform-define'),
+  {
+    'process.env.BUILD_EXCLUDE_BABEL_REGISTER': true,
+  },
+];
+
 module.exports = {
   process(src /*: string */, file /*: string */) /*: {code: string, ...} */ {
     if (nodeFiles.test(file)) {
@@ -46,6 +56,10 @@ module.exports = {
         filename: file,
         sourceType: 'script',
         ...nodeBabelOptions,
+        plugins: [
+          ...(nodeBabelOptions.plugins ?? []),
+          babelPluginPreventBabelRegister,
+        ],
         ast: false,
       });
     }
@@ -78,6 +92,7 @@ module.exports = {
       plugins: [
         // TODO(moti): Replace with require('metro-transform-plugins').inlineRequiresPlugin when available in OSS
         require('babel-preset-fbjs/plugins/inline-requires'),
+        babelPluginPreventBabelRegister,
       ],
       sourceType: 'module',
     });

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -40,8 +40,7 @@ beforeAll(() => {
   jest.resetModules();
 });
 
-// TODO T169943794
-xdescribe.each(['HTTP', 'HTTPS'])(
+describe.each(['HTTP', 'HTTPS'])(
   'inspector proxy CDP rewriting hacks over %s',
   protocol => {
     const serverRef = withServerForEachTest({

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -23,8 +23,7 @@ jest.useRealTimers();
 
 jest.setTimeout(10000);
 
-// TODO T169943794
-xdescribe.each(['HTTP', 'HTTPS'])(
+describe.each(['HTTP', 'HTTPS'])(
   'inspector proxy CDP transport over %s',
   protocol => {
     const serverRef = withServerForEachTest({

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -24,8 +24,7 @@ const PAGES_POLLING_DELAY = 1000;
 
 jest.useFakeTimers();
 
-// TODO T169943794
-xdescribe('inspector proxy HTTP API', () => {
+describe('inspector proxy HTTP API', () => {
   const serverRef = withServerForEachTest({
     logger: undefined,
     projectRoot: '',

--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -23,8 +23,7 @@ jest.useRealTimers();
 
 jest.setTimeout(10000);
 
-// TODO T169943794
-xdescribe('inspector proxy React Native reloads', () => {
+describe('inspector proxy React Native reloads', () => {
   const serverRef = withServerForEachTest({
     logger: undefined,
     projectRoot: '',

--- a/scripts/build/babel-register.js
+++ b/scripts/build/babel-register.js
@@ -50,7 +50,7 @@ function registerPackage(packageName /*: string */) {
   const registerConfig = {
     ...getBabelConfig(packageName),
     root: packageDir,
-    ignore: [/\/node_modules\//],
+    ignore: [/[/\\]node_modules[/\\]/],
   };
 
   require('@babel/register')(registerConfig);


### PR DESCRIPTION
Summary:
Since D53125777, these should be safe to re-enable

Changelog:
[Internal] Re-enable dev-middleware InspectorProxy* tests

Differential Revision: D53125778


