### PR TITLE
Make bridgeless the default when the New Arch is enabled

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -251,7 +251,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (BOOL)bridgelessEnabled
 {
-  return NO;
+  return [self newArchEnabled];
 }
 
 #pragma mark - RCTComponentViewFactoryComponentProvider

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -19,7 +19,8 @@ import com.facebook.react.config.ReactFeatureFlags
  * By default it loads a library called `appmodules`. `appmodules` is a convention used to refer to
  * the application dynamic library. If changed here should be updated also inside the template.
  *
- * By default it also enables both TurboModules, Fabric and Concurrent React (aka React 18)
+ * By default it also enables both TurboModules, Fabric and Concurrent React (aka React 18), and
+ * Bridgeless
  */
 object DefaultNewArchitectureEntryPoint {
   @JvmStatic
@@ -27,7 +28,7 @@ object DefaultNewArchitectureEntryPoint {
   fun load(
       turboModulesEnabled: Boolean = true,
       fabricEnabled: Boolean = true,
-      bridgelessEnabled: Boolean = false
+      bridgelessEnabled: Boolean = true
   ) {
     val (isValid, errorMessage) =
         isConfigurationValid(turboModulesEnabled, fabricEnabled, bridgelessEnabled)


### PR DESCRIPTION
Summary:
For 0.74, we would like to have Bridgeless as the default when the New Architecture is enabled.

## Changelog:
[Android][Breaking] - Make bridgeless the default when the New Arch is enabled

Reviewed By: cortinico

Differential Revision: D52600227


