### PR TITLE
fix crash in ReactGroupView when subview clipping is enabled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fccbff20f478efc0778ed7991065d189>>
+ * @generated SignedSource<<f4268973a38ba972e68474cc31bab5a7>>
  */
 
 /**
@@ -63,6 +63,12 @@ object ReactNativeFeatureFlags {
    */
   @JvmStatic
   fun enableCustomDrawOrderFabric() = accessor.enableCustomDrawOrderFabric()
+
+  /**
+   * Attempt at fixing a crash related to subview clipping on Android. This is a kill switch for the fix
+   */
+  @JvmStatic
+  fun enableFixForClippedSubviewsCrash() = accessor.enableFixForClippedSubviewsCrash()
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<126de7eafa27c27df31d9d4e984ab96c>>
+ * @generated SignedSource<<5b653e8a53f557ffc0f46b3e81e99bed>>
  */
 
 /**
@@ -26,6 +26,7 @@ class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccessor {
   private var batchRenderingUpdatesInEventLoopCache: Boolean? = null
   private var enableSpannableBuildingUnificationCache: Boolean? = null
   private var enableCustomDrawOrderFabricCache: Boolean? = null
+  private var enableFixForClippedSubviewsCrashCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -77,6 +78,15 @@ class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccessor {
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.enableCustomDrawOrderFabric()
       enableCustomDrawOrderFabricCache = cached
+    }
+    return cached
+  }
+
+  override fun enableFixForClippedSubviewsCrash(): Boolean {
+    var cached = enableFixForClippedSubviewsCrashCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.enableFixForClippedSubviewsCrash()
+      enableFixForClippedSubviewsCrashCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9638eb154fe6e488aebcf20c462f498e>>
+ * @generated SignedSource<<47be3dbe5558f720a6c61742f2c63bf8>>
  */
 
 /**
@@ -39,6 +39,8 @@ object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic external fun enableSpannableBuildingUnification(): Boolean
 
   @DoNotStrip @JvmStatic external fun enableCustomDrawOrderFabric(): Boolean
+
+  @DoNotStrip @JvmStatic external fun enableFixForClippedSubviewsCrash(): Boolean
 
   @DoNotStrip @JvmStatic external fun override(provider: Any)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<53537c2dcc2f4e298822eaa92b5c507f>>
+ * @generated SignedSource<<70c19d5bb1e0c09f52b89b4bb3645b9d>>
  */
 
 /**
@@ -34,4 +34,6 @@ open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvider {
   override fun enableSpannableBuildingUnification(): Boolean = false
 
   override fun enableCustomDrawOrderFabric(): Boolean = false
+
+  override fun enableFixForClippedSubviewsCrash(): Boolean = false
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9ea3b9587aa49be565b990b4c2f4a870>>
+ * @generated SignedSource<<7ba0cb94c10989838250252fa06768a0>>
  */
 
 /**
@@ -30,6 +30,7 @@ class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAccessor {
   private var batchRenderingUpdatesInEventLoopCache: Boolean? = null
   private var enableSpannableBuildingUnificationCache: Boolean? = null
   private var enableCustomDrawOrderFabricCache: Boolean? = null
+  private var enableFixForClippedSubviewsCrashCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -87,6 +88,16 @@ class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAccessor {
       cached = currentProvider.enableCustomDrawOrderFabric()
       accessedFeatureFlags.add("enableCustomDrawOrderFabric")
       enableCustomDrawOrderFabricCache = cached
+    }
+    return cached
+  }
+
+  override fun enableFixForClippedSubviewsCrash(): Boolean {
+    var cached = enableFixForClippedSubviewsCrashCache
+    if (cached == null) {
+      cached = currentProvider.enableFixForClippedSubviewsCrash()
+      accessedFeatureFlags.add("enableFixForClippedSubviewsCrash")
+      enableFixForClippedSubviewsCrashCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9abdc5010330b660feded87e9db882c4>>
+ * @generated SignedSource<<b0f60718eedab65390ebfb7864a10a27>>
  */
 
 /**
@@ -34,4 +34,6 @@ interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip fun enableSpannableBuildingUnification(): Boolean
 
   @DoNotStrip fun enableCustomDrawOrderFabric(): Boolean
+
+  @DoNotStrip fun enableFixForClippedSubviewsCrash(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -754,7 +754,6 @@ public class ReactViewGroup extends ViewGroup
     }
   }
 
-  // This method also sets the child's mParent to null
   private void removeFromArray(int index) {
     final View[] children = Assertions.assertNotNull(mAllChildren);
     final int count = mAllChildrenCount;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -686,7 +686,8 @@ public class ReactViewGroup extends ViewGroup
     }
   }
 
-  /*package*/ void removeViewWithSubviewClippingEnabled(View view) {
+  // TODO: make this method package only once we remove Android's mounting layer retry mechanism.
+  public void removeViewWithSubviewClippingEnabled(View view) {
     UiThreadUtil.assertOnUiThread();
 
     Assertions.assertCondition(mRemoveClippedSubviews);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1ba33b527792e241891e821b18b11000>>
+ * @generated SignedSource<<dab6daf99192f983b7c8ad7633b43a33>>
  */
 
 /**
@@ -53,6 +53,11 @@ bool JReactNativeFeatureFlagsCxxInterop::enableCustomDrawOrderFabric(
   return ReactNativeFeatureFlags::enableCustomDrawOrderFabric();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::enableFixForClippedSubviewsCrash(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::enableFixForClippedSubviewsCrash();
+}
+
 void JReactNativeFeatureFlagsCxxInterop::override(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/,
     jni::alias_ref<jobject> provider) {
@@ -88,6 +93,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "enableCustomDrawOrderFabric",
         JReactNativeFeatureFlagsCxxInterop::enableCustomDrawOrderFabric),
+      makeNativeMethod(
+        "enableFixForClippedSubviewsCrash",
+        JReactNativeFeatureFlagsCxxInterop::enableFixForClippedSubviewsCrash),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c1e65591af5042353647d3afb4e181b4>>
+ * @generated SignedSource<<c2a4da926b870497f76c03c8f97199e2>>
  */
 
 /**
@@ -46,6 +46,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableCustomDrawOrderFabric(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool enableFixForClippedSubviewsCrash(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static void override(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<47d7a81b555e133f79db174f599a1940>>
+ * @generated SignedSource<<feb0342515d10b3519675cd91efa65dc>>
  */
 
 /**
@@ -60,6 +60,12 @@ bool ReactNativeFeatureFlagsProviderHolder::enableSpannableBuildingUnification()
 bool ReactNativeFeatureFlagsProviderHolder::enableCustomDrawOrderFabric() {
   static const auto method =
       getJClass()->getMethod<jboolean()>("enableCustomDrawOrderFabric");
+  return method(javaProvider_);
+}
+
+bool ReactNativeFeatureFlagsProviderHolder::enableFixForClippedSubviewsCrash() {
+  static const auto method =
+      getJClass()->getMethod<jboolean()>("enableFixForClippedSubviewsCrash");
   return method(javaProvider_);
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/ReactNativeFeatureFlagsProviderHolder.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<228921c4374aa45bdcd496f0f10d653a>>
+ * @generated SignedSource<<879b0c096c4a2e9692a5e133bdfd8809>>
  */
 
 /**
@@ -41,6 +41,7 @@ class ReactNativeFeatureFlagsProviderHolder
   bool batchRenderingUpdatesInEventLoop() override;
   bool enableSpannableBuildingUnification() override;
   bool enableCustomDrawOrderFabric() override;
+  bool enableFixForClippedSubviewsCrash() override;
 
  private:
   jni::global_ref<jobject> javaProvider_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a9ddd8a35e80c21c36fd57526a58ae84>>
+ * @generated SignedSource<<6ccf42209dea35cd5c6ac9eb882c2ef7>>
  */
 
 /**
@@ -43,6 +43,10 @@ bool ReactNativeFeatureFlags::enableSpannableBuildingUnification() {
 
 bool ReactNativeFeatureFlags::enableCustomDrawOrderFabric() {
   return getAccessor().enableCustomDrawOrderFabric();
+}
+
+bool ReactNativeFeatureFlags::enableFixForClippedSubviewsCrash() {
+  return getAccessor().enableFixForClippedSubviewsCrash();
 }
 
 void ReactNativeFeatureFlags::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<479f3a75128ee7e9ea60af544b69e0d7>>
+ * @generated SignedSource<<d3e8b0cc31fd8e44c3f83d836485e6f6>>
  */
 
 /**
@@ -61,6 +61,11 @@ class ReactNativeFeatureFlags {
    * When enabled, Fabric will use customDrawOrder in ReactViewGroup (similar to old architecture).
    */
   static bool enableCustomDrawOrderFabric();
+
+  /**
+   * Attempt at fixing a crash related to subview clipping on Android. This is a kill switch for the fix
+   */
+  static bool enableFixForClippedSubviewsCrash();
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dc95df7a5e58ca72e19a77e4d190225e>>
+ * @generated SignedSource<<7d50752c48503e31eccfe64d66ee2e99>>
  */
 
 /**
@@ -128,6 +128,23 @@ bool ReactNativeFeatureFlagsAccessor::enableCustomDrawOrderFabric() {
   }
 
   return enableCustomDrawOrderFabric_.value();
+}
+
+bool ReactNativeFeatureFlagsAccessor::enableFixForClippedSubviewsCrash() {
+  if (!enableFixForClippedSubviewsCrash_.has_value()) {
+    // Mark the flag as accessed.
+    static const char* flagName = "enableFixForClippedSubviewsCrash";
+    if (std::find(
+            accessedFeatureFlags_.begin(),
+            accessedFeatureFlags_.end(),
+            flagName) == accessedFeatureFlags_.end()) {
+      accessedFeatureFlags_.push_back(flagName);
+    }
+
+    enableFixForClippedSubviewsCrash_.emplace(currentProvider_->enableFixForClippedSubviewsCrash());
+  }
+
+  return enableFixForClippedSubviewsCrash_.value();
 }
 
 void ReactNativeFeatureFlagsAccessor::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f85ebb4efba429a4c943dc26e5a70541>>
+ * @generated SignedSource<<1514c04fb9d175308e106b84a14bc89d>>
  */
 
 /**
@@ -36,6 +36,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool batchRenderingUpdatesInEventLoop();
   bool enableSpannableBuildingUnification();
   bool enableCustomDrawOrderFabric();
+  bool enableFixForClippedSubviewsCrash();
 
   void override(std::unique_ptr<ReactNativeFeatureFlagsProvider> provider);
 
@@ -49,6 +50,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::optional<bool> batchRenderingUpdatesInEventLoop_;
   std::optional<bool> enableSpannableBuildingUnification_;
   std::optional<bool> enableCustomDrawOrderFabric_;
+  std::optional<bool> enableFixForClippedSubviewsCrash_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<10089e5b138ecb72a6d2b2de22496cb5>>
+ * @generated SignedSource<<b39abca7a1fcce7ae124565cfc619d04>>
  */
 
 /**
@@ -48,6 +48,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableCustomDrawOrderFabric() override {
+    return false;
+  }
+
+  bool enableFixForClippedSubviewsCrash() override {
     return false;
   }
 };

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<646e0d7982b7e72f9ff227c80d4c2a49>>
+ * @generated SignedSource<<72abac7cc75e65bf1ded596033637050>>
  */
 
 /**
@@ -31,6 +31,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool batchRenderingUpdatesInEventLoop() = 0;
   virtual bool enableSpannableBuildingUnification() = 0;
   virtual bool enableCustomDrawOrderFabric() = 0;
+  virtual bool enableFixForClippedSubviewsCrash() = 0;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1fc0f55ffba5d6a7be9bb8f7942d45a2>>
+ * @generated SignedSource<<64ea070fb82bd703eb617dcf64c6a7d1>>
  */
 
 /**
@@ -63,6 +63,11 @@ bool NativeReactNativeFeatureFlags::enableSpannableBuildingUnification(
 bool NativeReactNativeFeatureFlags::enableCustomDrawOrderFabric(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enableCustomDrawOrderFabric();
+}
+
+bool NativeReactNativeFeatureFlags::enableFixForClippedSubviewsCrash(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::enableFixForClippedSubviewsCrash();
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1642f4bbd50bb535c369642dd3a647ad>>
+ * @generated SignedSource<<994628655312f57c8ab774e9f119eb18>>
  */
 
 /**
@@ -41,6 +41,8 @@ class NativeReactNativeFeatureFlags
   bool enableSpannableBuildingUnification(jsi::Runtime& runtime);
 
   bool enableCustomDrawOrderFabric(jsi::Runtime& runtime);
+
+  bool enableFixForClippedSubviewsCrash(jsi::Runtime& runtime);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.json
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.json
@@ -23,6 +23,10 @@
     "enableCustomDrawOrderFabric": {
       "description": "When enabled, Fabric will use customDrawOrder in ReactViewGroup (similar to old architecture).",
       "defaultValue": false
+    },
+    "enableFixForClippedSubviewsCrash": {
+      "description": "Attempt at fixing a crash related to subview clipping on Android. This is a kill switch for the fix",
+      "defaultValue": false
     }
   },
   "jsOnly": {

--- a/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4617616de77a1e9255f727fdc8039d92>>
+ * @generated SignedSource<<2ca87dc970592f66d83f4799c4047c9b>>
  * @flow strict-local
  */
 
@@ -29,6 +29,7 @@ export interface Spec extends TurboModule {
   +batchRenderingUpdatesInEventLoop?: () => boolean;
   +enableSpannableBuildingUnification?: () => boolean;
   +enableCustomDrawOrderFabric?: () => boolean;
+  +enableFixForClippedSubviewsCrash?: () => boolean;
 }
 
 const NativeReactNativeFeatureFlags: ?Spec = TurboModuleRegistry.get<Spec>(

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c43dd1db78ac69ca3c39577d45a04071>>
+ * @generated SignedSource<<559256ac71f23725dac2ed9aec1bd102>>
  * @flow strict-local
  */
 
@@ -45,6 +45,7 @@ export type ReactNativeFeatureFlags = {
   batchRenderingUpdatesInEventLoop: Getter<boolean>,
   enableSpannableBuildingUnification: Getter<boolean>,
   enableCustomDrawOrderFabric: Getter<boolean>,
+  enableFixForClippedSubviewsCrash: Getter<boolean>,
 }
 
 /**
@@ -106,6 +107,10 @@ export const enableSpannableBuildingUnification: Getter<boolean> = createNativeF
  * When enabled, Fabric will use customDrawOrder in ReactViewGroup (similar to old architecture).
  */
 export const enableCustomDrawOrderFabric: Getter<boolean> = createNativeFlagGetter('enableCustomDrawOrderFabric', false);
+/**
+ * Attempt at fixing a crash related to subview clipping on Android. This is a kill switch for the fix
+ */
+export const enableFixForClippedSubviewsCrash: Getter<boolean> = createNativeFlagGetter('enableFixForClippedSubviewsCrash', false);
 
 /**
  * Overrides the feature flags with the provided methods.


### PR DESCRIPTION
Summary:
changelog: [internal]

Attempt to fixing a crash in ReactViewGroup when removeClippedSubviews is enabled.
The implementation of removeClippedSubviews in ReactViewGroup is stateful and must be in sync between children of view and [member variables in ReactViewGroup](https://fburl.com/code/l22wewzc) that keep reference to all children. When it gets out of sync, it manifests itself as `java.lang.IndexOutOfBoundsException` crash.

The mounting layer counts on the fact that view hierarchy will never be directly mutated and all mutations will go through [ReactClippingViewManager](https://fburl.com/code/esl3vqhh). ReactClippingViewManager, if clipping is enabled, calls appropriate methods on ReactViewGroup to make sure member variables to manage clipping are in sync with view hierarchy. 

This is true, except for a retry mechanism in SurfaceMountingManager. The retry mechanism tries to manually reconciliation the state with android view hierarchy. It bypasses ReactClippingViewManager in the process.

Reviewed By: javache

Differential Revision: D53348831


