### PR TITLE
Add Flow and document template init script, simplify args

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -360,7 +360,7 @@ jobs:
           command: |
             REPO_ROOT=$(pwd)
             node ./scripts/releases/update-template-package.js "{\"react-native\":\"file:$REPO_ROOT/build/$(cat build/react-native-package-version)\"}"
-            node ./scripts/template/initialize.js --reactNativeRootPath $REPO_ROOT --templateName $PROJECT_NAME --templateConfigPath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME"
+            node ./scripts/template/initialize.js --projectName $PROJECT_NAME --templatePath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME"
       - with_gradle_cache:
           steps:
             - run:
@@ -458,7 +458,7 @@ jobs:
             PACKAGE=$(cat build/react-native-package-version)
             PATH_TO_PACKAGE="$REPO_ROOT/build/$PACKAGE"
             node ./scripts/releases/update-template-package.js "{\"react-native\":\"file:$PATH_TO_PACKAGE\"}"
-            node ./scripts/template/initialize.js --reactNativeRootPath $REPO_ROOT --templateName $PROJECT_NAME --templateConfigPath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME"
+            node ./scripts/template/initialize.js --projectName $PROJECT_NAME --templatePath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME"
       - with_xcodebuild_cache:
           podfile_lock_path: << parameters.podfile_lock_path >>
           pods_build_folder: << parameters.pods_build_folder >>

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -20,7 +20,7 @@
  */
 
 const forEachPackage = require('./monorepo/for-each-package');
-const setupVerdaccio = require('./setup-verdaccio');
+const setupVerdaccio = require('./template/setup-verdaccio');
 const tryExecNTimes = require('./try-n-times');
 const {execFileSync, spawn} = require('child_process');
 const path = require('path');

--- a/scripts/template/setup-verdaccio.js
+++ b/scripts/template/setup-verdaccio.js
@@ -4,7 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
+ * @oncall react_native
  */
 
 'use strict';
@@ -12,22 +14,10 @@
 const {execSync, spawn} = require('child_process');
 
 function setupVerdaccio(
-  reactNativeRootPath, // Path to React Native root folder
-  verdaccioConfigPath, // Path to Verdaccio config file, which you want to use for bootstrapping Verdaccio
-  verdaccioStoragePath, // Path to Verdaccio storage, where it should keep packages. Optional. Default value will be decided by your Verdaccio config
-) {
-  if (!reactNativeRootPath) {
-    throw new Error(
-      'Path to React Native repo root is not specified. You should provide it as a first argument',
-    );
-  }
-
-  if (!verdaccioConfigPath) {
-    throw new Error(
-      'Path to Verdaccio config is not specified. You should provide it as a second argument',
-    );
-  }
-
+  reactNativeRootPath /*: string */,
+  verdaccioConfigPath /*: string */,
+  verdaccioStoragePath /*: ?string */,
+) /*: number */ {
   execSync('echo "//localhost:4873/:_authToken=secretToken" > .npmrc', {
     cwd: reactNativeRootPath,
   });
@@ -38,12 +28,10 @@ function setupVerdaccio(
     {env: {...process.env, VERDACCIO_STORAGE_PATH: verdaccioStoragePath}},
   );
 
-  const VERDACCIO_PID = verdaccioProcess.pid;
-
   execSync('npx wait-on@6.0.1 http://localhost:4873');
   execSync('npm set registry http://localhost:4873');
 
-  return VERDACCIO_PID;
+  return verdaccioProcess.pid;
 }
 
 module.exports = setupVerdaccio;


### PR DESCRIPTION
Summary:

- Add Flow, switch from `yargs` to `parseArgs` (built-in to Node.js, Flow-safe).
- Document script via `--help` output (relevant ahead of reusing this script for local release testing).
- Relocate and add Flow to `setup-verdaccio.js` util.

Also:
- Remove `--reactNativeRootPath` arg.
- Tweak other arg names.

Changelog: [Internal]

Differential Revision: D53484322

