### PR TITLE
feat(iOS): add RCTUIInterfaceOrientation method and remove usage of statusBarOrientation

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -95,6 +95,9 @@ RCT_EXTERN UIApplication *__nullable RCTSharedApplication(void);
 // or view controller
 RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
 
+//Returns current window interface orientation
+RCT_EXTERN UIInterfaceOrientation RCTUIInterfaceOrientation(void);
+
 // Returns the presented view controller, useful if you need
 // e.g. to present a modal view controller or alert over it
 RCT_EXTERN UIViewController *__nullable RCTPresentedViewController(void);

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -579,6 +579,11 @@ UIWindow *__nullable RCTKeyWindow(void)
   return nil;
 }
 
+UIInterfaceOrientation RCTUIInterfaceOrientation(void) 
+{
+  return RCTKeyWindow().windowScene.interfaceOrientation;
+}
+
 UIStatusBarManager *__nullable RCTUIStatusBarManager(void)
 {
   return RCTKeyWindow().windowScene.statusBarManager;

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -52,7 +52,7 @@ RCT_EXPORT_MODULE()
                                                name:RCTAccessibilityManagerDidUpdateMultiplierNotification
                                              object:[_moduleRegistry moduleForName:"AccessibilityManager"]];
 
-  _currentInterfaceOrientation = [RCTSharedApplication() statusBarOrientation];
+  _currentInterfaceOrientation = RCTUIInterfaceOrientation();
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceOrientationDidChange)
@@ -210,7 +210,7 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 - (void)_interfaceOrientationDidChange
 {
   UIApplication *application = RCTSharedApplication();
-  UIInterfaceOrientation nextOrientation = [application statusBarOrientation];
+  UIInterfaceOrientation nextOrientation = RCTUIInterfaceOrientation();
 
   BOOL isRunningInFullScreen =
       CGRectEqualToRect(application.delegate.window.frame, application.delegate.window.screen.bounds);

--- a/packages/react-native/React/Views/RCTModalHostView.m
+++ b/packages/react-native/React/Views/RCTModalHostView.m
@@ -76,7 +76,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     return;
   }
 
-  UIInterfaceOrientation currentOrientation = [RCTSharedApplication() statusBarOrientation];
+  UIInterfaceOrientation currentOrientation = RCTUIInterfaceOrientation();
   if (currentOrientation == _lastKnownOrientation) {
     return;
   }


### PR DESCRIPTION
## Summary:

This PR removes usage of deprecated `statusBarOrientation` method in `RCTDeviceInfo` and `RCTModalHostView` for retrieving interface orientation and adds `RCTUIInterfaceOrientation` helper method to get orientation from window scene instead.

## Changelog:

[IOS] [REMOVED] - Remove usage of deprecated statusBarOrientation method
[IOS] [ADDED] - Add RCTUIInterfaceOrientation helper method

## Test Plan:

`RNTester` builds and runs successfully
