### PR TITLE
Remove release-branch-cutoff from yarn bump-all-updated-packages

### DIFF
--- a/scripts/monorepo/bump-all-updated-packages/index.js
+++ b/scripts/monorepo/bump-all-updated-packages/index.js
@@ -27,18 +27,8 @@ const {execSync} = require('child_process');
 const inquirer = require('inquirer');
 const path = require('path');
 const {echo, exec, exit} = require('shelljs');
-const yargs = require('yargs');
 
 const ROOT_LOCATION = path.join(__dirname, '..', '..', '..');
-
-const {
-  argv: {releaseBranchCutoff},
-} = yargs
-  .option('release-branch-cutoff', {
-    type: 'boolean',
-    describe: 'Should force bump minor version for each public package',
-  })
-  .strict();
 
 const buildExecutor =
   (packageAbsolutePath, packageRelativePathFromRoot, packageManifest) =>
@@ -46,21 +36,6 @@ const buildExecutor =
     const {name: packageName} = packageManifest;
     if (packageManifest.private) {
       echo(`\u23ED Skipping private package ${chalk.dim(packageName)}`);
-
-      return;
-    }
-
-    if (releaseBranchCutoff) {
-      const updatedVersion = bumpPackageVersion(
-        packageAbsolutePath,
-        packageManifest,
-        'minor',
-      );
-      echo(
-        `\u2705 Successfully bumped ${chalk.green(
-          packageName,
-        )} to ${chalk.green(updatedVersion)}`,
-      );
 
       return;
     }


### PR DESCRIPTION
Summary: Changelog: [Internal] Remove release-branch-cutoff option as its been replaced by `yarn set-version --skip-react-native-version`

Differential Revision: D53742450


