### PR TITLE
fix(virtualized-lists): declare missing `react` peer dependency

### DIFF
--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -27,6 +27,7 @@
     "react-test-renderer": "18.2.0"
   },
   "peerDependencies": {
+    "react": "*",
     "react-native": "*"
   }
 }


### PR DESCRIPTION
## Summary:

In setups with `pnpm`  `@react-native/virtualized-lists` gets bundled incorrectly because of the following error:

`Module not found: Error: Can't resolve 'react'`

As 'react' is used inside of the package, it should declared explicitly, instead of being a phantom dependency.

## Changelog:

[GENERAL] [FIXED] - Declare missing peer dependency `react`

## Test Plan:

not needed
