### PR TITLE
[iOS] Fabric: make built-in components recycle optional

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
@@ -91,6 +91,8 @@ static UIActivityIndicatorViewStyle convertActivityIndicatorViewStyle(const Acti
   [super updateProps:props oldProps:oldProps];
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 @end
 
 Class<RCTComponentViewProtocol> RCTActivityIndicatorViewCls(void)

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/DebuggingOverlay/RCTDebuggingOverlayComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/DebuggingOverlay/RCTDebuggingOverlayComponentView.mm
@@ -43,6 +43,8 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<DebuggingOverlayComponentDescriptor>();
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 #pragma mark - Native commands
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -125,6 +125,8 @@ using namespace facebook::react;
   _imageView.image = nil;
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 #pragma mark - RCTImageResponseDelegate
 
 - (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(const void *)observer

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -145,6 +145,8 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   _textInput = nil;
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 @end
 
 Class<RCTComponentViewProtocol> RCTInputAccessoryCls(void)

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -266,6 +266,8 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   updatePropsIfNeeded(updateMask);
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 - (void)_setPropsWithUpdateMask:(RNComponentViewUpdateMask)updateMask
 {
   if (updateMask & RNComponentViewUpdateMaskProps) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -281,6 +281,8 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   [childComponentView removeFromSuperview];
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 @end
 
 #ifdef __cplusplus

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.mm
@@ -31,4 +31,6 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<RootComponentDescriptor>();
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 @end

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
@@ -92,6 +92,8 @@ using namespace facebook::react;
   _state.reset();
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 @end
 
 Class<RCTComponentViewProtocol> RCTSafeAreaViewCls(void)

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -84,6 +84,8 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 #pragma mark -
 
 - (void)handleUIControlEventValueChanged

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -430,6 +430,8 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   [super prepareForRecycle];
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 #pragma mark - UIScrollViewDelegate
 
 - (BOOL)touchesShouldCancelInContentView:(__unused UIView *)view

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -100,6 +100,8 @@ using namespace facebook::react;
       .onChange(SwitchEventEmitter::OnChange{.value = static_cast<bool>(sender.on)});
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 #pragma mark - Native Commands
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -115,6 +115,8 @@ using namespace facebook::react;
   _accessibilityProvider = nil;
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 - (void)drawRect:(CGRect)rect
 {
   if (!_state) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -265,6 +265,8 @@ using namespace facebook::react;
   [_backedTextInputView resignFirstResponder];
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 #pragma mark - RCTBackedTextInputDelegate
 
 - (BOOL)textInputShouldBeginEditing

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
@@ -56,4 +56,6 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 @end

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
@@ -64,6 +64,8 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 @end
 
 Class<RCTComponentViewProtocol> RCTUnimplementedNativeViewCls(void)

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -19,6 +19,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#define RCTComponentViewShouldBeRecycled(recycled)    \
+  static bool _shouldBeRecycled = recycled;           \
+  +(bool)shouldBeRecycled                             \
+  {                                                   \
+    return _shouldBeRecycled;                         \
+  }                                                   \
+                                                      \
+  +(void)setShouldBeRecycled : (bool)shouldBeRecycled \
+  {                                                   \
+    _shouldBeRecycled = shouldBeRecycled;             \
+  }
+
 /**
  * UIView class for <View> component.
  */

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -100,6 +100,8 @@ using namespace facebook::react;
   }
 }
 
+RCTComponentViewShouldBeRecycled(true);
+
 #pragma mark - RCTComponentViewProtocol
 
 + (ComponentDescriptorProvider)componentDescriptorProvider

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -125,6 +125,11 @@ typedef NS_OPTIONS(NSInteger, RNComponentViewUpdateMask) {
 - (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(nullable NSSet<NSString *> *)props;
 - (nullable NSSet<NSString *> *)propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
 
+/*
+ * Mark component view should be recycled.
+ */
++ (void)setShouldBeRecycled:(bool)shouldBeRecycled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
+++ b/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
@@ -46,6 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(UIView *)clipView;
 
++ (void)setShouldBeRecycled:(bool)shouldBeRecycled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -168,4 +168,9 @@ using namespace facebook::react;
   }
 }
 
++ (void)setShouldBeRecycled:(bool)shouldBeRecycled
+{
+  // Default implementation does nothing.
+}
+
 @end


### PR DESCRIPTION
## Summary:

Fixes #42732. We already support custom component view recycle optional, but seems we have no interface to disable built-in components recycling.

## Changelog:

[IOS] [ADDED] - Fabric: make built-in components recycle optional

## Test Plan:

To disable built-in components recycle, we can call like  `[*ComponentView setShouldBeRecycled:false]`.
