### PR TITLE
Deprecated legacy methods in ReactContext.

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1047,6 +1047,7 @@ public class com/facebook/react/bridge/ReactBridge {
 public class com/facebook/react/bridge/ReactContext : android/content/ContextWrapper {
 	protected field mInteropModuleRegistry Lcom/facebook/react/bridge/interop/InteropModuleRegistry;
 	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Lcom/facebook/react/bridge/ReactContext;Landroid/content/Context;)V
 	public fun addActivityEventListener (Lcom/facebook/react/bridge/ActivityEventListener;)V
 	public fun addLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
 	public fun addWindowFocusChangeListener (Lcom/facebook/react/bridge/WindowFocusChangeListener;)V
@@ -4738,16 +4739,10 @@ public class com/facebook/react/uimanager/ThemedReactContext : com/facebook/reac
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;)V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;Ljava/lang/String;)V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;Ljava/lang/String;I)V
-	public fun addLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
-	public fun getCurrentActivity ()Landroid/app/Activity;
-	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun getReactApplicationContext ()Lcom/facebook/react/bridge/ReactApplicationContext;
 	public fun getSurfaceID ()Ljava/lang/String;
 	public fun getSurfaceId ()I
-	public fun hasCurrentActivity ()Z
-	public fun isBridgeless ()Z
-	public fun removeLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
 }
 
 public class com/facebook/react/uimanager/TouchTargetHelper {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -51,6 +51,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.infer.annotation.ThreadSafe;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.BridgeReactContext;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.CatalystInstanceImpl;
 import com.facebook.react.bridge.JSBundleLoader;
@@ -1336,7 +1337,7 @@ public class ReactInstanceManager {
       JavaScriptExecutor jsExecutor, JSBundleLoader jsBundleLoader) {
     FLog.d(ReactConstants.TAG, "ReactInstanceManager.createReactContext()");
     ReactMarker.logMarker(CREATE_REACT_CONTEXT_START, jsExecutor.getName());
-    final ReactApplicationContext reactContext = new ReactApplicationContext(mApplicationContext);
+    final BridgeReactContext reactContext = new BridgeReactContext(mApplicationContext);
 
     JSExceptionHandler exceptionHandler =
         mJSExceptionHandler != null ? mJSExceptionHandler : mDevSupportManager;
@@ -1363,7 +1364,7 @@ public class ReactInstanceManager {
       ReactMarker.logMarker(CREATE_CATALYST_INSTANCE_END);
     }
 
-    reactContext.initializeWithInstance(catalystInstance);
+    reactContext.initialize(catalystInstance);
 
     // On Old Architecture, we need to initialize the Native Runtime Scheduler so that
     // the `nativeRuntimeScheduler` object is registered on JS.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
@@ -93,6 +93,7 @@ class BridgeReactContext(base: Context) : ReactApplicationContext(base) {
     return instance.getRuntimeExecutor()
   }
 
+  @Deprecated("This API is unsupported in the New Architecture.")
   override fun getCatalystInstance(): CatalystInstance {
     return Assertions.assertNotNull(catalystInstance)
   }
@@ -108,6 +109,7 @@ class BridgeReactContext(base: Context) : ReactApplicationContext(base) {
     return instance != null && !instance.isDestroyed
   }
 
+  @Deprecated("This API is unsupported in the New Architecture.")
   override fun hasCatalystInstance(): Boolean {
     return catalystInstance != null
   }
@@ -142,6 +144,7 @@ class BridgeReactContext(base: Context) : ReactApplicationContext(base) {
     return false
   }
 
+  @Deprecated("This API is unsupported in the New Architecture.")
   override fun getJavaScriptContextHolder(): JavaScriptContextHolder? {
     return catalystInstance?.javaScriptContextHolder
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+import android.content.Context
+import com.facebook.common.logging.FLog
+import com.facebook.infer.annotation.Assertions
+import com.facebook.react.bridge.queue.ReactQueueConfiguration
+import com.facebook.react.common.ReactConstants
+import com.facebook.react.common.annotations.FrameworkAPI
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+
+class BridgeReactContext(base: Context) : ReactApplicationContext(base) {
+  @Volatile private var destroyed = false
+  private var catalystInstance: CatalystInstance? = null
+
+  fun initialize(otherCatalystInstance: CatalystInstance?) {
+    if (otherCatalystInstance == null) {
+      throw IllegalArgumentException("CatalystInstance cannot be null.")
+    }
+    if (catalystInstance != null) {
+      throw IllegalStateException("ReactContext has been already initialized")
+    }
+    if (destroyed) {
+      ReactSoftExceptionLogger.logSoftException(
+          TAG, IllegalStateException("Cannot initialize ReactContext after it has been destroyed."))
+    }
+
+    catalystInstance = otherCatalystInstance
+
+    val queueConfig: ReactQueueConfiguration = otherCatalystInstance.reactQueueConfiguration
+    initialize(queueConfig)
+    initializeInteropModules()
+  }
+
+  override fun <T : JavaScriptModule?> getJSModule(jsInterface: Class<T>?): T? {
+    val instance =
+        catalystInstance
+            ?: throw IllegalStateException(
+                if (destroyed) LATE_JS_ACCESS_EXCEPTION_MESSAGE
+                else EARLY_JS_ACCESS_EXCEPTION_MESSAGE)
+
+    val interopModuleRegistry = mInteropModuleRegistry
+    if (interopModuleRegistry != null &&
+        interopModuleRegistry.shouldReturnInteropModule(jsInterface)) {
+      return interopModuleRegistry.getInteropModule(jsInterface)
+    }
+
+    return instance.getJSModule(jsInterface)
+  }
+
+  override fun <T : NativeModule?> hasNativeModule(nativeModuleInterface: Class<T>?): Boolean {
+    val instance =
+        catalystInstance
+            ?: throw IllegalStateException(
+                if (destroyed) LATE_NATIVE_MODULE_EXCEPTION_MESSAGE
+                else EARLY_NATIVE_MODULE_EXCEPTION_MESSAGE)
+    return instance.hasNativeModule(nativeModuleInterface)
+  }
+
+  override fun getNativeModules(): MutableCollection<NativeModule> {
+    val instance =
+        catalystInstance
+            ?: throw IllegalStateException(
+                if (destroyed) LATE_NATIVE_MODULE_EXCEPTION_MESSAGE
+                else EARLY_NATIVE_MODULE_EXCEPTION_MESSAGE)
+    return instance.nativeModules
+  }
+
+  override fun <T : NativeModule?> getNativeModule(nativeModuleInterface: Class<T>?): T? {
+    val instance =
+        catalystInstance
+            ?: throw IllegalStateException(
+                if (destroyed) LATE_NATIVE_MODULE_EXCEPTION_MESSAGE
+                else EARLY_NATIVE_MODULE_EXCEPTION_MESSAGE)
+    return instance.getNativeModule(nativeModuleInterface)
+  }
+
+  @FrameworkAPI
+  @UnstableReactNativeAPI
+  override fun getRuntimeExecutor(): RuntimeExecutor? {
+    val instance =
+        catalystInstance
+            ?: throw IllegalStateException(
+                if (destroyed) LATE_RUNTIME_EXECUTOR_ACCESS_EXCEPTION_MESSAGE
+                else EARLY_RUNTIME_EXECUTOR_ACCESS_EXCEPTION_MESSAGE)
+
+    return instance.getRuntimeExecutor()
+  }
+
+  override fun getCatalystInstance(): CatalystInstance {
+    return Assertions.assertNotNull(catalystInstance)
+  }
+
+  @Deprecated(
+      "This API is unsupported in the New Architecture.", ReplaceWith("hasActiveReactInstance()"))
+  override fun hasActiveCatalystInstance(): Boolean {
+    return hasActiveReactInstance()
+  }
+
+  override fun hasActiveReactInstance(): Boolean {
+    val instance = catalystInstance
+    return instance != null && !instance.isDestroyed
+  }
+
+  override fun hasCatalystInstance(): Boolean {
+    return catalystInstance != null
+  }
+
+  override fun destroy() {
+    UiThreadUtil.assertOnUiThread()
+
+    destroyed = true
+    catalystInstance?.destroy()
+  }
+
+  override fun handleException(e: Exception?) {
+    val jsExceptionHandler: JSExceptionHandler? = jsExceptionHandler
+
+    if (hasActiveReactInstance() && jsExceptionHandler != null) {
+      jsExceptionHandler.handleException(e)
+    } else {
+      FLog.e(
+          ReactConstants.TAG,
+          "Unable to handle Exception - catalystInstanceVariableExists: " +
+              (catalystInstance != null) +
+              " - isCatalystInstanceAlive: " +
+              hasActiveReactInstance() +
+              " - hasExceptionHandler: " +
+              (jsExceptionHandler != null),
+          e)
+      throw IllegalStateException(e)
+    }
+  }
+
+  override fun isBridgeless(): Boolean {
+    return false
+  }
+
+  override fun getJavaScriptContextHolder(): JavaScriptContextHolder? {
+    return catalystInstance?.javaScriptContextHolder
+  }
+
+  override fun getFabricUIManager(): UIManager? {
+    val instance =
+        catalystInstance
+            ?: throw IllegalStateException(
+                if (destroyed) LATE_FABRIC_UI_MANAGER_ACCESS_EXCEPTION_MESSAGE
+                else EARLY_FABRIC_UI_MANAGER_ACCESS_EXCEPTION_MESSAGE)
+
+    return instance.fabricUIManager ?: instance.getJSIModule(JSIModuleType.UIManager) as? UIManager
+  }
+
+  override fun getSourceURL(): String? {
+    return catalystInstance?.sourceURL
+  }
+
+  override fun registerSegment(segmentId: Int, path: String?, callback: Callback?) {
+    Assertions.assertNotNull(catalystInstance).registerSegment(segmentId, path)
+    Assertions.assertNotNull(callback).invoke()
+  }
+
+  companion object {
+    private const val TAG = "BridgeReactContext"
+
+    private const val EARLY_JS_ACCESS_EXCEPTION_MESSAGE =
+        ("Tried to access a JS module before the React instance was fully set up. Calls to " +
+            "ReactContext#getJSModule should only happen once initialize() has been called on your " +
+            "native module.")
+    private const val LATE_JS_ACCESS_EXCEPTION_MESSAGE =
+        "Tried to access a JS module after the React instance was destroyed."
+    private const val EARLY_NATIVE_MODULE_EXCEPTION_MESSAGE =
+        "Trying to call native module before CatalystInstance has been set!"
+    private const val LATE_NATIVE_MODULE_EXCEPTION_MESSAGE =
+        "Trying to call native module after CatalystInstance has been destroyed!"
+
+    private const val EARLY_RUNTIME_EXECUTOR_ACCESS_EXCEPTION_MESSAGE =
+        "Tried to access a RuntimeExecutor before CatalystInstance has been set!"
+    private const val LATE_RUNTIME_EXECUTOR_ACCESS_EXCEPTION_MESSAGE =
+        "Tried to access a RuntimeExecutor after CatalystInstance has been destroyed!"
+
+    private const val LATE_FABRIC_UI_MANAGER_ACCESS_EXCEPTION_MESSAGE =
+        "Tried to access a FabricUIManager after CatalystInstance has been destroyed!"
+    private const val EARLY_FABRIC_UI_MANAGER_ACCESS_EXCEPTION_MESSAGE =
+        "Tried to access a FabricUIManager after CatalystInstance before it has been set!"
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactApplicationContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactApplicationContext.java
@@ -13,7 +13,7 @@ import android.content.Context;
  * A context wrapper that always wraps Android Application {@link Context} and {@link
  * CatalystInstance} by extending {@link ReactContext}
  */
-public class ReactApplicationContext extends ReactContext {
+public abstract class ReactApplicationContext extends ReactContext {
   // We want to wrap ApplicationContext, since there is no easy way to verify that application
   // context is passed as a param, we use {@link Context#getApplicationContext} to ensure that
   // the context we're wrapping is in fact an application context.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -78,12 +78,30 @@ public class ReactContext extends ContextWrapper {
   protected @Nullable InteropModuleRegistry mInteropModuleRegistry;
   private boolean mIsInitialized = false;
 
+  private @Nullable ReactContext mOtherReactContext = null;
+
   public ReactContext(Context base) {
     super(base);
   }
 
+  /**
+   * Use this constructor to create a ReactContext that decorates another. One usage is
+   * ThemedReactContext, which decorates the ReactContext with rendering-related APIs.
+   * @param other
+   * @param base
+   */
+  protected ReactContext(ReactContext other, Context base) {
+    super(base);
+    mOtherReactContext = other;
+  }
+
   /** Set and initialize CatalystInstance for this Context. This should be called exactly once. */
   public void initializeWithInstance(CatalystInstance catalystInstance) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.initializeWithInstance(catalystInstance);
+      return;
+    }
+
     if (catalystInstance == null) {
       throw new IllegalArgumentException("CatalystInstance cannot be null.");
     }
@@ -105,6 +123,11 @@ public class ReactContext extends ContextWrapper {
 
   /** Initialize message queue threads using a ReactQueueConfiguration. */
   public synchronized void initializeMessageQueueThreads(ReactQueueConfiguration queueConfig) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.initializeMessageQueueThreads(queueConfig);
+      return;
+    }
+
     FLog.d(TAG, "initializeMessageQueueThreads() is called.");
     if (mUiMessageQueueThread != null
         || mNativeModulesMessageQueueThread != null
@@ -129,14 +152,29 @@ public class ReactContext extends ContextWrapper {
   }
 
   protected void initializeInteropModules() {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.initializeInteropModules();
+      return;
+    }
+
     mInteropModuleRegistry = new InteropModuleRegistry();
   }
 
   protected void initializeInteropModules(ReactContext reactContext) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.initializeInteropModules(reactContext);
+      return;
+    }
+
     mInteropModuleRegistry = reactContext.mInteropModuleRegistry;
   }
 
   public void resetPerfStats() {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.resetPerfStats();
+      return;
+    }
+
     if (mNativeModulesMessageQueueThread != null) {
       mNativeModulesMessageQueueThread.resetPerfStats();
     }
@@ -146,6 +184,11 @@ public class ReactContext extends ContextWrapper {
   }
 
   public void setJSExceptionHandler(@Nullable JSExceptionHandler jSExceptionHandler) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.setJSExceptionHandler(jSExceptionHandler);
+      return;
+    }
+
     mJSExceptionHandler = jSExceptionHandler;
   }
 
@@ -160,6 +203,10 @@ public class ReactContext extends ContextWrapper {
   // TODO: T7538796 Check requirement for Override of getSystemService ReactContext
   @Override
   public Object getSystemService(String name) {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getSystemService(name);
+    }
+
     if (LAYOUT_INFLATER_SERVICE.equals(name)) {
       if (mInflater == null) {
         mInflater = LayoutInflater.from(getBaseContext()).cloneInContext(this);
@@ -173,6 +220,10 @@ public class ReactContext extends ContextWrapper {
    * @return handle to the specified JS module for the CatalystInstance associated with this Context
    */
   public <T extends JavaScriptModule> T getJSModule(Class<T> jsInterface) {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getJSModule(jsInterface);
+    }
+
     if (mCatalystInstance == null) {
       if (mDestroyed) {
         throw new IllegalStateException(LATE_JS_ACCESS_EXCEPTION_MESSAGE);
@@ -187,6 +238,10 @@ public class ReactContext extends ContextWrapper {
   }
 
   public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.hasNativeModule(nativeModuleInterface);
+    }
+
     if (mCatalystInstance == null) {
       raiseCatalystInstanceMissingException();
     }
@@ -194,6 +249,10 @@ public class ReactContext extends ContextWrapper {
   }
 
   public Collection<NativeModule> getNativeModules() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getNativeModules();
+    }
+
     if (mCatalystInstance == null) {
       raiseCatalystInstanceMissingException();
     }
@@ -203,6 +262,10 @@ public class ReactContext extends ContextWrapper {
   /** @return the instance of the specified module interface associated with this ReactContext. */
   @Nullable
   public <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getNativeModule(nativeModuleInterface);
+    }
+
     if (mCatalystInstance == null) {
       raiseCatalystInstanceMissingException();
     }
@@ -217,6 +280,10 @@ public class ReactContext extends ContextWrapper {
   @FrameworkAPI
   @UnstableReactNativeAPI
   public RuntimeExecutor getRuntimeExecutor() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getRuntimeExecutor();
+    }
+
     if (mCatalystInstance == null) {
       raiseCatalystInstanceMissingException();
     }
@@ -228,6 +295,11 @@ public class ReactContext extends ContextWrapper {
    * arguments.
    */
   public void emitDeviceEvent(String eventName, @Nullable Object args) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.emitDeviceEvent(eventName, args);
+      return;
+    }
+
     RCTDeviceEventEmitter eventEmitter = getJSModule(RCTDeviceEventEmitter.class);
     if (eventEmitter != null) {
       eventEmitter.emit(eventName, args);
@@ -235,10 +307,19 @@ public class ReactContext extends ContextWrapper {
   }
 
   public void emitDeviceEvent(String eventName) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.emitDeviceEvent(eventName);
+      return;
+    }
+
     emitDeviceEvent(eventName, null);
   }
 
   public CatalystInstance getCatalystInstance() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getCatalystInstance();
+    }
+
     return Assertions.assertNotNull(mCatalystInstance);
   }
 
@@ -250,23 +331,44 @@ public class ReactContext extends ContextWrapper {
    */
   @Deprecated
   public boolean hasActiveCatalystInstance() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.hasActiveCatalystInstance();
+    }
+
     return hasActiveReactInstance();
   }
 
   /** @return true if there is an non-null, alive react native instance */
   public boolean hasActiveReactInstance() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.hasActiveReactInstance();
+    }
+
     return mCatalystInstance != null && !mCatalystInstance.isDestroyed();
   }
 
   public boolean hasCatalystInstance() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.hasCatalystInstance();
+    }
+
     return mCatalystInstance != null;
   }
 
   public LifecycleState getLifecycleState() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getLifecycleState();
+    }
+
     return mLifecycleState;
   }
 
   public void addLifecycleEventListener(final LifecycleEventListener listener) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.addLifecycleEventListener(listener);
+      return;
+    }
+
     mLifecycleEventListeners.add(listener);
     if (hasActiveReactInstance() || isBridgeless()) {
       switch (mLifecycleState) {
@@ -296,28 +398,58 @@ public class ReactContext extends ContextWrapper {
   }
 
   public void removeLifecycleEventListener(LifecycleEventListener listener) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.removeLifecycleEventListener(listener);
+      return;
+    }
+
     mLifecycleEventListeners.remove(listener);
   }
 
   public void addActivityEventListener(ActivityEventListener listener) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.addActivityEventListener(listener);
+      return;
+    }
+
     mActivityEventListeners.add(listener);
   }
 
   public void removeActivityEventListener(ActivityEventListener listener) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.removeActivityEventListener(listener);
+      return;
+    }
+
     mActivityEventListeners.remove(listener);
   }
 
   public void addWindowFocusChangeListener(WindowFocusChangeListener listener) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.addWindowFocusChangeListener(listener);
+      return;
+    }
+
     mWindowFocusEventListeners.add(listener);
   }
 
   public void removeWindowFocusChangeListener(WindowFocusChangeListener listener) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.removeWindowFocusChangeListener(listener);
+      return;
+    }
+
     mWindowFocusEventListeners.remove(listener);
   }
 
   /** Should be called by the hosting Fragment in {@link Fragment#onResume} */
   @ThreadConfined(UI)
   public void onHostResume(@Nullable Activity activity) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.onHostResume(activity);
+      return;
+    }
+
     mLifecycleState = LifecycleState.RESUMED;
     mCurrentActivity = new WeakReference(activity);
     ReactMarker.logMarker(ReactMarkerConstants.ON_HOST_RESUME_START);
@@ -333,6 +465,11 @@ public class ReactContext extends ContextWrapper {
 
   @ThreadConfined(UI)
   public void onNewIntent(@Nullable Activity activity, Intent intent) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.onNewIntent(activity, intent);
+      return;
+    }
+
     UiThreadUtil.assertOnUiThread();
     mCurrentActivity = new WeakReference(activity);
     for (ActivityEventListener listener : mActivityEventListeners) {
@@ -347,6 +484,11 @@ public class ReactContext extends ContextWrapper {
   /** Should be called by the hosting Fragment in {@link Fragment#onPause} */
   @ThreadConfined(UI)
   public void onHostPause() {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.onHostPause();
+      return;
+    }
+
     mLifecycleState = LifecycleState.BEFORE_RESUME;
     ReactMarker.logMarker(ReactMarkerConstants.ON_HOST_PAUSE_START);
     for (LifecycleEventListener listener : mLifecycleEventListeners) {
@@ -362,6 +504,11 @@ public class ReactContext extends ContextWrapper {
   /** Should be called by the hosting Fragment in {@link Fragment#onDestroy} */
   @ThreadConfined(UI)
   public void onHostDestroy() {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.onHostDestroy();
+      return;
+    }
+
     UiThreadUtil.assertOnUiThread();
     mLifecycleState = LifecycleState.BEFORE_CREATE;
     for (LifecycleEventListener listener : mLifecycleEventListeners) {
@@ -377,6 +524,11 @@ public class ReactContext extends ContextWrapper {
   /** Destroy this instance, making it unusable. */
   @ThreadConfined(UI)
   public void destroy() {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.destroy();
+      return;
+    }
+
     UiThreadUtil.assertOnUiThread();
 
     mDestroyed = true;
@@ -388,6 +540,11 @@ public class ReactContext extends ContextWrapper {
   /** Should be called by the hosting Fragment in {@link Fragment#onActivityResult} */
   public void onActivityResult(
       Activity activity, int requestCode, int resultCode, @Nullable Intent data) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.onActivityResult(activity, requestCode, resultCode, data);
+      return;
+    }
+
     for (ActivityEventListener listener : mActivityEventListeners) {
       try {
         listener.onActivityResult(activity, requestCode, resultCode, data);
@@ -399,6 +556,11 @@ public class ReactContext extends ContextWrapper {
 
   @ThreadConfined(UI)
   public void onWindowFocusChange(boolean hasFocus) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.onWindowFocusChange(hasFocus);
+      return;
+    }
+
     UiThreadUtil.assertOnUiThread();
     for (WindowFocusChangeListener listener : mWindowFocusEventListeners) {
       try {
@@ -410,18 +572,37 @@ public class ReactContext extends ContextWrapper {
   }
 
   public void assertOnUiQueueThread() {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.assertOnUiQueueThread();
+      return;
+    }
+
     Assertions.assertNotNull(mUiMessageQueueThread).assertIsOnThread();
   }
 
   public boolean isOnUiQueueThread() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.isOnUiQueueThread();
+    }
+
     return Assertions.assertNotNull(mUiMessageQueueThread).isOnThread();
   }
 
   public void runOnUiQueueThread(Runnable runnable) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.runOnUiQueueThread(runnable);
+      return;
+    }
+
     Assertions.assertNotNull(mUiMessageQueueThread).runOnQueue(runnable);
   }
 
   public void assertOnNativeModulesQueueThread() {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.assertOnNativeModulesQueueThread();
+      return;
+    }
+
     /** TODO(T85807990): Fail fast if the ReactContext isn't initialized */
     if (!mIsInitialized) {
       throw new IllegalStateException(
@@ -431,6 +612,11 @@ public class ReactContext extends ContextWrapper {
   }
 
   public void assertOnNativeModulesQueueThread(String message) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.assertOnNativeModulesQueueThread(message);
+      return;
+    }
+
     /** TODO(T85807990): Fail fast if the ReactContext isn't initialized */
     if (!mIsInitialized) {
       throw new IllegalStateException(
@@ -440,34 +626,68 @@ public class ReactContext extends ContextWrapper {
   }
 
   public boolean isOnNativeModulesQueueThread() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.isOnNativeModulesQueueThread();
+    }
+
     return Assertions.assertNotNull(mNativeModulesMessageQueueThread).isOnThread();
   }
 
   public void runOnNativeModulesQueueThread(Runnable runnable) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.runOnNativeModulesQueueThread(runnable);
+      return;
+    }
+
     Assertions.assertNotNull(mNativeModulesMessageQueueThread).runOnQueue(runnable);
   }
 
   public void assertOnJSQueueThread() {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.assertOnJSQueueThread();
+      return;
+    }
+
     Assertions.assertNotNull(mJSMessageQueueThread).assertIsOnThread();
   }
 
   public boolean isOnJSQueueThread() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.isOnJSQueueThread();
+    }
+
     return Assertions.assertNotNull(mJSMessageQueueThread).isOnThread();
   }
 
   public boolean runOnJSQueueThread(Runnable runnable) {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.runOnJSQueueThread(runnable);
+    }
+
     return Assertions.assertNotNull(mJSMessageQueueThread).runOnQueue(runnable);
   }
 
   public @Nullable MessageQueueThread getJSMessageQueueThread() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getJSMessageQueueThread();
+    }
+
     return mJSMessageQueueThread;
   }
 
   public @Nullable MessageQueueThread getNativeModulesMessageQueueThread() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getNativeModulesMessageQueueThread();
+    }
+
     return mNativeModulesMessageQueueThread;
   }
 
   public @Nullable MessageQueueThread getUiMessageQueueThread() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getUiMessageQueueThread();
+    }
+
     return mUiMessageQueueThread;
   }
 
@@ -476,6 +696,11 @@ public class ReactContext extends ContextWrapper {
    * otherwise.
    */
   public void handleException(Exception e) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.handleException(e);
+      return;
+    }
+
     boolean catalystInstanceVariableExists = mCatalystInstance != null;
     boolean isCatalystInstanceAlive =
         catalystInstanceVariableExists && !mCatalystInstance.isDestroyed();
@@ -505,6 +730,10 @@ public class ReactContext extends ContextWrapper {
   }
 
   public JSExceptionHandler getExceptionHandler() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getExceptionHandler();
+    }
+
     if (mExceptionHandlerWrapper == null) {
       mExceptionHandlerWrapper = new ExceptionHandlerWrapper();
     }
@@ -512,10 +741,18 @@ public class ReactContext extends ContextWrapper {
   }
 
   public JSExceptionHandler getJSExceptionHandler() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getJSExceptionHandler();
+    }
+
     return mJSExceptionHandler;
   }
 
   public boolean hasCurrentActivity() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.hasCurrentActivity();
+    }
+
     return mCurrentActivity != null && mCurrentActivity.get() != null;
   }
 
@@ -525,6 +762,10 @@ public class ReactContext extends ContextWrapper {
    * called before the context is in the right state.
    */
   public boolean startActivityForResult(Intent intent, int code, Bundle bundle) {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.startActivityForResult(intent, code, bundle);
+    }
+
     Activity activity = getCurrentActivity();
     if (activity != null) {
       activity.startActivityForResult(intent, code, bundle);
@@ -539,6 +780,10 @@ public class ReactContext extends ContextWrapper {
    * MEMORY LEAKS.
    */
   public @Nullable Activity getCurrentActivity() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getCurrentActivity();
+    }
+
     if (mCurrentActivity == null) {
       return null;
     }
@@ -548,6 +793,10 @@ public class ReactContext extends ContextWrapper {
   /** @deprecated DO NOT USE, this method will be removed in the near future. */
   @Deprecated
   public boolean isBridgeless() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.isBridgeless();
+    }
+
     return false;
   }
 
@@ -558,6 +807,10 @@ public class ReactContext extends ContextWrapper {
    * synchronized(jsContext) { nativeThingNeedingJsContext(jsContext.get()); }
    */
   public @Nullable JavaScriptContextHolder getJavaScriptContextHolder() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getJavaScriptContextHolder();
+    }
+
     if (mCatalystInstance != null) {
       return mCatalystInstance.getJavaScriptContextHolder();
     }
@@ -573,6 +826,10 @@ public class ReactContext extends ContextWrapper {
    * @return The UIManager when CatalystInstance is active.
    */
   public @Nullable UIManager getFabricUIManager() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getFabricUIManager();
+    }
+
     UIManager uiManager = mCatalystInstance.getFabricUIManager();
     return uiManager != null
         ? uiManager
@@ -586,6 +843,10 @@ public class ReactContext extends ContextWrapper {
    * @return The JS bundle URL set when the bundle was loaded
    */
   public @Nullable String getSourceURL() {
+    if (mOtherReactContext != null) {
+      return mOtherReactContext.getSourceURL();
+    }
+
     return mCatalystInstance == null ? null : mCatalystInstance.getSourceURL();
   }
 
@@ -594,6 +855,11 @@ public class ReactContext extends ContextWrapper {
    * properly initialised and not null before calling.
    */
   public void registerSegment(int segmentId, String path, Callback callback) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.registerSegment(segmentId, path, callback);
+      return;
+    }
+
     Assertions.assertNotNull(mCatalystInstance).registerSegment(segmentId, path);
     Assertions.assertNotNull(callback).invoke();
   }
@@ -606,6 +872,11 @@ public class ReactContext extends ContextWrapper {
    */
   public <T extends JavaScriptModule> void internal_registerInteropModule(
       Class<T> interopModuleInterface, Object interopModule) {
+    if (mOtherReactContext != null) {
+      mOtherReactContext.internal_registerInteropModule(interopModuleInterface, interopModule);
+      return;
+    }
+
     if (mInteropModuleRegistry != null) {
       mInteropModuleRegistry.registerInteropModule(interopModuleInterface, interopModule);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -211,6 +211,7 @@ public abstract class ReactContext extends ContextWrapper {
     emitDeviceEvent(eventName, null);
   }
 
+  @Deprecated
   public abstract CatalystInstance getCatalystInstance();
 
   /**
@@ -225,6 +226,7 @@ public abstract class ReactContext extends ContextWrapper {
   /** @return true if there is an non-null, alive react native instance */
   public abstract boolean hasActiveReactInstance();
 
+  @Deprecated
   public abstract boolean hasCatalystInstance();
 
   public LifecycleState getLifecycleState() {
@@ -636,6 +638,7 @@ public abstract class ReactContext extends ContextWrapper {
    * JavaScriptContextHolder jsContext = reactContext.getJavaScriptContextHolder()
    * synchronized(jsContext) { nativeThingNeedingJsContext(jsContext.get()); }
    */
+  @Deprecated
   public abstract @Nullable JavaScriptContextHolder getJavaScriptContextHolder();
 
   @DeprecatedInNewArchitecture(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -82,6 +82,7 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
     return mReactHost.getUIManager();
   }
 
+  @Deprecated
   @Override
   public CatalystInstance getCatalystInstance() {
     ReactSoftExceptionLogger.logSoftExceptionVerbose(
@@ -102,6 +103,7 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
     return mReactHost.isInstanceInitialized();
   }
 
+  @Deprecated
   @Override
   public boolean hasCatalystInstance() {
     return mReactHost.isInstanceInitialized();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -91,10 +91,24 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
     throw new UnsupportedOperationException("There is no Catalyst instance in bridgeless mode.");
   }
 
+  @Deprecated
+  @Override
+  public boolean hasActiveCatalystInstance() {
+    return hasActiveReactInstance();
+  }
+
   @Override
   public boolean hasActiveReactInstance() {
     return mReactHost.isInstanceInitialized();
   }
+
+  @Override
+  public boolean hasCatalystInstance() {
+    return mReactHost.isInstanceInitialized();
+  }
+
+  @Override
+  public void destroy() {}
 
   DevSupportManager getDevSupportManager() {
     return mReactHost.getDevSupportManager();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -132,8 +132,8 @@ final class ReactInstance {
             .setNativeModulesQueueThreadSpec(nativeModulesSpec)
             .build();
     mQueueConfiguration = ReactQueueConfigurationImpl.create(spec, exceptionHandler);
-    FLog.d(TAG, "Calling initializeMessageQueueThreads()");
-    mBridgelessReactContext.initializeMessageQueueThreads(mQueueConfiguration);
+    FLog.d(TAG, "Calling ReactContext.initialize(ReactQueueConfiguration)");
+    mBridgelessReactContext.initialize(mQueueConfiguration);
     MessageQueueThread jsMessageQueueThread = mQueueConfiguration.getJSQueueThread();
     MessageQueueThread nativeModulesMessageQueueThread =
         mQueueConfiguration.getNativeModulesQueueThread();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -9,8 +9,18 @@ package com.facebook.react.uimanager;
 
 import android.content.Context;
 import androidx.annotation.Nullable;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.JavaScriptContextHolder;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.RuntimeExecutor;
+import com.facebook.react.bridge.UIManager;
+import com.facebook.react.common.annotations.FrameworkAPI;
+import com.facebook.react.common.annotations.UnstableReactNativeAPI;
+import java.util.Collection;
 
 /**
  * Wraps {@link ReactContext} with the base {@link Context} passed into the constructor. It provides
@@ -48,6 +58,60 @@ public class ThemedReactContext extends ReactContext {
     mSurfaceId = surfaceId;
   }
 
+  @Override
+  public <T extends JavaScriptModule> T getJSModule(Class<T> jsInterface) {
+    return mReactApplicationContext.getJSModule(jsInterface);
+  }
+
+  @Override
+  public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
+    return mReactApplicationContext.hasNativeModule(nativeModuleInterface);
+  }
+
+  @Override
+  public Collection<NativeModule> getNativeModules() {
+    return mReactApplicationContext.getNativeModules();
+  }
+
+  @Nullable
+  @Override
+  public <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
+    return mReactApplicationContext.getNativeModule(nativeModuleInterface);
+  }
+
+  @Nullable
+  @FrameworkAPI
+  @UnstableReactNativeAPI
+  public RuntimeExecutor getRuntimeExecutor() {
+    return mReactApplicationContext.getRuntimeExecutor();
+  }
+
+  @Override
+  public CatalystInstance getCatalystInstance() {
+    return mReactApplicationContext.getCatalystInstance();
+  }
+
+  @Deprecated
+  @Override
+  public boolean hasActiveCatalystInstance() {
+    return mReactApplicationContext.hasActiveCatalystInstance();
+  }
+
+  @Override
+  public boolean hasActiveReactInstance() {
+    return mReactApplicationContext.hasActiveCatalystInstance();
+  }
+
+  @Override
+  public boolean hasCatalystInstance() {
+    return mReactApplicationContext.hasCatalystInstance();
+  }
+
+  @Override
+  public void destroy() {
+    mReactApplicationContext.destroy();
+  }
+
   /**
    * This is misnamed but has some uses out in the wild. It will be deleted in a future release of
    * RN.
@@ -74,5 +138,38 @@ public class ThemedReactContext extends ReactContext {
 
   public ReactApplicationContext getReactApplicationContext() {
     return mReactApplicationContext;
+  }
+
+  @Override
+  public void handleException(Exception e) {
+    mReactApplicationContext.handleException(e);
+  }
+
+  @Deprecated
+  @Override
+  public boolean isBridgeless() {
+    return mReactApplicationContext.isBridgeless();
+  }
+
+  @Nullable
+  @Override
+  public JavaScriptContextHolder getJavaScriptContextHolder() {
+    return mReactApplicationContext.getJavaScriptContextHolder();
+  }
+
+  @Override
+  public UIManager getFabricUIManager() {
+    return mReactApplicationContext.getFabricUIManager();
+  }
+
+  @Nullable
+  @Override
+  public String getSourceURL() {
+    return mReactApplicationContext.getSourceURL();
+  }
+
+  @Override
+  public void registerSegment(int segmentId, String path, Callback callback) {
+    mReactApplicationContext.registerSegment(segmentId, path, callback);
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -7,13 +7,10 @@
 
 package com.facebook.react.uimanager;
 
-import android.app.Activity;
 import android.content.Context;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.UIManager;
 
 /**
  * Wraps {@link ReactContext} with the base {@link Context} passed into the constructor. It provides
@@ -45,34 +42,10 @@ public class ThemedReactContext extends ReactContext {
       Context base,
       @Nullable String moduleName,
       int surfaceId) {
-    super(base);
-    if (reactApplicationContext.hasCatalystInstance()) {
-      initializeWithInstance(reactApplicationContext.getCatalystInstance());
-    }
-    initializeInteropModules(reactApplicationContext);
+    super(reactApplicationContext, base);
     mReactApplicationContext = reactApplicationContext;
     mModuleName = moduleName;
     mSurfaceId = surfaceId;
-  }
-
-  @Override
-  public void addLifecycleEventListener(LifecycleEventListener listener) {
-    mReactApplicationContext.addLifecycleEventListener(listener);
-  }
-
-  @Override
-  public void removeLifecycleEventListener(LifecycleEventListener listener) {
-    mReactApplicationContext.removeLifecycleEventListener(listener);
-  }
-
-  @Override
-  public boolean hasCurrentActivity() {
-    return mReactApplicationContext.hasCurrentActivity();
-  }
-
-  @Override
-  public @Nullable Activity getCurrentActivity() {
-    return mReactApplicationContext.getCurrentActivity();
   }
 
   /**
@@ -101,18 +74,5 @@ public class ThemedReactContext extends ReactContext {
 
   public ReactApplicationContext getReactApplicationContext() {
     return mReactApplicationContext;
-  }
-
-  @Override
-  public boolean isBridgeless() {
-    return mReactApplicationContext.isBridgeless();
-  }
-
-  @Override
-  public UIManager getFabricUIManager() {
-    if (isBridgeless()) {
-      return mReactApplicationContext.getFabricUIManager();
-    }
-    return super.getFabricUIManager();
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -86,6 +86,7 @@ public class ThemedReactContext extends ReactContext {
     return mReactApplicationContext.getRuntimeExecutor();
   }
 
+  @Deprecated
   @Override
   public CatalystInstance getCatalystInstance() {
     return mReactApplicationContext.getCatalystInstance();
@@ -102,6 +103,7 @@ public class ThemedReactContext extends ReactContext {
     return mReactApplicationContext.hasActiveCatalystInstance();
   }
 
+  @Deprecated
   @Override
   public boolean hasCatalystInstance() {
     return mReactApplicationContext.hasCatalystInstance();
@@ -151,6 +153,7 @@ public class ThemedReactContext extends ReactContext {
     return mReactApplicationContext.isBridgeless();
   }
 
+  @Deprecated
   @Nullable
   @Override
   public JavaScriptContextHolder getJavaScriptContextHolder() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/CompositeReactPackageTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/CompositeReactPackageTest.kt
@@ -7,8 +7,8 @@
 
 package com.facebook.react
 
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.NativeModule
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 import java.util.*
 import org.junit.Assert
@@ -26,14 +26,14 @@ class CompositeReactPackageTest {
   private lateinit var packageNo1: ReactPackage
   private lateinit var packageNo2: ReactPackage
   private lateinit var packageNo3: ReactPackage
-  private lateinit var reactContext: ReactApplicationContext
+  private lateinit var reactContext: BridgeReactContext
 
   @Before
   fun setUp() {
     packageNo1 = mock(ReactPackage::class.java)
     packageNo2 = mock(ReactPackage::class.java)
     packageNo3 = mock(ReactPackage::class.java)
-    reactContext = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -16,10 +16,10 @@ import android.view.MotionEvent
 import android.view.WindowInsets
 import android.view.WindowManager
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactTestHelper
 import com.facebook.react.bridge.WritableArray
@@ -66,8 +66,8 @@ class RootViewTest {
     systemClock.`when`<Long> { SystemClock.uptimeMillis() }.thenReturn(ts)
 
     catalystInstanceMock = ReactTestHelper.createMockCatalystInstance()
-    reactContext = spy(ReactApplicationContext(RuntimeEnvironment.getApplication()))
-    reactContext.initializeWithInstance(catalystInstanceMock)
+    reactContext = spy(BridgeReactContext(RuntimeEnvironment.getApplication()))
+    reactContext.initialize(catalystInstanceMock)
 
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(reactContext)
     val uiManagerModuleMock = mock(UIManagerModule::class.java)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ReactTestHelper.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ReactTestHelper.kt
@@ -24,8 +24,8 @@ object ReactTestHelper {
    */
   @JvmStatic
   fun createCatalystContextForTest(): ReactApplicationContext =
-      ReactApplicationContext(RuntimeEnvironment.getApplication()).apply {
-        initializeWithInstance(createMockCatalystInstance())
+      BridgeReactContext(RuntimeEnvironment.getApplication()).apply {
+        initialize(createMockCatalystInstance())
       }
 
   /** @return a CatalystInstance mock that has a default working ReactQueueConfiguration. */

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricUIManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricUIManagerTest.kt
@@ -7,7 +7,7 @@
 
 package com.facebook.react.fabric
 
-import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.uimanager.ViewManagerRegistry
 import com.facebook.react.uimanager.events.BatchEventDispatchedListener
 import com.facebook.testutils.fakes.FakeBatchEventDispatchedListener
@@ -24,14 +24,14 @@ import org.robolectric.annotation.Config
 @Config(shadows = [ShadowSoLoader::class])
 class FabricUIManagerTest {
 
-  private lateinit var reactContext: ReactApplicationContext
+  private lateinit var reactContext: BridgeReactContext
   private lateinit var viewManagerRegistry: ViewManagerRegistry
   private lateinit var batchEventDispatchedListener: BatchEventDispatchedListener
   private lateinit var underTest: FabricUIManager
 
   @Before
   fun setup() {
-    reactContext = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
     viewManagerRegistry = ViewManagerRegistry(emptyList())
     batchEventDispatchedListener = FakeBatchEventDispatchedListener()
     underTest = FabricUIManager(reactContext, viewManagerRegistry, batchEventDispatchedListener)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/internal/interop/InteropEventEmitterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/internal/interop/InteropEventEmitterTest.kt
@@ -9,9 +9,9 @@
 
 package com.facebook.react.internal.interop
 
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContext
 import com.facebook.testutils.fakes.FakeEventDispatcher
 import org.junit.Assert.assertEquals
@@ -29,7 +29,7 @@ class InteropEventEmitterTest {
 
   @Before
   fun setup() {
-    reactContext = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
     eventDispatcher = FakeEventDispatcher()
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.kt
@@ -7,8 +7,8 @@
 
 package com.facebook.react.modules.deviceinfo
 
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactTestHelper
 import com.facebook.react.bridge.WritableMap
@@ -32,7 +32,7 @@ class DeviceInfoModuleTest : TestCase() {
   private lateinit var deviceInfoModule: DeviceInfoModule
   private lateinit var fakePortraitDisplayMetrics: WritableMap
   private lateinit var fakeLandscapeDisplayMetrics: WritableMap
-  private lateinit var reactContext: ReactApplicationContext
+  private lateinit var reactContext: BridgeReactContext
   private lateinit var displayMetricsHolder: MockedStatic<DisplayMetricsHolder>
 
   @Before
@@ -45,9 +45,9 @@ class DeviceInfoModuleTest : TestCase() {
     fakeLandscapeDisplayMetrics.putInt("height", 100)
 
     displayMetricsHolder = mockStatic(DisplayMetricsHolder::class.java)
-    reactContext = spy(ReactApplicationContext(RuntimeEnvironment.getApplication()))
+    reactContext = spy(BridgeReactContext(RuntimeEnvironment.getApplication()))
     val catalystInstanceMock = ReactTestHelper.createMockCatalystInstance()
-    reactContext.initializeWithInstance(catalystInstanceMock)
+    reactContext.initialize(catalystInstanceMock)
     deviceInfoModule = DeviceInfoModule(reactContext)
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.uimanager
 
 import android.view.View
-import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
@@ -84,7 +84,7 @@ class ReactPropConstantsTest {
   @Test
   fun testNativePropsIncludeCorrectTypes() {
     val viewManagers = listOf<ViewManager<*, *>>(ViewManagerUnderTest())
-    val reactContext = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    val reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
     val uiManagerModule = UIManagerModule(reactContext, viewManagers, 0)
     val constants: Map<*, *> =
         valueAtPath(uiManagerModule.constants as Map<*, *>, "SomeView", "NativeProps")

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSetterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSetterTest.kt
@@ -7,8 +7,8 @@
 
 package com.facebook.react.uimanager
 
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.annotations.ReactProp
@@ -65,7 +65,7 @@ class ReactPropForShadowNodeSetterTest {
 
     init {
       setViewClassName("ShadowViewUnderTest")
-      val context = ReactApplicationContext(RuntimeEnvironment.getApplication())
+      val context = BridgeReactContext(RuntimeEnvironment.getApplication())
       setThemedContext(ThemedReactContext(context, context, null, -1))
     }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.kt
@@ -9,9 +9,9 @@ package com.facebook.react.uimanager
 
 import android.graphics.drawable.ColorDrawable
 import android.view.View
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactTestHelper.createMockCatalystInstance
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.touch.JSResponderHandler
@@ -45,16 +45,16 @@ class SimpleViewPropertyTest {
     }
   }
 
-  private lateinit var context: ReactApplicationContext
+  private lateinit var context: BridgeReactContext
   private lateinit var catalystInstanceMock: CatalystInstance
   private lateinit var themedContext: ThemedReactContext
   private lateinit var manager: ConcreteViewManager
 
   @Before
   fun setup() {
-    context = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    context = BridgeReactContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
-    context.initializeWithInstance(catalystInstanceMock)
+    context.initialize(catalystInstanceMock)
     themedContext = ThemedReactContext(context, context, null, surfaceId)
     manager = ConcreteViewManager()
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsTest.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.uimanager
 
 import android.view.View
-import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.common.MapBuilder
 import org.assertj.core.api.Assertions
 import org.assertj.core.data.MapEntry
@@ -45,11 +45,11 @@ class UIManagerModuleConstantsTest {
     override fun getNativeProps(): MutableMap<String, String> = MapBuilder.of("fooProp", "number")
   }
 
-  private lateinit var reactContext: ReactApplicationContext
+  private lateinit var reactContext: BridgeReactContext
 
   @Before
   fun setUp() {
-    reactContext = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
   }
 
   @Suppress("UNCHECKED_CAST")

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
@@ -12,10 +12,10 @@ import android.util.DisplayMetrics
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.drawable.ScalingUtils
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactTestHelper.createMockCatalystInstance
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
@@ -41,7 +41,7 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class ReactImagePropertyTest {
 
-  private var context: ReactApplicationContext? = null
+  private var context: BridgeReactContext? = null
   private var catalystInstanceMock: CatalystInstance? = null
   private var themeContext: ThemedReactContext? = null
   private lateinit var arguments: MockedStatic<Arguments>
@@ -57,9 +57,9 @@ class ReactImagePropertyTest {
     rnLog.`when`<Boolean> { RNLog.w(any(), anyString()) }.thenAnswer {}
 
     SoLoader.setInTestMode()
-    context = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    context = BridgeReactContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
-    context!!.initializeWithInstance(catalystInstanceMock)
+    context!!.initialize(catalystInstanceMock)
     themeContext = ThemedReactContext(context, context, null, -1)
     Fresco.initialize(context)
     DisplayMetricsHolder.setWindowDisplayMetrics(DisplayMetrics())

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
@@ -17,9 +17,9 @@ import android.util.DisplayMetrics
 import android.view.Gravity
 import android.view.inputmethod.EditorInfo
 import androidx.core.content.res.ResourcesCompat.ID_NULL
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactTestHelper.createMockCatalystInstance
 import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.uimanager.ReactStylesDiffMap
@@ -36,7 +36,7 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class ReactTextInputPropertyTest {
 
-  private lateinit var context: ReactApplicationContext
+  private lateinit var context: BridgeReactContext
   private lateinit var catalystInstanceMock: CatalystInstance
   private lateinit var themedContext: ThemedReactContext
   private lateinit var manager: ReactTextInputManager
@@ -54,9 +54,9 @@ class ReactTextInputPropertyTest {
 
   @Before
   fun setup() {
-    context = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    context = BridgeReactContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
-    context.initializeWithInstance(catalystInstanceMock)
+    context.initialize(catalystInstanceMock)
     themedContext = ThemedReactContext(context, context.baseContext, null, ID_NULL)
     manager = ReactTextInputManager()
     DisplayMetricsHolder.setWindowDisplayMetrics(DisplayMetrics())


### PR DESCRIPTION
Summary:
These APIs have no future in the React Native new architecture. Let's deprecate them!

Changelog: [Android][Deprecated] Deprecate ReactContext APIs: getCatalystInstance(), hasCatalystInstance(), getJavaScriptContextHolder()

Reviewed By: cortinico

Differential Revision: D53166752


