### PR TITLE
hide "Open Debugger" item when using local bundle

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevMenu.h
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.h
@@ -98,6 +98,8 @@ typedef NSString * (^RCTDevMenuItemTitleBlock)(void);
  */
 + (instancetype)buttonItemWithTitleBlock:(RCTDevMenuItemTitleBlock)titleBlock handler:(dispatch_block_t)handler;
 
+@property (nonatomic, assign, getter=isDisabled) BOOL disabled;
+
 @end
 
 /**

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.h
@@ -17,6 +17,7 @@
 
 + (id<RCTInspectorPackagerConnectionProtocol>)connectWithBundleURL:(NSURL *)bundleURL;
 + (void)disableDebugger;
++ (BOOL)isPackagerDisconnected;
 + (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage;
 @end
 

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -118,6 +118,17 @@ static void sendEventToAllConnections(NSString *event)
   }
 }
 
++ (BOOL)isPackagerDisconnected
+{
+  for (NSString *socketId in socketConnections) {
+    if ([socketConnections[socketId] isConnected]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 + (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage
 {
   NSString *appId = [[[NSBundle mainBundle] bundleIdentifier]


### PR DESCRIPTION
Summary:
Changelog:
[iOS][Fixed] Hide the "Open Debugger" item from dev menu if the bundle is local

# Existing
In our dev menu, the "Open Debugger" menu item is shown even if Metro isn't connected.

{F1434746954}

# In this PR
The "Open Debugger" menu item is disabled when Metro is disconnected.

## Connect to Metro to debug JavaScript 
{F1451344668}

Differential Revision: D53354110


