### PR TITLE
Align ActivityIndicator JSDoc to website doc

### DIFF
--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -6,7 +6,6 @@
  *
  * @format
  * @flow
- * @generate-docs
  */
 
 'use strict';
@@ -125,9 +124,9 @@ const ActivityIndicator = (
 /**
   Displays a circular loading indicator.
 
-  ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example
-  import React from "react";
-  import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+  ```SnackPlayer name=ActivityIndicator%20Example
+  import React from 'react';
+  import {ActivityIndicator, StyleSheet, View} from 'react-native';
 
   const App = () => (
     <View style={[styles.container, styles.horizontal]}>
@@ -141,47 +140,17 @@ const ActivityIndicator = (
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      justifyContent: "center"
+      justifyContent: 'center',
     },
     horizontal: {
-      flexDirection: "row",
-      justifyContent: "space-around",
-      padding: 10
-    }
-  });
-  export default App;
-  ```
-
-  ```SnackPlayer name=ActivityIndicator%20Class%20Component%20Example
-  import React, { Component } from "react";
-  import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
-
-  class App extends Component {
-    render() {
-      return (
-        <View style={[styles.container, styles.horizontal]}>
-          <ActivityIndicator />
-          <ActivityIndicator size="large" />
-          <ActivityIndicator size="small" color="#0000ff" />
-          <ActivityIndicator size="large" color="#00ff00" />
-        </View>
-      );
-    }
-  }
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      justifyContent: "center"
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      padding: 10,
     },
-    horizontal: {
-      flexDirection: "row",
-      justifyContent: "space-around",
-      padding: 10
-    }
   });
+
   export default App;
-  ```
+```
 */
 
 const ActivityIndicatorWithRef: React.AbstractComponent<


### PR DESCRIPTION
Summary:
I stumbled upon the JSDoc in the [ActivityIndicator](https://fburl.com/code/aq8ljc86) component and noticed a discrepancy wrt our [website](https://reactnative.dev/docs/activityindicator).

So I looked more and found out that the doc is not really generated from the code (even though there is a confusing `generate-docs`) but actually lives in the react-native-website [codebase](https://github.com/facebook/react-native-website/blob/994cab25b63d4bed57cedfba95f0133537d42ac7/docs/activityindicator.md?plain=1#L6).

Here I'm just aligning the JSDoc to the source of truth (i.e. react-native-website) but this begs the question on whether there is any value in keeping both.

Changelog: [Internal]

Reviewed By: lunaleaps

Differential Revision: D53307738


