### PR TITLE
Rename performance.reactNativeStartupTiming as performance.rnStartupTiming

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/Performance.js
+++ b/packages/react-native/Libraries/WebPerformance/Performance.js
@@ -141,7 +141,7 @@ export default class Performance {
   }
 
   // Startup metrics is not used in web, but only in React Native.
-  get reactNativeStartupTiming(): ReactNativeStartupTiming {
+  get rnStartupTiming(): ReactNativeStartupTiming {
     if (NativePerformance?.getReactNativeStartupTiming) {
       const {
         startTime,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8976,7 +8976,7 @@ declare export class PerformanceMeasure extends PerformanceEntry {
 declare export default class Performance {
   eventCounts: EventCounts;
   get memory(): MemoryInfo;
-  get reactNativeStartupTiming(): ReactNativeStartupTiming;
+  get rnStartupTiming(): ReactNativeStartupTiming;
   mark(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
   clearMarks(markName?: string): void;
   measure(

--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -27,8 +27,6 @@ function MemoryExample(): React.Node {
   const onGetMemoryInfo = useCallback(() => {
     // performance.memory is not included in bom.js yet.
     // Once we release the change in flow this can be removed.
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-call]
     setMemoryInfo(performance.memory);
   }, []);
   return (
@@ -58,9 +56,7 @@ function StartupTimingExample(): React.Node {
   const onGetStartupTiming = useCallback(() => {
     // performance.reactNativeStartupTiming is not included in bom.js yet.
     // Once we release the change in flow this can be removed.
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-call]
-    setStartUpTiming(performance.reactNativeStartupTiming);
+    setStartUpTiming(performance.rnStartupTiming);
   }, []);
   return (
     <RNTesterPage noScroll={true} title="performance.reactNativeStartupTiming">


### PR DESCRIPTION
Summary:
This renames `performance.reactNativeStartupTiming` as `performance.rnStartupTiming` to align with the recommended vendor prefix for React Native.

This API is still private, so it's safe to rename.

Changelog: [internal]

Differential Revision: D53264515


