### PR TITLE
[Android] Update ColorPropConverterto support color function values

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java
@@ -9,7 +9,10 @@ package com.facebook.react.bridge;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.graphics.Color;
+import android.graphics.ColorSpace;
 import android.util.TypedValue;
+import androidx.annotation.ColorLong;
 import androidx.annotation.Nullable;
 import androidx.core.content.res.ResourcesCompat;
 import com.facebook.common.logging.FLog;
@@ -24,13 +27,13 @@ public class ColorPropConverter {
   private static final String ATTR = "attr";
   private static final String ATTR_SEGMENT = "attr/";
 
-  public static Integer getColor(Object value, Context context) {
+  public static Color getColorInstance(Object value, Context context) {
     if (value == null) {
       return null;
     }
 
     if (value instanceof Double) {
-      return ((Double) value).intValue();
+      return Color.valueOf(((Double) value).intValue());
     }
 
     if (context == null) {
@@ -39,6 +42,22 @@ public class ColorPropConverter {
 
     if (value instanceof ReadableMap) {
       ReadableMap map = (ReadableMap) value;
+
+      // handle color(space r g b a) value
+      if (map.hasKey("space")) {
+        String rawColorSpace = map.getString("space");
+        boolean isDisplayP3 = rawColorSpace.equals("display-p3");
+        ColorSpace space = ColorSpace.get(isDisplayP3 ? ColorSpace.Named.DISPLAY_P3 : ColorSpace.Named.SRGB);
+        float r = (float) map.getDouble("r");
+        float g = (float) map.getDouble("g");
+        float b = (float) map.getDouble("b");
+        float a = (float) map.getDouble("a");
+
+        @ColorLong
+        long color = Color.pack(r, g, b, a, space);
+        return Color.valueOf(color);
+      }
+
       ReadableArray resourcePaths = map.getArray(JSON_KEY);
 
       if (resourcePaths == null) {
@@ -49,7 +68,7 @@ public class ColorPropConverter {
       for (int i = 0; i < resourcePaths.size(); i++) {
         Integer result = resolveResourcePath(context, resourcePaths.getString(i));
         if (result != null) {
-          return result;
+          return Color.valueOf(result);
         }
       }
 
@@ -61,6 +80,14 @@ public class ColorPropConverter {
 
     throw new JSApplicationCausedNativeException(
         "ColorValue: the value must be a number or Object.");
+  }
+
+  public static Integer getColor(Object value, Context context) {
+    Color color = getColorInstance(value, context);
+    if (color == null) {
+      return null;
+    }
+    return color.toArgb();
   }
 
   public static Integer getColor(Object value, Context context, int defaultInt) {
@@ -89,8 +116,9 @@ public class ColorPropConverter {
         return resolveThemeAttribute(context, resourcePath);
       }
     } catch (Resources.NotFoundException exception) {
-      // The resource could not be found so do nothing to allow the for loop to continue and
-      // try the next fallback resource in the array.  If none of the fallbacks are
+      // The resource could not be found so do nothing to allow the for loop to
+      // continue and
+      // try the next fallback resource in the array. If none of the fallbacks are
       // found then the exception immediately after the for loop will be thrown.
     }
     return null;


### PR DESCRIPTION
## Summary:

This adds support for color function values to ColorPropConverter per the wide gamut color [RFC](https://github.com/react-native-community/discussions-and-proposals/pull/738). It updates the color conversion code so that it returns a Color instance before ultimately being converted to an Integer in preparation for returning long values as needed.

## Changelog:

[ANDROID] [ADDED] - Update ColorPropConverter to support color function values

## Test Plan:

Colors should work exactly the same as before.

Follow test steps from https://github.com/facebook/react-native/pull/42831 to test support for color() function syntax.

While colors specified with color() function syntax will not yet render in DisplayP3 color space they will not be misrecognized as resource path colors but will instead fallback to their sRGB color space values.
