### PR TITLE
[Android] Add isWideColorGamutEnabled to ReactActivityDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -10,9 +10,11 @@ package com.facebook.react;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.KeyEvent;
+import android.view.Window;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Callback;
@@ -98,6 +100,9 @@ public class ReactActivityDelegate {
   public void onCreate(Bundle savedInstanceState) {
     String mainComponentName = getMainComponentName();
     final Bundle launchOptions = composeLaunchOptions();
+    if (isWideColorGamutEnabled()) {
+      mActivity.getWindow().setColorMode(ActivityInfo.COLOR_MODE_WIDE_COLOR_GAMUT);
+    }
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
       mReactDelegate =
           new ReactDelegate(getPlainActivity(), getReactHost(), mainComponentName, launchOptions);
@@ -208,5 +213,14 @@ public class ReactActivityDelegate {
    */
   protected boolean isFabricEnabled() {
     return ReactFeatureFlags.enableFabricRenderer;
+  }
+
+  /**
+   * Override this method if you wish to selectively toggle wide color gamut for a specific surface.
+   *
+   * @return true if wide gamut is enabled for this Activity, false otherwise.
+   */
+  protected boolean isWideColorGamutEnabled() {
+    return false;
   }
 }


### PR DESCRIPTION
## Summary:

This adds support for enabling wide color gamut mode for ReactActivity per the wide gamut color [RFC](https://github.com/react-native-community/discussions-and-proposals/pull/738). 

## Changelog:

[ANDROID] [ADDED] - Add isWideColorGamutEnabled to ReactActivityDelegate

## Test Plan:

Update RNTesterActivity.kt to enable wide color gamut:

```diff
  class RNTesterActivity : ReactActivity() {
    class RNTesterActivityDelegate(val activity: ReactActivity, mainComponentName: String) :
      // ...  
      override fun getLaunchOptions() =
          if (this::initialProps.isInitialized) initialProps else Bundle()
  
+     override fun isWideColorGamutEnabled() = true
    }
```