### PR TITLE
RuntimeTarget refactor - RuntimeAgent --> RuntimeAgentDelegate

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/Instance.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.cpp
@@ -40,6 +40,8 @@ Instance::~Instance() {
 
 void Instance::unregisterFromInspector() {
   if (inspectorTarget_) {
+    assert(runtimeInspectorTarget_);
+    inspectorTarget_->unregisterRuntime(*runtimeInspectorTarget_);
     assert(parentInspectorTarget_);
     parentInspectorTarget_->unregisterInstance(*inspectorTarget_);
     parentInspectorTarget_ = nullptr;
@@ -65,6 +67,8 @@ void Instance::initializeBridge(
 
         if (parentInspectorTarget) {
           inspectorTarget_ = &parentInspectorTarget->registerInstance(*this);
+          runtimeInspectorTarget_ = &inspectorTarget_->registerRuntime(
+              nativeToJsBridge_->getInspectorTargetDelegate());
         }
 
         /**
@@ -314,12 +318,6 @@ void Instance::JSCallInvoker::scheduleAsync(
           executor->flush();
         });
   }
-}
-
-std::unique_ptr<jsinspector_modern::RuntimeAgent> Instance::createRuntimeAgent(
-    jsinspector_modern::FrontendChannel frontendChannel,
-    jsinspector_modern::SessionState& sessionState) {
-  return nativeToJsBridge_->createRuntimeAgent(frontendChannel, sessionState);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/Instance.h
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.h
@@ -151,11 +151,6 @@ class RN_EXPORT Instance : private jsinspector_modern::InstanceTargetDelegate {
       std::unique_ptr<const JSBigString> startupScript,
       std::string startupScriptSourceURL);
 
-  // From InstanceTargetDelegate
-  std::unique_ptr<jsinspector_modern::RuntimeAgent> createRuntimeAgent(
-      jsinspector_modern::FrontendChannel channel,
-      jsinspector_modern::SessionState& sessionState) override;
-
   std::shared_ptr<InstanceCallback> callback_;
   std::shared_ptr<NativeToJsBridge> nativeToJsBridge_;
   std::shared_ptr<ModuleRegistry> moduleRegistry_;
@@ -185,6 +180,7 @@ class RN_EXPORT Instance : private jsinspector_modern::InstanceTargetDelegate {
 
   jsinspector_modern::PageTarget* parentInspectorTarget_{nullptr};
   jsinspector_modern::InstanceTarget* inspectorTarget_{nullptr};
+  jsinspector_modern::RuntimeTarget* runtimeInspectorTarget_{nullptr};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
@@ -35,10 +35,11 @@ double JSExecutor::performanceNow() {
   return duration / NANOSECONDS_IN_MILLISECOND;
 }
 
-std::unique_ptr<jsinspector_modern::RuntimeAgent> JSExecutor::createAgent(
+std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
+JSExecutor::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState) {
-  return std::make_unique<jsinspector_modern::FallbackRuntimeAgent>(
+  return std::make_unique<jsinspector_modern::FallbackRuntimeAgentDelegate>(
       std::move(frontendChannel), sessionState, getDescription());
 }
 

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
@@ -35,8 +35,7 @@ double JSExecutor::performanceNow() {
   return duration / NANOSECONDS_IN_MILLISECOND;
 }
 
-std::unique_ptr<jsinspector_modern::RuntimeAgent>
-JSExecutor::createRuntimeAgent(
+std::unique_ptr<jsinspector_modern::RuntimeAgent> JSExecutor::createAgent(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState) {
   return std::make_unique<jsinspector_modern::FallbackRuntimeAgent>(

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
@@ -55,7 +55,7 @@ class JSExecutorFactory {
   virtual ~JSExecutorFactory() {}
 };
 
-class RN_EXPORT JSExecutor {
+class RN_EXPORT JSExecutor : public jsinspector_modern::RuntimeTargetDelegate {
  public:
   /**
    * Prepares the JS runtime for React Native by installing global variables.
@@ -114,7 +114,7 @@ class RN_EXPORT JSExecutor {
   /**
    * Returns whether or not the underlying executor supports debugging via the
    * Chrome remote debugging protocol. If true, the executor should also
-   * override the \c createRuntimeAgent method.
+   * override the \c createAgent method.
    */
   virtual bool isInspectable() {
     return false;
@@ -143,9 +143,9 @@ class RN_EXPORT JSExecutor {
   /**
    * Create a RuntimeAgent that can be used to debug the JS VM instance.
    */
-  virtual std::unique_ptr<jsinspector_modern::RuntimeAgent> createRuntimeAgent(
+  virtual std::unique_ptr<jsinspector_modern::RuntimeAgent> createAgent(
       jsinspector_modern::FrontendChannel frontendChannel,
-      jsinspector_modern::SessionState& sessionState);
+      jsinspector_modern::SessionState& sessionState) override;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
@@ -114,7 +114,7 @@ class RN_EXPORT JSExecutor : public jsinspector_modern::RuntimeTargetDelegate {
   /**
    * Returns whether or not the underlying executor supports debugging via the
    * Chrome remote debugging protocol. If true, the executor should also
-   * override the \c createAgent method.
+   * override the \c createAgentDelegate method.
    */
   virtual bool isInspectable() {
     return false;
@@ -141,9 +141,10 @@ class RN_EXPORT JSExecutor : public jsinspector_modern::RuntimeTargetDelegate {
   static double performanceNow();
 
   /**
-   * Create a RuntimeAgent that can be used to debug the JS VM instance.
+   * Create a RuntimeAgentDelegate that can be used to debug the JS VM instance.
    */
-  virtual std::unique_ptr<jsinspector_modern::RuntimeAgent> createAgent(
+  virtual std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
+  createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState) override;
 };

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -343,13 +343,9 @@ NativeToJsBridge::getDecoratedNativeMethodCallInvoker(
       m_delegate, std::move(nativeMethodCallInvoker));
 }
 
-std::unique_ptr<jsinspector_modern::RuntimeAgent>
-NativeToJsBridge::createRuntimeAgent(
-    jsinspector_modern::FrontendChannel frontendChannel,
-    jsinspector_modern::SessionState& sessionState) {
-  auto agent =
-      m_executor->createRuntimeAgent(std::move(frontendChannel), sessionState);
-  return agent;
+jsinspector_modern::RuntimeTargetDelegate&
+NativeToJsBridge::getInspectorTargetDelegate() {
+  return *m_executor;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -107,13 +107,7 @@ class NativeToJsBridge {
   std::shared_ptr<NativeMethodCallInvoker> getDecoratedNativeMethodCallInvoker(
       std::shared_ptr<NativeMethodCallInvoker> nativeInvoker) const;
 
-  /**
-   * Create a RuntimeAgent that can be used to debug the underlying JS VM
-   * instance.
-   */
-  virtual std::unique_ptr<jsinspector_modern::RuntimeAgent> createRuntimeAgent(
-      jsinspector_modern::FrontendChannel frontendChannel,
-      jsinspector_modern::SessionState& sessionState);
+  jsinspector_modern::RuntimeTargetDelegate& getInspectorTargetDelegate();
 
  private:
   // This is used to avoid a race condition where a proxyCallback gets queued

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -257,8 +257,7 @@ HermesExecutor::HermesExecutor(
       runtime_(runtime),
       hermesRuntime_(hermesRuntime) {}
 
-std::unique_ptr<jsinspector_modern::RuntimeAgent>
-HermesExecutor::createRuntimeAgent(
+std::unique_ptr<jsinspector_modern::RuntimeAgent> HermesExecutor::createAgent(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState) {
   std::shared_ptr<HermesRuntime> hermesRuntimeShared(runtime_, &hermesRuntime_);

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -257,12 +257,13 @@ HermesExecutor::HermesExecutor(
       runtime_(runtime),
       hermesRuntime_(hermesRuntime) {}
 
-std::unique_ptr<jsinspector_modern::RuntimeAgent> HermesExecutor::createAgent(
+std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
+HermesExecutor::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState) {
   std::shared_ptr<HermesRuntime> hermesRuntimeShared(runtime_, &hermesRuntime_);
-  return std::unique_ptr<jsinspector_modern::RuntimeAgent>(
-      new jsinspector_modern::HermesRuntimeAgent(
+  return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
+      new jsinspector_modern::HermesRuntimeAgentDelegate(
           frontendChannel,
           sessionState,
           hermesRuntimeShared,

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -54,7 +54,7 @@ class HermesExecutor : public JSIExecutor {
       RuntimeInstaller runtimeInstaller,
       hermes::HermesRuntime& hermesRuntime);
 
-  virtual std::unique_ptr<jsinspector_modern::RuntimeAgent> createRuntimeAgent(
+  virtual std::unique_ptr<jsinspector_modern::RuntimeAgent> createAgent(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState) override;
 

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -54,7 +54,8 @@ class HermesExecutor : public JSIExecutor {
       RuntimeInstaller runtimeInstaller,
       hermes::HermesRuntime& hermesRuntime);
 
-  virtual std::unique_ptr<jsinspector_modern::RuntimeAgent> createAgent(
+  virtual std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
+  createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState) override;
 

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h
@@ -15,10 +15,10 @@
 namespace facebook::react::jsinspector_modern {
 
 /**
- * A RuntimeAgent that handles requests from the Chrome DevTools Protocol for
- * an instance of Hermes.
+ * A RuntimeAgentDelegate that handles requests from the Chrome DevTools
+ * Protocol for an instance of Hermes.
  */
-class HermesRuntimeAgent : public RuntimeAgent {
+class HermesRuntimeAgentDelegate : public RuntimeAgentDelegate {
  public:
   /**
    * \param frontendChannel A channel used to send responses and events to the
@@ -31,7 +31,7 @@ class HermesRuntimeAgent : public RuntimeAgent {
    * \c runtimeExecutor may drop scheduled work if the runtime is destroyed
    * first.
    */
-  HermesRuntimeAgent(
+  HermesRuntimeAgentDelegate(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
       std::shared_ptr<hermes::HermesRuntime> runtime,

--- a/packages/react-native/ReactCommon/jsinspector-modern/CONCEPTS.md
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CONCEPTS.md
@@ -21,3 +21,7 @@ A single connection between a debugger frontend and a target. There can be multi
 ### Agent
 
 A handler for a subset of CDP messages for a specific target as part of a specific session.
+
+### Agent Delegate
+
+An interface between an Agent class and some integration-specific, per-session logic/state it relies on (that does not fit in a Target Delegate). For example, a RuntimeAgentDelegate is used by RuntimeAgent to host Hermes's native CDP handler and delegate messages to it. The interface may look exactly like an Agent (purely CDP messages in/out) or there may be a more involved API to expose state/functionality needed by the Agent.

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <jsinspector-modern/FallbackRuntimeAgent.h>
+#include "FallbackRuntimeAgentDelegate.h"
 
 #include <chrono>
 #include <string>
@@ -22,7 +22,7 @@ namespace facebook::react::jsinspector_modern {
 #define ANSI_STYLE_RESET "\x1B[23m"
 #define ANSI_COLOR_BG_YELLOW "\x1B[48;2;253;247;231m"
 
-FallbackRuntimeAgent::FallbackRuntimeAgent(
+FallbackRuntimeAgentDelegate::FallbackRuntimeAgentDelegate(
     FrontendChannel frontendChannel,
     const SessionState& sessionState,
     std::string engineDescription)
@@ -32,7 +32,8 @@ FallbackRuntimeAgent::FallbackRuntimeAgent(
   }
 }
 
-bool FallbackRuntimeAgent::handleRequest(const cdp::PreparsedRequest& req) {
+bool FallbackRuntimeAgentDelegate::handleRequest(
+    const cdp::PreparsedRequest& req) {
   if (req.method == "Log.enable") {
     sendFallbackRuntimeWarning();
 
@@ -44,7 +45,7 @@ bool FallbackRuntimeAgent::handleRequest(const cdp::PreparsedRequest& req) {
   return false;
 }
 
-void FallbackRuntimeAgent::sendFallbackRuntimeWarning() {
+void FallbackRuntimeAgentDelegate::sendFallbackRuntimeWarning() {
   sendWarningLogEntry(
       "The current JavaScript engine, " ANSI_STYLE_ITALIC + engineDescription_ +
       ANSI_STYLE_RESET
@@ -52,7 +53,7 @@ void FallbackRuntimeAgent::sendFallbackRuntimeWarning() {
       "See https://reactnative.dev/docs/debugging for more information.");
 }
 
-void FallbackRuntimeAgent::sendWarningLogEntry(std::string_view text) {
+void FallbackRuntimeAgentDelegate::sendWarningLogEntry(std::string_view text) {
   frontendChannel_(
       folly::toJson(folly::dynamic::object("method", "Log.entryAdded")(
           "params",

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.h
@@ -15,10 +15,10 @@
 namespace facebook::react::jsinspector_modern {
 
 /**
- * A RuntimeAgent that handles requests from the Chrome DevTools Protocol for
- * a JavaScript runtime that does not support debugging.
+ * A RuntimeAgentDelegate that handles requests from the Chrome DevTools
+ * Protocol for a JavaScript runtime that does not support debugging.
  */
-class FallbackRuntimeAgent : public RuntimeAgent {
+class FallbackRuntimeAgentDelegate : public RuntimeAgentDelegate {
  public:
   /**
    * \param frontendChannel A channel used to send responses and events to the
@@ -27,7 +27,7 @@ class FallbackRuntimeAgent : public RuntimeAgent {
    * \param engineDescription A description of the JavaScript engine being
    * debugged. This string will be used in messages sent to the frontend.
    */
-  FallbackRuntimeAgent(
+  FallbackRuntimeAgentDelegate(
       FrontendChannel frontendChannel,
       const SessionState& sessionState,
       std::string engineDescription);

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -6,16 +6,17 @@
  */
 
 #include <jsinspector-modern/InstanceAgent.h>
+#include "RuntimeTarget.h"
 
 namespace facebook::react::jsinspector_modern {
 
 InstanceAgent::InstanceAgent(
     FrontendChannel frontendChannel,
     InstanceTarget& target,
-    std::unique_ptr<RuntimeAgent> runtimeAgent)
+    SessionState& sessionState)
     : frontendChannel_(frontendChannel),
       target_(target),
-      runtimeAgent_(std::move(runtimeAgent)) {
+      sessionState_(sessionState) {
   (void)target_;
 }
 
@@ -24,6 +25,14 @@ bool InstanceAgent::handleRequest(const cdp::PreparsedRequest& req) {
     return true;
   }
   return false;
+}
+
+void InstanceAgent::setCurrentRuntime(RuntimeTarget* runtimeTarget) {
+  if (runtimeTarget) {
+    runtimeAgent_ = runtimeTarget->createAgent(frontendChannel_, sessionState_);
+  } else {
+    runtimeAgent_.reset();
+  }
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -24,7 +24,7 @@ class InstanceTarget;
  * An Agent that handles requests from the Chrome DevTools Protocol for the
  * given InstanceTarget.
  */
-class InstanceAgent {
+class InstanceAgent final {
  public:
   /**
    * \param frontendChannel A channel used to send responses and events to the

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -7,9 +7,13 @@
 
 #pragma once
 
+#include "RuntimeTarget.h"
+#include "SessionState.h"
+
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/Parsing.h>
 #include <jsinspector-modern/RuntimeAgent.h>
+
 #include <functional>
 
 namespace facebook::react::jsinspector_modern {
@@ -28,13 +32,12 @@ class InstanceAgent {
    * \param target The InstanceTarget that this agent is attached to. The
    * caller is responsible for ensuring that the InstanceTarget outlives this
    * object.
-   * \param runtimeAgent The RuntimeAgent that this agent will use to
-   * communicate with the JS runtime.
+   * \param sessionState The state of the session that created this agent.
    */
   explicit InstanceAgent(
       FrontendChannel frontendChannel,
       InstanceTarget& target,
-      std::unique_ptr<RuntimeAgent> runtimeAgent);
+      SessionState& sessionState);
 
   /**
    * Handle a CDP request. The response will be sent over the provided
@@ -43,10 +46,19 @@ class InstanceAgent {
    */
   bool handleRequest(const cdp::PreparsedRequest& req);
 
+  /**
+   * Replace the current RuntimeAgent pageAgent_ with a new one
+   * connected to the new RuntimeTarget.
+   * \param runtime The new runtime target. May be nullptr to indicate
+   * there's no current debuggable runtime.
+   */
+  void setCurrentRuntime(RuntimeTarget* runtime);
+
  private:
   FrontendChannel frontendChannel_;
   InstanceTarget& target_;
   std::unique_ptr<RuntimeAgent> runtimeAgent_;
+  SessionState& sessionState_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -30,6 +30,21 @@ std::shared_ptr<InstanceAgent> InstanceTarget::createAgent(
   return instanceAgent;
 }
 
+void InstanceTarget::removeExpiredAgents() {
+  // Remove all expired agents.
+  forEachAgent([](auto&) {});
+}
+
+InstanceTarget::~InstanceTarget() {
+  removeExpiredAgents();
+
+  // Agents are owned by the session, not by InstanceTarget, but
+  // they hold an InstanceTarget& that we must guarantee is valid.
+  assert(
+      agents_.empty() &&
+      "InstanceAgent objects must be destroyed before their InstanceTarget. Did you call PageTarget::unregisterInstance()?");
+}
+
 RuntimeTarget& InstanceTarget::registerRuntime(
     RuntimeTargetDelegate& delegate) {
   assert(!currentRuntime_ && "Only one Runtime allowed");

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -19,12 +19,33 @@ InstanceTarget::InstanceTarget(InstanceTargetDelegate& delegate)
 
 InstanceTargetDelegate::~InstanceTargetDelegate() {}
 
-std::unique_ptr<InstanceAgent> InstanceTarget::createAgent(
+std::shared_ptr<InstanceAgent> InstanceTarget::createAgent(
     FrontendChannel channel,
     SessionState& sessionState) {
-  auto runtimeAgent = delegate_.createRuntimeAgent(channel, sessionState);
-  return std::make_unique<InstanceAgent>(
-      channel, *this, std::move(runtimeAgent));
+  auto instanceAgent =
+      std::make_shared<InstanceAgent>(channel, *this, sessionState);
+  instanceAgent->setCurrentRuntime(
+      currentRuntime_.has_value() ? &*currentRuntime_ : nullptr);
+  agents_.push_back(instanceAgent);
+  return instanceAgent;
+}
+
+RuntimeTarget& InstanceTarget::registerRuntime(
+    RuntimeTargetDelegate& delegate) {
+  assert(!currentRuntime_ && "Only one Runtime allowed");
+  currentRuntime_.emplace(delegate);
+  forEachAgent([currentRuntime = &*currentRuntime_](InstanceAgent& agent) {
+    agent.setCurrentRuntime(currentRuntime);
+  });
+  return *currentRuntime_;
+}
+
+void InstanceTarget::unregisterRuntime(RuntimeTarget& Runtime) {
+  assert(
+      currentRuntime_.has_value() && &currentRuntime_.value() == &Runtime &&
+      "Invalid unregistration");
+  forEachAgent([](InstanceAgent& agent) { agent.setCurrentRuntime(nullptr); });
+  currentRuntime_.reset();
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -53,6 +53,7 @@ class InstanceTarget {
   InstanceTarget(InstanceTarget&&) = delete;
   InstanceTarget& operator=(const InstanceTarget&) = delete;
   InstanceTarget& operator=(InstanceTarget&&) = delete;
+  ~InstanceTarget();
 
   std::shared_ptr<InstanceAgent> createAgent(
       FrontendChannel channel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -40,7 +40,7 @@ class InstanceTargetDelegate {
 /**
  * A Target that represents a single instance of React Native.
  */
-class InstanceTarget {
+class InstanceTarget final {
  public:
   /**
    * \param delegate The object that will receive events from this target.

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.cpp
@@ -128,7 +128,7 @@ void PageAgent::sendInfoLogEntry(std::string_view text) {
 }
 
 void PageAgent::setCurrentInstanceAgent(
-    std::unique_ptr<InstanceAgent> instanceAgent) {
+    std::shared_ptr<InstanceAgent> instanceAgent) {
   auto previousInstanceAgent = std::move(instanceAgent_);
   instanceAgent_ = std::move(instanceAgent);
   if (!sessionState_.isRuntimeDomainEnabled) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
@@ -60,7 +60,7 @@ class PageAgent {
    * \param agent The new InstanceAgent. May be null to signify that there is
    * currently no active instance.
    */
-  void setCurrentInstanceAgent(std::unique_ptr<InstanceAgent> agent);
+  void setCurrentInstanceAgent(std::shared_ptr<InstanceAgent> agent);
 
  private:
   /**
@@ -77,7 +77,7 @@ class PageAgent {
   FrontendChannel frontendChannel_;
   PageTargetController& targetController_;
   const PageTarget::SessionMetadata sessionMetadata_;
-  std::unique_ptr<InstanceAgent> instanceAgent_;
+  std::shared_ptr<InstanceAgent> instanceAgent_;
 
   /**
    * A shared reference to the session's state. This is only safe to access

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageAgent.h
@@ -30,7 +30,7 @@ class InstanceTarget;
  * same thread, which is also the thread where the associated PageTarget is
  * constructed and managed.
  */
-class PageAgent {
+class PageAgent final {
  public:
   /**
    * \param frontendChannel A channel used to send responses and events to the

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
@@ -78,7 +78,7 @@ class PageTargetDelegate {
  * The limited interface that PageTarget exposes to its associated
  * sessions/agents.
  */
-class PageTargetController {
+class PageTargetController final {
  public:
   explicit PageTargetController(PageTarget& target);
 
@@ -95,7 +95,7 @@ class PageTargetController {
  * "Host" in React Native's architecture - the entity that manages the
  * lifecycle of a React Instance.
  */
-class JSINSPECTOR_EXPORT PageTarget {
+class JSINSPECTOR_EXPORT PageTarget final {
  public:
   struct SessionMetadata {
     std::optional<std::string> integrationName;

--- a/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <jsinspector-modern/FallbackRuntimeAgent.h>
+#include <jsinspector-modern/FallbackRuntimeAgentDelegate.h>
 #include <jsinspector-modern/InstanceTarget.h>
 #include <jsinspector-modern/PageTarget.h>
 #include <jsinspector-modern/RuntimeTarget.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
@@ -10,5 +10,5 @@
 #include <jsinspector-modern/FallbackRuntimeAgent.h>
 #include <jsinspector-modern/InstanceTarget.h>
 #include <jsinspector-modern/PageTarget.h>
-#include <jsinspector-modern/RuntimeAgent.h>
+#include <jsinspector-modern/RuntimeTarget.h>
 #include <jsinspector-modern/SessionState.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -5,10 +5,28 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <jsinspector-modern/RuntimeAgent.h>
+#include "RuntimeAgent.h"
 
 namespace facebook::react::jsinspector_modern {
 
-RuntimeAgent::~RuntimeAgent() {}
+RuntimeAgent::RuntimeAgent(
+    FrontendChannel frontendChannel,
+    RuntimeTarget& target,
+    SessionState& sessionState,
+    std::unique_ptr<RuntimeAgentDelegate> delegate)
+    : frontendChannel_(std::move(frontendChannel)),
+      target_(target),
+      sessionState_(sessionState),
+      delegate_(std::move(delegate)) {
+  (void)target_;
+  (void)sessionState_;
+}
+
+bool RuntimeAgent::handleRequest(const cdp::PreparsedRequest& req) {
+  if (delegate_) {
+    return delegate_->handleRequest(req);
+  }
+  return false;
+}
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -7,29 +7,59 @@
 
 #pragma once
 
+#include "InspectorInterfaces.h"
+#include "RuntimeAgentDelegate.h"
+#include "RuntimeTarget.h"
+#include "SessionState.h"
+
 #include <jsinspector-modern/Parsing.h>
 
 namespace facebook::react::jsinspector_modern {
 
+class RuntimeTarget;
+
 /**
- * An Agent interface that handles requests from the Chrome DevTools Protocol
- * for a particular JS runtime instance. The exact mechanism of sending
- * responses/events to the frontend is left up to the implementation, but
- * implementations SHOULD use FrontendChannel or a similar abstraction.
+ * An Agent that handles requests from the Chrome DevTools Protocol
+ * for a particular JS runtime instance. RuntimeAgent implements
+ * engine-agnostic functionality based on interfaces available in JSI /
+ * RuntimeTarget, and delegates engine-specific functionality to a
+ * RuntimeAgentDelegate.
  */
-class RuntimeAgent {
+class RuntimeAgent final {
  public:
-  virtual ~RuntimeAgent();
+  /**
+   * \param frontendChannel A channel used to send responses and events to the
+   * frontend.
+   * \param target The RuntimeTarget that this agent is attached to. The
+   * caller is responsible for ensuring that the RuntimeTarget outlives this
+   * object.
+   * \param sessionState The state of the session that created this agent.
+   * \param delegate The RuntimeAgentDelegate providing engine-specific
+   * CDP functionality.
+   */
+  RuntimeAgent(
+      FrontendChannel frontendChannel,
+      RuntimeTarget& target,
+      SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate> delegate);
 
   /**
-   * Handle a CDP request. This implementation must perform any synchronization
-   * required between the thread on which this method is called and the thread
-   * where the JS runtime is executing.
+   * Handle a CDP request. The response will be sent over the provided
+   * \c FrontendChannel synchronously or asynchronously. Performs any
+   * synchronization required between the thread on which this method is
+   * called and the thread where the JS runtime is executing.
+   * \param req The parsed request.
    * \returns true if this agent has responded, or will respond asynchronously,
    * to the request (with either a success or error message). False if the
    * agent expects another agent to respond to the request instead.
    */
-  virtual bool handleRequest(const cdp::PreparsedRequest& req) = 0;
+  bool handleRequest(const cdp::PreparsedRequest& req);
+
+ private:
+  FrontendChannel frontendChannel_;
+  RuntimeTarget& target_;
+  SessionState& sessionState_;
+  const std::unique_ptr<RuntimeAgentDelegate> delegate_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgentDelegate.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsinspector-modern/Parsing.h>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * An Agent interface that handles requests from the Chrome DevTools Protocol
+ * for a particular JS runtime instance. The exact mechanism of sending
+ * responses/events to the frontend is left up to the implementation, but
+ * implementations SHOULD use FrontendChannel or a similar abstraction.
+ */
+class RuntimeAgentDelegate {
+ public:
+  virtual ~RuntimeAgentDelegate() = default;
+
+  /**
+   * Handle a CDP request. This implementation must perform any synchronization
+   * required between the thread on which this method is called and the thread
+   * where the JS runtime is executing.
+   * \returns true if this agent has responded, or will respond asynchronously,
+   * to the request (with either a success or error message). False if the
+   * agent expects another agent to respond to the request instead.
+   */
+  virtual bool handleRequest(const cdp::PreparsedRequest& req) = 0;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <jsinspector-modern/RuntimeTarget.h>
+
+namespace facebook::react::jsinspector_modern {
+RuntimeTarget::RuntimeTarget(RuntimeTargetDelegate& delegate)
+    : delegate_(delegate) {}
+
+std::unique_ptr<RuntimeAgent> RuntimeTarget::createAgent(
+    FrontendChannel channel,
+    SessionState& sessionState) {
+  return delegate_.createAgent(channel, sessionState);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -14,7 +14,11 @@ RuntimeTarget::RuntimeTarget(RuntimeTargetDelegate& delegate)
 std::unique_ptr<RuntimeAgent> RuntimeTarget::createAgent(
     FrontendChannel channel,
     SessionState& sessionState) {
-  return delegate_.createAgent(channel, sessionState);
+  return std::make_unique<RuntimeAgent>(
+      channel,
+      *this,
+      sessionState,
+      delegate_.createAgentDelegate(channel, sessionState));
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -27,6 +27,9 @@
 
 namespace facebook::react::jsinspector_modern {
 
+class RuntimeAgent;
+class RuntimeAgentDelegate;
+
 /**
  * Receives events from a RuntimeTarget. This is a shared interface that
  * each React Native platform needs to implement in order to integrate with
@@ -35,7 +38,7 @@ namespace facebook::react::jsinspector_modern {
 class RuntimeTargetDelegate {
  public:
   virtual ~RuntimeTargetDelegate() = default;
-  virtual std::unique_ptr<RuntimeAgent> createAgent(
+  virtual std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
       FrontendChannel channel,
       SessionState& sessionState) = 0;
 };
@@ -43,7 +46,7 @@ class RuntimeTargetDelegate {
 /**
  * A Target corresponding to a JavaScript runtime.
  */
-class JSINSPECTOR_EXPORT RuntimeTarget {
+class JSINSPECTOR_EXPORT RuntimeTarget final {
  public:
   /**
    * \param delegate The object that will receive events from this target.

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "InspectorInterfaces.h"
+#include "RuntimeAgent.h"
+#include "SessionState.h"
+
+#include <memory>
+
+#ifndef JSINSPECTOR_EXPORT
+#ifdef _MSC_VER
+#ifdef CREATE_SHARED_LIBRARY
+#define JSINSPECTOR_EXPORT __declspec(dllexport)
+#else
+#define JSINSPECTOR_EXPORT
+#endif // CREATE_SHARED_LIBRARY
+#else // _MSC_VER
+#define JSINSPECTOR_EXPORT __attribute__((visibility("default")))
+#endif // _MSC_VER
+#endif // !defined(JSINSPECTOR_EXPORT)
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Receives events from a RuntimeTarget. This is a shared interface that
+ * each React Native platform needs to implement in order to integrate with
+ * the debugging stack.
+ */
+class RuntimeTargetDelegate {
+ public:
+  virtual ~RuntimeTargetDelegate() = default;
+  virtual std::unique_ptr<RuntimeAgent> createAgent(
+      FrontendChannel channel,
+      SessionState& sessionState) = 0;
+};
+
+/**
+ * A Target corresponding to a JavaScript runtime.
+ */
+class JSINSPECTOR_EXPORT RuntimeTarget {
+ public:
+  /**
+   * \param delegate The object that will receive events from this target.
+   * The caller is responsible for ensuring that the delegate outlives this
+   * object.
+   */
+  explicit RuntimeTarget(RuntimeTargetDelegate& delegate);
+
+  RuntimeTarget(const RuntimeTarget&) = delete;
+  RuntimeTarget(RuntimeTarget&&) = delete;
+  RuntimeTarget& operator=(const RuntimeTarget&) = delete;
+  RuntimeTarget& operator=(RuntimeTarget&&) = delete;
+
+  /**
+   * Create a new RuntimeAgent that can be used to debug the underlying JS VM.
+   * The agent will be destroyed when the session ends, the containing
+   * InstanceTarget is unregistered from its PageTarget, or the RuntimeAgent is
+   * unregistered from its InstanceTarget (whichever happens first).
+   * \param channel A thread-safe channel for sending CDP messages to the
+   * frontend.
+   * \returns The new agent, or nullptr if the runtime is not debuggable.
+   */
+  std::unique_ptr<RuntimeAgent> createAgent(
+      FrontendChannel channel,
+      SessionState& sessionState);
+
+ private:
+  RuntimeTargetDelegate& delegate_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -121,12 +121,14 @@ class MockPageTargetDelegate : public PageTargetDelegate {
   MOCK_METHOD(void, onReload, (const PageReloadRequest& request), (override));
 };
 
-class MockInstanceTargetDelegate : public InstanceTargetDelegate {
+class MockInstanceTargetDelegate : public InstanceTargetDelegate {};
+
+class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
  public:
-  // InstanceTargetDelegate methods
+  // RuntimeTargetDelegate methods
   MOCK_METHOD(
       std::unique_ptr<RuntimeAgent>,
-      createRuntimeAgent,
+      createAgent,
       (FrontendChannel channel, SessionState& sessionState),
       (override));
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -127,21 +127,21 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
  public:
   // RuntimeTargetDelegate methods
   MOCK_METHOD(
-      std::unique_ptr<RuntimeAgent>,
-      createAgent,
+      std::unique_ptr<RuntimeAgentDelegate>,
+      createAgentDelegate,
       (FrontendChannel channel, SessionState& sessionState),
       (override));
 };
 
-class MockRuntimeAgent : public RuntimeAgent {
+class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {
  public:
-  inline MockRuntimeAgent(
+  inline MockRuntimeAgentDelegate(
       FrontendChannel frontendChannel,
       SessionState& sessionState)
       : frontendChannel(std::move(frontendChannel)),
         sessionState(sessionState) {}
 
-  // RuntimeAgent methods
+  // RuntimeAgentDelegate methods
   MOCK_METHOD(
       bool,
       handleRequest,

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
@@ -18,8 +18,7 @@ JSIRuntimeHolder::JSIRuntimeHolder(std::unique_ptr<jsi::Runtime> runtime)
   assert(runtime_ != nullptr);
 }
 
-std::unique_ptr<jsinspector_modern::RuntimeAgent>
-JSIRuntimeHolder::createInspectorAgent(
+std::unique_ptr<jsinspector_modern::RuntimeAgent> JSIRuntimeHolder::createAgent(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState) {
   return std::make_unique<jsinspector_modern::FallbackRuntimeAgent>(

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
@@ -18,10 +18,11 @@ JSIRuntimeHolder::JSIRuntimeHolder(std::unique_ptr<jsi::Runtime> runtime)
   assert(runtime_ != nullptr);
 }
 
-std::unique_ptr<jsinspector_modern::RuntimeAgent> JSIRuntimeHolder::createAgent(
+std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
+JSIRuntimeHolder::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState) {
-  return std::make_unique<jsinspector_modern::FallbackRuntimeAgent>(
+  return std::make_unique<jsinspector_modern::FallbackRuntimeAgentDelegate>(
       std::move(frontendChannel), sessionState, runtime_->description());
 }
 

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
@@ -17,19 +17,9 @@ namespace facebook::react {
 /**
  * An interface that represents an instance of a JS VM
  */
-class JSRuntime {
+class JSRuntime : public jsinspector_modern::RuntimeTargetDelegate {
  public:
   virtual jsi::Runtime& getRuntime() noexcept = 0;
-
-  /**
-   * Creates a new inspector agent for this runtime, if the runtime is
-   * inspectable. Returns nullptr otherwise.
-   * \see InspectorTargetDelegate::createRuntimeAgent
-   */
-  virtual std::unique_ptr<jsinspector_modern::RuntimeAgent>
-  createInspectorAgent(
-      jsinspector_modern::FrontendChannel frontendChannel,
-      jsinspector_modern::SessionState& sessionState) = 0;
 
   virtual ~JSRuntime() = default;
 };
@@ -51,7 +41,7 @@ class JSRuntimeFactory {
 class JSIRuntimeHolder : public JSRuntime {
  public:
   jsi::Runtime& getRuntime() noexcept override;
-  std::unique_ptr<jsinspector_modern::RuntimeAgent> createInspectorAgent(
+  std::unique_ptr<jsinspector_modern::RuntimeAgent> createAgent(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState) override;
 

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
@@ -41,7 +41,7 @@ class JSRuntimeFactory {
 class JSIRuntimeHolder : public JSRuntime {
  public:
   jsi::Runtime& getRuntime() noexcept override;
-  std::unique_ptr<jsinspector_modern::RuntimeAgent> createAgent(
+  std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate> createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState) override;
 

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -72,10 +72,6 @@ class ReactInstance final : private jsinspector_modern::InstanceTargetDelegate {
   void unregisterFromInspector();
 
  private:
-  std::unique_ptr<jsinspector_modern::RuntimeAgent> createRuntimeAgent(
-      jsinspector_modern::FrontendChannel channel,
-      jsinspector_modern::SessionState& sessionState) override;
-
   std::shared_ptr<JSRuntime> runtime_;
   std::shared_ptr<MessageQueueThread> jsMessageQueueThread_;
   std::shared_ptr<BufferedRuntimeExecutor> bufferedRuntimeExecutor_;
@@ -88,6 +84,7 @@ class ReactInstance final : private jsinspector_modern::InstanceTargetDelegate {
   std::shared_ptr<bool> hasFatalJsError_;
 
   jsinspector_modern::InstanceTarget* inspectorTarget_{nullptr};
+  jsinspector_modern::RuntimeTarget* runtimeInspectorTarget_{nullptr};
   jsinspector_modern::PageTarget* parentInspectorTarget_{nullptr};
 };
 

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -104,7 +104,7 @@ class HermesJSRuntime : public JSRuntime {
     return *runtime_;
   }
 
-  std::unique_ptr<jsinspector_modern::RuntimeAgent> createInspectorAgent(
+  std::unique_ptr<jsinspector_modern::RuntimeAgent> createAgent(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState) override {
     return std::unique_ptr<jsinspector_modern::RuntimeAgent>(


### PR DESCRIPTION
Summary:
Changelog: [Internal]

I'm refactoring the way the Runtime concept works in the modern CDP backend to bring it in line with the Page/Instance concepts.

Overall, this will let us:

* Integrate with engines that require us to instantiate a shared Target-like object (e.g. Hermes AsyncDebuggingAPI) in addition to an per-session Agent-like object.
* Access JSI in a CDP context (both at target setup/teardown time and during a CDP session) to implement our own engine-agnostic functionality (`console` interception, `Runtime.addBinding`, etc).
* Manage CDP execution contexts natively in RN, and (down the line) enable first-class debugging support for multiple Runtimes in an Instance.

The core diffs in this stack will:

* ~~Introduce a `RuntimeTarget` class similar to `{Page,Instance}Target`.~~ (D53233914)
* ~~Make runtime registration explicit (`InstanceTarget::registerRuntime` similar to `PageTarget::registerInstance`).~~ (D53233914)
* Rename the existing `RuntimeAgent` interface to `RuntimeAgentDelegate`.   *← This diff*
* Create a new concrete `RuntimeAgent` class similar to `{Page,Instance}Agent`.   *← Also in this diff*
* Provide `RuntimeTarget` and `RuntimeAgent` with primitives for safe JSI access, namely a `RuntimeExecutor` for scheduling work on the JS thread.
  * We'll likely develop a similar mechanism for scheduling work on the "main" thread from the JS thread, for when we need to do more than just send a CDP message (which we can already do with the thread-safe `FrontendChannel`) in response to a JS event.

## Architecture diagrams

Before this stack:
https://pxl.cl/4h7m0

After this stack:
https://pxl.cl/4h7m7

Reviewed By: hoxyq

Differential Revision: D53266707

