### PR TITLE
fix: cannot find module `react-native-*/Libraries/Core/InitializeCore`

### DIFF
--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -66,6 +66,7 @@ function getOverrideConfig(
         ...outOfTreePlatforms.map(platform =>
           require.resolve(
             `${ctx.platforms[platform].npmPackageName}/Libraries/Core/InitializeCore`,
+            {paths: [ctx.root]},
           ),
         ),
       ],


### PR DESCRIPTION
## Summary:

`@react-native/community-cli-plugin` is unable to resolve out-of-tree platforms in monorepos because the package may not be hoisted to the same location. For example, if `@react-native/community-cli-plugin` was hoisted:

```
/~/node_modules/@react-native/community-cli-plugin/dist/utils
```

It may never find `react-native-macos` if it wasn't hoisted:

```
/~/packages/my-app/node_modules/react-native-macos
```

## Changelog:

[GENERAL] [FIXED] - Fix `@react-native/community-cli-plugin` is unable to resolve out-of-tree platforms in monorepos

## Test Plan:

Tested in an internal project.