### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
@@ -18,7 +18,8 @@ import java.util.List;
 
 @Deprecated(
     since =
-        "CompositeReactPackageTurboModuleManagerDelegate is deprecated and will be deleted in the future. Please use ReactPackage interface or BaseReactPackage instead.")
+        "CompositeReactPackageTurboModuleManagerDelegate is deprecated and will be deleted in the"
+            + " future. Please use ReactPackage interface or BaseReactPackage instead.")
 @DoNotStrip
 public class CompositeReactPackageTurboModuleManagerDelegate
     extends ReactPackageTurboModuleManagerDelegate {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -91,7 +91,9 @@ class DebugCorePackage extends TurboReactPackage implements ViewManagerOnDemandR
     map.put(name, ModuleSpec.viewManagerSpec(provider));
   }
 
-  /** @return a map of view managers that should be registered with {@link UIManagerModule} */
+  /**
+   * @return a map of view managers that should be registered with {@link UIManagerModule}
+   */
   private Map<String, ModuleSpec> getViewManagersMap() {
     if (mViewManagers == null) {
       Map<String, ModuleSpec> viewManagers = new HashMap<>();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -106,6 +106,7 @@ public abstract class LazyReactPackage implements ReactPackage {
     }
     return modules;
   }
+
   /**
    * @param reactContext react application context that can be used to create View Managers.
    * @return list of module specs that can create the View Managers.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.java
@@ -50,8 +50,12 @@ public class NativeModuleRegistryBuilder {
                   + name
                   + " tried to override "
                   + existingNativeModule.getClassName()
-                  + ". Check the getPackages() method in MainApplication.java, it might be that module is being created twice. If this was your intention, set canOverrideExistingModule=true. "
-                  + "This error may also be present if the package is present only once in getPackages() but is also automatically added later during build time by autolinking. Try removing the existing entry and rebuild.");
+                  + ". Check the getPackages() method in MainApplication.java, it might be that"
+                  + " module is being created twice. If this was your intention, set"
+                  + " canOverrideExistingModule=true. This error may also be present if the package"
+                  + " is present only once in getPackages() but is also automatically added later"
+                  + " during build time by autolinking. Try removing the existing entry and"
+                  + " rebuild.");
         }
         mModules.remove(existingNativeModule);
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -113,6 +113,7 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     super.onDestroy();
     mReactDelegate.onHostDestroy();
   }
+
   // endregion
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1020,7 +1020,8 @@ public class ReactInstanceManager {
             } else {
               FLog.w(
                   ReactConstants.TAG,
-                  "Package %s is not a ViewManagerOnDemandReactPackage, view managers will not be loaded",
+                  "Package %s is not a ViewManagerOnDemandReactPackage, view managers will not be"
+                      + " loaded",
                   reactPackage.getClass().getSimpleName());
             }
             Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
@@ -1046,7 +1047,9 @@ public class ReactInstanceManager {
     mReactInstanceEventListeners.remove(listener);
   }
 
-  /** @return current ReactApplicationContext */
+  /**
+   * @return current ReactApplicationContext
+   */
   @VisibleForTesting
   public @Nullable ReactContext getCurrentReactContext() {
     synchronized (mReactContextLock) {
@@ -1355,7 +1358,9 @@ public class ReactInstanceManager {
     mDevSupportManager.onReactInstanceDestroyed(reactContext);
   }
 
-  /** @return instance of {@link ReactContext} configured a {@link CatalystInstance} set */
+  /**
+   * @return instance of {@link ReactContext} configured a {@link CatalystInstance} set
+   */
   private ReactApplicationContext createReactContext(
       JavaScriptExecutor jsExecutor, JSBundleLoader jsBundleLoader) {
     FLog.d(ReactConstants.TAG, "ReactInstanceManager.createReactContext()");

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -30,7 +30,8 @@ import java.util.List;
  */
 @DeprecatedInNewArchitecture(
     message =
-        "This class will be replaced by com.facebook.react.ReactHost in the new architecture of React Native.")
+        "This class will be replaced by com.facebook.react.ReactHost in the new architecture of"
+            + " React Native.")
 public abstract class ReactNativeHost {
 
   private final Application mApplication;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java
@@ -46,7 +46,9 @@ public interface ReactPackage {
   @DeprecatedInNewArchitecture
   List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext);
 
-  /** @return a list of view managers that should be registered with {@link UIManagerModule} */
+  /**
+   * @return a list of view managers that should be registered with {@link UIManagerModule}
+   */
   @NonNull
   List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -273,10 +273,12 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
     public ReactPackageTurboModuleManagerDelegate build() {
       Assertions.assertNotNull(
           mContext,
-          "The ReactApplicationContext must be provided to create ReactPackageTurboModuleManagerDelegate");
+          "The ReactApplicationContext must be provided to create"
+              + " ReactPackageTurboModuleManagerDelegate");
       Assertions.assertNotNull(
           mPackages,
-          "A set of ReactPackages must be provided to create ReactPackageTurboModuleManagerDelegate");
+          "A set of ReactPackages must be provided to create"
+              + " ReactPackageTurboModuleManagerDelegate");
       return build(mContext, mPackages);
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -317,7 +317,8 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     if (!hasActiveReactContext() || !isViewAttachedToReactInstance()) {
       FLog.w(
           TAG,
-          "Unable to handle child focus changed event as the catalyst instance has not been attached");
+          "Unable to handle child focus changed event as the catalyst instance has not been"
+              + " attached");
       super.requestChildFocus(child, focused);
       return;
     }
@@ -420,8 +421,9 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
                 ReactSoftExceptionLogger.logSoftException(
                     TAG,
                     new ReactNoCrashSoftException(
-                        "A view was illegally added as a child of a ReactRootView. "
-                            + "This View should not be a direct child of a ReactRootView, because it is not visible and will never be reachable. Child: "
+                        "A view was illegally added as a child of a ReactRootView. This View should"
+                            + " not be a direct child of a ReactRootView, because it is not visible"
+                            + " and will never be reachable. Child: "
                             + child.getClass().getCanonicalName().toString()
                             + " child ID: "
                             + child.getId()));
@@ -758,11 +760,11 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     super.finalize();
     Assertions.assertCondition(
         !mIsAttachedToInstance,
-        "The application this ReactRootView was rendering was not unmounted before the "
-            + "ReactRootView was garbage collected. This usually means that your application is "
-            + "leaking large amounts of memory. To solve this, make sure to call "
-            + "ReactRootView#unmountReactApplication in the onDestroy() of your hosting Activity or in "
-            + "the onDestroyView() of your hosting Fragment.");
+        "The application this ReactRootView was rendering was not unmounted before the"
+            + " ReactRootView was garbage collected. This usually means that your application is"
+            + " leaking large amounts of memory. To solve this, make sure to call"
+            + " ReactRootView#unmountReactApplication in the onDestroy() of your hosting Activity"
+            + " or in the onDestroyView() of your hosting Fragment.");
   }
 
   public int getRootViewTag() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ViewManagerOnDemandReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ViewManagerOnDemandReactPackage.java
@@ -18,6 +18,7 @@ public interface ViewManagerOnDemandReactPackage {
    * Typically, this is ViewManager.getName().
    */
   Collection<String> getViewManagerNames(ReactApplicationContext reactContext);
+
   /**
    * Creates and returns a ViewManager with a specific name {@param viewManagerName}. It's up to an
    * implementing package how to interpret the name.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -441,7 +441,8 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
       ReactSoftExceptionLogger.logSoftException(
           NAME,
           new RuntimeException(
-              "initializeLifecycleEventListenersForViewTag could not get NativeAnimatedNodesManager"));
+              "initializeLifecycleEventListenersForViewTag could not get"
+                  + " NativeAnimatedNodesManager"));
     }
 
     // Subscribe to UIManager (Fabric or non-Fabric) lifecycle events if we haven't yet

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -427,7 +427,8 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
     }
     if (mReactApplicationContext == null) {
       throw new IllegalStateException(
-          "connectAnimatedNodeToView: Animated node could not be connected, no ReactApplicationContext: "
+          "connectAnimatedNodeToView: Animated node could not be connected, no"
+              + " ReactApplicationContext: "
               + viewTag);
     }
 
@@ -438,7 +439,8 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new ReactNoCrashSoftException(
-              "connectAnimatedNodeToView: Animated node could not be connected to UIManager - uiManager disappeared for tag: "
+              "connectAnimatedNodeToView: Animated node could not be connected to UIManager -"
+                  + " uiManager disappeared for tag: "
                   + viewTag));
       return;
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ActivityEventListener.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ActivityEventListener.java
@@ -24,5 +24,6 @@ public interface ActivityEventListener {
   void onNewIntent(Intent intent);
 
   /** Called when host activity receives an {@link Activity#onUserLeaveHint()} call. */
-  default void onUserLeaveHint(Activity activity) {};
+  default void onUserLeaveHint(Activity activity) {}
+  ;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseActivityEventListener.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseActivityEventListener.java
@@ -14,7 +14,9 @@ import androidx.annotation.Nullable;
 /** An empty implementation of {@link ActivityEventListener} */
 public class BaseActivityEventListener implements ActivityEventListener {
 
-  /** @deprecated use {@link #onActivityResult(Activity, int, int, Intent)} instead. */
+  /**
+   * @deprecated use {@link #onActivityResult(Activity, int, int, Intent)} instead.
+   */
   @Deprecated
   public void onActivityResult(int requestCode, int resultCode, Intent data) {}
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -64,7 +64,9 @@ public abstract class BaseJavaModule implements NativeModule {
     mReactApplicationContext = reactContext;
   }
 
-  /** @return a map of constants this module exports to JS. Supports JSON types. */
+  /**
+   * @return a map of constants this module exports to JS. Supports JSON types.
+   */
   @DeprecatedInNewArchitecture()
   public @Nullable Map<String, Object> getConstants() {
     return null;
@@ -94,7 +96,8 @@ public abstract class BaseJavaModule implements NativeModule {
   protected final ReactApplicationContext getReactApplicationContext() {
     return Assertions.assertNotNull(
         mReactApplicationContext,
-        "Tried to get ReactApplicationContext even though NativeModule wasn't instantiated with one");
+        "Tried to get ReactApplicationContext even though NativeModule wasn't instantiated with"
+            + " one");
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
@@ -46,6 +46,7 @@ public interface CatalystInstance
 
   @DoNotStrip
   void callFunction(String module, String method, NativeArray arguments);
+
   /**
    * Destroys this catalyst instance, waiting for any other threads in ReactQueueConfiguration
    * (besides the UI thread) to finish running. Must be called from the UI thread so that we can
@@ -73,7 +74,9 @@ public interface CatalystInstance
 
   @Deprecated(
       since =
-          "getJSIModule(JSIModuleType moduleType) is deprecated and will be deleted in the future. Please use ReactInstanceEventListener to subscribe for react instance events instead.")
+          "getJSIModule(JSIModuleType moduleType) is deprecated and will be deleted in the future."
+              + " Please use ReactInstanceEventListener to subscribe for react instance events"
+              + " instead.")
   JSIModule getJSIModule(JSIModuleType moduleType);
 
   Collection<NativeModule> getNativeModules();
@@ -136,21 +139,26 @@ public interface CatalystInstance
 
   @Deprecated(
       since =
-          "setTurboModuleManager(JSIModule getter) is deprecated and will be deleted in the future. Please use setTurboModuleRegistry(TurboModuleRegistry turboModuleRegistry)instead.")
+          "setTurboModuleManager(JSIModule getter) is deprecated and will be deleted in the future."
+              + " Please use setTurboModuleRegistry(TurboModuleRegistry"
+              + " turboModuleRegistry)instead.")
   void setTurboModuleManager(JSIModule getter);
 
   @DeprecatedInNewArchitecture(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not"
+              + " encouraged usage.")
   void setTurboModuleRegistry(TurboModuleRegistry turboModuleRegistry);
 
   @DeprecatedInNewArchitecture(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not"
+              + " encouraged usage.")
   void setFabricUIManager(UIManager fabricUIManager);
 
   @DeprecatedInNewArchitecture(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not"
+              + " encouraged usage.")
   UIManager getFabricUIManager();
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/FallbackJSBundleLoader.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/FallbackJSBundleLoader.java
@@ -31,7 +31,9 @@ public final class FallbackJSBundleLoader extends JSBundleLoader {
   // Reasons why we fell-back on previous loaders, in order of occurrence.
   private final ArrayList<Exception> mRecoveredErrors = new ArrayList<>();
 
-  /** @param loaders Loaders for the sources to try, in descending order of preference. */
+  /**
+   * @param loaders Loaders for the sources to try, in descending order of preference.
+   */
   public FallbackJSBundleLoader(List<JSBundleLoader> loaders) {
     mLoaders = new Stack<>();
     ListIterator<JSBundleLoader> it = loaders.listIterator(loaders.size());

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModulePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModulePackage.java
@@ -12,7 +12,9 @@ import java.util.List;
 /** Interface used to initialize JSI Modules into the JSI Bridge. */
 public interface JSIModulePackage {
 
-  /** @return a {@link List< JSIModuleSpec >} that contain the list of JSI Modules. */
+  /**
+   * @return a {@link List< JSIModuleSpec >} that contain the list of JSI Modules.
+   */
   List<JSIModuleSpec> getJSIModules(
       ReactApplicationContext reactApplicationContext, JavaScriptContextHolder jsContext);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
@@ -67,7 +67,9 @@ public class JavaOnlyMap implements ReadableMap, WritableMap {
     return res;
   }
 
-  /** @param keysAndValues keys and values, interleaved */
+  /**
+   * @param keysAndValues keys and values, interleaved
+   */
   private JavaOnlyMap(Object... keysAndValues) {
     if (keysAndValues.length % 2 != 0) {
       throw new IllegalArgumentException("You must provide the same number of keys and values");

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleSpec.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleSpec.java
@@ -34,7 +34,8 @@ public class ModuleSpec {
           TAG,
           "Could not find @ReactModule annotation on "
               + type.getName()
-              + ". So creating the module eagerly to get the name. Consider adding an annotation to make this Lazy");
+              + ". So creating the module eagerly to get the name. Consider adding an annotation to"
+              + " make this Lazy");
       NativeModule nativeModule = provider.get();
       return new ModuleSpec(provider, nativeModule.getName());
     } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -200,7 +200,9 @@ public class ReactContext extends ContextWrapper {
     return mCatalystInstance.getNativeModules();
   }
 
-  /** @return the instance of the specified module interface associated with this ReactContext. */
+  /**
+   * @return the instance of the specified module interface associated with this ReactContext.
+   */
   @Nullable
   public <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
     if (mCatalystInstance == null) {
@@ -253,7 +255,9 @@ public class ReactContext extends ContextWrapper {
     return hasActiveReactInstance();
   }
 
-  /** @return true if there is an non-null, alive react native instance */
+  /**
+   * @return true if there is an non-null, alive react native instance
+   */
   public boolean hasActiveReactInstance() {
     return mCatalystInstance != null && !mCatalystInstance.isDestroyed();
   }
@@ -447,7 +451,8 @@ public class ReactContext extends ContextWrapper {
     /** TODO(T85807990): Fail fast if the ReactContext isn't initialized */
     if (!mIsInitialized) {
       throw new IllegalStateException(
-          "Tried to call assertOnNativeModulesQueueThread(message) on an uninitialized ReactContext");
+          "Tried to call assertOnNativeModulesQueueThread(message) on an uninitialized"
+              + " ReactContext");
     }
     Assertions.assertNotNull(mNativeModulesMessageQueueThread).assertIsOnThread(message);
   }
@@ -558,7 +563,9 @@ public class ReactContext extends ContextWrapper {
     return mCurrentActivity.get();
   }
 
-  /** @deprecated DO NOT USE, this method will be removed in the near future. */
+  /**
+   * @deprecated DO NOT USE, this method will be removed in the near future.
+   */
   @Deprecated
   public boolean isBridgeless() {
     return false;
@@ -579,7 +586,8 @@ public class ReactContext extends ContextWrapper {
 
   @DeprecatedInNewArchitecture(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not"
+              + " encouraged usage.")
   /**
    * Get the UIManager for Fabric from the CatalystInstance.
    *

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.java
@@ -16,7 +16,8 @@ import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
  */
 @DeprecatedInNewArchitecture(
     message =
-        "ReactContextBaseJavaModule will be deprecated in new Architecture of React Native, use BaseJavaModule instead")
+        "ReactContextBaseJavaModule will be deprecated in new Architecture of React Native, use"
+            + " BaseJavaModule instead")
 public abstract class ReactContextBaseJavaModule extends BaseJavaModule {
 
   public ReactContextBaseJavaModule() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -45,7 +45,8 @@ public class ReactMarker {
 
   public interface MarkerListener {
     void logMarker(ReactMarkerConstants name, @Nullable String tag, int instanceKey);
-  };
+  }
+  ;
 
   // This is for verbose, Fabric-only logging
   // In the future we can deprecate the old logMarker API and
@@ -61,7 +62,8 @@ public class ReactMarker {
         int counter) {
       logFabricMarker(name, tag, instanceKey, timestamp);
     }
-  };
+  }
+  ;
 
   // Use a list instead of a set here because we expect the number of listeners
   // to be very small, and we want listeners to be called in a deterministic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactModuleWithSpec.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactModuleWithSpec.java
@@ -9,7 +9,9 @@ package com.facebook.react.bridge;
 
 import com.facebook.proguard.annotations.DoNotStrip;
 
-/** @deprecated Use {@link TurboModule} to identify generated specs */
+/**
+ * @deprecated Use {@link TurboModule} to identify generated specs
+ */
 @DoNotStrip
 @Deprecated
 public interface ReactModuleWithSpec {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.java
@@ -74,7 +74,9 @@ public interface UIManager extends PerformanceCounter {
    */
   void dispatchCommand(int reactTag, String commandId, @Nullable ReadableArray commandArgs);
 
-  /** @return the {@link EventDispatcher} object that is used by this class. */
+  /**
+   * @return the {@link EventDispatcher} object that is used by this class.
+   */
   <T> T getEventDispatcher();
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UiThreadUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UiThreadUtil.java
@@ -29,7 +29,9 @@ public class UiThreadUtil {
     return sMainHandler;
   }
 
-  /** @return {@code true} if the current thread is the UI thread. */
+  /**
+   * @return {@code true} if the current thread is the UI thread.
+   */
   public static boolean isOnUiThread() {
     return Looper.getMainLooper().getThread() == Thread.currentThread();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadImpl.java
@@ -187,7 +187,9 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
     }
   }
 
-  /** @return a MessageQueueThreadImpl corresponding to Android's main UI thread. */
+  /**
+   * @return a MessageQueueThreadImpl corresponding to Android's main UI thread.
+   */
   private static MessageQueueThreadImpl createForMainThread(
       String name, QueueThreadExceptionHandler exceptionHandler) {
     final MessageQueueThreadImpl mqt =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/DebugServerException.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/DebugServerException.java
@@ -23,12 +23,17 @@ import org.json.JSONObject;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class DebugServerException extends RuntimeException {
   private static final String GENERIC_ERROR_MESSAGE =
-      "\n\nTry the following to fix the issue:\n"
+      "\n\n"
+          + "Try the following to fix the issue:\n"
           + "\u2022 Ensure that Metro is running\n"
-          + "\u2022 Ensure that your device/emulator is connected to your machine and has USB debugging enabled - run 'adb devices' to see a list of connected devices\n"
+          + "\u2022 Ensure that your device/emulator is connected to your machine and has USB"
+          + " debugging enabled - run 'adb devices' to see a list of connected devices\n"
           + "\u2022 Ensure Airplane Mode is disabled\n"
-          + "\u2022 If you're on a physical device connected to the same machine, run 'adb reverse tcp:<PORT> tcp:<PORT>' to forward requests from your device\n"
-          + "\u2022 If your device is on the same Wi-Fi network, set 'Debug server host & port for device' in 'Dev settings' to your machine's IP address and the port of the local dev server - e.g. 10.0.1.1:<PORT>\n\n";
+          + "\u2022 If you're on a physical device connected to the same machine, run 'adb reverse"
+          + " tcp:<PORT> tcp:<PORT>' to forward requests from your device\n"
+          + "\u2022 If your device is on the same Wi-Fi network, set 'Debug server host & port for"
+          + " device' in 'Dev settings' to your machine's IP address and the port of the local dev"
+          + " server - e.g. 10.0.1.1:<PORT>\n\n";
 
   public static DebugServerException makeGeneric(
       @NonNull String url, @NonNull String reason, Throwable t) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/StandardCharsets.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/StandardCharsets.java
@@ -30,6 +30,7 @@ public final class StandardCharsets {
 
   /** Sixteen-bit UCS Transformation Format, big-endian byte order */
   public static final Charset UTF_16BE = Charset.forName("UTF-16BE");
+
   /** Sixteen-bit UCS Transformation Format, little-endian byte order */
   public static final Charset UTF_16LE = Charset.forName("UTF-16LE");
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -38,7 +38,8 @@ import com.facebook.react.common.ReactConstants;
       intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       FLog.w(
           ReactConstants.TAG,
-          "Overlay permissions needs to be granted in order for react native apps to run in dev mode");
+          "Overlay permissions needs to be granted in order for react native apps to run in dev"
+              + " mode");
       if (canHandleIntent(context, intent)) {
         context.startActivity(intent);
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.java
@@ -31,7 +31,9 @@ public class DefaultDevSupportManagerFactory implements DevSupportManagerFactory
   private static final String DEVSUPPORT_IMPL_PACKAGE = "com.facebook.react.devsupport";
   private static final String DEVSUPPORT_IMPL_CLASS = "BridgeDevSupportManager";
 
-  /** @deprecated in favor of the customisable create for DevSupportManagerFactory */
+  /**
+   * @deprecated in favor of the customisable create for DevSupportManagerFactory
+   */
   @Deprecated
   public DevSupportManager create(
       Context applicationContext,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -336,7 +336,9 @@ public class DevServerHelper {
         callback, outputFile, bundleURL, bundleInfo, requestBuilder);
   }
 
-  /** @return the host to use when connecting to the bundle server from the host itself. */
+  /**
+   * @return the host to use when connecting to the bundle server from the host itself.
+   */
   private String getHostForJSProxy() {
     // Use custom port if configured. Note that host stays "localhost".
     String host = Assertions.assertNotNull(mPackagerConnectionSettings.getDebugServerHost());
@@ -348,12 +350,16 @@ public class DevServerHelper {
     }
   }
 
-  /** @return whether we should enable dev mode when requesting JS bundles. */
+  /**
+   * @return whether we should enable dev mode when requesting JS bundles.
+   */
   private boolean getDevMode() {
     return mSettings.isJSDevModeEnabled();
   }
 
-  /** @return whether we should request minified JS bundles. */
+  /**
+   * @return whether we should request minified JS bundles.
+   */
   private boolean getJSMinifyMode() {
     return mSettings.isJSMinifyEnabled();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -190,7 +190,8 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
             ? devLoadingViewManager
             : new DefaultDevLoadingViewImplementation(reactInstanceDevHelper);
     mSurfaceDelegateFactory = surfaceDelegateFactory;
-  };
+  }
+  ;
 
   protected abstract String getUniqueTag();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSplitBundleCallback.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSplitBundleCallback.java
@@ -11,6 +11,7 @@ package com.facebook.react.devsupport.interfaces;
 public interface DevSplitBundleCallback {
   /** Called when the split JS bundle has been downloaded and evaluated. */
   void onSuccess();
+
   /** Called when the split JS bundle failed to load. */
   void onError(String url, Throwable cause);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricComponents.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricComponents.java
@@ -44,7 +44,9 @@ public class FabricComponents {
     sComponentNames.put("ImpressionTrackingView", "RCTImpressionTrackingView");
   }
 
-  /** @return the name of component in the Fabric environment */
+  /**
+   * @return the name of component in the Fabric environment
+   */
   public static String getFabricComponentName(String componentName) {
     String component = sComponentNames.get(componentName);
     return component != null ? component : componentName;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -133,7 +133,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener, UIBlo
                 + " - Total commit time: %d ms. Avg: %.2f. Median: %.2f ms. Max: %d ms.\n"
                 + " - Layout time: %d ms. Avg: %.2f. Median: %.2f ms. Max: %d ms.\n"
                 + " - Diffing time: %d ms. Avg: %.2f. Median: %.2f ms. Max: %d ms.\n"
-                + " - FinishTransaction (Diffing + JNI serialization): %d ms. Avg: %.2f. Median: %.2f ms. Max: %d ms.\n"
+                + " - FinishTransaction (Diffing + JNI serialization): %d ms. Avg: %.2f. Median:"
+                + " %.2f ms. Max: %d ms.\n"
                 + " - Mounting: %d ms. Avg: %.2f. Median: %.2f ms. Max: %d ms.\n",
             commitPoint.getCommitNumber(),
             commitDuration,
@@ -1019,7 +1020,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener, UIBlo
   public void dispatchCommand(
       final int reactTag, final int commandId, @Nullable final ReadableArray commandArgs) {
     throw new UnsupportedOperationException(
-        "dispatchCommand called without surfaceId - Fabric dispatchCommand must be called through Fabric JSI API");
+        "dispatchCommand called without surfaceId - Fabric dispatchCommand must be called through"
+            + " Fabric JSI API");
   }
 
   @Override
@@ -1029,7 +1031,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener, UIBlo
   public void dispatchCommand(
       final int reactTag, final String commandId, @Nullable final ReadableArray commandArgs) {
     throw new UnsupportedOperationException(
-        "dispatchCommand called without surfaceId - Fabric dispatchCommand must be called through Fabric JSI API");
+        "dispatchCommand called without surfaceId - Fabric dispatchCommand must be called through"
+            + " Fabric JSI API");
   }
 
   @Deprecated

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -126,7 +126,8 @@ public class MountItemDispatcher {
             new ReactNoCrashSoftException(
                 "Re-dispatched "
                     + mReDispatchCounter
-                    + " times. This indicates setState (?) is likely being called too many times during mounting."));
+                    + " times. This indicates setState (?) is likely being called too many times"
+                    + " during mounting."));
       }
 
       mReDispatchCounter++;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -208,13 +208,15 @@ public class SurfaceMountingManager {
           } else if (rootView.getId() != View.NO_ID) {
             FLog.e(
                 TAG,
-                "Trying to add RootTag to RootView that already has a tag: existing tag: [%d] new tag: [%d]",
+                "Trying to add RootTag to RootView that already has a tag: existing tag: [%d] new"
+                    + " tag: [%d]",
                 rootView.getId(),
                 mSurfaceId);
             throw new IllegalViewOperationException(
-                "Trying to add a root view with an explicit id already set. React Native uses "
-                    + "the id field to track react tags and will overwrite this field. If that is fine, "
-                    + "explicitly overwrite the id field to View.NO_ID before calling addRootView.");
+                "Trying to add a root view with an explicit id already set. React Native uses the"
+                    + " id field to track react tags and will overwrite this field. If that is"
+                    + " fine, explicitly overwrite the id field to View.NO_ID before calling"
+                    + " addRootView.");
           }
           rootView.setId(mSurfaceId);
 
@@ -450,7 +452,8 @@ public class SurfaceMountingManager {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new IllegalViewOperationException(
-              "removeViewAt tried to remove a React View that was actually reused. This indicates a bug in the Differ (specifically instruction ordering). ["
+              "removeViewAt tried to remove a React View that was actually reused. This indicates a"
+                  + " bug in the Differ (specifically instruction ordering). ["
                   + tag
                   + "]"));
       return;
@@ -1421,7 +1424,8 @@ public class SurfaceMountingManager {
             ReactSoftExceptionLogger.logSoftException(
                 TAG,
                 new IllegalViewOperationException(
-                    "RemoveDeleteTree recursively tried to remove a React View that was actually reused. This indicates a bug in the Differ. ["
+                    "RemoveDeleteTree recursively tried to remove a React View that was actually"
+                        + " reused. This indicates a bug in the Differ. ["
                         + reactTag
                         + "]"));
             continue;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/BatchMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/BatchMountItem.java
@@ -9,6 +9,8 @@ package com.facebook.react.fabric.mounting.mountitems;
 
 public interface BatchMountItem extends MountItem {
 
-  /** @return if the BatchMountItem contains any MountItem */
+  /**
+   * @return if the BatchMountItem contains any MountItem
+   */
   boolean isBatchEmpty();
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/FabricNameComponentMapping.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/FabricNameComponentMapping.java
@@ -44,7 +44,9 @@ class FabricNameComponentMapping {
     sComponentNames.put("ImpressionTrackingView", "RCTImpressionTrackingView");
   }
 
-  /** @return the name of component in the Fabric environment */
+  /**
+   * @return the name of component in the Fabric environment
+   */
   static String getFabricComponentName(String componentName) {
     String component = sComponentNames.get(componentName);
     return component != null ? component : componentName;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.java
@@ -19,25 +19,33 @@ import com.facebook.react.uimanager.StateWrapper;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class MountItemFactory {
 
-  /** @return a {@link DispatchCommandMountItem} for commands identified by an int */
+  /**
+   * @return a {@link DispatchCommandMountItem} for commands identified by an int
+   */
   public static DispatchCommandMountItem createDispatchCommandMountItem(
       int surfaceId, int reactTag, int commandId, @Nullable ReadableArray commandArgs) {
     return new DispatchIntCommandMountItem(surfaceId, reactTag, commandId, commandArgs);
   }
 
-  /** @return a {@link DispatchCommandMountItem} for commands identified by a String */
+  /**
+   * @return a {@link DispatchCommandMountItem} for commands identified by a String
+   */
   public static DispatchCommandMountItem createDispatchCommandMountItem(
       int surfaceId, int reactTag, @NonNull String commandId, @Nullable ReadableArray commandArgs) {
     return new DispatchStringCommandMountItem(surfaceId, reactTag, commandId, commandArgs);
   }
 
-  /** @return a {@link MountItem} that will control the execution of an AccessibilityEvent */
+  /**
+   * @return a {@link MountItem} that will control the execution of an AccessibilityEvent
+   */
   public static MountItem createSendAccessibilityEventMountItem(
       int surfaceId, int reactTag, int eventType) {
     return new SendAccessibilityEventMountItem(surfaceId, reactTag, eventType);
   }
 
-  /** @return a {@link MountItem} that will be used to preallocate views */
+  /**
+   * @return a {@link MountItem} that will be used to preallocate views
+   */
   public static MountItem createPreAllocateViewMountItem(
       int surfaceId,
       int reactTag,
@@ -49,6 +57,7 @@ public class MountItemFactory {
     return new PreAllocateViewMountItem(
         surfaceId, reactTag, component, props, stateWrapper, eventEmitterWrapper, isLayoutable);
   }
+
   /**
    * @return a {@link MountItem} that will be read and execute a collection of MountItems serialized
    *     in the int[] and Object[] received by parameter

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/ChoreographerProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/ChoreographerProvider.java
@@ -17,6 +17,7 @@ public interface ChoreographerProvider {
 
     /** Posts a frame callback to run on the next frame. */
     void postFrameCallback(android.view.Choreographer.FrameCallback callback);
+
     /** Removes a previously posted frame callback. */
     void removeFrameCallback(android.view.Choreographer.FrameCallback callback);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -227,7 +227,8 @@ class TurboModuleInteropUtils {
           throw new ParsingException(
               moduleName,
               methodName,
-              "Unable to parse JavaScript arg count. Promises must be used as last parameter only.");
+              "Unable to parse JavaScript arg count. Promises must be used as last parameter"
+                  + " only.");
         }
 
         return paramClasses.length - 1;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
@@ -58,7 +58,8 @@ public abstract class TurboModuleManagerDelegate {
 
   public boolean unstable_isLegacyModuleRegistered(String moduleName) {
     return false;
-  };
+  }
+  ;
 
   public List<String> getEagerInitModuleNames() {
     return new ArrayList<>();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.java
@@ -69,7 +69,9 @@ public class ReactModuleInfo {
     return mNeedsEagerInit;
   }
 
-  /** @deprecated this is hardcoded to return true, regardless if the module has constants or not */
+  /**
+   * @deprecated this is hardcoded to return true, regardless if the module has constants or not
+   */
   @Deprecated
   public boolean hasConstants() {
     return true;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/processing/ReactModuleSpecProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/processing/ReactModuleSpecProcessor.java
@@ -93,7 +93,8 @@ public class ReactModuleSpecProcessor extends ProcessorBase {
         reactModuleList = typeElement.getAnnotation(ReactModuleList.class);
       } catch (Exception ex) {
         throw new RuntimeException(
-            "Could not load classes set in @ReactModuleList.nativeModules. Check that they exist and are imported correctly on class: "
+            "Could not load classes set in @ReactModuleList.nativeModules. Check that they exist"
+                + " and are imported correctly on class: "
                 + typeElement.getQualifiedName(),
             ex);
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
@@ -10,7 +10,9 @@ package com.facebook.react.modules.core;
 import android.view.Choreographer;
 
 public class ChoreographerCompat {
-  /** @deprecated Use Choreographer.FrameCallback instead */
+  /**
+   * @deprecated Use Choreographer.FrameCallback instead
+   */
   @Deprecated
   public abstract static class FrameCallback implements Choreographer.FrameCallback {}
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.java
@@ -10,31 +10,47 @@ package com.facebook.react.modules.debug.interfaces;
 /** Provides access to React Native developers settings. */
 public interface DeveloperSettings {
 
-  /** @return whether an overlay showing current FPS should be shown. */
+  /**
+   * @return whether an overlay showing current FPS should be shown.
+   */
   boolean isFpsDebugEnabled();
 
-  /** @return Whether debug information about transitions should be displayed. */
+  /**
+   * @return Whether debug information about transitions should be displayed.
+   */
   boolean isAnimationFpsDebugEnabled();
 
-  /** @return Whether dev mode should be enabled in JS bundles. */
+  /**
+   * @return Whether dev mode should be enabled in JS bundles.
+   */
   boolean isJSDevModeEnabled();
 
-  /** @return Whether JS bundle should be minified. */
+  /**
+   * @return Whether JS bundle should be minified.
+   */
   boolean isJSMinifyEnabled();
 
-  /** @return Whether element inspector is enabled. */
+  /**
+   * @return Whether element inspector is enabled.
+   */
   boolean isElementInspectorEnabled();
 
-  /** @return Whether Nuclide JS debugging is enabled. */
+  /**
+   * @return Whether Nuclide JS debugging is enabled.
+   */
   boolean isDeviceDebugEnabled();
 
-  /** @return Whether remote JS debugging is enabled. */
+  /**
+   * @return Whether remote JS debugging is enabled.
+   */
   boolean isRemoteJSDebugEnabled();
 
   /** Enable/Disable remote JS debugging. */
   void setRemoteJSDebugEnabled(boolean remoteJSDebugEnabled);
 
-  /** @return Whether Start Sampling Profiler on App Start is enabled. */
+  /**
+   * @return Whether Start Sampling Profiler on App Start is enabled.
+   */
   boolean isStartSamplingProfilerOnInit();
 
   /** Add an item to the dev menu. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactOkHttpNetworkFetcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactOkHttpNetworkFetcher.java
@@ -29,7 +29,9 @@ class ReactOkHttpNetworkFetcher extends OkHttpNetworkFetcher {
   private final OkHttpClient mOkHttpClient;
   private final Executor mCancellationExecutor;
 
-  /** @param okHttpClient client to use */
+  /**
+   * @param okHttpClient client to use
+   */
   public ReactOkHttpNetworkFetcher(OkHttpClient okHttpClient) {
     super(okHttpClient);
     mOkHttpClient = okHttpClient;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -139,7 +139,9 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
     this(context, defaultUserAgent, client, null);
   }
 
-  /** @param context the ReactContext of the application */
+  /**
+   * @param context the ReactContext of the application
+   */
   public NetworkingModule(final ReactApplicationContext context) {
     this(context, null, OkHttpClientProvider.createClient(context), null);
   }
@@ -256,7 +258,9 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
     }
   }
 
-  /** @param timeout value of 0 results in no timeout */
+  /**
+   * @param timeout value of 0 results in no timeout
+   */
   public void sendRequestInternal(
       String method,
       String url,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientFactory.java
@@ -11,4 +11,5 @@ import okhttp3.OkHttpClient;
 
 public interface OkHttpClientFactory {
   OkHttpClient createNewNetworkModuleClient();
-};
+}
+;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressiveStringDecoder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressiveStringDecoder.java
@@ -31,7 +31,9 @@ class ProgressiveStringDecoder {
 
   private byte[] remainder = null;
 
-  /** @param charset expected charset of the data */
+  /**
+   * @param charset expected charset of the data
+   */
   public ProgressiveStringDecoder(Charset charset) {
     mDecoder = charset.newDecoder();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/FileIoHandler.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/FileIoHandler.java
@@ -53,7 +53,8 @@ public class FileIoHandler implements Runnable {
     public void close() throws IOException {
       mStream.close();
     }
-  };
+  }
+  ;
 
   private int mNextHandle;
   private final Handler mHandler;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -85,7 +85,8 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   public CatalystInstance getCatalystInstance() {
     Log.w(
         TAG,
-        "[WARNING] Bridgeless doesn't support CatalystInstance. Accessing an API that's not part of the new architecture is not encouraged usage.");
+        "[WARNING] Bridgeless doesn't support CatalystInstance. Accessing an API that's not part of"
+            + " the new architecture is not encouraged usage.");
     return new BridgelessCatalystInstance(mReactHost);
   }
 
@@ -151,6 +152,7 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   public @Nullable <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
     return mReactHost.getNativeModule(nativeModuleInterface);
   }
+
   /**
    * @return the RuntimeExecutor, a thread-safe handler for accessing the runtime. If the runtime is
    *     not initialized yet, it will return null.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -498,7 +498,8 @@ public class ReactHostImpl implements ReactHost {
               if (mReloadTask != null) {
                 log(
                     method,
-                    "Reloading React Native. Waiting for reload to finish before destroying React Native.");
+                    "Reloading React Native. Waiting for reload to finish before destroying React"
+                        + " Native.");
                 return mReloadTask.continueWithTask(
                     task -> getOrCreateDestroyTask(reason, ex), mBGExecutor);
               }
@@ -592,7 +593,8 @@ public class ReactHostImpl implements ReactHost {
       ReactSoftExceptionLogger.logSoftExceptionVerbose(
           TAG,
           new ReactNoCrashBridgeNotAllowedSoftException(
-              "getNativeModule(UIManagerModule.class) cannot be called when the bridge is disabled"));
+              "getNativeModule(UIManagerModule.class) cannot be called when the bridge is"
+                  + " disabled"));
     }
 
     final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -490,7 +490,8 @@ final class ReactInstance {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new ReactNoCrashSoftException(
-              "Native method handleMemoryPressureJs is called earlier than librninstance.so got ready."));
+              "Native method handleMemoryPressureJs is called earlier than librninstance.so got"
+                  + " ready."));
     }
   }
 
@@ -501,7 +502,9 @@ final class ReactInstance {
     return mFabricUIManager.getEventDispatcher();
   }
 
-  /** @return The {@link FabricUIManager} if it's been initialized. */
+  /**
+   * @return The {@link FabricUIManager} if it's been initialized.
+   */
   /* package */ FabricUIManager getUIManager() {
     return mFabricUIManager;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/AggregateException.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/AggregateException.java
@@ -103,7 +103,9 @@ class AggregateException extends Exception {
     }
   }
 
-  /** @deprecated Please use {@link #getInnerThrowables()} instead. */
+  /**
+   * @deprecated Please use {@link #getInnerThrowables()} instead.
+   */
   @Deprecated
   public @NonNull List<Exception> getErrors() {
     List<Exception> errors = new ArrayList<Exception>();
@@ -121,7 +123,9 @@ class AggregateException extends Exception {
     return errors;
   }
 
-  /** @deprecated Please use {@link #getInnerThrowables()} instead. */
+  /**
+   * @deprecated Please use {@link #getInnerThrowables()} instead.
+   */
   @Deprecated
   public @NonNull Throwable[] getCauses() {
     return innerThrowables.toArray(new Throwable[innerThrowables.size()]);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/AndroidExecutors.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/AndroidExecutors.java
@@ -54,6 +54,7 @@ final class AndroidExecutors {
    * <p>https://github.com/android/platform_frameworks_base/commit/719c44e03b97e850a46136ba336d729f5fbd1f47
    */
   private static final int CPU_COUNT = Runtime.getRuntime().availableProcessors();
+
   /* package */ static final int CORE_POOL_SIZE = CPU_COUNT + 1;
   /* package */ static final int MAX_POOL_SIZE = CPU_COUNT * 2 + 1;
   /* package */ static final long KEEP_ALIVE_TIME = 1L;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/CancellationTokenSource.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/CancellationTokenSource.java
@@ -49,7 +49,9 @@ public class CancellationTokenSource implements Closeable {
     }
   }
 
-  /** @return the token that can be passed to asynchronous method to control cancellation. */
+  /**
+   * @return the token that can be passed to asynchronous method to control cancellation.
+   */
   public @NonNull CancellationToken getToken() {
     synchronized (lock) {
       throwIfClosed();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
@@ -125,7 +125,9 @@ public class Task<TResult> implements TaskInterface<TResult> {
     }
   }
 
-  /** @return {@code true} if the task was cancelled, {@code false} otherwise. */
+  /**
+   * @return {@code true} if the task was cancelled, {@code false} otherwise.
+   */
   @Override
   public boolean isCancelled() {
     synchronized (lock) {
@@ -133,7 +135,9 @@ public class Task<TResult> implements TaskInterface<TResult> {
     }
   }
 
-  /** @return {@code true} if the task has an error, {@code false} otherwise. */
+  /**
+   * @return {@code true} if the task has an error, {@code false} otherwise.
+   */
   @Override
   public boolean isFaulted() {
     synchronized (lock) {
@@ -141,7 +145,9 @@ public class Task<TResult> implements TaskInterface<TResult> {
     }
   }
 
-  /** @return The result of the task, if set. {@code null} otherwise. */
+  /**
+   * @return The result of the task, if set. {@code null} otherwise.
+   */
   @Override
   public TResult getResult() {
     synchronized (lock) {
@@ -149,7 +155,9 @@ public class Task<TResult> implements TaskInterface<TResult> {
     }
   }
 
-  /** @return The error for the task, if set. {@code null} otherwise. */
+  /**
+   * @return The error for the task, if set. {@code null} otherwise.
+   */
   @Override
   public Exception getError() {
     synchronized (lock) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/TaskCompletionSource.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/TaskCompletionSource.java
@@ -28,7 +28,9 @@ public class TaskCompletionSource<TResult> {
     task = new Task<>();
   }
 
-  /** @return the Task associated with this TaskCompletionSource. */
+  /**
+   * @return the Task associated with this TaskCompletionSource.
+   */
   public @NonNull Task<TResult> getTask() {
     return task;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -190,7 +190,9 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
     map.put(name, ModuleSpec.viewManagerSpec(provider));
   }
 
-  /** @return a map of view managers that should be registered with {@link UIManagerModule} */
+  /**
+   * @return a map of view managers that should be registered with {@link UIManagerModule}
+   */
   @SuppressLint("VisibleForTests")
   public Map<String, ModuleSpec> getViewManagersMap() {
     if (mViewManagers == null) {
@@ -302,11 +304,13 @@ public class MainReactPackage extends TurboReactPackage implements ViewManagerOn
       return () -> reactModuleInfoMap;
     } catch (InstantiationException e) {
       throw new RuntimeException(
-          "No ReactModuleInfoProvider for com.facebook.react.shell.MainReactPackage$$ReactModuleInfoProvider",
+          "No ReactModuleInfoProvider for"
+              + " com.facebook.react.shell.MainReactPackage$$ReactModuleInfoProvider",
           e);
     } catch (IllegalAccessException e) {
       throw new RuntimeException(
-          "No ReactModuleInfoProvider for com.facebook.react.shell.MainReactPackage$$ReactModuleInfoProvider",
+          "No ReactModuleInfoProvider for"
+              + " com.facebook.react.shell.MainReactPackage$$ReactModuleInfoProvider",
           e);
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FabricViewStateManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FabricViewStateManager.java
@@ -28,7 +28,8 @@ import com.facebook.react.bridge.WritableMap;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 @Deprecated(
     since =
-        "Deprecated class since v0.73.0, please use com.facebook.react.uimanager.StateWrapper instead.",
+        "Deprecated class since v0.73.0, please use com.facebook.react.uimanager.StateWrapper"
+            + " instead.",
     forRemoval = true)
 public class FabricViewStateManager {
   private static final String TAG = "FabricViewStateManager";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewGroupManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewGroupManager.java
@@ -19,7 +19,9 @@ public interface IViewGroupManager<T extends View> extends IViewManagerWithChild
   /** Adds a child view into the parent at the index specified as a parameter */
   void addView(T parent, View child, int index);
 
-  /** @return child of the parent view at the index specified as a parameter. */
+  /**
+   * @return child of the parent view at the index specified as a parameter.
+   */
   @Nullable
   View getChildAt(T parent, int index);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.java
@@ -100,7 +100,9 @@ public class MatrixMathHelper {
     out[15] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
   }
 
-  /** @param transformMatrix 16-element array of numbers representing 4x4 transform matrix */
+  /**
+   * @param transformMatrix 16-element array of numbers representing 4x4 transform matrix
+   */
   public static void decomposeMatrix(double[] transformMatrix, MatrixDecompositionContext ctx) {
     Assertions.assertCondition(transformMatrix.length == 16);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -603,10 +603,9 @@ public class NativeViewHierarchyManager {
           TAG,
           "Trying to add a root view with an explicit id ("
               + view.getId()
-              + ") already "
-              + "set. React Native uses the id field to track react tags and will overwrite this field. "
-              + "If that is fine, explicitly overwrite the id field to View.NO_ID before calling "
-              + "addRootView.");
+              + ") already set. React Native uses the id field to track react tags and will"
+              + " overwrite this field. If that is fine, explicitly overwrite the id field to"
+              + " View.NO_ID before calling addRootView.");
     }
 
     mTagsToViews.put(tag, view);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.java
@@ -53,7 +53,9 @@ public class PixelUtil {
     return value / DisplayMetricsHolder.getWindowDisplayMetrics().density;
   }
 
-  /** @return {@link float} that represents the density of the display metrics for device screen. */
+  /**
+   * @return {@link float} that represents the density of the display metrics for device screen.
+   */
   public static float getDisplayMetricDensity() {
     return DisplayMetricsHolder.getWindowDisplayMetrics().density;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactRoot.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactRoot.java
@@ -20,6 +20,7 @@ public interface ReactRoot {
 
   /** This constant represents that ReactRoot hasn't started yet or it has been destroyed. */
   int STATE_STOPPED = 0;
+
   /** This constant represents that ReactRoot has started. */
   int STATE_STARTED = 1;
 
@@ -46,10 +47,14 @@ public interface ReactRoot {
   /** Return native view for root */
   ViewGroup getRootViewGroup();
 
-  /** @return Cached values for widthMeasureSpec. */
+  /**
+   * @return Cached values for widthMeasureSpec.
+   */
   int getWidthMeasureSpec();
 
-  /** @return Cached values for and heightMeasureSpec. */
+  /**
+   * @return Cached values for and heightMeasureSpec.
+   */
   int getHeightMeasureSpec();
 
   /** Sets a flag that determines whether to log that content appeared on next view added. */
@@ -64,6 +69,8 @@ public interface ReactRoot {
   @Nullable
   String getSurfaceID();
 
-  /** @return an {@link AtomicInteger} that represents the state of the ReactRoot object. */
+  /**
+   * @return an {@link AtomicInteger} that represents the state of the ReactRoot object.
+   */
   AtomicInteger getState();
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
@@ -254,16 +254,24 @@ public interface ReactShadowNode<T extends ReactShadowNode> {
 
   float getLayoutHeight();
 
-  /** @return the x position of the corresponding view on the screen, rounded to pixels */
+  /**
+   * @return the x position of the corresponding view on the screen, rounded to pixels
+   */
   int getScreenX();
 
-  /** @return the y position of the corresponding view on the screen, rounded to pixels */
+  /**
+   * @return the y position of the corresponding view on the screen, rounded to pixels
+   */
   int getScreenY();
 
-  /** @return width corrected for rounding to pixels. */
+  /**
+   * @return width corrected for rounding to pixels.
+   */
   int getScreenWidth();
 
-  /** @return height corrected for rounding to pixels. */
+  /**
+   * @return height corrected for rounding to pixels.
+   */
   int getScreenHeight();
 
   YogaDirection getLayoutDirection();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -685,25 +685,33 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
     return mYogaNode.getLayoutHeight();
   }
 
-  /** @return the x position of the corresponding view on the screen, rounded to pixels */
+  /**
+   * @return the x position of the corresponding view on the screen, rounded to pixels
+   */
   @Override
   public int getScreenX() {
     return mScreenX;
   }
 
-  /** @return the y position of the corresponding view on the screen, rounded to pixels */
+  /**
+   * @return the y position of the corresponding view on the screen, rounded to pixels
+   */
   @Override
   public int getScreenY() {
     return mScreenY;
   }
 
-  /** @return width corrected for rounding to pixels. */
+  /**
+   * @return width corrected for rounding to pixels.
+   */
   @Override
   public int getScreenWidth() {
     return mScreenWidth;
   }
 
-  /** @return height corrected for rounding to pixels. */
+  /**
+   * @return height corrected for rounding to pixels.
+   */
   @Override
   public int getScreenHeight() {
     return mScreenHeight;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
@@ -19,7 +19,9 @@ public interface RootView {
    */
   void onChildStartedNativeGesture(View childView, MotionEvent ev);
 
-  /** @deprecated */
+  /**
+   * @deprecated
+   */
   @Deprecated
   default void onChildStartedNativeGesture(MotionEvent ev) {
     onChildStartedNativeGesture(null, ev);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/Spacing.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/Spacing.java
@@ -21,38 +21,49 @@ public class Spacing {
 
   /** Spacing type that represents the left direction. E.g. {@code marginLeft}. */
   public static final int LEFT = 0;
+
   /** Spacing type that represents the top direction. E.g. {@code marginTop}. */
   public static final int TOP = 1;
+
   /** Spacing type that represents the right direction. E.g. {@code marginRight}. */
   public static final int RIGHT = 2;
+
   /** Spacing type that represents the bottom direction. E.g. {@code marginBottom}. */
   public static final int BOTTOM = 3;
+
   /**
    * Spacing type that represents start direction e.g. left in left-to-right, right in
    * right-to-left.
    */
   public static final int START = 4;
+
   /**
    * Spacing type that represents end direction e.g. right in left-to-right, left in right-to-left.
    */
   public static final int END = 5;
+
   /**
    * Spacing type that represents horizontal direction (left and right). E.g. {@code
    * marginHorizontal}.
    */
   public static final int HORIZONTAL = 6;
+
   /**
    * Spacing type that represents vertical direction (top and bottom). E.g. {@code marginVertical}.
    */
   public static final int VERTICAL = 7;
+
   /**
    * Spacing type that represents all directions (left, top, right, bottom). E.g. {@code margin}.
    */
   public static final int ALL = 8;
+
   /** Spacing type that represents block directions (top, bottom). E.g. {@code marginBlock}. */
   public static final int BLOCK = 9;
+
   /** Spacing type that represents the block end direction (bottom). E.g. {@code marginBlockEnd}. */
   public static final int BLOCK_END = 10;
+
   /**
    * Spacing type that represents the block start direction (top). E.g. {@code marginBlockStart}.
    */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
@@ -36,13 +36,17 @@ public class UIManagerHelper {
   public static final int PADDING_TOP_INDEX = 2;
   public static final int PADDING_BOTTOM_INDEX = 3;
 
-  /** @return a {@link UIManager} that can handle the react tag received by parameter. */
+  /**
+   * @return a {@link UIManager} that can handle the react tag received by parameter.
+   */
   @Nullable
   public static UIManager getUIManagerForReactTag(ReactContext context, int reactTag) {
     return getUIManager(context, getUIManagerType(reactTag));
   }
 
-  /** @return a {@link UIManager} that can handle the react tag received by parameter. */
+  /**
+   * @return a {@link UIManager} that can handle the react tag received by parameter.
+   */
   @Nullable
   public static UIManager getUIManager(ReactContext context, @UIManagerType int uiManagerType) {
     return getUIManager(context, uiManagerType, true);
@@ -78,7 +82,8 @@ public class UIManagerHelper {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new ReactNoCrashSoftException(
-              "Cannot get UIManager because the context doesn't contain an active CatalystInstance."));
+              "Cannot get UIManager because the context doesn't contain an active"
+                  + " CatalystInstance."));
       if (returnNullIfCatalystIsInactive) {
         return null;
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java
@@ -72,12 +72,16 @@ public abstract class Event<T extends Event> {
     mInitialized = true;
   }
 
-  /** @return the view id for the view that generated this event */
+  /**
+   * @return the view id for the view that generated this event
+   */
   public final int getViewTag() {
     return mViewTag;
   }
 
-  /** @return the surfaceId for the view that generated this event */
+  /**
+   * @return the surfaceId for the view that generated this event
+   */
   public final int getSurfaceId() {
     return mSurfaceId;
   }
@@ -90,7 +94,9 @@ public abstract class Event<T extends Event> {
     return mTimestampMs;
   }
 
-  /** @return false if this Event can *never* be coalesced */
+  /**
+   * @return false if this Event can *never* be coalesced
+   */
   public boolean canCoalesce() {
     return true;
   }
@@ -116,7 +122,9 @@ public abstract class Event<T extends Event> {
     return 0;
   }
 
-  /** @return The unique id of this event. */
+  /**
+   * @return The unique id of this event.
+   */
   public int getUniqueID() {
     return mUniqueID;
   }
@@ -136,7 +144,9 @@ public abstract class Event<T extends Event> {
     onDispose();
   }
 
-  /** @return the name of this event as registered in JS */
+  /**
+   * @return the name of this event as registered in JS
+   */
   public abstract String getEventName();
 
   public EventAnimationDriverMatchSpec getEventAnimationDriverMatchSpec() {
@@ -146,7 +156,8 @@ public abstract class Event<T extends Event> {
             @Override
             public boolean match(int viewTag, String eventName) {
               return viewTag == getViewTag() && eventName.equals(getEventName());
-            };
+            }
+            ;
           };
     }
     return mEventAnimationDriverMatchSpec;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
@@ -102,7 +102,8 @@ public class PointerEvent extends Event<PointerEvent> {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new IllegalStateException(
-              "Cannot dispatch a Pointer that has no MotionEvent; the PointerEvehas been recycled"));
+              "Cannot dispatch a Pointer that has no MotionEvent; the PointerEvehas been"
+                  + " recycled"));
       return;
     }
     if (mPointersEventData == null) {
@@ -308,7 +309,8 @@ public class PointerEvent extends Event<PointerEvent> {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new IllegalStateException(
-              "Cannot dispatch a Pointer that has no MotionEvent; the PointerEvehas been recycled"));
+              "Cannot dispatch a Pointer that has no MotionEvent; the PointerEvehas been"
+                  + " recycled"));
       return;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTModernEventEmitter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTModernEventEmitter.java
@@ -31,7 +31,9 @@ public interface RCTModernEventEmitter extends RCTEventEmitter {
       @Nullable WritableMap event,
       @EventCategoryDef int category);
 
-  /** @deprecated Dispatch the TouchEvent using {@link EventDispatcher} instead */
+  /**
+   * @deprecated Dispatch the TouchEvent using {@link EventDispatcher} instead
+   */
   @Deprecated
   void receiveTouches(TouchEvent event);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchEvent.java
@@ -229,7 +229,8 @@ public class TouchEvent extends Event<TouchEvent> {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new IllegalStateException(
-              "Cannot dispatch a TouchEvent that has no MotionEvent; the TouchEvent has been recycled"));
+              "Cannot dispatch a TouchEvent that has no MotionEvent; the TouchEvent has been"
+                  + " recycled"));
       return false;
     }
     return true;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.java
@@ -130,7 +130,8 @@ public class TouchesHelper {
         ReactSoftExceptionLogger.logSoftException(
             TAG,
             new IllegalStateException(
-                "Cannot dispatch a TouchEvent that has no MotionEvent; the TouchEvent has been recycled"));
+                "Cannot dispatch a TouchEvent that has no MotionEvent; the TouchEvent has been"
+                    + " recycled"));
         return;
       }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.java
@@ -52,7 +52,8 @@ public class DebuggingOverlayManager extends SimpleViewManager<DebuggingOverlay>
               ReactSoftExceptionLogger.logSoftException(
                   REACT_CLASS,
                   new ReactNoCrashSoftException(
-                      "Unexpected payload for highlighting trace updates: rectangle field is null"));
+                      "Unexpected payload for highlighting trace updates: rectangle field is"
+                          + " null"));
 
               successfullyParsedPayload = false;
               break;
@@ -79,7 +80,8 @@ public class DebuggingOverlayManager extends SimpleViewManager<DebuggingOverlay>
               ReactSoftExceptionLogger.logSoftException(
                   REACT_CLASS,
                   new ReactNoCrashSoftException(
-                      "Unexpected payload for highlighting trace updates: rectangle field should have x, y, width, height fields"));
+                      "Unexpected payload for highlighting trace updates: rectangle field should"
+                          + " have x, y, width, height fields"));
 
               successfullyParsedPayload = false;
               break;
@@ -123,7 +125,8 @@ public class DebuggingOverlayManager extends SimpleViewManager<DebuggingOverlay>
               ReactSoftExceptionLogger.logSoftException(
                   REACT_CLASS,
                   new ReactNoCrashSoftException(
-                      "Unexpected payload for highlighting elements: every element should have x, y, width, height fields"));
+                      "Unexpected payload for highlighting elements: every element should have x,"
+                          + " y, width, height fields"));
 
               successfullyParsedPayload = false;
               break;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -94,7 +94,9 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     return mDraweeControllerBuilder;
   }
 
-  /** @deprecated use {@link ReactCallerContextFactory} instead */
+  /**
+   * @deprecated use {@link ReactCallerContextFactory} instead
+   */
   @Deprecated
   public Object getCallerContext() {
     return mCallerContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -416,7 +416,8 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
 
   public void setStateWrapper(StateWrapper stateWrapper) {
     mHostView.setStateWrapper(stateWrapper);
-  };
+  }
+  ;
 
   public void updateState(final int width, final int height) {
     mHostView.updateState(width, height);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -176,8 +176,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
         } else {
           FLog.w(
               TAG,
-              "Failed to cast mScroller field in HorizontalScrollView (probably due to OEM changes to AOSP)! "
-                  + "This app will exhibit the bounce-back scrolling bug :(");
+              "Failed to cast mScroller field in HorizontalScrollView (probably due to OEM changes"
+                  + " to AOSP)! This app will exhibit the bounce-back scrolling bug :(");
           scroller = null;
         }
       } catch (IllegalAccessException e) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1236,7 +1236,8 @@ public class ReactScrollView extends ScrollView
 
     Assertions.assertCondition(
         count <= 1,
-        "React Native ScrollView should not have more than one child, it should have exactly 1 child; a content View");
+        "React Native ScrollView should not have more than one child, it should have exactly 1"
+            + " child; a content View");
 
     if (count > 0) {
       for (int i = 0; i < count; i++) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewAccessibilityDelegate.java
@@ -33,7 +33,8 @@ class ReactScrollViewAccessibilityDelegate extends AccessibilityDelegateCompat {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new AssertionException(
-              "ReactScrollViewAccessibilityDelegate should only be used with ReactScrollView or ReactHorizontalScrollView, not with class: "
+              "ReactScrollViewAccessibilityDelegate should only be used with ReactScrollView or"
+                  + " ReactHorizontalScrollView, not with class: "
                   + host.getClass().getSimpleName()));
     }
   }
@@ -47,10 +48,12 @@ class ReactScrollViewAccessibilityDelegate extends AccessibilityDelegateCompat {
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           new AssertionException(
-              "ReactScrollViewAccessibilityDelegate should only be used with ReactScrollView or ReactHorizontalScrollView, not with class: "
+              "ReactScrollViewAccessibilityDelegate should only be used with ReactScrollView or"
+                  + " ReactHorizontalScrollView, not with class: "
                   + host.getClass().getSimpleName()));
     }
-  };
+  }
+  ;
 
   private void onInitializeAccessibilityEventInternal(View view, AccessibilityEvent event) {
     final ReadableMap accessibilityCollection =
@@ -154,4 +157,5 @@ class ReactScrollViewAccessibilityDelegate extends AccessibilityDelegateCompat {
       info.setScrollable(scrollView.getScrollEnabled());
     }
   }
-};
+}
+;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -459,6 +459,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode
   protected int mFontStyle = ReactConstants.UNSET;
 
   protected int mFontWeight = ReactConstants.UNSET;
+
   /**
    * NB: If a font family is used that does not have a style in a certain Android version (ie.
    * monospace bold pre Android 5.0), that style (ie. bold) will not be inherited by nested Text
@@ -482,7 +483,9 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode
    */
   protected @Nullable String mFontFamily = null;
 
-  /** @see android.graphics.Paint#setFontFeatureSettings */
+  /**
+   * @see android.graphics.Paint#setFontFeatureSettings
+   */
   protected @Nullable String mFontFeatureSettings = null;
 
   protected boolean mContainsImages = false;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -111,6 +111,7 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
 
   protected int mFontStyle = ReactConstants.UNSET;
   protected int mFontWeight = ReactConstants.UNSET;
+
   /**
    * NB: If a font family is used that does not have a style in a certain Android version (ie.
    * monospace bold pre Android 5.0), that style (ie. bold) will not be inherited by nested Text
@@ -134,7 +135,9 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
    */
   protected @Nullable String mFontFamily = null;
 
-  /** @see android.graphics.Paint#setFontFeatureSettings */
+  /**
+   * @see android.graphics.Paint#setFontFeatureSettings
+   */
   protected @Nullable String mFontFeatureSettings = null;
 
   protected boolean mContainsImages = false;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -664,7 +664,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         new View.OnLongClickListener() {
           public boolean onLongClick(View v) {
             return _contextMenuHidden;
-          };
+          }
+          ;
         });
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -677,8 +677,8 @@ public class ReactViewGroup extends ViewGroup
                 ReactSoftExceptionLogger.logSoftException(
                     TAG,
                     new ReactNoCrashSoftException(
-                        "Child view has been added to Parent view in which it is clipped and not visible."
-                            + " This is not legal for this particular child view. Child: ["
+                        "Child view has been added to Parent view in which it is clipped and not"
+                            + " visible. This is not legal for this particular child view. Child: ["
                             + child.getId()
                             + "] "
                             + child.toString()

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -185,7 +185,8 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec {
   @SuppressWarnings("unused")
   public void voidFuncThrows() {
     throw new RuntimeException("Intentional exception from JVM voidFuncThrows");
-  };
+  }
+  ;
 
   @Override
   @DoNotStrip
@@ -193,21 +194,24 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec {
   public WritableMap getObjectThrows(ReadableMap arg) {
     throw new RuntimeException(
         "Intentional exception from JVM getObjectThrows with " + arg.toString());
-  };
+  }
+  ;
 
   @Override
   @DoNotStrip
   @SuppressWarnings("unused")
   public void promiseThrows(Promise promise) {
     throw new RuntimeException("Intentional exception from JVM promiseThrows");
-  };
+  }
+  ;
 
   @Override
   @DoNotStrip
   @SuppressWarnings("unused")
   public void voidFuncAssert() {
     assert false : "Intentional assert from JVM voidFuncAssert";
-  };
+  }
+  ;
 
   @Override
   @DoNotStrip
@@ -215,14 +219,16 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec {
   public WritableMap getObjectAssert(ReadableMap arg) {
     assert false : "Intentional assert from JVM getObjectAssert with " + arg.toString();
     return null;
-  };
+  }
+  ;
 
   @Override
   @DoNotStrip
   @SuppressWarnings("unused")
   public void promiseAssert(Promise promise) {
     assert false : "Intentional assert from JVM promiseAssert";
-  };
+  }
+  ;
 
   private void log(String method, Object input, Object output) {
     if (mToast != null) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/hhvm/pull/9431

X-link: https://github.com/WhatsApp/eqwalizer/pull/52

X-link: https://github.com/facebookincubator/spectrum/pull/1858

X-link: https://github.com/fbsamples/metapay/pull/1

X-link: https://github.com/facebookincubator/fbjni/pull/95

X-link: https://github.com/facebookincubator/Battery-Metrics/pull/30

X-link: https://github.com/facebook/ktfmt/pull/440

X-link: https://github.com/facebook/flipper/pull/5456

X-link: https://github.com/facebook/hermes/pull/1290

X-link: https://github.com/facebook/TextLayoutBuilder/pull/35

X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052

