### PR TITLE
fix Cannot read properties of undefined (reading __REACT_DEVTOOLS_GLO…

### DIFF
--- a/Libraries/ReactNative/AppContainer.js
+++ b/Libraries/ReactNative/AppContainer.js
@@ -17,7 +17,8 @@ import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import {RootTagContext, createRootTag} from './RootTag';
 import * as React from 'react';
 
-const reactDevToolsHook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+const reactDevToolsHook = 
+window?.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 
 type Props = $ReadOnly<{|
   children?: React.Node,


### PR DESCRIPTION
…BAL_HOOK__)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
After upgrading RN to new version my tests are broken. I found [problem](https://github.com/facebook/react-native/pull/38784) :)
This is just small improvement but this would help

```Cannot read properties of undefined (reading '__REACT_DEVTOOLS_GLOBAL_HOOK__')```

small example from jest test:
<img width="749" alt="Screenshot 2024-02-15 at 17 04 15" src="https://github.com/facebook/react-native/assets/5881611/409cb30f-6b92-4c82-9fb4-ce5097beb32c">

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v07113

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->


