### PR TITLE
RNTester - Legacy component example: do not convert commands to string

### DIFF
--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -50,9 +50,8 @@ export function callNativeMethodToChangeBackgroundColor(
   }
   UIManager.dispatchViewManagerCommand(
     reactTag,
-    UIManager.getViewManagerConfig(
-      'RNTMyLegacyNativeView',
-    ).Commands.changeBackgroundColor.toString(),
+    UIManager.getViewManagerConfig('RNTMyLegacyNativeView').Commands
+      .changeBackgroundColor,
     [color],
   );
 }
@@ -73,9 +72,8 @@ export function callNativeMethodToAddOverlays(
 
   UIManager.dispatchViewManagerCommand(
     reactTag,
-    UIManager.getViewManagerConfig(
-      'RNTMyLegacyNativeView',
-    ).Commands.addOverlays.toString(),
+    UIManager.getViewManagerConfig('RNTMyLegacyNativeView').Commands
+      .addOverlays,
     [overlayColors],
   );
 }
@@ -95,9 +93,8 @@ export function callNativeMethodToRemoveOverlays(
 
   UIManager.dispatchViewManagerCommand(
     reactTag,
-    UIManager.getViewManagerConfig(
-      'RNTMyLegacyNativeView',
-    ).Commands.removeOverlays.toString(),
+    UIManager.getViewManagerConfig('RNTMyLegacyNativeView').Commands
+      .removeOverlays,
     [],
   );
 }


### PR DESCRIPTION
Summary:
The conversion to string was introduced in D45043929. It was supposed to fix command execution for `MyLegacyNativeComponent` in RNTester on Android/Old Architecture.

At the same time it introduced a regression on iOS, since we have [different code path](https://www.internalfb.com/code/fbsource/[ffee789cab9514c0a15b8a63869cbfdf4e534a56]/xplat/js/react-native-github/packages/react-native/React/Modules/RCTUIManager.m?lines=1088-1092) for string commands in iOS, where we expect command name, and not command number converted to string.

I tried to remove that conversion, did local tests, and saw no issues with executing commands on Android.
Looks like the underlying issue has been fixed in some other way.

So let's just remove those conversions.

Changelog: [Internal]

Differential Revision: D53123956


