### PR TITLE
[iOS] Fixes root view's background color in bridgeless mode

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -107,6 +107,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
         sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact];
 
     rootView = (RCTRootView *)surfaceHostingProxyRootView;
+    rootView.backgroundColor = [UIColor systemBackgroundColor];
   } else {
     if (!self.bridge) {
       self.bridge = [self createBridgeWithDelegate:self launchOptions:launchOptions];


### PR DESCRIPTION
## Summary:
Fixes root view's background color in bridgeless mode, the top area has white background color when in dark mode.

Before:
![Simulator Screenshot - iPhone 15 - 2024-01-30 at 23 28 48](https://github.com/facebook/react-native/assets/5061845/4359385d-370d-48cf-a58e-e2e9eb871400)

After:
![Simulator Screenshot - iPhone 15 - 2024-01-30 at 23 25 39](https://github.com/facebook/react-native/assets/5061845/5e9d2029-43d2-40c3-b2cb-c8a9ee80a5e1)

## Changelog:

[IOS] [FIXED] - [iOS] Fixes the root view's background color in bridgeless mode

## Test Plan:

Run RNTester and see the top area's background color.
