### PR TITLE
Cleanup ios_hermes:rn_heap_size_mb

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -148,18 +148,11 @@ std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
       ? reactNativeConfig->getInt64("ios_hermes:vm_experiment_flags")
       : 0;
 
-  int64_t heapSizeConfig = reactNativeConfig
-      ? reactNativeConfig->getInt64("ios_hermes:rn_heap_size_mb")
-      : 0;
-  // Default to 3GB if MobileConfigs is not available
-  auto heapSizeMB = heapSizeConfig > 0
-      ? static_cast<::hermes::vm::gcheapsize_t>(heapSizeConfig)
-      : 3072;
-
   ::hermes::vm::RuntimeConfig::Builder runtimeConfigBuilder =
       ::hermes::vm::RuntimeConfig::Builder()
           .withGCConfig(::hermes::vm::GCConfig::Builder()
-                            .withMaxHeapSize(heapSizeMB << 20)
+                            // Default to 3GB
+                            .withMaxHeapSize(3072 << 20)
                             .withName("RNBridgeless")
                             // For the next two arguments: avoid GC before TTI
                             // by initializing the runtime to allocate directly


### PR DESCRIPTION
Summary: Unused mobile config, and is not consistently used across all the many places we can initialize a Hermes instance.

Differential Revision: D53761942


