### PR TITLE
fix: add missing `target` property in `LayoutChangeEvent`

### DIFF
--- a/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
@@ -18,7 +18,7 @@ export interface LayoutRectangle {
 }
 
 // @see TextProps.onLayout
-export type LayoutChangeEvent = NativeSyntheticEvent<{layout: LayoutRectangle}>;
+export type LayoutChangeEvent = NativeSyntheticEvent<{layout: LayoutRectangle; target?: number | null}>;
 
 interface TextLayoutLine {
   ascender: number;

--- a/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
@@ -18,7 +18,10 @@ export interface LayoutRectangle {
 }
 
 // @see TextProps.onLayout
-export type LayoutChangeEvent = NativeSyntheticEvent<{layout: LayoutRectangle; target?: number | null}>;
+export type LayoutChangeEvent = NativeSyntheticEvent<{
+  layout: LayoutRectangle;
+  target: number | null | undefined;
+}>;
 
 interface TextLayoutLine {
   ascender: number;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

According to [documentation](https://reactnative.dev/docs/layoutevent#example) the `target` property exist:

<img width="1391" alt="image" src="https://github.com/facebook/react-native/assets/22820318/2ab9303d-3956-46b3-94ae-873a8a5b1148">

Also if you log `nativeEvent` you'll see that the property indeed exist, however from TS declaration perspective this property doesn't exist.

In this PR I'm adding it at according to RN documentation types.

## Changelog:

- [General] [Fixed] - add missing target property in LayoutChangeEvent

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

|Before|After|
|-------|-----|
|<img width="1045" alt="image" src="https://github.com/facebook/react-native/assets/22820318/09968224-5643-4f8b-b8ee-4f68da127eda">|<img width="613" alt="image" src="https://github.com/facebook/react-native/assets/22820318/8de261c7-726a-42ff-a9da-1d11278060df">|
