### PR TITLE
Add findAll base query method

### DIFF
--- a/packages/react-native-test-renderer/src/renderer/__tests__/render-test.js
+++ b/packages/react-native-test-renderer/src/renderer/__tests__/render-test.js
@@ -45,4 +45,19 @@ describe('render', () => {
       expect(result.toJSON()).toMatchSnapshot();
     });
   });
+
+  describe('findAll', () => {
+    it('returns all nodes matching the predicate', () => {
+      const result = ReactNativeTestRenderer.render(<TestComponent />);
+      const textNode = result.findAll(node => {
+        return node.props?.text === 'Hello';
+      })[0];
+      expect(textNode).not.toBeUndefined();
+
+      const viewNodes = result.findAll(node => {
+        return node.viewName === 'RCTView';
+      });
+      expect(viewNodes.length).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
Summary: This is the base query method that we can wrap to use specific matchers like `findByTestID` or `findByRole`

Differential Revision: D53359005

Changelog: [internal]


