### PR TITLE
build backwards compat API for runtime pointer

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeProxy.h
+++ b/packages/react-native/React/Base/RCTBridgeProxy.h
@@ -20,7 +20,8 @@
                        bundleManager:(RCTBundleManager *)bundleManager
                    callableJSModules:(RCTCallableJSModules *)callableJSModules
                   dispatchToJSThread:(void (^)(dispatch_block_t))dispatchToJSThread
-               registerSegmentWithId:(void (^)(NSNumber *, NSString *))registerSegmentWithId NS_DESIGNATED_INITIALIZER;
+               registerSegmentWithId:(void (^)(NSNumber *, NSString *))registerSegmentWithId
+                             runtime:(void *)runtime NS_DESIGNATED_INITIALIZER;
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)sel;
 - (void)forwardInvocation:(NSInvocation *)invocation;

--- a/packages/react-native/React/Base/RCTBridgeProxy.mm
+++ b/packages/react-native/React/Base/RCTBridgeProxy.mm
@@ -28,6 +28,7 @@ using namespace facebook;
   RCTCallableJSModules *_callableJSModules;
   void (^_dispatchToJSThread)(dispatch_block_t);
   void (^_registerSegmentWithId)(NSNumber *, NSString *);
+  void *_runtime;
 }
 
 - (instancetype)initWithViewRegistry:(RCTViewRegistry *)viewRegistry
@@ -36,15 +37,17 @@ using namespace facebook;
                    callableJSModules:(RCTCallableJSModules *)callableJSModules
                   dispatchToJSThread:(void (^)(dispatch_block_t))dispatchToJSThread
                registerSegmentWithId:(void (^)(NSNumber *, NSString *))registerSegmentWithId
+                             runtime:(void *)runtime
 {
   self = [super self];
   if (self) {
-    self->_uiManagerProxy = [[RCTUIManagerProxy alloc] initWithViewRegistry:viewRegistry];
-    self->_moduleRegistry = moduleRegistry;
-    self->_bundleManager = bundleManager;
-    self->_callableJSModules = callableJSModules;
-    self->_dispatchToJSThread = dispatchToJSThread;
-    self->_registerSegmentWithId = registerSegmentWithId;
+    _uiManagerProxy = [[RCTUIManagerProxy alloc] initWithViewRegistry:viewRegistry];
+    _moduleRegistry = moduleRegistry;
+    _bundleManager = bundleManager;
+    _callableJSModules = callableJSModules;
+    _dispatchToJSThread = dispatchToJSThread;
+    _registerSegmentWithId = registerSegmentWithId;
+    _runtime = runtime;
   }
   return self;
 }
@@ -75,10 +78,10 @@ using namespace facebook;
  * Used By:
  *  - RCTBlobCollector
  */
-- (jsi::Runtime *)runtime
+- (void *)runtime
 {
-  [self logWarning:@"This method is unsupported. Returning nullptr." cmd:_cmd];
-  return nullptr;
+  [self logWarning:@"Please migrate to C++ TurboModule or RuntimeExecutor." cmd:_cmd];
+  return _runtime;
 }
 
 /**
@@ -162,7 +165,7 @@ using namespace facebook;
 
 - (void)registerSegmentWithId:(NSUInteger)segmentId path:(NSString *)path
 {
-  self->_registerSegmentWithId(@(segmentId), path);
+  _registerSegmentWithId(@(segmentId), path);
 }
 
 - (id<RCTBridgeDelegate>)delegate

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -12,6 +12,7 @@ import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.JavaScriptModuleRegistry;
 import com.facebook.react.bridge.NativeArray;
@@ -161,6 +162,13 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   @UnstableReactNativeAPI
   public @Nullable RuntimeExecutor getRuntimeExecutor() {
     return mReactHost.getRuntimeExecutor();
+  }
+
+  @Override
+  @FrameworkAPI
+  @UnstableReactNativeAPI
+  public @Nullable JavaScriptContextHolder getJavaScriptContextHolder() {
+    return mReactHost.getJavaScriptContextHolder();
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -29,6 +29,7 @@ import com.facebook.react.ReactHost;
 import com.facebook.react.ReactInstanceEventListener;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.JSBundleLoader;
+import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.MemoryPressureListener;
 import com.facebook.react.bridge.NativeArray;
 import com.facebook.react.bridge.NativeModule;
@@ -596,6 +597,15 @@ public class ReactHostImpl implements ReactHost {
     ReactSoftExceptionLogger.logSoftException(
         TAG,
         new ReactNoCrashSoftException("Tried to get runtime executor while instance is not ready"));
+    return null;
+  }
+
+  @Nullable
+  JavaScriptContextHolder getJavaScriptContextHolder() {
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance != null) {
+      return reactInstance.getJavaScriptContextHolder();
+    }
     return null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -20,6 +20,7 @@ import com.facebook.react.ViewManagerOnDemandReactPackage;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JSBundleLoaderDelegate;
+import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.NativeArray;
 import com.facebook.react.bridge.NativeMap;
@@ -94,6 +95,8 @@ final class ReactInstance {
   private final FabricUIManager mFabricUIManager;
   private final JavaTimerManager mJavaTimerManager;
   private final BridgelessViewManagerResolver mViewManagerResolver;
+
+  private JavaScriptContextHolder mJavaScriptContextHolder;
 
   @DoNotStrip @Nullable private ComponentNameResolverManager mComponentNameResolverManager;
   @DoNotStrip @Nullable private UIConstantsProviderManager mUIConstantsProviderManager;
@@ -180,6 +183,8 @@ final class ReactInstance {
             reactExceptionManager,
             bindingsInstaller,
             isProfiling);
+
+    mJavaScriptContextHolder = new JavaScriptContextHolder(getJavaScriptContext());
 
     // Set up TurboModules
     Systrace.beginSection(
@@ -430,6 +435,10 @@ final class ReactInstance {
     mFabricUIManager.stopSurface(surface.getSurfaceHandler());
   }
 
+  /* package */ JavaScriptContextHolder getJavaScriptContextHolder() {
+    return mJavaScriptContextHolder;
+  }
+
   /* --- Lifecycle methods --- */
   @ThreadConfined("ReactHost")
   /* package */ void destroy() {
@@ -440,6 +449,7 @@ final class ReactInstance {
     mHybridData.resetNative();
     mComponentNameResolverManager = null;
     mUIConstantsProviderManager = null;
+    mJavaScriptContextHolder.clear();
   }
 
   /* --- Native methods --- */
@@ -474,6 +484,8 @@ final class ReactInstance {
   /* package */ native RuntimeExecutor getBufferedRuntimeExecutor();
 
   private native RuntimeScheduler getRuntimeScheduler();
+
+  private native long getJavaScriptContext();
 
   /* package */ native void callFunctionOnModule(
       String moduleName, String methodName, NativeArray args);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -201,6 +201,10 @@ void JReactInstance::handleMemoryPressureJs(jint level) {
   instance_->handleMemoryPressureJs(level);
 }
 
+jlong JReactInstance::getJavaScriptContext() {
+  return (jlong)(intptr_t)instance_->getJavaScriptContext();
+}
+
 void JReactInstance::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", JReactInstance::initHybrid),
@@ -230,6 +234,8 @@ void JReactInstance::registerNatives() {
           "registerSegmentNative", JReactInstance::registerSegment),
       makeNativeMethod(
           "handleMemoryPressureJs", JReactInstance::handleMemoryPressureJs),
+      makeNativeMethod(
+          "getJavaScriptContext", JReactInstance::getJavaScriptContext),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.h
@@ -105,6 +105,8 @@ class JReactInstance : public jni::HybridClass<JReactInstance> {
       nativeMethodCallInvokerHolder_;
   jni::global_ref<JReactExceptionManager::javaobject> jReactExceptionManager_;
   jni::global_ref<JBindingsInstaller::javaobject> jBindingsInstaller_;
+
+  jlong getJavaScriptContext();
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -465,4 +465,8 @@ void ReactInstance::handleMemoryPressureJs(int pressureLevel) {
   }
 }
 
+void* ReactInstance::getJavaScriptContext() {
+  return &runtime_->getRuntime();
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -71,6 +71,8 @@ class ReactInstance final : private jsinspector_modern::InstanceTargetDelegate {
    */
   void unregisterFromInspector();
 
+  void* getJavaScriptContext();
+
  private:
   std::shared_ptr<JSRuntime> runtime_;
   std::shared_ptr<MessageQueueThread> jsMessageQueueThread_;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -263,7 +263,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
             if (strongSelf && strongSelf->_valid) {
               [strongSelf registerSegmentWithId:segmentId path:path];
             }
-          }];
+          }
+          runtime:_reactInstance->getJavaScriptContext()];
   [RCTBridge setCurrentBridge:(RCTBridge *)bridgeProxy];
 
   // Set up TurboModules


### PR DESCRIPTION
Summary:
Changelog: [iOS][Added]

This introduces the backwards-compat functionality to give access to the jsi::Runtime in iOS in bridgeless. In bridge, this value is a private selector on RCTBridge that is exposed via category. We build this into the backwards compatible RCTBridgeProxy here.

This should work out of the box in bridgeless if you are already retrieveing the pointer via the bridge. However, we recommend users to eventually migrate towards C++ TurboModule or the RuntimeExecutor if possible. This will be removed in the future.

Differential Revision: D53646413


