### PR TITLE
constrain on github.actor

### DIFF
--- a/.github/workflows/nightlies-feedback.yml
+++ b/.github/workflows/nightlies-feedback.yml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - if: ${{ !contains(fromJSON(env.allowed_users), github.actor.login) }}
+      - if: ${{ !contains(fromJSON(env.allowed_users), github.actor) }}
         run: |
           echo "Request from actor's login wasn't on the allowed_users list."
           curl -X POST \


### PR DESCRIPTION
Summary:
[CI] Currently rejecting all users, use the [github.actor](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context:~:text=The%20username%20of%20the%20user%20that%20triggered,run%20(github.triggering_actor)%20has%20different%20privileges.)

Changelog: [Internal]

Reviewed By: hoxyq

Differential Revision: D53275232


