### PR TITLE
Load custom RCTURLRequestHandler dynamically.

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTURLRequestHandlerProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTURLRequestHandlerProvider.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RCTURLRequestHandlerProvider : NSObject
+
++ (NSArray<NSString *> *)customURLRequestHandlerClassNames;
+
+@end

--- a/packages/react-native/Libraries/AppDelegate/RCTURLRequestHandlerProvider.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTURLRequestHandlerProvider.mm
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTURLRequestHandlerProvider.h"
+
+@implementation RCTURLRequestHandlerProvider : NSObject
+
++ (NSArray<NSString *> *)customURLRequestHandlerClassNames
+{
+  return @[
+    // The content of this array is codegenerated reading the
+    // codegenConfig.ios.customURLRequestHandler array
+    // e.g.:
+    @"MyCustomURLRequestHandler",
+  ];
+}
+
+@end


### PR DESCRIPTION
Summary:
Libraries can declare their own objects and modules that can conform to `RCTURLRequestHandler`. The new architecture has no mechanism to load those custom classes.

This change is a proposal on how this can be achieved in a declarative way, by leveraging codegen.

If users want to opt-out from codegen, they can update the `RCTURLRequestHandlerProvider.mm` manually.

## Changelog:
[iOS][Added] - Offer mechanism to link custom RCTURLHandler when the app starts

Differential Revision: D53312017


