### PR TITLE
RuntimeTarget refactor - introduce WeakList for Target→Agent refs

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -209,7 +209,7 @@ class RCTBridgePageTargetDelegate : public facebook::react::jsinspector_modern::
   NSURL *_delegateBundleURL;
 
   std::unique_ptr<RCTBridgePageTargetDelegate> _inspectorPageDelegate;
-  std::unique_ptr<facebook::react::jsinspector_modern::PageTarget> _inspectorTarget;
+  std::shared_ptr<facebook::react::jsinspector_modern::PageTarget> _inspectorTarget;
   std::optional<int> _inspectorPageId;
 }
 
@@ -412,7 +412,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
   auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
   if (inspectorFlags.getEnableModernCDPRegistry() && !_inspectorPageId.has_value()) {
-    _inspectorTarget = std::make_unique<facebook::react::jsinspector_modern::PageTarget>(*_inspectorPageDelegate);
+    _inspectorTarget =
+        facebook::react::jsinspector_modern::PageTarget::create(*_inspectorPageDelegate, [](auto callback) {
+          RCTExecuteOnMainQueue(^{
+            callback();
+          });
+        });
     __weak RCTBridge *weakSelf = self;
     _inspectorPageId = facebook::react::jsinspector_modern::getInspectorInstance().addPage(
         "React Native Bridge (Experimental)",

--- a/packages/react-native/ReactCommon/cxxreact/Instance.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.cpp
@@ -67,8 +67,10 @@ void Instance::initializeBridge(
 
         if (parentInspectorTarget) {
           inspectorTarget_ = &parentInspectorTarget->registerInstance(*this);
+          RuntimeExecutor runtimeExecutorIfJsi = getRuntimeExecutor();
           runtimeInspectorTarget_ = &inspectorTarget_->registerRuntime(
-              nativeToJsBridge_->getInspectorTargetDelegate());
+              nativeToJsBridge_->getInspectorTargetDelegate(),
+              runtimeExecutorIfJsi ? runtimeExecutorIfJsi : [](auto) {});
         }
 
         /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -22,4 +22,5 @@ target_link_libraries(jsinspector
         folly_runtime
         glog
         react_featureflags
+        runtimeexecutor
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -46,9 +46,10 @@ InstanceTarget::~InstanceTarget() {
 }
 
 RuntimeTarget& InstanceTarget::registerRuntime(
-    RuntimeTargetDelegate& delegate) {
+    RuntimeTargetDelegate& delegate,
+    RuntimeExecutor executor) {
   assert(!currentRuntime_ && "Only one Runtime allowed");
-  currentRuntime_.emplace(delegate);
+  currentRuntime_.emplace(delegate, executor);
   forEachAgent([currentRuntime = &*currentRuntime_](InstanceAgent& agent) {
     agent.setCurrentRuntime(currentRuntime);
   });

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -59,7 +59,9 @@ class InstanceTarget final {
       FrontendChannel channel,
       SessionState& sessionState);
 
-  RuntimeTarget& registerRuntime(RuntimeTargetDelegate& delegate);
+  RuntimeTarget& registerRuntime(
+      RuntimeTargetDelegate& delegate,
+      RuntimeExecutor executor);
   void unregisterRuntime(RuntimeTarget& runtime);
 
  private:

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -10,6 +10,7 @@
 #include "RuntimeTarget.h"
 #include "ScopedExecutor.h"
 #include "SessionState.h"
+#include "WeakList.h"
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/RuntimeAgent.h>
@@ -83,25 +84,7 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
 
   InstanceTargetDelegate& delegate_;
   std::shared_ptr<RuntimeTarget> currentRuntime_{nullptr};
-  std::list<std::weak_ptr<InstanceAgent>> agents_;
-
-  /**
-   * Call the given function for every active agent, and clean up any
-   * references to inactive agents.
-   */
-  template <typename Fn>
-  void forEachAgent(Fn&& fn) {
-    for (auto it = agents_.begin(); it != agents_.end();) {
-      if (auto agent = it->lock()) {
-        fn(*agent);
-        ++it;
-      } else {
-        it = agents_.erase(it);
-      }
-    }
-  }
-
-  void removeExpiredAgents();
+  WeakList<InstanceAgent> agents_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
@@ -8,11 +8,11 @@
 #pragma once
 
 #include "ScopedExecutor.h"
+#include "WeakList.h"
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/InstanceTarget.h>
 
-#include <list>
 #include <optional>
 #include <string>
 
@@ -164,27 +164,9 @@ class JSINSPECTOR_EXPORT PageTarget
   PageTarget(PageTargetDelegate& delegate);
 
   PageTargetDelegate& delegate_;
-  std::list<std::weak_ptr<PageTargetSession>> sessions_;
+  WeakList<PageTargetSession> sessions_;
   PageTargetController controller_{*this};
   std::shared_ptr<InstanceTarget> currentInstance_{nullptr};
-
-  /**
-   * Call the given function for every active session, and clean up any
-   * references to inactive sessions.
-   */
-  template <typename Fn>
-  void forEachSession(Fn&& fn) {
-    for (auto it = sessions_.begin(); it != sessions_.end();) {
-      if (auto session = it->lock()) {
-        fn(*session);
-        ++it;
-      } else {
-        it = sessions_.erase(it);
-      }
-    }
-  }
-
-  void removeExpiredSessions();
 
   inline PageTargetDelegate& getDelegate() {
     return delegate_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -51,4 +51,5 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-featureflags"
   s.dependency "DoubleConversion"
+  s.dependency "React-runtimeexecutor", version
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
@@ -11,4 +11,5 @@
 #include <jsinspector-modern/InstanceTarget.h>
 #include <jsinspector-modern/PageTarget.h>
 #include <jsinspector-modern/RuntimeTarget.h>
+#include <jsinspector-modern/ScopedExecutor.h>
 #include <jsinspector-modern/SessionState.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -9,10 +9,20 @@
 
 namespace facebook::react::jsinspector_modern {
 
+std::shared_ptr<RuntimeTarget> RuntimeTarget::create(
+    RuntimeTargetDelegate& delegate,
+    RuntimeExecutor jsExecutor,
+    VoidExecutor selfExecutor) {
+  std::shared_ptr<RuntimeTarget> runtimeTarget{
+      new RuntimeTarget(delegate, jsExecutor)};
+  runtimeTarget->setExecutor(selfExecutor);
+  return runtimeTarget;
+}
+
 RuntimeTarget::RuntimeTarget(
     RuntimeTargetDelegate& delegate,
-    RuntimeExecutor executor)
-    : delegate_(delegate), executor_(executor) {}
+    RuntimeExecutor jsExecutor)
+    : delegate_(delegate), jsExecutor_(jsExecutor) {}
 
 std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
     FrontendChannel channel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -8,8 +8,11 @@
 #include <jsinspector-modern/RuntimeTarget.h>
 
 namespace facebook::react::jsinspector_modern {
-RuntimeTarget::RuntimeTarget(RuntimeTargetDelegate& delegate)
-    : delegate_(delegate) {}
+
+RuntimeTarget::RuntimeTarget(
+    RuntimeTargetDelegate& delegate,
+    RuntimeExecutor executor)
+    : delegate_(delegate), executor_(executor) {}
 
 std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
     FrontendChannel channel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -32,18 +32,11 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
       *this,
       sessionState,
       delegate_.createAgentDelegate(channel, sessionState));
-  agents_.push_back(runtimeAgent);
+  agents_.insert(runtimeAgent);
   return runtimeAgent;
 }
 
-void RuntimeTarget::removeExpiredAgents() {
-  // Remove all expired agents.
-  forEachAgent([](auto&) {});
-}
-
 RuntimeTarget::~RuntimeTarget() {
-  removeExpiredAgents();
-
   // Agents are owned by the session, not by RuntimeTarget, but
   // they hold a RuntimeTarget& that we must guarantee is valid.
   assert(

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -12,8 +12,8 @@
 #include "RuntimeAgent.h"
 #include "ScopedExecutor.h"
 #include "SessionState.h"
+#include "WeakList.h"
 
-#include <list>
 #include <memory>
 
 #ifndef JSINSPECTOR_EXPORT
@@ -106,25 +106,7 @@ class JSINSPECTOR_EXPORT RuntimeTarget
 
   RuntimeTargetDelegate& delegate_;
   RuntimeExecutor jsExecutor_;
-  std::list<std::weak_ptr<RuntimeAgent>> agents_;
-
-  /**
-   * Call the given function for every active agent, and clean up any
-   * references to inactive agents.
-   */
-  template <typename Fn>
-  void forEachAgent(Fn&& fn) {
-    for (auto it = agents_.begin(); it != agents_.end();) {
-      if (auto agent = it->lock()) {
-        fn(*agent);
-        ++it;
-      } else {
-        it = agents_.erase(it);
-      }
-    }
-  }
-
-  void removeExpiredAgents();
+  WeakList<RuntimeAgent> agents_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <ReactCommon/RuntimeExecutor.h>
 #include "InspectorInterfaces.h"
 #include "RuntimeAgent.h"
 #include "SessionState.h"
@@ -53,8 +54,12 @@ class JSINSPECTOR_EXPORT RuntimeTarget final {
    * \param delegate The object that will receive events from this target.
    * The caller is responsible for ensuring that the delegate outlives this
    * object.
+   * \param executor A RuntimeExecutor that can be used to schedule work on
+   * the JS runtime's thread. The executor's queue should be empty when
+   * RuntimeTarget is constructed (i.e. anything scheduled during the
+   * constructor should be executed before any user code is run).
    */
-  explicit RuntimeTarget(RuntimeTargetDelegate& delegate);
+  RuntimeTarget(RuntimeTargetDelegate& delegate, RuntimeExecutor executor);
 
   RuntimeTarget(const RuntimeTarget&) = delete;
   RuntimeTarget(RuntimeTarget&&) = delete;
@@ -77,6 +82,7 @@ class JSINSPECTOR_EXPORT RuntimeTarget final {
 
  private:
   RuntimeTargetDelegate& delegate_;
+  RuntimeExecutor executor_;
   std::list<std::weak_ptr<RuntimeAgent>> agents_;
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/ScopedExecutor.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ScopedExecutor.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <functional>
+#include <memory>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Takes a function and calls it when it is safe to access the Self&
+ * parameter without locking. The function is not called if
+ * the underlying Self object is destroyed while the function is pending.
+ */
+template <typename Self>
+using ScopedExecutor =
+    std::function<void(std::function<void(Self& self)>&& callback)>;
+
+using VoidExecutor = std::function<void(std::function<void()>&& callback)>;
+
+/**
+ * Creates a ScopedExecutor<Self> from a shared (weak) pointer to Self plus some
+ * base executor for a "parent" object of Self. The resulting executor will call
+ * the callback with a valid reference to Self iff Self is still alive.
+ */
+template <typename Self, typename Parent>
+ScopedExecutor<Self> makeScopedExecutor(
+    std::shared_ptr<Self> self,
+    ScopedExecutor<Parent> executor) {
+  return makeScopedExecutor(self, makeVoidExecutor(executor));
+}
+
+/**
+ * Creates a ScopedExecutor<Self> from a shared (weak) pointer to Self plus some
+ * base executor. The resulting executor will call the callback with a valid
+ * reference to Self iff Self is still alive.
+ */
+template <typename Self>
+ScopedExecutor<Self> makeScopedExecutor(
+    std::shared_ptr<Self> self,
+    VoidExecutor executor) {
+  return [self = std::weak_ptr(self), executor](auto&& callback) {
+    executor([self, callback = std::move(callback)]() {
+      auto lockedSelf = self.lock();
+      if (!lockedSelf) {
+        return;
+      }
+      callback(*lockedSelf);
+    });
+  };
+}
+
+/**
+ * Creates a VoidExecutor from a ScopedExecutor<Self> by ignoring the Self&
+ * parameter.
+ */
+template <typename Self>
+VoidExecutor makeVoidExecutor(ScopedExecutor<Self> executor) {
+  return [executor](auto&& callback) {
+    executor([callback = std::move(callback)](Self&) { callback(); });
+  };
+}
+
+template <typename Self>
+class EnableExecutorFromThis : public std::enable_shared_from_this<Self> {
+ public:
+  /**
+   * Returns an executor that can be used to safely invoke methods on Self.
+   * Must not be called during the constructor of Self.
+   */
+  ScopedExecutor<Self> executorFromThis() {
+    assert(baseExecutor_);
+    return makeScopedExecutor(this->shared_from_this(), baseExecutor_);
+  }
+
+  template <typename Other>
+  void setExecutor(ScopedExecutor<Other> executor) {
+    setExecutor(makeVoidExecutor(executor));
+  }
+
+  void setExecutor(VoidExecutor executor) {
+    assert(executor);
+    assert(!baseExecutor_);
+    baseExecutor_ = std::move(executor);
+  }
+
+ private:
+  VoidExecutor baseExecutor_;
+};
+
+}; // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/WeakList.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/WeakList.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A list that holds weak pointers to objects of type `T`. Null pointers are not
+ * considered to be in the list.
+ *
+ * The list is not thread-safe! The caller is responsible for synchronization.
+ */
+template <typename T>
+class WeakList {
+ public:
+  /**
+   * Call the given function for every element in the list, ensuring the element
+   * is not destroyed for the duration of the call. Elements are visited in the
+   * order they were inserted.
+   *
+   * As a side effect, any null pointers in the underlying list (corresponding
+   * to destroyed elements) will be removed during iteration.
+   */
+  template <typename Fn>
+  void forEach(Fn&& fn) const {
+    for (auto it = ptrs_.begin(); it != ptrs_.end();) {
+      if (auto ptr = it->lock()) {
+        fn(*ptr);
+        ++it;
+      } else {
+        it = ptrs_.erase(it);
+      }
+    }
+  }
+
+  /**
+   * Returns the number of (non-null) elements in the list. The count will only
+   * remain accurate as long as the list is not modified and elements are
+   * not destroyed.
+   *
+   * As a side effect, any null pointers in the underlying list (corresponding
+   * to destroyed elements) will be removed during this method.
+   */
+  size_t size() const {
+    size_t count{0};
+    forEach([&count](const auto&) { ++count; });
+    return count;
+  }
+
+  /**
+   * Returns true if there are no elements in the list.
+   *
+   * As a side effect, any null pointers in the underlying list (corresponding
+   * to destroyed elements) will be removed during this method.
+   */
+  bool empty() const {
+    return !size();
+  }
+
+  /**
+   * Inserts an element into the list.
+   */
+  void insert(std::weak_ptr<T> ptr) {
+    ptrs_.push_back(ptr);
+  }
+
+ private:
+  mutable std::list<std::weak_ptr<T>> ptrs_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/WeakListTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/WeakListTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <jsinspector-modern/WeakList.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace ::testing;
+
+namespace facebook::react::jsinspector_modern {
+
+TEST(WeakListTest, Size) {
+  WeakList<int> list;
+  EXPECT_EQ(list.size(), 0);
+
+  auto p1 = std::make_shared<int>(1);
+  list.insert(p1);
+  EXPECT_EQ(list.size(), 1);
+
+  auto p2 = std::make_shared<int>(2);
+  list.insert(p2);
+  EXPECT_EQ(list.size(), 2);
+
+  p1.reset();
+  EXPECT_EQ(list.size(), 1);
+
+  p2.reset();
+  EXPECT_EQ(list.size(), 0);
+}
+
+TEST(WeakListTest, Empty) {
+  WeakList<int> list;
+  EXPECT_EQ(list.empty(), true);
+
+  auto p1 = std::make_shared<int>(1);
+  list.insert(p1);
+  EXPECT_EQ(list.empty(), false);
+
+  auto p2 = std::make_shared<int>(2);
+  list.insert(p2);
+  EXPECT_EQ(list.empty(), false);
+
+  p1.reset();
+  EXPECT_EQ(list.empty(), false);
+
+  p2.reset();
+  EXPECT_EQ(list.empty(), true);
+}
+
+TEST(WeakListTest, ForEach) {
+  WeakList<int> list;
+  auto p1 = std::make_shared<int>(1);
+  list.insert(p1);
+  auto p2 = std::make_shared<int>(2);
+  list.insert(p2);
+  auto p3 = std::make_shared<int>(3);
+  list.insert(p3);
+
+  p2.reset();
+
+  std::vector<int> visited;
+  list.forEach([&visited](const int& value) { visited.push_back(value); });
+  EXPECT_THAT(visited, ElementsAre(1, 3));
+}
+
+TEST(WeakListTest, ElementsAreAliveDuringCallback) {
+  WeakList<int> list;
+  auto p1 = std::make_shared<int>(1);
+  // A separate weak_ptr to observe the lifetime of `p1`.
+  std::weak_ptr wp1 = p1;
+  list.insert(p1);
+
+  std::vector<int> visited;
+  list.forEach([&](const int& value) {
+    p1.reset();
+    EXPECT_FALSE(wp1.expired());
+    visited.push_back(value);
+  });
+
+  EXPECT_TRUE(wp1.expired());
+  EXPECT_THAT(visited, ElementsAre(1));
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -37,10 +37,6 @@ ReactInstance::ReactInstance(
       jsErrorHandler_(jsErrorHandlingFunc),
       hasFatalJsError_(std::make_shared<bool>(false)),
       parentInspectorTarget_(parentInspectorTarget) {
-  if (parentInspectorTarget_) {
-    inspectorTarget_ = &parentInspectorTarget_->registerInstance(*this);
-    runtimeInspectorTarget_ = &inspectorTarget_->registerRuntime(*runtime_);
-  }
   auto runtimeExecutor = [weakRuntime = std::weak_ptr<JSRuntime>(runtime_),
                           weakTimerManager =
                               std::weak_ptr<TimerManager>(timerManager_),
@@ -87,6 +83,12 @@ ReactInstance::ReactInstance(
           });
     }
   };
+
+  if (parentInspectorTarget_) {
+    inspectorTarget_ = &parentInspectorTarget_->registerInstance(*this);
+    runtimeInspectorTarget_ =
+        &inspectorTarget_->registerRuntime(*runtime_, runtimeExecutor);
+  }
 
   runtimeScheduler_ =
       std::make_shared<RuntimeScheduler>(std::move(runtimeExecutor));

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -68,7 +68,7 @@ class RCTHostPageTargetDelegate : public facebook::react::jsinspector_modern::Pa
   RCTModuleRegistry *_moduleRegistry;
 
   std::unique_ptr<RCTHostPageTargetDelegate> _inspectorPageDelegate;
-  std::unique_ptr<jsinspector_modern::PageTarget> _inspectorTarget;
+  std::shared_ptr<jsinspector_modern::PageTarget> _inspectorTarget;
   std::optional<int> _inspectorPageId;
 }
 
@@ -168,7 +168,12 @@ class RCTHostPageTargetDelegate : public facebook::react::jsinspector_modern::Pa
 {
   auto &inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
   if (inspectorFlags.getEnableModernCDPRegistry() && !_inspectorPageId.has_value()) {
-    _inspectorTarget = std::make_unique<jsinspector_modern::PageTarget>(*_inspectorPageDelegate);
+    _inspectorTarget =
+        facebook::react::jsinspector_modern::PageTarget::create(*_inspectorPageDelegate, [](auto callback) {
+          RCTExecuteOnMainQueue(^{
+            callback();
+          });
+        });
     __weak RCTHost *weakSelf = self;
     _inspectorPageId = facebook::react::jsinspector_modern::getInspectorInstance().addPage(
         "React Native Bridgeless (Experimental)",


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Replaces the copypasta'd `PageTarget::forEachSession`, `InstanceTarget::forEachAgent` and `RuntimeTarget::forEachAgent` with a shared utility class for managing a list of `weak_ptr`s.

In a `WeakList`, elements can only be added (`insert`), iterated over (`forEach`), and counted (`size`, `empty`). Conceptually, elements are automatically removed from the list as soon as they're destroyed, but internally, space is reclaimed *lazily*: the next time we have a reason to iterate over the underlying list, we delete any pointers that are found to be null.

## Naming

This is almost a WeakSet, but we don't bother checking for duplicates, hence "WeakList".

Differential Revision: D53671483

