### PR TITLE
fix: update error message to use `npx` when calling `react-native`

### DIFF
--- a/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
@@ -34,7 +34,7 @@ exports.checkVersions = function checkVersions(): void {
         `Native version: ${_formatVersion(nativeVersion)}\n\n` +
         'Make sure that you have rebuilt the native code. If the problem ' +
         'persists try clearing the Watchman and packager caches with ' +
-        '`watchman watch-del-all && react-native start --reset-cache`.',
+        '`watchman watch-del-all && npx react-native start --reset-cache`.',
     );
   }
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Just small fix for those who are copy & pasting commands from error message.

## Changelog:

[INTERNAL] [CHANGED] - Update erorr message to use `npx` when calling `react-native`

## Test Plan:

_