### PR TITLE
[iOS] Add basic DisplayP3 color support

### DIFF
--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -134,6 +134,8 @@ Pod::Spec.new do |s|
 
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "RCTDeprecation")
+  add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
+
 
   if use_hermes
     s.dependency 'React-hermes'

--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -17,6 +17,15 @@
 #import <React/RCTTextDecorationLineType.h>
 #import <yoga/Yoga.h>
 
+typedef NS_ENUM(NSInteger, RCTColorSpace) {
+  RCTColorSpaceSRGB,
+  RCTColorSpaceDisplayP3,
+};
+
+// Change the default color space
+RCTColorSpace RCTGetDefaultColorSpace(void);
+RCT_EXTERN void RCTSetDefaultColorSpace(RCTColorSpace colorSpace);
+
 /**
  * This class provides a collection of conversion functions for mapping
  * JSON objects to native types and classes. These are useful when writing
@@ -91,6 +100,13 @@ typedef NSURL RCTFileURL;
 
 + (CGAffineTransform)CGAffineTransform:(id)json;
 
++ (UIColor *)createColorFrom:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
++ (UIColor *)createColorFrom:(CGFloat)red
+                       green:(CGFloat)green
+                        blue:(CGFloat)blue
+                       alpha:(CGFloat)alpha
+               andColorSpace:(RCTColorSpace)colorSpace;
++ (RCTColorSpace)colorSpaceFromString:(NSString *)colorSpace;
 + (UIColor *)UIColor:(id)json;
 + (CGColorRef)CGColor:(id)json CF_RETURNS_NOT_RETAINED;
 

--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -100,12 +100,12 @@ typedef NSURL RCTFileURL;
 
 + (CGAffineTransform)CGAffineTransform:(id)json;
 
-+ (UIColor *)createColorFrom:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
-+ (UIColor *)createColorFrom:(CGFloat)red
-                       green:(CGFloat)green
-                        blue:(CGFloat)blue
-                       alpha:(CGFloat)alpha
-               andColorSpace:(RCTColorSpace)colorSpace;
++ (UIColor *)RCTCreateColorWith:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
++ (UIColor *)RCTCreateColorWith:(CGFloat)red
+                          green:(CGFloat)green
+                           blue:(CGFloat)blue
+                          alpha:(CGFloat)alpha
+                  andColorSpace:(RCTColorSpace)colorSpace;
 + (RCTColorSpace)colorSpaceFromString:(NSString *)colorSpace;
 + (UIColor *)UIColor:(id)json;
 + (CGColorRef)CGColor:(id)json CF_RETURNS_NOT_RETAINED;

--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -880,7 +880,6 @@ static NSString *RCTSemanticColorNames(void)
   return names;
 }
 
-static RCTColorSpace defaultColorSpace = (RCTColorSpace)facebook::react::getDefaultColorSpace();
 RCTColorSpace RCTGetDefaultColorSpace(void)
 {
   return (RCTColorSpace)facebook::react::getDefaultColorSpace();
@@ -890,12 +889,12 @@ void RCTSetDefaultColorSpace(RCTColorSpace colorSpace)
   facebook::react::setDefaultColorSpace((facebook::react::ColorSpace)colorSpace);
 }
 
-+ (UIColor *)createColorFrom:(CGFloat)r green:(CGFloat)g blue:(CGFloat)b alpha:(CGFloat)a
++ (UIColor *)RCTCreateColorWith:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha
 {
   RCTColorSpace space = RCTGetDefaultColorSpace();
-  return [self createColorFrom:r green:g blue:b alpha:a andColorSpace:space];
+  return [self RCTCreateColorWith:red green:green blue:blue alpha:alpha andColorSpace:space];
 }
-+ (UIColor *)createColorFrom:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha andColorSpace:(RCTColorSpace)colorSpace
++ (UIColor *)RCTCreateColorWith:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha andColorSpace:(RCTColorSpace)colorSpace
 {
   if (colorSpace == RCTColorSpaceDisplayP3) {
     return [UIColor colorWithDisplayP3Red:red green:green blue:blue alpha:alpha];
@@ -920,17 +919,17 @@ void RCTSetDefaultColorSpace(RCTColorSpace colorSpace)
   if ([json isKindOfClass:[NSArray class]]) {
     NSArray *components = [self NSNumberArray:json];
     CGFloat alpha = components.count > 3 ? [self CGFloat:components[3]] : 1.0;
-    return [self createColorFrom:[self CGFloat:components[0]]
-                           green:[self CGFloat:components[1]]
-                            blue:[self CGFloat:components[2]]
-                           alpha:alpha];
+    return [self RCTCreateColorWith:[self CGFloat:components[0]]
+                              green:[self CGFloat:components[1]]
+                               blue:[self CGFloat:components[2]]
+                              alpha:alpha];
   } else if ([json isKindOfClass:[NSNumber class]]) {
     NSUInteger argb = [self NSUInteger:json];
     CGFloat a = ((argb >> 24) & 0xFF) / 255.0;
     CGFloat r = ((argb >> 16) & 0xFF) / 255.0;
     CGFloat g = ((argb >> 8) & 0xFF) / 255.0;
     CGFloat b = (argb & 0xFF) / 255.0;
-    return [self createColorFrom:r green:g blue:b alpha:a];
+    return [self RCTCreateColorWith:r green:g blue:b alpha:a];
   } else if ([json isKindOfClass:[NSDictionary class]]) {
     NSDictionary *dictionary = json;
     id value = nil;
@@ -941,7 +940,7 @@ void RCTSetDefaultColorSpace(RCTColorSpace colorSpace)
       CGFloat b = [[dictionary objectForKey:@"b"] floatValue];
       CGFloat a = [[dictionary objectForKey:@"a"] floatValue];
       RCTColorSpace colorSpace = [self colorSpaceFromString: rawColorSpace];
-      return [self createColorFrom:r green:g blue:b alpha:a andColorSpace:colorSpace];
+      return [self RCTCreateColorWith:r green:g blue:b alpha:a andColorSpace:colorSpace];
     } else if ((value = [dictionary objectForKey:@"semantic"])) {
       if ([value isKindOfClass:[NSString class]]) {
         NSString *semanticName = value;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorComponents.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorComponents.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ColorComponents.h"
+
+namespace facebook::react {
+
+static ColorSpace defaultColorSpace = ColorSpace::sRGB;
+
+ColorSpace getDefaultColorSpace() {
+  return defaultColorSpace;
+}
+
+void setDefaultColorSpace(ColorSpace newColorSpace) {
+  defaultColorSpace = newColorSpace;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorComponents.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorComponents.h
@@ -9,11 +9,17 @@
 
 namespace facebook::react {
 
+enum class ColorSpace { sRGB, DisplayP3 };
+
+ColorSpace getDefaultColorSpace();
+void setDefaultColorSpace(ColorSpace newColorSpace);
+
 struct ColorComponents {
   float red{0};
   float green{0};
   float blue{0};
   float alpha{0};
+  ColorSpace colorSpace{getDefaultColorSpace()};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -61,7 +61,8 @@ Pod::Spec.new do |s|
 
   s.dependency "glog"
   s.dependency "RCT-Folly/Fabric", folly_version
-  s.dependency "React-Core/Default", version
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
   s.dependency "React-utils"
   s.dependency "DoubleConversion"
   s.dependency "fmt", "9.1.0"

--- a/packages/react-native/ReactCommon/react/renderer/graphics/fromRawValueShared.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/fromRawValueShared.h
@@ -44,6 +44,24 @@ inline void fromRawValueShared(
 
     result = colorFromComponents(colorComponents);
   } else {
+    if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
+      auto items = (std::unordered_map<std::string, RawValue>)value;
+      if (items.find("space") != items.end()) {
+        colorComponents.red = (float)items.at("r");
+        colorComponents.green = (float)items.at("g");
+        colorComponents.blue = (float)items.at("b");
+        colorComponents.alpha = (float)items.at("a");
+        colorComponents.colorSpace = getDefaultColorSpace();
+        std::string space = (std::string)items.at("space");
+        if (space == "display-p3") {
+          colorComponents.colorSpace = ColorSpace::DisplayP3;
+        } else if (space == "srgb") {
+          colorComponents.colorSpace = ColorSpace::sRGB;
+        }
+        result = colorFromComponents(colorComponents);
+        return;
+      }
+    }
     result = parsePlatformColor(contextContainer, surfaceId, value);
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
@@ -87,6 +87,9 @@ int32_t ColorFromUIColor(const std::shared_ptr<void> &uiColor)
 
 UIColor *_Nullable UIColorFromComponentsColor(const facebook::react::ColorComponents &components)
 {
+  if (components.colorSpace == ColorSpace::DisplayP3) {
+    return [UIColor colorWithDisplayP3Red:components.red green:components.green blue:components.blue alpha:components.alpha];
+  }
   return [UIColor colorWithRed:components.red green:components.green blue:components.blue alpha:components.alpha];
 }
 } // anonymous namespace


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This adds initial support for wide gamut (DisplayP3) colors to React Native iOS per the [RFC](https://github.com/react-native-community/discussions-and-proposals/pull/738). It provides the ability to set the default color space to sRGB or DisplayP3 and provides the native code necessary to support `color()` function syntax per the [W3C CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#color-function) spec. It does _not_ yet support animations and requires additional JS code before fully supporting the `color()` function syntax. 

## Changelog:

[IOS] [ADDED] - Add basic DisplayP3 color support

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
![Screenshot_20240131-100112](https://github.com/facebook/react-native/assets/1944151/bbd011b1-dab0-47d6-b341-74fa8fac6757)

Follow test steps from #42831 to test support for `color()` function syntax.

To globally change the default color space to DisplayP3 make the following changes to RNTester AppDelegate.mm:
```diff
+ #import <React/RCTConvert.h>

   - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
   {
     // ...
+    RCTSetDefaultColorSpace(RCTColorSpaceDisplayP3);
     return [super application:application didFinishLaunchingWithOptions:launchOptions];
   }
```
