### PR TITLE
Fix Template for Bridgeless mode

### DIFF
--- a/packages/react-native/template/ios/HelloWorld/AppDelegate.mm
+++ b/packages/react-native/template/ios/HelloWorld/AppDelegate.mm
@@ -16,10 +16,10 @@
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
-  return [self getBundleURL];
+  return [self bundleURL];
 }
 
-- (NSURL *)getBundleURL
+- (NSURL *)bundleURL
 {
 #if DEBUG
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];


### PR DESCRIPTION
Summary:
Change in [31cf4c4ead](https://github.com/facebook/react-native/commit/31cf4c4eada59bde62f30e14024719779fc23a91) broke the template for bridgeless as we changed the signature of a method in the header of `RCTAppDelegate`.

This change aligns the API between RCTAppDelegate and the template's AppDelegate

## Changelog:
[iOS][Fixed] - Align the the bundleURL API from `RCTAppDelegate` to template's `AppDelegate`

Reviewed By: cortinico, dmytrorykun

Differential Revision: D53274434


