### PR TITLE
Fix forwarding touches to components in the Interop Layer

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -46,7 +46,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   UIView *result = [super hitTest:point withEvent:event];
 
   if (result == _adapter.paperView) {
-    return self;
+    return _adapter.paperView;
   }
 
   return result;


### PR DESCRIPTION
Summary:
When analyzing the `hitTest:withEvent` function, I realized that we were not forwarding the touches to the legacy view.

The previous algorithm was returning the InteropLegacyWrapper view itself when the touches were happening in the legacy view, preventing the handlers attached to the legacy view to fire.

With this change, if the legacy view receives a touch, it can handle it.

Differential Revision: D53806218


