### PR TITLE
[RNTester] Correctly specify react-native dependency (yarn classic)

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -1160,6 +1160,8 @@ jobs:
             - "1f:c7:61:c4:e2:ff:77:e3:cc:ca:a7:34:c2:79:e3:3c"
       - brew_install:
           package: cmake
+      - brew_install:
+          package: jq
       - run:
           name: "Set new react-native version and commit changes"
           command: |

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -25,11 +25,9 @@
   "dependencies": {
     "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",
-    "nullthrows": "^1.1.1"
-  },
-  "peerDependencies": {
+    "nullthrows": "^1.1.1",
     "react": "18.2.0",
-    "react-native": "*"
+    "react-native": "1000.0.0"
   },
   "codegenConfig": {
     "name": "AppSpecs",

--- a/scripts/releases-ci/prepare-package-for-release.js
+++ b/scripts/releases-ci/prepare-package-for-release.js
@@ -95,8 +95,19 @@ async function main() {
   }
 
   // Release builds should commit the version bumps, and create tags.
+  echo('Updating RNTester react-native dependency...');
+  if (
+    exec(`source scripts/update_rn_tester.sh && update_package_json ${version}`)
+      .code
+  ) {
+    echo('Failed to update RNTester react-native dependency.');
+    echo('Fix the issue, revert and try again.');
+    exit(1);
+  }
+
+  // Release builds should commit the version bumps, and create tags.
   echo('Updating RNTester Podfile.lock...');
-  if (exec('source scripts/update_podfile_lock.sh && update_pods').code) {
+  if (exec('source scripts/update_rn_tester.sh && update_pods').code) {
     echo('Failed to update RNTester Podfile.lock.');
     echo('Fix the issue, revert and try again.');
     exit(1);

--- a/scripts/update_rn_tester.sh
+++ b/scripts/update_rn_tester.sh
@@ -25,3 +25,15 @@ update_pods () {
   bundle exec pod install
   cd "$THIS_DIR" || exit
 }
+
+update_package_json () {
+  if [ $# -eq 0 ]
+  then
+    exit
+  fi
+  cd "$RNTESTER_DIR" || exit
+  VERSION=$1 || exit
+  contents=$(jq ".dependencies[\"react-native\"] = \"$VERSION\"" package.json) || exit
+  echo $contents > package.json || exit
+  cd "$THIS_DIR" || exit
+}


### PR DESCRIPTION
## Summary:

Related: https://github.com/microsoft/react-native-macos/pull/2065

React Native macOS switched to use Yarn 4 for its monorepo. Upon doing so, running `yarn start` (an alias of `react-native start`)  in `packages/rn-tester` leads to this error:
> command not found: react-native

This seems to be because Yarn 4 is much stricter about only using declared dependencies as compared to Yarn 1, and RNTester's package.json only specifies react-native as a peer dependency (a `"*"` at that!):
```
...
  "peerDependencies": {
    "react": "18.2.0",
    "react-native": "*"
  },
...
``` 

What we want is tell RNTester ( a private package that will never be published) to use the workspace copy of react-native, rather than download it from NPM. Modern package managers have the `workspace:*` syntax for exactly that, and that is the fix I am making for React Native macOS. React Native however, uses yarn 1, and thus we need a different fix. 

With yarn 1, as long as both packages are in the same workspace and specify the same version, it will use the workspace copy instead of downloading it from NPM (See: https://classic.yarnpkg.com/lang/en/docs/workspaces/ ). We also still need to update the dependency every time we cut a new nightly / stable release. For that, I updated the `prepare-package-for-release.js` script, to do so with a simple sed command. This script _already_ updated RNTester's `Podfile.lock`, so I figured this was a natural place to put it. 

## Changelog:

[INTERNAL] [FIXED] - Correctly specify react-native dependency in rn-tester

## Test Plan:

Locally running `node scripts/prepare-package-for-release.js -d -v 0.74.0` indeed updates RNTester's package.json as well.
