### PR TITLE
Fix missing packager resources after applying an OTA update

### DIFF
--- a/packages/react-native/Libraries/Image/AssetSourceResolver.js
+++ b/packages/react-native/Libraries/Image/AssetSourceResolver.js
@@ -77,7 +77,12 @@ class AssetSourceResolver {
     }
 
     if (Platform.OS === 'android') {
-      return this.isLoadedFromFileSystem()
+      // Bundle itself may be side-loaded from the file system, not from the 'assets://'
+      // path (such as in the OTA update scenarios), however this doesn't guarantee
+      // that images themselves, which are expected to originally be loaded from 'assets://'
+      // will be present at the same location as the bundle. Therefore, we want to still
+      // load these images from the 'assets://' path.
+      return this.isLoadedFromFileSystem() && !this.asset.__packager_asset
         ? this.drawableFolderInBundle()
         : this.resourceIdentifierWithoutScale();
     } else {


### PR DESCRIPTION
Summary:
## Changelog:
[Internal]-

There was an heuristic in the asset resolving logic RN code (coming from back in 2016), whereas if JS bundle URL starts from `file://`, then all of the local image paths are expected to be relative to the JS bundle path itself (this is Android-only).

This is not the case in certain scenarios, when the new JS bundle is located in a `file://...` folder, however all of the assets that were served from the local file system and coming from the APK should continue doing so, as there is no images being downloaded with the JS bundle patch update - indeed, such images should be served as remote assets.

The diff makes sure that the local files continue to be served from the correct paths.

Differential Revision: D53407804


