### PR TITLE
Check for platform color in isColorMeaningful

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
@@ -14,7 +14,13 @@ bool isColorMeaningful(const SharedColor& color) noexcept {
     return false;
   }
 
-  return colorComponentsFromColor(color).alpha > 0;
+  // On some host platforms, semantic colors can only be resolved from the UI
+  // thread. Since this method is called by ViewShadowNode to determine whether
+  // a color should disable view flattening from a background thread, we need
+  // an alternative option to simply check if the color instance represents a
+  // semantic color. The host platform implementation of this method only needs
+  // to return true if it requries UI thread bound semantic color resolution.
+  return hasPlatformColor(*color) || colorComponentsFromColor(color).alpha > 0;
 }
 
 SharedColor colorFromComponents(ColorComponents components) {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -36,4 +36,8 @@ inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
       (float)((color >> 24) & 0xff) / ratio};
 }
 
+inline bool hasPlatformColor(Color color) {
+  return false;
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
@@ -36,4 +36,8 @@ inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
       (float)((color >> 24) & 0xff) / ratio};
 }
 
+inline bool hasPlatformColor(Color color) {
+  return false;
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -36,4 +36,8 @@ inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
       (float)((color >> 24) & 0xff) / ratio};
 }
 
+inline bool hasPlatformColor(Color color) {
+  return false;
+}
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Some platforms (e.g., Windows) allow semantic colors that are only accessible from the UI thread. Since isColorMeaningful is used on a background thread for shadow node commits, we can only check that a platform color exists on Windows (not resolve the actual platform color). Adding this helper, which effectively no-ops on mobile platforms without the same semantic color limitation, unblocks Windows.

## Changelog

[Internal]

Differential Revision: D53127956


