### PR TITLE
Remove .npmrc write from setupVerdaccio util

### DIFF
--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -23,6 +23,7 @@ const forEachPackage = require('./monorepo/for-each-package');
 const setupVerdaccio = require('./template/setup-verdaccio');
 const tryExecNTimes = require('./try-n-times');
 const {execFileSync, spawn} = require('child_process');
+const fs = require('fs');
 const path = require('path');
 const {cd, cp, echo, exec, exit, mv} = require('shelljs');
 const argv = require('yargs').argv;
@@ -36,8 +37,6 @@ const REACT_NATIVE_TEMP_DIR = exec(
 ).stdout.trim();
 const REACT_NATIVE_APP_DIR = `${REACT_NATIVE_TEMP_DIR}/template`;
 const numberOfRetries = argv.retries || 1;
-
-const VERDACCIO_CONFIG_PATH = path.join(ROOT, '.circleci/verdaccio.yml');
 
 let SERVER_PID;
 let APPIUM_PID;
@@ -85,7 +84,7 @@ try {
   );
 
   describe('Set up Verdaccio');
-  VERDACCIO_PID = setupVerdaccio(ROOT, VERDACCIO_CONFIG_PATH);
+  VERDACCIO_PID = setupVerdaccio();
 
   describe('Build and publish packages');
   if (exec('node ./scripts/build/build.js', {cwd: ROOT}).code) {
@@ -117,6 +116,7 @@ try {
   mv('_eslintrc.js', '.eslintrc.js');
   mv('_prettierrc.js', '.prettierrc.js');
   mv('_watchmanconfig', '.watchmanconfig');
+  fs.writeFileSync('.npmrc', 'registry=http://localhost:4873');
 
   describe('Install React Native package');
   exec(`npm install ${REACT_NATIVE_PACKAGE}`);

--- a/scripts/template/initialize.js
+++ b/scripts/template/initialize.js
@@ -19,7 +19,6 @@ const {execSync} = require('child_process');
 const path = require('path');
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
-const VERDACCIO_CONFIG_PATH = `${REPO_ROOT}/.circleci/verdaccio.yml`;
 const NPM_REGISTRY_SERVER = 'http://localhost:4873';
 
 const config = {
@@ -60,7 +59,7 @@ async function main() {
     return;
   }
 
-  const VERDACCIO_PID = setupVerdaccio(REPO_ROOT, VERDACCIO_CONFIG_PATH);
+  const VERDACCIO_PID = setupVerdaccio();
 
   try {
     process.stdout.write('Bootstrapped Verdaccio \u2705\n');

--- a/scripts/template/setup-verdaccio.js
+++ b/scripts/template/setup-verdaccio.js
@@ -12,24 +12,38 @@
 'use strict';
 
 const {execSync, spawn} = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
-function setupVerdaccio(
-  reactNativeRootPath /*: string */,
-  verdaccioConfigPath /*: string */,
-  verdaccioStoragePath /*: ?string */,
-) /*: number */ {
-  execSync('echo "//localhost:4873/:_authToken=secretToken" > .npmrc', {
-    cwd: reactNativeRootPath,
-  });
+const REPO_ROOT = path.join(__dirname, '../..');
+const NPM_CONFIG_PATH = path.join(REPO_ROOT, '.npmrc');
+
+// TODO(huntie): Relocate (used by both local and CI scripts)
+const VERDACCIO_CONFIG_PATH = `${REPO_ROOT}/.circleci/verdaccio.yml`;
+const VERDACCIO_STORAGE_PATH = `${REPO_ROOT}/.circleci/storage`;
+const VERDACCIO_SERVER_URL = 'http://localhost:4873';
+
+/**
+ * Configure and run a local Verdaccio server. This is an npm proxy that can be
+ * used with `npm publish` and `npm install`, configured in
+ * `.circleci/verdaccio.yml`.
+ */
+function setupVerdaccio() /*: number */ {
+  const {host} = new URL(VERDACCIO_SERVER_URL);
+
+  // NOTE: Reading from/writing to an .npmrc in a workspaces project root is
+  // invalid from npm 9.x. Keyed config, such as `--registry`, should be
+  // specified in env vars or command invocations instead.
+  // See https://github.com/npm/cli/issues/6099
+  fs.writeFileSync(NPM_CONFIG_PATH, `//${host}/:_authToken=secretToken\n`);
 
   const verdaccioProcess = spawn(
     'npx',
-    ['verdaccio@5.16.3', '--config', verdaccioConfigPath],
-    {env: {...process.env, VERDACCIO_STORAGE_PATH: verdaccioStoragePath}},
+    ['verdaccio@5.16.3', '--config', VERDACCIO_CONFIG_PATH],
+    {env: {...process.env, VERDACCIO_STORAGE_PATH}},
   );
 
-  execSync('npx wait-on@6.0.1 http://localhost:4873');
-  execSync('npm set registry http://localhost:4873');
+  execSync(`npx wait-on@6.0.1 ${VERDACCIO_SERVER_URL}`);
 
   return verdaccioProcess.pid;
 }


### PR DESCRIPTION
Summary:
I noticed that programatically running `npm set registry <value>` would fail within the repo root dir (intended run location) (`node` version `18.18.2`).

```
npm ERR! This command does not support workspaces.
```

It turns out this is no longer supported from npm 9.x: https://github.com/npm/cli/issues/6099.  **Note**: The workaround discussed in this thread is incompatible/nontrivial with `npx`, so I've opted to remove this behaviour.

**Changes**

- Remove `npm set registry http://localhost:4873` call.
    - This is non-breaking due to the [explicit `--registry` arg already present in `run-e2e-ci-tests.js`](https://github.com/facebook/react-native/blob/b366b4b42e0f91eb2b1850c404fadd0f0322fc61/scripts/run-ci-e2e-tests.js#L102). The previous `.npmrc` config value is unnecessary, and probably was being ignored (will be validated for this PR in CircleCI run).
- Add comment against remaining `.npmrc` write, convert to `fs` call.
- Remove unused params on `setupVerdaccio` (moved to constants which will be exported and referenced in the next diff).

Changelog: [Internal]

Differential Revision: D53609308

