### PR TITLE
'[skip ci] [RN][Android] Mark classes of packages packagerconnection as @Nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
@@ -30,7 +30,7 @@ private constructor(
     cxxReactPackages: List<CxxReactPackage>,
 ) : ReactPackageTurboModuleManagerDelegate(context, packages, initHybrid(cxxReactPackages)) {
 
-  override fun initHybrid(): HybridData? {
+  override fun initHybrid(): HybridData {
     throw UnsupportedOperationException(
         "DefaultTurboModuleManagerDelegate.initHybrid() must never be called!")
   }
@@ -72,6 +72,6 @@ private constructor(
 
     @DoNotStrip
     @JvmStatic
-    external fun initHybrid(cxxReactPackages: List<CxxReactPackage>): HybridData?
+    external fun initHybrid(cxxReactPackages: List<CxxReactPackage>): HybridData
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/AndroidChoreographerProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/AndroidChoreographerProvider.java
@@ -7,9 +7,11 @@
 
 package com.facebook.react.internal;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.UiThreadUtil;
 
 /** An implementation of ChoreographerProvider that directly uses android.view.Choreographer. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public final class AndroidChoreographerProvider implements ChoreographerProvider {
 
   public static final class AndroidChoreographer implements ChoreographerProvider.Choreographer {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
@@ -8,6 +8,7 @@
 package com.facebook.react.internal.turbomodule.core;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.NativeModule;
@@ -15,6 +16,7 @@ import com.facebook.react.internal.turbomodule.core.interfaces.TurboModule;
 import java.util.ArrayList;
 import java.util.List;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class TurboModuleManagerDelegate {
   @DoNotStrip
   @SuppressWarnings("unused")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModulePerfLogger.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModulePerfLogger.java
@@ -7,10 +7,12 @@
 
 package com.facebook.react.internal.turbomodule.core;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.perflogger.NativeModulePerfLogger;
 import javax.annotation.Nullable;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStrip
 class TurboModulePerfLogger {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jstasks/LinearCountingRetryPolicy.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jstasks/LinearCountingRetryPolicy.java
@@ -7,6 +7,9 @@
 
 package com.facebook.react.jstasks;
 
+import com.facebook.infer.annotation.Nullsafe;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class LinearCountingRetryPolicy implements HeadlessJsTaskRetryPolicy {
 
   private final int mRetryAttempts;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jstasks/NoRetryPolicy.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jstasks/NoRetryPolicy.java
@@ -7,6 +7,9 @@
 
 package com.facebook.react.jstasks;
 
+import com.facebook.infer.annotation.Nullsafe;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class NoRetryPolicy implements HeadlessJsTaskRetryPolicy {
 
   public static final NoRetryPolicy INSTANCE = new NoRetryPolicy();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/FileIoHandler.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/FileIoHandler.java
@@ -12,6 +12,7 @@ import android.os.Looper;
 import android.util.Base64;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.util.Iterator;
 import java.util.Map;
 import org.json.JSONObject;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class FileIoHandler implements Runnable {
   private static final String TAG = JSPackagerClient.class.getSimpleName();
   private static final long FILE_TTL = 30 * 1000;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/NotificationOnlyHandler.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/NotificationOnlyHandler.java
@@ -9,7 +9,9 @@ package com.facebook.react.packagerconnection;
 
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class NotificationOnlyHandler implements RequestHandler {
   private static final String TAG = JSPackagerClient.class.getSimpleName();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
@@ -14,8 +14,10 @@ import android.text.TextUtils;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class PackagerConnectionSettings {
   private static final String TAG = PackagerConnectionSettings.class.getSimpleName();
   private static final String PREFS_DEBUG_SERVER_HOST_KEY = "debug_http_host";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/RequestOnlyHandler.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/RequestOnlyHandler.java
@@ -9,7 +9,9 @@ package com.facebook.react.packagerconnection;
 
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class RequestOnlyHandler implements RequestHandler {
   private static final String TAG = JSPackagerClient.class.getSimpleName();
 


### PR DESCRIPTION
Summary:
All these classes are NullSafe, let'\''s mark them as NullSafe(Local) to ensure lint detect errors in the future

changelog: [internal] internal

Differential Revision: D53393141

