### PR TITLE
introduce native api to access RuntimeExecutor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -206,6 +206,15 @@ public class ReactContext extends ContextWrapper {
     return mCatalystInstance.getNativeModule(nativeModuleInterface);
   }
 
+  /** @return the RuntimeExecutor, a thread-safe handler for accessing the runtime. */
+  @Nullable
+  public RuntimeExecutor getRuntimeExecutor() {
+    if (mCatalystInstance == null) {
+      raiseCatalystInstanceMissingException();
+    }
+    return mCatalystInstance.getRuntimeExecutor();
+  }
+
   /**
    * Calls RCTDeviceEventEmitter.emit to JavaScript, with given event name and an optional list of
    * arguments.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
+import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.config.ReactFeatureFlags;
@@ -148,6 +149,14 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   @Override
   public @Nullable <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
     return mReactHost.getNativeModule(nativeModuleInterface);
+  }
+  /**
+   * @return the RuntimeExecutor, a thread-safe handler for accessing the runtime. If the runtime is
+   *     not initialized yet, it will return null.
+   */
+  @Override
+  public @Nullable RuntimeExecutor getRuntimeExecutor() {
+    return mReactHost.getRuntimeExecutor();
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -38,6 +38,7 @@ import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
+import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.queue.QueueThreadExceptionHandler;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
@@ -542,7 +543,8 @@ public class ReactHostImpl implements ReactHost {
     return reactInstance.getEventDispatcher();
   }
 
-  /* package */ @Nullable
+  /* package */
+  @Nullable
   FabricUIManager getUIManager() {
     final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
     if (reactInstance == null) {
@@ -567,7 +569,8 @@ public class ReactHostImpl implements ReactHost {
     return new ArrayList<>();
   }
 
-  /* package */ @Nullable
+  /* package */
+  @Nullable
   <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
     if (nativeModuleInterface == UIManagerModule.class) {
       ReactSoftExceptionLogger.logSoftExceptionVerbose(
@@ -579,6 +582,16 @@ public class ReactHostImpl implements ReactHost {
     final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
     if (reactInstance != null) {
       return reactInstance.getNativeModule(nativeModuleInterface);
+    }
+    return null;
+  }
+
+  /* package */
+  @Nullable
+  RuntimeExecutor getRuntimeExecutor() {
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance != null) {
+      return reactInstance.getBufferedRuntimeExecutor();
     }
     return null;
   }
@@ -699,6 +712,7 @@ public class ReactHostImpl implements ReactHost {
   }
 
   /* package */ interface VeniceThenable<T> {
+
     void then(T t);
   }
 
@@ -913,6 +927,7 @@ public class ReactHostImpl implements ReactHost {
                         });
 
                     class Result {
+
                       final ReactInstance mInstance = instance;
                       final ReactContext mContext = reactContext;
                       final boolean mIsReloading = mReloadTask != null;
@@ -1087,6 +1102,7 @@ public class ReactHostImpl implements ReactHost {
   private @Nullable Task<ReactInstance> mReloadTask = null;
 
   private interface ReactInstanceTaskUnwrapper {
+
     @Nullable
     ReactInstance unwrap(Task<ReactInstance> task, String stage);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -471,7 +471,7 @@ final class ReactInstance {
 
   private native RuntimeExecutor getUnbufferedRuntimeExecutor();
 
-  private native RuntimeExecutor getBufferedRuntimeExecutor();
+  /* package */ native RuntimeExecutor getBufferedRuntimeExecutor();
 
   private native RuntimeScheduler getRuntimeScheduler();
 


### PR DESCRIPTION
Summary:
Changelog: [Android][Added] - introduce native api to access RuntimeExecutor

This is the android equivalent of [PR#42758](https://github.com/facebook/react-native/pull/42758).

From [PR#42758](https://github.com/facebook/react-native/pull/42758)

> The goal of this API is to provide a safe way to access the jsi::runtime in bridgeless mode. The decision to limit access to the runtime in bridgeless was a conscious one - the runtime pointer is not thread-safe and its lifecycle must be managed correctly by owners.

> However, interacting with the runtime is an advanced use case we would want to support. Our recommended ways to access the runtime in bridgeless mode is either 1) via the RuntimeExecutor, or 2) via a C++ TurboModule.

This diff introduces the API that would allow for 1). because react context can be non-null before react instance is ready, i created an async api that will guarantee the runtime executor will be ready.

Differential Revision: D53461821


