### PR TITLE
Run RNTR against simple product test

### DIFF
--- a/packages/react-native-test-renderer/package.json
+++ b/packages/react-native-test-renderer/package.json
@@ -11,10 +11,6 @@
       "@babel/preset-flow": "^7.20.0"
     },
     "dependencies": {},
-    "exports": {
-      ".": "./index.js",
-      "./jest-environment": "./dist/jest-environment/index.js",
-      "./jest-setup": "./dist/jest-setup/index.js"
-    },
+    "main": "src/index.js",
     "peerDependencies": { "jest": "^29.7.0" }
   }

--- a/packages/react-native-test-renderer/src/index.js
+++ b/packages/react-native-test-renderer/src/index.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+export {render} from './renderer/index.js';
+
+export {ReactNativeEnvironment} from './jest/environment.js';

--- a/packages/react-native-test-renderer/src/jest/environment.js
+++ b/packages/react-native-test-renderer/src/jest/environment.js
@@ -69,6 +69,7 @@ module.exports = class ReactNativeEnvironment extends NodeEnv {
           getConstants: () => ({settings: {}}),
         },
         LinkingManager: {},
+        I18n: {getConstants: () => ({})},
       })[name];
   }
 };


### PR DESCRIPTION
Summary:
This is a simple snapshot test using ReactTestRender's toJSON. We have almost the same functionality in RNTR already, so let's see if we can support tests like this.

Merging the new setup and environment with the existing configuration (https://fburl.com/code/s85sma77) still causes issues so here we add unmocking and new setup inline. Added task T177114228 to track following up on this

Note that some formatting is changed and props are dropped on the snapshot. This is resolved with refactor in next diff

Reviewed By: yungsters

Differential Revision: D53321823

Changelog: [internal]


