### PR TITLE
fix C++ memory crash

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAlertManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertManager.mm
@@ -84,6 +84,7 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
   NSString *destructiveButtonKey = [RCTConvert NSString:args.destructiveButtonKey()];
   NSString *preferredButtonKey = [RCTConvert NSString:args.preferredButtonKey()];
   UIKeyboardType keyboardType = [RCTConvert UIKeyboardType:args.keyboardType()];
+  UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:args.userInterfaceStyle()];
 
   if (!title && !message) {
     RCTLogError(@"Must specify either an alert title, or message, or both");
@@ -108,7 +109,6 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
                                                                                message:nil
                                                                         preferredStyle:UIAlertControllerStyleAlert];
 
-    UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:args.userInterfaceStyle()];
     alertController.overrideUserInterfaceStyle = userInterfaceStyle;
 
     switch (type) {


### PR DESCRIPTION
Summary:
blocks don't capture C++ objects so this will would crash

Changelog: [iOS][Internal]

Reviewed By: sammy-SC, cipolleschi

Differential Revision: D53572123


