### PR TITLE
Add Flashlight performance testing on RN Tester

### DIFF
--- a/.github/workflow-scripts/flashlight-daily-perf-check.sh
+++ b/.github/workflow-scripts/flashlight-daily-perf-check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# See https://app.flashlight.dev/projects/c172eb70-c96b-4d02-b865-1d1cdb80c519/test-list
+PROJECT_ID="c172eb70-c96b-4d02-b865-1d1cdb80c519"
+
+# Getting the nightly version name instead of the commit hash makes it easier to sort results in the dashboard by version
+NIGHTLY_VERSION=$(node -e 'console.log(require("./scripts/npm-utils.js").getNpmInfo("nightly").version)')
+
+MAESTRO_TEST_FOLDER="packages/rn-tester/js/components/perftesting"
+
+curl https://get.flashlight.dev | bash
+# For some reason path overriding doesn't work so we can't run `flashlight` directly
+/home/runner/.flashlight/bin/flashlight cloud \
+  --test "$MAESTRO_TEST_FOLDER/FlatListExample_start.yaml" \
+  --beforeAll "$MAESTRO_TEST_FOLDER/FlatListExample_beforeAll.yaml" \
+  --duration 10000 \
+  --app app-hermes-armeabi-v7a-release.apk \
+  --projectId "$PROJECT_ID" \
+  --testName "FlatListExample_$ARCH" \
+  --tagName "$NIGHTLY_VERSION"

--- a/.github/workflows/build-rntester-android.yml
+++ b/.github/workflows/build-rntester-android.yml
@@ -1,0 +1,35 @@
+name: 'Build RN Tester Android'
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+
+jobs:
+  build_rn_tester_android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Set up JDK 18
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "18"
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Build APK
+        run: |
+          # Ensure we let gradle install whichever NDK version it needs
+          export ANDROID_NDK=""
+          yarn
+          ./gradlew :packages:rn-tester:android:app:assembleHermesRelease -PreactNativeArchitectures=armeabi-v7a -PnewArchEnabled=${{ inputs.arch == 'NewArch' && 'true' || 'false' }}
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "${{ inputs.arch }}"
+          path: packages/rn-tester/android/app/build/outputs/apk/hermes/release/app-hermes-armeabi-v7a-release.apk

--- a/.github/workflows/flashlight-daily-perf-check.yml
+++ b/.github/workflows/flashlight-daily-perf-check.yml
@@ -1,0 +1,28 @@
+name: Daily Flashlight performance measures
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *" # Runs at 1 AM (UTC) every day
+
+jobs:
+  build_rntester_release_old_arch:
+    uses: ./.github/workflows/build-rntester-android.yml
+    with:
+      arch: 'OldArch'
+  flashlight_old_arch:
+    needs: build_rntester_release_old_arch
+    uses: ./.github/workflows/flashlight-test.yml
+    with:
+      arch: 'OldArch'
+    secrets: inherit
+  build_rntester_release_new_arch:
+    uses: ./.github/workflows/build-rntester-android.yml
+    with:
+      arch: 'NewArch'
+  flashlight_new_arch:
+    needs: build_rntester_release_new_arch
+    uses: ./.github/workflows/flashlight-test.yml
+    with:
+      arch: 'NewArch'
+    secrets: inherit

--- a/.github/workflows/flashlight-test.yml
+++ b/.github/workflows/flashlight-test.yml
@@ -1,0 +1,27 @@
+name: Flashlight Measure
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+    secrets:
+      FLASHLIGHT_API_KEY:
+        required: true
+
+jobs:
+  flashlight_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download APK
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{inputs.arch}}
+      - name: Send to Flashlight
+        env:
+          FLASHLIGHT_API_KEY: ${{ secrets.FLASHLIGHT_API_KEY }}
+        run: |
+          yarn
+          export FLASHLIGHT_API_KEY=$FLASHLIGHT_API_KEY
+          ARCH=${{inputs.arch}} ./.github/workflow-scripts/flashlight-daily-perf-check.sh

--- a/packages/rn-tester/README.md
+++ b/packages/rn-tester/README.md
@@ -80,3 +80,10 @@ _Note: The native libs are still built using gradle. Full build with buck is com
 Building the app on both iOS and Android means building the React Native framework from source. This way you're running the latest native and JS code the way you see it in your clone of the github repo.
 
 This is different from apps created using `react-native init` which have a dependency on a specific version of React Native JS and native code, declared in a `package.json` file (and `build.gradle` for Android apps).
+
+## Performance testing
+
+To open the performance testing example on Android, close the app, then run:
+```bash
+adb shell am start -W -a android.intent.action.VIEW -d "rntester://example/perftesting/flatlistexample" com.facebook.react.uiapp
+```

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -15,6 +15,7 @@ import RNTesterModuleList from './components/RNTesterModuleList';
 import RNTesterNavBar, {navBarHeight} from './components/RNTesterNavbar';
 import {RNTesterThemeContext, themes} from './components/RNTesterTheme';
 import RNTTitleBar from './components/RNTTitleBar';
+import {overrideAppWithPerfExample} from './utils/deeplinking/overrideAppWithPerfExample';
 import {resolveUrl} from './utils/deeplinking/resolveUrl';
 import RNTesterList from './utils/RNTesterList';
 import {
@@ -215,7 +216,7 @@ const RNTesterApp = ({
   );
 };
 
-export default RNTesterApp;
+export default overrideAppWithPerfExample(RNTesterApp);
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/rn-tester/js/components/perftesting/FlatListExample.js
+++ b/packages/rn-tester/js/components/perftesting/FlatListExample.js
@@ -1,0 +1,156 @@
+import React, {memo} from 'react';
+import {
+  FlatList,
+  Image,
+  SafeAreaView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+  useColorScheme,
+} from 'react-native';
+import {Colors} from 'react-native/Libraries/NewAppScreen';
+
+const pokedex: Pokemon[] = require('./pokedex.json');
+
+interface Pokemon {
+  gameIndex: string;
+  name: string;
+  types: {name: string}[];
+  imageUrl: string;
+}
+// Taken directly from https://github.com/MatheusPires99/pokedex
+const POKEMON_TYPE_COLORS: {[type: string]: string} = {
+  normal: '#A8A878',
+  fighting: '#C03028',
+  flying: '#A890F0',
+  poison: '#A040A0',
+  ground: '#E0C068',
+  rock: '#B8A038',
+  bug: '#A8B820',
+  ghost: '#705898',
+  steel: '#B8B8D0',
+  fire: '#FA6C6C',
+  water: '#6890F0',
+  grass: '#48CFB2',
+  electric: '#FFCE4B',
+  psychic: '#F85888',
+  ice: '#98D8D8',
+  dragon: '#7038F8',
+  dark: '#705848',
+  fairy: '#EE99AC',
+};
+
+/**
+ * Having 4 columns is voluntarily a bit extreme, so we can have more granularity to compare CPU usage between releases
+ */
+const COLUMN_COUNT = 4;
+
+const cardStyles = StyleSheet.create({
+  container: {width: `${100 / COLUMN_COUNT}%`},
+  innerContainer: {
+    padding: (10 * 2) / COLUMN_COUNT,
+    paddingRight: 0,
+    margin: (5 * 2) / COLUMN_COUNT,
+    borderRadius: (10 * 2) / COLUMN_COUNT,
+    elevation: 7,
+  },
+  name: {
+    fontSize: (16 * 2) / COLUMN_COUNT,
+    color: 'white',
+    fontWeight: 'bold',
+    flex: 1,
+    paddingRight: (5 * 2) / COLUMN_COUNT,
+  },
+  typeContainer: {
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#6662',
+    borderRadius: (10 * 2) / COLUMN_COUNT,
+    marginTop: (5 * 2) / COLUMN_COUNT,
+    padding: (5 * 2) / COLUMN_COUNT,
+  },
+  nameAndIndexContainer: {
+    flexDirection: 'row',
+    width: '100%',
+    justifyContent: 'space-between',
+    paddingRight: (10 * 2) / COLUMN_COUNT,
+  },
+  index: {fontSize: (12 * 2) / COLUMN_COUNT, color: '#6666'},
+  type: {
+    color: '#fffa',
+    fontSize: (12 * 2) / COLUMN_COUNT,
+  },
+  image: {width: (100 * 2) / COLUMN_COUNT, height: (100 * 2) / COLUMN_COUNT},
+  typesContainer: {flex: 1, paddingTop: (20 * 2) / COLUMN_COUNT},
+  typeRow: {
+    flexDirection: 'row',
+    width: '100%',
+    justifyContent: 'space-between',
+  },
+});
+
+const PokemonCard = memo(({item}: {item: Pokemon}) => {
+  return (
+    <View style={cardStyles.container}>
+      <View
+        style={[
+          cardStyles.innerContainer,
+          {
+            backgroundColor: POKEMON_TYPE_COLORS[item.types[0].name],
+          },
+        ]}>
+        <View style={cardStyles.nameAndIndexContainer}>
+          <Text numberOfLines={1} style={cardStyles.name}>
+            {item.name.toUpperCase()}
+          </Text>
+          <Text style={cardStyles.index}>#{item.gameIndex}</Text>
+        </View>
+        <View style={cardStyles.typeRow}>
+          <View style={cardStyles.typesContainer}>
+            {item.types.map(type => (
+              <View key={type.name} style={cardStyles.typeContainer}>
+                <Text style={cardStyles.type}>{type.name}</Text>
+              </View>
+            ))}
+          </View>
+          {item.imageUrl && (
+            <Image
+              source={{uri: item.imageUrl}}
+              style={cardStyles.image}
+            />
+          )}
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const renderItem = ({item}: {item: Pokemon}) => {
+  return <PokemonCard item={item} />;
+};
+
+const styles = StyleSheet.create({list: {paddingHorizontal: 5}});
+
+export const FlatListExample = () => {
+  const isDarkMode = useColorScheme() === 'dark';
+
+  const backgroundStyle = {
+    backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
+  };
+
+  return (
+    <SafeAreaView style={backgroundStyle}>
+      <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
+
+      <FlatList
+        numColumns={COLUMN_COUNT}
+        keyExtractor={item => item.name}
+        data={pokedex}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+      />
+    </SafeAreaView>
+  );
+};

--- a/packages/rn-tester/js/components/perftesting/FlatListExample.js
+++ b/packages/rn-tester/js/components/perftesting/FlatListExample.js
@@ -147,7 +147,13 @@ export const FlatListExample = () => {
       <FlatList
         numColumns={COLUMN_COUNT}
         keyExtractor={item => item.name}
-        data={pokedex}
+        /**
+         * Slicing here to make sure we always render the same amount of items
+         * It seems that on certain iterations FlatList would render one more page and have a worse Flashlight score
+         *
+         * By default windowSize is 21, so at start, we render 11 screens, which should amount to 448 items
+         */
+        data={pokedex.slice(0, 448)}
         renderItem={renderItem}
         contentContainerStyle={styles.list}
       />

--- a/packages/rn-tester/js/components/perftesting/FlatListExample_beforeAll.yaml
+++ b/packages/rn-tester/js/components/perftesting/FlatListExample_beforeAll.yaml
@@ -1,0 +1,8 @@
+# This is a Maestro short e2e test used for Flashlight performance testing
+# Since Flashlight cloud doesn't support Appium tests yet, we use Maestro instead
+appId: com.facebook.react.uiapp
+---
+- openLink: rntester://example/perftesting/flatlistexample
+# Makes sure to fail the test if the app is crashing
+# We don't do this in the perf measures, to ensure Maestro doesn't impact performance measures
+- assertVisible: "CHARMANDER"

--- a/packages/rn-tester/js/components/perftesting/FlatListExample_start.yaml
+++ b/packages/rn-tester/js/components/perftesting/FlatListExample_start.yaml
@@ -1,0 +1,5 @@
+# This is a Maestro short e2e test used for Flashlight performance testing
+# Since Flashlight cloud doesn't support Appium tests yet, we use Maestro instead
+appId: com.facebook.react.uiapp
+---
+- openLink: rntester://example/perftesting/flatlistexample

--- a/packages/rn-tester/js/components/perftesting/pokedex.json
+++ b/packages/rn-tester/js/components/perftesting/pokedex.json
@@ -1,0 +1,5698 @@
+[
+  {
+    "gameIndex": 153,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "bulbasaur",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/1.png"
+  },
+  {
+    "gameIndex": 9,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "ivysaur",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/2.png"
+  },
+  {
+    "gameIndex": 154,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "venusaur",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/3.png"
+  },
+  {
+    "gameIndex": 176,
+    "types": [{"name": "fire"}],
+    "name": "charmander",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/4.png"
+  },
+  {
+    "gameIndex": 178,
+    "types": [{"name": "fire"}],
+    "name": "charmeleon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/5.png"
+  },
+  {
+    "gameIndex": 180,
+    "types": [{"name": "fire"}, {"name": "flying"}],
+    "name": "charizard",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/6.png"
+  },
+  {
+    "gameIndex": 177,
+    "types": [{"name": "water"}],
+    "name": "squirtle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/7.png"
+  },
+  {
+    "gameIndex": 179,
+    "types": [{"name": "water"}],
+    "name": "wartortle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/8.png"
+  },
+  {
+    "gameIndex": 28,
+    "types": [{"name": "water"}],
+    "name": "blastoise",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/9.png"
+  },
+  {
+    "gameIndex": 123,
+    "types": [{"name": "bug"}],
+    "name": "caterpie",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10.png"
+  },
+  {
+    "gameIndex": 124,
+    "types": [{"name": "bug"}],
+    "name": "metapod",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/11.png"
+  },
+  {
+    "gameIndex": 125,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "butterfree",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/12.png"
+  },
+  {
+    "gameIndex": 112,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "weedle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/13.png"
+  },
+  {
+    "gameIndex": 113,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "kakuna",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/14.png"
+  },
+  {
+    "gameIndex": 114,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "beedrill",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/15.png"
+  },
+  {
+    "gameIndex": 36,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "pidgey",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/16.png"
+  },
+  {
+    "gameIndex": 150,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "pidgeotto",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/17.png"
+  },
+  {
+    "gameIndex": 151,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "pidgeot",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/18.png"
+  },
+  {
+    "gameIndex": 165,
+    "types": [{"name": "normal"}],
+    "name": "rattata",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/19.png"
+  },
+  {
+    "gameIndex": 166,
+    "types": [{"name": "normal"}],
+    "name": "raticate",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/20.png"
+  },
+  {
+    "gameIndex": 5,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "spearow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/21.png"
+  },
+  {
+    "gameIndex": 35,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "fearow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/22.png"
+  },
+  {
+    "gameIndex": 108,
+    "types": [{"name": "poison"}],
+    "name": "ekans",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/23.png"
+  },
+  {
+    "gameIndex": 45,
+    "types": [{"name": "poison"}],
+    "name": "arbok",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/24.png"
+  },
+  {
+    "gameIndex": 84,
+    "types": [{"name": "electric"}],
+    "name": "pikachu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/25.png"
+  },
+  {
+    "gameIndex": 85,
+    "types": [{"name": "electric"}],
+    "name": "raichu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/26.png"
+  },
+  {
+    "gameIndex": 96,
+    "types": [{"name": "ground"}],
+    "name": "sandshrew",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/27.png"
+  },
+  {
+    "gameIndex": 97,
+    "types": [{"name": "ground"}],
+    "name": "sandslash",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/28.png"
+  },
+  {
+    "gameIndex": 15,
+    "types": [{"name": "poison"}],
+    "name": "nidoran-f",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/29.png"
+  },
+  {
+    "gameIndex": 168,
+    "types": [{"name": "poison"}],
+    "name": "nidorina",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/30.png"
+  },
+  {
+    "gameIndex": 16,
+    "types": [{"name": "poison"}, {"name": "ground"}],
+    "name": "nidoqueen",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/31.png"
+  },
+  {
+    "gameIndex": 3,
+    "types": [{"name": "poison"}],
+    "name": "nidoran-m",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/32.png"
+  },
+  {
+    "gameIndex": 167,
+    "types": [{"name": "poison"}],
+    "name": "nidorino",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/33.png"
+  },
+  {
+    "gameIndex": 7,
+    "types": [{"name": "poison"}, {"name": "ground"}],
+    "name": "nidoking",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/34.png"
+  },
+  {
+    "gameIndex": 4,
+    "types": [{"name": "fairy"}],
+    "name": "clefairy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/35.png"
+  },
+  {
+    "gameIndex": 142,
+    "types": [{"name": "fairy"}],
+    "name": "clefable",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/36.png"
+  },
+  {
+    "gameIndex": 82,
+    "types": [{"name": "fire"}],
+    "name": "vulpix",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/37.png"
+  },
+  {
+    "gameIndex": 83,
+    "types": [{"name": "fire"}],
+    "name": "ninetales",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/38.png"
+  },
+  {
+    "gameIndex": 100,
+    "types": [{"name": "normal"}, {"name": "fairy"}],
+    "name": "jigglypuff",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/39.png"
+  },
+  {
+    "gameIndex": 101,
+    "types": [{"name": "normal"}, {"name": "fairy"}],
+    "name": "wigglytuff",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/40.png"
+  },
+  {
+    "gameIndex": 107,
+    "types": [{"name": "poison"}, {"name": "flying"}],
+    "name": "zubat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/41.png"
+  },
+  {
+    "gameIndex": 130,
+    "types": [{"name": "poison"}, {"name": "flying"}],
+    "name": "golbat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/42.png"
+  },
+  {
+    "gameIndex": 185,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "oddish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/43.png"
+  },
+  {
+    "gameIndex": 186,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "gloom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/44.png"
+  },
+  {
+    "gameIndex": 187,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "vileplume",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/45.png"
+  },
+  {
+    "gameIndex": 109,
+    "types": [{"name": "bug"}, {"name": "grass"}],
+    "name": "paras",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/46.png"
+  },
+  {
+    "gameIndex": 46,
+    "types": [{"name": "bug"}, {"name": "grass"}],
+    "name": "parasect",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/47.png"
+  },
+  {
+    "gameIndex": 65,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "venonat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/48.png"
+  },
+  {
+    "gameIndex": 119,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "venomoth",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/49.png"
+  },
+  {
+    "gameIndex": 59,
+    "types": [{"name": "ground"}],
+    "name": "diglett",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/50.png"
+  },
+  {
+    "gameIndex": 118,
+    "types": [{"name": "ground"}],
+    "name": "dugtrio",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/51.png"
+  },
+  {
+    "gameIndex": 77,
+    "types": [{"name": "normal"}],
+    "name": "meowth",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/52.png"
+  },
+  {
+    "gameIndex": 144,
+    "types": [{"name": "normal"}],
+    "name": "persian",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/53.png"
+  },
+  {
+    "gameIndex": 47,
+    "types": [{"name": "water"}],
+    "name": "psyduck",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/54.png"
+  },
+  {
+    "gameIndex": 128,
+    "types": [{"name": "water"}],
+    "name": "golduck",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/55.png"
+  },
+  {
+    "gameIndex": 57,
+    "types": [{"name": "fighting"}],
+    "name": "mankey",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/56.png"
+  },
+  {
+    "gameIndex": 117,
+    "types": [{"name": "fighting"}],
+    "name": "primeape",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/57.png"
+  },
+  {
+    "gameIndex": 33,
+    "types": [{"name": "fire"}],
+    "name": "growlithe",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/58.png"
+  },
+  {
+    "gameIndex": 20,
+    "types": [{"name": "fire"}],
+    "name": "arcanine",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/59.png"
+  },
+  {
+    "gameIndex": 71,
+    "types": [{"name": "water"}],
+    "name": "poliwag",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/60.png"
+  },
+  {
+    "gameIndex": 110,
+    "types": [{"name": "water"}],
+    "name": "poliwhirl",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/61.png"
+  },
+  {
+    "gameIndex": 111,
+    "types": [{"name": "water"}, {"name": "fighting"}],
+    "name": "poliwrath",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/62.png"
+  },
+  {
+    "gameIndex": 148,
+    "types": [{"name": "psychic"}],
+    "name": "abra",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/63.png"
+  },
+  {
+    "gameIndex": 38,
+    "types": [{"name": "psychic"}],
+    "name": "kadabra",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/64.png"
+  },
+  {
+    "gameIndex": 149,
+    "types": [{"name": "psychic"}],
+    "name": "alakazam",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/65.png"
+  },
+  {
+    "gameIndex": 106,
+    "types": [{"name": "fighting"}],
+    "name": "machop",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/66.png"
+  },
+  {
+    "gameIndex": 41,
+    "types": [{"name": "fighting"}],
+    "name": "machoke",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/67.png"
+  },
+  {
+    "gameIndex": 126,
+    "types": [{"name": "fighting"}],
+    "name": "machamp",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/68.png"
+  },
+  {
+    "gameIndex": 188,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "bellsprout",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/69.png"
+  },
+  {
+    "gameIndex": 189,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "weepinbell",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/70.png"
+  },
+  {
+    "gameIndex": 190,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "victreebel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/71.png"
+  },
+  {
+    "gameIndex": 24,
+    "types": [{"name": "water"}, {"name": "poison"}],
+    "name": "tentacool",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/72.png"
+  },
+  {
+    "gameIndex": 155,
+    "types": [{"name": "water"}, {"name": "poison"}],
+    "name": "tentacruel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/73.png"
+  },
+  {
+    "gameIndex": 169,
+    "types": [{"name": "rock"}, {"name": "ground"}],
+    "name": "geodude",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/74.png"
+  },
+  {
+    "gameIndex": 39,
+    "types": [{"name": "rock"}, {"name": "ground"}],
+    "name": "graveler",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/75.png"
+  },
+  {
+    "gameIndex": 49,
+    "types": [{"name": "rock"}, {"name": "ground"}],
+    "name": "golem",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/76.png"
+  },
+  {
+    "gameIndex": 163,
+    "types": [{"name": "fire"}],
+    "name": "ponyta",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/77.png"
+  },
+  {
+    "gameIndex": 164,
+    "types": [{"name": "fire"}],
+    "name": "rapidash",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/78.png"
+  },
+  {
+    "gameIndex": 37,
+    "types": [{"name": "water"}, {"name": "psychic"}],
+    "name": "slowpoke",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/79.png"
+  },
+  {
+    "gameIndex": 8,
+    "types": [{"name": "water"}, {"name": "psychic"}],
+    "name": "slowbro",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/80.png"
+  },
+  {
+    "gameIndex": 173,
+    "types": [{"name": "electric"}, {"name": "steel"}],
+    "name": "magnemite",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/81.png"
+  },
+  {
+    "gameIndex": 54,
+    "types": [{"name": "electric"}, {"name": "steel"}],
+    "name": "magneton",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/82.png"
+  },
+  {
+    "gameIndex": 64,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "farfetchd",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/83.png"
+  },
+  {
+    "gameIndex": 70,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "doduo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/84.png"
+  },
+  {
+    "gameIndex": 116,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "dodrio",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/85.png"
+  },
+  {
+    "gameIndex": 58,
+    "types": [{"name": "water"}],
+    "name": "seel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/86.png"
+  },
+  {
+    "gameIndex": 120,
+    "types": [{"name": "water"}, {"name": "ice"}],
+    "name": "dewgong",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/87.png"
+  },
+  {
+    "gameIndex": 13,
+    "types": [{"name": "poison"}],
+    "name": "grimer",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/88.png"
+  },
+  {
+    "gameIndex": 136,
+    "types": [{"name": "poison"}],
+    "name": "muk",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/89.png"
+  },
+  {
+    "gameIndex": 23,
+    "types": [{"name": "water"}],
+    "name": "shellder",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/90.png"
+  },
+  {
+    "gameIndex": 139,
+    "types": [{"name": "water"}, {"name": "ice"}],
+    "name": "cloyster",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/91.png"
+  },
+  {
+    "gameIndex": 25,
+    "types": [{"name": "ghost"}, {"name": "poison"}],
+    "name": "gastly",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/92.png"
+  },
+  {
+    "gameIndex": 147,
+    "types": [{"name": "ghost"}, {"name": "poison"}],
+    "name": "haunter",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/93.png"
+  },
+  {
+    "gameIndex": 14,
+    "types": [{"name": "ghost"}, {"name": "poison"}],
+    "name": "gengar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/94.png"
+  },
+  {
+    "gameIndex": 34,
+    "types": [{"name": "rock"}, {"name": "ground"}],
+    "name": "onix",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/95.png"
+  },
+  {
+    "gameIndex": 48,
+    "types": [{"name": "psychic"}],
+    "name": "drowzee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/96.png"
+  },
+  {
+    "gameIndex": 129,
+    "types": [{"name": "psychic"}],
+    "name": "hypno",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/97.png"
+  },
+  {
+    "gameIndex": 78,
+    "types": [{"name": "water"}],
+    "name": "krabby",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/98.png"
+  },
+  {
+    "gameIndex": 138,
+    "types": [{"name": "water"}],
+    "name": "kingler",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/99.png"
+  },
+  {
+    "gameIndex": 6,
+    "types": [{"name": "electric"}],
+    "name": "voltorb",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/100.png"
+  },
+  {
+    "gameIndex": 141,
+    "types": [{"name": "electric"}],
+    "name": "electrode",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/101.png"
+  },
+  {
+    "gameIndex": 12,
+    "types": [{"name": "grass"}, {"name": "psychic"}],
+    "name": "exeggcute",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/102.png"
+  },
+  {
+    "gameIndex": 10,
+    "types": [{"name": "grass"}, {"name": "psychic"}],
+    "name": "exeggutor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/103.png"
+  },
+  {
+    "gameIndex": 17,
+    "types": [{"name": "ground"}],
+    "name": "cubone",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/104.png"
+  },
+  {
+    "gameIndex": 145,
+    "types": [{"name": "ground"}],
+    "name": "marowak",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/105.png"
+  },
+  {
+    "gameIndex": 43,
+    "types": [{"name": "fighting"}],
+    "name": "hitmonlee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/106.png"
+  },
+  {
+    "gameIndex": 44,
+    "types": [{"name": "fighting"}],
+    "name": "hitmonchan",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/107.png"
+  },
+  {
+    "gameIndex": 11,
+    "types": [{"name": "normal"}],
+    "name": "lickitung",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/108.png"
+  },
+  {
+    "gameIndex": 55,
+    "types": [{"name": "poison"}],
+    "name": "koffing",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/109.png"
+  },
+  {
+    "gameIndex": 143,
+    "types": [{"name": "poison"}],
+    "name": "weezing",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/110.png"
+  },
+  {
+    "gameIndex": 18,
+    "types": [{"name": "ground"}, {"name": "rock"}],
+    "name": "rhyhorn",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/111.png"
+  },
+  {
+    "gameIndex": 1,
+    "types": [{"name": "ground"}, {"name": "rock"}],
+    "name": "rhydon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/112.png"
+  },
+  {
+    "gameIndex": 40,
+    "types": [{"name": "normal"}],
+    "name": "chansey",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/113.png"
+  },
+  {
+    "gameIndex": 30,
+    "types": [{"name": "grass"}],
+    "name": "tangela",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/114.png"
+  },
+  {
+    "gameIndex": 2,
+    "types": [{"name": "normal"}],
+    "name": "kangaskhan",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/115.png"
+  },
+  {
+    "gameIndex": 92,
+    "types": [{"name": "water"}],
+    "name": "horsea",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/116.png"
+  },
+  {
+    "gameIndex": 93,
+    "types": [{"name": "water"}],
+    "name": "seadra",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/117.png"
+  },
+  {
+    "gameIndex": 157,
+    "types": [{"name": "water"}],
+    "name": "goldeen",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/118.png"
+  },
+  {
+    "gameIndex": 158,
+    "types": [{"name": "water"}],
+    "name": "seaking",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/119.png"
+  },
+  {
+    "gameIndex": 27,
+    "types": [{"name": "water"}],
+    "name": "staryu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/120.png"
+  },
+  {
+    "gameIndex": 152,
+    "types": [{"name": "water"}, {"name": "psychic"}],
+    "name": "starmie",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/121.png"
+  },
+  {
+    "gameIndex": 42,
+    "types": [{"name": "psychic"}, {"name": "fairy"}],
+    "name": "mr-mime",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/122.png"
+  },
+  {
+    "gameIndex": 26,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "scyther",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/123.png"
+  },
+  {
+    "gameIndex": 72,
+    "types": [{"name": "ice"}, {"name": "psychic"}],
+    "name": "jynx",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/124.png"
+  },
+  {
+    "gameIndex": 53,
+    "types": [{"name": "electric"}],
+    "name": "electabuzz",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/125.png"
+  },
+  {
+    "gameIndex": 51,
+    "types": [{"name": "fire"}],
+    "name": "magmar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/126.png"
+  },
+  {
+    "gameIndex": 29,
+    "types": [{"name": "bug"}],
+    "name": "pinsir",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/127.png"
+  },
+  {
+    "gameIndex": 60,
+    "types": [{"name": "normal"}],
+    "name": "tauros",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/128.png"
+  },
+  {
+    "gameIndex": 133,
+    "types": [{"name": "water"}],
+    "name": "magikarp",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/129.png"
+  },
+  {
+    "gameIndex": 22,
+    "types": [{"name": "water"}, {"name": "flying"}],
+    "name": "gyarados",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/130.png"
+  },
+  {
+    "gameIndex": 19,
+    "types": [{"name": "water"}, {"name": "ice"}],
+    "name": "lapras",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/131.png"
+  },
+  {
+    "gameIndex": 76,
+    "types": [{"name": "normal"}],
+    "name": "ditto",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/132.png"
+  },
+  {
+    "gameIndex": 102,
+    "types": [{"name": "normal"}],
+    "name": "eevee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/133.png"
+  },
+  {
+    "gameIndex": 105,
+    "types": [{"name": "water"}],
+    "name": "vaporeon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/134.png"
+  },
+  {
+    "gameIndex": 104,
+    "types": [{"name": "electric"}],
+    "name": "jolteon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/135.png"
+  },
+  {
+    "gameIndex": 103,
+    "types": [{"name": "fire"}],
+    "name": "flareon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/136.png"
+  },
+  {
+    "gameIndex": 170,
+    "types": [{"name": "normal"}],
+    "name": "porygon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/137.png"
+  },
+  {
+    "gameIndex": 98,
+    "types": [{"name": "rock"}, {"name": "water"}],
+    "name": "omanyte",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/138.png"
+  },
+  {
+    "gameIndex": 99,
+    "types": [{"name": "rock"}, {"name": "water"}],
+    "name": "omastar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/139.png"
+  },
+  {
+    "gameIndex": 90,
+    "types": [{"name": "rock"}, {"name": "water"}],
+    "name": "kabuto",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/140.png"
+  },
+  {
+    "gameIndex": 91,
+    "types": [{"name": "rock"}, {"name": "water"}],
+    "name": "kabutops",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/141.png"
+  },
+  {
+    "gameIndex": 171,
+    "types": [{"name": "rock"}, {"name": "flying"}],
+    "name": "aerodactyl",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/142.png"
+  },
+  {
+    "gameIndex": 132,
+    "types": [{"name": "normal"}],
+    "name": "snorlax",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/143.png"
+  },
+  {
+    "gameIndex": 74,
+    "types": [{"name": "ice"}, {"name": "flying"}],
+    "name": "articuno",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/144.png"
+  },
+  {
+    "gameIndex": 75,
+    "types": [{"name": "electric"}, {"name": "flying"}],
+    "name": "zapdos",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/145.png"
+  },
+  {
+    "gameIndex": 73,
+    "types": [{"name": "fire"}, {"name": "flying"}],
+    "name": "moltres",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/146.png"
+  },
+  {
+    "gameIndex": 88,
+    "types": [{"name": "dragon"}],
+    "name": "dratini",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/147.png"
+  },
+  {
+    "gameIndex": 89,
+    "types": [{"name": "dragon"}],
+    "name": "dragonair",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/148.png"
+  },
+  {
+    "gameIndex": 66,
+    "types": [{"name": "dragon"}, {"name": "flying"}],
+    "name": "dragonite",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/149.png"
+  },
+  {
+    "gameIndex": 131,
+    "types": [{"name": "psychic"}],
+    "name": "mewtwo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/150.png"
+  },
+  {
+    "gameIndex": 21,
+    "types": [{"name": "psychic"}],
+    "name": "mew",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/151.png"
+  },
+  {
+    "gameIndex": 152,
+    "types": [{"name": "grass"}],
+    "name": "chikorita",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/152.png"
+  },
+  {
+    "gameIndex": 153,
+    "types": [{"name": "grass"}],
+    "name": "bayleef",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/153.png"
+  },
+  {
+    "gameIndex": 154,
+    "types": [{"name": "grass"}],
+    "name": "meganium",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/154.png"
+  },
+  {
+    "gameIndex": 155,
+    "types": [{"name": "fire"}],
+    "name": "cyndaquil",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/155.png"
+  },
+  {
+    "gameIndex": 156,
+    "types": [{"name": "fire"}],
+    "name": "quilava",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/156.png"
+  },
+  {
+    "gameIndex": 157,
+    "types": [{"name": "fire"}],
+    "name": "typhlosion",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/157.png"
+  },
+  {
+    "gameIndex": 158,
+    "types": [{"name": "water"}],
+    "name": "totodile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/158.png"
+  },
+  {
+    "gameIndex": 159,
+    "types": [{"name": "water"}],
+    "name": "croconaw",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/159.png"
+  },
+  {
+    "gameIndex": 160,
+    "types": [{"name": "water"}],
+    "name": "feraligatr",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/160.png"
+  },
+  {
+    "gameIndex": 161,
+    "types": [{"name": "normal"}],
+    "name": "sentret",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/161.png"
+  },
+  {
+    "gameIndex": 162,
+    "types": [{"name": "normal"}],
+    "name": "furret",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/162.png"
+  },
+  {
+    "gameIndex": 163,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "hoothoot",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/163.png"
+  },
+  {
+    "gameIndex": 164,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "noctowl",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/164.png"
+  },
+  {
+    "gameIndex": 165,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "ledyba",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/165.png"
+  },
+  {
+    "gameIndex": 166,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "ledian",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/166.png"
+  },
+  {
+    "gameIndex": 167,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "spinarak",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/167.png"
+  },
+  {
+    "gameIndex": 168,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "ariados",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/168.png"
+  },
+  {
+    "gameIndex": 169,
+    "types": [{"name": "poison"}, {"name": "flying"}],
+    "name": "crobat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/169.png"
+  },
+  {
+    "gameIndex": 170,
+    "types": [{"name": "water"}, {"name": "electric"}],
+    "name": "chinchou",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/170.png"
+  },
+  {
+    "gameIndex": 171,
+    "types": [{"name": "water"}, {"name": "electric"}],
+    "name": "lanturn",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/171.png"
+  },
+  {
+    "gameIndex": 172,
+    "types": [{"name": "electric"}],
+    "name": "pichu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/172.png"
+  },
+  {
+    "gameIndex": 173,
+    "types": [{"name": "fairy"}],
+    "name": "cleffa",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/173.png"
+  },
+  {
+    "gameIndex": 174,
+    "types": [{"name": "normal"}, {"name": "fairy"}],
+    "name": "igglybuff",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/174.png"
+  },
+  {
+    "gameIndex": 175,
+    "types": [{"name": "fairy"}],
+    "name": "togepi",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/175.png"
+  },
+  {
+    "gameIndex": 176,
+    "types": [{"name": "fairy"}, {"name": "flying"}],
+    "name": "togetic",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/176.png"
+  },
+  {
+    "gameIndex": 177,
+    "types": [{"name": "psychic"}, {"name": "flying"}],
+    "name": "natu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/177.png"
+  },
+  {
+    "gameIndex": 178,
+    "types": [{"name": "psychic"}, {"name": "flying"}],
+    "name": "xatu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/178.png"
+  },
+  {
+    "gameIndex": 179,
+    "types": [{"name": "electric"}],
+    "name": "mareep",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/179.png"
+  },
+  {
+    "gameIndex": 180,
+    "types": [{"name": "electric"}],
+    "name": "flaaffy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/180.png"
+  },
+  {
+    "gameIndex": 181,
+    "types": [{"name": "electric"}],
+    "name": "ampharos",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/181.png"
+  },
+  {
+    "gameIndex": 182,
+    "types": [{"name": "grass"}],
+    "name": "bellossom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/182.png"
+  },
+  {
+    "gameIndex": 183,
+    "types": [{"name": "water"}, {"name": "fairy"}],
+    "name": "marill",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/183.png"
+  },
+  {
+    "gameIndex": 184,
+    "types": [{"name": "water"}, {"name": "fairy"}],
+    "name": "azumarill",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/184.png"
+  },
+  {
+    "gameIndex": 185,
+    "types": [{"name": "rock"}],
+    "name": "sudowoodo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/185.png"
+  },
+  {
+    "gameIndex": 186,
+    "types": [{"name": "water"}],
+    "name": "politoed",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/186.png"
+  },
+  {
+    "gameIndex": 187,
+    "types": [{"name": "grass"}, {"name": "flying"}],
+    "name": "hoppip",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/187.png"
+  },
+  {
+    "gameIndex": 188,
+    "types": [{"name": "grass"}, {"name": "flying"}],
+    "name": "skiploom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/188.png"
+  },
+  {
+    "gameIndex": 189,
+    "types": [{"name": "grass"}, {"name": "flying"}],
+    "name": "jumpluff",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/189.png"
+  },
+  {
+    "gameIndex": 190,
+    "types": [{"name": "normal"}],
+    "name": "aipom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/190.png"
+  },
+  {
+    "gameIndex": 191,
+    "types": [{"name": "grass"}],
+    "name": "sunkern",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/191.png"
+  },
+  {
+    "gameIndex": 192,
+    "types": [{"name": "grass"}],
+    "name": "sunflora",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/192.png"
+  },
+  {
+    "gameIndex": 193,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "yanma",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/193.png"
+  },
+  {
+    "gameIndex": 194,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "wooper",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/194.png"
+  },
+  {
+    "gameIndex": 195,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "quagsire",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/195.png"
+  },
+  {
+    "gameIndex": 196,
+    "types": [{"name": "psychic"}],
+    "name": "espeon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/196.png"
+  },
+  {
+    "gameIndex": 197,
+    "types": [{"name": "dark"}],
+    "name": "umbreon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/197.png"
+  },
+  {
+    "gameIndex": 198,
+    "types": [{"name": "dark"}, {"name": "flying"}],
+    "name": "murkrow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/198.png"
+  },
+  {
+    "gameIndex": 199,
+    "types": [{"name": "water"}, {"name": "psychic"}],
+    "name": "slowking",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/199.png"
+  },
+  {
+    "gameIndex": 200,
+    "types": [{"name": "ghost"}],
+    "name": "misdreavus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/200.png"
+  },
+  {
+    "gameIndex": 201,
+    "types": [{"name": "psychic"}],
+    "name": "unown",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/201.png"
+  },
+  {
+    "gameIndex": 202,
+    "types": [{"name": "psychic"}],
+    "name": "wobbuffet",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/202.png"
+  },
+  {
+    "gameIndex": 203,
+    "types": [{"name": "normal"}, {"name": "psychic"}],
+    "name": "girafarig",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/203.png"
+  },
+  {
+    "gameIndex": 204,
+    "types": [{"name": "bug"}],
+    "name": "pineco",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/204.png"
+  },
+  {
+    "gameIndex": 205,
+    "types": [{"name": "bug"}, {"name": "steel"}],
+    "name": "forretress",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/205.png"
+  },
+  {
+    "gameIndex": 206,
+    "types": [{"name": "normal"}],
+    "name": "dunsparce",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/206.png"
+  },
+  {
+    "gameIndex": 207,
+    "types": [{"name": "ground"}, {"name": "flying"}],
+    "name": "gligar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/207.png"
+  },
+  {
+    "gameIndex": 208,
+    "types": [{"name": "steel"}, {"name": "ground"}],
+    "name": "steelix",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/208.png"
+  },
+  {
+    "gameIndex": 209,
+    "types": [{"name": "fairy"}],
+    "name": "snubbull",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/209.png"
+  },
+  {
+    "gameIndex": 210,
+    "types": [{"name": "fairy"}],
+    "name": "granbull",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/210.png"
+  },
+  {
+    "gameIndex": 211,
+    "types": [{"name": "water"}, {"name": "poison"}],
+    "name": "qwilfish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/211.png"
+  },
+  {
+    "gameIndex": 212,
+    "types": [{"name": "bug"}, {"name": "steel"}],
+    "name": "scizor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/212.png"
+  },
+  {
+    "gameIndex": 213,
+    "types": [{"name": "bug"}, {"name": "rock"}],
+    "name": "shuckle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/213.png"
+  },
+  {
+    "gameIndex": 214,
+    "types": [{"name": "bug"}, {"name": "fighting"}],
+    "name": "heracross",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/214.png"
+  },
+  {
+    "gameIndex": 215,
+    "types": [{"name": "dark"}, {"name": "ice"}],
+    "name": "sneasel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/215.png"
+  },
+  {
+    "gameIndex": 216,
+    "types": [{"name": "normal"}],
+    "name": "teddiursa",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/216.png"
+  },
+  {
+    "gameIndex": 217,
+    "types": [{"name": "normal"}],
+    "name": "ursaring",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/217.png"
+  },
+  {
+    "gameIndex": 218,
+    "types": [{"name": "fire"}],
+    "name": "slugma",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/218.png"
+  },
+  {
+    "gameIndex": 219,
+    "types": [{"name": "fire"}, {"name": "rock"}],
+    "name": "magcargo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/219.png"
+  },
+  {
+    "gameIndex": 220,
+    "types": [{"name": "ice"}, {"name": "ground"}],
+    "name": "swinub",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/220.png"
+  },
+  {
+    "gameIndex": 221,
+    "types": [{"name": "ice"}, {"name": "ground"}],
+    "name": "piloswine",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/221.png"
+  },
+  {
+    "gameIndex": 222,
+    "types": [{"name": "water"}, {"name": "rock"}],
+    "name": "corsola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/222.png"
+  },
+  {
+    "gameIndex": 223,
+    "types": [{"name": "water"}],
+    "name": "remoraid",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/223.png"
+  },
+  {
+    "gameIndex": 224,
+    "types": [{"name": "water"}],
+    "name": "octillery",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/224.png"
+  },
+  {
+    "gameIndex": 225,
+    "types": [{"name": "ice"}, {"name": "flying"}],
+    "name": "delibird",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/225.png"
+  },
+  {
+    "gameIndex": 226,
+    "types": [{"name": "water"}, {"name": "flying"}],
+    "name": "mantine",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/226.png"
+  },
+  {
+    "gameIndex": 227,
+    "types": [{"name": "steel"}, {"name": "flying"}],
+    "name": "skarmory",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/227.png"
+  },
+  {
+    "gameIndex": 228,
+    "types": [{"name": "dark"}, {"name": "fire"}],
+    "name": "houndour",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/228.png"
+  },
+  {
+    "gameIndex": 229,
+    "types": [{"name": "dark"}, {"name": "fire"}],
+    "name": "houndoom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/229.png"
+  },
+  {
+    "gameIndex": 230,
+    "types": [{"name": "water"}, {"name": "dragon"}],
+    "name": "kingdra",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/230.png"
+  },
+  {
+    "gameIndex": 231,
+    "types": [{"name": "ground"}],
+    "name": "phanpy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/231.png"
+  },
+  {
+    "gameIndex": 232,
+    "types": [{"name": "ground"}],
+    "name": "donphan",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/232.png"
+  },
+  {
+    "gameIndex": 233,
+    "types": [{"name": "normal"}],
+    "name": "porygon2",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/233.png"
+  },
+  {
+    "gameIndex": 234,
+    "types": [{"name": "normal"}],
+    "name": "stantler",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/234.png"
+  },
+  {
+    "gameIndex": 235,
+    "types": [{"name": "normal"}],
+    "name": "smeargle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/235.png"
+  },
+  {
+    "gameIndex": 236,
+    "types": [{"name": "fighting"}],
+    "name": "tyrogue",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/236.png"
+  },
+  {
+    "gameIndex": 237,
+    "types": [{"name": "fighting"}],
+    "name": "hitmontop",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/237.png"
+  },
+  {
+    "gameIndex": 238,
+    "types": [{"name": "ice"}, {"name": "psychic"}],
+    "name": "smoochum",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/238.png"
+  },
+  {
+    "gameIndex": 239,
+    "types": [{"name": "electric"}],
+    "name": "elekid",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/239.png"
+  },
+  {
+    "gameIndex": 240,
+    "types": [{"name": "fire"}],
+    "name": "magby",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/240.png"
+  },
+  {
+    "gameIndex": 241,
+    "types": [{"name": "normal"}],
+    "name": "miltank",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/241.png"
+  },
+  {
+    "gameIndex": 242,
+    "types": [{"name": "normal"}],
+    "name": "blissey",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/242.png"
+  },
+  {
+    "gameIndex": 243,
+    "types": [{"name": "electric"}],
+    "name": "raikou",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/243.png"
+  },
+  {
+    "gameIndex": 244,
+    "types": [{"name": "fire"}],
+    "name": "entei",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/244.png"
+  },
+  {
+    "gameIndex": 245,
+    "types": [{"name": "water"}],
+    "name": "suicune",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/245.png"
+  },
+  {
+    "gameIndex": 246,
+    "types": [{"name": "rock"}, {"name": "ground"}],
+    "name": "larvitar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/246.png"
+  },
+  {
+    "gameIndex": 247,
+    "types": [{"name": "rock"}, {"name": "ground"}],
+    "name": "pupitar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/247.png"
+  },
+  {
+    "gameIndex": 248,
+    "types": [{"name": "rock"}, {"name": "dark"}],
+    "name": "tyranitar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/248.png"
+  },
+  {
+    "gameIndex": 249,
+    "types": [{"name": "psychic"}, {"name": "flying"}],
+    "name": "lugia",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/249.png"
+  },
+  {
+    "gameIndex": 250,
+    "types": [{"name": "fire"}, {"name": "flying"}],
+    "name": "ho-oh",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/250.png"
+  },
+  {
+    "gameIndex": 251,
+    "types": [{"name": "psychic"}, {"name": "grass"}],
+    "name": "celebi",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/251.png"
+  },
+  {
+    "gameIndex": 277,
+    "types": [{"name": "grass"}],
+    "name": "treecko",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/252.png"
+  },
+  {
+    "gameIndex": 278,
+    "types": [{"name": "grass"}],
+    "name": "grovyle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/253.png"
+  },
+  {
+    "gameIndex": 279,
+    "types": [{"name": "grass"}],
+    "name": "sceptile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/254.png"
+  },
+  {
+    "gameIndex": 280,
+    "types": [{"name": "fire"}],
+    "name": "torchic",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/255.png"
+  },
+  {
+    "gameIndex": 281,
+    "types": [{"name": "fire"}, {"name": "fighting"}],
+    "name": "combusken",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/256.png"
+  },
+  {
+    "gameIndex": 282,
+    "types": [{"name": "fire"}, {"name": "fighting"}],
+    "name": "blaziken",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/257.png"
+  },
+  {
+    "gameIndex": 283,
+    "types": [{"name": "water"}],
+    "name": "mudkip",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/258.png"
+  },
+  {
+    "gameIndex": 284,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "marshtomp",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/259.png"
+  },
+  {
+    "gameIndex": 285,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "swampert",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/260.png"
+  },
+  {
+    "gameIndex": 286,
+    "types": [{"name": "dark"}],
+    "name": "poochyena",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/261.png"
+  },
+  {
+    "gameIndex": 287,
+    "types": [{"name": "dark"}],
+    "name": "mightyena",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/262.png"
+  },
+  {
+    "gameIndex": 288,
+    "types": [{"name": "normal"}],
+    "name": "zigzagoon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/263.png"
+  },
+  {
+    "gameIndex": 289,
+    "types": [{"name": "normal"}],
+    "name": "linoone",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/264.png"
+  },
+  {
+    "gameIndex": 290,
+    "types": [{"name": "bug"}],
+    "name": "wurmple",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/265.png"
+  },
+  {
+    "gameIndex": 291,
+    "types": [{"name": "bug"}],
+    "name": "silcoon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/266.png"
+  },
+  {
+    "gameIndex": 292,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "beautifly",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/267.png"
+  },
+  {
+    "gameIndex": 293,
+    "types": [{"name": "bug"}],
+    "name": "cascoon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/268.png"
+  },
+  {
+    "gameIndex": 294,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "dustox",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/269.png"
+  },
+  {
+    "gameIndex": 295,
+    "types": [{"name": "water"}, {"name": "grass"}],
+    "name": "lotad",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/270.png"
+  },
+  {
+    "gameIndex": 296,
+    "types": [{"name": "water"}, {"name": "grass"}],
+    "name": "lombre",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/271.png"
+  },
+  {
+    "gameIndex": 297,
+    "types": [{"name": "water"}, {"name": "grass"}],
+    "name": "ludicolo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/272.png"
+  },
+  {
+    "gameIndex": 298,
+    "types": [{"name": "grass"}],
+    "name": "seedot",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/273.png"
+  },
+  {
+    "gameIndex": 299,
+    "types": [{"name": "grass"}, {"name": "dark"}],
+    "name": "nuzleaf",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/274.png"
+  },
+  {
+    "gameIndex": 300,
+    "types": [{"name": "grass"}, {"name": "dark"}],
+    "name": "shiftry",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/275.png"
+  },
+  {
+    "gameIndex": 304,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "taillow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/276.png"
+  },
+  {
+    "gameIndex": 305,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "swellow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/277.png"
+  },
+  {
+    "gameIndex": 309,
+    "types": [{"name": "water"}, {"name": "flying"}],
+    "name": "wingull",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/278.png"
+  },
+  {
+    "gameIndex": 310,
+    "types": [{"name": "water"}, {"name": "flying"}],
+    "name": "pelipper",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/279.png"
+  },
+  {
+    "gameIndex": 392,
+    "types": [{"name": "psychic"}, {"name": "fairy"}],
+    "name": "ralts",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/280.png"
+  },
+  {
+    "gameIndex": 393,
+    "types": [{"name": "psychic"}, {"name": "fairy"}],
+    "name": "kirlia",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/281.png"
+  },
+  {
+    "gameIndex": 394,
+    "types": [{"name": "psychic"}, {"name": "fairy"}],
+    "name": "gardevoir",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/282.png"
+  },
+  {
+    "gameIndex": 311,
+    "types": [{"name": "bug"}, {"name": "water"}],
+    "name": "surskit",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/283.png"
+  },
+  {
+    "gameIndex": 312,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "masquerain",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/284.png"
+  },
+  {
+    "gameIndex": 306,
+    "types": [{"name": "grass"}],
+    "name": "shroomish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/285.png"
+  },
+  {
+    "gameIndex": 307,
+    "types": [{"name": "grass"}, {"name": "fighting"}],
+    "name": "breloom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/286.png"
+  },
+  {
+    "gameIndex": 364,
+    "types": [{"name": "normal"}],
+    "name": "slakoth",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/287.png"
+  },
+  {
+    "gameIndex": 365,
+    "types": [{"name": "normal"}],
+    "name": "vigoroth",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/288.png"
+  },
+  {
+    "gameIndex": 366,
+    "types": [{"name": "normal"}],
+    "name": "slaking",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/289.png"
+  },
+  {
+    "gameIndex": 301,
+    "types": [{"name": "bug"}, {"name": "ground"}],
+    "name": "nincada",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/290.png"
+  },
+  {
+    "gameIndex": 302,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "ninjask",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/291.png"
+  },
+  {
+    "gameIndex": 303,
+    "types": [{"name": "bug"}, {"name": "ghost"}],
+    "name": "shedinja",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/292.png"
+  },
+  {
+    "gameIndex": 370,
+    "types": [{"name": "normal"}],
+    "name": "whismur",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/293.png"
+  },
+  {
+    "gameIndex": 371,
+    "types": [{"name": "normal"}],
+    "name": "loudred",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/294.png"
+  },
+  {
+    "gameIndex": 372,
+    "types": [{"name": "normal"}],
+    "name": "exploud",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/295.png"
+  },
+  {
+    "gameIndex": 335,
+    "types": [{"name": "fighting"}],
+    "name": "makuhita",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/296.png"
+  },
+  {
+    "gameIndex": 336,
+    "types": [{"name": "fighting"}],
+    "name": "hariyama",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/297.png"
+  },
+  {
+    "gameIndex": 350,
+    "types": [{"name": "normal"}, {"name": "fairy"}],
+    "name": "azurill",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/298.png"
+  },
+  {
+    "gameIndex": 320,
+    "types": [{"name": "rock"}],
+    "name": "nosepass",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/299.png"
+  },
+  {
+    "gameIndex": 315,
+    "types": [{"name": "normal"}],
+    "name": "skitty",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/300.png"
+  },
+  {
+    "gameIndex": 316,
+    "types": [{"name": "normal"}],
+    "name": "delcatty",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/301.png"
+  },
+  {
+    "gameIndex": 322,
+    "types": [{"name": "dark"}, {"name": "ghost"}],
+    "name": "sableye",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/302.png"
+  },
+  {
+    "gameIndex": 355,
+    "types": [{"name": "steel"}, {"name": "fairy"}],
+    "name": "mawile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/303.png"
+  },
+  {
+    "gameIndex": 382,
+    "types": [{"name": "steel"}, {"name": "rock"}],
+    "name": "aron",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/304.png"
+  },
+  {
+    "gameIndex": 383,
+    "types": [{"name": "steel"}, {"name": "rock"}],
+    "name": "lairon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/305.png"
+  },
+  {
+    "gameIndex": 384,
+    "types": [{"name": "steel"}, {"name": "rock"}],
+    "name": "aggron",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/306.png"
+  },
+  {
+    "gameIndex": 356,
+    "types": [{"name": "fighting"}, {"name": "psychic"}],
+    "name": "meditite",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/307.png"
+  },
+  {
+    "gameIndex": 357,
+    "types": [{"name": "fighting"}, {"name": "psychic"}],
+    "name": "medicham",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/308.png"
+  },
+  {
+    "gameIndex": 337,
+    "types": [{"name": "electric"}],
+    "name": "electrike",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/309.png"
+  },
+  {
+    "gameIndex": 338,
+    "types": [{"name": "electric"}],
+    "name": "manectric",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/310.png"
+  },
+  {
+    "gameIndex": 353,
+    "types": [{"name": "electric"}],
+    "name": "plusle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/311.png"
+  },
+  {
+    "gameIndex": 354,
+    "types": [{"name": "electric"}],
+    "name": "minun",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/312.png"
+  },
+  {
+    "gameIndex": 386,
+    "types": [{"name": "bug"}],
+    "name": "volbeat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/313.png"
+  },
+  {
+    "gameIndex": 387,
+    "types": [{"name": "bug"}],
+    "name": "illumise",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/314.png"
+  },
+  {
+    "gameIndex": 363,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "roselia",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/315.png"
+  },
+  {
+    "gameIndex": 367,
+    "types": [{"name": "poison"}],
+    "name": "gulpin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/316.png"
+  },
+  {
+    "gameIndex": 368,
+    "types": [{"name": "poison"}],
+    "name": "swalot",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/317.png"
+  },
+  {
+    "gameIndex": 330,
+    "types": [{"name": "water"}, {"name": "dark"}],
+    "name": "carvanha",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/318.png"
+  },
+  {
+    "gameIndex": 331,
+    "types": [{"name": "water"}, {"name": "dark"}],
+    "name": "sharpedo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/319.png"
+  },
+  {
+    "gameIndex": 313,
+    "types": [{"name": "water"}],
+    "name": "wailmer",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/320.png"
+  },
+  {
+    "gameIndex": 314,
+    "types": [{"name": "water"}],
+    "name": "wailord",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/321.png"
+  },
+  {
+    "gameIndex": 339,
+    "types": [{"name": "fire"}, {"name": "ground"}],
+    "name": "numel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/322.png"
+  },
+  {
+    "gameIndex": 340,
+    "types": [{"name": "fire"}, {"name": "ground"}],
+    "name": "camerupt",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/323.png"
+  },
+  {
+    "gameIndex": 321,
+    "types": [{"name": "fire"}],
+    "name": "torkoal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/324.png"
+  },
+  {
+    "gameIndex": 351,
+    "types": [{"name": "psychic"}],
+    "name": "spoink",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/325.png"
+  },
+  {
+    "gameIndex": 352,
+    "types": [{"name": "psychic"}],
+    "name": "grumpig",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/326.png"
+  },
+  {
+    "gameIndex": 308,
+    "types": [{"name": "normal"}],
+    "name": "spinda",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/327.png"
+  },
+  {
+    "gameIndex": 332,
+    "types": [{"name": "ground"}],
+    "name": "trapinch",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/328.png"
+  },
+  {
+    "gameIndex": 333,
+    "types": [{"name": "ground"}, {"name": "dragon"}],
+    "name": "vibrava",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/329.png"
+  },
+  {
+    "gameIndex": 334,
+    "types": [{"name": "ground"}, {"name": "dragon"}],
+    "name": "flygon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/330.png"
+  },
+  {
+    "gameIndex": 344,
+    "types": [{"name": "grass"}],
+    "name": "cacnea",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/331.png"
+  },
+  {
+    "gameIndex": 345,
+    "types": [{"name": "grass"}, {"name": "dark"}],
+    "name": "cacturne",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/332.png"
+  },
+  {
+    "gameIndex": 358,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "swablu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/333.png"
+  },
+  {
+    "gameIndex": 359,
+    "types": [{"name": "dragon"}, {"name": "flying"}],
+    "name": "altaria",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/334.png"
+  },
+  {
+    "gameIndex": 380,
+    "types": [{"name": "normal"}],
+    "name": "zangoose",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/335.png"
+  },
+  {
+    "gameIndex": 379,
+    "types": [{"name": "poison"}],
+    "name": "seviper",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/336.png"
+  },
+  {
+    "gameIndex": 348,
+    "types": [{"name": "rock"}, {"name": "psychic"}],
+    "name": "lunatone",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/337.png"
+  },
+  {
+    "gameIndex": 349,
+    "types": [{"name": "rock"}, {"name": "psychic"}],
+    "name": "solrock",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/338.png"
+  },
+  {
+    "gameIndex": 323,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "barboach",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/339.png"
+  },
+  {
+    "gameIndex": 324,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "whiscash",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/340.png"
+  },
+  {
+    "gameIndex": 326,
+    "types": [{"name": "water"}],
+    "name": "corphish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/341.png"
+  },
+  {
+    "gameIndex": 327,
+    "types": [{"name": "water"}, {"name": "dark"}],
+    "name": "crawdaunt",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/342.png"
+  },
+  {
+    "gameIndex": 318,
+    "types": [{"name": "ground"}, {"name": "psychic"}],
+    "name": "baltoy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/343.png"
+  },
+  {
+    "gameIndex": 319,
+    "types": [{"name": "ground"}, {"name": "psychic"}],
+    "name": "claydol",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/344.png"
+  },
+  {
+    "gameIndex": 388,
+    "types": [{"name": "rock"}, {"name": "grass"}],
+    "name": "lileep",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/345.png"
+  },
+  {
+    "gameIndex": 389,
+    "types": [{"name": "rock"}, {"name": "grass"}],
+    "name": "cradily",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/346.png"
+  },
+  {
+    "gameIndex": 390,
+    "types": [{"name": "rock"}, {"name": "bug"}],
+    "name": "anorith",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/347.png"
+  },
+  {
+    "gameIndex": 391,
+    "types": [{"name": "rock"}, {"name": "bug"}],
+    "name": "armaldo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/348.png"
+  },
+  {
+    "gameIndex": 328,
+    "types": [{"name": "water"}],
+    "name": "feebas",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/349.png"
+  },
+  {
+    "gameIndex": 329,
+    "types": [{"name": "water"}],
+    "name": "milotic",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/350.png"
+  },
+  {
+    "gameIndex": 385,
+    "types": [{"name": "normal"}],
+    "name": "castform",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/351.png"
+  },
+  {
+    "gameIndex": 317,
+    "types": [{"name": "normal"}],
+    "name": "kecleon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/352.png"
+  },
+  {
+    "gameIndex": 377,
+    "types": [{"name": "ghost"}],
+    "name": "shuppet",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/353.png"
+  },
+  {
+    "gameIndex": 378,
+    "types": [{"name": "ghost"}],
+    "name": "banette",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/354.png"
+  },
+  {
+    "gameIndex": 361,
+    "types": [{"name": "ghost"}],
+    "name": "duskull",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/355.png"
+  },
+  {
+    "gameIndex": 362,
+    "types": [{"name": "ghost"}],
+    "name": "dusclops",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/356.png"
+  },
+  {
+    "gameIndex": 369,
+    "types": [{"name": "grass"}, {"name": "flying"}],
+    "name": "tropius",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/357.png"
+  },
+  {
+    "gameIndex": 411,
+    "types": [{"name": "psychic"}],
+    "name": "chimecho",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/358.png"
+  },
+  {
+    "gameIndex": 376,
+    "types": [{"name": "dark"}],
+    "name": "absol",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/359.png"
+  },
+  {
+    "gameIndex": 360,
+    "types": [{"name": "psychic"}],
+    "name": "wynaut",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/360.png"
+  },
+  {
+    "gameIndex": 346,
+    "types": [{"name": "ice"}],
+    "name": "snorunt",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/361.png"
+  },
+  {
+    "gameIndex": 347,
+    "types": [{"name": "ice"}],
+    "name": "glalie",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/362.png"
+  },
+  {
+    "gameIndex": 341,
+    "types": [{"name": "ice"}, {"name": "water"}],
+    "name": "spheal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/363.png"
+  },
+  {
+    "gameIndex": 342,
+    "types": [{"name": "ice"}, {"name": "water"}],
+    "name": "sealeo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/364.png"
+  },
+  {
+    "gameIndex": 343,
+    "types": [{"name": "ice"}, {"name": "water"}],
+    "name": "walrein",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/365.png"
+  },
+  {
+    "gameIndex": 373,
+    "types": [{"name": "water"}],
+    "name": "clamperl",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/366.png"
+  },
+  {
+    "gameIndex": 374,
+    "types": [{"name": "water"}],
+    "name": "huntail",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/367.png"
+  },
+  {
+    "gameIndex": 375,
+    "types": [{"name": "water"}],
+    "name": "gorebyss",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/368.png"
+  },
+  {
+    "gameIndex": 381,
+    "types": [{"name": "water"}, {"name": "rock"}],
+    "name": "relicanth",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/369.png"
+  },
+  {
+    "gameIndex": 325,
+    "types": [{"name": "water"}],
+    "name": "luvdisc",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/370.png"
+  },
+  {
+    "gameIndex": 395,
+    "types": [{"name": "dragon"}],
+    "name": "bagon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/371.png"
+  },
+  {
+    "gameIndex": 396,
+    "types": [{"name": "dragon"}],
+    "name": "shelgon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/372.png"
+  },
+  {
+    "gameIndex": 397,
+    "types": [{"name": "dragon"}, {"name": "flying"}],
+    "name": "salamence",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/373.png"
+  },
+  {
+    "gameIndex": 398,
+    "types": [{"name": "steel"}, {"name": "psychic"}],
+    "name": "beldum",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/374.png"
+  },
+  {
+    "gameIndex": 399,
+    "types": [{"name": "steel"}, {"name": "psychic"}],
+    "name": "metang",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/375.png"
+  },
+  {
+    "gameIndex": 400,
+    "types": [{"name": "steel"}, {"name": "psychic"}],
+    "name": "metagross",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/376.png"
+  },
+  {
+    "gameIndex": 401,
+    "types": [{"name": "rock"}],
+    "name": "regirock",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/377.png"
+  },
+  {
+    "gameIndex": 402,
+    "types": [{"name": "ice"}],
+    "name": "regice",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/378.png"
+  },
+  {
+    "gameIndex": 403,
+    "types": [{"name": "steel"}],
+    "name": "registeel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/379.png"
+  },
+  {
+    "gameIndex": 407,
+    "types": [{"name": "dragon"}, {"name": "psychic"}],
+    "name": "latias",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/380.png"
+  },
+  {
+    "gameIndex": 408,
+    "types": [{"name": "dragon"}, {"name": "psychic"}],
+    "name": "latios",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/381.png"
+  },
+  {
+    "gameIndex": 404,
+    "types": [{"name": "water"}],
+    "name": "kyogre",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/382.png"
+  },
+  {
+    "gameIndex": 405,
+    "types": [{"name": "ground"}],
+    "name": "groudon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/383.png"
+  },
+  {
+    "gameIndex": 406,
+    "types": [{"name": "dragon"}, {"name": "flying"}],
+    "name": "rayquaza",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/384.png"
+  },
+  {
+    "gameIndex": 409,
+    "types": [{"name": "steel"}, {"name": "psychic"}],
+    "name": "jirachi",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/385.png"
+  },
+  {
+    "gameIndex": 410,
+    "types": [{"name": "psychic"}],
+    "name": "deoxys-normal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/386.png"
+  },
+  {
+    "gameIndex": 387,
+    "types": [{"name": "grass"}],
+    "name": "turtwig",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/387.png"
+  },
+  {
+    "gameIndex": 388,
+    "types": [{"name": "grass"}],
+    "name": "grotle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/388.png"
+  },
+  {
+    "gameIndex": 389,
+    "types": [{"name": "grass"}, {"name": "ground"}],
+    "name": "torterra",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/389.png"
+  },
+  {
+    "gameIndex": 390,
+    "types": [{"name": "fire"}],
+    "name": "chimchar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/390.png"
+  },
+  {
+    "gameIndex": 391,
+    "types": [{"name": "fire"}, {"name": "fighting"}],
+    "name": "monferno",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/391.png"
+  },
+  {
+    "gameIndex": 392,
+    "types": [{"name": "fire"}, {"name": "fighting"}],
+    "name": "infernape",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/392.png"
+  },
+  {
+    "gameIndex": 393,
+    "types": [{"name": "water"}],
+    "name": "piplup",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/393.png"
+  },
+  {
+    "gameIndex": 394,
+    "types": [{"name": "water"}],
+    "name": "prinplup",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/394.png"
+  },
+  {
+    "gameIndex": 395,
+    "types": [{"name": "water"}, {"name": "steel"}],
+    "name": "empoleon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/395.png"
+  },
+  {
+    "gameIndex": 396,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "starly",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/396.png"
+  },
+  {
+    "gameIndex": 397,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "staravia",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/397.png"
+  },
+  {
+    "gameIndex": 398,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "staraptor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/398.png"
+  },
+  {
+    "gameIndex": 399,
+    "types": [{"name": "normal"}],
+    "name": "bidoof",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/399.png"
+  },
+  {
+    "gameIndex": 400,
+    "types": [{"name": "normal"}, {"name": "water"}],
+    "name": "bibarel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/400.png"
+  },
+  {
+    "gameIndex": 401,
+    "types": [{"name": "bug"}],
+    "name": "kricketot",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/401.png"
+  },
+  {
+    "gameIndex": 402,
+    "types": [{"name": "bug"}],
+    "name": "kricketune",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/402.png"
+  },
+  {
+    "gameIndex": 403,
+    "types": [{"name": "electric"}],
+    "name": "shinx",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/403.png"
+  },
+  {
+    "gameIndex": 404,
+    "types": [{"name": "electric"}],
+    "name": "luxio",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/404.png"
+  },
+  {
+    "gameIndex": 405,
+    "types": [{"name": "electric"}],
+    "name": "luxray",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/405.png"
+  },
+  {
+    "gameIndex": 406,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "budew",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/406.png"
+  },
+  {
+    "gameIndex": 407,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "roserade",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/407.png"
+  },
+  {
+    "gameIndex": 408,
+    "types": [{"name": "rock"}],
+    "name": "cranidos",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/408.png"
+  },
+  {
+    "gameIndex": 409,
+    "types": [{"name": "rock"}],
+    "name": "rampardos",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/409.png"
+  },
+  {
+    "gameIndex": 410,
+    "types": [{"name": "rock"}, {"name": "steel"}],
+    "name": "shieldon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/410.png"
+  },
+  {
+    "gameIndex": 411,
+    "types": [{"name": "rock"}, {"name": "steel"}],
+    "name": "bastiodon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/411.png"
+  },
+  {
+    "gameIndex": 412,
+    "types": [{"name": "bug"}],
+    "name": "burmy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/412.png"
+  },
+  {
+    "gameIndex": 413,
+    "types": [{"name": "bug"}, {"name": "grass"}],
+    "name": "wormadam-plant",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/413.png"
+  },
+  {
+    "gameIndex": 414,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "mothim",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/414.png"
+  },
+  {
+    "gameIndex": 415,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "combee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/415.png"
+  },
+  {
+    "gameIndex": 416,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "vespiquen",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/416.png"
+  },
+  {
+    "gameIndex": 417,
+    "types": [{"name": "electric"}],
+    "name": "pachirisu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/417.png"
+  },
+  {
+    "gameIndex": 418,
+    "types": [{"name": "water"}],
+    "name": "buizel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/418.png"
+  },
+  {
+    "gameIndex": 419,
+    "types": [{"name": "water"}],
+    "name": "floatzel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/419.png"
+  },
+  {
+    "gameIndex": 420,
+    "types": [{"name": "grass"}],
+    "name": "cherubi",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/420.png"
+  },
+  {
+    "gameIndex": 421,
+    "types": [{"name": "grass"}],
+    "name": "cherrim",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/421.png"
+  },
+  {
+    "gameIndex": 422,
+    "types": [{"name": "water"}],
+    "name": "shellos",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/422.png"
+  },
+  {
+    "gameIndex": 423,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "gastrodon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/423.png"
+  },
+  {
+    "gameIndex": 424,
+    "types": [{"name": "normal"}],
+    "name": "ambipom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/424.png"
+  },
+  {
+    "gameIndex": 425,
+    "types": [{"name": "ghost"}, {"name": "flying"}],
+    "name": "drifloon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/425.png"
+  },
+  {
+    "gameIndex": 426,
+    "types": [{"name": "ghost"}, {"name": "flying"}],
+    "name": "drifblim",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/426.png"
+  },
+  {
+    "gameIndex": 427,
+    "types": [{"name": "normal"}],
+    "name": "buneary",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/427.png"
+  },
+  {
+    "gameIndex": 428,
+    "types": [{"name": "normal"}],
+    "name": "lopunny",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/428.png"
+  },
+  {
+    "gameIndex": 429,
+    "types": [{"name": "ghost"}],
+    "name": "mismagius",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/429.png"
+  },
+  {
+    "gameIndex": 430,
+    "types": [{"name": "dark"}, {"name": "flying"}],
+    "name": "honchkrow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/430.png"
+  },
+  {
+    "gameIndex": 431,
+    "types": [{"name": "normal"}],
+    "name": "glameow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/431.png"
+  },
+  {
+    "gameIndex": 432,
+    "types": [{"name": "normal"}],
+    "name": "purugly",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/432.png"
+  },
+  {
+    "gameIndex": 433,
+    "types": [{"name": "psychic"}],
+    "name": "chingling",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/433.png"
+  },
+  {
+    "gameIndex": 434,
+    "types": [{"name": "poison"}, {"name": "dark"}],
+    "name": "stunky",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/434.png"
+  },
+  {
+    "gameIndex": 435,
+    "types": [{"name": "poison"}, {"name": "dark"}],
+    "name": "skuntank",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/435.png"
+  },
+  {
+    "gameIndex": 436,
+    "types": [{"name": "steel"}, {"name": "psychic"}],
+    "name": "bronzor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/436.png"
+  },
+  {
+    "gameIndex": 437,
+    "types": [{"name": "steel"}, {"name": "psychic"}],
+    "name": "bronzong",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/437.png"
+  },
+  {
+    "gameIndex": 438,
+    "types": [{"name": "rock"}],
+    "name": "bonsly",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/438.png"
+  },
+  {
+    "gameIndex": 439,
+    "types": [{"name": "psychic"}, {"name": "fairy"}],
+    "name": "mime-jr",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/439.png"
+  },
+  {
+    "gameIndex": 440,
+    "types": [{"name": "normal"}],
+    "name": "happiny",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/440.png"
+  },
+  {
+    "gameIndex": 441,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "chatot",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/441.png"
+  },
+  {
+    "gameIndex": 442,
+    "types": [{"name": "ghost"}, {"name": "dark"}],
+    "name": "spiritomb",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/442.png"
+  },
+  {
+    "gameIndex": 443,
+    "types": [{"name": "dragon"}, {"name": "ground"}],
+    "name": "gible",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/443.png"
+  },
+  {
+    "gameIndex": 444,
+    "types": [{"name": "dragon"}, {"name": "ground"}],
+    "name": "gabite",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/444.png"
+  },
+  {
+    "gameIndex": 445,
+    "types": [{"name": "dragon"}, {"name": "ground"}],
+    "name": "garchomp",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/445.png"
+  },
+  {
+    "gameIndex": 446,
+    "types": [{"name": "normal"}],
+    "name": "munchlax",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/446.png"
+  },
+  {
+    "gameIndex": 447,
+    "types": [{"name": "fighting"}],
+    "name": "riolu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/447.png"
+  },
+  {
+    "gameIndex": 448,
+    "types": [{"name": "fighting"}, {"name": "steel"}],
+    "name": "lucario",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/448.png"
+  },
+  {
+    "gameIndex": 449,
+    "types": [{"name": "ground"}],
+    "name": "hippopotas",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/449.png"
+  },
+  {
+    "gameIndex": 450,
+    "types": [{"name": "ground"}],
+    "name": "hippowdon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/450.png"
+  },
+  {
+    "gameIndex": 451,
+    "types": [{"name": "poison"}, {"name": "bug"}],
+    "name": "skorupi",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/451.png"
+  },
+  {
+    "gameIndex": 452,
+    "types": [{"name": "poison"}, {"name": "dark"}],
+    "name": "drapion",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/452.png"
+  },
+  {
+    "gameIndex": 453,
+    "types": [{"name": "poison"}, {"name": "fighting"}],
+    "name": "croagunk",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/453.png"
+  },
+  {
+    "gameIndex": 454,
+    "types": [{"name": "poison"}, {"name": "fighting"}],
+    "name": "toxicroak",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/454.png"
+  },
+  {
+    "gameIndex": 455,
+    "types": [{"name": "grass"}],
+    "name": "carnivine",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/455.png"
+  },
+  {
+    "gameIndex": 456,
+    "types": [{"name": "water"}],
+    "name": "finneon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/456.png"
+  },
+  {
+    "gameIndex": 457,
+    "types": [{"name": "water"}],
+    "name": "lumineon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/457.png"
+  },
+  {
+    "gameIndex": 458,
+    "types": [{"name": "water"}, {"name": "flying"}],
+    "name": "mantyke",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/458.png"
+  },
+  {
+    "gameIndex": 459,
+    "types": [{"name": "grass"}, {"name": "ice"}],
+    "name": "snover",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/459.png"
+  },
+  {
+    "gameIndex": 460,
+    "types": [{"name": "grass"}, {"name": "ice"}],
+    "name": "abomasnow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/460.png"
+  },
+  {
+    "gameIndex": 461,
+    "types": [{"name": "dark"}, {"name": "ice"}],
+    "name": "weavile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/461.png"
+  },
+  {
+    "gameIndex": 462,
+    "types": [{"name": "electric"}, {"name": "steel"}],
+    "name": "magnezone",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/462.png"
+  },
+  {
+    "gameIndex": 463,
+    "types": [{"name": "normal"}],
+    "name": "lickilicky",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/463.png"
+  },
+  {
+    "gameIndex": 464,
+    "types": [{"name": "ground"}, {"name": "rock"}],
+    "name": "rhyperior",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/464.png"
+  },
+  {
+    "gameIndex": 465,
+    "types": [{"name": "grass"}],
+    "name": "tangrowth",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/465.png"
+  },
+  {
+    "gameIndex": 466,
+    "types": [{"name": "electric"}],
+    "name": "electivire",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/466.png"
+  },
+  {
+    "gameIndex": 467,
+    "types": [{"name": "fire"}],
+    "name": "magmortar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/467.png"
+  },
+  {
+    "gameIndex": 468,
+    "types": [{"name": "fairy"}, {"name": "flying"}],
+    "name": "togekiss",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/468.png"
+  },
+  {
+    "gameIndex": 469,
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "yanmega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/469.png"
+  },
+  {
+    "gameIndex": 470,
+    "types": [{"name": "grass"}],
+    "name": "leafeon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/470.png"
+  },
+  {
+    "gameIndex": 471,
+    "types": [{"name": "ice"}],
+    "name": "glaceon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/471.png"
+  },
+  {
+    "gameIndex": 472,
+    "types": [{"name": "ground"}, {"name": "flying"}],
+    "name": "gliscor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/472.png"
+  },
+  {
+    "gameIndex": 473,
+    "types": [{"name": "ice"}, {"name": "ground"}],
+    "name": "mamoswine",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/473.png"
+  },
+  {
+    "gameIndex": 474,
+    "types": [{"name": "normal"}],
+    "name": "porygon-z",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/474.png"
+  },
+  {
+    "gameIndex": 475,
+    "types": [{"name": "psychic"}, {"name": "fighting"}],
+    "name": "gallade",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/475.png"
+  },
+  {
+    "gameIndex": 476,
+    "types": [{"name": "rock"}, {"name": "steel"}],
+    "name": "probopass",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/476.png"
+  },
+  {
+    "gameIndex": 477,
+    "types": [{"name": "ghost"}],
+    "name": "dusknoir",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/477.png"
+  },
+  {
+    "gameIndex": 478,
+    "types": [{"name": "ice"}, {"name": "ghost"}],
+    "name": "froslass",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/478.png"
+  },
+  {
+    "gameIndex": 479,
+    "types": [{"name": "electric"}, {"name": "ghost"}],
+    "name": "rotom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/479.png"
+  },
+  {
+    "gameIndex": 480,
+    "types": [{"name": "psychic"}],
+    "name": "uxie",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/480.png"
+  },
+  {
+    "gameIndex": 481,
+    "types": [{"name": "psychic"}],
+    "name": "mesprit",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/481.png"
+  },
+  {
+    "gameIndex": 482,
+    "types": [{"name": "psychic"}],
+    "name": "azelf",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/482.png"
+  },
+  {
+    "gameIndex": 483,
+    "types": [{"name": "steel"}, {"name": "dragon"}],
+    "name": "dialga",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/483.png"
+  },
+  {
+    "gameIndex": 484,
+    "types": [{"name": "water"}, {"name": "dragon"}],
+    "name": "palkia",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/484.png"
+  },
+  {
+    "gameIndex": 485,
+    "types": [{"name": "fire"}, {"name": "steel"}],
+    "name": "heatran",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/485.png"
+  },
+  {
+    "gameIndex": 486,
+    "types": [{"name": "normal"}],
+    "name": "regigigas",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/486.png"
+  },
+  {
+    "gameIndex": 487,
+    "types": [{"name": "ghost"}, {"name": "dragon"}],
+    "name": "giratina-altered",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/487.png"
+  },
+  {
+    "gameIndex": 488,
+    "types": [{"name": "psychic"}],
+    "name": "cresselia",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/488.png"
+  },
+  {
+    "gameIndex": 489,
+    "types": [{"name": "water"}],
+    "name": "phione",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/489.png"
+  },
+  {
+    "gameIndex": 490,
+    "types": [{"name": "water"}],
+    "name": "manaphy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/490.png"
+  },
+  {
+    "gameIndex": 491,
+    "types": [{"name": "dark"}],
+    "name": "darkrai",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/491.png"
+  },
+  {
+    "gameIndex": 492,
+    "types": [{"name": "grass"}],
+    "name": "shaymin-land",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/492.png"
+  },
+  {
+    "gameIndex": 493,
+    "types": [{"name": "normal"}],
+    "name": "arceus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/493.png"
+  },
+  {
+    "gameIndex": 494,
+    "types": [{"name": "psychic"}, {"name": "fire"}],
+    "name": "victini",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/494.png"
+  },
+  {
+    "gameIndex": 495,
+    "types": [{"name": "grass"}],
+    "name": "snivy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/495.png"
+  },
+  {
+    "gameIndex": 496,
+    "types": [{"name": "grass"}],
+    "name": "servine",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/496.png"
+  },
+  {
+    "gameIndex": 497,
+    "types": [{"name": "grass"}],
+    "name": "serperior",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/497.png"
+  },
+  {
+    "gameIndex": 498,
+    "types": [{"name": "fire"}],
+    "name": "tepig",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/498.png"
+  },
+  {
+    "gameIndex": 499,
+    "types": [{"name": "fire"}, {"name": "fighting"}],
+    "name": "pignite",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/499.png"
+  },
+  {
+    "gameIndex": 500,
+    "types": [{"name": "fire"}, {"name": "fighting"}],
+    "name": "emboar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/500.png"
+  },
+  {
+    "gameIndex": 501,
+    "types": [{"name": "water"}],
+    "name": "oshawott",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/501.png"
+  },
+  {
+    "gameIndex": 502,
+    "types": [{"name": "water"}],
+    "name": "dewott",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/502.png"
+  },
+  {
+    "gameIndex": 503,
+    "types": [{"name": "water"}],
+    "name": "samurott",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/503.png"
+  },
+  {
+    "gameIndex": 504,
+    "types": [{"name": "normal"}],
+    "name": "patrat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/504.png"
+  },
+  {
+    "gameIndex": 505,
+    "types": [{"name": "normal"}],
+    "name": "watchog",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/505.png"
+  },
+  {
+    "gameIndex": 506,
+    "types": [{"name": "normal"}],
+    "name": "lillipup",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/506.png"
+  },
+  {
+    "gameIndex": 507,
+    "types": [{"name": "normal"}],
+    "name": "herdier",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/507.png"
+  },
+  {
+    "gameIndex": 508,
+    "types": [{"name": "normal"}],
+    "name": "stoutland",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/508.png"
+  },
+  {
+    "gameIndex": 509,
+    "types": [{"name": "dark"}],
+    "name": "purrloin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/509.png"
+  },
+  {
+    "gameIndex": 510,
+    "types": [{"name": "dark"}],
+    "name": "liepard",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/510.png"
+  },
+  {
+    "gameIndex": 511,
+    "types": [{"name": "grass"}],
+    "name": "pansage",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/511.png"
+  },
+  {
+    "gameIndex": 512,
+    "types": [{"name": "grass"}],
+    "name": "simisage",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/512.png"
+  },
+  {
+    "gameIndex": 513,
+    "types": [{"name": "fire"}],
+    "name": "pansear",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/513.png"
+  },
+  {
+    "gameIndex": 514,
+    "types": [{"name": "fire"}],
+    "name": "simisear",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/514.png"
+  },
+  {
+    "gameIndex": 515,
+    "types": [{"name": "water"}],
+    "name": "panpour",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/515.png"
+  },
+  {
+    "gameIndex": 516,
+    "types": [{"name": "water"}],
+    "name": "simipour",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/516.png"
+  },
+  {
+    "gameIndex": 517,
+    "types": [{"name": "psychic"}],
+    "name": "munna",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/517.png"
+  },
+  {
+    "gameIndex": 518,
+    "types": [{"name": "psychic"}],
+    "name": "musharna",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/518.png"
+  },
+  {
+    "gameIndex": 519,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "pidove",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/519.png"
+  },
+  {
+    "gameIndex": 520,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "tranquill",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/520.png"
+  },
+  {
+    "gameIndex": 521,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "unfezant",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/521.png"
+  },
+  {
+    "gameIndex": 522,
+    "types": [{"name": "electric"}],
+    "name": "blitzle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/522.png"
+  },
+  {
+    "gameIndex": 523,
+    "types": [{"name": "electric"}],
+    "name": "zebstrika",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/523.png"
+  },
+  {
+    "gameIndex": 524,
+    "types": [{"name": "rock"}],
+    "name": "roggenrola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/524.png"
+  },
+  {
+    "gameIndex": 525,
+    "types": [{"name": "rock"}],
+    "name": "boldore",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/525.png"
+  },
+  {
+    "gameIndex": 526,
+    "types": [{"name": "rock"}],
+    "name": "gigalith",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/526.png"
+  },
+  {
+    "gameIndex": 527,
+    "types": [{"name": "psychic"}, {"name": "flying"}],
+    "name": "woobat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/527.png"
+  },
+  {
+    "gameIndex": 528,
+    "types": [{"name": "psychic"}, {"name": "flying"}],
+    "name": "swoobat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/528.png"
+  },
+  {
+    "gameIndex": 529,
+    "types": [{"name": "ground"}],
+    "name": "drilbur",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/529.png"
+  },
+  {
+    "gameIndex": 530,
+    "types": [{"name": "ground"}, {"name": "steel"}],
+    "name": "excadrill",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/530.png"
+  },
+  {
+    "gameIndex": 531,
+    "types": [{"name": "normal"}],
+    "name": "audino",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/531.png"
+  },
+  {
+    "gameIndex": 532,
+    "types": [{"name": "fighting"}],
+    "name": "timburr",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/532.png"
+  },
+  {
+    "gameIndex": 533,
+    "types": [{"name": "fighting"}],
+    "name": "gurdurr",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/533.png"
+  },
+  {
+    "gameIndex": 534,
+    "types": [{"name": "fighting"}],
+    "name": "conkeldurr",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/534.png"
+  },
+  {
+    "gameIndex": 535,
+    "types": [{"name": "water"}],
+    "name": "tympole",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/535.png"
+  },
+  {
+    "gameIndex": 536,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "palpitoad",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/536.png"
+  },
+  {
+    "gameIndex": 537,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "seismitoad",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/537.png"
+  },
+  {
+    "gameIndex": 538,
+    "types": [{"name": "fighting"}],
+    "name": "throh",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/538.png"
+  },
+  {
+    "gameIndex": 539,
+    "types": [{"name": "fighting"}],
+    "name": "sawk",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/539.png"
+  },
+  {
+    "gameIndex": 540,
+    "types": [{"name": "bug"}, {"name": "grass"}],
+    "name": "sewaddle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/540.png"
+  },
+  {
+    "gameIndex": 541,
+    "types": [{"name": "bug"}, {"name": "grass"}],
+    "name": "swadloon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/541.png"
+  },
+  {
+    "gameIndex": 542,
+    "types": [{"name": "bug"}, {"name": "grass"}],
+    "name": "leavanny",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/542.png"
+  },
+  {
+    "gameIndex": 543,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "venipede",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/543.png"
+  },
+  {
+    "gameIndex": 544,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "whirlipede",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/544.png"
+  },
+  {
+    "gameIndex": 545,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "scolipede",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/545.png"
+  },
+  {
+    "gameIndex": 546,
+    "types": [{"name": "grass"}, {"name": "fairy"}],
+    "name": "cottonee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/546.png"
+  },
+  {
+    "gameIndex": 547,
+    "types": [{"name": "grass"}, {"name": "fairy"}],
+    "name": "whimsicott",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/547.png"
+  },
+  {
+    "gameIndex": 548,
+    "types": [{"name": "grass"}],
+    "name": "petilil",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/548.png"
+  },
+  {
+    "gameIndex": 549,
+    "types": [{"name": "grass"}],
+    "name": "lilligant",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/549.png"
+  },
+  {
+    "gameIndex": 550,
+    "types": [{"name": "water"}],
+    "name": "basculin-red-striped",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/550.png"
+  },
+  {
+    "gameIndex": 551,
+    "types": [{"name": "ground"}, {"name": "dark"}],
+    "name": "sandile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/551.png"
+  },
+  {
+    "gameIndex": 552,
+    "types": [{"name": "ground"}, {"name": "dark"}],
+    "name": "krokorok",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/552.png"
+  },
+  {
+    "gameIndex": 553,
+    "types": [{"name": "ground"}, {"name": "dark"}],
+    "name": "krookodile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/553.png"
+  },
+  {
+    "gameIndex": 554,
+    "types": [{"name": "fire"}],
+    "name": "darumaka",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/554.png"
+  },
+  {
+    "gameIndex": 555,
+    "types": [{"name": "fire"}],
+    "name": "darmanitan-standard",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/555.png"
+  },
+  {
+    "gameIndex": 556,
+    "types": [{"name": "grass"}],
+    "name": "maractus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/556.png"
+  },
+  {
+    "gameIndex": 557,
+    "types": [{"name": "bug"}, {"name": "rock"}],
+    "name": "dwebble",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/557.png"
+  },
+  {
+    "gameIndex": 558,
+    "types": [{"name": "bug"}, {"name": "rock"}],
+    "name": "crustle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/558.png"
+  },
+  {
+    "gameIndex": 559,
+    "types": [{"name": "dark"}, {"name": "fighting"}],
+    "name": "scraggy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/559.png"
+  },
+  {
+    "gameIndex": 560,
+    "types": [{"name": "dark"}, {"name": "fighting"}],
+    "name": "scrafty",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/560.png"
+  },
+  {
+    "gameIndex": 561,
+    "types": [{"name": "psychic"}, {"name": "flying"}],
+    "name": "sigilyph",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/561.png"
+  },
+  {
+    "gameIndex": 562,
+    "types": [{"name": "ghost"}],
+    "name": "yamask",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/562.png"
+  },
+  {
+    "gameIndex": 563,
+    "types": [{"name": "ghost"}],
+    "name": "cofagrigus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/563.png"
+  },
+  {
+    "gameIndex": 564,
+    "types": [{"name": "water"}, {"name": "rock"}],
+    "name": "tirtouga",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/564.png"
+  },
+  {
+    "gameIndex": 565,
+    "types": [{"name": "water"}, {"name": "rock"}],
+    "name": "carracosta",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/565.png"
+  },
+  {
+    "gameIndex": 566,
+    "types": [{"name": "rock"}, {"name": "flying"}],
+    "name": "archen",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/566.png"
+  },
+  {
+    "gameIndex": 567,
+    "types": [{"name": "rock"}, {"name": "flying"}],
+    "name": "archeops",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/567.png"
+  },
+  {
+    "gameIndex": 568,
+    "types": [{"name": "poison"}],
+    "name": "trubbish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/568.png"
+  },
+  {
+    "gameIndex": 569,
+    "types": [{"name": "poison"}],
+    "name": "garbodor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/569.png"
+  },
+  {
+    "gameIndex": 570,
+    "types": [{"name": "dark"}],
+    "name": "zorua",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/570.png"
+  },
+  {
+    "gameIndex": 571,
+    "types": [{"name": "dark"}],
+    "name": "zoroark",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/571.png"
+  },
+  {
+    "gameIndex": 572,
+    "types": [{"name": "normal"}],
+    "name": "minccino",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/572.png"
+  },
+  {
+    "gameIndex": 573,
+    "types": [{"name": "normal"}],
+    "name": "cinccino",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/573.png"
+  },
+  {
+    "gameIndex": 574,
+    "types": [{"name": "psychic"}],
+    "name": "gothita",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/574.png"
+  },
+  {
+    "gameIndex": 575,
+    "types": [{"name": "psychic"}],
+    "name": "gothorita",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/575.png"
+  },
+  {
+    "gameIndex": 576,
+    "types": [{"name": "psychic"}],
+    "name": "gothitelle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/576.png"
+  },
+  {
+    "gameIndex": 577,
+    "types": [{"name": "psychic"}],
+    "name": "solosis",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/577.png"
+  },
+  {
+    "gameIndex": 578,
+    "types": [{"name": "psychic"}],
+    "name": "duosion",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/578.png"
+  },
+  {
+    "gameIndex": 579,
+    "types": [{"name": "psychic"}],
+    "name": "reuniclus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/579.png"
+  },
+  {
+    "gameIndex": 580,
+    "types": [{"name": "water"}, {"name": "flying"}],
+    "name": "ducklett",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/580.png"
+  },
+  {
+    "gameIndex": 581,
+    "types": [{"name": "water"}, {"name": "flying"}],
+    "name": "swanna",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/581.png"
+  },
+  {
+    "gameIndex": 582,
+    "types": [{"name": "ice"}],
+    "name": "vanillite",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/582.png"
+  },
+  {
+    "gameIndex": 583,
+    "types": [{"name": "ice"}],
+    "name": "vanillish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/583.png"
+  },
+  {
+    "gameIndex": 584,
+    "types": [{"name": "ice"}],
+    "name": "vanilluxe",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/584.png"
+  },
+  {
+    "gameIndex": 585,
+    "types": [{"name": "normal"}, {"name": "grass"}],
+    "name": "deerling",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/585.png"
+  },
+  {
+    "gameIndex": 586,
+    "types": [{"name": "normal"}, {"name": "grass"}],
+    "name": "sawsbuck",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/586.png"
+  },
+  {
+    "gameIndex": 587,
+    "types": [{"name": "electric"}, {"name": "flying"}],
+    "name": "emolga",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/587.png"
+  },
+  {
+    "gameIndex": 588,
+    "types": [{"name": "bug"}],
+    "name": "karrablast",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/588.png"
+  },
+  {
+    "gameIndex": 589,
+    "types": [{"name": "bug"}, {"name": "steel"}],
+    "name": "escavalier",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/589.png"
+  },
+  {
+    "gameIndex": 590,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "foongus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/590.png"
+  },
+  {
+    "gameIndex": 591,
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "amoonguss",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/591.png"
+  },
+  {
+    "gameIndex": 592,
+    "types": [{"name": "water"}, {"name": "ghost"}],
+    "name": "frillish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/592.png"
+  },
+  {
+    "gameIndex": 593,
+    "types": [{"name": "water"}, {"name": "ghost"}],
+    "name": "jellicent",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/593.png"
+  },
+  {
+    "gameIndex": 594,
+    "types": [{"name": "water"}],
+    "name": "alomomola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/594.png"
+  },
+  {
+    "gameIndex": 595,
+    "types": [{"name": "bug"}, {"name": "electric"}],
+    "name": "joltik",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/595.png"
+  },
+  {
+    "gameIndex": 596,
+    "types": [{"name": "bug"}, {"name": "electric"}],
+    "name": "galvantula",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/596.png"
+  },
+  {
+    "gameIndex": 597,
+    "types": [{"name": "grass"}, {"name": "steel"}],
+    "name": "ferroseed",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/597.png"
+  },
+  {
+    "gameIndex": 598,
+    "types": [{"name": "grass"}, {"name": "steel"}],
+    "name": "ferrothorn",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/598.png"
+  },
+  {
+    "gameIndex": 599,
+    "types": [{"name": "steel"}],
+    "name": "klink",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/599.png"
+  },
+  {
+    "gameIndex": 600,
+    "types": [{"name": "steel"}],
+    "name": "klang",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/600.png"
+  },
+  {
+    "gameIndex": 601,
+    "types": [{"name": "steel"}],
+    "name": "klinklang",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/601.png"
+  },
+  {
+    "gameIndex": 602,
+    "types": [{"name": "electric"}],
+    "name": "tynamo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/602.png"
+  },
+  {
+    "gameIndex": 603,
+    "types": [{"name": "electric"}],
+    "name": "eelektrik",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/603.png"
+  },
+  {
+    "gameIndex": 604,
+    "types": [{"name": "electric"}],
+    "name": "eelektross",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/604.png"
+  },
+  {
+    "gameIndex": 605,
+    "types": [{"name": "psychic"}],
+    "name": "elgyem",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/605.png"
+  },
+  {
+    "gameIndex": 606,
+    "types": [{"name": "psychic"}],
+    "name": "beheeyem",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/606.png"
+  },
+  {
+    "gameIndex": 607,
+    "types": [{"name": "ghost"}, {"name": "fire"}],
+    "name": "litwick",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/607.png"
+  },
+  {
+    "gameIndex": 608,
+    "types": [{"name": "ghost"}, {"name": "fire"}],
+    "name": "lampent",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/608.png"
+  },
+  {
+    "gameIndex": 609,
+    "types": [{"name": "ghost"}, {"name": "fire"}],
+    "name": "chandelure",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/609.png"
+  },
+  {
+    "gameIndex": 610,
+    "types": [{"name": "dragon"}],
+    "name": "axew",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/610.png"
+  },
+  {
+    "gameIndex": 611,
+    "types": [{"name": "dragon"}],
+    "name": "fraxure",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/611.png"
+  },
+  {
+    "gameIndex": 612,
+    "types": [{"name": "dragon"}],
+    "name": "haxorus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/612.png"
+  },
+  {
+    "gameIndex": 613,
+    "types": [{"name": "ice"}],
+    "name": "cubchoo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/613.png"
+  },
+  {
+    "gameIndex": 614,
+    "types": [{"name": "ice"}],
+    "name": "beartic",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/614.png"
+  },
+  {
+    "gameIndex": 615,
+    "types": [{"name": "ice"}],
+    "name": "cryogonal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/615.png"
+  },
+  {
+    "gameIndex": 616,
+    "types": [{"name": "bug"}],
+    "name": "shelmet",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/616.png"
+  },
+  {
+    "gameIndex": 617,
+    "types": [{"name": "bug"}],
+    "name": "accelgor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/617.png"
+  },
+  {
+    "gameIndex": 618,
+    "types": [{"name": "ground"}, {"name": "electric"}],
+    "name": "stunfisk",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/618.png"
+  },
+  {
+    "gameIndex": 619,
+    "types": [{"name": "fighting"}],
+    "name": "mienfoo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/619.png"
+  },
+  {
+    "gameIndex": 620,
+    "types": [{"name": "fighting"}],
+    "name": "mienshao",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/620.png"
+  },
+  {
+    "gameIndex": 621,
+    "types": [{"name": "dragon"}],
+    "name": "druddigon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/621.png"
+  },
+  {
+    "gameIndex": 622,
+    "types": [{"name": "ground"}, {"name": "ghost"}],
+    "name": "golett",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/622.png"
+  },
+  {
+    "gameIndex": 623,
+    "types": [{"name": "ground"}, {"name": "ghost"}],
+    "name": "golurk",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/623.png"
+  },
+  {
+    "gameIndex": 624,
+    "types": [{"name": "dark"}, {"name": "steel"}],
+    "name": "pawniard",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/624.png"
+  },
+  {
+    "gameIndex": 625,
+    "types": [{"name": "dark"}, {"name": "steel"}],
+    "name": "bisharp",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/625.png"
+  },
+  {
+    "gameIndex": 626,
+    "types": [{"name": "normal"}],
+    "name": "bouffalant",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/626.png"
+  },
+  {
+    "gameIndex": 627,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "rufflet",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/627.png"
+  },
+  {
+    "gameIndex": 628,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "braviary",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/628.png"
+  },
+  {
+    "gameIndex": 629,
+    "types": [{"name": "dark"}, {"name": "flying"}],
+    "name": "vullaby",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/629.png"
+  },
+  {
+    "gameIndex": 630,
+    "types": [{"name": "dark"}, {"name": "flying"}],
+    "name": "mandibuzz",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/630.png"
+  },
+  {
+    "gameIndex": 631,
+    "types": [{"name": "fire"}],
+    "name": "heatmor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/631.png"
+  },
+  {
+    "gameIndex": 632,
+    "types": [{"name": "bug"}, {"name": "steel"}],
+    "name": "durant",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/632.png"
+  },
+  {
+    "gameIndex": 633,
+    "types": [{"name": "dark"}, {"name": "dragon"}],
+    "name": "deino",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/633.png"
+  },
+  {
+    "gameIndex": 634,
+    "types": [{"name": "dark"}, {"name": "dragon"}],
+    "name": "zweilous",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/634.png"
+  },
+  {
+    "gameIndex": 635,
+    "types": [{"name": "dark"}, {"name": "dragon"}],
+    "name": "hydreigon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/635.png"
+  },
+  {
+    "gameIndex": 636,
+    "types": [{"name": "bug"}, {"name": "fire"}],
+    "name": "larvesta",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/636.png"
+  },
+  {
+    "gameIndex": 637,
+    "types": [{"name": "bug"}, {"name": "fire"}],
+    "name": "volcarona",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/637.png"
+  },
+  {
+    "gameIndex": 638,
+    "types": [{"name": "steel"}, {"name": "fighting"}],
+    "name": "cobalion",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/638.png"
+  },
+  {
+    "gameIndex": 639,
+    "types": [{"name": "rock"}, {"name": "fighting"}],
+    "name": "terrakion",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/639.png"
+  },
+  {
+    "gameIndex": 640,
+    "types": [{"name": "grass"}, {"name": "fighting"}],
+    "name": "virizion",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/640.png"
+  },
+  {
+    "gameIndex": 641,
+    "types": [{"name": "flying"}],
+    "name": "tornadus-incarnate",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/641.png"
+  },
+  {
+    "gameIndex": 642,
+    "types": [{"name": "electric"}, {"name": "flying"}],
+    "name": "thundurus-incarnate",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/642.png"
+  },
+  {
+    "gameIndex": 643,
+    "types": [{"name": "dragon"}, {"name": "fire"}],
+    "name": "reshiram",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/643.png"
+  },
+  {
+    "gameIndex": 644,
+    "types": [{"name": "dragon"}, {"name": "electric"}],
+    "name": "zekrom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/644.png"
+  },
+  {
+    "gameIndex": 645,
+    "types": [{"name": "ground"}, {"name": "flying"}],
+    "name": "landorus-incarnate",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/645.png"
+  },
+  {
+    "gameIndex": 646,
+    "types": [{"name": "dragon"}, {"name": "ice"}],
+    "name": "kyurem",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/646.png"
+  },
+  {
+    "gameIndex": 647,
+    "types": [{"name": "water"}, {"name": "fighting"}],
+    "name": "keldeo-ordinary",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/647.png"
+  },
+  {
+    "gameIndex": 648,
+    "types": [{"name": "normal"}, {"name": "psychic"}],
+    "name": "meloetta-aria",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/648.png"
+  },
+  {
+    "gameIndex": 649,
+    "types": [{"name": "bug"}, {"name": "steel"}],
+    "name": "genesect",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/649.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "chespin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/650.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "quilladin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/651.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "fighting"}],
+    "name": "chesnaught",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/652.png"
+  },
+  {
+    "types": [{"name": "fire"}],
+    "name": "fennekin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/653.png"
+  },
+  {
+    "types": [{"name": "fire"}],
+    "name": "braixen",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/654.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "psychic"}],
+    "name": "delphox",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/655.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "froakie",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/656.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "frogadier",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/657.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "dark"}],
+    "name": "greninja",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/658.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "bunnelby",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/659.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "ground"}],
+    "name": "diggersby",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/660.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "fletchling",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/661.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "flying"}],
+    "name": "fletchinder",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/662.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "flying"}],
+    "name": "talonflame",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/663.png"
+  },
+  {
+    "types": [{"name": "bug"}],
+    "name": "scatterbug",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/664.png"
+  },
+  {
+    "types": [{"name": "bug"}],
+    "name": "spewpa",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/665.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "vivillon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/666.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "normal"}],
+    "name": "litleo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/667.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "normal"}],
+    "name": "pyroar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/668.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "flabebe",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/669.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "floette",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/670.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "florges",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/671.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "skiddo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/672.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "gogoat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/673.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "pancham",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/674.png"
+  },
+  {
+    "types": [{"name": "fighting"}, {"name": "dark"}],
+    "name": "pangoro",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/675.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "furfrou",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/676.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "espurr",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/677.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "meowstic-male",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/678.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "ghost"}],
+    "name": "honedge",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/679.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "ghost"}],
+    "name": "doublade",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/680.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "ghost"}],
+    "name": "aegislash-shield",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/681.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "spritzee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/682.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "aromatisse",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/683.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "swirlix",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/684.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "slurpuff",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/685.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "psychic"}],
+    "name": "inkay",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/686.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "psychic"}],
+    "name": "malamar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/687.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "water"}],
+    "name": "binacle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/688.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "water"}],
+    "name": "barbaracle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/689.png"
+  },
+  {
+    "types": [{"name": "poison"}, {"name": "water"}],
+    "name": "skrelp",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/690.png"
+  },
+  {
+    "types": [{"name": "poison"}, {"name": "dragon"}],
+    "name": "dragalge",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/691.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "clauncher",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/692.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "clawitzer",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/693.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "normal"}],
+    "name": "helioptile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/694.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "normal"}],
+    "name": "heliolisk",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/695.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "dragon"}],
+    "name": "tyrunt",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/696.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "dragon"}],
+    "name": "tyrantrum",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/697.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "ice"}],
+    "name": "amaura",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/698.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "ice"}],
+    "name": "aurorus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/699.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "sylveon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/700.png"
+  },
+  {
+    "types": [{"name": "fighting"}, {"name": "flying"}],
+    "name": "hawlucha",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/701.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "fairy"}],
+    "name": "dedenne",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/702.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "fairy"}],
+    "name": "carbink",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/703.png"
+  },
+  {
+    "types": [{"name": "dragon"}],
+    "name": "goomy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/704.png"
+  },
+  {
+    "types": [{"name": "dragon"}],
+    "name": "sliggoo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/705.png"
+  },
+  {
+    "types": [{"name": "dragon"}],
+    "name": "goodra",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/706.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "fairy"}],
+    "name": "klefki",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/707.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "phantump",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/708.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "trevenant",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/709.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "pumpkaboo-average",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/710.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "gourgeist-average",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/711.png"
+  },
+  {
+    "types": [{"name": "ice"}],
+    "name": "bergmite",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/712.png"
+  },
+  {
+    "types": [{"name": "ice"}],
+    "name": "avalugg",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/713.png"
+  },
+  {
+    "types": [{"name": "flying"}, {"name": "dragon"}],
+    "name": "noibat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/714.png"
+  },
+  {
+    "types": [{"name": "flying"}, {"name": "dragon"}],
+    "name": "noivern",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/715.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "xerneas",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/716.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "flying"}],
+    "name": "yveltal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/717.png"
+  },
+  {
+    "types": [{"name": "dragon"}, {"name": "ground"}],
+    "name": "zygarde-50",
+    "imageUrl": null
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "fairy"}],
+    "name": "diancie",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/719.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "ghost"}],
+    "name": "hoopa",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/720.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "water"}],
+    "name": "volcanion",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/721.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "flying"}],
+    "name": "rowlet",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/722.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "flying"}],
+    "name": "dartrix",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/723.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "ghost"}],
+    "name": "decidueye",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/724.png"
+  },
+  {
+    "types": [{"name": "fire"}],
+    "name": "litten",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/725.png"
+  },
+  {
+    "types": [{"name": "fire"}],
+    "name": "torracat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/726.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "dark"}],
+    "name": "incineroar",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/727.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "popplio",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/728.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "brionne",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/729.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "fairy"}],
+    "name": "primarina",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/730.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "pikipek",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/731.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "trumbeak",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/732.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "toucannon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/733.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "yungoos",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/734.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "gumshoos",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/735.png"
+  },
+  {
+    "types": [{"name": "bug"}],
+    "name": "grubbin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/736.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "electric"}],
+    "name": "charjabug",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/737.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "electric"}],
+    "name": "vikavolt",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/738.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "crabrawler",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/739.png"
+  },
+  {
+    "types": [{"name": "fighting"}, {"name": "ice"}],
+    "name": "crabominable",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/740.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "flying"}],
+    "name": "oricorio-baile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/741.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "fairy"}],
+    "name": "cutiefly",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/742.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "fairy"}],
+    "name": "ribombee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/743.png"
+  },
+  {
+    "types": [{"name": "rock"}],
+    "name": "rockruff",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/744.png"
+  },
+  {
+    "types": [{"name": "rock"}],
+    "name": "lycanroc-midday",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/745.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "wishiwashi-solo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/746.png"
+  },
+  {
+    "types": [{"name": "poison"}, {"name": "water"}],
+    "name": "mareanie",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/747.png"
+  },
+  {
+    "types": [{"name": "poison"}, {"name": "water"}],
+    "name": "toxapex",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/748.png"
+  },
+  {
+    "types": [{"name": "ground"}],
+    "name": "mudbray",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/749.png"
+  },
+  {
+    "types": [{"name": "ground"}],
+    "name": "mudsdale",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/750.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "bug"}],
+    "name": "dewpider",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/751.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "bug"}],
+    "name": "araquanid",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/752.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "fomantis",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/753.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "lurantis",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/754.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "fairy"}],
+    "name": "morelull",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/755.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "fairy"}],
+    "name": "shiinotic",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/756.png"
+  },
+  {
+    "types": [{"name": "poison"}, {"name": "fire"}],
+    "name": "salandit",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/757.png"
+  },
+  {
+    "types": [{"name": "poison"}, {"name": "fire"}],
+    "name": "salazzle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/758.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "fighting"}],
+    "name": "stufful",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/759.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "fighting"}],
+    "name": "bewear",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/760.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "bounsweet",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/761.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "steenee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/762.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "tsareena",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/763.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "comfey",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/764.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "psychic"}],
+    "name": "oranguru",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/765.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "passimian",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/766.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "water"}],
+    "name": "wimpod",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/767.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "water"}],
+    "name": "golisopod",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/768.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "ground"}],
+    "name": "sandygast",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/769.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "ground"}],
+    "name": "palossand",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/770.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "pyukumuku",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/771.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "type-null",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/772.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "silvally",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/773.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "flying"}],
+    "name": "minior-red-meteor",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/774.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "komala",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/775.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "dragon"}],
+    "name": "turtonator",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/776.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "steel"}],
+    "name": "togedemaru",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/777.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "fairy"}],
+    "name": "mimikyu-disguised",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/778.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "psychic"}],
+    "name": "bruxish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/779.png"
+  },
+  {
+    "types": [{"name": "normal"}, {"name": "dragon"}],
+    "name": "drampa",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/780.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "dhelmise",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/781.png"
+  },
+  {
+    "types": [{"name": "dragon"}],
+    "name": "jangmo-o",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/782.png"
+  },
+  {
+    "types": [{"name": "dragon"}, {"name": "fighting"}],
+    "name": "hakamo-o",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/783.png"
+  },
+  {
+    "types": [{"name": "dragon"}, {"name": "fighting"}],
+    "name": "kommo-o",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/784.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "fairy"}],
+    "name": "tapu-koko",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/785.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "fairy"}],
+    "name": "tapu-lele",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/786.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "fairy"}],
+    "name": "tapu-bulu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/787.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "fairy"}],
+    "name": "tapu-fini",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/788.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "cosmog",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/789.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "cosmoem",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/790.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "steel"}],
+    "name": "solgaleo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/791.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "ghost"}],
+    "name": "lunala",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/792.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "poison"}],
+    "name": "nihilego",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/793.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "fighting"}],
+    "name": "buzzwole",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/794.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "fighting"}],
+    "name": "pheromosa",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/795.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "xurkitree",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/796.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "flying"}],
+    "name": "celesteela",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/797.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "steel"}],
+    "name": "kartana",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/798.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "dragon"}],
+    "name": "guzzlord",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/799.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "necrozma",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/800.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "fairy"}],
+    "name": "magearna",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/801.png"
+  },
+  {
+    "types": [{"name": "fighting"}, {"name": "ghost"}],
+    "name": "marshadow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/802.png"
+  },
+  {
+    "types": [{"name": "poison"}],
+    "name": "poipole",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/803.png"
+  },
+  {
+    "types": [{"name": "poison"}, {"name": "dragon"}],
+    "name": "naganadel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/804.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "steel"}],
+    "name": "stakataka",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/805.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "ghost"}],
+    "name": "blacephalon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/806.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "zeraora",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/807.png"
+  },
+  {
+    "types": [{"name": "steel"}],
+    "name": "meltan",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/808.png"
+  },
+  {
+    "types": [{"name": "steel"}],
+    "name": "melmetal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/809.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "grookey",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/810.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "thwackey",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/811.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "rillaboom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/812.png"
+  },
+  {
+    "types": [{"name": "fire"}],
+    "name": "scorbunny",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/813.png"
+  },
+  {
+    "types": [{"name": "fire"}],
+    "name": "raboot",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/814.png"
+  },
+  {
+    "types": [{"name": "fire"}],
+    "name": "cinderace",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/815.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "sobble",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/816.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "drizzile",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/817.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "inteleon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/818.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "skwovet",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/819.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "greedent",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/820.png"
+  },
+  {
+    "types": [{"name": "flying"}],
+    "name": "rookidee",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/821.png"
+  },
+  {
+    "types": [{"name": "flying"}],
+    "name": "corvisquire",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/822.png"
+  },
+  {
+    "types": [{"name": "flying"}, {"name": "steel"}],
+    "name": "corviknight",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/823.png"
+  },
+  {
+    "types": [{"name": "bug"}],
+    "name": "blipbug",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/824.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "psychic"}],
+    "name": "dottler",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/825.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "psychic"}],
+    "name": "orbeetle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/826.png"
+  },
+  {
+    "types": [{"name": "dark"}],
+    "name": "nickit",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/827.png"
+  },
+  {
+    "types": [{"name": "dark"}],
+    "name": "thievul",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/828.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "gossifleur",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/829.png"
+  },
+  {
+    "types": [{"name": "grass"}],
+    "name": "eldegoss",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/830.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "wooloo",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/831.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "dubwool",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/832.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "chewtle",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/833.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "rock"}],
+    "name": "drednaw",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/834.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "yamper",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/835.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "boltund",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/836.png"
+  },
+  {
+    "types": [{"name": "rock"}],
+    "name": "rolycoly",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/837.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "fire"}],
+    "name": "carkol",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/838.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "fire"}],
+    "name": "coalossal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/839.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "dragon"}],
+    "name": "applin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/840.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "dragon"}],
+    "name": "flapple",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/841.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "dragon"}],
+    "name": "appletun",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/842.png"
+  },
+  {
+    "types": [{"name": "ground"}],
+    "name": "silicobra",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/843.png"
+  },
+  {
+    "types": [{"name": "ground"}],
+    "name": "sandaconda",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/844.png"
+  },
+  {
+    "types": [{"name": "flying"}, {"name": "water"}],
+    "name": "cramorant",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/845.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "arrokuda",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/846.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "barraskewda",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/847.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "poison"}],
+    "name": "toxel",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/848.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "poison"}],
+    "name": "toxtricity-amped",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/849.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "bug"}],
+    "name": "sizzlipede",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/850.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "bug"}],
+    "name": "centiskorch",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/851.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "clobbopus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/852.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "grapploct",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/853.png"
+  },
+  {
+    "types": [{"name": "ghost"}],
+    "name": "sinistea",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/854.png"
+  },
+  {
+    "types": [{"name": "ghost"}],
+    "name": "polteageist",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/855.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "hatenna",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/856.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "hattrem",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/857.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "fairy"}],
+    "name": "hatterene",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/858.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "fairy"}],
+    "name": "impidimp",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/859.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "fairy"}],
+    "name": "morgrem",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/860.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "fairy"}],
+    "name": "grimmsnarl",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/861.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "normal"}],
+    "name": "obstagoon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/862.png"
+  },
+  {
+    "types": [{"name": "steel"}],
+    "name": "perrserker",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/863.png"
+  },
+  {
+    "types": [{"name": "ghost"}],
+    "name": "cursola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/864.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "sirfetchd",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/865.png"
+  },
+  {
+    "types": [{"name": "ice"}, {"name": "psychic"}],
+    "name": "mr-rime",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/866.png"
+  },
+  {
+    "types": [{"name": "ground"}, {"name": "ghost"}],
+    "name": "runerigus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/867.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "milcery",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/868.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "alcremie",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/869.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "falinks",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/870.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "pincurchin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/871.png"
+  },
+  {
+    "types": [{"name": "ice"}, {"name": "bug"}],
+    "name": "snom",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/872.png"
+  },
+  {
+    "types": [{"name": "ice"}, {"name": "bug"}],
+    "name": "frosmoth",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/873.png"
+  },
+  {
+    "types": [{"name": "rock"}],
+    "name": "stonjourner",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/874.png"
+  },
+  {
+    "types": [{"name": "ice"}],
+    "name": "eiscue-ice",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/875.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "normal"}],
+    "name": "indeedee-male",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/876.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "dark"}],
+    "name": "morpeko-full-belly",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/877.png"
+  },
+  {
+    "types": [{"name": "steel"}],
+    "name": "cufant",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/878.png"
+  },
+  {
+    "types": [{"name": "steel"}],
+    "name": "copperajah",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/879.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "dragon"}],
+    "name": "dracozolt",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/880.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "ice"}],
+    "name": "arctozolt",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/881.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "dragon"}],
+    "name": "dracovish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/882.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "ice"}],
+    "name": "arctovish",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/883.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "dragon"}],
+    "name": "duraludon",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/884.png"
+  },
+  {
+    "types": [{"name": "dragon"}, {"name": "ghost"}],
+    "name": "dreepy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/885.png"
+  },
+  {
+    "types": [{"name": "dragon"}, {"name": "ghost"}],
+    "name": "drakloak",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/886.png"
+  },
+  {
+    "types": [{"name": "dragon"}, {"name": "ghost"}],
+    "name": "dragapult",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/887.png"
+  },
+  {
+    "types": [{"name": "fairy"}],
+    "name": "zacian",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/888.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "zamazenta",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/889.png"
+  },
+  {
+    "types": [{"name": "poison"}, {"name": "dragon"}],
+    "name": "eternatus",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/890.png"
+  },
+  {
+    "types": [{"name": "fighting"}],
+    "name": "kubfu",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/891.png"
+  },
+  {
+    "types": [{"name": "fighting"}, {"name": "dark"}],
+    "name": "urshifu-single-strike",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/892.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "grass"}],
+    "name": "zarude",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/893.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "regieleki",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/894.png"
+  },
+  {
+    "types": [{"name": "dragon"}],
+    "name": "regidrago",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/895.png"
+  },
+  {
+    "types": [{"name": "ice"}],
+    "name": "glastrier",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/896.png"
+  },
+  {
+    "types": [{"name": "ghost"}],
+    "name": "spectrier",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/897.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "grass"}],
+    "name": "calyrex",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/898.png"
+  },
+  {
+    "gameIndex": 410,
+    "types": [{"name": "psychic"}],
+    "name": "deoxys-attack",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10001.png"
+  },
+  {
+    "gameIndex": 410,
+    "types": [{"name": "psychic"}],
+    "name": "deoxys-defense",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10002.png"
+  },
+  {
+    "gameIndex": 410,
+    "types": [{"name": "psychic"}],
+    "name": "deoxys-speed",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10003.png"
+  },
+  {
+    "gameIndex": 499,
+    "types": [{"name": "bug"}, {"name": "ground"}],
+    "name": "wormadam-sandy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10004.png"
+  },
+  {
+    "gameIndex": 500,
+    "types": [{"name": "bug"}, {"name": "steel"}],
+    "name": "wormadam-trash",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10005.png"
+  },
+  {
+    "gameIndex": 502,
+    "types": [{"name": "grass"}, {"name": "flying"}],
+    "name": "shaymin-sky",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10006.png"
+  },
+  {
+    "gameIndex": 501,
+    "types": [{"name": "ghost"}, {"name": "dragon"}],
+    "name": "giratina-origin",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10007.png"
+  },
+  {
+    "gameIndex": 503,
+    "types": [{"name": "electric"}, {"name": "fire"}],
+    "name": "rotom-heat",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10008.png"
+  },
+  {
+    "gameIndex": 504,
+    "types": [{"name": "electric"}, {"name": "water"}],
+    "name": "rotom-wash",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10009.png"
+  },
+  {
+    "gameIndex": 505,
+    "types": [{"name": "electric"}, {"name": "ice"}],
+    "name": "rotom-frost",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10010.png"
+  },
+  {
+    "gameIndex": 506,
+    "types": [{"name": "electric"}, {"name": "flying"}],
+    "name": "rotom-fan",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10011.png"
+  },
+  {
+    "gameIndex": 507,
+    "types": [{"name": "electric"}, {"name": "grass"}],
+    "name": "rotom-mow",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10012.png"
+  },
+  {
+    "gameIndex": 662,
+    "types": [{"name": "fire"}],
+    "name": "castform-sunny",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10013.png"
+  },
+  {
+    "gameIndex": 663,
+    "types": [{"name": "water"}],
+    "name": "castform-rainy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10014.png"
+  },
+  {
+    "gameIndex": 664,
+    "types": [{"name": "ice"}],
+    "name": "castform-snowy",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10015.png"
+  },
+  {
+    "gameIndex": 665,
+    "types": [{"name": "water"}],
+    "name": "basculin-blue-striped",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10016.png"
+  },
+  {
+    "gameIndex": 666,
+    "types": [{"name": "fire"}, {"name": "psychic"}],
+    "name": "darmanitan-zen",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10017.png"
+  },
+  {
+    "gameIndex": 667,
+    "types": [{"name": "normal"}, {"name": "fighting"}],
+    "name": "meloetta-pirouette",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10018.png"
+  },
+  {
+    "gameIndex": 706,
+    "types": [{"name": "flying"}],
+    "name": "tornadus-therian",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10019.png"
+  },
+  {
+    "gameIndex": 707,
+    "types": [{"name": "electric"}, {"name": "flying"}],
+    "name": "thundurus-therian",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10020.png"
+  },
+  {
+    "gameIndex": 708,
+    "types": [{"name": "ground"}, {"name": "flying"}],
+    "name": "landorus-therian",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10021.png"
+  },
+  {
+    "gameIndex": 704,
+    "types": [{"name": "dragon"}, {"name": "ice"}],
+    "name": "kyurem-black",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10022.png"
+  },
+  {
+    "gameIndex": 703,
+    "types": [{"name": "dragon"}, {"name": "ice"}],
+    "name": "kyurem-white",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10023.png"
+  },
+  {
+    "gameIndex": 705,
+    "types": [{"name": "water"}, {"name": "fighting"}],
+    "name": "keldeo-resolute",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10024.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "meowstic-female",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10025.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "ghost"}],
+    "name": "aegislash-blade",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10026.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "pumpkaboo-small",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10027.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "pumpkaboo-large",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10028.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "pumpkaboo-super",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10029.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "gourgeist-small",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10030.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "gourgeist-large",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10031.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "grass"}],
+    "name": "gourgeist-super",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10032.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "poison"}],
+    "name": "venusaur-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10033.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "dragon"}],
+    "name": "charizard-mega-x",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10034.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "flying"}],
+    "name": "charizard-mega-y",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10035.png"
+  },
+  {
+    "types": [{"name": "water"}],
+    "name": "blastoise-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10036.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "alakazam-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10037.png"
+  },
+  {
+    "types": [{"name": "ghost"}, {"name": "poison"}],
+    "name": "gengar-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10038.png"
+  },
+  {
+    "types": [{"name": "normal"}],
+    "name": "kangaskhan-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10039.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "flying"}],
+    "name": "pinsir-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10040.png"
+  },
+  {
+    "types": [{"name": "water"}, {"name": "dark"}],
+    "name": "gyarados-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10041.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "flying"}],
+    "name": "aerodactyl-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10042.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "fighting"}],
+    "name": "mewtwo-mega-x",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10043.png"
+  },
+  {
+    "types": [{"name": "psychic"}],
+    "name": "mewtwo-mega-y",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10044.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "dragon"}],
+    "name": "ampharos-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10045.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "steel"}],
+    "name": "scizor-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10046.png"
+  },
+  {
+    "types": [{"name": "bug"}, {"name": "fighting"}],
+    "name": "heracross-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10047.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "fire"}],
+    "name": "houndoom-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10048.png"
+  },
+  {
+    "types": [{"name": "rock"}, {"name": "dark"}],
+    "name": "tyranitar-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10049.png"
+  },
+  {
+    "types": [{"name": "fire"}, {"name": "fighting"}],
+    "name": "blaziken-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10050.png"
+  },
+  {
+    "types": [{"name": "psychic"}, {"name": "fairy"}],
+    "name": "gardevoir-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10051.png"
+  },
+  {
+    "types": [{"name": "steel"}, {"name": "fairy"}],
+    "name": "mawile-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10052.png"
+  },
+  {
+    "types": [{"name": "steel"}],
+    "name": "aggron-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10053.png"
+  },
+  {
+    "types": [{"name": "fighting"}, {"name": "psychic"}],
+    "name": "medicham-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10054.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "manectric-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10055.png"
+  },
+  {
+    "types": [{"name": "ghost"}],
+    "name": "banette-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10056.png"
+  },
+  {
+    "types": [{"name": "dark"}],
+    "name": "absol-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10057.png"
+  },
+  {
+    "types": [{"name": "dragon"}, {"name": "ground"}],
+    "name": "garchomp-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10058.png"
+  },
+  {
+    "types": [{"name": "fighting"}, {"name": "steel"}],
+    "name": "lucario-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10059.png"
+  },
+  {
+    "types": [{"name": "grass"}, {"name": "ice"}],
+    "name": "abomasnow-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10060.png"
+  },
+  {"types": [{"name": "fairy"}], "name": "floette-eternal", "imageUrl": null},
+  {
+    "types": [{"name": "dragon"}, {"name": "psychic"}],
+    "name": "latias-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10062.png"
+  },
+  {
+    "types": [{"name": "dragon"}, {"name": "psychic"}],
+    "name": "latios-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10063.png"
+  },
+  {
+    "gameIndex": 799,
+    "types": [{"name": "water"}, {"name": "ground"}],
+    "name": "swampert-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10064.png"
+  },
+  {
+    "gameIndex": 800,
+    "types": [{"name": "grass"}, {"name": "dragon"}],
+    "name": "sceptile-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10065.png"
+  },
+  {
+    "gameIndex": 801,
+    "types": [{"name": "dark"}, {"name": "ghost"}],
+    "name": "sableye-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10066.png"
+  },
+  {
+    "gameIndex": 802,
+    "types": [{"name": "dragon"}, {"name": "fairy"}],
+    "name": "altaria-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10067.png"
+  },
+  {
+    "gameIndex": 803,
+    "types": [{"name": "psychic"}, {"name": "fighting"}],
+    "name": "gallade-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10068.png"
+  },
+  {
+    "gameIndex": 804,
+    "types": [{"name": "normal"}, {"name": "fairy"}],
+    "name": "audino-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10069.png"
+  },
+  {
+    "gameIndex": 805,
+    "types": [{"name": "water"}, {"name": "dark"}],
+    "name": "sharpedo-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10070.png"
+  },
+  {
+    "gameIndex": 806,
+    "types": [{"name": "water"}, {"name": "psychic"}],
+    "name": "slowbro-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10071.png"
+  },
+  {
+    "gameIndex": 807,
+    "types": [{"name": "steel"}, {"name": "ground"}],
+    "name": "steelix-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10072.png"
+  },
+  {
+    "gameIndex": 808,
+    "types": [{"name": "normal"}, {"name": "flying"}],
+    "name": "pidgeot-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10073.png"
+  },
+  {
+    "gameIndex": 809,
+    "types": [{"name": "ice"}],
+    "name": "glalie-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10074.png"
+  },
+  {
+    "gameIndex": 810,
+    "types": [{"name": "rock"}, {"name": "fairy"}],
+    "name": "diancie-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10075.png"
+  },
+  {
+    "gameIndex": 811,
+    "types": [{"name": "steel"}, {"name": "psychic"}],
+    "name": "metagross-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10076.png"
+  },
+  {
+    "gameIndex": 812,
+    "types": [{"name": "water"}],
+    "name": "kyogre-primal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10077.png"
+  },
+  {
+    "gameIndex": 813,
+    "types": [{"name": "ground"}, {"name": "fire"}],
+    "name": "groudon-primal",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10078.png"
+  },
+  {
+    "gameIndex": 814,
+    "types": [{"name": "dragon"}, {"name": "flying"}],
+    "name": "rayquaza-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10079.png"
+  },
+  {
+    "gameIndex": 815,
+    "types": [{"name": "electric"}],
+    "name": "pikachu-rock-star",
+    "imageUrl": null
+  },
+  {
+    "gameIndex": 816,
+    "types": [{"name": "electric"}],
+    "name": "pikachu-belle",
+    "imageUrl": null
+  },
+  {
+    "gameIndex": 817,
+    "types": [{"name": "electric"}],
+    "name": "pikachu-pop-star",
+    "imageUrl": null
+  },
+  {
+    "gameIndex": 818,
+    "types": [{"name": "electric"}],
+    "name": "pikachu-phd",
+    "imageUrl": null
+  },
+  {
+    "gameIndex": 819,
+    "types": [{"name": "electric"}],
+    "name": "pikachu-libre",
+    "imageUrl": null
+  },
+  {
+    "gameIndex": 820,
+    "types": [{"name": "electric"}],
+    "name": "pikachu-cosplay",
+    "imageUrl": null
+  },
+  {
+    "gameIndex": 821,
+    "types": [{"name": "psychic"}, {"name": "dark"}],
+    "name": "hoopa-unbound",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10086.png"
+  },
+  {
+    "gameIndex": 822,
+    "types": [{"name": "fire"}, {"name": "ground"}],
+    "name": "camerupt-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10087.png"
+  },
+  {
+    "gameIndex": 823,
+    "types": [{"name": "normal"}, {"name": "fighting"}],
+    "name": "lopunny-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10088.png"
+  },
+  {
+    "gameIndex": 824,
+    "types": [{"name": "dragon"}, {"name": "flying"}],
+    "name": "salamence-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10089.png"
+  },
+  {
+    "gameIndex": 825,
+    "types": [{"name": "bug"}, {"name": "poison"}],
+    "name": "beedrill-mega",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10090.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "normal"}],
+    "name": "rattata-alola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10091.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "normal"}],
+    "name": "raticate-alola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10092.png"
+  },
+  {
+    "types": [{"name": "dark"}, {"name": "normal"}],
+    "name": "raticate-totem-alola",
+    "imageUrl": null
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "pikachu-original-cap",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10094.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "pikachu-hoenn-cap",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10095.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "pikachu-sinnoh-cap",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10096.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "pikachu-unova-cap",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10097.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "pikachu-kalos-cap",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10098.png"
+  },
+  {
+    "types": [{"name": "electric"}],
+    "name": "pikachu-alola-cap",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10099.png"
+  },
+  {
+    "types": [{"name": "electric"}, {"name": "psychic"}],
+    "name": "raichu-alola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10100.png"
+  },
+  {
+    "types": [{"name": "ice"}, {"name": "steel"}],
+    "name": "sandshrew-alola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10101.png"
+  },
+  {
+    "types": [{"name": "ice"}, {"name": "steel"}],
+    "name": "sandslash-alola",
+    "imageUrl": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/10102.png"
+  }
+]

--- a/packages/rn-tester/js/utils/deeplinking/overrideAppWithPerfExample.js
+++ b/packages/rn-tester/js/utils/deeplinking/overrideAppWithPerfExample.js
@@ -1,8 +1,6 @@
+import { FlatListExample } from '../../components/perftesting/FlatListExample';
 import React from 'react';
 import { Linking } from 'react-native';
-
-// null for now, added in next commit
-const FlatListExample  = () => null;
 
 const useHandleInitialUrl = () => {
   const [{
@@ -40,7 +38,7 @@ const useHandleInitialUrl = () => {
  * The reason is to make sure we test the performance of RN and not of RN Tester
  * as in, if we make changes to RN Tester, we don't want it to impact the perf results
  */
-export const overrideAppWithPerfExample = App => (props) => {
+export const overrideAppWithPerfExample = (App: React.AbstractComponent<AppProps>) => (props: AppProps): React.Node => {
   const {initialURL, loadingInitialURL} = useHandleInitialUrl();
 
   if (loadingInitialURL) {

--- a/packages/rn-tester/js/utils/deeplinking/overrideAppWithPerfExample.js
+++ b/packages/rn-tester/js/utils/deeplinking/overrideAppWithPerfExample.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Linking } from 'react-native';
+
+// null for now, added in next commit
+const FlatListExample  = () => null;
+
+const useHandleInitialUrl = () => {
+  const [{
+    initialURL,
+    loadingInitialURL,
+  }, setState] = React.useState({
+    loadingInitialURL: true,
+    initialURL: null,
+  });
+
+  React.useEffect(() => {
+    const getUrlAndSetInitialURL = async () => {
+      const url = await Linking.getInitialURL();
+      setState({
+        initialURL: url,
+        loadingInitialURL: false,
+      });
+    };
+
+    getUrlAndSetInitialURL().catch(error => {
+      console.error(error);
+      setState({
+        initialURL: null,
+        loadingInitialURL: false,
+      });
+    });
+  }, []);
+
+  return {initialURL, loadingInitialURL};
+};
+
+/**
+ * For performance testing, we completely override the app with the perf component
+ *
+ * The reason is to make sure we test the performance of RN and not of RN Tester
+ * as in, if we make changes to RN Tester, we don't want it to impact the perf results
+ */
+export const overrideAppWithPerfExample = App => (props) => {
+  const {initialURL, loadingInitialURL} = useHandleInitialUrl();
+
+  if (loadingInitialURL) {
+    return null;
+  }
+
+  if (initialURL === 'rntester://example/perftesting/flatlistexample') {
+    return <FlatListExample />;
+  }
+
+  return <App {...props} />;
+};

--- a/packages/rn-tester/js/utils/deeplinking/resolveUrl.js
+++ b/packages/rn-tester/js/utils/deeplinking/resolveUrl.js
@@ -1,0 +1,66 @@
+import RNTesterList from '../RNTesterList';
+
+// Supported URL pattern(s):
+// *  rntester://example/<moduleKey>
+// *  rntester://example/<moduleKey>/<exampleKey>
+export const resolveUrl = (url: string) => {
+  const match =
+    /^rntester:\/\/example\/([a-zA-Z0-9_-]+)(?:\/([a-zA-Z0-9_-]+))?$/.exec(
+      url,
+    );
+  if (!match) {
+    console.warn(
+      `handleOpenUrlRequest: Received unsupported URL: '${url}'`,
+    );
+    return;
+  }
+
+  const rawModuleKey = match[1];
+  const exampleKey = match[2];
+
+  // For tooling compatibility, allow all these variants for each module key:
+  const validModuleKeys = [
+    rawModuleKey,
+    `${rawModuleKey}Index`,
+    `${rawModuleKey}Example`,
+  ].filter(k => RNTesterList.Modules[k] != null);
+  if (validModuleKeys.length !== 1) {
+    if (validModuleKeys.length === 0) {
+      console.error(
+        `handleOpenUrlRequest: Unable to find requested module with key: '${rawModuleKey}'`,
+      );
+    } else {
+      console.error(
+        `handleOpenUrlRequest: Found multiple matching module with key: '${rawModuleKey}', unable to resolve`,
+      );
+    }
+    return;
+  }
+
+  const resolvedModuleKey = validModuleKeys[0];
+  const exampleModule = RNTesterList.Modules[resolvedModuleKey];
+
+  if (exampleKey != null) {
+    const validExampleKeys = exampleModule.examples.filter(
+      e => e.name === exampleKey,
+    );
+    if (validExampleKeys.length !== 1) {
+      if (validExampleKeys.length === 0) {
+        console.error(
+          `handleOpenUrlRequest: Unable to find requested example with key: '${exampleKey}' within module: '${resolvedModuleKey}'`,
+        );
+      } else {
+        console.error(
+          `handleOpenUrlRequest: Found multiple matching example with key: '${exampleKey}' within module: '${resolvedModuleKey}', unable to resolve`,
+        );
+      }
+      return;
+    }
+  }
+
+  return {
+    moduleKey: resolvedModuleKey,
+    exampleModule,
+    exampleKey,
+  };
+};


### PR DESCRIPTION
## Summary:

Adds performance testing on nightly builds with Github actions and Flashlight

Results available on [this url](https://app.flashlight.dev/projects/c172eb70-c96b-4d02-b865-1d1cdb80c519/evolution?testName=FlatListExample_OldArch&testName=FlatListExample_NewArch&order=version) at the moment
I actually think we should still keep https://github.com/Almouro/react-native-flashlight-tests + https://app.flashlight.dev/projects/react-native which is based on the nighly version. 
However, setting this up on the RN repo can allow us to go further and test each commit individually if we want to.

I'm also currently receiving daily Discord messages about the status, comparing with previous commits
<img width="517" alt="image" src="https://github.com/facebook/react-native/assets/4534323/6bf62b46-0760-4475-8274-c0fd77e7b44e">

Note than this requires setting a Github action secret called `FLASHLIGHT_API_KEY`.
I can either give one on private message on Discord for instance, or alternatively someone can create one on https://app.flashlight.dev/api-key and give me their Flashlight account email address, so that I can add them to the RN project on Flashlight

## Changelog:

[INTERNAL] [ADDED] - Setup RN Tester daily performance testing on Flashlight Cloud

## Test Plan:

- [Example old arch report](https://app.flashlight.dev/report?testRunIds=b61f2df1-4e40-4fec-b84e-8ee00d0886fc) 
  - we have the video showing the app is working ✅
  - also we see CPU usage for the old bridge confirming the old arch is used ✅
<img width="688" alt="image" src="https://github.com/facebook/react-native/assets/4534323/5d255ddd-67ba-4a62-9c0f-f0cfacec707a">

- [Example new arch report](https://app.flashlight.dev/report?testRunIds=00fb48f8-e41f-4a70-bdf3-78274ca9c4de)
  - we have the video showing the app is working ✅
  - also we see CPU usage for the `mqt_v_js` ✅
  
<img width="677" alt="image" src="https://github.com/facebook/react-native/assets/4534323/a0b2b72f-9439-4964-bb47-2ea1de21fa39">

  
