### PR TITLE
'[skip ci] [RN][Android] Fix wrong type in kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
@@ -31,6 +31,6 @@ class JSCExecutor internal constructor(jscConfig: ReadableNativeMap) :
       SoLoader.loadLibrary("jscexecutor")
     }
 
-    @JvmStatic private external fun initHybrid(jscConfig: ReadableNativeMap): HybridData?
+    @JvmStatic private external fun initHybrid(jscConfig: ReadableNativeMap): HybridData
   }
 }


### PR DESCRIPTION
Summary:
initHybrid always return a HybridData. we shouldn'\''t allow null here.

changelog: [internal] internal

Reviewed By: NickGerleman

Differential Revision: D53200101

