### PR TITLE
Allow package to be imported by tests in xplat

### DIFF
--- a/packages/react-native-test-renderer/package.json
+++ b/packages/react-native-test-renderer/package.json
@@ -11,10 +11,6 @@
       "@babel/preset-flow": "^7.20.0"
     },
     "dependencies": {},
-    "exports": {
-      ".": "./index.js",
-      "./jest-environment": "./dist/jest-environment/index.js",
-      "./jest-setup": "./dist/jest-setup/index.js"
-    },
+    "main": "src/index.js",
     "peerDependencies": { "jest": "^29.7.0" }
   }

--- a/packages/react-native-test-renderer/src/index.js
+++ b/packages/react-native-test-renderer/src/index.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+export {render} from './renderer/index.js';
+
+export {ReactNativeEnvironment} from './jest/environment.js';


### PR DESCRIPTION
Summary: yungsters debugged the failing test library import and found that we don't yet support package exports. Switching this to main with an index file allows us to import the library in other places.

Reviewed By: yungsters

Differential Revision: D53240712

Changelog: [internal]
