### PR TITLE
[GENERAL] [FIXED] VirtualizedList/FlatList: Stricter typing for onViewableItemsChanged

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.d.ts
+++ b/packages/react-native/Libraries/Lists/FlatList.d.ts
@@ -116,8 +116,8 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
    */
   onViewableItemsChanged?:
     | ((info: {
-        viewableItems: Array<ViewToken>;
-        changed: Array<ViewToken>;
+        viewableItems: Array<ViewToken<ItemT>>;
+        changed: Array<ViewToken<ItemT>>;
       }) => void)
     | null
     | undefined;

--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -18,8 +18,8 @@ import type {
   ScrollView,
 } from 'react-native';
 
-export interface ViewToken {
-  item: any;
+export interface ViewToken<ItemT = any> {
+  item: ItemT;
   key: string;
   index: number | null;
   isViewable: boolean;
@@ -330,8 +330,8 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
    */
   onViewableItemsChanged?:
     | ((info: {
-        viewableItems: Array<ViewToken>;
-        changed: Array<ViewToken>;
+        viewableItems: Array<ViewToken<ItemT>>;
+        changed: Array<ViewToken<ItemT>>;
       }) => void)
     | null
     | undefined;


### PR DESCRIPTION
## Summary:

The previous typing of FlatList and VirtualizedList did not convey any information on the type of the items passed in to `onViewableItemsChanged`, but instead the type was set to `any`. This PR adds the type information.

I set a default type `any` for thy ViewToken, because the type is exported and not having it would be a breaking change if that type is used. Like this it gracefully falls back to the default behavior of the `any` type.

Notice: I don't know how typing in "flow" works, but the same "issue" seems to be in there as well. Maybe someone with more flow experience can fix that as well:
https://github.com/facebook/react-native/blob/ae42e0202de2c3db489caf63839fced7b52efc5d/packages/virtualized-lists/Lists/ViewabilityHelper.js#L19-L20

## Changelog:

[GENERAL] [FIXED] - Add type information for items of VirtualizedList in `onViewableItemsChanged` signature
[GENERAL] [FIXED] - Add type information for items of FlatList in `onViewableItemsChanged` signature

## Test Plan:

Without the changes, typecheck of the project was fine, but with the changes applied to the node_modules/react-native copy a type error was found:
```
$ npm run typecheck

> my-project@1.0.0 typecheck
> tsc --skipLibCheck

src/MyComponent.tsx:385:29 - error TS2345: Argument of type '(string | number)[]' is not assignable to parameter of type 'number[]'.
  Type 'string | number' is not assignable to type 'number'.
    Type 'string' is not assignable to type 'number'.

385                             viewableItems
                                ~~~~~~~~~~~~~
386                                 .filter(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```