### PR TITLE
Remove matching of Modern/Legacy page types

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -475,19 +475,14 @@ describe.each(['HTTP', 'HTTPS'])(
       );
     });
 
-    describe.each([
-      ['for modern targets', {}],
-      [
-        "when target has 'nativeSourceMapFetching' capability flag",
-        {nativeSourceMapFetching: true},
-      ],
-    ])('disabled %s', (_, capabilities: TargetCapabilityFlags) => {
+    describe("disabled when target has 'nativeSourceCodeFetching' capability flag", () => {
       const pageDescription = {
         app: 'bar-app',
         id: 'page1',
         title: 'bar-title',
-        type: 'Modern',
-        capabilities,
+        capabilities: {
+          nativeSourceCodeFetching: true,
+        },
         vm: 'bar-vm',
       };
 

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -193,7 +193,6 @@ describe('inspector proxy HTTP API', () => {
             reactNative: {
               capabilities: {},
               logicalDeviceId: 'device1',
-              type: 'Legacy',
             },
             title: 'bar-title',
             type: 'node',
@@ -209,7 +208,6 @@ describe('inspector proxy HTTP API', () => {
             reactNative: {
               capabilities: {},
               logicalDeviceId: 'device2',
-              type: 'Legacy',
             },
             title: 'bar-title',
             type: 'node',

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -191,6 +191,7 @@ describe('inspector proxy HTTP API', () => {
             faviconUrl: 'https://reactjs.org/favicon.ico',
             id: 'device1-page1',
             reactNative: {
+              capabilities: {},
               logicalDeviceId: 'device1',
               type: 'Legacy',
             },
@@ -206,6 +207,7 @@ describe('inspector proxy HTTP API', () => {
             faviconUrl: 'https://reactjs.org/favicon.ico',
             id: 'device2-page1',
             reactNative: {
+              capabilities: {},
               logicalDeviceId: 'device2',
               type: 'Legacy',
             },

--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -397,13 +397,7 @@ describe('inspector proxy React Native reloads', () => {
     }
   });
 
-  test.each([
-    ['for modern targets', {}],
-    [
-      "when target has 'nativePageReloads' capability flag",
-      {nativePageReloads: true},
-    ],
-  ])('disabled %s', async (_, capabilities) => {
+  test("disabled when target has 'nativePageReloads' capability flag", async () => {
     let device1;
     try {
       /***
@@ -420,8 +414,9 @@ describe('inspector proxy React Native reloads', () => {
           // NOTE: 'React' is a magic string used to detect React Native pages
           // in legacy mode.
           title: 'React Native (mock)',
-          type: 'Modern',
-          capabilities,
+          capabilities: {
+            nativePageReloads: true,
+          },
           vm: 'vm',
         },
       ]);
@@ -456,8 +451,9 @@ describe('inspector proxy React Native reloads', () => {
           id: 'originalPage-updated',
           // NOTE: 'React' is a magic string used to detect React Native pages.
           title: 'React Native (mock)',
-          type: 'Modern',
-          capabilities,
+          capabilities: {
+            nativePageReloads: true,
+          },
           vm: 'vm',
         },
       ]);

--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -397,7 +397,13 @@ describe('inspector proxy React Native reloads', () => {
     }
   });
 
-  test('disabled for modern targets', async () => {
+  test.each([
+    ['for modern targets', {}],
+    [
+      "when target has 'nativePageReloads' capability flag",
+      {nativePageReloads: true},
+    ],
+  ])('disabled %s', async (_, capabilities) => {
     let device1;
     try {
       /***
@@ -415,6 +421,7 @@ describe('inspector proxy React Native reloads', () => {
           // in legacy mode.
           title: 'React Native (mock)',
           type: 'Modern',
+          capabilities,
           vm: 'vm',
         },
       ]);
@@ -450,6 +457,7 @@ describe('inspector proxy React Native reloads', () => {
           // NOTE: 'React' is a magic string used to detect React Native pages.
           title: 'React Native (mock)',
           type: 'Modern',
+          capabilities,
           vm: 'vm',
         },
       ]);

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -167,7 +167,6 @@ export default class Device {
         title: 'React Native Experimental (Improved Chrome Reloads)',
         vm: "don't use",
         app: this.#app,
-        type: 'Legacy',
         capabilities: {},
       };
       return [...this.#pages.values(), reactNativeReloadablePage];
@@ -306,11 +305,10 @@ export default class Device {
   }
 
   /**
-   * Returns `true` if a page reports `type: 'Modern'` or supports the given
-   * target capability flag.
+   * Returns `true` if a page supports the given target capability flag.
    */
   #pageHasCapability(page: Page, flag: $Keys<TargetCapabilityFlags>): boolean {
-    return page.type === 'Modern' || page.capabilities[flag] === true;
+    return page.capabilities[flag] === true;
   }
 
   // Handles messages received from device:
@@ -323,11 +321,10 @@ export default class Device {
   #handleMessageFromDevice(message: MessageFromDevice) {
     if (message.event === 'getPages') {
       this.#pages = new Map(
-        message.payload.map(({type, capabilities, ...page}) => [
+        message.payload.map(({capabilities, ...page}) => [
           page.id,
           {
             ...page,
-            type: type ?? 'Legacy',
             capabilities: capabilities ?? {},
           },
         ]),

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -9,6 +9,7 @@
  */
 
 import type {EventReporter} from '../types/EventReporter';
+import type {CDPResponse} from './cdp-types/messages';
 
 import TTLCache from '@isaacs/ttlcache';
 
@@ -69,11 +70,7 @@ class DeviceEventReporter {
   }
 
   logResponse(
-    res: $ReadOnly<{
-      id: number,
-      error?: {message: string, data?: mixed},
-      ...
-    }>,
+    res: CDPResponse<>,
     origin: 'device' | 'proxy',
     metadata: $ReadOnly<{
       pageId: string | null,

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -153,6 +153,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
       reactNative: {
         logicalDeviceId: deviceId,
         type: nullthrows(page.type),
+        capabilities: nullthrows(page.capabilities),
       },
     };
   }

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -152,7 +152,6 @@ export default class InspectorProxy implements InspectorProxyQueries {
       deviceName: device.getName(),
       reactNative: {
         logicalDeviceId: deviceId,
-        type: nullthrows(page.type),
         capabilities: nullthrows(page.capabilities),
       },
     };

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
@@ -41,5 +41,12 @@ export type CDPRequestError = $ReadOnly<{
 
 export type CDPClientMessage =
   | CDPRequest<'Debugger.getScriptSource'>
+  | CDPRequest<'Debugger.scriptParsed'>
   | CDPRequest<'Debugger.setBreakpointByUrl'>
   | CDPRequest<>;
+
+export type CDPServerMessage =
+  | CDPEvent<'Debugger.scriptParsed'>
+  | CDPEvent<>
+  | CDPResponse<'Debugger.getScriptSource'>
+  | CDPResponse<>;

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Commands, Events} from './protocol';
+
+// Note: A CDP event is a JSON-RPC notification with no `id` member.
+export type CDPEvent<TEvent: $Keys<Events> = 'unknown'> = $ReadOnly<{
+  method: TEvent,
+  params: Events[TEvent],
+}>;
+
+export type CDPRequest<TCommand: $Keys<Commands> = 'unknown'> = $ReadOnly<{
+  method: TCommand,
+  params: Commands[TCommand]['paramsType'],
+  id: number,
+}>;
+
+export type CDPResponse<TCommand: $Keys<Commands> = 'unknown'> =
+  | $ReadOnly<{
+      result: Commands[TCommand]['resultType'],
+      id: number,
+    }>
+  | $ReadOnly<{
+      error: CDPRequestError,
+      id: number,
+    }>;
+
+export type CDPRequestError = $ReadOnly<{
+  code: number,
+  message: string,
+  data?: mixed,
+}>;
+
+export type CDPClientMessage =
+  | CDPRequest<'Debugger.getScriptSource'>
+  | CDPRequest<'Debugger.setBreakpointByUrl'>
+  | CDPRequest<>;

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
@@ -11,6 +11,8 @@
 
 // Adapted from https://github.com/ChromeDevTools/devtools-protocol/blob/master/types/protocol.d.ts
 
+type integer = number;
+
 export interface Debugger {
   GetScriptSourceParams: $ReadOnly<{
     /**
@@ -35,7 +37,7 @@ export interface Debugger {
     /**
      * Line number to set breakpoint at.
      */
-    lineNumber: number,
+    lineNumber: integer,
 
     /**
      * URL of the resources to set breakpoint on.
@@ -56,7 +58,7 @@ export interface Debugger {
     /**
      * Offset in the line to set breakpoint at.
      */
-    columnNumber?: number,
+    columnNumber?: integer,
 
     /**
      * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
@@ -64,9 +66,27 @@ export interface Debugger {
      */
     condition?: string,
   }>;
+
+  ScriptParsedEvent: $ReadOnly<{
+    /**
+     * Identifier of the script parsed.
+     */
+    scriptId: string,
+
+    /**
+     * URL or name of the script parsed (if any).
+     */
+    url: string,
+
+    /**
+     * URL of source map associated with script (if any).
+     */
+    sourceMapURL: string,
+  }>;
 }
 
 export type Events = {
+  'Debugger.scriptParsed': Debugger['ScriptParsedEvent'],
   [method: string]: mixed,
 };
 
@@ -75,12 +95,10 @@ export type Commands = {
     paramsType: Debugger['GetScriptSourceParams'],
     resultType: Debugger['GetScriptSourceResult'],
   },
-
   'Debugger.setBreakpointByUrl': {
     paramsType: Debugger['SetBreakpointByUrlParams'],
     resultType: void,
   },
-
   [method: string]: {
     paramsType: mixed,
     resultType: mixed,

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+// Adapted from https://github.com/ChromeDevTools/devtools-protocol/blob/master/types/protocol.d.ts
+
+export interface Debugger {
+  GetScriptSourceParams: $ReadOnly<{
+    /**
+     * Id of the script to get source for.
+     */
+    scriptId: string,
+  }>;
+
+  GetScriptSourceResult: $ReadOnly<{
+    /**
+     * Script source (empty in case of Wasm bytecode).
+     */
+    scriptSource: string,
+
+    /**
+     * Wasm bytecode. (Encoded as a base64 string when passed over JSON)
+     */
+    bytecode?: string,
+  }>;
+
+  SetBreakpointByUrlParams: $ReadOnly<{
+    /**
+     * Line number to set breakpoint at.
+     */
+    lineNumber: number,
+
+    /**
+     * URL of the resources to set breakpoint on.
+     */
+    url?: string,
+
+    /**
+     * Regex pattern for the URLs of the resources to set breakpoints on. Either `url` or
+     * `urlRegex` must be specified.
+     */
+    urlRegex?: string,
+
+    /**
+     * Script hash of the resources to set breakpoint on.
+     */
+    scriptHash?: string,
+
+    /**
+     * Offset in the line to set breakpoint at.
+     */
+    columnNumber?: number,
+
+    /**
+     * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
+     * breakpoint if this expression evaluates to true.
+     */
+    condition?: string,
+  }>;
+}
+
+export type Events = {
+  [method: string]: mixed,
+};
+
+export type Commands = {
+  'Debugger.getScriptSource': {
+    paramsType: Debugger['GetScriptSourceParams'],
+    resultType: Debugger['GetScriptSourceResult'],
+  },
+
+  'Debugger.setBreakpointByUrl': {
+    paramsType: Debugger['SetBreakpointByUrlParams'],
+    resultType: void,
+  },
+
+  [method: string]: {
+    paramsType: mixed,
+    resultType: mixed,
+  },
+};

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -23,6 +23,13 @@ export type TargetCapabilityFlags = $ReadOnly<{
    * In the launch flow, this allows targets to be matched directly by `appId`.
    */
   nativePageReloads?: boolean,
+
+  /**
+   * The target supports fetching source code and source maps.
+   *
+   * In the proxy, this disables source fetching emulation and host rewrites.
+   */
+  nativeSourceCodeFetching?: boolean,
 }>;
 
 // Page information received from the device. New page is created for

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -95,49 +95,6 @@ export type JsonVersionResponse = $ReadOnly<{
   'Protocol-Version': string,
 }>;
 
-/**
- * Types were exported from https://github.com/ChromeDevTools/devtools-protocol/blob/master/types/protocol.d.ts
- */
-
-export type SetBreakpointByUrlRequest = $ReadOnly<{
-  id: number,
-  method: 'Debugger.setBreakpointByUrl',
-  params: $ReadOnly<{
-    lineNumber: number,
-    url?: string,
-    urlRegex?: string,
-    scriptHash?: string,
-    columnNumber?: number,
-    condition?: string,
-  }>,
-}>;
-
-export type GetScriptSourceRequest = $ReadOnly<{
-  id: number,
-  method: 'Debugger.getScriptSource',
-  params: {
-    scriptId: string,
-  },
-}>;
-
-export type GetScriptSourceResponse = $ReadOnly<{
-  scriptSource: string,
-  /**
-   * Wasm bytecode.
-   */
-  bytecode?: string,
-}>;
-
-export type ErrorResponse = $ReadOnly<{
-  error: $ReadOnly<{
-    message: string,
-  }>,
-}>;
-
-export type DebuggerRequest =
-  | SetBreakpointByUrlRequest
-  | GetScriptSourceRequest;
-
 export type JSONSerializable =
   | boolean
   | number

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -9,6 +9,22 @@
  * @oncall react_native
  */
 
+/**
+ * A capability flag disables a specific feature/hack in the InspectorProxy
+ * layer by indicating that the target supports one or more modern CDP features.
+ */
+export type TargetCapabilityFlags = $ReadOnly<{
+  /**
+   * The target supports a stable page representation across reloads.
+   *
+   * In the proxy, this disables legacy page reload emulation and the
+   * additional '(Experimental)' target in `/json/list`.
+   *
+   * In the launch flow, this allows targets to be matched directly by `appId`.
+   */
+  nativePageReloads?: boolean,
+}>;
+
 // Page information received from the device. New page is created for
 // each new instance of VM and can appear when user reloads React Native
 // application.
@@ -19,6 +35,7 @@ export type PageFromDevice = $ReadOnly<{
   vm: string,
   app: string,
   type?: 'Legacy' | 'Modern',
+  capabilities?: TargetCapabilityFlags,
 }>;
 
 export type Page = Required<PageFromDevice>;
@@ -83,6 +100,7 @@ export type PageDescription = $ReadOnly<{
   reactNative: $ReadOnly<{
     logicalDeviceId: string,
     type: $NonMaybeType<Page['type']>,
+    capabilities: Page['capabilities'],
   }>,
 }>;
 

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -41,7 +41,6 @@ export type PageFromDevice = $ReadOnly<{
   title: string,
   vm: string,
   app: string,
-  type?: 'Legacy' | 'Modern',
   capabilities?: TargetCapabilityFlags,
 }>;
 
@@ -106,7 +105,6 @@ export type PageDescription = $ReadOnly<{
   // Metadata specific to React Native
   reactNative: $ReadOnly<{
     logicalDeviceId: string,
-    type: $NonMaybeType<Page['type']>,
     capabilities: Page['capabilities'],
   }>,
 }>;

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -63,8 +63,7 @@ export default function openDebuggerMiddleware({
         // Only use targets with better reloading support
         app =>
           app.title === 'React Native Experimental (Improved Chrome Reloads)' ||
-          app.reactNative.capabilities?.nativePageReloads === true ||
-          app.reactNative.type === 'Modern',
+          app.reactNative.capabilities?.nativePageReloads === true,
       );
 
       let target;

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -63,6 +63,7 @@ export default function openDebuggerMiddleware({
         // Only use targets with better reloading support
         app =>
           app.title === 'React Native Experimental (Improved Chrome Reloads)' ||
+          app.reactNative.capabilities?.nativePageReloads === true ||
           app.reactNative.type === 'Modern',
       );
 

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -430,7 +430,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
                   .integrationName = "iOS Bridge (RCTBridge)",
               });
         },
-        facebook::react::jsinspector_modern::InspectorPageType::Modern);
+        {.nativePageReloads = true});
   }
 
   Class bridgeClass = self.bridgeClass;

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
@@ -24,6 +24,13 @@ IRemoteConnection::~IRemoteConnection() {}
 IInspector::~IInspector() {}
 IPageStatusListener::~IPageStatusListener() {}
 
+const folly::dynamic targetCapabilitiesToDynamic(
+    const InspectorTargetCapabilities& capabilities) {
+  return folly::dynamic::object(
+      "nativePageReloads", capabilities.nativePageReloads)(
+      "nativeSourceCodeFetching", capabilities.nativeSourceCodeFetching);
+}
+
 namespace {
 
 class InspectorImpl : public IInspector {
@@ -32,7 +39,7 @@ class InspectorImpl : public IInspector {
       const std::string& title,
       const std::string& vm,
       ConnectFunc connectFunc,
-      InspectorPageType type) override;
+      InspectorTargetCapabilities capabilities) override;
   void removePage(int pageId) override;
 
   std::vector<InspectorPageDescription> getPages() const override;
@@ -51,7 +58,7 @@ class InspectorImpl : public IInspector {
         const std::string& title,
         const std::string& vm,
         ConnectFunc connectFunc,
-        InspectorPageType type);
+        InspectorTargetCapabilities capabilities);
     operator InspectorPageDescription() const;
 
     ConnectFunc getConnectFunc() const;
@@ -61,7 +68,7 @@ class InspectorImpl : public IInspector {
     std::string title_;
     std::string vm_;
     ConnectFunc connectFunc_;
-    InspectorPageType type_;
+    InspectorTargetCapabilities capabilities_;
   };
   mutable std::mutex mutex_;
   int nextPageId_{1};
@@ -74,19 +81,19 @@ InspectorImpl::Page::Page(
     const std::string& title,
     const std::string& vm,
     ConnectFunc connectFunc,
-    InspectorPageType type)
+    InspectorTargetCapabilities capabilities)
     : id_(id),
       title_(title),
       vm_(vm),
       connectFunc_(std::move(connectFunc)),
-      type_(type) {}
+      capabilities_(std::move(capabilities)) {}
 
 InspectorImpl::Page::operator InspectorPageDescription() const {
   return InspectorPageDescription{
       .id = id_,
       .title = title_,
       .vm = vm_,
-      .type = type_,
+      .capabilities = capabilities_,
   };
 }
 
@@ -98,12 +105,13 @@ int InspectorImpl::addPage(
     const std::string& title,
     const std::string& vm,
     ConnectFunc connectFunc,
-    InspectorPageType type) {
+    InspectorTargetCapabilities capabilities) {
   std::scoped_lock lock(mutex_);
 
   int pageId = nextPageId_++;
   assert(pages_.count(pageId) == 0 && "Unexpected duplicate page ID");
-  pages_.emplace(pageId, Page{pageId, title, vm, std::move(connectFunc), type});
+  pages_.emplace(
+      pageId, Page{pageId, title, vm, std::move(connectFunc), capabilities});
 
   return pageId;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <folly/dynamic.h>
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -31,25 +33,19 @@ class IDestructible {
   virtual ~IDestructible() = 0;
 };
 
-enum class InspectorPageType {
-  Legacy,
-  Modern,
+struct InspectorTargetCapabilities {
+  const bool nativePageReloads = false;
+  const bool nativeSourceCodeFetching = false;
 };
 
-inline const char* pageTypeToString(InspectorPageType type) {
-  switch (type) {
-    case InspectorPageType::Legacy:
-      return "Legacy";
-    case InspectorPageType::Modern:
-      return "Modern";
-  }
-}
+const folly::dynamic targetCapabilitiesToDynamic(
+    const InspectorTargetCapabilities& capabilities);
 
 struct InspectorPageDescription {
   const int id;
   const std::string title;
   const std::string vm;
-  const InspectorPageType type;
+  const InspectorTargetCapabilities capabilities;
 };
 
 // Alias for backwards compatibility.
@@ -106,7 +102,7 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
       const std::string& title,
       const std::string& vm,
       ConnectFunc connectFunc,
-      InspectorPageType type = InspectorPageType::Legacy) = 0;
+      InspectorTargetCapabilities capabilities = {}) = 0;
 
   /// removePage is called by the VM to remove a page from the list of
   /// debuggable pages.

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
@@ -157,9 +157,15 @@ folly::dynamic InspectorPackagerConnection::Impl::pages() {
   folly::dynamic array = folly::dynamic::array();
 
   for (const auto& page : pages) {
-    array.push_back(folly::dynamic::object("id", std::to_string(page.id))(
-        "title", page.title + " [C++ connection]")(
-        "app", app_)("vm", page.vm)("type", pageTypeToString(page.type)));
+    folly::dynamic pageDescription = folly::dynamic::object;
+    pageDescription["id"] = std::to_string(page.id);
+    pageDescription["title"] = page.title + " [C++ connection]";
+    pageDescription["app"] = app_;
+    pageDescription["vm"] = page.vm;
+    pageDescription["capabilities"] =
+        targetCapabilitiesToDynamic(page.capabilities);
+
+    array.push_back(pageDescription);
   }
   return array;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
@@ -203,7 +203,8 @@ TEST_F(InspectorPackagerConnectionTest, TestGetPages) {
       "mock-title",
       "mock-vm",
       localConnections_
-          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>(),
+      {.nativePageReloads = true});
 
   // getPages now reports the page we registered.
   EXPECT_CALL(
@@ -217,7 +218,10 @@ TEST_F(InspectorPackagerConnectionTest, TestGetPages) {
                   AtJsonPtr("/title", Eq("mock-title [C++ connection]")),
                   AtJsonPtr("/vm", Eq("mock-vm")),
                   AtJsonPtr("/id", Eq(std::to_string(pageId))),
-                  AtJsonPtr("/type", Eq("Legacy")))}))))))
+                  AtJsonPtr("/capabilities/nativePageReloads", Eq(true)),
+                  AtJsonPtr(
+                      "/capabilities/nativeSourceCodeFetching",
+                      Eq(false)))}))))))
       .RetiresOnSaturation();
   webSockets_[0]->getDelegate().didReceiveMessage(R"({
       "event": "getPages"

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -186,7 +186,7 @@ class RCTHostPageTargetDelegate : public facebook::react::jsinspector_modern::Pa
                   .integrationName = "iOS Bridgeless (RCTHost)",
               });
         },
-        facebook::react::jsinspector_modern::InspectorPageType::Modern);
+        {.nativePageReloads = true});
   }
   if (_instance) {
     RCTLogWarn(


### PR DESCRIPTION
Summary:
## Context

We're introducing the concept of **capability flags** to provide granular control of behaviours in the Inspector Proxy, to replace the recently added `type: 'Legacy' | 'Modern'` target switch.

A capability flag disables a specific feature/hack in the Inspector Proxy layer by indicating that the target supports one or more modern CDP features.

## This diff

Following D53355413, we're now able to remove the previous `type: 'Legacy' | 'Modern'` page concept, implemented in this diff.

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D53358480


