### PR TITLE
Backport addUIBlock and prependUIBlock to Fabric for Android

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2520,6 +2520,7 @@ public class com/facebook/react/fabric/FabricUIManager : com/facebook/react/brid
 	public field mDevToolsReactPerfLogger Lcom/facebook/react/fabric/DevToolsReactPerfLogger;
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Lcom/facebook/react/uimanager/ViewManagerRegistry;Lcom/facebook/react/uimanager/events/BatchEventDispatchedListener;)V
 	public fun addRootView (Landroid/view/View;Lcom/facebook/react/bridge/WritableMap;)I
+	public fun addUIBlock (Lcom/facebook/react/fabric/interop/UIBlock;)V
 	public fun addUIManagerEventListener (Lcom/facebook/react/bridge/UIManagerListener;)V
 	public fun attachRootView (Lcom/facebook/react/interfaces/fabric/SurfaceHandler;Landroid/view/View;)V
 	public fun clearJSResponder ()V
@@ -2541,6 +2542,7 @@ public class com/facebook/react/fabric/FabricUIManager : com/facebook/react/brid
 	public fun onHostPause ()V
 	public fun onHostResume ()V
 	public fun onRequestEventBeat ()V
+	public fun prependUIBlock (Lcom/facebook/react/fabric/interop/UIBlock;)V
 	public fun profileNextBatch ()V
 	public fun receiveEvent (IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public fun receiveEvent (IILjava/lang/String;ZLcom/facebook/react/bridge/WritableMap;I)V
@@ -2631,6 +2633,14 @@ public class com/facebook/react/fabric/events/FabricEventEmitter : com/facebook/
 	public fun receiveEvent (ILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public fun receiveTouches (Lcom/facebook/react/uimanager/events/TouchEvent;)V
 	public fun receiveTouches (Ljava/lang/String;Lcom/facebook/react/bridge/WritableArray;Lcom/facebook/react/bridge/WritableArray;)V
+}
+
+public abstract interface class com/facebook/react/fabric/interop/UIBlock {
+	public abstract fun execute (Lcom/facebook/react/fabric/interop/UIBlockViewResolver;)V
+}
+
+public abstract interface class com/facebook/react/fabric/interop/UIBlockViewResolver {
+	public abstract fun resolveView (I)Landroid/view/View;
 }
 
 public abstract interface class com/facebook/react/fabric/mounting/LayoutMetricsConversions {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -56,6 +56,8 @@ import com.facebook.react.common.mapbuffer.ReadableMapBuffer;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.fabric.events.EventEmitterWrapper;
 import com.facebook.react.fabric.events.FabricEventEmitter;
+import com.facebook.react.fabric.internal.interop.InteropUIBlockListener;
+import com.facebook.react.fabric.interop.UIBlock;
 import com.facebook.react.fabric.mounting.MountItemDispatcher;
 import com.facebook.react.fabric.mounting.MountingManager;
 import com.facebook.react.fabric.mounting.SurfaceMountingManager;
@@ -208,6 +210,10 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
           mMountItemDispatcher.dispatchMountItems(items);
         }
       };
+
+  // Interop UIManagerListener used to support addUIBlock and prependUIBlock.
+  // It's initialized only when addUIBlock or prependUIBlock is called the first time.
+  @Nullable private InteropUIBlockListener mInteropUIBlockListener;
 
   public FabricUIManager(
       @NonNull ReactApplicationContext reactContext,
@@ -443,6 +449,31 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     // TODO T83943316: Remove this IF once StaticViewConfigs are enabled by default
     if (!ReactFeatureFlags.enableBridgelessArchitecture) {
       mEventDispatcher.onCatalystInstanceDestroyed();
+    }
+  }
+
+  /**
+   * Method added to Fabric for backward compatibility reasons, as users on Paper could call
+   * [addUiBlock] and [prependUiBlock] on UIManagerModule.
+   */
+  public void addUIBlock(UIBlock block) {
+    initInteropUIBlockListener();
+    mInteropUIBlockListener.addUIBlock(block);
+  }
+
+  /**
+   * Method added to Fabric for backward compatibility reasons, as users on Paper could call
+   * [addUiBlock] and [prependUiBlock] on UIManagerModule.
+   */
+  public void prependUIBlock(UIBlock block) {
+    initInteropUIBlockListener();
+    mInteropUIBlockListener.prependUIBlock(block);
+  }
+
+  private void initInteropUIBlockListener() {
+    if (mInteropUIBlockListener == null) {
+      mInteropUIBlockListener = new InteropUIBlockListener();
+      addUIManagerEventListener(mInteropUIBlockListener);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@file:Suppress("DEPRECATION") // We want to test UIBlock and UIBlockViewResolver here.
+
+package com.facebook.react.fabric.internal.interop
+
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
+import com.facebook.react.fabric.interop.UIBlock
+import com.facebook.react.fabric.interop.UIBlockViewResolver
+
+/**
+ * Interop class used to support invoking [addUIBlock] and [prependUIBlock] in Fabric.
+ *
+ * Users on the Old Architecture used to call those methods to execute arbitrary [UIBlock]s This
+ * class effectively re-implements this logic by using a [UIManagerListener] and exposing the two
+ * methods that the user intend to call.
+ */
+internal class InteropUIBlockListener : UIManagerListener {
+
+  internal val beforeUIBlocks: MutableList<UIBlock> = mutableListOf()
+  internal val afterUIBlocks: MutableList<UIBlock> = mutableListOf()
+
+  @Synchronized
+  fun prependUIBlock(block: UIBlock) {
+    beforeUIBlocks.add(block)
+  }
+
+  @Synchronized
+  fun addUIBlock(block: UIBlock) {
+    afterUIBlocks.add(block)
+  }
+
+  override fun willMountItems(uiManager: UIManager?) {
+    beforeUIBlocks.forEach {
+      if (uiManager is UIBlockViewResolver) {
+        it.execute(uiManager)
+      }
+    }
+    beforeUIBlocks.clear()
+  }
+
+  override fun didMountItems(uiManager: UIManager?) {
+    afterUIBlocks.forEach {
+      if (uiManager is UIBlockViewResolver) {
+        it.execute(uiManager)
+      }
+    }
+    afterUIBlocks.clear()
+  }
+
+  override fun willDispatchViewUpdates(uiManager: UIManager?): Unit = Unit
+
+  override fun didDispatchMountItems(uiManager: UIManager?): Unit = Unit
+
+  override fun didScheduleMountItems(uiManager: UIManager?): Unit = Unit
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/interop/UIBlock.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/interop/UIBlock.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@file:Suppress("DEPRECATION") // Deprecation is added for backward compatibility reasons
+
+package com.facebook.react.fabric.interop
+
+/**
+ * Interop Interface added to support `addUiBlock` and `prependUIBlock` methods in Fabric.
+ * Historically those methods were only available in `UIManagerModule` (Paper, the old renderer).
+ * We're re-adding them to Fabric to make it easier to migrate.
+ *
+ * @deprecated When developing new libraries for Fabric you should instead use [UIManagerListener]
+ *   or View Commands to achieve a same results.
+ */
+@Deprecated("Use UIManagerListener or View Commands instead of addUIBlock and prependUIBlock.")
+public fun interface UIBlock {
+  public fun execute(resolver: UIBlockViewResolver)
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/interop/UIBlockViewResolver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/interop/UIBlockViewResolver.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.fabric.interop
+
+import android.view.View
+
+/**
+ * This interface is used as receiver parameter for [UIBlock].
+ *
+ * Users can invoke [resolveView] on this instance to get an Android [View] from the view tag.
+ *
+ * @deprecated When developing new libraries for Fabric you should instead use [UIManagerListener]
+ *   or View Commands to achieve a same results.
+ */
+@Deprecated("Use UIManagerListener or View Commands instead of addUIBlock and prependUIBlock.")
+public interface UIBlockViewResolver {
+  public fun resolveView(reactTag: Int): View?
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListenerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListenerTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.fabric.internal.interop
+
+import com.facebook.testutils.fakes.FakeUIManager
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InteropUiBlockListenerTest {
+
+  @Test
+  fun prependUIBlock_addsBlockCorrectly() {
+    val underTest = InteropUIBlockListener()
+    underTest.prependUIBlock {}
+
+    assertEquals(1, underTest.beforeUIBlocks.size)
+    assertEquals(0, underTest.afterUIBlocks.size)
+  }
+
+  @Test
+  fun addUIBlock_addsBlockCorrectly() {
+    val underTest = InteropUIBlockListener()
+    underTest.addUIBlock {}
+
+    assertEquals(0, underTest.beforeUIBlocks.size)
+    assertEquals(1, underTest.afterUIBlocks.size)
+  }
+
+  @Test
+  fun willMountItems_emptiesBeforeUIBlocks() {
+    val underTest = InteropUIBlockListener()
+    underTest.prependUIBlock {}
+    underTest.addUIBlock {}
+
+    underTest.willMountItems(null)
+
+    assertEquals(0, underTest.beforeUIBlocks.size)
+    assertEquals(1, underTest.afterUIBlocks.size)
+  }
+
+  @Test
+  fun didMountItems_emptiesAfterUIBlocks() {
+    val underTest = InteropUIBlockListener()
+    underTest.prependUIBlock {}
+    underTest.addUIBlock {}
+
+    underTest.didMountItems(null)
+
+    assertEquals(1, underTest.beforeUIBlocks.size)
+    assertEquals(0, underTest.afterUIBlocks.size)
+  }
+
+  @Test
+  fun willMountItems_deliversUiManagerCorrectly() {
+    val fakeUIManager = FakeUIManager()
+    val underTest = InteropUIBlockListener()
+
+    underTest.prependUIBlock { uiManager -> uiManager.resolveView(0) }
+
+    underTest.willMountItems(fakeUIManager)
+
+    assertEquals(1, fakeUIManager.resolvedViewCount)
+  }
+
+  @Test
+  fun didMountItems_deliversUiManagerCorrectly() {
+    val fakeUIManager = FakeUIManager()
+    val underTest = InteropUIBlockListener()
+
+    underTest.addUIBlock { uiManager -> uiManager.resolveView(0) }
+
+    underTest.didMountItems(fakeUIManager)
+
+    assertEquals(1, fakeUIManager.resolvedViewCount)
+  }
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@file:Suppress("DEPRECATION") // We want to test against UIBlockViewResolver
+
+package com.facebook.testutils.fakes
+
+import android.view.View
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.fabric.interop.UIBlockViewResolver
+
+class FakeUIManager : UIManager, UIBlockViewResolver {
+
+  // The number of times resolveView was called
+  var resolvedViewCount = 0
+
+  override fun profileNextBatch() {
+    TODO("Not yet implemented")
+  }
+
+  override fun getPerformanceCounters(): MutableMap<String, Long> {
+    TODO("Not yet implemented")
+  }
+
+  override fun <T : View?> addRootView(rootView: T, initialProps: WritableMap?): Int {
+    TODO("Not yet implemented")
+  }
+
+  override fun <T : View?> startSurface(
+      rootView: T,
+      moduleName: String?,
+      initialProps: WritableMap?,
+      widthMeasureSpec: Int,
+      heightMeasureSpec: Int
+  ): Int {
+    TODO("Not yet implemented")
+  }
+
+  override fun stopSurface(surfaceId: Int) {
+    TODO("Not yet implemented")
+  }
+
+  override fun updateRootLayoutSpecs(
+      rootTag: Int,
+      widthMeasureSpec: Int,
+      heightMeasureSpec: Int,
+      offsetX: Int,
+      offsetY: Int
+  ) {
+    TODO("Not yet implemented")
+  }
+
+  override fun dispatchCommand(reactTag: Int, commandId: Int, commandArgs: ReadableArray?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun dispatchCommand(reactTag: Int, commandId: String?, commandArgs: ReadableArray?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun <T : Any?> getEventDispatcher(): T {
+    TODO("Not yet implemented")
+  }
+
+  override fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun sendAccessibilityEvent(reactTag: Int, eventType: Int) {
+    TODO("Not yet implemented")
+  }
+
+  override fun addUIManagerEventListener(listener: UIManagerListener?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun removeUIManagerEventListener(listener: UIManagerListener?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun resolveView(reactTag: Int): View? {
+    resolvedViewCount += 1
+    return null
+  }
+
+  override fun receiveEvent(reactTag: Int, eventName: String?, event: WritableMap?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun receiveEvent(
+      surfaceId: Int,
+      reactTag: Int,
+      eventName: String?,
+      event: WritableMap?
+  ) {
+    TODO("Not yet implemented")
+  }
+
+  override fun resolveCustomDirectEventName(eventName: String?): String? {
+    TODO("Not yet implemented")
+  }
+
+  override fun initialize() {
+    TODO("Not yet implemented")
+  }
+
+  override fun invalidate() {
+    TODO("Not yet implemented")
+  }
+}


### PR DESCRIPTION
Summary:
The `.addUIBlock` and `.prependUIBlock` APIs on UiManagerModule are missing on Fabric.
Here I'm re-implementing them to make migration to Fabric easier.

Set of changes:
- Moved `NativeViewHierarchyManager` to `NativeViewHierarchyManagerImpl` and extracted an interface
- Moved `addUIBlock` and `prependUIBlock` to the shared `UIManager` interface
- Added a `InteropUIBlockListener` class that takes care of executing the UI Blocks, implemented as a `UIManagerListener`

Changelog:
[Android] [Changed] - Changed the API of addUIBlock and prependUIBlock to implement it also in Fabric.

Differential Revision: D53612514

