### PR TITLE
Fix Reload behavior being different on Bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessDevSupportManager.java
@@ -11,11 +11,15 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
+import com.facebook.debug.holder.PrinterHolder;
+import com.facebook.debug.tags.ReactDebugOverlayTags;
+import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JavaJSExecutor;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.devsupport.DevSupportManagerBase;
 import com.facebook.react.devsupport.HMRClient;
 import com.facebook.react.devsupport.ReactInstanceDevHelper;
@@ -93,8 +97,17 @@ class BridgelessDevSupportManager extends DevSupportManagerBase {
 
   @Override
   public void handleReloadJS() {
+    UiThreadUtil.assertOnUiThread();
+
+    // dismiss redbox if exists
     hideRedboxDialog();
     mReactHost.reload("BridgelessDevSupportManager.handleReloadJS()");
+
+    PrinterHolder.getPrinter()
+        .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server");
+    String bundleURL =
+        getDevServerHelper().getDevServerBundleURL(Assertions.assertNotNull(getJSAppBundleName()));
+    reloadJSFromServer(bundleURL);
   }
 
   private static ReactInstanceDevHelper createInstanceDevHelper(final ReactHostImpl reactHost) {


### PR DESCRIPTION
Summary:
If the app is not connected to Metro, the behavior of the refresh is different between bridgeless and bridge. This is because the `handleReloadJS` is implemented differently between the two support managers. I'm fixing it.

Changelog:
[Android] [Fixed] - Fix Reload behavior being different on Bridgeless

Differential Revision: D53526369


