### PR TITLE
[RN][iOS] Fix warning when loading RCTUIManager and A11yManager

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -179,15 +179,20 @@ RCT_EXPORT_MODULE()
       _componentDataByName[componentData.name] = componentData;
     }
   }
-
+  // Preload the a11yManager as the RCTUIManager needs it to listen for notification
+  // By eagerly preloading it in the setBridge method, we make sure that the manager is
+  // properly initialized in the Main Thread and that we do not incur in any race condition
+  // or concurrency problem.
+  id<RCTBridgeModule> a11yManager = [self->_bridge moduleForName:@"AccessibilityManager"
+                                           lazilyLoadIfNecessary:YES];
+  __weak NSObject * a11yManagerWeakObject = a11yManager;
   // This dispatch_async avoids a deadlock while configuring native modules
-  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
-    id a11yManager = [self->_bridge moduleForName:@"AccessibilityManager"
-                                             lazilyLoadIfNecessary:YES];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    __strong NSObject * a11yManagerStrongObject = a11yManagerWeakObject;
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didReceiveNewContentSizeMultiplier)
                                                  name:@"RCTAccessibilityManagerDidUpdateMultiplierNotification"
-                                               object:a11yManager];
+                                               object:a11yManagerStrongObject];
   });
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(namedOrientationDidChange)


### PR DESCRIPTION
## Summary:
When we fixed the race condition between A11yManager and RCTUIManager, we did it by moving the A11yManager on a background queue.
In the old architecture, this was raising a warning which our users might find confusing. Plus, that change was not aligned with what the A11yManager declared in its configuration because we are actually initializing it starting from a BG queue.

<img width="320" alt="a11y_warning" src="https://github.com/facebook/react-native/assets/11162307/8b18eba7-87c8-4c13-b008-fc14497955c2">

With this change we anticipate the initialization of the module in a place where:
1. We know we are in the main queue
1. We know we are going to need it (so it is not violating the lazy load principle)
1. We know it is safe.
This should allow us to also remove the feature flag of RCTUIManagerDispatchAccessibilityManagerInitOntoMain because now it is safe to use the main_queue as requested by the module.

## Changelog:
[iOS][Fixed] - Initialize the A11yManager in the main queue and when we need it.

## Test Plan:
Tested in an app running 0.73.3, using the following configurations:
* Old Arch | Debug
* Old Arch | Release
* New Arch | Debug
* New Arch | Release
