### PR TITLE
'[skip ci] [RN][Android][TmCxxAutolinking] Add cxxModule to RN-Tester'\''s codegenConfig

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -37,6 +37,12 @@
     "jsSrcsDir": ".",
     "android": {
       "javaPackageName": "com.facebook.fbreact.specs"
-    }
+    },
+    "cxxModules": [
+      {
+        "name": "NativeCxxModuleExample",
+        "headerPath": "NativeCxxModuleExample.h"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Summary:
This introduces the  field for RNTester where the local TM-CXX modules
are specified.

Changelog:
[Internal] [Changed] - Add cxxModule to RN-Tester'\''s codegenConfig

Differential Revision: D53669913

