### PR TITLE
fix(iOS): remove deprecated method from RCTPerfMonitor & fix position

### DIFF
--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -447,7 +447,8 @@ RCT_EXPORT_MODULE()
 {
   [self loadPerformanceLoggerData];
   if (CGRectIsEmpty(_storedMonitorFrame)) {
-    _storedMonitorFrame = CGRectMake(0, 20, self.container.window.frame.size.width, RCTPerfMonitorExpandHeight);
+    UIEdgeInsets safeInsets = RCTKeyWindow().safeAreaInsets;
+    _storedMonitorFrame = CGRectMake(safeInsets.left, safeInsets.top, self.container.window.frame.size.width, RCTPerfMonitorExpandHeight);
     [self.container addSubview:self.metrics];
   } else {
     [_metrics reloadData];

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -171,15 +171,13 @@ RCT_EXPORT_MODULE()
 - (UIView *)container
 {
   if (!_container) {
-    CGSize statusBarSize = RCTUIStatusBarManager().statusBarFrame.size;
-    CGFloat statusBarHeight = statusBarSize.height;
-    _container = [[UIView alloc] initWithFrame:CGRectMake(10, statusBarHeight, 180, RCTPerfMonitorBarHeight)];
+    UIEdgeInsets safeInsets = RCTKeyWindow().safeAreaInsets;
+      
+    _container = [[UIView alloc] initWithFrame:CGRectMake(safeInsets.left, safeInsets.top, 180, RCTPerfMonitorBarHeight)];
     _container.layer.borderWidth = 2;
     _container.layer.borderColor = [UIColor lightGrayColor].CGColor;
     [_container addGestureRecognizer:self.gestureRecognizer];
     [_container addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap)]];
-
-    _container.backgroundColor = [UIColor whiteColor];
 
     _container.backgroundColor = [UIColor systemBackgroundColor];
   }


### PR DESCRIPTION
## Summary:

This PR removes usage of deprecated `statusBarFrame` method in `RCTPerfMonitor` . Instead `RCTPerfMonitor` now uses `safeAreaInsets` which also fixes issue causing Perf Monitor to appear under corner in landscape mode on e.g. `iPhone 15 Pro`. It also fixes initial position of expanded state which was causing it to render under notch.

Also removed duplicate background color setting

## Changelog:
[IOS] [REMOVED] - Remove usage of deprecated statusBarFrame method
[IOS] [FIXED] - Fix position of RCTPerfMonitor in landscape mode & expanded mode

## Test Plan:

`RNTester` builds and runs successfully, `RCTPerfMonitor` works and displays correctly