### PR TITLE
Make [RCTBridge currentBridge] work also inBridgeless for backward compatibility.

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -12,6 +12,7 @@
 
 #import <React/NSDataBigString.h>
 #import <React/RCTAssert.h>
+#import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBridgeModuleDecorator.h>
@@ -263,6 +264,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
               [strongSelf registerSegmentWithId:segmentId path:path];
             }
           }];
+  [RCTBridge setCurrentBridge:(RCTBridge *)bridgeProxy];
 
   // Set up TurboModules
   _turboModuleManager = [[RCTTurboModuleManager alloc]


### PR DESCRIPTION
Summary:
We might have some libraries that goes through the interop layer that are using [RCTBridge currentBridge]. Although this is an API that we would like them not to use, that's the sad reality and if we don't want to force a migration on those libraries, we need to be backward compatible.

This diff sets the `RCTBridgeProxy` as the `currentBridge` in case the app is running in BridgelessMode. This should make Bridgeless backward compatible.

## Changelog
[iOS][Fixed] - Make [RCTBridge currentBridge] work in bridgeless mode

Reviewed By: RSNara

Differential Revision: D53575361


