### PR TITLE
add rows props to TextInput.d.ts

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -387,6 +387,13 @@ export interface TextInputAndroidProps {
   returnKeyLabel?: string | undefined;
 
   /**
+   * Sets the number of rows for a `TextInput`. Use it with multiline set to
+   * `true` to be able to fill the lines.
+   * @platform android
+   */
+  rows?: number | undefined,
+
+  /**
    * Set text break strategy on Android API Level 23+, possible values are simple, highQuality, balanced
    * The default value is simple.
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I am currently building a mobile app and upgrade to react-native 0.73. I was annoyed when my IDE kept signaling errors that certain props are not valid on TextInputProps when extended on interfaces I'm using. I just want to add a few of the props that already exist in the js file for TextInput but are missing in the ts file leading to annoying IDE warnings/errors.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[ANDROID] [ADDED] - just added rows to the TextInput.d.ts so that when passing props IDE's will not be confused.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Nothing is breaking. Simple add to props on the typescript file of what is already declared and used in the TextInput.js file. 
