### PR TITLE
Fix broken ReactNativeFeatureFlagsTest test on iOS

### DIFF
--- a/packages/react-native/ReactCommon/react/featureflags/tests/ReactNativeFeatureFlagsTest.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/tests/ReactNativeFeatureFlagsTest.cpp
@@ -28,6 +28,10 @@ class ReactNativeFeatureFlagsTest : public testing::Test {
   void SetUp() override {
     overrideAccessCount = 0;
   }
+
+  void TearDown() override {
+    ReactNativeFeatureFlags::dangerouslyReset();
+  }
 };
 
 TEST_F(ReactNativeFeatureFlagsTest, providesDefaults) {


### PR DESCRIPTION
Summary:
Changelog: [internal]

The test was fine on C++. The reason is probably that C++ destroys the process between tests (effectively resetting singletons) while iOS doesn't.

This fixes the test by implementing a correct `TearDown` method to reset the flags.

Differential Revision: D53178474


