### PR TITLE
RCTModuleData cache name (RCTBridgeModuleNameForClass)

### DIFF
--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -45,6 +45,7 @@ int32_t getUniqueId()
   RCTBundleManager *_bundleManager;
   RCTCallableJSModules *_callableJSModules;
   BOOL _isInitialized;
+  NSString *_moduleName;
 }
 
 @synthesize methods = _methods;
@@ -395,7 +396,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
 
 - (NSString *)name
 {
-  return RCTBridgeModuleNameForClass(_moduleClass);
+  if (!_moduleName) {
+    _moduleName = RCTBridgeModuleNameForClass(_moduleClass);
+  }
+  return _moduleName;
 }
 
 - (NSArray<id<RCTBridgeMethod>> *)methods


### PR DESCRIPTION
## Summary:

I was looking at JS thread activity in instruments and noticed some wasted overhead in the code that checks for timer updates every frame. It's likely there is more that can be done in this codepath, but this trivial change was the most obvious. Instead of rebuilding the module name every access, this change caches it on the RCTModuleData object.

### Before
<img width="1531" alt="image" src="https://github.com/facebook/react-native/assets/1498529/32c2292b-9770-463b-b903-51d69cdef455">

### After
<img width="1723" alt="image" src="https://github.com/facebook/react-native/assets/1498529/7bfc6546-5322-4ead-b908-d27afaa00c21">

NOTE: These screenshots were taken from debug builds on an iOS simulator, I suspect much of the retain/release traffic would be optimized in a production build (That appears to be mostly what's happening with the UTF8String calls). I wasn't too concerned with the exact improvement difference at the time I found this, so I didn't bother rebuilding with optimizations enabled.

## Changelog:

[IOS] [CHANGED] - Cache module name in RCTModuleData, improves performance of retrieving module instance.

## Test Plan:

N/A
