### PR TITLE
Fix for #36828 - props not being copied into constructor

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -425,6 +425,7 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
 
   constructor(props: Props<ItemT>) {
     super(props);
+    this.props = props;
     this._checkProps(this.props);
     if (this.props.viewabilityConfigCallbackPairs) {
       this._virtualizedListPairs =

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -425,8 +425,7 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
 
   constructor(props: Props<ItemT>) {
     super(props);
-    this.props = props;
-    this._checkProps(this.props);
+    this._checkProps(props);
     if (this.props.viewabilityConfigCallbackPairs) {
       this._virtualizedListPairs =
         this.props.viewabilityConfigCallbackPairs.map(pair => ({


### PR DESCRIPTION
## Summary:

Fixes an error when trying to render FlatLists where the local class variable this.props is undefined preventing the component from getting to first render. 

This is the change that introduced super(props) https://github.com/facebook/react-native/commit/ad733ad430a4b1d69b89041be8b227e2dfdb5501

For some reason super(props) is not lifting the props up into the parent class constructor. I think this could be due to the changes in this commit which added a wrapper component and removed the legacy implementation. (I have no idea what this is and didn't look further though I suspect that the legacy implementation handled the passing of the props previously and the virtualized one does not for some reason.

https://github.com/facebook/react-native/commit/af4903ed7351cb250149ec6ed66e25862fabdc7f

I ran into this issue after updating my RN expo project from SDK 49 to SDK 50 which bumps react native up to 0.73 from 0.72.4 to give a possible trail on where and how this broke on this type of setup.

## Changelog:

[GENERAL] [FIXED] - added a single line
this.props = props which takes the passed props and stores them in the class constructor
this change likely is not solving the actual problem here but it does skirt the issue where the error is being raised. I think this may need a deeper look by the RN team.

## Test Plan:

Quite a few people mentioned this in the comments of issue #36828 and other similar threads. All signs point to the issue being with the flatlist file. [NickGerleman](https://github.com/NickGerleman) [originally came up with the solution](https://github.com/facebook/react-native/issues/36828#issuecomment-1500829880) and a handful of people have made this change with a patch package with success but none submitted a PR. I can verify that this works in the interim until another solution is found.