### PR TITLE
Drop `@generate-docs` from all components

### DIFF
--- a/packages/react-native/Libraries/Components/Button.flow.js
+++ b/packages/react-native/Libraries/Components/Button.flow.js
@@ -6,7 +6,6 @@
  *
  * @format
  * @flow strict-local
- * @generate-docs
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -6,7 +6,6 @@
  *
  * @format
  * @flow
- * @generate-docs
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @generate-docs
  */
 
 import type {ColorValue} from '../../StyleSheet/StyleSheet';


### PR DESCRIPTION
Summary:
As mentioned also in D53307738, `generate-docs` doesn't seem to be used.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D53308808


