### PR TITLE
Remove takeSnapshot from UIManager TypeScript types

### DIFF
--- a/packages/react-native/Libraries/ReactNative/UIManager.d.ts
+++ b/packages/react-native/Libraries/ReactNative/UIManager.d.ts
@@ -16,33 +16,6 @@ import {
 
 export interface UIManagerStatic {
   /**
-   * Capture an image of the screen, window or an individual view. The image
-   * will be stored in a temporary file that will only exist for as long as the
-   * app is running.
-   *
-   * The `view` argument can be the literal string `window` if you want to
-   * capture the entire window, or it can be a reference to a specific
-   * React Native component.
-   *
-   * The `options` argument may include:
-   * - width/height (number) - the width and height of the image to capture.
-   * - format (string) - either 'png' or 'jpeg'. Defaults to 'png'.
-   * - quality (number) - the quality when using jpeg. 0.0 - 1.0 (default).
-   *
-   * Returns a Promise<string> (tempFilePath)
-   * @platform ios
-   */
-  takeSnapshot: (
-    view?: 'window' | React.ReactElement | number,
-    options?: {
-      width?: number | undefined;
-      height?: number | undefined;
-      format?: 'png' | 'jpeg' | undefined;
-      quality?: number | undefined;
-    },
-  ) => Promise<string>;
-
-  /**
    * Determines the location on screen, width, and height of the given view and
    * returns the values via an async callback. If successful, the callback will
    * be called with the following arguments:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR removes the TypeScript entry for `UIManager.takeSnapshot()`. This function does not appear to be implemented anywhere, and calling it throws `TypeError: _reactNative.UIManager.takeSnapshot is not a function (it is undefined)`.

I think this functionality is still supported by [react-native-view-shot](https://github.com/gre/react-native-view-shot) for anyone who needs it!

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[General] [Removed] - Removed type definition `UIManager.takeSnapshot()`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Ran TypeScript checks.