### PR TITLE
Turbo Modules allow mock of Bridgeless Native Modules

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -126,24 +126,19 @@ void TurboModuleBinding::install(
           }));
 
   if (runtime.global().hasProperty(runtime, "RN$Bridgeless")) {
-    if (legacyModuleProvider != nullptr) {
-      defineReadOnlyGlobal(runtime, "RN$TurboInterop", jsi::Value(true));
-      defineReadOnlyGlobal(
-          runtime,
-          "nativeModuleProxy",
-          jsi::Object::createFromHostObject(
-              runtime,
-              std::make_shared<BridgelessNativeModuleProxy>(
-                  std::make_unique<TurboModuleBinding>(
-                      std::move(legacyModuleProvider),
-                      longLivedObjectCollection))));
-    } else {
-      defineReadOnlyGlobal(
-          runtime,
-          "nativeModuleProxy",
-          jsi::Object::createFromHostObject(
-              runtime, std::make_shared<BridgelessNativeModuleProxy>(nullptr)));
-    }
+    bool rnTurboInterop = legacyModuleProvider != nullptr;
+    auto turboModuleBinding = legacyModuleProvider
+        ? std::make_unique<TurboModuleBinding>(
+              std::move(legacyModuleProvider), longLivedObjectCollection)
+        : nullptr;
+    auto nativeModuleProxy = std::make_shared<BridgelessNativeModuleProxy>(
+        std::move(turboModuleBinding));
+    defineReadOnlyGlobal(
+        runtime, "RN$TurboInterop", jsi::Value(rnTurboInterop));
+    defineReadOnlyGlobal(
+        runtime,
+        "nativeModuleProxy",
+        jsi::Object::createFromHostObject(runtime, nativeModuleProxy));
   }
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -15,7 +15,29 @@
 
 namespace facebook::react {
 
-class BridgelessNativeModuleProxy;
+class BridgelessNativeModuleProxy : public jsi::HostObject {
+ public:
+  explicit BridgelessNativeModuleProxy(
+      std::unique_ptr<TurboModuleBinding> binding);
+
+  jsi::Value get(jsi::Runtime& runtime, const jsi::PropNameID& name) override;
+
+  void set(
+      jsi::Runtime& runtime,
+      const jsi::PropNameID& /*name*/,
+      const jsi::Value& /*value*/) override;
+
+ private:
+  std::unique_ptr<TurboModuleBinding> binding_;
+};
+
+/**
+ * An app/platform-specific provider function to get an instance of a
+ * BridgelessNativeModuleProxy.
+ */
+using BridgelessNativeModuleProxyFactoryFunctionType =
+    std::function<std::shared_ptr<BridgelessNativeModuleProxy>(
+        std::unique_ptr<TurboModuleBinding> binding)>;
 
 /**
  * Represents the JavaScript binding for the TurboModule system.
@@ -31,7 +53,9 @@ class TurboModuleBinding {
       TurboModuleProviderFunctionType&& moduleProvider,
       TurboModuleProviderFunctionType&& legacyModuleProvider = nullptr,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection =
-          nullptr);
+          nullptr,
+      BridgelessNativeModuleProxyFactoryFunctionType&&
+          nativeModuleProxyFactory = nullptr);
 
   TurboModuleBinding(
       TurboModuleProviderFunctionType&& moduleProvider,


### PR DESCRIPTION
Summary:
Primarily for debugging purposes it is useful to be able overriding / mocking Native Modules in JS code.

This change allows to pass in a function pointer to create custom BridgelessNativeModuleProxy.

Changelog: [Internal]

Differential Revision: D53312051


