### PR TITLE
Fixup bad ANDROIDLINT Automatic Fix

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ScaleTypeStartInside.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ScaleTypeStartInside.java
@@ -28,7 +28,7 @@ class ScaleTypeStartInside extends ScalingUtils.AbstractScaleType {
     float dx = parentRect.left;
     float dy = parentRect.top;
     outTransform.setScale(scale, scale);
-    outTransform.postTranslate((dx + 0.5f), (dy + 0.5f));
+    outTransform.postTranslate(Math.round(dx), Math.round(dy));
   }
 
   @Override


### PR DESCRIPTION
Summary:
D53115471 commited all the automatically fixable lints by `ANDROIDLINT`. When I looked again, closer, there was one automatic fix that I'm fairly sure is incorrect.

Before:

`outTransform.postTranslate((int) (dx + 0.5f), (int) (dy + 0.5f));`

After:

`outTransform.postTranslate((dx + 0.5f), (dy + 0.5f));`

I think the linter did this because the underlying API accepts a float, so this was (incorrectly) seen as an extraneous cast causing precision loss, but the previous behavior was using the cast and addition to round the float, instead of adding 0.5 to it.

This replaces the call with an explicit rounding, for the same behavior as before (though, I'm not sure if the rounding is intentional, since in and out are both fp).


Changelog: [Internal]

Differential Revision: D53158801


