### PR TITLE
Teach CSSValue about every length unit

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSParser.cpp
@@ -82,7 +82,96 @@ static std::optional<CSSKeyword> parseKeyword(std::string_view keyword) {
 };
 
 static std::optional<CSSLengthUnit> parseLengthUnit(std::string_view unit) {
-  return unit == "px" ? std::make_optional(CSSLengthUnit::Px) : std::nullopt;
+  switch (fnv1a(unit)) {
+    case fnv1a("cap"):
+      return CSSLengthUnit::Cap;
+    case fnv1a("ch"):
+      return CSSLengthUnit::Ch;
+    case fnv1a("cm"):
+      return CSSLengthUnit::Cm;
+    case fnv1a("dvb"):
+      return CSSLengthUnit::Dvb;
+    case fnv1a("dvh"):
+      return CSSLengthUnit::Dvh;
+    case fnv1a("dvi"):
+      return CSSLengthUnit::Dvi;
+    case fnv1a("dvmax"):
+      return CSSLengthUnit::Dvmax;
+    case fnv1a("dvmin"):
+      return CSSLengthUnit::Dvmin;
+    case fnv1a("dvw"):
+      return CSSLengthUnit::Dvw;
+    case fnv1a("em"):
+      return CSSLengthUnit::Em;
+    case fnv1a("ex"):
+      return CSSLengthUnit::Ex;
+    case fnv1a("ic"):
+      return CSSLengthUnit::Ic;
+    case fnv1a("in"):
+      return CSSLengthUnit::In;
+    case fnv1a("lh"):
+      return CSSLengthUnit::Lh;
+    case fnv1a("lvb"):
+      return CSSLengthUnit::Lvb;
+    case fnv1a("lvh"):
+      return CSSLengthUnit::Lvh;
+    case fnv1a("lvi"):
+      return CSSLengthUnit::Lvi;
+    case fnv1a("lvmax"):
+      return CSSLengthUnit::Lvmax;
+    case fnv1a("lvmin"):
+      return CSSLengthUnit::Lvmin;
+    case fnv1a("lvw"):
+      return CSSLengthUnit::Lvw;
+    case fnv1a("mm"):
+      return CSSLengthUnit::Mm;
+    case fnv1a("pc"):
+      return CSSLengthUnit::Pc;
+    case fnv1a("pt"):
+      return CSSLengthUnit::Pt;
+    case fnv1a("px"):
+      return CSSLengthUnit::Px;
+    case fnv1a("q"):
+      return CSSLengthUnit::Q;
+    case fnv1a("rcap"):
+      return CSSLengthUnit::Rcap;
+    case fnv1a("rch"):
+      return CSSLengthUnit::Rch;
+    case fnv1a("rem"):
+      return CSSLengthUnit::Rem;
+    case fnv1a("rex"):
+      return CSSLengthUnit::Rex;
+    case fnv1a("ric"):
+      return CSSLengthUnit::Ric;
+    case fnv1a("rlh"):
+      return CSSLengthUnit::Rlh;
+    case fnv1a("svb"):
+      return CSSLengthUnit::Svb;
+    case fnv1a("svh"):
+      return CSSLengthUnit::Svh;
+    case fnv1a("svi"):
+      return CSSLengthUnit::Svi;
+    case fnv1a("svmax"):
+      return CSSLengthUnit::Svmax;
+    case fnv1a("svmin"):
+      return CSSLengthUnit::Svmin;
+    case fnv1a("svw"):
+      return CSSLengthUnit::Svw;
+    case fnv1a("vb"):
+      return CSSLengthUnit::Vb;
+    case fnv1a("vh"):
+      return CSSLengthUnit::Vh;
+    case fnv1a("vi"):
+      return CSSLengthUnit::Vi;
+    case fnv1a("vmax"):
+      return CSSLengthUnit::Vmax;
+    case fnv1a("vmin"):
+      return CSSLengthUnit::Vmin;
+    case fnv1a("vw"):
+      return CSSLengthUnit::Vw;
+    default:
+      return std::nullopt;
+  }
 }
 
 template <typename T, typename CSSValueT>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSParser.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <locale>
+
+#include <react/renderer/components/view/CSSParser.h>
+#include <react/renderer/components/view/CSSTokenizer.h>
+
+namespace facebook::react {
+
+static std::optional<CSSKeyword> parseKeyword(std::string_view keyword) {
+  struct LowerCaseTransform {
+    char operator()(char c) const {
+      return static_cast<char>(tolower(c));
+    }
+  };
+
+  switch (fnv1a<LowerCaseTransform>(keyword)) {
+    case fnv1a("absolute"):
+      return CSSKeyword::Absolute;
+    case fnv1a("auto"):
+      return CSSKeyword::Auto;
+    case fnv1a("baseline"):
+      return CSSKeyword::Baseline;
+    case fnv1a("center"):
+      return CSSKeyword::Center;
+    case fnv1a("column"):
+      return CSSKeyword::Column;
+    case fnv1a("column-reverse"):
+      return CSSKeyword::ColumnReverse;
+    case fnv1a("flex"):
+      return CSSKeyword::Flex;
+    case fnv1a("flex-end"):
+      return CSSKeyword::FlexEnd;
+    case fnv1a("flex-start"):
+      return CSSKeyword::FlexStart;
+    case fnv1a("hidden"):
+      return CSSKeyword::Hidden;
+    case fnv1a("inherit"):
+      return CSSKeyword::Inherit;
+    case fnv1a("inline"):
+      return CSSKeyword::Inline;
+    case fnv1a("ltr"):
+      return CSSKeyword::Ltr;
+    case fnv1a("none"):
+      return CSSKeyword::None;
+    case fnv1a("no-wrap"):
+      return CSSKeyword::NoWrap;
+    case fnv1a("relative"):
+      return CSSKeyword::Relative;
+    case fnv1a("row"):
+      return CSSKeyword::Row;
+    case fnv1a("row-reverse"):
+      return CSSKeyword::RowReverse;
+    case fnv1a("rtl"):
+      return CSSKeyword::Rtl;
+    case fnv1a("space-between"):
+      return CSSKeyword::SpaceBetween;
+    case fnv1a("space-around"):
+      return CSSKeyword::SpaceAround;
+    case fnv1a("space-evenly"):
+      return CSSKeyword::SpaceEvenly;
+    case fnv1a("scroll"):
+      return CSSKeyword::Scroll;
+    case fnv1a("static"):
+      return CSSKeyword::Static;
+    case fnv1a("stretch"):
+      return CSSKeyword::Stretch;
+    case fnv1a("visible"):
+      return CSSKeyword::Visible;
+    case fnv1a("wrap"):
+      return CSSKeyword::Wrap;
+    case fnv1a("wrap-reverse"):
+      return CSSKeyword::WrapReverse;
+    default:
+      return std::nullopt;
+  }
+};
+
+static std::optional<CSSLengthUnit> parseLengthUnit(std::string_view unit) {
+  return unit == "px" ? std::make_optional(CSSLengthUnit::Px) : std::nullopt;
+}
+
+template <typename T, typename CSSValueT>
+concept CSSTokenConsumer = requires(T t, CSSToken token) {
+  { t(token) } -> std::same_as<CSSValueT>;
+};
+
+template <typename CSSValueT, CSSTokenConsumer<CSSValueT> TokenConsumer>
+CSSValueT parseComponentValue(std::string_view css, TokenConsumer consumer) {
+  CSSTokenizer tokenizer(css);
+
+  auto token = tokenizer.next();
+  while (token.type() == CSSTokenType::WhiteSpace) {
+    token = tokenizer.next();
+  }
+
+  auto value = consumer(token);
+
+  token = tokenizer.next();
+  while (token.type() == CSSTokenType::WhiteSpace) {
+    token = tokenizer.next();
+  }
+  if (token.type() == CSSTokenType::EndOfFile) {
+    return value;
+  }
+
+  return {};
+}
+
+template <>
+CSSKeywordValue parseCSSValue<CSSKeywordValue>(std::string_view css) {
+  return parseComponentValue<CSSKeywordValue>(css, [](const CSSToken& token) {
+    if (token.type() == CSSTokenType::Ident) {
+      if (auto keyword = parseKeyword(token.stringValue())) {
+        return CSSKeywordValue{CSSValueType::Keyword, {.keyword = *keyword}};
+      }
+    };
+
+    return CSSKeywordValue{};
+  });
+}
+
+template <>
+CSSLengthValue parseCSSValue<CSSLengthValue>(std::string_view css) {
+  return parseComponentValue<CSSLengthValue>(css, [](const CSSToken& token) {
+    switch (token.type()) {
+      case CSSTokenType::Ident:
+        if (auto keyword = parseKeyword(token.stringValue())) {
+          return CSSLengthValue{CSSValueType::Keyword, {.keyword = *keyword}};
+        }
+        break;
+      case CSSTokenType::Dimension:
+        if (auto unit = parseLengthUnit(token.unit())) {
+          return CSSLengthValue{
+              CSSValueType::Length, {.length = {token.numericValue(), *unit}}};
+        }
+        break;
+      default:
+        break;
+    }
+
+    return CSSLengthValue{};
+  });
+}
+
+template <>
+CSSLengthPercentageValue parseCSSValue<CSSLengthPercentageValue>(
+    std::string_view css) {
+  return parseComponentValue<CSSLengthPercentageValue>(
+      css, [](const CSSToken& token) {
+        switch (token.type()) {
+          case CSSTokenType::Ident:
+            if (auto keyword = parseKeyword(token.stringValue())) {
+              return CSSLengthPercentageValue{
+                  CSSValueType::Keyword, {.keyword = *keyword}};
+            }
+            break;
+          case CSSTokenType::Dimension:
+            if (auto unit = parseLengthUnit(token.unit())) {
+              return CSSLengthPercentageValue{
+                  CSSValueType::Length,
+                  {.length = {token.numericValue(), *unit}}};
+            }
+            break;
+          case CSSTokenType::Percent:
+            return CSSLengthPercentageValue{
+                CSSValueType::Percent, {.percent = {token.numericValue()}}};
+            break;
+          default:
+            break;
+        }
+
+        return CSSLengthPercentageValue{};
+      });
+}
+
+template <>
+CSSNumberValue parseCSSValue<CSSNumberValue>(std::string_view css) {
+  return parseComponentValue<CSSNumberValue>(css, [](const CSSToken& token) {
+    switch (token.type()) {
+      case CSSTokenType::Ident:
+        if (auto keyword = parseKeyword(token.stringValue())) {
+          return CSSNumberValue{CSSValueType::Keyword, {.keyword = *keyword}};
+        }
+        break;
+      case CSSTokenType::Number:
+        return CSSNumberValue{
+            CSSValueType::Number, {.number = {token.numericValue()}}};
+        break;
+      default:
+        break;
+    }
+
+    return CSSNumberValue{};
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSParser.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <react/renderer/components/view/CSSValue.h>
+
+namespace facebook::react {
+
+/*
+ * Parses a single CSS component value, specialized to a given type.
+ * See https://www.w3.org/TR/css-syntax-3/#parse-component-value
+ */
+template <typename CSSValueT>
+CSSValueT parseCSSValue(std::string_view css) = delete;
+
+template <>
+CSSKeywordValue parseCSSValue<CSSKeywordValue>(std::string_view css);
+
+template <>
+CSSLengthValue parseCSSValue<CSSLengthValue>(std::string_view css);
+
+template <>
+CSSLengthPercentageValue parseCSSValue<CSSLengthPercentageValue>(
+    std::string_view css);
+
+template <>
+CSSNumberValue parseCSSValue<CSSNumberValue>(std::string_view css);
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSValue.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <type_traits>
+
+#include <react/utils/fnv1a.h>
+
+namespace facebook::react {
+
+#pragma pack(push, 1)
+
+/**
+ * Represents a CSS component value type.
+ * https://www.w3.org/TR/css-values-3/#component-types
+ */
+enum class CSSValueType : uint8_t {
+  Undefined,
+  Keyword,
+  Length,
+  Number,
+  Percent,
+};
+
+/**
+ * One of the predefined CSS keywords.
+ * https://www.w3.org/TR/css-values-3/#keywords
+ */
+enum class CSSKeyword : uint8_t {
+  Absolute,
+  Auto,
+  Baseline,
+  Center,
+  Column,
+  ColumnReverse,
+  Flex,
+  FlexEnd,
+  FlexStart,
+  Hidden,
+  Inherit,
+  Inline,
+  Ltr,
+  None,
+  NoWrap,
+  Relative,
+  Row,
+  RowReverse,
+  Rtl,
+  Scroll,
+  SpaceAround,
+  SpaceBetween,
+  SpaceEvenly,
+  Static,
+  Stretch,
+  Visible,
+  Wrap,
+  WrapReverse,
+};
+
+/**
+ * Unit for the CSS <length> type.
+ * https://www.w3.org/TR/css-values-3/#lengths
+ */
+enum class CSSLengthUnit : uint8_t {
+  Px,
+};
+
+/**
+ * CSS <length> value.
+ * https://www.w3.org/TR/css-values-3/#lengths
+ */
+struct CSSLength {
+  float value;
+  CSSLengthUnit unit;
+};
+
+static_assert(std::is_trivial_v<CSSLength>);
+
+/**
+ * CSS <percent> value.
+ * https://www.w3.org/TR/css-values-3/#percentages
+ */
+struct CSSPercent {
+  float value;
+};
+static_assert(std::is_trivial_v<CSSPercent>);
+
+/**
+ * CSS <number> value.
+ * https://www.w3.org/TR/css-values-3/#numbers
+ */
+struct CSSNumber {
+  float value;
+};
+static_assert(std::is_trivial_v<CSSNumber>);
+
+/**
+ * Represents a CSS property value of an arbitrary type
+ */
+struct CSSValue {
+  CSSValueType type{CSSValueType::Undefined};
+  union {
+    CSSKeyword keyword;
+    CSSLength length;
+    CSSNumber number;
+    CSSPercent percent;
+  };
+};
+static_assert(sizeof(CSSValue) == 6, "CSSValue must be tightly packed");
+
+/*
+ *  Represents a CSS property value accepting a keyword
+ */
+struct CSSKeywordValue {
+  CSSValueType type{CSSValueType::Undefined};
+  union {
+    CSSKeyword keyword;
+  };
+};
+static_assert(
+    sizeof(CSSKeywordValue) == 2,
+    "CSSKeywordValue must be tightly packed");
+
+/*
+ *  Represents a CSS property value accepting a <length>
+ */
+struct CSSLengthValue {
+  CSSValueType type{CSSValueType::Undefined};
+  union {
+    CSSKeyword keyword;
+    CSSLength length;
+  };
+};
+static_assert(
+    sizeof(CSSLengthValue) == 6,
+    "CSSLengthValue must be tightly packed");
+
+/*
+ * Represents a CSS property value accepting a <length-percentage>
+ */
+struct CSSLengthPercentageValue {
+  CSSValueType type{CSSValueType::Undefined};
+  union {
+    CSSKeyword keyword;
+    CSSLength length;
+    CSSPercent percent;
+  };
+};
+static_assert(
+    sizeof(CSSLengthPercentageValue) == 6,
+    "CSSLengthPercentageValue must be tightly packed");
+
+/*
+ *  Represents a CSS property value accepting a <length>
+ */
+struct CSSNumberValue {
+  CSSValueType type{CSSValueType::Undefined};
+  union {
+    CSSKeyword keyword;
+    CSSNumber number;
+  };
+};
+static_assert(
+    sizeof(CSSNumberValue) == 5,
+    "CSSNumberValue must be tightly packed");
+
+#pragma pack(pop)
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSValue.h
@@ -66,10 +66,52 @@ enum class CSSKeyword : uint8_t {
 
 /**
  * Unit for the CSS <length> type.
- * https://www.w3.org/TR/css-values-3/#lengths
+ * https://www.w3.org/TR/css-values-4/#lengths
  */
 enum class CSSLengthUnit : uint8_t {
+  Cap,
+  Ch,
+  Cm,
+  Dvb,
+  Dvh,
+  Dvi,
+  Dvmax,
+  Dvmin,
+  Dvw,
+  Em,
+  Ex,
+  Ic,
+  In,
+  Lh,
+  Lvb,
+  Lvh,
+  Lvi,
+  Lvmax,
+  Lvmin,
+  Lvw,
+  Mm,
+  Pc,
+  Pt,
   Px,
+  Q,
+  Rcap,
+  Rch,
+  Rem,
+  Rex,
+  Ric,
+  Rlh,
+  Svb,
+  Svh,
+  Svi,
+  Svmax,
+  Svmin,
+  Svw,
+  Vb,
+  Vh,
+  Vi,
+  Vmax,
+  Vmin,
+  Vw,
 };
 
 /**

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/CSSParserTesst.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/CSSParserTesst.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/components/view/CSSParser.h>
+
+namespace facebook::react {
+
+TEST(CSSParser, keyword_values) {
+  auto emptyValue = parseCSSValue<CSSKeywordValue>("");
+  EXPECT_EQ(emptyValue.type, CSSValueType::Undefined);
+
+  auto autoValue = parseCSSValue<CSSKeywordValue>("auto");
+  EXPECT_EQ(autoValue.type, CSSValueType::Keyword);
+  EXPECT_EQ(autoValue.keyword, CSSKeyword::Auto);
+
+  auto autoCapsValue = parseCSSValue<CSSKeywordValue>("AuTO");
+  EXPECT_EQ(autoCapsValue.type, CSSValueType::Keyword);
+  EXPECT_EQ(autoCapsValue.keyword, CSSKeyword::Auto);
+
+  auto whitespaceValue = parseCSSValue<CSSKeywordValue>(" flex-start   ");
+  EXPECT_EQ(whitespaceValue.type, CSSValueType::Keyword);
+  EXPECT_EQ(whitespaceValue.keyword, CSSKeyword::FlexStart);
+
+  auto badIdentValue = parseCSSValue<CSSKeywordValue>("bad");
+  EXPECT_EQ(badIdentValue.type, CSSValueType::Undefined);
+
+  auto pxValue = parseCSSValue<CSSKeywordValue>("20px");
+  EXPECT_EQ(pxValue.type, CSSValueType::Undefined);
+
+  auto multiValue = parseCSSValue<CSSKeywordValue>("auto flex-start");
+  EXPECT_EQ(multiValue.type, CSSValueType::Undefined);
+}
+
+TEST(CSSParser, length_values) {
+  auto emptyValue = parseCSSValue<CSSLengthValue>("");
+  EXPECT_EQ(emptyValue.type, CSSValueType::Undefined);
+
+  auto autoValue = parseCSSValue<CSSLengthValue>("auto");
+  EXPECT_EQ(autoValue.type, CSSValueType::Keyword);
+  EXPECT_EQ(autoValue.keyword, CSSKeyword::Auto);
+
+  auto pxValue = parseCSSValue<CSSLengthValue>("20px");
+  EXPECT_EQ(pxValue.type, CSSValueType::Length);
+  EXPECT_EQ(pxValue.length.value, 20.0f);
+  EXPECT_EQ(pxValue.length.unit, CSSLengthUnit::Px);
+
+  auto pctValue = parseCSSValue<CSSLengthValue>("-40%");
+  EXPECT_EQ(pctValue.type, CSSValueType::Undefined);
+}
+
+TEST(CSSParser, length_percentage_values) {
+  auto emptyValue = parseCSSValue<CSSLengthPercentageValue>("");
+  EXPECT_EQ(emptyValue.type, CSSValueType::Undefined);
+
+  auto autoValue = parseCSSValue<CSSLengthPercentageValue>("auto");
+  EXPECT_EQ(autoValue.type, CSSValueType::Keyword);
+  EXPECT_EQ(autoValue.keyword, CSSKeyword::Auto);
+
+  auto pxValue = parseCSSValue<CSSLengthPercentageValue>("20px");
+  EXPECT_EQ(pxValue.type, CSSValueType::Length);
+  EXPECT_EQ(pxValue.length.value, 20.0f);
+  EXPECT_EQ(pxValue.length.unit, CSSLengthUnit::Px);
+
+  auto pctValue = parseCSSValue<CSSLengthPercentageValue>("-40%");
+  EXPECT_EQ(pctValue.type, CSSValueType::Percent);
+  EXPECT_EQ(pctValue.percent.value, -40.0f);
+}
+
+TEST(CSSParser, number_values) {
+  auto emptyValue = parseCSSValue<CSSNumberValue>("");
+  EXPECT_EQ(emptyValue.type, CSSValueType::Undefined);
+
+  auto inheritValue = parseCSSValue<CSSNumberValue>("inherit");
+  EXPECT_EQ(inheritValue.type, CSSValueType::Keyword);
+  EXPECT_EQ(inheritValue.keyword, CSSKeyword::Inherit);
+
+  auto pxValue = parseCSSValue<CSSNumberValue>("20px");
+  EXPECT_EQ(pxValue.type, CSSValueType::Undefined);
+
+  auto numberValue = parseCSSValue<CSSNumberValue>("123.456");
+  EXPECT_EQ(numberValue.type, CSSValueType::Number);
+  EXPECT_EQ(numberValue.number.value, 123.456f);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/CSSParserTesst.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/CSSParserTesst.cpp
@@ -49,6 +49,11 @@ TEST(CSSParser, length_values) {
   EXPECT_EQ(pxValue.length.value, 20.0f);
   EXPECT_EQ(pxValue.length.unit, CSSLengthUnit::Px);
 
+  auto cmValue = parseCSSValue<CSSLengthValue>("453cm");
+  EXPECT_EQ(cmValue.type, CSSValueType::Length);
+  EXPECT_EQ(cmValue.length.value, 453.0f);
+  EXPECT_EQ(cmValue.length.unit, CSSLengthUnit::Cm);
+
   auto pctValue = parseCSSValue<CSSLengthValue>("-40%");
   EXPECT_EQ(pctValue.type, CSSValueType::Undefined);
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/CSSTokenizerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/CSSTokenizerTest.cpp
@@ -7,7 +7,6 @@
 
 #include <gtest/gtest.h>
 #include <react/renderer/components/view/CSSTokenizer.h>
-#include <deque>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/utils/fnv1a.h
+++ b/packages/react-native/ReactCommon/react/utils/fnv1a.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <string_view>
+
 namespace facebook::react {
 
 /**
@@ -17,13 +21,14 @@ namespace facebook::react {
  * when std::hash does not provide the needed functionality. For example,
  * constexpr.
  */
+template <typename CharTransformT = std::identity>
 constexpr uint32_t fnv1a(std::string_view string) noexcept {
   constexpr uint32_t offset_basis = 2166136261;
 
   uint32_t hash = offset_basis;
 
   for (auto const& c : string) {
-    hash ^= static_cast<int8_t>(c);
+    hash ^= static_cast<int8_t>(CharTransformT{}(c));
     // Using shifts and adds instead of multiplication with a prime number.
     // This is faster when compiled with optimizations.
     hash +=


### PR DESCRIPTION
Summary:
Adds all the units from CSS Values and Units Module Level 4 to the parsing/storage layer.

There is no code yet to absolutize them, but there is no harm in fleshing this out fully, before implementing logic for absolutization.

Changelog: [Internal]

Differential Revision: D53347982


