### PR TITLE
Fix CircleCI template tests by excluding dry-run build types

### DIFF
--- a/scripts/releases-ci/__tests__/publish-npm-test.js
+++ b/scripts/releases-ci/__tests__/publish-npm-test.js
@@ -14,6 +14,7 @@ const exitMock = jest.fn();
 const consoleErrorMock = jest.fn();
 const isTaggedLatestMock = jest.fn();
 const setVersionMock = jest.fn();
+const setReactNativeVersionMock = jest.fn();
 const publishAndroidArtifactsToMavenMock = jest.fn();
 const removeNewArchFlags = jest.fn();
 const env = process.env;
@@ -34,6 +35,9 @@ jest
     publishAndroidArtifactsToMaven: publishAndroidArtifactsToMavenMock,
   }))
   .mock('../../releases/set-version', () => setVersionMock)
+  .mock('../../releases/set-rn-version', () => ({
+    setReactNativeVersion: setReactNativeVersionMock,
+  }))
   .mock('../../releases/remove-new-arch-flags', () => ({
     removeNewArchFlags,
   }));
@@ -51,6 +55,7 @@ describe('publish-npm', () => {
   beforeAll(() => {
     jest.setSystemTime(date);
   });
+
   beforeEach(() => {
     consoleError = console.error;
     console.error = consoleErrorMock;
@@ -59,9 +64,6 @@ describe('publish-npm', () => {
   afterEach(() => {
     process.env = env;
     console.error = consoleError;
-  });
-
-  afterEach(() => {
     jest.resetModules();
     jest.resetAllMocks();
   });
@@ -84,7 +86,12 @@ describe('publish-npm', () => {
       expect(echoMock).toHaveBeenCalledWith(
         'Skipping `npm publish` because --dry-run is set.',
       );
-      expect(setVersionMock).toBeCalledWith('1000.0.0-currentco');
+      expect(setReactNativeVersionMock).toBeCalledWith(
+        '1000.0.0-currentco',
+        null,
+        'dry-run',
+      );
+      expect(setVersionMock).not.toBeCalled();
     });
   });
 

--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -17,6 +17,7 @@ import type {BuildType} from '../releases/utils/version-utils';
 
 const {getNpmInfo, publishPackage} = require('../npm-utils');
 const {removeNewArchFlags} = require('../releases/remove-new-arch-flags');
+const {setReactNativeVersion} = require('../releases/set-rn-version');
 const setVersion = require('../releases/set-version');
 const {
   generateAndroidArtifacts,
@@ -73,11 +74,15 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
     removeNewArchFlags();
   }
 
-  // Set same version for all monorepo packages
   // For stable releases, CircleCI job `prepare_package_for_release` handles this
   if (['dry-run', 'nightly', 'prealpha'].includes(buildType)) {
     try {
-      await setVersion(version);
+      if (buildType === 'nightly') {
+        // Set same version for all monorepo packages
+        await setVersion(version);
+      } else {
+        await setReactNativeVersion(version, null, buildType);
+      }
     } catch (e) {
       console.error(`Failed to set version number to ${version}`);
       console.error(e);


### PR DESCRIPTION
Summary:
Changelog: [Internal] - We still use the `dry-run` build variant in template tests on CircleCI

Previous diff migrated `set-rn-version` to `set-version` for dry-run, prealpha, and nightly build types. I didn't realize that template test flow used `dry-run` builds. I thought it was just for commitlies (which are deprecated).

To properly migrate this site, I need to fix the template test flow to accept monorepo packages at the same version as the dry-run react-native version (1000-<commithash>)

For now, let's just make this change more precise, and only update the nightly flow

See this error: {F1455663616}

Template test flow doesn't fake publish the monorepo packages at this version -- they're still using the versions off of main

Differential Revision: D53688238


