### PR TITLE
introduce native api to access RuntimeExecutor

### DIFF
--- a/packages/react-native/React/Base/RCTRuntimeExecutorModule.h
+++ b/packages/react-native/React/Base/RCTRuntimeExecutorModule.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@class RCTRuntimeExecutor;
+
+/**
+ * Have your module conform to this protocol to access the RuntimeExecutor.
+ * Only available in the bridgeless runtime.
+ */
+@protocol RCTRuntimeExecutorModule <NSObject>
+
+@property (nonatomic, nullable, readwrite) RCTRuntimeExecutor *runtimeExecutor;
+
+@end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTRuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTRuntimeExecutor.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <ReactCommon/RuntimeExecutor.h>
+#import <jsi/jsi.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^RCTJSIRuntimeHandlingBlock)(facebook::jsi::Runtime &runtime);
+
+@interface RCTRuntimeExecutor : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Initializes an object that wraps ways to access the RuntimeExecutor.
+
+ @param runtimeExecutor The instance of RuntimeExecutor.
+ */
+- (instancetype)initWithRuntimeExecutor:(facebook::react::RuntimeExecutor)runtimeExecutor NS_DESIGNATED_INITIALIZER;
+
+- (void)execute:(RCTJSIRuntimeHandlingBlock)block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTRuntimeExecutor.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTRuntimeExecutor.mm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTRuntimeExecutor.h"
+
+@implementation RCTRuntimeExecutor {
+  facebook::react::RuntimeExecutor _runtimeExecutor;
+}
+
+#pragma mark - Initializer
+
+- (instancetype)initWithRuntimeExecutor:(facebook::react::RuntimeExecutor)runtimeExecutor
+{
+  if (self = [super init]) {
+    _runtimeExecutor = runtimeExecutor;
+  }
+
+  return self;
+}
+
+#pragma mark - Public API
+
+- (void)execute:(RCTJSIRuntimeHandlingBlock)block
+{
+  if (_runtimeExecutor) {
+    _runtimeExecutor([=](facebook::jsi::Runtime &runtime) { block(runtime); });
+  }
+}
+
+@end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -15,7 +15,10 @@
 #import <React/RCTTurboModuleRegistry.h>
 #import <ReactCommon/RuntimeExecutor.h>
 #import <ReactCommon/TurboModuleBinding.h>
+
 #import "RCTTurboModule.h"
+
+@class RCTTurboModuleManager;
 
 @protocol RCTTurboModuleManagerDelegate <NSObject>
 
@@ -52,6 +55,12 @@
 
 @end
 
+@protocol RCTTurboModuleManagerRuntimeHandler <NSObject>
+
+- (facebook::react::RuntimeExecutor)runtimeExecutorForTurboModuleManager:(RCTTurboModuleManager *)turboModuleManager;
+
+@end
+
 @interface RCTTurboModuleManager : NSObject <RCTTurboModuleRegistry>
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge
@@ -66,5 +75,7 @@
 - (void)installJSBindings:(facebook::jsi::Runtime &)runtime;
 
 - (void)invalidate;
+
+@property (nonatomic, weak, readwrite) id<RCTTurboModuleManagerRuntimeHandler> runtimeHandler;
 
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -7,6 +7,7 @@
 
 #import "RCTTurboModuleManager.h"
 #import "RCTInteropTurboModule.h"
+#import "RCTRuntimeExecutor.h"
 
 #import <atomic>
 #import <cassert>
@@ -24,8 +25,8 @@
 #import <React/RCTLog.h>
 #import <React/RCTModuleData.h>
 #import <React/RCTPerformanceLogger.h>
+#import <React/RCTRuntimeExecutorModule.h>
 #import <React/RCTUtils.h>
-#import <ReactCommon/RuntimeExecutor.h>
 #import <ReactCommon/TurboCxxModule.h>
 #import <ReactCommon/TurboModulePerfLogger.h>
 #import <ReactCommon/TurboModuleUtils.h>
@@ -674,6 +675,13 @@ static Class getFallbackClassFromName(const char *name)
            "or provide your own setter method.",
           RCTBridgeModuleNameForClass([module class]));
     }
+  }
+
+  // This is a more performant alternative for conformsToProtocol:@protocol(RCTRuntimeExecutorModule)
+  if ([module respondsToSelector:@selector(setRuntimeExecutor:)]) {
+    RCTRuntimeExecutor *runtimeExecutor = [[RCTRuntimeExecutor alloc]
+        initWithRuntimeExecutor:[_runtimeHandler runtimeExecutorForTurboModuleManager:self]];
+    [(id<RCTRuntimeExecutorModule>)module setRuntimeExecutor:runtimeExecutor];
   }
 
   /**

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -63,7 +63,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   sRuntimeDiagnosticFlags = [flags copy];
 }
 
-@interface RCTInstance () <RCTTurboModuleManagerDelegate>
+@interface RCTInstance () <RCTTurboModuleManagerDelegate, RCTTurboModuleManagerRuntimeHandler>
 @end
 
 @implementation RCTInstance {
@@ -208,6 +208,17 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   return nullptr;
 }
 
+#pragma mark - RCTTurboModuleManagerRuntimeHandler
+
+- (RuntimeExecutor)runtimeExecutorForTurboModuleManager:(RCTTurboModuleManager *)turboModuleManager
+{
+  if (_valid) {
+    return _reactInstance->getBufferedRuntimeExecutor();
+  }
+
+  return nullptr;
+}
+
 #pragma mark - Private
 
 - (void)_start
@@ -259,6 +270,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       bridgeModuleDecorator:_bridgeModuleDecorator
                    delegate:self
                   jsInvoker:std::make_shared<BridgelessJSCallInvoker>(bufferedRuntimeExecutor)];
+  _turboModuleManager.runtimeHandler = self;
 
 #if RCT_DEV
   /**


### PR DESCRIPTION
Summary:
Changelog: [Added][iOS] introduce native api to access RuntimeExecutor

The goal of this API is to provide a safe way to access the `jsi::runtime` in bridgeless mode. The decision to limit access to the runtime in bridgeless was a conscious one - the runtime pointer is not thread-safe and its lifecycle must be managed correctly by owners.

However, interacting with the runtime is an advanced use case we would want to support. Our recommended ways to access the runtime in bridgeless mode is either 1) via the RuntimeExecutor, or 2) via a C++ TurboModule.

This diff introduces the API that would allow for 1). The integration consists of these parts:
- Wrapper objects for RuntimeExecutor access. These are `RCTRuntimeExecution` and `RCTRuntimeExecutionWrapper`. RCTRuntimeExecutionWrapper is a C++ free wrapper of RCTRuntimeExecution to be reliably used in Swift modules.
- The new API on RCTBridgeModule, following a similar pattern to other decoration APIs, and integration with our module infrastructure.

Differential Revision: D53256188


