### PR TITLE
fix nightlies dont exit early

### DIFF
--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -89,7 +89,6 @@ async function publishMonorepoPackages(tag /*: ?string */) {
       exit(1);
     } else {
       echo(`Published ${spec} to npm`);
-      exit(0);
     }
   }
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal] - We early-exited because of poor copy-pasta and the fact that our tests don't properly emulate the behavior of mock `exit`

Will try and clean this up in next diff but want to quickly fix so it unbreaks nightlies

Reviewed By: yungsters

Differential Revision: D53779109


