### PR TITLE
Add Github Action to mirror partner's nightly CI results

### DIFF
--- a/.github/workflows/nightlies-feedback.yml
+++ b/.github/workflows/nightlies-feedback.yml
@@ -1,0 +1,52 @@
+name: Nightlies Partners Feedback
+env:
+  # Add accounts for users who are part of the nightlies program
+  allowed_users: >
+    [
+      "blakef",
+      "alanjhughes"
+    ]
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: 'What project is running against the nighties build?'
+        required: true
+        type: string
+      outcome:
+        description: 'Did the CI run: ["pass", "fail"]?'
+        required: true
+        type: string
+      stage:
+        description: 'Stage in the run that failed: ["build", "test"]?'
+        required: true
+        type: string
+      link:
+        description: 'URL to the failing test'
+        required: true
+        type: string
+      version:
+        description: 'What is the Nightlies version this was run against?'
+        required: true
+        type: string
+jobs:
+  share-nightlies-feedback:
+    name: ${{ inputs.project}} 💨 Nightlies CI
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - if: ${{ !contains(fromJSON(env.allowed_users), github.actor.login) }}
+        run: |
+          echo "Request from actor's login wasn't on the allowed_users list."
+          curl -X POST \
+               -H "Accept: application/vnd.github.v3+json" \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel
+      - run: |
+          echo "Project: ${{ inputs.project }}"
+          echo "Outcome: ${{ inputs.outcome }}"
+          echo "Stage: ${{ inputs.stage }}"
+          echo "Link: ${{ inputs.link }}"
+          echo "Version: ${{ inputs.version }}"
+          [[ "${{ inputs.outcome }}" == "pass" ]] && { exit 0; } || { exit 1; }


### PR DESCRIPTION
Summary:
This adds a nightlies-feedback workflow, which our partners can get permission to mirror the results of their nightlies CI workflows.  We do this to use our internal tools that are restricted to Meta owned Github projects.

The benefit to partners is that they can add this step to their workflow:

```
      - if: ${{ success() || failure() }}
        env:
          OUTCOME: ${{ contains(steps.*.conclusion, 'failure') && 'fail' || 'pass' }}
        run: |
          curl -X POST \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               https://api.github.com/repos/facebook/react-native/actions/workflows/nightlies-feedback.yml/dispatches \
               -d "$(printf '{"ref":"main","inputs":{"outcome":"%s","stage":"needs_an_action","link":"http://github.com/some/action","version":"%s"}}' "$OUTCOME" "${{ inputs.version }}" )"

```

There's certainly a lot of room for improvement, which we could provide with a published action (populate the ref correctly, simplify gathering the outcome, labelling of failing step correctly, etc...).

Differential Revision: D53229996


