### PR TITLE
[rn-tester]: don't run `hermes` specific tests inside `Pods` dir.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,7 @@ module.exports = {
     '<rootDir>/packages/react-native/sdks',
     '<rootDir>/packages/react-native/Libraries/Renderer',
     '<rootDir>/packages/rn-tester/e2e',
+    '<rootDir>/packages/rn-tester/Pods',
     '<rootDir>/packages/react-native-test-renderer/src',
   ],
   transformIgnorePatterns: ['node_modules/(?!@react-native/)'],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In https://github.com/facebook/react-native/pull/40734 I added a similar PR to prevent unwanted tests. 
In this one, I'm adding the `Pods` dir for the same particular reason.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[INTERNAL][FIXED]: don't run `hermes` specific tests inside `Pods` dir.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

> If you run the tests without running Pods first, you'll notice that the tests run property. 

1. `cd packages/rn-tester`
2. Follow [rn-tester#running-on-ios ](https://github.com/facebook/react-native/tree/main/packages/rn-tester#running-on-ios) and build the app
3. run `yarn test`
4. Notice the failing `rn-tester/Pods/hermes-engine` failing tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
