### PR TITLE
fix(Codegen): case where no `platform` or `deployment_target` is specified

### DIFF
--- a/packages/react-native-codegen/src/generators/components/ComponentsProviderUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsProviderUtils.js
@@ -26,6 +26,16 @@ function generateSupportedApplePlatformsMacro(
     return fileTemplate;
   }
 
+  // According to Podspec Syntax Reference, when `platform` or `deployment_target` is not specified, it defaults to all platforms.
+  // https://guides.cocoapods.org/syntax/podspec.html#platform
+  const everyPlatformIsUnsupported = Object.keys(supportedPlatformsMap).every(
+    platform => supportedPlatformsMap[platform] === false,
+  );
+
+  if (everyPlatformIsUnsupported) {
+    return fileTemplate;
+  }
+
   const compilerMacroString = Object.keys(supportedPlatformsMap)
     .reduce((acc: string[], platform) => {
       if (!supportedPlatformsMap[platform]) {


### PR DESCRIPTION
## Summary:

This PR fixes a specific case pointed out by @dmytrorykun, where there might be no platform or `deployment_target` specified at all and in that case we assume that this library supports every platform (same as Cocoapods). 

## Changelog:

[IOS] [FIXED] - Don't add compiler conditionals when no platforms are specified

## Test Plan:

Test running codegen when library doesn't specify a `platform`: 

```
require 'json'

package = JSON.parse(File.read(File.join(__dir__, 'package.json')))

Pod::Spec.new do |s|
  s.name            = 'OSSLibraryExample'
  s.version         = package['version']
  s.summary         = package['description']
  s.description     = package['description']
  s.homepage        = package['homepage']
  s.license         = package['license']
  s.author          = 'Meta Platforms, Inc. and its affiliates'
  s.source          = { :git => package['repository'], :tag => '#{s.version}' }

  s.source_files = 'ios/**/*.{h,m,mm,cpp}'

  install_modules_dependencies(s)
end
```

Check generated `RCTThirdPartyFabricComponentsProvider`