### PR TITLE
Update tsconfig to not run on files inside Pods

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -36,5 +36,8 @@
       "skipLibCheck": true,
       // Causes issues with package.json "exports"
       "forceConsistentCasingInFileNames": false
-    }
+    },
+    "exclude": [
+      "**/Pods/**"
+    ]
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Opening the VisionOS fork crashes `tsserver.js` inside VSCode because of some Pods files. This stops `tsserver` from looking at any files inside Pods 

[Link to issue](https://github.com/callstack/react-native-visionos/issues/97)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [ADDED] - Added a folder inside the `exclude` array inside `tsconfig`

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
