### PR TITLE
fix: PerfMonitor option not showing on iOS (Bridgeless)

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -299,6 +299,14 @@ RCT_EXPORT_MODULE()
                            devSettings.isHotLoadingEnabled = !devSettings.isHotLoadingEnabled;
                          }]];
   }
+  
+  id perfMonitorItemOpaque = [_moduleRegistry moduleForName:"PerfMonitor"];
+  SEL devMenuItem = NSSelectorFromString(@"devMenuItem");
+  if ([perfMonitorItemOpaque respondsToSelector:devMenuItem]) {
+    RCTDevMenuItem *perfMonitorItem = [perfMonitorItemOpaque performSelector:devMenuItem];
+    [items addObject:perfMonitorItem];
+  }
+  
 
   [items
       addObject:[RCTDevMenuItem

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -63,7 +63,6 @@ static vm_size_t RCTGetResidentMemorySize(void)
 @interface RCTPerfMonitor : NSObject <
                                 RCTBridgeModule,
                                 RCTTurboModule,
-                                RCTInitializing,
                                 RCTInvalidating,
                                 UITableViewDataSource,
                                 UITableViewDelegate>
@@ -129,13 +128,6 @@ RCT_EXPORT_MODULE()
 - (dispatch_queue_t)methodQueue
 {
   return dispatch_get_main_queue();
-}
-
-- (void)initialize
-{
-#if __has_include(<React/RCTDevMenu.h>)
-  [(RCTDevMenu *)[_moduleRegistry moduleForName:"DevMenu"] addItem:self.devMenuItem];
-#endif
 }
 
 - (void)invalidate


### PR DESCRIPTION
## Summary:

This PR fixes PerfMonitor option not showing on iOS when running bridgeless. The `initialize` method is not called in bridgeless which causes this option to not be added. I've converted this approach to work for both bridgeless and non-bridgeless. 

## Changelog:

[IOS] [FIXED] - Perf Monitor option not showing in Bridgeless


## Test Plan:

Run RNTester, open Perf monitor
