### PR TITLE
resolve getInitialNotification with userInfo dict instead of whole notification

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -535,12 +535,13 @@ RCT_EXPORT_METHOD(getInitialNotification
   if (self.initialNotification) {
     NSDictionary<NSString *, id> *notificationDict =
         RCTFormatUNNotificationContent(self.initialNotification.request.content);
+    NSDictionary *userInfo = notificationDict[@"userInfo"];
     if (IsNotificationRemote(self.initialNotification)) {
-      NSMutableDictionary<NSString *, id> *notificationDictCopy = [notificationDict mutableCopy];
-      notificationDictCopy[@"remote"] = @YES;
-      resolve(notificationDictCopy);
+      NSMutableDictionary<NSString *, id> *userInfoCopy = [userInfo mutableCopy];
+      userInfoCopy[@"remote"] = @YES;
+      resolve(userInfoCopy);
     } else {
-      resolve(notificationDict);
+      resolve(userInfo);
     }
     return;
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

`getInitialNotification` only expect the user info dictionary of the dictionary, not the complete formatted notification.

Differential Revision: D53691569


