### PR TITLE
Fix broken build_android due to Kotlin Explicit API mode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
@@ -40,12 +40,12 @@ private constructor(
         MutableList<((context: ReactApplicationContext) -> CxxReactPackage)> =
         mutableListOf()
 
-    fun addCxxReactPackage(provider: () -> CxxReactPackage): Builder {
+    public fun addCxxReactPackage(provider: () -> CxxReactPackage): Builder {
       cxxReactPackageProviders.add { _ -> provider() }
       return this
     }
 
-    fun addCxxReactPackage(
+    public fun addCxxReactPackage(
         provider: (context: ReactApplicationContext) -> CxxReactPackage
     ): Builder {
       cxxReactPackageProviders.add(provider)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5f3eba4807f850a67572c0ea0ff33dbd>>
+ * @generated SignedSource<<de038facca377ff545878c7eba4141df>>
  */
 
 /**
@@ -91,7 +91,7 @@ public object ReactNativeFeatureFlags {
    * ```
    */
   @JvmStatic
-  public fun override(provider: ReactNativeFeatureFlagsProvider) = accessor.override(provider)
+  public fun override(provider: ReactNativeFeatureFlagsProvider): Unit = accessor.override(provider)
 
   /**
    * Removes the overridden feature flags and makes the API return default

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6e7270533df9a6ad0f3c5efc8645dd2b>>
+ * @generated SignedSource<<42f8526cf5c3ca10ac068c3bc30433ca>>
  */
 
 /**
@@ -44,7 +44,7 @@ public object ReactNativeFeatureFlagsCxxInterop {
 
   @DoNotStrip @JvmStatic public external fun enableFixForClippedSubviewsCrash(): Boolean
 
-  @DoNotStrip @JvmStatic external fun override(provider: Any)
+  @DoNotStrip @JvmStatic public external fun override(provider: Any)
 
-  @DoNotStrip @JvmStatic external fun dangerouslyReset()
+  @DoNotStrip @JvmStatic public external fun dangerouslyReset()
 }

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlags.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlags.kt-template.js
@@ -72,7 +72,7 @@ ${Object.entries(definitions.common)
    * \`\`\`
    */
   @JvmStatic
-  public fun override(provider: ReactNativeFeatureFlagsProvider) = accessor.override(provider)
+  public fun override(provider: ReactNativeFeatureFlagsProvider): Unit = accessor.override(provider)
 
   /**
    * Removes the overridden feature flags and makes the API return default

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsCxxInterop.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsCxxInterop.kt-template.js
@@ -48,9 +48,9 @@ ${Object.entries(definitions.common)
   )
   .join('\n\n')}
 
-  @DoNotStrip @JvmStatic external fun override(provider: Any)
+  @DoNotStrip @JvmStatic public external fun override(provider: Any)
 
-  @DoNotStrip @JvmStatic external fun dangerouslyReset()
+  @DoNotStrip @JvmStatic public external fun dangerouslyReset()
 }
 `);
 }


### PR DESCRIPTION
Summary:
Fix broken build_android due to Kotlin Explicit API mode

Changelog:
[Internal] [Changed] - Fix broken build_android due to Kotlin Explicit API mode

Differential Revision: D53656201


