### PR TITLE
Do not lower-case header set.

### DIFF
--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -475,7 +475,7 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): any) {
     if (this.readyState !== this.OPENED) {
       throw new Error('Request has not been opened');
     }
-    this._headers[header.toLowerCase()] = String(value);
+    this._headers[header] = String(value);
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While https headers are case insensitive, some http servers out there are still case sensitive to http headers, and react native breaks this by forcing lowercase on all headers!

## Changelog:

[General] [Fixed] Remove setRequestHeader lowercase!

## Test Plan:

I tested it and it sets the header to the correct case the user desires.
