### PR TITLE
revert: cherry-picking 'Avoid using Cocoapods 1.15 until it fixes an issue affection RN. (#42702)' onto 0.71

### DIFF
--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -1,8 +1,6 @@
 # Gemfile
 source 'https://rubygems.org'
 
-# Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
-# bound in the template on Cocoapods with next React Native release.
-gem 'cocoapods', '>= 1.13', '< 1.15'
+gem 'cocoapods', '>= 1.11.3'
 gem 'rexml'
 gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'

--- a/template/Gemfile
+++ b/template/Gemfile
@@ -3,7 +3,5 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby '>= 2.6.10'
 
-# Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
-# bound in the template on Cocoapods with next React Native release.
-gem 'cocoapods', '>= 1.13', '< 1.15'
+gem 'cocoapods', '>= 1.11.3'
 gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Release crew decided to only fix cocoapods 1.15 issue in 0.73 patch, so this fix is not valid for 71 anymore. Hence the reason we are reverting it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[iOS][Removed] don't allow cocoapods 1.15.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

CI
