### PR TITLE
Make ReactContext support decoration

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1073,6 +1073,7 @@ public class com/facebook/react/bridge/ReactBridge {
 public class com/facebook/react/bridge/ReactContext : android/content/ContextWrapper {
 	protected field mInteropModuleRegistry Lcom/facebook/react/bridge/interop/InteropModuleRegistry;
 	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Lcom/facebook/react/bridge/ReactContext;Landroid/content/Context;)V
 	public fun addActivityEventListener (Lcom/facebook/react/bridge/ActivityEventListener;)V
 	public fun addLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
 	public fun addWindowFocusChangeListener (Lcom/facebook/react/bridge/WindowFocusChangeListener;)V
@@ -4813,16 +4814,10 @@ public class com/facebook/react/uimanager/ThemedReactContext : com/facebook/reac
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;)V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;Ljava/lang/String;)V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;Ljava/lang/String;I)V
-	public fun addLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
-	public fun getCurrentActivity ()Landroid/app/Activity;
-	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun getReactApplicationContext ()Lcom/facebook/react/bridge/ReactApplicationContext;
 	public fun getSurfaceID ()Ljava/lang/String;
 	public fun getSurfaceId ()I
-	public fun hasCurrentActivity ()Z
-	public fun isBridgeless ()Z
-	public fun removeLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
 }
 
 public class com/facebook/react/uimanager/TouchTargetHelper {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -7,13 +7,10 @@
 
 package com.facebook.react.uimanager;
 
-import android.app.Activity;
 import android.content.Context;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.UIManager;
 
 /**
  * Wraps {@link ReactContext} with the base {@link Context} passed into the constructor. It provides
@@ -45,34 +42,10 @@ public class ThemedReactContext extends ReactContext {
       Context base,
       @Nullable String moduleName,
       int surfaceId) {
-    super(base);
-    if (reactApplicationContext.hasCatalystInstance()) {
-      initializeWithInstance(reactApplicationContext.getCatalystInstance());
-    }
-    initializeInteropModules(reactApplicationContext);
+    super(reactApplicationContext, base);
     mReactApplicationContext = reactApplicationContext;
     mModuleName = moduleName;
     mSurfaceId = surfaceId;
-  }
-
-  @Override
-  public void addLifecycleEventListener(LifecycleEventListener listener) {
-    mReactApplicationContext.addLifecycleEventListener(listener);
-  }
-
-  @Override
-  public void removeLifecycleEventListener(LifecycleEventListener listener) {
-    mReactApplicationContext.removeLifecycleEventListener(listener);
-  }
-
-  @Override
-  public boolean hasCurrentActivity() {
-    return mReactApplicationContext.hasCurrentActivity();
-  }
-
-  @Override
-  public @Nullable Activity getCurrentActivity() {
-    return mReactApplicationContext.getCurrentActivity();
   }
 
   /**
@@ -101,18 +74,5 @@ public class ThemedReactContext extends ReactContext {
 
   public ReactApplicationContext getReactApplicationContext() {
     return mReactApplicationContext;
-  }
-
-  @Override
-  public boolean isBridgeless() {
-    return mReactApplicationContext.isBridgeless();
-  }
-
-  @Override
-  public UIManager getFabricUIManager() {
-    if (isBridgeless()) {
-      return mReactApplicationContext.getFabricUIManager();
-    }
-    return super.getFabricUIManager();
   }
 }


### PR DESCRIPTION
Summary:
## Context
ThemedReactContext decorates ReactContext with some render-related APIs.

## Problem
ThemedReactContext is a separate ReactContext that is separately/independently initialized from the original ReactContext.

ReactContext is stateful. And ThemedReactContext does not forward all its public APIs to the ReactContext.

**Consequence:** ThemedReactContext and ReactContext over time can carry different versions of the same state.

## Changes
Make the ReactContext responsible for decoration.

**How:** Make the ReactContext accept an optional other ReactContext param. If the other ReactContext exists, just delegate to it, in every public method.

This way, ThemedReactContext can just implement the rendering APIs it cares about. Importantly, this means that when someone extends ReactContext with a new API, that API will work automatically with ThemedReactContext. (Assuming the person implemented delegation correctly in ReactContext).

## Concerns
ThemedReactContext did not delgate every public API to ReactContext. So, this change carries some risk: some product code could have come to depend on this "broken behaviour." And that product code might break, now that we "fixed" this "broken" behaviour.

Changelog: [Internal]

Differential Revision: D53640981


