### PR TITLE
Fix overriding EXCLUDED_ARCHS when installing Hermes on RN v0.72

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -179,11 +179,33 @@ class UtilsTests < Test::Unit::TestCase
     # ============================ #
     # Test - Exclude Architectures #
     # ============================ #
-    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_excludeNothing
+    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_withNoValue_leaveUnset
+      # Arrange
+      user_project_mock = prepare_empty_user_project_mock()
+      pods_projects_mock = PodsProjectMock.new()
+      installer = InstallerMock.new(PodsProjectMock.new(), [
+          AggregatedProjectMock.new(user_project_mock)
+      ])
+
+      # Act
+      ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
+
+      # Assert
+      user_project_mock.build_configurations.each do |config|
+          assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], nil)
+      end
+      assert_equal(user_project_mock.save_invocation_count, 0)
+      assert_equal(pods_projects_mock.save_invocation_count, 0)
+    end
+
+    def test_excludeArchitectures_whenHermesEngineIsNotIncluded_withExistingValue_preserveExistingValue
         # Arrange
         user_project_mock = prepare_empty_user_project_mock()
+        user_project_mock.build_configurations.each do |config|
+            config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+        end
         pods_projects_mock = PodsProjectMock.new()
-        installer = InstallerMock.new(PodsProjectMock.new(), [
+        installer = InstallerMock.new(pods_projects_mock, [
             AggregatedProjectMock.new(user_project_mock)
         ])
 
@@ -192,13 +214,14 @@ class UtilsTests < Test::Unit::TestCase
 
         # Assert
         user_project_mock.build_configurations.each do |config|
-            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "")
+            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "arm64")
         end
-        assert_equal(user_project_mock.save_invocation_count, 1)
+
+        assert_equal(user_project_mock.save_invocation_count, 0)
         assert_equal(pods_projects_mock.save_invocation_count, 0)
     end
 
-    def test_excludeArchitectures_whenHermesEngineIsIncluded_excludeI386
+    def test_excludeArchitectures_whenHermesEngineIsIncluded_withNoValue_onlyExcludeI386
         # Arrange
         user_project_mock = prepare_empty_user_project_mock()
         pods_projects_mock = PodsProjectMock.new([], {"hermes-engine" => {}})
@@ -212,6 +235,29 @@ class UtilsTests < Test::Unit::TestCase
         # Assert
         user_project_mock.build_configurations.each do |config|
             assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "i386")
+        end
+
+        assert_equal(user_project_mock.save_invocation_count, 1)
+        assert_equal(pods_projects_mock.save_invocation_count, 1)
+    end
+
+    def test_excludeArchitectures_whenHermesEngineIsIncluded_withExistingValue_appendI386
+        # Arrange
+        user_project_mock = prepare_empty_user_project_mock()
+        user_project_mock.build_configurations.each do |config|
+            config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+        end
+        pods_projects_mock = PodsProjectMock.new([], {"hermes-engine" => {}})
+        installer = InstallerMock.new(pods_projects_mock, [
+            AggregatedProjectMock.new(user_project_mock)
+        ])
+
+        # Act
+        ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
+
+        # Assert
+        user_project_mock.build_configurations.each do |config|
+            assert_equal(config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"], "arm64 i386")
         end
 
         assert_equal(user_project_mock.save_invocation_count, 1)

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -54,18 +54,28 @@ class ReactNativePodsUtils
     end
 
     def self.exclude_i386_architecture_while_using_hermes(installer)
-        projects = self.extract_projects(installer)
+      is_using_hermes = self.has_pod(installer, 'hermes-engine')
 
-        # Hermes does not support `i386` architecture
-        excluded_archs_default = self.has_pod(installer, 'hermes-engine') ? "i386" : ""
+      if is_using_hermes
+          key = "EXCLUDED_ARCHS[sdk=iphonesimulator*]"
 
-        projects.each do |project|
-            project.build_configurations.each do |config|
-                config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = excluded_archs_default
-            end
+          projects = self.extract_projects(installer)
 
-            project.save()
-        end
+          projects.each do |project|
+              project.build_configurations.each do |config|
+                  current_setting = config.build_settings[key] || ""
+
+                  excluded_archs_includes_I386 = current_setting.include?("i386")
+
+                  if !excluded_archs_includes_I386
+                      # Hermes does not support `i386` architecture
+                      config.build_settings[key] = "#{current_setting} i386".strip
+                  end
+              end
+
+              project.save()
+          end
+      end
     end
 
     def self.set_node_modules_user_settings(installer, react_native_path)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Created the same fix on RN v0.72 as the previous fix was only available on RN v0.71 https://github.com/facebook/react-native/pull/39763

No need to fix for RN v0.73.

ref
* https://github.com/facebook/react-native/pull/39060
* https://github.com/facebook/react-native/pull/38132
* https://github.com/facebook/react-native/pull/40656

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - don't override EXCLUDED_ARCHS when installing Hermes

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tests pass