### PR TITLE
refactor URL construction

### DIFF
--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -20,14 +20,18 @@ export default function getDevToolsFrontendUrl(
   devServerUrl: string,
 ): string {
   const scheme = new URL(webSocketDebuggerUrl).protocol.slice(0, -1);
-  const appUrl = `${devServerUrl}/debugger-frontend/rn_inspector.html`;
   const webSocketUrlWithoutProtocol = encodeURIComponent(
     webSocketDebuggerUrl.replace(/^wss?:\/\//, ''),
   );
+  const appUrl = `${devServerUrl}/debugger-frontend/rn_inspector.html`;
 
-  const devToolsUrl = `${appUrl}?${scheme}=${webSocketUrlWithoutProtocol}&sources.hide_add_folder=true`;
+  const searchParams = new URLSearchParams([
+    [scheme, webSocketUrlWithoutProtocol],
+    ['sources.hide_add_folder', 'true'],
+  ]);
+  if (experiments.enableNetworkInspector) {
+    searchParams.append('unstable_enableNetworkPanel', 'true');
+  }
 
-  return experiments.enableNetworkInspector
-    ? `${devToolsUrl}&unstable_enableNetworkPanel=true`
-    : devToolsUrl;
+  return appUrl + '?' + searchParams.toString();
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Refactor URL construction for DevTools.

Next diffs in the stack will add additional URL query params.

Support for both absolute and relative `devServerUrl`s maintained.

Differential Revision: D53620915


