### PR TITLE
cxx module autolinking without codegen

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/CxxTurboModuleUtils.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/CxxTurboModuleUtils.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CxxTurboModuleUtils.h"
+
+namespace facebook::react {
+
+std::unordered_map<
+    std::string,
+    std::function<
+        std::shared_ptr<TurboModule>(std::shared_ptr<CallInvoker> jsInvoker)>>&
+cxxTurboModuleMap() {
+  static std::unordered_map<
+      std::string,
+      std::function<std::shared_ptr<TurboModule>(
+          std::shared_ptr<CallInvoker> jsInvoker)>>
+      map;
+  return map;
+}
+
+void registerCxxModule(
+    std::string name,
+    std::function<std::shared_ptr<TurboModule>(
+        std::shared_ptr<CallInvoker> jsInvoker)> moduleProviderFunc) {
+  cxxTurboModuleMap()[name] = moduleProviderFunc;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/CxxTurboModuleUtils.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/CxxTurboModuleUtils.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <string>
+#include <unordered_map>
+
+#include <jsi/jsi.h>
+
+#include <ReactCommon/CallInvoker.h>
+#include <ReactCommon/CallbackWrapper.h>
+#include <ReactCommon/TurboModule.h>
+
+namespace facebook::react {
+
+std::unordered_map<
+    std::string,
+    std::function<
+        std::shared_ptr<TurboModule>(std::shared_ptr<CallInvoker> jsInvoker)>>&
+cxxTurboModuleMap();
+
+void registerCxxModule(
+    std::string name,
+    std::function<std::shared_ptr<TurboModule>(
+        std::shared_ptr<CallInvoker> jsInvoker)> moduleProviderFunc);
+
+} // namespace facebook::react
+
+#define RCT_EXPORT_CXX_MODULE_EXPERIMENTAL(name)                           \
+  _Pragma("clang diagnostic push")                                         \
+      _Pragma("clang diagnostic ignored \"-Wglobal-constructors\"") struct \
+      name##Load {                                                         \
+    name##Load() {                                                         \
+      facebook::react::registerCxxModule(                                  \
+          #name,                                                           \
+          [&](std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {   \
+            return std::make_shared<facebook::react::name>(jsInvoker);     \
+          });                                                              \
+    }                                                                      \
+  };                                                                       \
+  static name##Load _##name##Load;                                \
+  _Pragma("clang diagnostic pop")
+
+// RCT_EXPORT_CXX_MODULE(NativeCxxModuleExample) turns into the following:
+// #pragma clang diagnostic push
+// #pragma clang diagnostic ignored "-Wglobal-constructors"
+// struct NativeCxxModuleExampleLoad {
+//   NativeCxxModuleExampleLoad() {
+//       facebook::react::registerCxxModule(name,
+//       [&](std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
+//         return
+//         std::make_shared<facebook::react::NativeCxxModuleExample>(jsInvoker);
+//     });
+//   }
+// };
+// constexpr static NativeCxxModuleExampleLoad nativeCxxModuleExampleLoad;
+// #pragma clang diagnostic pop

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -27,6 +27,7 @@
 #import <React/RCTPerformanceLogger.h>
 #import <React/RCTRuntimeExecutorModule.h>
 #import <React/RCTUtils.h>
+#import <ReactCommon/CxxTurboModuleUtils.h>
 #import <ReactCommon/TurboCxxModule.h>
 #import <ReactCommon/TurboModulePerfLogger.h>
 #import <ReactCommon/TurboModuleUtils.h>
@@ -323,6 +324,14 @@ static Class getFallbackClassFromName(const char *name)
     }
 
     TurboModulePerfLogger::moduleCreateFail(moduleName, moduleId);
+  }
+
+  auto cxxTurboModuleMapProvider = cxxTurboModuleMap();
+  auto it = cxxTurboModuleMapProvider.find(moduleName);
+  if (it != cxxTurboModuleMapProvider.end()) {
+    auto turboModule = it->second(_jsInvoker);
+    _turboModuleCache.insert({moduleName, turboModule});
+    return turboModule;
   }
 
   /**


### PR DESCRIPTION
Summary:

Changelog: [iOS][Added] Experimental macro to autolink C++ turbomodules

this implementation is inspired by RCT_EXPORT_MODULE, we keep a global data structure that maps module names to a lambda that returns the C++ turbomodule. this will come with a hit to startup time. the only way to avoid that is a codegen solution.

this is a temporary solution because we don't have a proper autolinking solution for ios modules that doesn't require changes in the app layer.

there's still a catch here, because the static can still get compiled out if the compiler thinks the file is not being used. so potentially the framework / app using this will have to have a dummy file that links the c++ turbomodule files. i'm not sure if this is really an acceptable experience or not, but it would avoid a change in app userland.

Differential Revision: D53602544


