### PR TITLE
feat: make __gitignore file work for OOT platforms

### DIFF
--- a/packages/react-native/template/_gitignore
+++ b/packages/react-native/template/_gitignore
@@ -20,7 +20,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
-ios/.xcode.env.local
+**/.xcode.env.local
 
 # Android/IntelliJ
 #
@@ -56,7 +56,7 @@ yarn-error.log
 *.jsbundle
 
 # Ruby / CocoaPods
-/ios/Pods/
+**/Pods/
 /vendor/bundle/
 
 # Temporary files created by Metro to check the health of the file watcher


### PR DESCRIPTION
## Summary:

This PR makes `__gitignore` file universal for Apple OOT platforms. 

## Changelog:

[GENERAL] [CHANGED] - Make template's .gitignore file universal for OOT platforms

## Test Plan:

CI Green
