### PR TITLE
Assign auto-incrementing execution context IDs

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
@@ -38,7 +38,10 @@ double JSExecutor::performanceNow() {
 std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
 JSExecutor::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
-    jsinspector_modern::SessionState& sessionState) {
+    jsinspector_modern::SessionState& sessionState,
+    const jsinspector_modern::ExecutionContextDescription&
+        executionContextDescription) {
+  (void)executionContextDescription;
   return std::make_unique<jsinspector_modern::FallbackRuntimeAgentDelegate>(
       std::move(frontendChannel), sessionState, getDescription());
 }

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
@@ -146,7 +146,9 @@ class RN_EXPORT JSExecutor : public jsinspector_modern::RuntimeTargetDelegate {
   virtual std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
   createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
-      jsinspector_modern::SessionState& sessionState) override;
+      jsinspector_modern::SessionState& sessionState,
+      const jsinspector_modern::ExecutionContextDescription&
+          executionContextDescription) override;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -260,12 +260,15 @@ HermesExecutor::HermesExecutor(
 std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
 HermesExecutor::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
-    jsinspector_modern::SessionState& sessionState) {
+    jsinspector_modern::SessionState& sessionState,
+    const jsinspector_modern::ExecutionContextDescription&
+        executionContextDescription) {
   std::shared_ptr<HermesRuntime> hermesRuntimeShared(runtime_, &hermesRuntime_);
   return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
       new jsinspector_modern::HermesRuntimeAgentDelegate(
           frontendChannel,
           sessionState,
+          executionContextDescription,
           hermesRuntimeShared,
           [jsQueueWeak = std::weak_ptr(jsQueue_),
            runtimeWeak = std::weak_ptr(runtime_)](auto fn) {

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -57,7 +57,9 @@ class HermesExecutor : public JSIExecutor {
   virtual std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
   createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
-      jsinspector_modern::SessionState& sessionState) override;
+      jsinspector_modern::SessionState& sessionState,
+      const jsinspector_modern::ExecutionContextDescription&
+          executionContextDescription) override;
 
  private:
   JSIScopedTimeoutInvoker timeoutInvoker_;

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h
@@ -26,6 +26,10 @@ class HermesRuntimeAgentDelegate : public RuntimeAgentDelegate {
    * \param sessionState The state of the current CDP session. This will only
    * be accessed on the main thread (during the constructor, in handleRequest,
    * etc).
+   * \param executionContextDescription A description of the execution context
+   * represented by this runtime. This is used for disambiguating the
+   * source/destination of CDP messages when there are multiple runtimes
+   * (concurrently or over the life of a Page).
    * \param runtime The HermesRuntime that this agent is attached to.
    * \param runtimeExecutor A callback for scheduling work on the JS thread.
    * \c runtimeExecutor may drop scheduled work if the runtime is destroyed
@@ -34,6 +38,7 @@ class HermesRuntimeAgentDelegate : public RuntimeAgentDelegate {
   HermesRuntimeAgentDelegate(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
+      const ExecutionContextDescription& executionContextDescription,
       std::shared_ptr<hermes::HermesRuntime> runtime,
       RuntimeExecutor runtimeExecutor);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cinttypes>
+#include <optional>
+#include <string>
+
+namespace facebook::react::jsinspector_modern {
+
+struct ExecutionContextDescription {
+  int32_t id{};
+  std::string origin{""};
+  std::string name{"<anonymous>"};
+  std::optional<std::string> uniqueId;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContextManager.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContextManager.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ExecutionContextManager.h"
+
+#include <cassert>
+
+namespace facebook::react::jsinspector_modern {
+
+int32_t ExecutionContextManager::allocateExecutionContextId() {
+  assert(nextExecutionContextId_ != INT32_MAX);
+  return nextExecutionContextId_++;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContextManager.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContextManager.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cinttypes>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Generates unique execution context IDs.
+ */
+class ExecutionContextManager {
+ public:
+  int32_t allocateExecutionContextId();
+
+ private:
+  int32_t nextExecutionContextId_{1};
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -55,6 +55,8 @@ class InstanceAgent final {
   void setCurrentRuntime(RuntimeTarget* runtime);
 
  private:
+  void maybeSendExecutionContextCreatedNotification();
+
   FrontendChannel frontendChannel_;
   InstanceTarget& target_;
   std::shared_ptr<RuntimeAgent> runtimeAgent_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -50,7 +50,15 @@ RuntimeTarget& InstanceTarget::registerRuntime(
     RuntimeExecutor jsExecutor) {
   assert(!currentRuntime_ && "Only one Runtime allowed");
   currentRuntime_ = RuntimeTarget::create(
-      delegate, jsExecutor, makeVoidExecutor(executorFromThis()));
+      ExecutionContextDescription{
+          // TODO: IDs should be unique within the current Page.
+          .id = 1,
+          .origin = "",
+          .name = "main",
+          .uniqueId = std::nullopt},
+      delegate,
+      jsExecutor,
+      makeVoidExecutor(executorFromThis()));
 
   agents_.forEach([currentRuntime = &*currentRuntime_](InstanceAgent& agent) {
     agent.setCurrentRuntime(currentRuntime);

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "ExecutionContextManager.h"
 #include "RuntimeTarget.h"
 #include "ScopedExecutor.h"
 #include "SessionState.h"
@@ -46,6 +47,7 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
  public:
   /**
    * Constructs a new InstanceTarget.
+   * \param executionContextManager Assigns unique execution context IDs.
    * \param delegate The object that will receive events from this target.
    * The caller is responsible for ensuring that the delegate outlives this
    * object.
@@ -54,6 +56,7 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
    * executor will not be called after the InstanceTarget is destroyed.
    */
   static std::shared_ptr<InstanceTarget> create(
+      std::shared_ptr<ExecutionContextManager> executionContextManager,
       InstanceTargetDelegate& delegate,
       VoidExecutor executor);
 
@@ -76,15 +79,19 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
   /**
    * Constructs a new InstanceTarget. The caller must call setExecutor
    * immediately afterwards.
+   * \param executionContextManager Assigns unique execution context IDs.
    * \param delegate The object that will receive events from this target.
    * The caller is responsible for ensuring that the delegate outlives this
    * object.
    */
-  InstanceTarget(InstanceTargetDelegate& delegate);
+  InstanceTarget(
+      std::shared_ptr<ExecutionContextManager> executionContextManager,
+      InstanceTargetDelegate& delegate);
 
   InstanceTargetDelegate& delegate_;
   std::shared_ptr<RuntimeTarget> currentRuntime_{nullptr};
   WeakList<InstanceAgent> agents_;
+  std::shared_ptr<ExecutionContextManager> executionContextManager_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.cpp
@@ -107,7 +107,9 @@ std::shared_ptr<PageTarget> PageTarget::create(
   return pageTarget;
 }
 
-PageTarget::PageTarget(PageTargetDelegate& delegate) : delegate_(delegate) {}
+PageTarget::PageTarget(PageTargetDelegate& delegate)
+    : delegate_(delegate),
+      executionContextManager_{std::make_shared<ExecutionContextManager>()} {}
 
 std::unique_ptr<ILocalConnection> PageTarget::connect(
     std::unique_ptr<IRemoteConnection> connectionToFrontend,
@@ -132,8 +134,8 @@ PageTargetDelegate::~PageTargetDelegate() {}
 
 InstanceTarget& PageTarget::registerInstance(InstanceTargetDelegate& delegate) {
   assert(!currentInstance_ && "Only one instance allowed");
-  currentInstance_ =
-      InstanceTarget::create(delegate, makeVoidExecutor(executorFromThis()));
+  currentInstance_ = InstanceTarget::create(
+      executionContextManager_, delegate, makeVoidExecutor(executorFromThis()));
   sessions_.forEach(
       [currentInstance = &*currentInstance_](PageTargetSession& session) {
         session.setCurrentInstance(currentInstance);

--- a/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PageTarget.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "ExecutionContextManager.h"
 #include "ScopedExecutor.h"
 #include "WeakList.h"
 
@@ -166,6 +167,10 @@ class JSINSPECTOR_EXPORT PageTarget
   PageTargetDelegate& delegate_;
   WeakList<PageTargetSession> sessions_;
   PageTargetController controller_{*this};
+  // executionContextManager_ is a shared_ptr to guarantee its validity while
+  // the InstanceTarget is alive (just in case the InstanceTarget ends up
+  // briefly outliving the PageTarget, which it generally shouldn't).
+  std::shared_ptr<ExecutionContextManager> executionContextManager_;
   std::shared_ptr<InstanceTarget> currentInstance_{nullptr};
 
   inline PageTargetDelegate& getDelegate() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <jsinspector-modern/ExecutionContext.h>
 #include <jsinspector-modern/FallbackRuntimeAgentDelegate.h>
 #include <jsinspector-modern/InstanceTarget.h>
 #include <jsinspector-modern/PageTarget.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -12,12 +12,14 @@ namespace facebook::react::jsinspector_modern {
 RuntimeAgent::RuntimeAgent(
     FrontendChannel frontendChannel,
     RuntimeTarget& target,
+    const ExecutionContextDescription& executionContextDescription,
     SessionState& sessionState,
     std::unique_ptr<RuntimeAgentDelegate> delegate)
     : frontendChannel_(std::move(frontendChannel)),
       target_(target),
       sessionState_(sessionState),
-      delegate_(std::move(delegate)) {
+      delegate_(std::move(delegate)),
+      executionContextDescription_(executionContextDescription) {
   (void)target_;
   (void)sessionState_;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -33,6 +33,10 @@ class RuntimeAgent final {
    * \param target The RuntimeTarget that this agent is attached to. The
    * caller is responsible for ensuring that the RuntimeTarget outlives this
    * object.
+   * \param executionContextDescription A description of the execution context
+   * represented by this runtime. This is used for disambiguating the
+   * source/destination of CDP messages when there are multiple runtimes
+   * (concurrently or over the life of a Page).
    * \param sessionState The state of the session that created this agent.
    * \param delegate The RuntimeAgentDelegate providing engine-specific
    * CDP functionality.
@@ -40,6 +44,7 @@ class RuntimeAgent final {
   RuntimeAgent(
       FrontendChannel frontendChannel,
       RuntimeTarget& target,
+      const ExecutionContextDescription& executionContextDescription,
       SessionState& sessionState,
       std::unique_ptr<RuntimeAgentDelegate> delegate);
 
@@ -55,11 +60,17 @@ class RuntimeAgent final {
    */
   bool handleRequest(const cdp::PreparsedRequest& req);
 
+  inline const ExecutionContextDescription& getExecutionContextDescription()
+      const {
+    return executionContextDescription_;
+  }
+
  private:
   FrontendChannel frontendChannel_;
   RuntimeTarget& target_;
   SessionState& sessionState_;
   const std::unique_ptr<RuntimeAgentDelegate> delegate_;
+  const ExecutionContextDescription executionContextDescription_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -10,19 +10,23 @@
 namespace facebook::react::jsinspector_modern {
 
 std::shared_ptr<RuntimeTarget> RuntimeTarget::create(
+    const ExecutionContextDescription& executionContextDescription,
     RuntimeTargetDelegate& delegate,
     RuntimeExecutor jsExecutor,
     VoidExecutor selfExecutor) {
   std::shared_ptr<RuntimeTarget> runtimeTarget{
-      new RuntimeTarget(delegate, jsExecutor)};
+      new RuntimeTarget(executionContextDescription, delegate, jsExecutor)};
   runtimeTarget->setExecutor(selfExecutor);
   return runtimeTarget;
 }
 
 RuntimeTarget::RuntimeTarget(
+    const ExecutionContextDescription& executionContextDescription,
     RuntimeTargetDelegate& delegate,
     RuntimeExecutor jsExecutor)
-    : delegate_(delegate), jsExecutor_(jsExecutor) {}
+    : executionContextDescription_(executionContextDescription),
+      delegate_(delegate),
+      jsExecutor_(jsExecutor) {}
 
 std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
     FrontendChannel channel,
@@ -30,8 +34,10 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
   auto runtimeAgent = std::make_shared<RuntimeAgent>(
       channel,
       *this,
+      executionContextDescription_,
       sessionState,
-      delegate_.createAgentDelegate(channel, sessionState));
+      delegate_.createAgentDelegate(
+          channel, sessionState, executionContextDescription_));
   agents_.insert(runtimeAgent);
   return runtimeAgent;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -129,7 +129,9 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
   MOCK_METHOD(
       std::unique_ptr<RuntimeAgentDelegate>,
       createAgentDelegate,
-      (FrontendChannel channel, SessionState& sessionState),
+      (FrontendChannel channel,
+       SessionState& sessionState,
+       const ExecutionContextDescription&),
       (override));
 };
 
@@ -137,9 +139,11 @@ class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {
  public:
   inline MockRuntimeAgentDelegate(
       FrontendChannel frontendChannel,
-      SessionState& sessionState)
+      SessionState& sessionState,
+      const ExecutionContextDescription& executionContextDescription)
       : frontendChannel(std::move(frontendChannel)),
-        sessionState(sessionState) {}
+        sessionState(sessionState),
+        executionContextDescription(executionContextDescription) {}
 
   // RuntimeAgentDelegate methods
   MOCK_METHOD(
@@ -150,6 +154,7 @@ class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {
 
   const FrontendChannel frontendChannel;
   SessionState& sessionState;
+  const ExecutionContextDescription executionContextDescription;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -211,12 +211,11 @@ TYPED_TEST(JsiIntegrationPortableTest, ExecutionContextNotifications) {
                                                    })")))
       .RetiresOnSaturation();
 
-  // TODO: Each new execution context should receive a new ID.
   EXPECT_CALL(this->fromPage(), onMessage(JsonEq(R"({
                                                      "method": "Runtime.executionContextCreated",
                                                      "params": {
                                                        "context": {
-                                                         "id": 1,
+                                                         "id": 2,
                                                          "origin": "",
                                                          "name": "main"
                                                        }
@@ -226,11 +225,10 @@ TYPED_TEST(JsiIntegrationPortableTest, ExecutionContextNotifications) {
   // Simulate a reload triggered by the app (not by the debugger).
   this->reload();
 
-  // TODO: Each new execution context should receive a new ID.
   EXPECT_CALL(this->fromPage(), onMessage(JsonEq(R"({
                                                      "method": "Runtime.executionContextDestroyed",
                                                      "params": {
-                                                       "executionContextId": 1
+                                                       "executionContextId": 2
                                                      }
                                                    })")))
       .RetiresOnSaturation();
@@ -239,12 +237,11 @@ TYPED_TEST(JsiIntegrationPortableTest, ExecutionContextNotifications) {
                                                      "method": "Runtime.executionContextsCleared"
                                                    })")))
       .RetiresOnSaturation();
-  // TODO: Each new execution context should receive a new ID.
   EXPECT_CALL(this->fromPage(), onMessage(JsonEq(R"({
                                                      "method": "Runtime.executionContextCreated",
                                                      "params": {
                                                        "context": {
-                                                         "id": 1,
+                                                         "id": 3,
                                                          "origin": "",
                                                          "name": "main"
                                                        }

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.cpp
@@ -23,7 +23,8 @@ JsiIntegrationTestGenericEngineAdapter::JsiIntegrationTestGenericEngineAdapter(
 std::unique_ptr<RuntimeAgentDelegate>
 JsiIntegrationTestGenericEngineAdapter::createAgentDelegate(
     FrontendChannel frontendChannel,
-    SessionState& sessionState) {
+    SessionState& sessionState,
+    const ExecutionContextDescription&) {
   return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
       new FallbackRuntimeAgentDelegate(
           frontendChannel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.h
@@ -27,7 +27,8 @@ class JsiIntegrationTestGenericEngineAdapter : public RuntimeTargetDelegate {
 
   virtual std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
       FrontendChannel frontendChannel,
-      SessionState& sessionState) override;
+      SessionState& sessionState,
+      const ExecutionContextDescription& executionContextDescription) override;
 
   jsi::Runtime& getRuntime() const noexcept;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
@@ -22,10 +22,15 @@ JsiIntegrationTestHermesEngineAdapter::JsiIntegrationTestHermesEngineAdapter(
 std::unique_ptr<RuntimeAgentDelegate>
 JsiIntegrationTestHermesEngineAdapter::createAgentDelegate(
     FrontendChannel frontendChannel,
-    SessionState& sessionState) {
+    SessionState& sessionState,
+    const ExecutionContextDescription& executionContextDescription) {
   return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
       new HermesRuntimeAgentDelegate(
-          frontendChannel, sessionState, runtime_, getRuntimeExecutor()));
+          frontendChannel,
+          sessionState,
+          executionContextDescription,
+          runtime_,
+          getRuntimeExecutor()));
 }
 
 jsi::Runtime& JsiIntegrationTestHermesEngineAdapter::getRuntime()

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
@@ -27,7 +27,8 @@ class JsiIntegrationTestHermesEngineAdapter : public RuntimeTargetDelegate {
 
   virtual std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
       FrontendChannel frontendChannel,
-      SessionState& sessionState) override;
+      SessionState& sessionState,
+      const ExecutionContextDescription& executionContextDescription) override;
 
   jsi::Runtime& getRuntime() const noexcept;
 

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
@@ -21,7 +21,10 @@ JSIRuntimeHolder::JSIRuntimeHolder(std::unique_ptr<jsi::Runtime> runtime)
 std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
 JSIRuntimeHolder::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
-    jsinspector_modern::SessionState& sessionState) {
+    jsinspector_modern::SessionState& sessionState,
+    const jsinspector_modern::ExecutionContextDescription&
+        executionContextDescription) {
+  (void)executionContextDescription;
   return std::make_unique<jsinspector_modern::FallbackRuntimeAgentDelegate>(
       std::move(frontendChannel), sessionState, runtime_->description());
 }

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
@@ -43,7 +43,9 @@ class JSIRuntimeHolder : public JSRuntime {
   jsi::Runtime& getRuntime() noexcept override;
   std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate> createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
-      jsinspector_modern::SessionState& sessionState) override;
+      jsinspector_modern::SessionState& sessionState,
+      const jsinspector_modern::ExecutionContextDescription&
+          executionContextDescription) override;
 
   explicit JSIRuntimeHolder(std::unique_ptr<jsi::Runtime> runtime);
 

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -106,11 +106,14 @@ class HermesJSRuntime : public JSRuntime {
 
   std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate> createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
-      jsinspector_modern::SessionState& sessionState) override {
+      jsinspector_modern::SessionState& sessionState,
+      const jsinspector_modern::ExecutionContextDescription&
+          executionContextDescription) override {
     return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
         new jsinspector_modern::HermesRuntimeAgentDelegate(
             frontendChannel,
             sessionState,
+            executionContextDescription,
             runtime_,
             [msgQueueThreadWeak = std::weak_ptr(msgQueueThread_),
              runtimeWeak = std::weak_ptr(runtime_)](auto fn) {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Aligns React Native's CDP backend with V8's behaviour of assigning a sequential ID (here unique within a given PageTarget) to each execution context.

Reviewed By: huntie

Differential Revision: D53776531
