### PR TITLE
Change null-check in DefaultComponentsRegistry

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
@@ -25,12 +25,13 @@ std::shared_ptr<const ComponentDescriptorProviderRegistry>
 DefaultComponentsRegistry::sharedProviderRegistry() {
   auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
 
-  react_native_assert(
-      DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint &&
-      "'registerComponentDescriptorsFromEntryPoint' was not initialized in 'JNI_OnLoad'");
-
-  (DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint)(
-      providerRegistry);
+  if (DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint) {
+    (DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint)(
+        providerRegistry);
+  } else {
+    LOG(WARNING)
+        << "Custom component descriptors were not configured from JNI_OnLoad";
+  }
 
   return providerRegistry;
 }


### PR DESCRIPTION
Summary:
This matches the behaviour we have for DefaultTurboModuleManagerDelegate, where we handle the lack of this being set gracefully. It's probably worth still logging this, as it may point at an incorrectly configured app.

Changelog: [Internal]

Differential Revision: D53048064


