### PR TITLE
fix: use real_path to find plist files in update_ats Cocoapod util

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -133,11 +133,11 @@ end
 
 class PBXFileRefMock
     attr_reader :name
-    attr_reader :path
+    attr_reader :real_path
 
-    def initialize(name)
+    def initialize(name, path)
         @name = name
-        @path = name
+        @real_path = real_path
     end
 end
 

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -1094,10 +1094,10 @@ def prepare_empty_user_project_mock
     ])
 end
 
-def prepare_user_project_mock_with_plists
+def prepare_user_project_mock_with_plists()
     return UserProjectMock.new(:files => [
-        PBXFileRefMock.new("Info.plist"),
-        PBXFileRefMock.new("Extension-Info.plist"),
+        PBXFileRefMock.new("Info.plist", "/test/Info.plist"),
+        PBXFileRefMock.new("Extension-Info.plist", "/test/Extension-Info.plist"),
     ])
 end
 

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -555,7 +555,7 @@ class ReactNativePodsUtils
         ReactNativePodsUtils.update_header_paths_if_depends_on(target_installation_result, "React-ImageManager", header_search_paths)
     end
 
-    def self.get_plist_paths_from(user_project)
+    def self.get_plist_files_from(user_project)
         info_plists = user_project
           .files
           .select { |p|
@@ -564,10 +564,9 @@ class ReactNativePodsUtils
         return info_plists
       end
 
-    def self.update_ats_in_plist(plistPaths, parent)
-        plistPaths.each do |plistPath|
-            fullPlistPath = File.join(parent, plistPath.path)
-            plist = Xcodeproj::Plist.read_from_path(fullPlistPath)
+    def self.update_ats_in_plist(plist_files)
+        plist_files.each do |plist_file|
+            plist = Xcodeproj::Plist.read_from_path(plist_file.real_path)
             ats_configs = {
                 "NSAllowsArbitraryLoads" => false,
                 "NSAllowsLocalNetworking" => true,
@@ -580,7 +579,7 @@ class ReactNativePodsUtils
                 plist["NSAppTransportSecurity"] ||= {}
                 plist["NSAppTransportSecurity"] = plist["NSAppTransportSecurity"].merge(ats_configs)
             end
-            Xcodeproj::Plist.write_to_path(plist, fullPlistPath)
+            Xcodeproj::Plist.write_to_path(plist, plist_file.real_path)
         end
     end
 
@@ -588,8 +587,8 @@ class ReactNativePodsUtils
         user_project = installer.aggregate_targets
                     .map{ |t| t.user_project }
                     .first
-        plistPaths = self.get_plist_paths_from(user_project)
-        self.update_ats_in_plist(plistPaths, user_project.path.parent)
+        plist_files = self.get_plist_files_from(user_project)
+        self.update_ats_in_plist(plist_files)
     end
 
     def self.react_native_pods


### PR DESCRIPTION
## Summary:

This PR fixes a pod install failure detailed in #42239 which can occur when the `update_ats_in_plist` utility method in a Cocoapod script fails to find an Info.plist in the target folder. It does so by calling the Cocoapods `real_path` method instead of just `path` on the file reference, which correctly adds the target folder to the path.

## Changelog:

[iOS] [Fixed] - Fix pod install error when update_ats unable to find Info.plist in targets

## Test Plan:

Updated Ruby unit test:

```sh
ruby packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
```

Also tested using patch-package against my reproduction branch in: https://github.com/chriszs/reproducer-react-native/pull/2

To test, clone the branch, `cd ReproducerApp`, `yarn`, `npx pod-install`. CI fails with "error Cannot start server in new window because no terminal app was specified" on the build step, but I believe that's unrelated.