### PR TITLE
fix(dev-middleware): fix `react-native config` failing in pnpm setups

### DIFF
--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -33,7 +33,8 @@
     "open": "^7.0.3",
     "selfsigned": "^2.4.1",
     "serve-static": "^1.13.1",
-    "temp-dir": "^2.0.0"
+    "temp-dir": "^2.0.0",
+    "ws": "^6.2.2"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary:

In a pnpm setup, `react-native config` fails to read `react-native/react-native.config.js` because `ws` was not installed:

```
% node --print 'require("react-native/react-native.config.js")'
node:internal/modules/cjs/loader:1137
  throw err;
  ^

Error: Cannot find module 'ws'
```

## Changelog:

[GENERAL] [FIXED] - fix `react-native config` failing in pnpm setups

## Test Plan:

n/a