### PR TITLE
Migrate flag enablePropIteratorSetter to new system (re-land)

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -257,10 +257,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 {
   auto reactNativeConfig = _contextContainer->at<std::shared_ptr<const ReactNativeConfig>>("ReactNativeConfig");
 
-  if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_cpp_props_iterator_setter_ios")) {
-    CoreFeatures::enablePropIteratorSetter = true;
-  }
-
   if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_granular_scroll_view_state_updates_ios")) {
     CoreFeatures::enableGranularScrollViewStateUpdatesIOS = true;
   }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1890,7 +1890,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field enableBridgelessArchitectureNewCreateReloadDestroy Z
 	public static field enableBridgelessArchitectureSoftExceptions Z
 	public static field enableClonelessStateProgression Z
-	public static field enableCppPropsIteratorSetter Z
 	public static field enableEagerRootViewAttachment Z
 	public static field enableFabricLogs Z
 	public static field enableFabricPendingEventQueue Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -100,11 +100,6 @@ public class ReactFeatureFlags {
   public static boolean enableViewRecycling = false;
 
   /**
-   * Enable prop iterator setter-style construction of Props in C++ (this flag is not used in Java).
-   */
-  public static boolean enableCppPropsIteratorSetter = false;
-
-  /**
    * Allow Differentiator.cpp and FabricMountingManager.cpp to generate a RemoveDeleteTree mega-op.
    */
   public static boolean enableRemoveDeleteTreeInstruction = false;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c526fb1c44f00f5b032684396246e4d4>>
+ * @generated SignedSource<<e0feebb19816cd356ba2f28d3bec937a>>
  */
 
 /**
@@ -87,6 +87,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun inspectorEnableModernCDPRegistry(): Boolean = accessor.inspectorEnableModernCDPRegistry()
+
+  /**
+   * Specifies whether the iterator-style prop parsing is enabled.
+   */
+  @JvmStatic
+  public fun enablePropIteratorSetter(): Boolean = accessor.enablePropIteratorSetter()
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<11824621ee7ca5dbdf2f09bdf1a1f983>>
+ * @generated SignedSource<<144af28ad2eb5bf179ed003da3d76165>>
  */
 
 /**
@@ -30,6 +30,7 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
   private var enableFixForClippedSubviewsCrashCache: Boolean? = null
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
+  private var enablePropIteratorSetterCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -117,6 +118,15 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.inspectorEnableModernCDPRegistry()
       inspectorEnableModernCDPRegistryCache = cached
+    }
+    return cached
+  }
+
+  override fun enablePropIteratorSetter(): Boolean {
+    var cached = enablePropIteratorSetterCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.enablePropIteratorSetter()
+      enablePropIteratorSetterCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dfbe9bcab657e4c66dd104788639448d>>
+ * @generated SignedSource<<da9e28f14db819d8a15d59f311173f8b>>
  */
 
 /**
@@ -47,6 +47,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun inspectorEnableCxxInspectorPackagerConnection(): Boolean
 
   @DoNotStrip @JvmStatic public external fun inspectorEnableModernCDPRegistry(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun enablePropIteratorSetter(): Boolean
 
   @DoNotStrip @JvmStatic public external fun override(provider: Any)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cc8e437bf2f486949f256a19d3d73a1e>>
+ * @generated SignedSource<<f50066bc31b868f2ea202e20753326bd>>
  */
 
 /**
@@ -42,4 +42,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun inspectorEnableCxxInspectorPackagerConnection(): Boolean = false
 
   override fun inspectorEnableModernCDPRegistry(): Boolean = false
+
+  override fun enablePropIteratorSetter(): Boolean = false
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<63356ad414e641eae11ca07b1a876fd3>>
+ * @generated SignedSource<<ac6fa0c879e4748ad503944c9d10b3fd>>
  */
 
 /**
@@ -34,6 +34,7 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
   private var enableFixForClippedSubviewsCrashCache: Boolean? = null
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
+  private var enablePropIteratorSetterCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -131,6 +132,16 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
       cached = currentProvider.inspectorEnableModernCDPRegistry()
       accessedFeatureFlags.add("inspectorEnableModernCDPRegistry")
       inspectorEnableModernCDPRegistryCache = cached
+    }
+    return cached
+  }
+
+  override fun enablePropIteratorSetter(): Boolean {
+    var cached = enablePropIteratorSetterCache
+    if (cached == null) {
+      cached = currentProvider.enablePropIteratorSetter()
+      accessedFeatureFlags.add("enablePropIteratorSetter")
+      enablePropIteratorSetterCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c5388e841a06044520f6c89fcca27286>>
+ * @generated SignedSource<<01a82369c1bababe47535b8cceb487eb>>
  */
 
 /**
@@ -42,4 +42,6 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun inspectorEnableCxxInspectorPackagerConnection(): Boolean
 
   @DoNotStrip public fun inspectorEnableModernCDPRegistry(): Boolean
+
+  @DoNotStrip public fun enablePropIteratorSetter(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -413,8 +413,6 @@ void Binding::installFabricUIManager(
       "CalculateTransformedFramesEnabled",
       getFeatureFlagValue("calculateTransformedFramesEnabled"));
 
-  CoreFeatures::enablePropIteratorSetter =
-      getFeatureFlagValue("enableCppPropsIteratorSetter");
   CoreFeatures::enableClonelessStateProgression =
       getFeatureFlagValue("enableClonelessStateProgression");
   CoreFeatures::excludeYogaFromRawProps =

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f40d52242f2c758ed616f1e5d8c3a082>>
+ * @generated SignedSource<<faa13422c6380237c6a33f95f79302f2>>
  */
 
 /**
@@ -99,6 +99,12 @@ class ReactNativeFeatureFlagsProviderHolder
     return method(javaProvider_);
   }
 
+  bool enablePropIteratorSetter() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enablePropIteratorSetter");
+    return method(javaProvider_);
+  }
+
  private:
   jni::global_ref<jobject> javaProvider_;
 };
@@ -153,6 +159,11 @@ bool JReactNativeFeatureFlagsCxxInterop::inspectorEnableModernCDPRegistry(
   return ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::enablePropIteratorSetter(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::enablePropIteratorSetter();
+}
+
 void JReactNativeFeatureFlagsCxxInterop::override(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/,
     jni::alias_ref<jobject> provider) {
@@ -200,6 +211,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "inspectorEnableModernCDPRegistry",
         JReactNativeFeatureFlagsCxxInterop::inspectorEnableModernCDPRegistry),
+      makeNativeMethod(
+        "enablePropIteratorSetter",
+        JReactNativeFeatureFlagsCxxInterop::enablePropIteratorSetter),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a860f8ca5806886a2e7b0b9a508482a1>>
+ * @generated SignedSource<<70f4f8c1d6f86bcbcb13af782e7356cd>>
  */
 
 /**
@@ -58,6 +58,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool inspectorEnableModernCDPRegistry(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool enablePropIteratorSetter(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static void override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<82f226df2b3824d03b755a042b20bec5>>
+ * @generated SignedSource<<bebbf1ec03ad9dfdf59dd566618f69ef>>
  */
 
 /**
@@ -59,6 +59,10 @@ bool ReactNativeFeatureFlags::inspectorEnableCxxInspectorPackagerConnection() {
 
 bool ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry() {
   return getAccessor().inspectorEnableModernCDPRegistry();
+}
+
+bool ReactNativeFeatureFlags::enablePropIteratorSetter() {
+  return getAccessor().enablePropIteratorSetter();
 }
 
 void ReactNativeFeatureFlags::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3bfae310dfd28040f4b80d1a1df8b7b3>>
+ * @generated SignedSource<<98243d4cb18b03d4a2273416879f1081>>
  */
 
 /**
@@ -82,6 +82,11 @@ class ReactNativeFeatureFlags {
    * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
    */
   static bool inspectorEnableModernCDPRegistry();
+
+  /**
+   * Specifies whether the iterator-style prop parsing is enabled.
+   */
+  static bool enablePropIteratorSetter();
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2154292f89306f25289583537833a065>>
+ * @generated SignedSource<<94d6891851ba8d96e9049e9a4eb727ca>>
  */
 
 /**
@@ -204,6 +204,24 @@ bool ReactNativeFeatureFlagsAccessor::inspectorEnableModernCDPRegistry() {
 
     flagValue = currentProvider_->inspectorEnableModernCDPRegistry();
     inspectorEnableModernCDPRegistry_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
+bool ReactNativeFeatureFlagsAccessor::enablePropIteratorSetter() {
+  auto flagValue = enablePropIteratorSetter_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(10, "enablePropIteratorSetter");
+
+    flagValue = currentProvider_->enablePropIteratorSetter();
+    enablePropIteratorSetter_ = flagValue;
   }
 
   return flagValue.value();

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<95487968b66d40e1ec53936b06084931>>
+ * @generated SignedSource<<756f3b972dcc9f96e4fd5d0c67e945b6>>
  */
 
 /**
@@ -41,6 +41,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool enableFixForClippedSubviewsCrash();
   bool inspectorEnableCxxInspectorPackagerConnection();
   bool inspectorEnableModernCDPRegistry();
+  bool enablePropIteratorSetter();
 
   void override(std::unique_ptr<ReactNativeFeatureFlagsProvider> provider);
 
@@ -51,7 +52,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 10> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 11> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> enableBackgroundExecutor_;
@@ -63,6 +64,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enableFixForClippedSubviewsCrash_;
   std::atomic<std::optional<bool>> inspectorEnableCxxInspectorPackagerConnection_;
   std::atomic<std::optional<bool>> inspectorEnableModernCDPRegistry_;
+  std::atomic<std::optional<bool>> enablePropIteratorSetter_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4832483bb3648380f2bb9312311f579c>>
+ * @generated SignedSource<<22f3908006ed4979a639c7e374e6dc9a>>
  */
 
 /**
@@ -64,6 +64,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool inspectorEnableModernCDPRegistry() override {
+    return false;
+  }
+
+  bool enablePropIteratorSetter() override {
     return false;
   }
 };

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f707d15cf978d7342cdf5aab18444219>>
+ * @generated SignedSource<<37a53122381f8d5c2b953c609963e59b>>
  */
 
 /**
@@ -35,6 +35,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enableFixForClippedSubviewsCrash() = 0;
   virtual bool inspectorEnableCxxInspectorPackagerConnection() = 0;
   virtual bool inspectorEnableModernCDPRegistry() = 0;
+  virtual bool enablePropIteratorSetter() = 0;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<003a5e1b1e52d504e9cd29583b475041>>
+ * @generated SignedSource<<d57b64cc3f9cbaa045753808e7a7a2ff>>
  */
 
 /**
@@ -85,6 +85,11 @@ bool NativeReactNativeFeatureFlags::inspectorEnableCxxInspectorPackagerConnectio
 bool NativeReactNativeFeatureFlags::inspectorEnableModernCDPRegistry(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry();
+}
+
+bool NativeReactNativeFeatureFlags::enablePropIteratorSetter(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::enablePropIteratorSetter();
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e3760a947742d471dc64dde3f719fb0b>>
+ * @generated SignedSource<<579f03107b22c5a694716bb158765b1b>>
  */
 
 /**
@@ -53,6 +53,8 @@ class NativeReactNativeFeatureFlags
   bool inspectorEnableCxxInspectorPackagerConnection(jsi::Runtime& runtime);
 
   bool inspectorEnableModernCDPRegistry(jsi::Runtime& runtime);
+
+  bool enablePropIteratorSetter(jsi::Runtime& runtime);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(rrc_image
         jsi
         react_debug
         react_utils
+        react_featureflags
         react_render_core
         react_render_debug
         react_render_graphics

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/image/ImageProps.h>
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/core/propsConversions.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -18,15 +18,16 @@ ImageProps::ImageProps(
     const RawProps& rawProps)
     : ViewProps(context, sourceProps, rawProps),
       sources(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.sources
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "source",
-                                                       sourceProps.sources,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.sources
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "source",
+                    sourceProps.sources,
+                    {})),
       defaultSources(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.defaultSources
               : convertRawProp(
                     context,
@@ -35,7 +36,7 @@ ImageProps::ImageProps(
                     sourceProps.defaultSources,
                     {})),
       resizeMode(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.resizeMode
               : convertRawProp(
                     context,
@@ -44,31 +45,34 @@ ImageProps::ImageProps(
                     sourceProps.resizeMode,
                     ImageResizeMode::Stretch)),
       blurRadius(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.blurRadius
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "blurRadius",
-                                                       sourceProps.blurRadius,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.blurRadius
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "blurRadius",
+                    sourceProps.blurRadius,
+                    {})),
       capInsets(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.capInsets
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "capInsets",
-                                                       sourceProps.capInsets,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.capInsets
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "capInsets",
+                    sourceProps.capInsets,
+                    {})),
       tintColor(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.tintColor
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "tintColor",
-                                                       sourceProps.tintColor,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.tintColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "tintColor",
+                    sourceProps.tintColor,
+                    {})),
       internal_analyticTag(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.internal_analyticTag
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(rrc_scrollview
         glog_init
         jsi
         react_debug
+        react_featureflags
         react_render_core
         react_render_debug
         react_render_graphics

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -7,10 +7,10 @@
 
 #include "ScrollViewProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/scrollview/conversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
-#include <react/utils/CoreFeatures.h>
 
 #include <react/renderer/core/propsConversions.h>
 
@@ -22,7 +22,7 @@ ScrollViewProps::ScrollViewProps(
     const RawProps& rawProps)
     : ViewProps(context, sourceProps, rawProps),
       alwaysBounceHorizontal(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.alwaysBounceHorizontal
               : convertRawProp(
                     context,
@@ -31,7 +31,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.alwaysBounceHorizontal,
                     {})),
       alwaysBounceVertical(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.alwaysBounceVertical
               : convertRawProp(
                     context,
@@ -40,23 +40,25 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.alwaysBounceVertical,
                     {})),
       bounces(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.bounces
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "bounces",
-                                                       sourceProps.bounces,
-                                                       true)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.bounces
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "bounces",
+                    sourceProps.bounces,
+                    true)),
       bouncesZoom(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.bouncesZoom
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "bouncesZoom",
-                                                       sourceProps.bouncesZoom,
-                                                       true)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.bouncesZoom
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "bouncesZoom",
+                    sourceProps.bouncesZoom,
+                    true)),
       canCancelContentTouches(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.canCancelContentTouches
               : convertRawProp(
                     context,
@@ -65,7 +67,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.canCancelContentTouches,
                     true)),
       centerContent(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.centerContent
               : convertRawProp(
                     context,
@@ -74,7 +76,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.centerContent,
                     {})),
       automaticallyAdjustContentInsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.automaticallyAdjustContentInsets
               : convertRawProp(
                     context,
@@ -83,7 +85,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.automaticallyAdjustContentInsets,
                     {})),
       automaticallyAdjustsScrollIndicatorInsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.automaticallyAdjustsScrollIndicatorInsets
               : convertRawProp(
                     context,
@@ -92,7 +94,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.automaticallyAdjustsScrollIndicatorInsets,
                     true)),
       decelerationRate(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.decelerationRate
               : convertRawProp(
                     context,
@@ -101,7 +103,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.decelerationRate,
                     (Float)0.998)),
       endDraggingSensitivityMultiplier(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.endDraggingSensitivityMultiplier
               : convertRawProp(
                     context,
@@ -110,7 +112,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.endDraggingSensitivityMultiplier,
                     1)),
       endDraggingSensitivityVelocityMultiplier(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.endDraggingSensitivityVelocityMultiplier
               : convertRawProp(
                     context,
@@ -119,7 +121,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.endDraggingSensitivityVelocityMultiplier,
                     0)),
       directionalLockEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.directionalLockEnabled
               : convertRawProp(
                     context,
@@ -128,7 +130,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.directionalLockEnabled,
                     {})),
       indicatorStyle(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.indicatorStyle
               : convertRawProp(
                     context,
@@ -137,7 +139,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.indicatorStyle,
                     {})),
       keyboardDismissMode(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.keyboardDismissMode
               : convertRawProp(
                     context,
@@ -146,7 +148,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.keyboardDismissMode,
                     {})),
       maintainVisibleContentPosition(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.maintainVisibleContentPosition
               : convertRawProp(
                     context,
@@ -155,7 +157,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.maintainVisibleContentPosition,
                     {})),
       maximumZoomScale(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.maximumZoomScale
               : convertRawProp(
                     context,
@@ -164,7 +166,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.maximumZoomScale,
                     (Float)1.0)),
       minimumZoomScale(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.minimumZoomScale
               : convertRawProp(
                     context,
@@ -173,7 +175,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.minimumZoomScale,
                     (Float)1.0)),
       scrollEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.scrollEnabled
               : convertRawProp(
                     context,
@@ -182,7 +184,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.scrollEnabled,
                     true)),
       pagingEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.pagingEnabled
               : convertRawProp(
                     context,
@@ -191,7 +193,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.pagingEnabled,
                     {})),
       pinchGestureEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.pinchGestureEnabled
               : convertRawProp(
                     context,
@@ -200,15 +202,16 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.pinchGestureEnabled,
                     true)),
       scrollsToTop(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.scrollsToTop
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "scrollsToTop",
-                                                       sourceProps.scrollsToTop,
-                                                       true)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.scrollsToTop
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "scrollsToTop",
+                    sourceProps.scrollsToTop,
+                    true)),
       showsHorizontalScrollIndicator(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.showsHorizontalScrollIndicator
               : convertRawProp(
                     context,
@@ -217,7 +220,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.showsHorizontalScrollIndicator,
                     true)),
       showsVerticalScrollIndicator(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.showsVerticalScrollIndicator
               : convertRawProp(
                     context,
@@ -226,7 +229,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.showsVerticalScrollIndicator,
                     true)),
       scrollEventThrottle(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.scrollEventThrottle
               : convertRawProp(
                     context,
@@ -235,23 +238,25 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.scrollEventThrottle,
                     {})),
       zoomScale(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.zoomScale
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "zoomScale",
-                                                       sourceProps.zoomScale,
-                                                       (Float)1.0)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.zoomScale
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "zoomScale",
+                    sourceProps.zoomScale,
+                    (Float)1.0)),
       contentInset(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.contentInset
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "contentInset",
-                                                       sourceProps.contentInset,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.contentInset
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "contentInset",
+                    sourceProps.contentInset,
+                    {})),
       contentOffset(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.contentOffset
               : convertRawProp(
                     context,
@@ -260,7 +265,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.contentOffset,
                     {})),
       scrollIndicatorInsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.scrollIndicatorInsets
               : convertRawProp(
                     context,
@@ -269,7 +274,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.scrollIndicatorInsets,
                     {})),
       snapToInterval(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.snapToInterval
               : convertRawProp(
                     context,
@@ -278,7 +283,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.snapToInterval,
                     {})),
       snapToAlignment(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.snapToAlignment
               : convertRawProp(
                     context,
@@ -287,7 +292,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.snapToAlignment,
                     {})),
       disableIntervalMomentum(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.disableIntervalMomentum
               : convertRawProp(
                     context,
@@ -296,7 +301,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.disableIntervalMomentum,
                     {})),
       snapToOffsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.snapToOffsets
               : convertRawProp(
                     context,
@@ -305,23 +310,25 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.snapToOffsets,
                     {})),
       snapToStart(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.snapToStart
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "snapToStart",
-                                                       sourceProps.snapToStart,
-                                                       true)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.snapToStart
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "snapToStart",
+                    sourceProps.snapToStart,
+                    true)),
       snapToEnd(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.snapToEnd
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "snapToEnd",
-                                                       sourceProps.snapToEnd,
-                                                       true)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.snapToEnd
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "snapToEnd",
+                    sourceProps.snapToEnd,
+                    true)),
       contentInsetAdjustmentBehavior(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.contentInsetAdjustmentBehavior
               : convertRawProp(
                     context,
@@ -330,7 +337,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.contentInsetAdjustmentBehavior,
                     {ContentInsetAdjustmentBehavior::Never})),
       scrollToOverflowEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.scrollToOverflowEnabled
               : convertRawProp(
                     context,
@@ -339,7 +346,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.scrollToOverflowEnabled,
                     {})),
       isInvertedVirtualizedList(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.isInvertedVirtualizedList
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -7,11 +7,11 @@
 
 #include "BaseTextProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/DebugStringConvertibleItem.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -218,7 +218,7 @@ BaseTextProps::BaseTextProps(
     const BaseTextProps& sourceProps,
     const RawProps& rawProps)
     : textAttributes(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.textAttributes
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(rrc_text
         glog_init
         jsi
         react_debug
+        react_featureflags
         react_render_attributedstring
         react_render_core
         react_render_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -7,13 +7,11 @@
 
 #include "ParagraphProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/attributedstring/primitives.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
-#include <react/utils/CoreFeatures.h>
-
-#include <glog/logging.h>
 
 namespace facebook::react {
 
@@ -24,7 +22,7 @@ ParagraphProps::ParagraphProps(
     : ViewProps(context, sourceProps, rawProps),
       BaseTextProps(context, sourceProps, rawProps),
       paragraphAttributes(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.paragraphAttributes
               : convertRawProp(
                     context,
@@ -32,21 +30,23 @@ ParagraphProps::ParagraphProps(
                     sourceProps.paragraphAttributes,
                     {})),
       isSelectable(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.isSelectable
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "selectable",
-                                                       sourceProps.isSelectable,
-                                                       false)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.isSelectable
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "selectable",
+                    sourceProps.isSelectable,
+                    false)),
       onTextLayout(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.onTextLayout
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "onTextLayout",
-                                                       sourceProps.onTextLayout,
-                                                       {})) {
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.onTextLayout
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "onTextLayout",
+                    sourceProps.onTextLayout,
+                    {})) {
   /*
    * These props are applied to `View`, therefore they must not be a part of
    * base text attributes.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(rrc_textinput
         glog_init
         jsi
         react_debug
+        react_featureflags
         react_render_attributedstring
         react_render_componentregistry
         react_render_core

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -6,10 +6,10 @@
  */
 
 #include "AndroidTextInputProps.h"
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -38,209 +38,209 @@ AndroidTextInputProps::AndroidTextInputProps(
     const RawProps &rawProps)
     : ViewProps(context, sourceProps, rawProps),
       BaseTextProps(context, sourceProps, rawProps),
-      autoComplete(CoreFeatures::enablePropIteratorSetter? sourceProps.autoComplete : convertRawProp(
+      autoComplete(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.autoComplete : convertRawProp(
           context,
           rawProps,
           "autoComplete",
           sourceProps.autoComplete,
           {})),
-      returnKeyLabel(CoreFeatures::enablePropIteratorSetter? sourceProps.autoComplete : convertRawProp(context, rawProps,
+      returnKeyLabel(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.autoComplete : convertRawProp(context, rawProps,
           "returnKeyLabel",
           sourceProps.returnKeyLabel,
           {})),
-      numberOfLines(CoreFeatures::enablePropIteratorSetter? sourceProps.numberOfLines : convertRawProp(context, rawProps,
+      numberOfLines(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.numberOfLines : convertRawProp(context, rawProps,
           "numberOfLines",
           sourceProps.numberOfLines,
           {0})),
-      disableFullscreenUI(CoreFeatures::enablePropIteratorSetter? sourceProps.disableFullscreenUI : convertRawProp(context, rawProps,
+      disableFullscreenUI(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.disableFullscreenUI : convertRawProp(context, rawProps,
           "disableFullscreenUI",
           sourceProps.disableFullscreenUI,
           {false})),
-      textBreakStrategy(CoreFeatures::enablePropIteratorSetter? sourceProps.textBreakStrategy : convertRawProp(context, rawProps,
+      textBreakStrategy(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.textBreakStrategy : convertRawProp(context, rawProps,
           "textBreakStrategy",
           sourceProps.textBreakStrategy,
           {})),
-      underlineColorAndroid(CoreFeatures::enablePropIteratorSetter? sourceProps.underlineColorAndroid : convertRawProp(context, rawProps,
+      underlineColorAndroid(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.underlineColorAndroid : convertRawProp(context, rawProps,
           "underlineColorAndroid",
           sourceProps.underlineColorAndroid,
           {})),
-      inlineImageLeft(CoreFeatures::enablePropIteratorSetter? sourceProps.inlineImageLeft : convertRawProp(context, rawProps,
+      inlineImageLeft(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.inlineImageLeft : convertRawProp(context, rawProps,
           "inlineImageLeft",
           sourceProps.inlineImageLeft,
           {})),
-      inlineImagePadding(CoreFeatures::enablePropIteratorSetter? sourceProps.inlineImagePadding : convertRawProp(context, rawProps,
+      inlineImagePadding(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.inlineImagePadding : convertRawProp(context, rawProps,
           "inlineImagePadding",
           sourceProps.inlineImagePadding,
           {0})),
-      importantForAutofill(CoreFeatures::enablePropIteratorSetter? sourceProps.importantForAutofill : convertRawProp(context, rawProps,
+      importantForAutofill(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.importantForAutofill : convertRawProp(context, rawProps,
           "importantForAutofill",
           sourceProps.importantForAutofill,
           {})),
-      showSoftInputOnFocus(CoreFeatures::enablePropIteratorSetter? sourceProps.showSoftInputOnFocus : convertRawProp(context, rawProps,
+      showSoftInputOnFocus(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.showSoftInputOnFocus : convertRawProp(context, rawProps,
           "showSoftInputOnFocus",
           sourceProps.showSoftInputOnFocus,
           {false})),
-      autoCapitalize(CoreFeatures::enablePropIteratorSetter? sourceProps.autoCapitalize : convertRawProp(context, rawProps,
+      autoCapitalize(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.autoCapitalize : convertRawProp(context, rawProps,
           "autoCapitalize",
           sourceProps.autoCapitalize,
           {})),
-      autoCorrect(CoreFeatures::enablePropIteratorSetter? sourceProps.autoCorrect : convertRawProp(context, rawProps,
+      autoCorrect(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.autoCorrect : convertRawProp(context, rawProps,
           "autoCorrect",
           sourceProps.autoCorrect,
           {false})),
-      autoFocus(CoreFeatures::enablePropIteratorSetter? sourceProps.autoFocus : convertRawProp(context, rawProps,
+      autoFocus(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.autoFocus : convertRawProp(context, rawProps,
           "autoFocus",
           sourceProps.autoFocus,
           {false})),
-      allowFontScaling(CoreFeatures::enablePropIteratorSetter? sourceProps.allowFontScaling : convertRawProp(context, rawProps,
+      allowFontScaling(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.allowFontScaling : convertRawProp(context, rawProps,
           "allowFontScaling",
           sourceProps.allowFontScaling,
           {false})),
-      maxFontSizeMultiplier(CoreFeatures::enablePropIteratorSetter? sourceProps.maxFontSizeMultiplier : convertRawProp(context, rawProps,
+      maxFontSizeMultiplier(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.maxFontSizeMultiplier : convertRawProp(context, rawProps,
           "maxFontSizeMultiplier",
           sourceProps.maxFontSizeMultiplier,
           {0.0})),
-      editable(CoreFeatures::enablePropIteratorSetter? sourceProps.editable :
+      editable(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.editable :
           convertRawProp(context, rawProps, "editable", sourceProps.editable, {false})),
-      keyboardType(CoreFeatures::enablePropIteratorSetter? sourceProps.keyboardType : convertRawProp(context, rawProps,
+      keyboardType(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.keyboardType : convertRawProp(context, rawProps,
           "keyboardType",
           sourceProps.keyboardType,
           {})),
-      returnKeyType(CoreFeatures::enablePropIteratorSetter? sourceProps.returnKeyType : convertRawProp(context, rawProps,
+      returnKeyType(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.returnKeyType : convertRawProp(context, rawProps,
           "returnKeyType",
           sourceProps.returnKeyType,
           {})),
-      maxLength(CoreFeatures::enablePropIteratorSetter? sourceProps.maxLength :
+      maxLength(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.maxLength :
           convertRawProp(context, rawProps, "maxLength", sourceProps.maxLength, {0})),
-      multiline(CoreFeatures::enablePropIteratorSetter? sourceProps.multiline : convertRawProp(context, rawProps,
+      multiline(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.multiline : convertRawProp(context, rawProps,
           "multiline",
           sourceProps.multiline,
           {false})),
-      placeholder(CoreFeatures::enablePropIteratorSetter? sourceProps.placeholder :
+      placeholder(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.placeholder :
           convertRawProp(context, rawProps, "placeholder", sourceProps.placeholder, {})),
-      placeholderTextColor(CoreFeatures::enablePropIteratorSetter? sourceProps.placeholderTextColor : convertRawProp(context, rawProps,
+      placeholderTextColor(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.placeholderTextColor : convertRawProp(context, rawProps,
           "placeholderTextColor",
           sourceProps.placeholderTextColor,
           {})),
-      secureTextEntry(CoreFeatures::enablePropIteratorSetter? sourceProps.secureTextEntry : convertRawProp(context, rawProps,
+      secureTextEntry(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.secureTextEntry : convertRawProp(context, rawProps,
           "secureTextEntry",
           sourceProps.secureTextEntry,
           {false})),
-      selectionColor(CoreFeatures::enablePropIteratorSetter? sourceProps.selectionColor : convertRawProp(context, rawProps,
+      selectionColor(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.selectionColor : convertRawProp(context, rawProps,
           "selectionColor",
           sourceProps.selectionColor,
           {})),
-      selectionHandleColor(CoreFeatures::enablePropIteratorSetter? sourceProps.selectionHandleColor : convertRawProp(context, rawProps,
+      selectionHandleColor(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.selectionHandleColor : convertRawProp(context, rawProps,
           "selectionHandleColor",
           sourceProps.selectionHandleColor,
           {})),
-      value(CoreFeatures::enablePropIteratorSetter? sourceProps.value : convertRawProp(context, rawProps, "value", sourceProps.value, {})),
-      defaultValue(CoreFeatures::enablePropIteratorSetter? sourceProps.defaultValue : convertRawProp(context, rawProps,
+      value(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.value : convertRawProp(context, rawProps, "value", sourceProps.value, {})),
+      defaultValue(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.defaultValue : convertRawProp(context, rawProps,
           "defaultValue",
           sourceProps.defaultValue,
           {})),
-      selectTextOnFocus(CoreFeatures::enablePropIteratorSetter? sourceProps.selectTextOnFocus : convertRawProp(context, rawProps,
+      selectTextOnFocus(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.selectTextOnFocus : convertRawProp(context, rawProps,
           "selectTextOnFocus",
           sourceProps.selectTextOnFocus,
           {false})),
-      submitBehavior(CoreFeatures::enablePropIteratorSetter? sourceProps.submitBehavior : convertRawProp(context, rawProps,
+      submitBehavior(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.submitBehavior : convertRawProp(context, rawProps,
            "submitBehavior",
           sourceProps.submitBehavior,
           {})),
-      caretHidden(CoreFeatures::enablePropIteratorSetter? sourceProps.caretHidden : convertRawProp(context, rawProps,
+      caretHidden(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.caretHidden : convertRawProp(context, rawProps,
           "caretHidden",
           sourceProps.caretHidden,
           {false})),
-      contextMenuHidden(CoreFeatures::enablePropIteratorSetter? sourceProps.contextMenuHidden : convertRawProp(context, rawProps,
+      contextMenuHidden(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.contextMenuHidden : convertRawProp(context, rawProps,
           "contextMenuHidden",
           sourceProps.contextMenuHidden,
           {false})),
-      textShadowColor(CoreFeatures::enablePropIteratorSetter? sourceProps.textShadowColor : convertRawProp(context, rawProps,
+      textShadowColor(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.textShadowColor : convertRawProp(context, rawProps,
           "textShadowColor",
           sourceProps.textShadowColor,
           {})),
-      textShadowRadius(CoreFeatures::enablePropIteratorSetter? sourceProps.textShadowRadius : convertRawProp(context, rawProps,
+      textShadowRadius(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.textShadowRadius : convertRawProp(context, rawProps,
           "textShadowRadius",
           sourceProps.textShadowRadius,
           {0.0})),
-      textDecorationLine(CoreFeatures::enablePropIteratorSetter? sourceProps.textDecorationLine : convertRawProp(context, rawProps,
+      textDecorationLine(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.textDecorationLine : convertRawProp(context, rawProps,
           "textDecorationLine",
           sourceProps.textDecorationLine,
           {})),
-      fontStyle(CoreFeatures::enablePropIteratorSetter? sourceProps.fontStyle :
+      fontStyle(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.fontStyle :
           convertRawProp(context, rawProps, "fontStyle", sourceProps.fontStyle, {})),
-      textShadowOffset(CoreFeatures::enablePropIteratorSetter? sourceProps.textShadowOffset : convertRawProp(context, rawProps,
+      textShadowOffset(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.textShadowOffset : convertRawProp(context, rawProps,
           "textShadowOffset",
           sourceProps.textShadowOffset,
           {})),
-      lineHeight(CoreFeatures::enablePropIteratorSetter? sourceProps.lineHeight : convertRawProp(context, rawProps,
+      lineHeight(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.lineHeight : convertRawProp(context, rawProps,
           "lineHeight",
           sourceProps.lineHeight,
           {0.0})),
-      textTransform(CoreFeatures::enablePropIteratorSetter? sourceProps.textTransform : convertRawProp(context, rawProps,
+      textTransform(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.textTransform : convertRawProp(context, rawProps,
           "textTransform",
           sourceProps.textTransform,
           {})),
       color(0 /*convertRawProp(context, rawProps, "color", sourceProps.color, {0})*/),
-      letterSpacing(CoreFeatures::enablePropIteratorSetter? sourceProps.letterSpacing : convertRawProp(context, rawProps,
+      letterSpacing(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.letterSpacing : convertRawProp(context, rawProps,
           "letterSpacing",
           sourceProps.letterSpacing,
           {0.0})),
-      fontSize(CoreFeatures::enablePropIteratorSetter? sourceProps.fontSize :
+      fontSize(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.fontSize :
           convertRawProp(context, rawProps, "fontSize", sourceProps.fontSize, {0.0})),
-      textAlign(CoreFeatures::enablePropIteratorSetter? sourceProps.textAlign :
+      textAlign(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.textAlign :
           convertRawProp(context, rawProps, "textAlign", sourceProps.textAlign, {})),
-      includeFontPadding(CoreFeatures::enablePropIteratorSetter? sourceProps.includeFontPadding : convertRawProp(context, rawProps,
+      includeFontPadding(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.includeFontPadding : convertRawProp(context, rawProps,
           "includeFontPadding",
           sourceProps.includeFontPadding,
           {false})),
-      fontWeight(CoreFeatures::enablePropIteratorSetter? sourceProps.fontWeight :
+      fontWeight(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.fontWeight :
           convertRawProp(context, rawProps, "fontWeight", sourceProps.fontWeight, {})),
-      fontFamily(CoreFeatures::enablePropIteratorSetter? sourceProps.fontFamily :
+      fontFamily(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.fontFamily :
           convertRawProp(context, rawProps, "fontFamily", sourceProps.fontFamily, {})),
-      textAlignVertical(CoreFeatures::enablePropIteratorSetter? sourceProps.textAlignVertical : convertRawProp(context, rawProps,
+      textAlignVertical(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.textAlignVertical : convertRawProp(context, rawProps,
           "textAlignVertical",
           sourceProps.textAlignVertical,
           {})),
-      cursorColor(CoreFeatures::enablePropIteratorSetter? sourceProps.cursorColor :
+      cursorColor(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.cursorColor :
           convertRawProp(context, rawProps, "cursorColor", sourceProps.cursorColor, {})),
-      mostRecentEventCount(CoreFeatures::enablePropIteratorSetter? sourceProps.mostRecentEventCount : convertRawProp(context, rawProps,
+      mostRecentEventCount(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.mostRecentEventCount : convertRawProp(context, rawProps,
           "mostRecentEventCount",
           sourceProps.mostRecentEventCount,
           {0})),
-      text(CoreFeatures::enablePropIteratorSetter? sourceProps.text : convertRawProp(context, rawProps, "text", sourceProps.text, {})),
-      paragraphAttributes(CoreFeatures::enablePropIteratorSetter? sourceProps.paragraphAttributes :
+      text(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.text : convertRawProp(context, rawProps, "text", sourceProps.text, {})),
+      paragraphAttributes(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.paragraphAttributes :
           convertRawProp(context, rawProps, sourceProps.paragraphAttributes, {})),
       // See AndroidTextInputComponentDescriptor for usage
       // TODO T63008435: can these, and this feature, be removed entirely?
-      hasPadding(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPadding : hasValue(rawProps, sourceProps.hasPadding, "padding")),
-      hasPaddingHorizontal(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingHorizontal : hasValue(
+      hasPadding(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPadding : hasValue(rawProps, sourceProps.hasPadding, "padding")),
+      hasPaddingHorizontal(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPaddingHorizontal : hasValue(
           rawProps,
           sourceProps.hasPaddingHorizontal,
           "paddingHorizontal")),
-      hasPaddingVertical(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingVertical : hasValue(
+      hasPaddingVertical(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPaddingVertical : hasValue(
           rawProps,
           sourceProps.hasPaddingVertical,
           "paddingVertical")),
-      hasPaddingLeft(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingLeft : hasValue(
+      hasPaddingLeft(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPaddingLeft : hasValue(
           rawProps,
           sourceProps.hasPaddingLeft,
           "paddingLeft")),
-      hasPaddingTop(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingTop :
+      hasPaddingTop(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPaddingTop :
           hasValue(rawProps, sourceProps.hasPaddingTop, "paddingTop")),
-      hasPaddingRight(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingRight : hasValue(
+      hasPaddingRight(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPaddingRight : hasValue(
           rawProps,
           sourceProps.hasPaddingRight,
           "paddingRight")),
-      hasPaddingBottom(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingBottom : hasValue(
+      hasPaddingBottom(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPaddingBottom : hasValue(
           rawProps,
           sourceProps.hasPaddingBottom,
           "paddingBottom")),
-      hasPaddingStart(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingStart : hasValue(
+      hasPaddingStart(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPaddingStart : hasValue(
           rawProps,
           sourceProps.hasPaddingStart,
           "paddingStart")),
-      hasPaddingEnd(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingEnd :
+      hasPaddingEnd(ReactNativeFeatureFlags::enablePropIteratorSetter()? sourceProps.hasPaddingEnd :
           hasValue(rawProps, sourceProps.hasPaddingEnd, "paddingEnd")) {
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -7,11 +7,11 @@
 
 #include "AccessibilityProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/accessibilityPropsConversions.h>
 #include <react/renderer/components/view/propsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -20,15 +20,16 @@ AccessibilityProps::AccessibilityProps(
     const AccessibilityProps& sourceProps,
     const RawProps& rawProps)
     : accessible(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.accessible
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "accessible",
-                                                       sourceProps.accessible,
-                                                       false)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.accessible
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "accessible",
+                    sourceProps.accessible,
+                    false)),
       accessibilityState(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityState
               : convertRawProp(
                     context,
@@ -37,7 +38,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityState,
                     {})),
       accessibilityLabel(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityLabel
               : convertRawProp(
                     context,
@@ -46,7 +47,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLabel,
                     "")),
       accessibilityLabelledBy(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityLabelledBy
               : convertRawProp(
                     context,
@@ -55,7 +56,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLabelledBy,
                     {})),
       accessibilityLiveRegion(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityLiveRegion
               : convertRawProp(
                     context,
@@ -64,7 +65,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLiveRegion,
                     AccessibilityLiveRegion::None)),
       accessibilityHint(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityHint
               : convertRawProp(
                     context,
@@ -73,7 +74,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityHint,
                     "")),
       accessibilityLanguage(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityLanguage
               : convertRawProp(
                     context,
@@ -82,7 +83,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLanguage,
                     "")),
       accessibilityValue(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityValue
               : convertRawProp(
                     context,
@@ -91,7 +92,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityValue,
                     {})),
       accessibilityActions(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityActions
               : convertRawProp(
                     context,
@@ -100,7 +101,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityActions,
                     {})),
       accessibilityViewIsModal(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityViewIsModal
               : convertRawProp(
                     context,
@@ -109,7 +110,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityViewIsModal,
                     false)),
       accessibilityElementsHidden(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityElementsHidden
               : convertRawProp(
                     context,
@@ -118,7 +119,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityElementsHidden,
                     false)),
       accessibilityIgnoresInvertColors(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.accessibilityIgnoresInvertColors
               : convertRawProp(
                     context,
@@ -127,7 +128,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityIgnoresInvertColors,
                     false)),
       onAccessibilityTap(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.onAccessibilityTap
               : convertRawProp(
                     context,
@@ -136,7 +137,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.onAccessibilityTap,
                     {})),
       onAccessibilityMagicTap(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.onAccessibilityMagicTap
               : convertRawProp(
                     context,
@@ -145,7 +146,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.onAccessibilityMagicTap,
                     {})),
       onAccessibilityEscape(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.onAccessibilityEscape
               : convertRawProp(
                     context,
@@ -154,7 +155,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.onAccessibilityEscape,
                     {})),
       onAccessibilityAction(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.onAccessibilityAction
               : convertRawProp(
                     context,
@@ -163,7 +164,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.onAccessibilityAction,
                     {})),
       importantForAccessibility(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.importantForAccessibility
               : convertRawProp(
                     context,
@@ -172,13 +173,14 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.importantForAccessibility,
                     ImportantForAccessibility::Auto)),
       testId(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.testId
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "testID",
-                                                       sourceProps.testId,
-                                                       "")) {
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.testId
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "testID",
+                    sourceProps.testId,
+                    "")) {
   // It is a (severe!) perf deoptimization to request props out-of-order.
   // Thus, since we need to request the same prop twice here
   // (accessibilityRole) we "must" do them subsequently here to prevent
@@ -186,7 +188,7 @@ AccessibilityProps::AccessibilityProps(
   // it probably can, but this is a fairly rare edge-case that (1) is easy-ish
   // to work around here, and (2) would require very careful work to address
   // this case and not regress the more common cases.
-  if (!CoreFeatures::enablePropIteratorSetter) {
+  if (!ReactNativeFeatureFlags::enablePropIteratorSetter()) {
     auto* accessibilityRoleValue =
         rawProps.at("accessibilityRole", nullptr, nullptr);
     auto* roleValue = rawProps.at("role", nullptr, nullptr);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -9,12 +9,12 @@
 
 #include <algorithm>
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/components/view/propsConversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -55,15 +55,16 @@ BaseViewProps::BaseViewProps(
     : YogaStylableProps(context, sourceProps, rawProps),
       AccessibilityProps(context, sourceProps, rawProps),
       opacity(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.opacity
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "opacity",
-                                                       sourceProps.opacity,
-                                                       (Float)1.0)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.opacity
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "opacity",
+                    sourceProps.opacity,
+                    (Float)1.0)),
       backgroundColor(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.backgroundColor
               : convertRawProp(
                     context,
@@ -72,59 +73,65 @@ BaseViewProps::BaseViewProps(
                     sourceProps.backgroundColor,
                     {})),
       borderRadii(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderRadii
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "border",
-                                                       "Radius",
-                                                       sourceProps.borderRadii,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.borderRadii
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "border",
+                    "Radius",
+                    sourceProps.borderRadii,
+                    {})),
       borderColors(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderColors
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "border",
-                                                       "Color",
-                                                       sourceProps.borderColors,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.borderColors
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "border",
+                    "Color",
+                    sourceProps.borderColors,
+                    {})),
       borderCurves(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderCurves
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "border",
-                                                       "Curve",
-                                                       sourceProps.borderCurves,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.borderCurves
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "border",
+                    "Curve",
+                    sourceProps.borderCurves,
+                    {})),
       borderStyles(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderStyles
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "border",
-                                                       "Style",
-                                                       sourceProps.borderStyles,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.borderStyles
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "border",
+                    "Style",
+                    sourceProps.borderStyles,
+                    {})),
       shadowColor(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowColor
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "shadowColor",
-                                                       sourceProps.shadowColor,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.shadowColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shadowColor",
+                    sourceProps.shadowColor,
+                    {})),
       shadowOffset(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowOffset
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "shadowOffset",
-                                                       sourceProps.shadowOffset,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.shadowOffset
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shadowOffset",
+                    sourceProps.shadowOffset,
+                    {})),
       shadowOpacity(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.shadowOpacity
               : convertRawProp(
                     context,
@@ -133,23 +140,25 @@ BaseViewProps::BaseViewProps(
                     sourceProps.shadowOpacity,
                     {})),
       shadowRadius(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowRadius
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "shadowRadius",
-                                                       sourceProps.shadowRadius,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.shadowRadius
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shadowRadius",
+                    sourceProps.shadowRadius,
+                    {})),
       transform(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.transform
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "transform",
-                                                       sourceProps.transform,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.transform
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "transform",
+                    sourceProps.transform,
+                    {})),
       transformOrigin(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.transformOrigin
               : convertRawProp(
                     context,
@@ -158,7 +167,7 @@ BaseViewProps::BaseViewProps(
                     sourceProps.transformOrigin,
                     {})),
       backfaceVisibility(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.backfaceVisibility
               : convertRawProp(
                     context,
@@ -167,7 +176,7 @@ BaseViewProps::BaseViewProps(
                     sourceProps.backfaceVisibility,
                     {})),
       shouldRasterize(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.shouldRasterize
               : convertRawProp(
                     context,
@@ -176,15 +185,16 @@ BaseViewProps::BaseViewProps(
                     sourceProps.shouldRasterize,
                     {})),
       zIndex(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.zIndex
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "zIndex",
-                                                       sourceProps.zIndex,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.zIndex
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "zIndex",
+                    sourceProps.zIndex,
+                    {})),
       pointerEvents(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.pointerEvents
               : convertRawProp(
                     context,
@@ -193,35 +203,38 @@ BaseViewProps::BaseViewProps(
                     sourceProps.pointerEvents,
                     {})),
       hitSlop(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.hitSlop
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "hitSlop",
-                                                       sourceProps.hitSlop,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.hitSlop
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "hitSlop",
+                    sourceProps.hitSlop,
+                    {})),
       onLayout(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.onLayout
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "onLayout",
-                                                       sourceProps.onLayout,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.onLayout
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "onLayout",
+                    sourceProps.onLayout,
+                    {})),
       events(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.events
               : convertRawProp(context, rawProps, sourceProps.events, {})),
       collapsable(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.collapsable
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "collapsable",
-                                                       sourceProps.collapsable,
-                                                       true)),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.collapsable
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "collapsable",
+                    sourceProps.collapsable,
+                    true)),
       removeClippedSubviews(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.removeClippedSubviews
               : convertRawProp(
                     context,
@@ -230,7 +243,7 @@ BaseViewProps::BaseViewProps(
                     sourceProps.removeClippedSubviews,
                     false)),
       experimental_layoutConformance(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.experimental_layoutConformance
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(rrc_view
         jsi
         logger
         react_debug
+        react_featureflags
         react_render_core
         react_render_debug
         react_render_graphics

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -7,11 +7,11 @@
 
 #include "YogaStylableProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/components/view/propsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
-#include <react/utils/CoreFeatures.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -7,13 +7,11 @@
 
 #include "HostPlatformViewProps.h"
 
-#include <algorithm>
-
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/components/view/propsConversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -23,15 +21,16 @@ HostPlatformViewProps::HostPlatformViewProps(
     const RawProps& rawProps)
     : BaseViewProps(context, sourceProps, rawProps),
       elevation(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.elevation
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "elevation",
-                                                       sourceProps.elevation,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.elevation
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "elevation",
+                    sourceProps.elevation,
+                    {})),
       nativeBackground(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.nativeBackground
               : convertRawProp(
                     context,
@@ -40,7 +39,7 @@ HostPlatformViewProps::HostPlatformViewProps(
                     sourceProps.nativeBackground,
                     {})),
       nativeForeground(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.nativeForeground
               : convertRawProp(
                     context,
@@ -49,15 +48,16 @@ HostPlatformViewProps::HostPlatformViewProps(
                     sourceProps.nativeForeground,
                     {})),
       focusable(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.focusable
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "focusable",
-                                                       sourceProps.focusable,
-                                                       {})),
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
+              ? sourceProps.focusable
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "focusable",
+                    sourceProps.focusable,
+                    {})),
       hasTVPreferredFocus(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.hasTVPreferredFocus
               : convertRawProp(
                     context,
@@ -66,7 +66,7 @@ HostPlatformViewProps::HostPlatformViewProps(
                     sourceProps.hasTVPreferredFocus,
                     {})),
       needsOffscreenAlphaCompositing(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.needsOffscreenAlphaCompositing
               : convertRawProp(
                     context,
@@ -75,7 +75,7 @@ HostPlatformViewProps::HostPlatformViewProps(
                     sourceProps.needsOffscreenAlphaCompositing,
                     {})),
       renderToHardwareTextureAndroid(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enablePropIteratorSetter()
               ? sourceProps.renderToHardwareTextureAndroid
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(react_render_core
         logger
         react_config
         react_debug
+        react_featureflags
         react_render_debug
         react_render_graphics
         react_render_mapbuffer

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include <react/debug/react_native_assert.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventDispatcher.h>
 #include <react/renderer/core/Props.h>
@@ -117,7 +118,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     // Use the new-style iterator
     // Note that we just check if `Props` has this flag set, no matter
     // the type of ShadowNode; it acts as the single global flag.
-    if (CoreFeatures::enablePropIteratorSetter) {
+    if (ReactNativeFeatureFlags::enablePropIteratorSetter()) {
       rawProps.iterateOverValues([&](RawPropsPropNameHash hash,
                                      const char* propName,
                                      const RawValue& fn) {

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
@@ -8,8 +8,8 @@
 #include "Props.h"
 
 #include <folly/dynamic.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/propsConversions.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -24,7 +24,7 @@ void Props::initialize(
     const PropsParserContext& context,
     const Props& sourceProps,
     const RawProps& rawProps) {
-  nativeId = CoreFeatures::enablePropIteratorSetter
+  nativeId = ReactNativeFeatureFlags::enablePropIteratorSetter()
       ? sourceProps.nativeId
       : convertRawProp(context, rawProps, "nativeID", sourceProps.nativeId, {});
 #ifdef ANDROID

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
@@ -9,7 +9,6 @@
 
 namespace facebook::react {
 
-bool CoreFeatures::enablePropIteratorSetter = false;
 bool CoreFeatures::cacheLastTextMeasurement = false;
 bool CoreFeatures::enableGranularScrollViewStateUpdatesIOS = false;
 bool CoreFeatures::enableMountHooks = false;

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
@@ -16,9 +16,6 @@ namespace facebook::react {
  */
 class CoreFeatures {
  public:
-  // Specifies whether the iterator-style prop parsing is enabled.
-  static bool enablePropIteratorSetter;
-
   // Yoga might measure multiple times the same Text with the same constraints
   // This flag enables a caching mechanism to avoid subsequents measurements
   // of the same Text with the same constrainst.

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -63,6 +63,11 @@ const definitions: FeatureFlagDefinitions = {
         'Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.',
       defaultValue: false,
     },
+    enablePropIteratorSetter: {
+      description:
+        'Specifies whether the iterator-style prop parsing is enabled.',
+      defaultValue: false,
+    },
   },
 
   jsOnly: {

--- a/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8509d5ee87efb5aa8da7efcd2085d0a2>>
+ * @generated SignedSource<<1bf5b6cc6e759b02ab3dafd28f98db2c>>
  * @flow strict-local
  */
 
@@ -33,6 +33,7 @@ export interface Spec extends TurboModule {
   +enableFixForClippedSubviewsCrash?: () => boolean;
   +inspectorEnableCxxInspectorPackagerConnection?: () => boolean;
   +inspectorEnableModernCDPRegistry?: () => boolean;
+  +enablePropIteratorSetter?: () => boolean;
 }
 
 const NativeReactNativeFeatureFlags: ?Spec = TurboModuleRegistry.get<Spec>(

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7c83d5613c3be517efe48378e6356e79>>
+ * @generated SignedSource<<702649b31fb7da1880fcc4e2b8b8e656>>
  * @flow strict-local
  */
 
@@ -50,6 +50,7 @@ export type ReactNativeFeatureFlags = {
   enableFixForClippedSubviewsCrash: Getter<boolean>,
   inspectorEnableCxxInspectorPackagerConnection: Getter<boolean>,
   inspectorEnableModernCDPRegistry: Getter<boolean>,
+  enablePropIteratorSetter: Getter<boolean>,
 }
 
 /**
@@ -132,6 +133,10 @@ export const inspectorEnableCxxInspectorPackagerConnection: Getter<boolean> = cr
  * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
  */
 export const inspectorEnableModernCDPRegistry: Getter<boolean> = createNativeFlagGetter('inspectorEnableModernCDPRegistry', false);
+/**
+ * Specifies whether the iterator-style prop parsing is enabled.
+ */
+export const enablePropIteratorSetter: Getter<boolean> = createNativeFlagGetter('enablePropIteratorSetter', false);
 
 /**
  * Overrides the feature flags with the provided methods.


### PR DESCRIPTION
Summary:
Changelog: [internal]

This feature flag is accessed through `CoreFeatures` but it's initialized a few different ways:
* Android: assigned via `ReactFeatureFlags`, which is overridden by apps.
* iOS: `ReactNativeConfig` that's mapped to a dynamic configuration.

This migrates the flag to the new feature flag system.

Differential Revision: D53755840

