### PR TITLE
RuntimeTarget refactor - Add `this`-scoped async executors to all Targets

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -209,7 +209,7 @@ class RCTBridgePageTargetDelegate : public facebook::react::jsinspector_modern::
   NSURL *_delegateBundleURL;
 
   std::unique_ptr<RCTBridgePageTargetDelegate> _inspectorPageDelegate;
-  std::unique_ptr<facebook::react::jsinspector_modern::PageTarget> _inspectorTarget;
+  std::shared_ptr<facebook::react::jsinspector_modern::PageTarget> _inspectorTarget;
   std::optional<int> _inspectorPageId;
 }
 
@@ -412,7 +412,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
   auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
   if (inspectorFlags.getEnableModernCDPRegistry() && !_inspectorPageId.has_value()) {
-    _inspectorTarget = std::make_unique<facebook::react::jsinspector_modern::PageTarget>(*_inspectorPageDelegate);
+    _inspectorTarget =
+        facebook::react::jsinspector_modern::PageTarget::create(*_inspectorPageDelegate, [](auto callback) {
+          RCTExecuteOnMainQueue(^{
+            callback();
+          });
+        });
     __weak RCTBridge *weakSelf = self;
     _inspectorPageId = facebook::react::jsinspector_modern::getInspectorInstance().addPage(
         "React Native Bridge (Experimental)",

--- a/packages/react-native/ReactCommon/cxxreact/Instance.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.cpp
@@ -67,8 +67,10 @@ void Instance::initializeBridge(
 
         if (parentInspectorTarget) {
           inspectorTarget_ = &parentInspectorTarget->registerInstance(*this);
+          RuntimeExecutor runtimeExecutorIfJsi = getRuntimeExecutor();
           runtimeInspectorTarget_ = &inspectorTarget_->registerRuntime(
-              nativeToJsBridge_->getInspectorTargetDelegate());
+              nativeToJsBridge_->getInspectorTargetDelegate(),
+              runtimeExecutorIfJsi ? runtimeExecutorIfJsi : [](auto) {});
         }
 
         /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -22,4 +22,5 @@ target_link_libraries(jsinspector
         folly_runtime
         glog
         react_featureflags
+        runtimeexecutor
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -46,9 +46,10 @@ InstanceTarget::~InstanceTarget() {
 }
 
 RuntimeTarget& InstanceTarget::registerRuntime(
-    RuntimeTargetDelegate& delegate) {
+    RuntimeTargetDelegate& delegate,
+    RuntimeExecutor executor) {
   assert(!currentRuntime_ && "Only one Runtime allowed");
-  currentRuntime_.emplace(delegate);
+  currentRuntime_.emplace(delegate, executor);
   forEachAgent([currentRuntime = &*currentRuntime_](InstanceAgent& agent) {
     agent.setCurrentRuntime(currentRuntime);
   });

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -59,7 +59,9 @@ class InstanceTarget final {
       FrontendChannel channel,
       SessionState& sessionState);
 
-  RuntimeTarget& registerRuntime(RuntimeTargetDelegate& delegate);
+  RuntimeTarget& registerRuntime(
+      RuntimeTargetDelegate& delegate,
+      RuntimeExecutor executor);
   void unregisterRuntime(RuntimeTarget& runtime);
 
  private:

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -51,4 +51,5 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-featureflags"
   s.dependency "DoubleConversion"
+  s.dependency "React-runtimeexecutor", version
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
@@ -11,4 +11,5 @@
 #include <jsinspector-modern/InstanceTarget.h>
 #include <jsinspector-modern/PageTarget.h>
 #include <jsinspector-modern/RuntimeTarget.h>
+#include <jsinspector-modern/ScopedExecutor.h>
 #include <jsinspector-modern/SessionState.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -9,10 +9,20 @@
 
 namespace facebook::react::jsinspector_modern {
 
+std::shared_ptr<RuntimeTarget> RuntimeTarget::create(
+    RuntimeTargetDelegate& delegate,
+    RuntimeExecutor jsExecutor,
+    VoidExecutor selfExecutor) {
+  std::shared_ptr<RuntimeTarget> runtimeTarget{
+      new RuntimeTarget(delegate, jsExecutor)};
+  runtimeTarget->setExecutor(selfExecutor);
+  return runtimeTarget;
+}
+
 RuntimeTarget::RuntimeTarget(
     RuntimeTargetDelegate& delegate,
-    RuntimeExecutor executor)
-    : delegate_(delegate), executor_(executor) {}
+    RuntimeExecutor jsExecutor)
+    : delegate_(delegate), jsExecutor_(jsExecutor) {}
 
 std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
     FrontendChannel channel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -8,8 +8,11 @@
 #include <jsinspector-modern/RuntimeTarget.h>
 
 namespace facebook::react::jsinspector_modern {
-RuntimeTarget::RuntimeTarget(RuntimeTargetDelegate& delegate)
-    : delegate_(delegate) {}
+
+RuntimeTarget::RuntimeTarget(
+    RuntimeTargetDelegate& delegate,
+    RuntimeExecutor executor)
+    : delegate_(delegate), executor_(executor) {}
 
 std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
     FrontendChannel channel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <ReactCommon/RuntimeExecutor.h>
 #include "InspectorInterfaces.h"
 #include "RuntimeAgent.h"
 #include "SessionState.h"
@@ -53,8 +54,12 @@ class JSINSPECTOR_EXPORT RuntimeTarget final {
    * \param delegate The object that will receive events from this target.
    * The caller is responsible for ensuring that the delegate outlives this
    * object.
+   * \param executor A RuntimeExecutor that can be used to schedule work on
+   * the JS runtime's thread. The executor's queue should be empty when
+   * RuntimeTarget is constructed (i.e. anything scheduled during the
+   * constructor should be executed before any user code is run).
    */
-  explicit RuntimeTarget(RuntimeTargetDelegate& delegate);
+  RuntimeTarget(RuntimeTargetDelegate& delegate, RuntimeExecutor executor);
 
   RuntimeTarget(const RuntimeTarget&) = delete;
   RuntimeTarget(RuntimeTarget&&) = delete;
@@ -77,6 +82,7 @@ class JSINSPECTOR_EXPORT RuntimeTarget final {
 
  private:
   RuntimeTargetDelegate& delegate_;
+  RuntimeExecutor executor_;
   std::list<std::weak_ptr<RuntimeAgent>> agents_;
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/ScopedExecutor.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ScopedExecutor.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <functional>
+#include <memory>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Takes a function and calls it when it is safe to access the Self&
+ * parameter without locking. The function is not called if
+ * the underlying Self object is destroyed while the function is pending.
+ */
+template <typename Self>
+using ScopedExecutor =
+    std::function<void(std::function<void(Self& self)>&& callback)>;
+
+using VoidExecutor = std::function<void(std::function<void()>&& callback)>;
+
+/**
+ * Creates a ScopedExecutor<Self> from a shared (weak) pointer to Self plus some
+ * base executor for a "parent" object of Self. The resulting executor will call
+ * the callback with a valid reference to Self iff Self is still alive.
+ */
+template <typename Self, typename Parent>
+ScopedExecutor<Self> makeScopedExecutor(
+    std::shared_ptr<Self> self,
+    ScopedExecutor<Parent> executor) {
+  return makeScopedExecutor(self, makeVoidExecutor(executor));
+}
+
+/**
+ * Creates a ScopedExecutor<Self> from a shared (weak) pointer to Self plus some
+ * base executor. The resulting executor will call the callback with a valid
+ * reference to Self iff Self is still alive.
+ */
+template <typename Self>
+ScopedExecutor<Self> makeScopedExecutor(
+    std::shared_ptr<Self> self,
+    VoidExecutor executor) {
+  return [self = std::weak_ptr(self), executor](auto&& callback) {
+    executor([self, callback = std::move(callback)]() {
+      auto lockedSelf = self.lock();
+      if (!lockedSelf) {
+        return;
+      }
+      callback(*lockedSelf);
+    });
+  };
+}
+
+/**
+ * Creates a VoidExecutor from a ScopedExecutor<Self> by ignoring the Self&
+ * parameter.
+ */
+template <typename Self>
+VoidExecutor makeVoidExecutor(ScopedExecutor<Self> executor) {
+  return [executor](auto&& callback) {
+    executor([callback = std::move(callback)](Self&) { callback(); });
+  };
+}
+
+template <typename Self>
+class EnableExecutorFromThis : public std::enable_shared_from_this<Self> {
+ public:
+  /**
+   * Returns an executor that can be used to safely invoke methods on Self.
+   * Must not be called during the constructor of Self.
+   */
+  ScopedExecutor<Self> executorFromThis() {
+    assert(baseExecutor_);
+    return makeScopedExecutor(this->shared_from_this(), baseExecutor_);
+  }
+
+  template <typename Other>
+  void setExecutor(ScopedExecutor<Other> executor) {
+    setExecutor(makeVoidExecutor(executor));
+  }
+
+  void setExecutor(VoidExecutor executor) {
+    assert(executor);
+    assert(!baseExecutor_);
+    baseExecutor_ = std::move(executor);
+  }
+
+ private:
+  VoidExecutor baseExecutor_;
+};
+
+}; // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -37,10 +37,6 @@ ReactInstance::ReactInstance(
       jsErrorHandler_(jsErrorHandlingFunc),
       hasFatalJsError_(std::make_shared<bool>(false)),
       parentInspectorTarget_(parentInspectorTarget) {
-  if (parentInspectorTarget_) {
-    inspectorTarget_ = &parentInspectorTarget_->registerInstance(*this);
-    runtimeInspectorTarget_ = &inspectorTarget_->registerRuntime(*runtime_);
-  }
   auto runtimeExecutor = [weakRuntime = std::weak_ptr<JSRuntime>(runtime_),
                           weakTimerManager =
                               std::weak_ptr<TimerManager>(timerManager_),
@@ -87,6 +83,12 @@ ReactInstance::ReactInstance(
           });
     }
   };
+
+  if (parentInspectorTarget_) {
+    inspectorTarget_ = &parentInspectorTarget_->registerInstance(*this);
+    runtimeInspectorTarget_ =
+        &inspectorTarget_->registerRuntime(*runtime_, runtimeExecutor);
+  }
 
   runtimeScheduler_ =
       std::make_shared<RuntimeScheduler>(std::move(runtimeExecutor));

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -68,7 +68,7 @@ class RCTHostPageTargetDelegate : public facebook::react::jsinspector_modern::Pa
   RCTModuleRegistry *_moduleRegistry;
 
   std::unique_ptr<RCTHostPageTargetDelegate> _inspectorPageDelegate;
-  std::unique_ptr<jsinspector_modern::PageTarget> _inspectorTarget;
+  std::shared_ptr<jsinspector_modern::PageTarget> _inspectorTarget;
   std::optional<int> _inspectorPageId;
 }
 
@@ -168,7 +168,12 @@ class RCTHostPageTargetDelegate : public facebook::react::jsinspector_modern::Pa
 {
   auto &inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
   if (inspectorFlags.getEnableModernCDPRegistry() && !_inspectorPageId.has_value()) {
-    _inspectorTarget = std::make_unique<jsinspector_modern::PageTarget>(*_inspectorPageDelegate);
+    _inspectorTarget =
+        facebook::react::jsinspector_modern::PageTarget::create(*_inspectorPageDelegate, [](auto callback) {
+          RCTExecuteOnMainQueue(^{
+            callback();
+          });
+        });
     __weak RCTHost *weakSelf = self;
     _inspectorPageId = facebook::react::jsinspector_modern::getInspectorInstance().addPage(
         "React Native Bridgeless (Experimental)",


### PR DESCRIPTION
Summary:
Changelog: [Internal]

# This diff

1. Provides all Targets with an `executorFromThis()` method, which can be used from within a Target to access a *`this`-scoped main thread executor* = a `std::function` that will execute a callback asynchronously iff the current Target isn't destroyed first.
2. Refactors how (all) Target objects are constructed and retained, from a plain constructor to `static shared_ptr create()`. This is because `executorFromThis()` relies internally on `enable_shared_from_this` plus two-phase construction to populate the executor.
3. Creates utilities for deriving scoped executors from other executors and `shared_ptr`s.

The concept is very much like `RuntimeExecutor` in reverse: the #1 use case is moving from the JS thread back to the main thread - where "main thread" is defined loosely as "anywhere it's legal to call methods on Target/Agent objects, access session state, etc". The actual dispatching mechanism is left up to the owner of each `PageTarget` object; for now we only have an iOS integration, where we use `RCTExecuteOnMainQueue`.

Coupling the ownership/lifetime semantics with task scheduling is helpful, because it avoids the footgun of accidentally/nondeterministically moving `shared_ptr`s (and destructors!) to a different thread/queue .

# This stack
I'm refactoring the way the Runtime concept works in the modern CDP backend to bring it in line with the Page/Instance concepts.

Overall, this will let us:

* Integrate with engines that require us to instantiate a shared Target-like object (e.g. Hermes AsyncDebuggingAPI) in addition to an per-session Agent-like object.
* Access JSI in a CDP context (both at target setup/teardown time and during a CDP session) to implement our own engine-agnostic functionality (`console` interception, `Runtime.addBinding`, etc).
* Manage CDP execution contexts natively in RN, and (down the line) enable first-class debugging support for multiple Runtimes in an Instance.

The core diffs in this stack:

* ~~Introduce a `RuntimeTarget` class similar to `{Page,Instance}Target`. ~~
* ~~Make runtime registration explicit (`InstanceTarget::registerRuntime` similar to `PageTarget::registerInstance`). ~~
* ~~Rename the existing `RuntimeAgent` interface to `RuntimeAgentDelegate`.~~
* ~~Create a new concrete `RuntimeAgent` class similar to `{Page,Instance}Agent`.~~
* ~~Provide `RuntimeTarget` and `RuntimeAgent` with primitives for safe JSI access, namely a `RuntimeExecutor` for scheduling work on the JS thread.~~
  * Provide RuntimeTarget with mechanism for scheduling work on the "main" thread from the JS thread, for when we need to do more than just send a CDP message (which we can already do with the thread-safe `FrontendChannel`) in response to a JS event. *← This diff*

## Architecture diagrams

Before this stack:
https://pxl.cl/4h7m0

After this stack:
https://pxl.cl/4h7m7

Reviewed By: hoxyq

Differential Revision: D53356953

