### PR TITLE
Remove process.exit calls and throw exception instead

### DIFF
--- a/scripts/releases/utils/__tests__/version-utils-test.js
+++ b/scripts/releases/utils/__tests__/version-utils-test.js
@@ -51,6 +51,7 @@ describe('version-utils', () => {
         `"Unsupported build type: invalid_build_type"`,
       );
     });
+
     it('should throw error if invalid match with release', () => {
       function testInvalidVersion() {
         parseVersion('<invalid version>', 'release');
@@ -59,6 +60,7 @@ describe('version-utils', () => {
         `"You must pass a correctly formatted version; couldn't parse <invalid version>"`,
       );
     });
+
     it('should throw error if invalid match with dry-run', () => {
       function testInvalidVersion() {
         parseVersion('<invalid version>', 'dry-run');
@@ -351,6 +353,12 @@ describe('version-utils', () => {
 
       expect(testInvalidFunction).toThrowErrorMatchingInlineSnapshot(
         '"Version 1.0.0-2023100416 is not valid for prealphas"',
+      );
+    });
+
+    it('should reject stable releases with major > 0', () => {
+      expect(() => parseVersion('1.0.1', 'release')).toThrow(
+        'Version 1.0.1 is not valid for Release',
       );
     });
   });


### PR DESCRIPTION
Summary:
Changelog: [Internal] - `publish-npm.js` is a [script we call in our CI](https://www.internalfb.com/code/fbsource/[c0b8566ac0d66c2c0282eeb597bfb54bedf757c6]/xplat/js/react-native-github/.circleci/configurations/jobs.yml?lines=1243) to publish the react-native package and others.

Currently, the script leverages `exit/process.exit` to terminate early in a couple of places which makes the code hard to test because our tests don't truly early exit when `exit/process.exit` is called.

This change removes any explicit `exit` calls and instead leverages the uncaught error to terminate the process and set the non-zero exit code. This makes our tests more accurate to the real control flow of the script.

I've also updated the tests to better capture what we're actually testing by mocking at a higher level.

Differential Revision: D53792754


