### PR TITLE
'[skip ci] [RN][Android][TmCxxAutolinking] Update RNGP to handle cxxModule in codegenConfig

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelCodegenConfig.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelCodegenConfig.kt
@@ -13,4 +13,5 @@ data class ModelCodegenConfig(
     val jsSrcsDir: String?,
     val android: ModelCodegenConfigAndroid?,
     val includesGeneratedCode: Boolean?,
+    val cxxModules: List<ModelCodegenConfigCxxModules>?,
 )

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelCodegenConfigCxxModules.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelCodegenConfigCxxModules.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.model
+
+data class ModelCodegenConfigCxxModules(
+    val name: String,
+    val headerPath: String,
+)

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
@@ -263,7 +263,8 @@ class ProjectUtilsTest {
   @Test
   fun needsCodegenFromPackageJson_withCodegenConfigInModel_returnsTrue() {
     val project = createProject()
-    val model = ModelPackageJson("1000.0.0", ModelCodegenConfig(null, null, null, null, false))
+    val model =
+        ModelPackageJson("1000.0.0", ModelCodegenConfig(null, null, null, null, false, null))
 
     assertTrue(project.needsCodegenFromPackageJson(model))
   }

--- a/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
+++ b/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
@@ -72,6 +72,7 @@ function generateSpecFromInMemorySchema(
   packageName,
   libraryType,
   useLocalIncludePaths,
+  cxxModules,
 ) {
   validateLibraryType(libraryType);
   createOutputDirectoryIfNeeded(outputDirectory, libraryName);
@@ -111,6 +112,7 @@ function generateSpec(
   libraryName,
   packageName,
   libraryType,
+  cxxModules,
 ) {
   generateSpecFromInMemorySchema(
     platform,

--- a/packages/react-native/scripts/generate-specs-cli.js
+++ b/packages/react-native/scripts/generate-specs-cli.js
@@ -41,6 +41,12 @@ const argv = yargs
     describe: 'all, components, or modules.',
     default: 'all',
   })
+  .option('c', {
+    alias: 'cxxModules',
+    describe:
+      'A colon separated list of modules name & modules header path, used to support CXX TurboModule linking.',
+    default: 'all',
+  })
   .usage('Usage: $0 <args>')
   .demandOption(
     ['platform', 'schemaPath', 'outputDir'],
@@ -55,6 +61,7 @@ function main() {
     argv.libraryName,
     argv.javaPackageName,
     argv.libraryType,
+    argv.cxxModules,
   );
 }
 

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -37,6 +37,12 @@
     "jsSrcsDir": ".",
     "android": {
       "javaPackageName": "com.facebook.fbreact.specs"
-    }
+    },
+    "cxxModules": [
+      {
+        "name": "NativeCxxModuleExample",
+        "headerPath": "NativeCxxModuleExample.h"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Summary:
RNGP now supports parsing the cxxModule field in codegenConfig and passes it over to codegen.

Changelog:
[Internal] [Changed] - Update RNGP to handle cxxModule in codegenConfig

Differential Revision: D53669912

