### PR TITLE
Deprecate com/facebook/react/config/ReactFeatureFlags

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -17,6 +17,7 @@ import com.facebook.react.common.build.ReactBuildConfig;
  *
  * <p>These values are safe defaults and should not require manual changes.
  */
+@Deprecated(since = "Use com.facebook.react.internal.featureflags.ReactNativeFeatureFlags instead.")
 @DoNotStripAny
 public class ReactFeatureFlags {
   /**


### PR DESCRIPTION
Summary:
Deprecate com/facebook/react/config/ReactFeatureFlags, to be replaced by com.facebook.react.internal.featureflags.ReactNativeFeatureFlags

changelog: [internal] internal

Differential Revision: D53199655


