### PR TITLE
Refactor toJSON

### DIFF
--- a/packages/react-native-test-renderer/package.json
+++ b/packages/react-native-test-renderer/package.json
@@ -11,10 +11,6 @@
       "@babel/preset-flow": "^7.20.0"
     },
     "dependencies": {},
-    "exports": {
-      ".": "./index.js",
-      "./jest-environment": "./dist/jest-environment/index.js",
-      "./jest-setup": "./dist/jest-setup/index.js"
-    },
+    "main": "src/index.js",
     "peerDependencies": { "jest": "^29.7.0" }
   }

--- a/packages/react-native-test-renderer/src/index.js
+++ b/packages/react-native-test-renderer/src/index.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+export {render} from './renderer/index.js';
+
+export {ReactNativeEnvironment} from './jest/environment.js';

--- a/packages/react-native-test-renderer/src/jest/environment.js
+++ b/packages/react-native-test-renderer/src/jest/environment.js
@@ -69,6 +69,7 @@ module.exports = class ReactNativeEnvironment extends NodeEnv {
           getConstants: () => ({settings: {}}),
         },
         LinkingManager: {},
+        I18n: {getConstants: () => ({})},
       })[name];
   }
 };

--- a/packages/react-native-test-renderer/src/renderer/__tests__/__snapshots__/render-test.js.snap
+++ b/packages/react-native-test-renderer/src/renderer/__tests__/__snapshots__/render-test.js.snap
@@ -1,12 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`render toJSON renders View props 1`] = `
+<RCTView
+  pointerEvents="box-none"
+>
+  <RCTText
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    isHighlighted={false}
+    selectionColor={null}
+  >
+    Hello
+  </RCTText>
+  <RCTView
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  />
+</RCTView>
+`;
+
 exports[`render toJSON returns expected JSON output based on renderer component 1`] = `
-"<>
-  <RCTView>
-    <RCTText accessible=true allowFontScaling=true ellipsizeMode="tail" isHighlighted=false selectionColor=null>
-      <RCTRawText text="Hello" />
-    </RCTText>
-    <RCTView />
-  </RCTView>
-</>"
+<RCTView>
+  <RCTText
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    isHighlighted={false}
+    selectionColor={null}
+  >
+    Hello
+  </RCTText>
+  <RCTView />
+</RCTView>
 `;

--- a/packages/react-native-test-renderer/src/renderer/__tests__/render-test.js
+++ b/packages/react-native-test-renderer/src/renderer/__tests__/render-test.js
@@ -24,10 +24,24 @@ function TestComponent() {
   );
 }
 
+function TestComponentWithProps() {
+  return (
+    <View pointerEvents="box-none">
+      <Text>Hello</Text>
+      <View style={{flex: 1}} />
+    </View>
+  );
+}
+
 describe('render', () => {
   describe('toJSON', () => {
     it('returns expected JSON output based on renderer component', () => {
       const result = ReactNativeTestRenderer.render(<TestComponent />);
+      expect(result.toJSON()).toMatchSnapshot();
+    });
+
+    it('renders View props', () => {
+      const result = ReactNativeTestRenderer.render(<TestComponentWithProps />);
       expect(result.toJSON()).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
Summary:
Updates to toJSON:
- return object tree instead of formatted snapshot string. Applying the `'react.test.json'` symbol lets Jest do the formatting work for us
- Source props from `pendingProps` on `instanceHandle`. This adds props such as `pointerEvents` and `style` which were present on RTR's snapshots but don't get included in the node's `props` collection
- Render text node as text value, instead of RCTRawText like `<RCTRawText text="Hello" />`

Reviewed By: kassens

Differential Revision: D53321821

Changelog: [internal]


