### PR TITLE
store initial notification in static instead of ivar

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -11,8 +11,6 @@ extern NSString *const RCTRemoteNotificationReceived;
 
 @interface RCTPushNotificationManager : RCTEventEmitter
 
-@property (nonatomic, nullable, readwrite) UNNotification *initialNotification;
-
 typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
@@ -40,6 +38,12 @@ typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
  */
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification
               fetchCompletionHandler:(RCTRemoteNotificationCallback)completionHandler;
+
+/**
+ * Call this in `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:`
+ * to get the correct value from .getInitialNotification in JS.
+ */
++ (void)setInitialNotification:(UNNotification *)notification;
 
 /** DEPRECATED. Use didReceiveNotification instead. */
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification RCT_DEPRECATED;

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -535,13 +535,14 @@ RCT_EXPORT_METHOD(getInitialNotification
   if (self.initialNotification) {
     NSDictionary<NSString *, id> *notificationDict =
         RCTFormatUNNotificationContent(self.initialNotification.request.content);
-    NSDictionary *userInfo = notificationDict[@"userInfo"];
     if (IsNotificationRemote(self.initialNotification)) {
-      NSMutableDictionary<NSString *, id> *userInfoCopy = [userInfo mutableCopy];
+      // For backwards compatibility, remote notifications only returns a userInfo dict.
+      NSMutableDictionary<NSString *, id> *userInfoCopy = [notificationDict[@"userInfo"] mutableCopy];
       userInfoCopy[@"remote"] = @YES;
       resolve(userInfoCopy);
     } else {
-      resolve(userInfo);
+      // For backwards compatibility, local notifications return the notification.
+      resolve(notificationDict);
     }
     return;
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

I'm updating this API to match the semantics of the other new APIs, namely that they're static methods that don't depend on the instance of the native module. This should help streamline our documentation. Instead of capturing the launch notification as an ivar, we capture it in a static variable that we clear out when the object gets cleared or is invalidated, which is similar to an ivar.

Differential Revision: D53743761


