### PR TITLE
'[skip ci] [RN][Android] Mark classes of package animated as @Nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNode.java
@@ -9,11 +9,13 @@ package com.facebook.react.animated;
 
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import java.util.ArrayList;
 import java.util.List;
 
 /** Base class for all Animated.js library node types that can be created on the "native" side. */
-/*package*/ abstract class AnimatedNode {
+/*package*/ @Nullsafe(Nullsafe.Mode.LOCAL)
+abstract class AnimatedNode {
 
   public static final int INITIAL_BFS_COLOR = 0;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/DecayAnimation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/DecayAnimation.java
@@ -7,12 +7,14 @@
 
 package com.facebook.react.animated;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableMap;
 
 /**
  * Implementation of {@link AnimationDriver} providing support for decay animations. The
  * implementation is copied from the JS version in {@code AnimatedImplementation.js}.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class DecayAnimation extends AnimationDriver {
 
   private final double mVelocity;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/DiffClampAnimatedNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/DiffClampAnimatedNode.java
@@ -7,10 +7,12 @@
 
 package com.facebook.react.animated;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JSApplicationCausedNativeException;
 import com.facebook.react.bridge.ReadableMap;
 
-/*package*/ class DiffClampAnimatedNode extends ValueAnimatedNode {
+/*package*/ @Nullsafe(Nullsafe.Mode.LOCAL)
+class DiffClampAnimatedNode extends ValueAnimatedNode {
   private final NativeAnimatedNodesManager mNativeAnimatedNodesManager;
   private final int mInputNodeTag;
   private final double mMin;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.java
@@ -7,10 +7,12 @@
 
 package com.facebook.react.animated;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JSApplicationCausedNativeException;
 import com.facebook.react.bridge.ReadableMap;
 
-/*package*/ class ModulusAnimatedNode extends ValueAnimatedNode {
+/*package*/ @Nullsafe(Nullsafe.Mode.LOCAL)
+class ModulusAnimatedNode extends ValueAnimatedNode {
 
   private final NativeAnimatedNodesManager mNativeAnimatedNodesManager;
   private final int mInputNode;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ObjectAnimatedNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ObjectAnimatedNode.java
@@ -8,6 +8,7 @@
 package com.facebook.react.animated;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JavaOnlyArray;
 import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.ReadableArray;
@@ -19,7 +20,8 @@ import com.facebook.react.bridge.ReadableType;
  * Native counterpart of object animated node (see AnimatedObject class in
  * AnimatedImplementation.js)
  */
-/* package */ class ObjectAnimatedNode extends AnimatedNode {
+/* package */ @Nullsafe(Nullsafe.Mode.LOCAL)
+class ObjectAnimatedNode extends AnimatedNode {
 
   private static final String VALUE_KEY = "value";
   private static final String NODE_TAG_KEY = "nodeTag";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/SpringAnimation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/SpringAnimation.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.animated;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableMap;
 
 /**
@@ -14,7 +15,8 @@ import com.facebook.react.bridge.ReadableMap;
  * implementation has been copied from android implementation of Rebound library (see <a
  * href="http://facebook.github.io/rebound/">http://facebook.github.io/rebound/</a>)
  */
-/*package*/ class SpringAnimation extends AnimationDriver {
+/*package*/ @Nullsafe(Nullsafe.Mode.LOCAL)
+class SpringAnimation extends AnimationDriver {
 
   // maximum amount of time to simulate per physics iteration in seconds (4 frames at 60 FPS)
   private static final double MAX_DELTA_TIME_SEC = 0.064;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
@@ -31,6 +31,6 @@ class JSCExecutor internal constructor(jscConfig: ReadableNativeMap) :
       SoLoader.loadLibrary("jscexecutor")
     }
 
-    @JvmStatic private external fun initHybrid(jscConfig: ReadableNativeMap): HybridData?
+    @JvmStatic private external fun initHybrid(jscConfig: ReadableNativeMap): HybridData
   }
 }


### PR DESCRIPTION
Summary:
All these classes are NullSafe, let'\''s mark them as NullSafe(Local) to ensure lint detect errors in the future

changelog: [internal] internal

Reviewed By: NickGerleman

Differential Revision: D53200096

