### PR TITLE
Re-enable CustomDrawOrder in RN Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -17,6 +17,7 @@ import com.facebook.react.common.build.ReactBuildConfig;
  *
  * <p>These values are safe defaults and should not require manual changes.
  */
+@Deprecated(since = "Use com.facebook.react.internal.featureflags.ReactNativeFeatureFlags instead.")
 @DoNotStripAny
 public class ReactFeatureFlags {
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<52367278b4d0fdf7f436bd8c511d4ffe>>
+ * @generated SignedSource<<40d47e44c6f694855787d06b03049272>>
  */
 
 /**
@@ -31,22 +31,32 @@ object ReactNativeFeatureFlags {
   /**
    * Common flag for testing. Do NOT modify.
    */
+  @JvmStatic
   fun commonTestFlag() = accessor.commonTestFlag()
 
   /**
    * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.
    */
+  @JvmStatic
   fun useModernRuntimeScheduler() = accessor.useModernRuntimeScheduler()
 
   /**
    * Enables the use of microtasks in Hermes (scheduling) and RuntimeScheduler (execution).
    */
+  @JvmStatic
   fun enableMicrotasks() = accessor.enableMicrotasks()
 
   /**
    * When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.
    */
+  @JvmStatic
   fun batchRenderingUpdatesInEventLoop() = accessor.batchRenderingUpdatesInEventLoop()
+
+  /**
+   * When enabled, Fabric will use customDrawOrder in ReactViewGroup (similar to old architecture).
+   */
+  @JvmStatic
+  fun enableCustomDrawOrderFabric() = accessor.enableCustomDrawOrderFabric()
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<920bb26d238f935f63a77943df7ef6e2>>
+ * @generated SignedSource<<29e529fbf39a7bedb18938eac7f5fbbc>>
  */
 
 /**
@@ -24,6 +24,7 @@ class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccessor {
   private var useModernRuntimeSchedulerCache: Boolean? = null
   private var enableMicrotasksCache: Boolean? = null
   private var batchRenderingUpdatesInEventLoopCache: Boolean? = null
+  private var enableCustomDrawOrderFabricCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -57,6 +58,15 @@ class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccessor {
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.batchRenderingUpdatesInEventLoop()
       batchRenderingUpdatesInEventLoopCache = cached
+    }
+    return cached
+  }
+
+  override fun enableCustomDrawOrderFabric(): Boolean {
+    var cached = enableCustomDrawOrderFabricCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.enableCustomDrawOrderFabric()
+      enableCustomDrawOrderFabricCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<19d0606854e3e34efe67acf9dc1d26b4>>
+ * @generated SignedSource<<e237ec0556fef024fe2e294a05e753ad>>
  */
 
 /**
@@ -35,6 +35,8 @@ object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic external fun enableMicrotasks(): Boolean
 
   @DoNotStrip @JvmStatic external fun batchRenderingUpdatesInEventLoop(): Boolean
+
+  @DoNotStrip @JvmStatic external fun enableCustomDrawOrderFabric(): Boolean
 
   @DoNotStrip @JvmStatic external fun override(provider: Any)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<932fd2768c81d5a5f49929c89d6659ff>>
+ * @generated SignedSource<<f69dab426155bec528da9a5230d64f4f>>
  */
 
 /**
@@ -30,4 +30,6 @@ open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvider {
   override fun enableMicrotasks(): Boolean = false
 
   override fun batchRenderingUpdatesInEventLoop(): Boolean = false
+
+  override fun enableCustomDrawOrderFabric(): Boolean = false
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6254686d99a8bfd0531ed629655cf673>>
+ * @generated SignedSource<<871e0db7dedd2d49b739c89f7430c547>>
  */
 
 /**
@@ -28,6 +28,7 @@ class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAccessor {
   private var useModernRuntimeSchedulerCache: Boolean? = null
   private var enableMicrotasksCache: Boolean? = null
   private var batchRenderingUpdatesInEventLoopCache: Boolean? = null
+  private var enableCustomDrawOrderFabricCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -65,6 +66,16 @@ class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAccessor {
       cached = currentProvider.batchRenderingUpdatesInEventLoop()
       accessedFeatureFlags.add("batchRenderingUpdatesInEventLoop")
       batchRenderingUpdatesInEventLoopCache = cached
+    }
+    return cached
+  }
+
+  override fun enableCustomDrawOrderFabric(): Boolean {
+    var cached = enableCustomDrawOrderFabricCache
+    if (cached == null) {
+      cached = currentProvider.enableCustomDrawOrderFabric()
+      accessedFeatureFlags.add("enableCustomDrawOrderFabric")
+      enableCustomDrawOrderFabricCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c5c87368aae4df966b4b7971aadb79f2>>
+ * @generated SignedSource<<167c39fa71bf4d496f80e731554f62fa>>
  */
 
 /**
@@ -30,4 +30,6 @@ interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip fun enableMicrotasks(): Boolean
 
   @DoNotStrip fun batchRenderingUpdatesInEventLoop(): Boolean
+
+  @DoNotStrip fun enableCustomDrawOrderFabric(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -32,6 +32,7 @@ import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.touch.ReactHitSlopView;
@@ -496,7 +497,11 @@ public class ReactViewGroup extends ViewGroup
     if (getId() == NO_ID) {
       return false;
     }
-    return ViewUtil.getUIManagerType(getId()) == UIManagerType.FABRIC;
+    if (ViewUtil.getUIManagerType(getId()) != UIManagerType.FABRIC) {
+      return false;
+    }
+
+    return !ReactNativeFeatureFlags.enableCustomDrawOrderFabric();
   }
 
   private void handleAddView(View view) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bd4482119f1c4963aa4ad1e354f9107d>>
+ * @generated SignedSource<<e91eb11fffc75daa5c61b41cb2437748>>
  */
 
 /**
@@ -43,6 +43,11 @@ bool JReactNativeFeatureFlagsCxxInterop::batchRenderingUpdatesInEventLoop(
   return ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::enableCustomDrawOrderFabric(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::enableCustomDrawOrderFabric();
+}
+
 void JReactNativeFeatureFlagsCxxInterop::override(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/,
     jni::alias_ref<jobject> provider) {
@@ -72,6 +77,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "batchRenderingUpdatesInEventLoop",
         JReactNativeFeatureFlagsCxxInterop::batchRenderingUpdatesInEventLoop),
+      makeNativeMethod(
+        "enableCustomDrawOrderFabric",
+        JReactNativeFeatureFlagsCxxInterop::enableCustomDrawOrderFabric),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b7304c29a002ce5a8a612d7a08d798ff>>
+ * @generated SignedSource<<d39568f4a5cee2fdd2bbcf535027a91e>>
  */
 
 /**
@@ -40,6 +40,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool batchRenderingUpdatesInEventLoop(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool enableCustomDrawOrderFabric(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static void override(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<91f988022fbff7eba632f2ba46056025>>
+ * @generated SignedSource<<1518ec0b2ffc06d00cbe1fe189e3db83>>
  */
 
 /**
@@ -48,6 +48,12 @@ bool ReactNativeFeatureFlagsProviderHolder::enableMicrotasks() {
 bool ReactNativeFeatureFlagsProviderHolder::batchRenderingUpdatesInEventLoop() {
   static const auto method =
       getJClass()->getMethod<jboolean()>("batchRenderingUpdatesInEventLoop");
+  return method(javaProvider_);
+}
+
+bool ReactNativeFeatureFlagsProviderHolder::enableCustomDrawOrderFabric() {
+  static const auto method =
+      getJClass()->getMethod<jboolean()>("enableCustomDrawOrderFabric");
   return method(javaProvider_);
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3550f7ee28a53a4024a48301ee38ce7e>>
+ * @generated SignedSource<<0b52512b8366b21e0b20bac6abbaf9ad>>
  */
 
 /**
@@ -39,6 +39,7 @@ class ReactNativeFeatureFlagsProviderHolder
   bool useModernRuntimeScheduler() override;
   bool enableMicrotasks() override;
   bool batchRenderingUpdatesInEventLoop() override;
+  bool enableCustomDrawOrderFabric() override;
 
  private:
   jni::global_ref<jobject> javaProvider_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<eb9bb346a84321197849de2dd8bf7dc3>>
+ * @generated SignedSource<<18fb46f5d1e3ed6ea8ea30ae83c8fc6c>>
  */
 
 /**
@@ -35,6 +35,10 @@ bool ReactNativeFeatureFlags::enableMicrotasks() {
 
 bool ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop() {
   return getAccessor().batchRenderingUpdatesInEventLoop();
+}
+
+bool ReactNativeFeatureFlags::enableCustomDrawOrderFabric() {
+  return getAccessor().enableCustomDrawOrderFabric();
 }
 
 void ReactNativeFeatureFlags::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<be203871f94ca134f75b803b7d79a5ab>>
+ * @generated SignedSource<<7c8a87fe61d3e10d4aef3ad35e31312c>>
  */
 
 /**
@@ -51,6 +51,11 @@ class ReactNativeFeatureFlags {
    * When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.
    */
   static bool batchRenderingUpdatesInEventLoop();
+
+  /**
+   * When enabled, Fabric will use customDrawOrder in ReactViewGroup (similar to old architecture).
+   */
+  static bool enableCustomDrawOrderFabric();
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5df50987338c0541436b11cd5433013c>>
+ * @generated SignedSource<<29ae55180ce90835dc6b591c2b780595>>
  */
 
 /**
@@ -94,6 +94,23 @@ bool ReactNativeFeatureFlagsAccessor::batchRenderingUpdatesInEventLoop() {
   }
 
   return batchRenderingUpdatesInEventLoop_.value();
+}
+
+bool ReactNativeFeatureFlagsAccessor::enableCustomDrawOrderFabric() {
+  if (!enableCustomDrawOrderFabric_.has_value()) {
+    // Mark the flag as accessed.
+    static const char* flagName = "enableCustomDrawOrderFabric";
+    if (std::find(
+            accessedFeatureFlags_.begin(),
+            accessedFeatureFlags_.end(),
+            flagName) == accessedFeatureFlags_.end()) {
+      accessedFeatureFlags_.push_back(flagName);
+    }
+
+    enableCustomDrawOrderFabric_.emplace(currentProvider_->enableCustomDrawOrderFabric());
+  }
+
+  return enableCustomDrawOrderFabric_.value();
 }
 
 void ReactNativeFeatureFlagsAccessor::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<11335a9c0d793a3a5a0dfdb01cd43efd>>
+ * @generated SignedSource<<8c3c3c7c42203ba2fcf11787d8b631d8>>
  */
 
 /**
@@ -34,6 +34,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool useModernRuntimeScheduler();
   bool enableMicrotasks();
   bool batchRenderingUpdatesInEventLoop();
+  bool enableCustomDrawOrderFabric();
 
   void override(std::unique_ptr<ReactNativeFeatureFlagsProvider> provider);
 
@@ -45,6 +46,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::optional<bool> useModernRuntimeScheduler_;
   std::optional<bool> enableMicrotasks_;
   std::optional<bool> batchRenderingUpdatesInEventLoop_;
+  std::optional<bool> enableCustomDrawOrderFabric_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b354cb54b822e2dfa3e093d39fb4da4e>>
+ * @generated SignedSource<<e724089d19571a2f82ed06f949ef34ac>>
  */
 
 /**
@@ -40,6 +40,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool batchRenderingUpdatesInEventLoop() override {
+    return false;
+  }
+
+  bool enableCustomDrawOrderFabric() override {
     return false;
   }
 };

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6bf1fc0d7b32a36041c2371fe191792b>>
+ * @generated SignedSource<<50a03cd31670d12698b0c300abbb67f7>>
  */
 
 /**
@@ -29,6 +29,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useModernRuntimeScheduler() = 0;
   virtual bool enableMicrotasks() = 0;
   virtual bool batchRenderingUpdatesInEventLoop() = 0;
+  virtual bool enableCustomDrawOrderFabric() = 0;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<01b940f6716765f9359c42180db497c0>>
+ * @generated SignedSource<<9cb62d3659d89544ba6feeb2adc20062>>
  */
 
 /**
@@ -53,6 +53,11 @@ bool NativeReactNativeFeatureFlags::enableMicrotasks(
 bool NativeReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop();
+}
+
+bool NativeReactNativeFeatureFlags::enableCustomDrawOrderFabric(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::enableCustomDrawOrderFabric();
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<200fe2cf84a044164c60f6dd3c5569dd>>
+ * @generated SignedSource<<31f74ba982c9c6b29fb00588cc293528>>
  */
 
 /**
@@ -37,6 +37,8 @@ class NativeReactNativeFeatureFlags
   bool enableMicrotasks(jsi::Runtime& runtime);
 
   bool batchRenderingUpdatesInEventLoop(jsi::Runtime& runtime);
+
+  bool enableCustomDrawOrderFabric(jsi::Runtime& runtime);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.json
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.json
@@ -15,6 +15,10 @@
     "batchRenderingUpdatesInEventLoop": {
       "description": "When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.",
       "defaultValue": false
+    },
+    "enableCustomDrawOrderFabric": {
+      "description": "When enabled, Fabric will use customDrawOrder in ReactViewGroup (similar to old architecture).",
+      "defaultValue": false
     }
   },
   "jsOnly": {

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlags.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlags.kt-template.js
@@ -41,6 +41,7 @@ ${Object.entries(config.common)
       `  /**
    * ${flagConfig.description}
    */
+  @JvmStatic
   fun ${flagName}() = accessor.${flagName}()`,
   )
   .join('\n\n')}

--- a/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<564159837241d197ebc3084ff9e72b7c>>
+ * @generated SignedSource<<18f98c202263cc079edbfbdc864ae48c>>
  * @flow strict-local
  */
 
@@ -27,6 +27,7 @@ export interface Spec extends TurboModule {
   +useModernRuntimeScheduler?: () => boolean;
   +enableMicrotasks?: () => boolean;
   +batchRenderingUpdatesInEventLoop?: () => boolean;
+  +enableCustomDrawOrderFabric?: () => boolean;
 }
 
 const NativeReactNativeFeatureFlags: ?Spec = TurboModuleRegistry.get<Spec>(

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4e4ce58c1ce1a95355bba0dfe099e26e>>
+ * @generated SignedSource<<cc93114d806492f0b29196aa791383f9>>
  * @flow strict-local
  */
 
@@ -37,6 +37,7 @@ export type ReactNativeFeatureFlags = {
   useModernRuntimeScheduler: Getter<boolean>,
   enableMicrotasks: Getter<boolean>,
   batchRenderingUpdatesInEventLoop: Getter<boolean>,
+  enableCustomDrawOrderFabric: Getter<boolean>,
 }
 
 /**
@@ -60,6 +61,10 @@ export const enableMicrotasks: Getter<boolean> = createNativeFlagGetter('enableM
  * When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.
  */
 export const batchRenderingUpdatesInEventLoop: Getter<boolean> = createNativeFlagGetter('batchRenderingUpdatesInEventLoop', false);
+/**
+ * When enabled, Fabric will use customDrawOrder in ReactViewGroup (similar to old architecture).
+ */
+export const enableCustomDrawOrderFabric: Getter<boolean> = createNativeFlagGetter('enableCustomDrawOrderFabric', false);
 
 /**
  * Overrides the feature flags with the provided methods.


### PR DESCRIPTION
Summary:
The task T175989432 started firing on October 30 2020, which correspond to the landing of D24512203. I believe disabling CustomDrawOrder could be a potential cause of T175989432, that's why in this diff I'm creating an experiment to understand what is the impact (negative or positive) of re-enabling CustomDrawOrder in RN Android

Original diff: D24512203

Chagelog: [Internal] internal

Reviewed By: javache

Differential Revision: D53150292


