### PR TITLE
add 'unset' to DimensionValue type

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -21,6 +21,7 @@ type FlexAlignType =
 export type DimensionValue =
   | number
   | 'auto'
+  | 'unset'
   | `${number}%`
   | Animated.AnimatedNode
   | null;


### PR DESCRIPTION
## Summary:

Adds the `unset` property for DimensionValue type as it works.

## Test plan:

Create a component button with a height of 56 for example, and pass it style props. When using that component, send styles in the styles prop with a height of `unset`. Produces no errors on both iOS and Android.