### PR TITLE
Remove unneded character

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -7,7 +7,7 @@ require 'json'
 
 require_relative "./utils.rb"
 require_relative "./helpers.rb"
-\
+
 class NewArchitectureHelper
     @@cplusplus_version = "c++20"
 


### PR DESCRIPTION
Summary:
There is a `\` in the new_architecture.rb file that should not be there.

## Changelog:
[Internal] - remove unnecessary character

Differential Revision: D53886548


