### PR TITLE
refactor: remove source usages from getInspectorData

### DIFF
--- a/packages/react-native/Libraries/Inspector/ElementProperties.js
+++ b/packages/react-native/Libraries/Inspector/ElementProperties.js
@@ -12,12 +12,10 @@
 
 import type {InspectorData} from '../Renderer/shims/ReactNativeTypes';
 import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
-import type {InspectedElementSource} from './Inspector';
 
 const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
 const TouchableWithoutFeedback = require('../Components/Touchable/TouchableWithoutFeedback');
 const View = require('../Components/View/View');
-const openFileInEditor = require('../Core/Devtools/openFileInEditor');
 const flattenStyle = require('../StyleSheet/flattenStyle');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const Text = require('../Text/Text');
@@ -29,7 +27,6 @@ const React = require('react');
 type Props = $ReadOnly<{|
   hierarchy: ?InspectorData['hierarchy'],
   style?: ?ViewStyleProp,
-  source?: ?InspectedElementSource,
   frame?: ?Object,
   selection?: ?number,
   setSelection?: number => mixed,
@@ -39,22 +36,7 @@ class ElementProperties extends React.Component<Props> {
   render(): React.Node {
     const style = flattenStyle(this.props.style);
     const selection = this.props.selection;
-    let openFileButton;
-    const source = this.props.source;
-    const {fileName, lineNumber} = source || {};
-    if (fileName && lineNumber) {
-      const parts = fileName.split('/');
-      const fileNameShort = parts[parts.length - 1];
-      openFileButton = (
-        <TouchableHighlight
-          style={styles.openButton}
-          onPress={openFileInEditor.bind(null, fileName, lineNumber)}>
-          <Text style={styles.openButtonTitle} numberOfLines={1}>
-            {fileNameShort}:{lineNumber}
-          </Text>
-        </TouchableHighlight>
-      );
-    }
+
     // Without the `TouchableWithoutFeedback`, taps on this inspector pane
     // would change the inspected element to whatever is under the inspector
     return (
@@ -88,7 +70,6 @@ class ElementProperties extends React.Component<Props> {
           <View style={styles.row}>
             <View style={styles.col}>
               <StyleInspector style={style} />
-              {openFileButton}
             </View>
             {<BoxInspector style={style} frame={this.props.frame} />}
           </View>
@@ -133,17 +114,6 @@ const styles = StyleSheet.create({
   },
   info: {
     padding: 10,
-  },
-  openButton: {
-    padding: 10,
-    backgroundColor: '#000',
-    marginVertical: 5,
-    marginRight: 5,
-    borderRadius: 2,
-  },
-  openButtonTitle: {
-    color: 'white',
-    fontSize: 8,
   },
 });
 

--- a/packages/react-native/Libraries/Inspector/Inspector.js
+++ b/packages/react-native/Libraries/Inspector/Inspector.js
@@ -38,10 +38,8 @@ type SelectedTab =
   | 'performance-profiling';
 
 export type InspectedElementFrame = TouchedViewDataAtPoint['frame'];
-export type InspectedElementSource = InspectorData['source'];
 export type InspectedElement = $ReadOnly<{
   frame: InspectedElementFrame,
-  source?: InspectedElementSource,
   style?: ViewStyleProp,
 }>;
 export type ElementsHierarchy = InspectorData['hierarchy'];
@@ -74,14 +72,12 @@ function Inspector({
     }
 
     // We pass in findNodeHandle as the method is injected
-    const {measure, props, source} =
-      hierarchyItem.getInspectorData(findNodeHandle);
+    const {measure, props} = hierarchyItem.getInspectorData(findNodeHandle);
 
     measure((x, y, width, height, left, top) => {
       // $FlowFixMe[incompatible-call] `props` from InspectorData are defined as <string, string> dictionary, which is incompatible with ViewStyleProp
       setInspectedElement({
         frame: {left, top, width, height},
-        source,
         style: props.style,
       });
 
@@ -95,7 +91,6 @@ function Inspector({
         hierarchy,
         props,
         selectedIndex,
-        source,
         frame,
         pointerY,
         touchedViewTag,
@@ -120,7 +115,6 @@ function Inspector({
       // $FlowFixMe[incompatible-call] `props` from InspectorData are defined as <string, string> dictionary, which is incompatible with ViewStyleProp
       setInspectedElement({
         frame,
-        source,
         style: props.style,
       });
     };

--- a/packages/react-native/Libraries/Inspector/InspectorPanel.js
+++ b/packages/react-native/Libraries/Inspector/InspectorPanel.js
@@ -58,7 +58,6 @@ class InspectorPanel extends React.Component<Props> {
           <ElementProperties
             style={this.props.inspected.style}
             frame={this.props.inspected.frame}
-            source={this.props.inspected.source}
             hierarchy={this.props.hierarchy}
             selection={this.props.selection}
             setSelection={this.props.setSelection}

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4626,10 +4626,8 @@ declare module.exports: resolveAssetSource;
 exports[`public API should not change unintentionally Libraries/Inspector/Inspector.js 1`] = `
 "declare const React: $FlowFixMe;
 export type InspectedElementFrame = TouchedViewDataAtPoint[\\"frame\\"];
-export type InspectedElementSource = InspectorData[\\"source\\"];
 export type InspectedElement = $ReadOnly<{
   frame: InspectedElementFrame,
-  source?: InspectedElementSource,
   style?: ViewStyleProp,
 }>;
 export type ElementsHierarchy = InspectorData[\\"hierarchy\\"];


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Required for landing D53543159.

3 reasons for landing this:
1. Inspector is technically deprecated and will be removed once React DevTools are shipped with Chrome DevTools for RN debugging.
2. Long-term solution for source fetching is lazy loading based on component stacks - https://github.com/facebook/react/pull/28265
3. Although `source` field is accumulated and stored, it is not displayed anywhere, see InspectorOverlay.js.

Differential Revision: D53757524


