### PR TITLE
Add support for target capability flags

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -191,6 +191,7 @@ describe('inspector proxy HTTP API', () => {
             faviconUrl: 'https://reactjs.org/favicon.ico',
             id: 'device1-page1',
             reactNative: {
+              capabilities: {},
               logicalDeviceId: 'device1',
               type: 'Legacy',
             },
@@ -206,6 +207,7 @@ describe('inspector proxy HTTP API', () => {
             faviconUrl: 'https://reactjs.org/favicon.ico',
             id: 'device2-page1',
             reactNative: {
+              capabilities: {},
               logicalDeviceId: 'device2',
               type: 'Legacy',
             },

--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -397,7 +397,13 @@ describe('inspector proxy React Native reloads', () => {
     }
   });
 
-  test('disabled for modern targets', async () => {
+  test.each([
+    ['for modern targets', {}],
+    [
+      "when target has 'nativePageReloads' capability flag",
+      {nativePageReloads: true},
+    ],
+  ])('disabled %s', async (_, capabilities) => {
     let device1;
     try {
       /***
@@ -415,6 +421,7 @@ describe('inspector proxy React Native reloads', () => {
           // in legacy mode.
           title: 'React Native (mock)',
           type: 'Modern',
+          capabilities,
           vm: 'vm',
         },
       ]);
@@ -450,6 +457,7 @@ describe('inspector proxy React Native reloads', () => {
           // NOTE: 'React' is a magic string used to detect React Native pages.
           title: 'React Native (mock)',
           type: 'Modern',
+          capabilities,
           vm: 'vm',
         },
       ]);

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -9,6 +9,7 @@
  */
 
 import type {EventReporter} from '../types/EventReporter';
+import type {CDPResponse} from './cdp-types/messages';
 
 import TTLCache from '@isaacs/ttlcache';
 
@@ -69,11 +70,7 @@ class DeviceEventReporter {
   }
 
   logResponse(
-    res: $ReadOnly<{
-      id: number,
-      error?: {message: string, data?: mixed},
-      ...
-    }>,
+    res: CDPResponse<>,
     origin: 'device' | 'proxy',
     metadata: $ReadOnly<{
       pageId: string | null,

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -153,6 +153,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
       reactNative: {
         logicalDeviceId: deviceId,
         type: nullthrows(page.type),
+        capabilities: nullthrows(page.capabilities),
       },
     };
   }

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Commands, Events} from './protocol';
+
+// Note: A CDP event is a JSON-RPC notification with no `id` member.
+export type CDPEvent<TEvent: $Keys<Events> = 'unknown'> = $ReadOnly<{
+  method: TEvent,
+  params: Events[TEvent],
+}>;
+
+export type CDPRequest<TCommand: $Keys<Commands> = 'unknown'> = $ReadOnly<{
+  method: TCommand,
+  params: Commands[TCommand]['paramsType'],
+  id: number,
+}>;
+
+export type CDPResponse<TCommand: $Keys<Commands> = 'unknown'> =
+  | $ReadOnly<{
+      result: Commands[TCommand]['resultType'],
+      id: number,
+    }>
+  | $ReadOnly<{
+      error: CDPRequestError,
+      id: number,
+    }>;
+
+export type CDPRequestError = $ReadOnly<{
+  code: number,
+  message: string,
+  data?: mixed,
+}>;
+
+export type CDPClientMessage =
+  | CDPRequest<'Debugger.getScriptSource'>
+  | CDPRequest<'Debugger.setBreakpointByUrl'>
+  | CDPRequest<>;

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+// Adapted from https://github.com/ChromeDevTools/devtools-protocol/blob/master/types/protocol.d.ts
+
+export interface Debugger {
+  GetScriptSourceParams: $ReadOnly<{
+    /**
+     * Id of the script to get source for.
+     */
+    scriptId: string,
+  }>;
+
+  GetScriptSourceResult: $ReadOnly<{
+    /**
+     * Script source (empty in case of Wasm bytecode).
+     */
+    scriptSource: string,
+
+    /**
+     * Wasm bytecode. (Encoded as a base64 string when passed over JSON)
+     */
+    bytecode?: string,
+  }>;
+
+  SetBreakpointByUrlParams: $ReadOnly<{
+    /**
+     * Line number to set breakpoint at.
+     */
+    lineNumber: number,
+
+    /**
+     * URL of the resources to set breakpoint on.
+     */
+    url?: string,
+
+    /**
+     * Regex pattern for the URLs of the resources to set breakpoints on. Either `url` or
+     * `urlRegex` must be specified.
+     */
+    urlRegex?: string,
+
+    /**
+     * Script hash of the resources to set breakpoint on.
+     */
+    scriptHash?: string,
+
+    /**
+     * Offset in the line to set breakpoint at.
+     */
+    columnNumber?: number,
+
+    /**
+     * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
+     * breakpoint if this expression evaluates to true.
+     */
+    condition?: string,
+  }>;
+}
+
+export type Events = {
+  [method: string]: mixed,
+};
+
+export type Commands = {
+  'Debugger.getScriptSource': {
+    paramsType: Debugger['GetScriptSourceParams'],
+    resultType: Debugger['GetScriptSourceResult'],
+  },
+
+  'Debugger.setBreakpointByUrl': {
+    paramsType: Debugger['SetBreakpointByUrlParams'],
+    resultType: void,
+  },
+
+  [method: string]: {
+    paramsType: mixed,
+    resultType: mixed,
+  },
+};

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -95,49 +95,6 @@ export type JsonVersionResponse = $ReadOnly<{
   'Protocol-Version': string,
 }>;
 
-/**
- * Types were exported from https://github.com/ChromeDevTools/devtools-protocol/blob/master/types/protocol.d.ts
- */
-
-export type SetBreakpointByUrlRequest = $ReadOnly<{
-  id: number,
-  method: 'Debugger.setBreakpointByUrl',
-  params: $ReadOnly<{
-    lineNumber: number,
-    url?: string,
-    urlRegex?: string,
-    scriptHash?: string,
-    columnNumber?: number,
-    condition?: string,
-  }>,
-}>;
-
-export type GetScriptSourceRequest = $ReadOnly<{
-  id: number,
-  method: 'Debugger.getScriptSource',
-  params: {
-    scriptId: string,
-  },
-}>;
-
-export type GetScriptSourceResponse = $ReadOnly<{
-  scriptSource: string,
-  /**
-   * Wasm bytecode.
-   */
-  bytecode?: string,
-}>;
-
-export type ErrorResponse = $ReadOnly<{
-  error: $ReadOnly<{
-    message: string,
-  }>,
-}>;
-
-export type DebuggerRequest =
-  | SetBreakpointByUrlRequest
-  | GetScriptSourceRequest;
-
 export type JSONSerializable =
   | boolean
   | number

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -9,6 +9,22 @@
  * @oncall react_native
  */
 
+/**
+ * A capability flag disables a specific feature/hack in the InspectorProxy
+ * layer by indicating that the target supports one or more modern CDP features.
+ */
+export type TargetCapabilityFlags = $ReadOnly<{
+  /**
+   * The target supports a stable page representation across reloads.
+   *
+   * In the proxy, this disables legacy page reload emulation and the
+   * additional '(Experimental)' target in `/json/list`.
+   *
+   * In the launch flow, this allows targets to be matched directly by `appId`.
+   */
+  nativePageReloads?: boolean,
+}>;
+
 // Page information received from the device. New page is created for
 // each new instance of VM and can appear when user reloads React Native
 // application.
@@ -19,6 +35,7 @@ export type PageFromDevice = $ReadOnly<{
   vm: string,
   app: string,
   type?: 'Legacy' | 'Modern',
+  capabilities?: TargetCapabilityFlags,
 }>;
 
 export type Page = Required<PageFromDevice>;
@@ -83,6 +100,7 @@ export type PageDescription = $ReadOnly<{
   reactNative: $ReadOnly<{
     logicalDeviceId: string,
     type: $NonMaybeType<Page['type']>,
+    capabilities: Page['capabilities'],
   }>,
 }>;
 

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -63,6 +63,7 @@ export default function openDebuggerMiddleware({
         // Only use targets with better reloading support
         app =>
           app.title === 'React Native Experimental (Improved Chrome Reloads)' ||
+          app.reactNative.capabilities?.nativePageReloads === true ||
           app.reactNative.type === 'Modern',
       );
 


### PR DESCRIPTION
Summary:
## Context

We're introducing the concept of **capability flags** to provide granular control of behaviours in the Inspector Proxy, to replace the recently added `type: 'Legacy' | 'Modern'` target switch.

A capability flag disables a specific feature/hack in the Inspector Proxy layer by indicating that the target supports one or more modern CDP features.

## This diff

- Implements capability flags in `InspectorProxy`, via an optional `"capabilities"` key returned by a device's CDP server.
- Wires up an initial flag, `nativePageReloads`, to disable the legacy "React Native Experimental (Improved Chrome Reloads)" page and emulated page reload behaviour.

Changelog: [Internal]

Differential Revision: D53352244


