### PR TITLE
Restore missing call to `convertRawPropAliases`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -532,6 +532,8 @@ YogaStylableProps::YogaStylableProps(
       "aspectRatio",
       sourceProps.yogaStyle.aspectRatio(),
       yogaStyle.aspectRatio()));
+
+  convertRawPropAliases(context, sourceProps, rawProps);
 };
 
 void YogaStylableProps::setProp(


### PR DESCRIPTION
Summary:
D53072714 accidentally removed this call, which sets the values for props which have duplicates, and some precedence between them.

This organization is janky, and will be removed in D53073913 where we decuple the props from Yoga style (so the precedence and parsing order becomes a lot more sane).

Changelog:
[Android][Fixed] - Restore missing call to `convertRawPropAliases`

Reviewed By: mdvacca

Differential Revision: D53144603


