### PR TITLE
Fix event emits during initial rendering in Fabric

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
@@ -177,6 +177,7 @@ public class TextAttributes {
         : DEFAULT_MAX_FONT_SIZE_MULTIPLIER;
   }
 
+  @Override
   public String toString() {
     return ("TextAttributes {"
         + "\n  getAllowFontScaling(): "

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -810,6 +810,11 @@ void FabricMountingManager::preallocateShadowView(
 
   // Do not hold a reference to javaEventEmitter from the C++ side.
   jni::local_ref<EventEmitterWrapper::JavaPart> javaEventEmitter = nullptr;
+  SharedEventEmitter eventEmitter = shadowView.eventEmitter;
+  if (eventEmitter != nullptr) {
+    javaEventEmitter =
+        EventEmitterWrapper::newObjectCxxArgs(shadowView.eventEmitter);
+  }
 
   jni::local_ref<jobject> props = getProps({}, shadowView);
 


### PR DESCRIPTION
Summary:
During view preallocation eventEmitter information is not being passed to the platform. This causes bugs with emision of events during initial rendering when using the new Fabric Event dispatching system.

e.g. Rendering a TextInput that has 'onFocus' event and also has autoFocus enabled.

The new Fabric Event dispatching system dispatch events earlier (this is expected)

In this diff I'm fixing this issue by ensuring that all preallocated views have an eventEmitter (when its shadowNode has an eventEmitter)

This was actually implemented in the past, but in order to optimize, we run an experiment (D29117957) and it was later deleted.
(D40356386). I didn't find details of the results of the experiment.
We could run another experiment to understand potential negative perf impact of this change, although I believe it's the right thing to do here.


Changelog: [Android][Fixed] Fix delivery of events during initial rendering in new architecture

Reviewed By: sammy-SC

Differential Revision: D53108114


