### PR TITLE
fix: [Codegen] log supported apple platforms if there are any

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -193,11 +193,17 @@ function extractSupportedApplePlatforms(dependency, dependencyPath) {
     {},
   );
 
-  console.log(
-    `[Codegen] Supported Apple platforms: ${Object.keys(supportedPlatformsMap)
-      .filter(key => supportedPlatformsMap[key])
-      .join(', ')} for ${dependency}`,
+  const supportedPlatformsList = Object.keys(supportedPlatformsMap).filter(
+    key => supportedPlatformsMap[key],
   );
+
+  if (supportedPlatformsList.length > 0) {
+    console.log(
+      `[Codegen] Supported Apple platforms: ${supportedPlatformsList.join(
+        ', ',
+      )} for ${dependency}`,
+    );
+  }
 
   return supportedPlatformsMap;
 }


### PR DESCRIPTION
## Summary:

This PR adds check if there are any supported platforms to log. 

For built-in modules this was logging empty line (as some of them doesn't contain podspecs): 

![CleanShot 2024-02-02 at 15 54 42@2x](https://github.com/facebook/react-native/assets/52801365/c7e36052-9c48-4e00-a539-6ee5d528bbee)


## Changelog:

[GENERAL] [FIXED] - Log Codegen supported platforms if any are available

## Test Plan:

Run Codegen and check if it prints empty `Supported Apple platforms`