### PR TITLE
[Fabric] Fixes semantic color not work when dark mode changed

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.mm
@@ -10,6 +10,7 @@
 #import <react/renderer/core/RawValue.h>
 #import <react/renderer/graphics/HostPlatformColor.h>
 #import <react/renderer/graphics/RCTPlatformColorUtils.h>
+#import <react/utils/ManagedObjectWrapper.h>
 #import <string>
 #import <unordered_map>
 
@@ -55,7 +56,7 @@ SharedColor parsePlatformColor(const ContextContainer &contextContainer, int32_t
     auto items = (std::unordered_map<std::string, RawValue>)value;
     if (items.find("semantic") != items.end() && items.at("semantic").hasType<std::vector<std::string>>()) {
       auto semanticItems = (std::vector<std::string>)items.at("semantic");
-      return {colorFromComponents(RCTPlatformColorComponentsFromSemanticItems(semanticItems))};
+      return {wrapManagedObject(RCTPlatformColorFromSemanticItems(semanticItems))};
     } else if (
         items.find("dynamic") != items.end() &&
         items.at("dynamic").hasType<std::unordered_map<std::string, RawValue>>()) {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/RCTPlatformColorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/RCTPlatformColorUtils.h
@@ -13,5 +13,6 @@
 
 facebook::react::ColorComponents RCTPlatformColorComponentsFromSemanticItems(
     std::vector<std::string>& semanticItems);
-
+UIColor* RCTPlatformColorFromSemanticItems(
+    std::vector<std::string>& semanticItems);
 UIColor* RCTPlatformColorFromColor(const facebook::react::Color& color);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/RCTPlatformColorUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/RCTPlatformColorUtils.mm
@@ -186,19 +186,24 @@ static inline facebook::react::ColorComponents _ColorComponentsFromUIColor(UICol
 
 facebook::react::ColorComponents RCTPlatformColorComponentsFromSemanticItems(std::vector<std::string> &semanticItems)
 {
+  return _ColorComponentsFromUIColor(RCTPlatformColorFromSemanticItems(semanticItems));
+}
+
+UIColor *RCTPlatformColorFromSemanticItems(std::vector<std::string> &semanticItems)
+{
   for (const auto &semanticCString : semanticItems) {
     NSString *semanticNSString = _NSStringFromCString(semanticCString);
     UIColor *uiColor = [UIColor colorNamed:semanticNSString];
     if (uiColor != nil) {
-      return _ColorComponentsFromUIColor(uiColor);
+      return uiColor;
     }
     uiColor = _UIColorFromSemanticString(semanticNSString);
     if (uiColor != nil) {
-      return _ColorComponentsFromUIColor(uiColor);
+      return uiColor;
     }
   }
 
-  return {0, 0, 0, 0};
+  return UIColor.clearColor;
 }
 
 UIColor *RCTPlatformColorFromColor(const facebook::react::Color &color)


### PR DESCRIPTION
## Summary:

When we changed dark mode, the semantic color was not applied because we use color components, it's not dynamic. So let's store the `UIColor` for semantic color directly.

https://github.com/facebook/react-native/assets/5061845/bd6d15fe-01eb-4ad7-9844-a19ef8585dae

## Changelog:

[IOS] [FIXED] - [Fabric] Fixes semantic color not work when dark mode changed

## Test Plan:

semantic color changed when switch dark mode.
