### PR TITLE
feat(iOS): add support for missing text content types

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -255,6 +255,9 @@ export interface TextInputIOSProps {
    *  - `'birthdateDay'` (iOS 17+)
    *  - `'birthdateMonth'` (iOS 17+)
    *  - `'birthdateYear'` (iOS 17+)
+   *  - `'dateTime'` (iOS 15+)
+   *  - `'flightNumber'` (iOS 15+)
+   *  - `'shipmentTrackingNumber'` (iOS 15+)
    *
    */
   textContentType?:
@@ -299,6 +302,9 @@ export interface TextInputIOSProps {
     | 'birthdateDay'
     | 'birthdateMonth'
     | 'birthdateYear'
+    | 'dateTime'
+    | 'flightNumber'
+    | 'shipmentTrackingNumber'
     | undefined;
 
   /**

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -198,7 +198,10 @@ export type TextContentType =
   | 'birthdate'
   | 'birthdateDay'
   | 'birthdateMonth'
-  | 'birthdateYear';
+  | 'birthdateYear'
+  | 'dateTime'
+  | 'flightNumber'
+  | 'shipmentTrackingNumber';
 
 export type enterKeyHintType =
   | 'enter'

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -237,7 +237,10 @@ export type TextContentType =
   | 'birthdate'
   | 'birthdateDay'
   | 'birthdateMonth'
-  | 'birthdateYear';
+  | 'birthdateYear'
+  | 'dateTime'
+  | 'flightNumber'
+  | 'shipmentTrackingNumber';
 
 export type enterKeyHintType =
   // Cross Platform

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -304,7 +304,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
         @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
       }];
     }
-
+      
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000 /* __IPHONE_17_0 */
     if (@available(iOS 17.0, *)) {
       [mutableContentTypeMap addEntriesFromDictionary:@{
         @"creditCardExpiration" : UITextContentTypeCreditCardExpiration,
@@ -322,7 +323,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
         @"birthdateYear" : UITextContentTypeBirthdateYear,
       }];
     }
-      
+#endif
 
     contentTypeMap = mutableContentTypeMap;
   });

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -297,7 +297,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
       @"oneTimeCode" : UITextContentTypeOneTimeCode,
     }];
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000 /* __IPHONE_17_0 */
+    if (@available(iOS 15.0, *)) {
+      [mutableContentTypeMap addEntriesFromDictionary:@{
+        @"dateTime" : UITextContentTypeDateTime,
+        @"flightNumber" : UITextContentTypeFlightNumber,
+        @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
+      }];
+    }
+
     if (@available(iOS 17.0, *)) {
       [mutableContentTypeMap addEntriesFromDictionary:@{
         @"creditCardExpiration" : UITextContentTypeCreditCardExpiration,
@@ -315,17 +322,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
         @"birthdateYear" : UITextContentTypeBirthdateYear,
       }];
     }
-#endif
       
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
-    if (@available(iOS 15.0, *)) {
-      [mutableContentTypeMap addEntriesFromDictionary:@{
-        @"dateTime" : UITextContentTypeDateTime,
-        @"flightNumber" : UITextContentTypeFlightNumber,
-        @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
-      }];
-    }
-#endif
 
     contentTypeMap = mutableContentTypeMap;
   });

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -316,6 +316,16 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
       }];
     }
 #endif
+      
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
+    if (@available(iOS 15.0, *)) {
+      [mutableContentTypeMap addEntriesFromDictionary:@{
+        @"dateTime" : UITextContentTypeDateTime,
+        @"flightNumber" : UITextContentTypeFlightNumber,
+        @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
+      }];
+    }
+#endif
 
     contentTypeMap = mutableContentTypeMap;
   });

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2962,7 +2962,10 @@ export type TextContentType =
   | \\"birthdate\\"
   | \\"birthdateDay\\"
   | \\"birthdateMonth\\"
-  | \\"birthdateYear\\";
+  | \\"birthdateYear\\"
+  | \\"dateTime\\"
+  | \\"flightNumber\\"
+  | \\"shipmentTrackingNumber\\";
 export type enterKeyHintType =
   | \\"enter\\"
   | \\"done\\"
@@ -3307,7 +3310,10 @@ export type TextContentType =
   | \\"birthdate\\"
   | \\"birthdateDay\\"
   | \\"birthdateMonth\\"
-  | \\"birthdateYear\\";
+  | \\"birthdateYear\\"
+  | \\"dateTime\\"
+  | \\"flightNumber\\"
+  | \\"shipmentTrackingNumber\\";
 export type enterKeyHintType =
   | \\"done\\"
   | \\"go\\"

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -222,6 +222,7 @@ UITextContentType RCTUITextContentTypeFromString(const std::string &contentType)
       }];
     }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000 /* __IPHONE_17_0 */
     if (@available(iOS 17.0, *)) {
       [mutableContentTypeMap addEntriesFromDictionary:@{
         @"creditCardExpiration" : UITextContentTypeCreditCardExpiration,
@@ -239,6 +240,7 @@ UITextContentType RCTUITextContentTypeFromString(const std::string &contentType)
         @"birthdateYear" : UITextContentTypeBirthdateYear,
       }];
     }
+#endif
 
     contentTypeMap = mutableContentTypeMap;
   });

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -233,6 +233,16 @@ UITextContentType RCTUITextContentTypeFromString(const std::string &contentType)
       }];
     }
 #endif
+      
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
+    if (@available(iOS 15.0, *)) {
+      [mutableContentTypeMap addEntriesFromDictionary:@{
+        @"dateTime" : UITextContentTypeDateTime,
+        @"flightNumber" : UITextContentTypeFlightNumber,
+        @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
+      }];
+    }
+#endif
 
     contentTypeMap = mutableContentTypeMap;
   });

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -214,7 +214,14 @@ UITextContentType RCTUITextContentTypeFromString(const std::string &contentType)
       @"oneTimeCode" : UITextContentTypeOneTimeCode,
     }];
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000 /* __IPHONE_17_0 */
+    if (@available(iOS 15.0, *)) {
+      [mutableContentTypeMap addEntriesFromDictionary:@{
+        @"dateTime" : UITextContentTypeDateTime,
+        @"flightNumber" : UITextContentTypeFlightNumber,
+        @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
+      }];
+    }
+
     if (@available(iOS 17.0, *)) {
       [mutableContentTypeMap addEntriesFromDictionary:@{
         @"creditCardExpiration" : UITextContentTypeCreditCardExpiration,
@@ -232,17 +239,6 @@ UITextContentType RCTUITextContentTypeFromString(const std::string &contentType)
         @"birthdateYear" : UITextContentTypeBirthdateYear,
       }];
     }
-#endif
-      
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0
-    if (@available(iOS 15.0, *)) {
-      [mutableContentTypeMap addEntriesFromDictionary:@{
-        @"dateTime" : UITextContentTypeDateTime,
-        @"flightNumber" : UITextContentTypeFlightNumber,
-        @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
-      }];
-    }
-#endif
 
     contentTypeMap = mutableContentTypeMap;
   });

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -783,6 +783,18 @@ const textInputExamples: Array<RNTesterModuleExample> = [
           <WithLabel label="birthdate">
             <ExampleTextInput textContentType="birthdate" />
           </WithLabel>
+          <WithLabel label="dateTime">
+            <TextInput textContentType="dateTime" style={styles.default} />
+          </WithLabel>
+          <WithLabel label="flightNumber">
+            <TextInput textContentType="flightNumber" style={styles.default} />
+          </WithLabel>
+          <WithLabel label="shipmentTrackingNumber">
+            <TextInput
+              textContentType="shipmentTrackingNumber"
+              style={styles.default}
+            />
+          </WithLabel>
         </View>
       );
     },

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -784,16 +784,13 @@ const textInputExamples: Array<RNTesterModuleExample> = [
             <ExampleTextInput textContentType="birthdate" />
           </WithLabel>
           <WithLabel label="dateTime">
-            <TextInput textContentType="dateTime" style={styles.default} />
+            <ExampleTextInput textContentType="dateTime" />
           </WithLabel>
           <WithLabel label="flightNumber">
-            <TextInput textContentType="flightNumber" style={styles.default} />
+            <ExampleTextInput textContentType="flightNumber" />
           </WithLabel>
           <WithLabel label="shipmentTrackingNumber">
-            <TextInput
-              textContentType="shipmentTrackingNumber"
-              style={styles.default}
-            />
+            <ExampleTextInput textContentType="shipmentTrackingNumber" />
           </WithLabel>
         </View>
       );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR adds few missing text content types on iOS (available from iOS 15)

- dateTime
- flightNumber
- shipmentTrackingNumber

## Changelog:

[IOS] [ADDED] - Add support for missing text content types

## Test Plan:

Make sure that `RNTester` builds and runs successfully
