### PR TITLE
Remove unused `isPressable` text attribute

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -95,12 +95,6 @@ void TextAttributes::apply(TextAttributes textAttributes) {
   isHighlighted = textAttributes.isHighlighted.has_value()
       ? textAttributes.isHighlighted
       : isHighlighted;
-  // TextAttributes "inherits" the isPressable value from ancestors, so this
-  // only applies the current node's value for isPressable if it is truthy.
-  isPressable =
-      textAttributes.isPressable.has_value() && *textAttributes.isPressable
-      ? textAttributes.isPressable
-      : isPressable;
   layoutDirection = textAttributes.layoutDirection.has_value()
       ? textAttributes.layoutDirection
       : layoutDirection;
@@ -131,7 +125,6 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
              textShadowOffset,
              textShadowColor,
              isHighlighted,
-             isPressable,
              layoutDirection,
              accessibilityRole,
              role,
@@ -154,7 +147,6 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
              rhs.textShadowOffset,
              rhs.textShadowColor,
              rhs.isHighlighted,
-             rhs.isPressable,
              rhs.layoutDirection,
              rhs.accessibilityRole,
              rhs.role,
@@ -224,7 +216,6 @@ SharedDebugStringConvertibleList TextAttributes::getDebugProps() const {
 
       // Special
       debugStringConvertibleItem("isHighlighted", isHighlighted),
-      debugStringConvertibleItem("isPressable", isPressable),
       debugStringConvertibleItem("layoutDirection", layoutDirection),
       debugStringConvertibleItem("accessibilityRole", accessibilityRole),
       debugStringConvertibleItem("role", role),

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -74,7 +74,6 @@ class TextAttributes : public DebugStringConvertible {
 
   // Special
   std::optional<bool> isHighlighted{};
-  std::optional<bool> isPressable{};
 
   // TODO T59221129: document where this value comes from and how it is set.
   // It's not clear if this is being used properly, or if it's being set at all.
@@ -132,7 +131,6 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.textShadowRadius,
         textAttributes.textShadowColor,
         textAttributes.isHighlighted,
-        textAttributes.isPressable,
         textAttributes.layoutDirection,
         textAttributes.accessibilityRole,
         textAttributes.role);

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -165,12 +165,6 @@ static TextAttributes convertRawProp(
       "isHighlighted",
       sourceTextAttributes.isHighlighted,
       defaultTextAttributes.isHighlighted);
-  textAttributes.isPressable = convertRawProp(
-      context,
-      rawProps,
-      "isPressable",
-      sourceTextAttributes.isPressable,
-      defaultTextAttributes.isPressable);
 
   // In general, we want this class to access props in the same order
   // that ViewProps accesses them in, so that RawPropParser can optimize
@@ -300,8 +294,6 @@ void BaseTextProps::setProp(
         defaults, value, textAttributes, textShadowColor, "textShadowColor");
     REBUILD_FIELD_SWITCH_CASE(
         defaults, value, textAttributes, isHighlighted, "isHighlighted");
-    REBUILD_FIELD_SWITCH_CASE(
-        defaults, value, textAttributes, isPressable, "isPressable");
     REBUILD_FIELD_SWITCH_CASE(
         defaults,
         value,


### PR DESCRIPTION
## Summary:

Remove unused `isPressable` text attribute

## Changelog:

[INTERNAL] [REMOVED] - Remove unused `isPressable` text attribute

## Test Plan:
