### PR TITLE
Set BUILD_EXCLUDE_BABEL_REGISTER: true under Jest tests

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -38,6 +38,16 @@ const {only: _, ...nodeBabelOptions} = metroBabelRegister.config([]);
 require('../scripts/build/babel-register').registerForMonorepo();
 const transformer = require('@react-native/metro-babel-transformer');
 
+// Set BUILD_EXCLUDE_BABEL_REGISTER (see ../scripts/build/babel-register.js) to
+// prevent inline Babel registration in code under test, normally required when
+// running from source, but not in combination with the Jest transformer.
+const babelPluginPreventBabelRegister = [
+  require.resolve('babel-plugin-transform-define'),
+  {
+    'process.env.BUILD_EXCLUDE_BABEL_REGISTER': true,
+  },
+];
+
 module.exports = {
   process(src /*: string */, file /*: string */) /*: {code: string, ...} */ {
     if (nodeFiles.test(file)) {
@@ -46,6 +56,10 @@ module.exports = {
         filename: file,
         sourceType: 'script',
         ...nodeBabelOptions,
+        plugins: [
+          ...(nodeBabelOptions.plugins ?? []),
+          babelPluginPreventBabelRegister,
+        ],
         ast: false,
       });
     }
@@ -78,6 +92,7 @@ module.exports = {
       plugins: [
         // TODO(moti): Replace with require('metro-transform-plugins').inlineRequiresPlugin when available in OSS
         require('babel-preset-fbjs/plugins/inline-requires'),
+        babelPluginPreventBabelRegister,
       ],
       sourceType: 'module',
     });

--- a/scripts/build/babel-register.js
+++ b/scripts/build/babel-register.js
@@ -50,7 +50,7 @@ function registerPackage(packageName /*: string */) {
   const registerConfig = {
     ...getBabelConfig(packageName),
     root: packageDir,
-    ignore: [/\/node_modules\//],
+    ignore: [/[/\\]node_modules[/\\]/],
   };
 
   require('@babel/register')(registerConfig);


### PR DESCRIPTION
Summary:
Issues triggered by `InspectorProxy*` tests under `packages/dev-middleware` (T169943794) can be root-caused to `dev-middleware` performing Babel registration within a test run, after Jest has hooked its own transformer.

Babel registration is only required when running this code (`dev-middleware`, etc) directly from source - we already have the `BUILD_EXCLUDE_BABEL_REGISTER` mechanism to strip it out from production builds, but we currently don't prevent registration under tests, where Jest's transformer should be allowed to do its work.

This adds the same `babel-plugin-transform-define` mechanism that we use for production builds to the Jest transformer.

Changelog:
[Internal] Prevent inadvertent Babel registration during running of repo tests

Reviewed By: huntie

Differential Revision: D53125777


