### PR TITLE
'[skip ci] [RN][Android] Mark classes of package utils as @Nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/JSStackTrace.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/JSStackTrace.java
@@ -7,12 +7,14 @@
 
 package com.facebook.react.util;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class JSStackTrace {
 
   public static final String LINE_NUMBER_KEY = "lineNumber";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RNLog.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RNLog.java
@@ -9,11 +9,13 @@ package com.facebook.react.util;
 
 import android.util.Log;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.ReactConstants;
 import javax.annotation.Nullable;
 
 /** Logging wrapper for FLog with LogBox support. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class RNLog {
   public static final int MINIMUM_LEVEL_FOR_UI = Log.WARN;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RNLog.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RNLog.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.ReactConstants;
+import javax.annotation.Nullable;
 
 /** Logging wrapper for FLog with LogBox support. */
 public class RNLog {
@@ -60,7 +61,7 @@ public class RNLog {
    * @param context The React context of the application use to display the warning.
    * @param message The message to log.
    */
-  public static void w(ReactContext context, String message) {
+  public static void w(@Nullable ReactContext context, String message) {
     logInternal(context, message, WARN);
     FLog.w(ReactConstants.TAG, message);
   }
@@ -71,7 +72,7 @@ public class RNLog {
    * @param context The React context of the application use to display the error.
    * @param message The message to log.
    */
-  public static void e(ReactContext context, String message) {
+  public static void e(@Nullable ReactContext context, String message) {
     logInternal(context, message, ERROR);
     FLog.e(ReactConstants.TAG, message);
   }
@@ -86,7 +87,8 @@ public class RNLog {
     FLog.e(ReactConstants.TAG, message);
   }
 
-  private static void logInternal(ReactContext context, String message, int level) {
+  private static void logInternal(
+      @Nullable ReactContext context, @Nullable String message, int level) {
     if (level >= MINIMUM_LEVEL_FOR_UI) {
       if (context != null && context.hasActiveReactInstance() && message != null) {
         context.getJSModule(RCTLog.class).logIfNoNativeHook(levelToString(level), message);


### PR DESCRIPTION
Summary:
All these classes are NullSafe, let'\''s mark them as NullSafe(Local) to ensure lint detect errors in the future

changelog: [internal] internal

Differential Revision: D53393475

