### PR TITLE
Fix import in publish-npm script

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -16,7 +16,7 @@ const {
   publishAndroidArtifactsToMaven,
 } = require('./release-utils');
 const removeNewArchFlags = require('./releases/remove-new-arch-flags');
-const setReactNativeVersion = require('./releases/set-rn-version');
+const {setReactNativeVersion} = require('./releases/set-rn-version');
 const path = require('path');
 const {echo, exit} = require('shelljs');
 const yargs = require('yargs');


### PR DESCRIPTION
Summary:
Follow-up to a CircleCI breakage introduced by D53001971.

This was missed by both the typechecker (no Flow in file) and CI (no PR-time jobs covering this script).

Changelog: [Internal]

Reviewed By: GijsWeterings, cipolleschi

Differential Revision: D53228096


