### PR TITLE
Remove public APIs for YGNodePrint and YGConfigSetPrintTreeFlag

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfig.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfig.java
@@ -15,8 +15,6 @@ public abstract class YogaConfig {
 
   public abstract void setUseWebDefaults(boolean useWebDefaults);
 
-  public abstract void setPrintTreeFlag(boolean enable);
-
   public abstract void setPointScaleFactor(float pixelsInPoint);
 
   public abstract void setErrata(YogaErrata errata);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfigJNIBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfigJNIBase.java
@@ -35,10 +35,6 @@ public abstract class YogaConfigJNIBase extends YogaConfig {
     YogaNative.jni_YGConfigSetUseWebDefaultsJNI(mNativePointer, useWebDefaults);
   }
 
-  public void setPrintTreeFlag(boolean enable) {
-    YogaNative.jni_YGConfigSetPrintTreeFlagJNI(mNativePointer, enable);
-  }
-
   public void setPointScaleFactor(float pixelsInPoint) {
     YogaNative.jni_YGConfigSetPointScaleFactorJNI(mNativePointer, pixelsInPoint);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
@@ -22,7 +22,6 @@ public class YogaNative {
   static native void jni_YGConfigFreeJNI(long nativePointer);
   static native void jni_YGConfigSetExperimentalFeatureEnabledJNI(long nativePointer, int feature, boolean enabled);
   static native void jni_YGConfigSetUseWebDefaultsJNI(long nativePointer, boolean useWebDefaults);
-  static native void jni_YGConfigSetPrintTreeFlagJNI(long nativePointer, boolean enable);
   static native void jni_YGConfigSetPointScaleFactorJNI(long nativePointer, float pixelsInPoint);
   static native void jni_YGConfigSetErrataJNI(long nativePointer, int errata);
   static native int jni_YGConfigGetErrataJNI(long nativePointer);
@@ -111,7 +110,6 @@ public class YogaNative {
   static native void jni_YGNodeStyleSetGapJNI(long nativePointer, int gutter, float gapLength);
   static native void jni_YGNodeSetHasMeasureFuncJNI(long nativePointer, boolean hasMeasureFunc);
   static native void jni_YGNodeSetHasBaselineFuncJNI(long nativePointer, boolean hasMeasureFunc);
-  static native void jni_YGNodePrintJNI(long nativePointer);
   static native void jni_YGNodeSetStyleInputsJNI(long nativePointer, float[] styleInputsArray, int size);
   static native long jni_YGNodeCloneJNI(long nativePointer);
   static native void jni_YGNodeSetAlwaysFormsContainingBlockJNI(long nativePointer, boolean alwaysFormContainingBlock);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNode.java
@@ -221,8 +221,6 @@ public abstract class YogaNode implements YogaProps {
   @Nullable
   public abstract Object getData();
 
-  public abstract void print();
-
   public abstract YogaNode cloneWithoutChildren();
 
   public abstract YogaNode cloneWithChildren();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -557,14 +557,6 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
   }
 
   /**
-   * Use the set logger (defaults to adb log) to print out the styles, children, and computed layout
-   * of the tree rooted at this node.
-   */
-  public void print() {
-    YogaNative.jni_YGNodePrintJNI(mNativePointer);
-  }
-
-  /**
    * This method replaces the child at childIndex position with the newNode received by parameter.
    * This is different than calling removeChildAt and addChildAt because this method ONLY replaces
    * the child in the mChildren datastructure. @DoNotStrip: called from JNI

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -66,15 +66,6 @@ static void jni_YGConfigSetUseWebDefaultsJNI(
   YGConfigSetUseWebDefaults(config, useWebDefaults);
 }
 
-static void jni_YGConfigSetPrintTreeFlagJNI(
-    JNIEnv* /*env*/,
-    jobject /*obj*/,
-    jlong nativePointer,
-    jboolean enable) {
-  const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
-  YGConfigSetPrintTreeFlag(config, enable);
-}
-
 static void jni_YGConfigSetPointScaleFactorJNI(
     JNIEnv* /*env*/,
     jobject /*obj*/,
@@ -690,18 +681,6 @@ static void jni_YGNodeSetAlwaysFormsContainingBlockJNI(
       _jlong2YGNodeRef(nativePointer), alwaysFormsContainingBlock);
 }
 
-static void
-jni_YGNodePrintJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
-#ifdef DEBUG
-  const YGNodeRef node = _jlong2YGNodeRef(nativePointer);
-  YGNodePrint(
-      node,
-      (YGPrintOptions)(YGPrintOptionsStyle | YGPrintOptionsLayout | YGPrintOptionsChildren));
-#else
-  (void)nativePointer;
-#endif
-}
-
 static jlong
 jni_YGNodeCloneJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   auto node = _jlong2YGNodeRef(nativePointer);
@@ -744,9 +723,6 @@ static JNINativeMethod methods[] = {
     {"jni_YGConfigSetUseWebDefaultsJNI",
      "(JZ)V",
      (void*)jni_YGConfigSetUseWebDefaultsJNI},
-    {"jni_YGConfigSetPrintTreeFlagJNI",
-     "(JZ)V",
-     (void*)jni_YGConfigSetPrintTreeFlagJNI},
     {"jni_YGConfigSetPointScaleFactorJNI",
      "(JF)V",
      (void*)jni_YGConfigSetPointScaleFactorJNI},
@@ -970,7 +946,6 @@ static JNINativeMethod methods[] = {
     {"jni_YGNodeSetAlwaysFormsContainingBlockJNI",
      "(JZ)V",
      (void*)jni_YGNodeSetAlwaysFormsContainingBlockJNI},
-    {"jni_YGNodePrintJNI", "(J)V", (void*)jni_YGNodePrintJNI},
     {"jni_YGNodeCloneJNI", "(J)J", (void*)jni_YGNodeCloneJNI},
 };
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeYogaConfig.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeYogaConfig.kt
@@ -27,10 +27,6 @@ class FakeYogaConfig : YogaConfig() {
     // no-op
   }
 
-  override fun setPrintTreeFlag(enable: Boolean) {
-    // no-op
-  }
-
   override fun setPointScaleFactor(pixelsInPoint: Float) {
     // no-op
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeYogaNode.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeYogaNode.kt
@@ -243,10 +243,6 @@ class FakeYogaNode : YogaNode() {
 
   override fun getData(): Any? = null
 
-  override fun print() {
-    // no-op
-  }
-
   override fun cloneWithoutChildren(): YogaNode = FakeYogaNode()
 
   override fun cloneWithChildren(): YogaNode = FakeYogaNode()

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -855,9 +855,6 @@ yoga::Config& YogaLayoutableShadowNode::initializeYogaConfig(
     YGConfigSetErrata(&config, YGConfigGetErrata(previousConfig));
   }
 
-#ifdef RN_DEBUG_YOGA_LOGGER
-  YGConfigSetPrintTreeFlag(&config, true);
-#endif
   return config;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/debug/flags.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/flags.h
@@ -46,7 +46,3 @@
 // are logged to console before the `assert` is fired. More useful on Android vs
 // other platforms.
 //#define STUB_VIEW_TREE_VERBOSE 1
-
-// Verbose logging for certain Yoga-related things in the RN codebase (not Yoga
-// codebase). Useful for debugging layout.
-//#define RN_DEBUG_YOGA_LOGGER 1

--- a/packages/react-native/ReactCommon/yoga/yoga/YGConfig.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGConfig.cpp
@@ -90,7 +90,3 @@ void YGConfigSetCloneNodeFunc(
     const YGCloneNodeFunc callback) {
   resolveRef(config)->setCloneNodeCallback(callback);
 }
-
-void YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled) {
-  resolveRef(config)->setShouldPrintTree(enabled);
-}

--- a/packages/react-native/ReactCommon/yoga/yoga/YGConfig.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGConfig.h
@@ -155,9 +155,4 @@ YG_EXPORT void YGConfigSetCloneNodeFunc(
     YGConfigRef config,
     YGCloneNodeFunc callback);
 
-/**
- * Allows printing the Yoga node tree during layout for debugging purposes.
- */
-YG_EXPORT void YGConfigSetPrintTreeFlag(YGConfigRef config, bool enabled);
-
 YG_EXTERN_C_END

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -11,7 +11,6 @@
 #include <yoga/algorithm/CalculateLayout.h>
 #include <yoga/debug/AssertFatal.h>
 #include <yoga/debug/Log.h>
-#include <yoga/debug/NodeToString.h>
 #include <yoga/event/event.h>
 #include <yoga/node/Node.h>
 
@@ -329,12 +328,6 @@ void YGNodeSetAlwaysFormsContainingBlock(
     bool alwaysFormsContainingBlock) {
   resolveRef(node)->setAlwaysFormsContainingBlock(alwaysFormsContainingBlock);
 }
-
-#ifdef DEBUG
-void YGNodePrint(const YGNodeConstRef node, const YGPrintOptions options) {
-  yoga::print(resolveRef(node), scopedEnum(options));
-}
-#endif
 
 // TODO: This leaks internal details to the public API. Remove after removing
 // ComponentKit usage of it.

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -274,11 +274,6 @@ YG_EXPORT void YGNodeSetAlwaysFormsContainingBlock(
     bool alwaysFormsContainingBlock);
 
 /**
- * Print a node to log output.
- */
-YG_EXPORT void YGNodePrint(YGNodeConstRef node, YGPrintOptions options);
-
-/**
  * @deprecated
  */
 YG_DEPRECATED(


### PR DESCRIPTION
Summary:
We are planning on overhauling NodeToString to output JSON instead of HTML for the purposes of better benchmarking and capturing trees in JSON format to benchmark later. This gives us a bit of a headache as we have to revise several build files to ensure this new library works, ensure that it is only included in certain debug builds, and deal with the benchmark <-> internal cross boundary that arises as the benchmark code (which is a separate binary) tries to interact with it.

On top of it all this is really not used at all. 

The plan is to rip out this functionality and just put it in a separate binary that one can include if they really want to debug. That means that it cannot exist in the public API, so I am removing it here.

Private internals come next

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D53137544


