### PR TITLE
Relocate run-ci-e2e-tests script, add Flow

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -167,7 +167,7 @@ commands:
     steps:
       - run:
           name: "Run Tests: << parameters.platform >> End-to-End Tests"
-          command: node ./scripts/run-ci-e2e-tests.js --<< parameters.platform >> --retries << parameters.retries >>
+          command: node ./scripts/e2e/run-ci-e2e-tests.js --<< parameters.platform >> --retries << parameters.retries >>
 
   report_bundle_size:
     parameters:

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -360,7 +360,7 @@ jobs:
           command: |
             REPO_ROOT=$(pwd)
             node ./scripts/releases/update-template-package.js "{\"react-native\":\"file:$REPO_ROOT/build/$(cat build/react-native-package-version)\"}"
-            node ./scripts/template/initialize.js --projectName $PROJECT_NAME --templatePath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME" --verbose
+            node ./scripts/e2e/init-template-e2e.js --projectName $PROJECT_NAME --templatePath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME" --verbose
       - with_gradle_cache:
           steps:
             - run:
@@ -458,7 +458,7 @@ jobs:
             PACKAGE=$(cat build/react-native-package-version)
             PATH_TO_PACKAGE="$REPO_ROOT/build/$PACKAGE"
             node ./scripts/releases/update-template-package.js "{\"react-native\":\"file:$PATH_TO_PACKAGE\"}"
-            node ./scripts/template/initialize.js --projectName $PROJECT_NAME --templatePath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME" --verbose
+            node ./scripts/e2e/init-template-e2e.js --projectName $PROJECT_NAME --templatePath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME" --verbose
       - with_xcodebuild_cache:
           podfile_lock_path: << parameters.podfile_lock_path >>
           pods_build_folder: << parameters.pods_build_folder >>

--- a/.gitignore
+++ b/.gitignore
@@ -155,4 +155,3 @@ vendor/
 
 # CircleCI
 .circleci/generated_config.yml
-.circleci/storage

--- a/scripts/e2e/init-template-e2e.js
+++ b/scripts/e2e/init-template-e2e.js
@@ -17,7 +17,7 @@ const {
   VERDACCIO_SERVER_URL,
   VERDACCIO_STORAGE_PATH,
   setupVerdaccio,
-} = require('./setup-verdaccio');
+} = require('./utils/verdaccio');
 const {parseArgs} = require('@pkgjs/parseargs');
 const chalk = require('chalk');
 const {execSync} = require('child_process');
@@ -42,7 +42,7 @@ async function main() {
 
   if (help) {
     console.log(`
-  Usage: node ./scripts/template/initialize.js [OPTIONS]
+  Usage: node ./scripts/e2e/init-template-e2e.js [OPTIONS]
 
   Bootstraps and runs \`react-native init\`, using the currently checked out
   repository as the source of truth for the react-native package and

--- a/scripts/e2e/utils/try-n-times.js
+++ b/scripts/e2e/utils/try-n-times.js
@@ -4,20 +4,20 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  * @format
+ * @oncall react_native
  */
-
-'use strict';
 
 /**
- * Try executing a function n times recursively.
- * Return 0 the first time it succeeds
- * Return code of the last failed commands if not more retries left
- * @funcToRetry - function that gets retried
- * @retriesLeft - number of retries to execute funcToRetry
- * @onEveryError - func to execute if funcToRetry returns non 0
+ * Try executing a function n times recursively. Logs a warning message between
+ * each retry.
  */
-function tryExecNTimes(funcToRetry, retriesLeft, onEveryError) {
+function tryExecNTimes(
+  funcToRetry /*: () => number */,
+  retriesLeft /*: number */,
+  onEveryError /*: ?(() => mixed) */,
+) /*: number */ {
   const exitCode = funcToRetry();
   if (exitCode === 0) {
     return exitCode;

--- a/scripts/e2e/utils/verdaccio.js
+++ b/scripts/e2e/utils/verdaccio.js
@@ -15,18 +15,16 @@ const {execSync, spawn} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const REPO_ROOT = path.join(__dirname, '../..');
+const REPO_ROOT = path.join(__dirname, '../../..');
 const NPM_CONFIG_PATH = path.join(REPO_ROOT, '.npmrc');
-
-// TODO(huntie): Relocate (used by both local and CI scripts)
-const VERDACCIO_CONFIG_PATH = `${REPO_ROOT}/.circleci/verdaccio.yml`;
-const VERDACCIO_STORAGE_PATH = `${REPO_ROOT}/.circleci/storage`;
+const VERDACCIO_CONFIG_PATH = path.join(__dirname, '..', 'verdaccio.yml');
+const VERDACCIO_STORAGE_PATH = '/tmp/verdaccio';
 const VERDACCIO_SERVER_URL = 'http://localhost:4873';
 
 /**
  * Configure and run a local Verdaccio server. This is an npm proxy that can be
  * used with `npm publish` and `npm install`, configured in
- * `.circleci/verdaccio.yml`.
+ * `scripts/e2e/verdaccio.yml`.
  */
 function setupVerdaccio() /*: number */ {
   const {host} = new URL(VERDACCIO_SERVER_URL);

--- a/scripts/e2e/verdaccio.yml
+++ b/scripts/e2e/verdaccio.yml
@@ -1,4 +1,4 @@
-storage: ./storage
+storage: /tmp/verdaccio
 auth:
   htpasswd:
     file: ./htpasswd

--- a/scripts/release-testing/test-e2e-local-clean.js
+++ b/scripts/release-testing/test-e2e-local-clean.js
@@ -29,7 +29,7 @@
  *   - an option to uninstall the apps (RNTester, RNTestProject) from emulators
  */
 
-const {VERDACCIO_STORAGE_PATH} = require('../template/setup-verdaccio');
+const {VERDACCIO_STORAGE_PATH} = require('../e2e/utils/verdaccio');
 const {isPackagerRunning} = require('./utils/testing-utils');
 const {exec, exit} = require('shelljs');
 

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -17,8 +17,8 @@
  * and to make it more accessible for other devs to play around with.
  */
 
+const {initNewProjectFromSource} = require('../e2e/init-template-e2e');
 const updateTemplatePackage = require('../releases/update-template-package');
-const {initNewProjectFromSource} = require('../template/initialize');
 const {
   checkPackagerRunning,
   launchPackagerInSeparateWindow,

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -19,8 +19,8 @@
  * --retries [num] - how many times to retry possible flaky commands: yarn add and running tests, default 1
  */
 
+const {setupVerdaccio} = require('./e2e/utils/verdaccio');
 const forEachPackage = require('./monorepo/for-each-package');
-const {setupVerdaccio} = require('./template/setup-verdaccio');
 const tryExecNTimes = require('./try-n-times');
 const {execFileSync, spawn} = require('child_process');
 const fs = require('fs');


### PR DESCRIPTION
Summary:
- Relocate under `scripts/e2e/` (also move util used only by this cript).
- Type as Flow (to catch trivial errors). Some cleanup of `log()` calls as errors.

Changelog: [Internal]

Reviewed By: lunaleaps

Differential Revision: D53813023
