### PR TITLE
Fix UB in SessionState init

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -14,8 +14,8 @@ namespace facebook::react::jsinspector_modern {
 struct SessionState {
  public:
   // TODO: Generalise this to arbitrary domains
-  bool isLogDomainEnabled;
-  bool isRuntimeDomainEnabled;
+  bool isLogDomainEnabled{false};
+  bool isRuntimeDomainEnabled{false};
 
   // Here, we will eventually allow RuntimeAgents to store their own arbitrary
   // state (e.g. some sort of K/V storage of folly::dynamic?)


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Specifies initial values for `SessionState`'s bool fields to avoid relying on undefined behaviour.

Reviewed By: hoxyq

Differential Revision: D53704064


