### PR TITLE
Update Yoga.podspec: fixes archiving for Mac Catalyst

### DIFF
--- a/packages/react-native/ReactCommon/yoga/Yoga.podspec
+++ b/packages/react-native/ReactCommon/yoga/Yoga.podspec
@@ -32,7 +32,9 @@ Pod::Spec.new do |spec|
   spec.requires_arc = false
   spec.pod_target_xcconfig = {
       'DEFINES_MODULE' => 'YES'
-  }
+  }.merge!(ENV['USE_FRAMEWORKS'] != nil ? {
+      'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)"'
+  } : {})
   spec.compiler_flags = [
       '-fno-omit-frame-pointer',
       '-fexceptions',


### PR DESCRIPTION
Hi

## Summary:

When I tried to archive macos catalyst app in Xcode I got errors:

<img width="977" alt="Screenshot 2024-02-05 at 00 03 32" src="https://github.com/kesha-antonov/react-native/assets/11584712/b83f75a5-b42f-42e4-9afa-1e2527501baa">

This PR fixes archiving by linking PrivateHeaders in yoga.framework

<img width="399" alt="Screenshot 2024-02-05 at 01 03 48" src="https://github.com/kesha-antonov/react-native/assets/11584712/089080ad-b1dc-4703-9273-d8aa3253205e">

<img width="1404" alt="Screenshot 2024-02-05 at 01 05 18" src="https://github.com/kesha-antonov/react-native/assets/11584712/5263cb80-8a53-4a51-bcfc-9d3a2ba739b4">

Prev PR here https://github.com/facebook/react-native/pull/42159

## Changelog:

[IOS] [FIXED] - fixed archiving for Mac Catalyst

## Test Plan:

Try archive react-native tester app for macos catalyst in Xcode