### PR TITLE
Refactor package discovery in publish script

### DIFF
--- a/scripts/monorepo/__tests__/find-and-publish-all-bumped-packages-test.js
+++ b/scripts/monorepo/__tests__/find-and-publish-all-bumped-packages-test.js
@@ -4,7 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
+ * @oncall react_native
  */
 
 const {PUBLISH_PACKAGES_TAG} = require('../constants');
@@ -12,18 +14,21 @@ const {
   findAndPublishAllBumpedPackages,
   getTagsFromCommitMessage,
 } = require('../find-and-publish-all-bumped-packages');
-const forEachPackage = require('../for-each-package');
-const {spawnSync} = require('child_process');
 
-jest.mock('child_process', () => ({spawnSync: jest.fn()}));
-jest.mock('../for-each-package', () => jest.fn());
+const spawnSync = jest.fn();
+const forEachPackage = jest.fn();
+const execMock = jest.fn();
+
+jest.mock('child_process', () => ({spawnSync}));
+jest.mock('shelljs', () => ({exec: execMock}));
+jest.mock('../for-each-package', () => forEachPackage);
 
 describe('findAndPublishAllBumpedPackages', () => {
   beforeEach(() => {
-    // Silence logs.
     jest.spyOn(console, 'log').mockImplementation(() => {});
   });
-  it('throws an error if updated version is not 0.x.y', () => {
+
+  test('should throw an error if updated version is not 0.x.y', async () => {
     const mockedPackageNewVersion = '1.0.0';
 
     forEachPackage.mockImplementationOnce(callback => {
@@ -40,9 +45,63 @@ describe('findAndPublishAllBumpedPackages', () => {
       stdout: `This is my commit message\n\n${PUBLISH_PACKAGES_TAG}`,
     }));
 
-    expect(() => findAndPublishAllBumpedPackages()).toThrow(
+    await expect(findAndPublishAllBumpedPackages()).rejects.toThrow(
       `Package version expected to be 0.x.y, but received ${mockedPackageNewVersion}`,
     );
+  });
+
+  test('should publish all changed packages', async () => {
+    forEachPackage.mockImplementationOnce(callback => {
+      callback('absolute/path/to/package-a', 'to/package-a', {
+        version: '0.72.1',
+      });
+      callback('absolute/path/to/package-b', 'to/package-b', {
+        version: '0.72.1',
+      });
+      callback('absolute/path/to/package-c', 'to/package-b', {
+        version: '0.72.0',
+      });
+    });
+
+    spawnSync.mockImplementationOnce(() => ({
+      stdout: `-  "version": "0.72.0"\n+  "version": "0.72.1"\n`,
+    }));
+    spawnSync.mockImplementationOnce(() => ({
+      stdout: `This is my commit message\n\n${PUBLISH_PACKAGES_TAG}`,
+    }));
+    spawnSync.mockImplementationOnce(() => ({
+      stdout: `-  "version": "0.72.0"\n+  "version": "0.72.1"\n`,
+    }));
+    spawnSync.mockImplementationOnce(() => ({
+      stdout: `This is my commit message\n\n${PUBLISH_PACKAGES_TAG}`,
+    }));
+    spawnSync.mockImplementationOnce(() => ({
+      stdout: '\n',
+    }));
+    spawnSync.mockImplementationOnce(() => ({
+      stdout: `This is my commit message\n\n${PUBLISH_PACKAGES_TAG}`,
+    }));
+
+    execMock.mockImplementation(() => ({code: 0}));
+
+    await findAndPublishAllBumpedPackages();
+
+    expect(execMock.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "npm publish",
+          Object {
+            "cwd": "absolute/path/to/package-a",
+          },
+        ],
+        Array [
+          "npm publish",
+          Object {
+            "cwd": "absolute/path/to/package-b",
+          },
+        ],
+      ]
+    `);
   });
 });
 

--- a/scripts/monorepo/find-and-publish-all-bumped-packages.js
+++ b/scripts/monorepo/find-and-publish-all-bumped-packages.js
@@ -4,7 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
+ * @oncall react_native
  */
 
 const {publishPackage} = require('../npm-utils');
@@ -16,7 +18,7 @@ const path = require('path');
 const ROOT_LOCATION = path.join(__dirname, '..', '..');
 const NPM_CONFIG_OTP = process.env.NPM_CONFIG_OTP;
 
-function getTagsFromCommitMessage(msg) {
+function getTagsFromCommitMessage(msg /*: string */) /*: Array<string> */ {
   // ex message we're trying to parse tags out of
   // `_some_message_here_${PUBLISH_PACKAGES_TAG}&tagA&tagB\n`;
   return msg
@@ -26,12 +28,12 @@ function getTagsFromCommitMessage(msg) {
     .slice(1);
 }
 
-const findAndPublishAllBumpedPackages = () => {
+async function findAndPublishAllBumpedPackages() {
   console.log('Traversing all packages inside /packages...');
 
   forEachPackage(
     (packageAbsolutePath, packageRelativePathFromRoot, packageManifest) => {
-      if (packageManifest.private) {
+      if (packageManifest.private === true) {
         console.log(`\u23ED Skipping private package ${packageManifest.name}`);
 
         return;
@@ -58,9 +60,9 @@ const findAndPublishAllBumpedPackages = () => {
         process.exit(1);
       }
 
-      const previousVersionPatternMatches = diff.match(
-        /- {2}"version": "([0-9]+.[0-9]+.[0-9]+)"/,
-      );
+      const previousVersionPatternMatches = diff
+        .toString()
+        .match(/- {2}"version": "([0-9]+.[0-9]+.[0-9]+)"/);
 
       if (!previousVersionPatternMatches) {
         console.log(`\uD83D\uDD0E No version bump for ${packageManifest.name}`);
@@ -68,7 +70,7 @@ const findAndPublishAllBumpedPackages = () => {
         return;
       }
 
-      const {stdout: commitMessage, stderr: commitMessageStderr} = spawnSync(
+      const {stdout, stderr: commitMessageStderr} = spawnSync(
         'git',
         [
           'log',
@@ -79,6 +81,7 @@ const findAndPublishAllBumpedPackages = () => {
         ],
         {cwd: ROOT_LOCATION, shell: true, stdio: 'pipe', encoding: 'utf-8'},
       );
+      const commitMessage = stdout.toString();
 
       if (commitMessageStderr) {
         console.log(
@@ -131,12 +134,11 @@ const findAndPublishAllBumpedPackages = () => {
       }
     },
   );
-
-  process.exit(0);
-};
+}
 
 if (require.main === module) {
-  findAndPublishAllBumpedPackages();
+  // eslint-disable-next-line no-void
+  void findAndPublishAllBumpedPackages();
 }
 
 module.exports = {

--- a/scripts/monorepo/find-and-publish-all-bumped-packages.js
+++ b/scripts/monorepo/find-and-publish-all-bumped-packages.js
@@ -10,8 +10,8 @@
  */
 
 const {publishPackage} = require('../npm-utils');
+const {getPackages} = require('../releases/utils/monorepo');
 const {PUBLISH_PACKAGES_TAG} = require('./constants');
-const forEachPackage = require('./for-each-package');
 const {execSync, spawnSync} = require('child_process');
 const path = require('path');
 
@@ -40,76 +40,72 @@ async function findAndPublishAllBumpedPackages() {
 
   console.log('Traversing all packages inside /packages...');
 
-  forEachPackage(
-    (packageAbsolutePath, packageRelativePathFromRoot, packageManifest) => {
-      if (packageManifest.private === true) {
-        console.log(`\u23ED Skipping private package ${packageManifest.name}`);
+  const packages = await getPackages({
+    includeReactNative: false,
+  });
 
-        return;
-      }
+  for (const package of Object.values(packages)) {
+    const {stdout: diff, stderr: commitDiffStderr} = spawnSync(
+      'git',
+      [
+        'log',
+        '-p',
+        '--format=""',
+        'HEAD~1..HEAD',
+        `${package.path}/package.json`,
+      ],
+      {cwd: ROOT_LOCATION, shell: true, stdio: 'pipe', encoding: 'utf-8'},
+    );
 
-      const {stdout: diff, stderr: commitDiffStderr} = spawnSync(
-        'git',
-        [
-          'log',
-          '-p',
-          '--format=""',
-          'HEAD~1..HEAD',
-          `${packageRelativePathFromRoot}/package.json`,
-        ],
-        {cwd: ROOT_LOCATION, shell: true, stdio: 'pipe', encoding: 'utf-8'},
-      );
-
-      if (commitDiffStderr) {
-        console.log(
-          `\u274c Failed to get latest committed changes for ${packageManifest.name}:`,
-        );
-        console.log(commitDiffStderr);
-
-        process.exit(1);
-      }
-
-      const previousVersionPatternMatches = diff
-        .toString()
-        .match(/- {2}"version": "([0-9]+.[0-9]+.[0-9]+)"/);
-
-      if (!previousVersionPatternMatches) {
-        console.log(`\uD83D\uDD0E No version bump for ${packageManifest.name}`);
-
-        return;
-      }
-
-      const [, previousVersion] = previousVersionPatternMatches;
-      const nextVersion = packageManifest.version;
-
+    if (commitDiffStderr) {
       console.log(
-        `\uD83D\uDCA1 ${packageManifest.name} was updated: ${previousVersion} -> ${nextVersion}`,
+        `\u274c Failed to get latest committed changes for ${package.name}:`,
       );
+      console.log(commitDiffStderr);
 
-      if (!nextVersion.startsWith('0.')) {
-        throw new Error(
-          `Package version expected to be 0.x.y, but received ${nextVersion}`,
-        );
-      }
+      process.exit(1);
+    }
 
-      const result = publishPackage(packageAbsolutePath, {
-        tags,
-        otp: NPM_CONFIG_OTP,
-      });
-      if (result.code !== 0) {
-        console.log(
-          `\u274c Failed to publish version ${nextVersion} of ${packageManifest.name}. npm publish exited with code ${result.code}:`,
-        );
-        console.log(result.stderr);
+    const previousVersionPatternMatches = diff
+      .toString()
+      .match(/- {2}"version": "([0-9]+.[0-9]+.[0-9]+)"/);
 
-        process.exit(1);
-      } else {
-        console.log(
-          `\u2705 Successfully published new version of ${packageManifest.name}`,
-        );
-      }
-    },
-  );
+    if (!previousVersionPatternMatches) {
+      console.log(`\uD83D\uDD0E No version bump for ${package.name}`);
+
+      return;
+    }
+
+    const [, previousVersion] = previousVersionPatternMatches;
+    const nextVersion = package.packageJson.version;
+
+    console.log(
+      `\uD83D\uDCA1 ${package.name} was updated: ${previousVersion} -> ${nextVersion}`,
+    );
+
+    if (!nextVersion.startsWith('0.')) {
+      throw new Error(
+        `Package version expected to be 0.x.y, but received ${nextVersion}`,
+      );
+    }
+
+    const result = publishPackage(package.path, {
+      tags,
+      otp: NPM_CONFIG_OTP,
+    });
+    if (result.code !== 0) {
+      console.log(
+        `\u274c Failed to publish version ${nextVersion} of ${package.name}. npm publish exited with code ${result.code}:`,
+      );
+      console.log(result.stderr);
+
+      process.exit(1);
+    } else {
+      console.log(
+        `\u2705 Successfully published new version of ${package.name}`,
+      );
+    }
+  }
 }
 
 function getTagsFromCommitMessage(msg /*: string */) /*: Array<string> */ {

--- a/scripts/monorepo/for-each-package.js
+++ b/scripts/monorepo/for-each-package.js
@@ -40,6 +40,8 @@ const getDirectories = (source /*: string */) /*: Array<string> */ =>
     .map(directory => directory.name.toString());
 /**
  * Iterate through every package inside /packages (ignoring react-native) and call provided callback for each of them
+ *
+ * @deprecated Use scripts/releases/utils/monorepo.js#getPackages instead
  */
 const forEachPackage = (
   callback /*: (string, string, PackageJSON) => void */,

--- a/scripts/releases/utils/monorepo.js
+++ b/scripts/releases/utils/monorepo.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+const fs = require('fs');
+const glob = require('glob');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const WORKSPACES_CONFIG = 'packages/*';
+
+/*::
+export type PackageJson = {
+  name: string,
+  private?: boolean,
+  version: string,
+  dependencies: Record<string, string>,
+  devDependencies: Record<string, string>,
+  ...
+};
+
+type PackagesFilter = $ReadOnly<{
+  includeReactNative: boolean,
+  includePrivate?: boolean,
+}>;
+
+type ProjectInfo = {
+  [packageName: string]: {
+    // The name of the package
+    name: string,
+
+    // The absolute path to the package
+    path: string,
+
+    // The parsed package.json contents
+    packageJson: PackageJson,
+  },
+};
+*/
+
+/**
+ * Locates monrepo packages and returns a mapping of package names to their
+ * metadata. Considers Yarn workspaces under `packages/`.
+ */
+async function getPackages(
+  filter /*: PackagesFilter */,
+) /*: Promise<ProjectInfo> */ {
+  const {includeReactNative, includePrivate = false} = filter;
+
+  const packagesEntries = await Promise.all(
+    glob
+      .sync(`${WORKSPACES_CONFIG}/package.json`, {
+        cwd: REPO_ROOT,
+        absolute: true,
+        ignore: includeReactNative
+          ? []
+          : ['packages/react-native/package.json'],
+      })
+      .map(async packageJsonPath => {
+        const packagePath = path.dirname(packageJsonPath);
+        const packageJson = JSON.parse(
+          await fs.promises.readFile(packageJsonPath, 'utf-8'),
+        );
+
+        return [
+          packageJson.name,
+          {
+            name: packageJson.name,
+            path: packagePath,
+            packageJson,
+          },
+        ];
+      }),
+  );
+
+  return Object.fromEntries(
+    packagesEntries.filter(
+      ([_, {packageJson}]) => !packageJson.private || includePrivate,
+    ),
+  );
+}
+
+module.exports = {
+  getPackages,
+};


### PR DESCRIPTION
Summary:
Substitutes the `forEachPackage` util with a replacement async `getPackages` function. This will be used further in the next diff.

The new function aims to be more erganomic/versatile than `forEachPackage` by returning a package mapping (see updated test mock). The API aligns roughly with `yarn workspaces list` and [Lerna's `detectProjects`](https://lerna.js.org/docs/api-reference/utilities#detectprojects).

This also aligns with / replaces similar attempts in our existing scripts:
- [`getPackagesToPublish`](https://github.com/facebook/react-native/blob/2ca7bec0c2a7d821ceaaf39840a6cdc5eceb8678/scripts/monorepo/get-and-update-packages.js#L56)
- [`getPublicPackages`](https://github.com/facebook/react-native/blob/2ca7bec0c2a7d821ceaaf39840a6cdc5eceb8678/scripts/releases/set-version/index.js#L19)

Changelog: [Internal]

Differential Revision: D53607806


