### PR TITLE
Deprecate BatchedBridge.registerCallableModule

### DIFF
--- a/packages/react-native/Libraries/Core/registerCallableModule.js
+++ b/packages/react-native/Libraries/Core/registerCallableModule.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+type Module = {...};
+type RegisterCallableModule = (
+  name: string,
+  moduleOrFactory: Module | (void => Module),
+) => void;
+
+const registerCallableModule: RegisterCallableModule = (function () {
+  if (global.RN$Bridgeless === true) {
+    return (name, moduleOrFactory) => {
+      if (typeof moduleOrFactory === 'function') {
+        global.RN$registerCallableModule(name, moduleOrFactory);
+        return;
+      }
+
+      global.RN$registerCallableModule(name, () => moduleOrFactory);
+    };
+  }
+
+  const BatchedBridge = require('../BatchedBridge/BatchedBridge');
+  return (name, moduleOrFactory) => {
+    if (typeof moduleOrFactory === 'function') {
+      BatchedBridge.registerLazyCallableModule(name, moduleOrFactory);
+      return;
+    }
+
+    BatchedBridge.registerCallableModule(name, moduleOrFactory);
+  };
+})();
+
+export default registerCallableModule;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3929,6 +3929,17 @@ exports[`public API should not change unintentionally Libraries/Core/checkNative
 
 exports[`public API should not change unintentionally Libraries/Core/polyfillPromise.js 1`] = `""`;
 
+exports[`public API should not change unintentionally Libraries/Core/registerCallableModule.js 1`] = `
+"type Module = { ... };
+type RegisterCallableModule = (
+  name: string,
+  moduleOrFactory: Module | ((void) => Module)
+) => void;
+declare const registerCallableModule: RegisterCallableModule;
+declare export default typeof registerCallableModule;
+"
+`;
+
 exports[`public API should not change unintentionally Libraries/Core/setUpAlert.js 1`] = `""`;
 
 exports[`public API should not change unintentionally Libraries/Core/setUpBatchedBridge.js 1`] = `""`;
@@ -9164,6 +9175,7 @@ declare export default class EventEmitter<TEventToArgsMap: { ... }>
 exports[`public API should not change unintentionally index.js 1`] = `
 "export type HostComponent<T> = _HostComponentInternal<T>;
 declare module.exports: {
+  get registerCallableModule(): RegisterCallableModule,
   get AccessibilityInfo(): AccessibilityInfo,
   get ActivityIndicator(): ActivityIndicator,
   get Button(): Button,

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -43,6 +43,7 @@ import typeof TouchableNativeFeedback from './Libraries/Components/Touchable/Tou
 import typeof TouchableOpacity from './Libraries/Components/Touchable/TouchableOpacity';
 import typeof TouchableWithoutFeedback from './Libraries/Components/Touchable/TouchableWithoutFeedback';
 import typeof View from './Libraries/Components/View/View';
+import typeof RegisterCallableModule from './Libraries/Core/registerCallableModule';
 import typeof NativeEventEmitter from './Libraries/EventEmitter/NativeEventEmitter';
 import typeof RCTDeviceEventEmitter from './Libraries/EventEmitter/RCTDeviceEventEmitter';
 import typeof RCTNativeAppEventEmitter from './Libraries/EventEmitter/RCTNativeAppEventEmitter';
@@ -97,6 +98,9 @@ const invariant = require('invariant');
 export type HostComponent<T> = _HostComponentInternal<T>;
 
 module.exports = {
+  get registerCallableModule(): RegisterCallableModule {
+    return require('./Libraries/Core/registerCallableModule').default;
+  },
   // Components
   get AccessibilityInfo(): AccessibilityInfo {
     return require('./Libraries/Components/AccessibilityInfo/AccessibilityInfo')


### PR DESCRIPTION
Summary:
This diff introduces a new bridge/bridgeless-agnostic api for registering JavaScript modules with React Native.

Usage:
```
import {registerCallableModule} from 'react-native';

registerCallableModule('FooModule', () => {...});
registerCallableModule('BarModule', {...});
```

Changelog: [General][Deprecated] - Deprecate BatchedBridge.registerCallableModule. Please use registerCallableModule instead

Reviewed By: javache

Differential Revision: D52805387


