### PR TITLE
[IOS] [FIXED] - Fix nil reference to user project path

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -27,6 +27,7 @@ class NewArchitectureHelper
             projects = installer.aggregate_targets
                 .map{ |t| t.user_project }
                 .uniq{ |p| p.path }
+                .compact
 
             projects.each do |project|
                 Pod::UI.puts("Setting CLANG_CXX_LANGUAGE_STANDARD to #{ language_standard } on #{ project.path }")

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -370,6 +370,7 @@ class ReactNativePodsUtils
             .map{ |t| t.user_project }
             .uniq{ |p| p.path }
             .push(installer.pods_project)
+            .compact
     end
 
     def self.safe_init(config, setting_name)


### PR DESCRIPTION
## Summary:

I was integrating ReactNative in to native project. In some cases, the
`t.user_project` might be nil. Need to remove nil objects in array for further uses.

## Changelog:

[IOS] [FIXED] - Fix nil reference to user project path



## Test Plan:

Create a new project, run the iOS project, make sure there's no errors.