### PR TITLE
Fix compatibility issue with 'cp' command in shell script.

### DIFF
--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -103,8 +103,17 @@ generateArtifacts () {
 moveOutputs () {
     mkdir -p "$RCT_SCRIPT_OUTPUT_DIR"
 
+    # Test if 'cp' supports the '-X' flag (GNU's cp doesn't, but macOS's cp does)
+    touch /tmp/test-cp-X-flag-one /tmp/test-cp-X-flag-two
+    if cp -X /tmp/test-cp-X-flag-one /tmp/test-cp-X-flag-two > /dev/null 2>&1; then
+        CP_FLAGS="-R -X"
+    else
+        CP_FLAGS="-R"
+    fi
+    rm /tmp/test-cp-X-flag-one /tmp/test-cp-X-flag-two
+
     # Copy all output to output_dir
-    cp -R -X "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
+    cp $CP_FLAGS "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
     echo "$LIBRARY_NAME output has been written to $RCT_SCRIPT_OUTPUT_DIR:" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
     ls -1 "$RCT_SCRIPT_OUTPUT_DIR" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
 }


### PR DESCRIPTION
## Summary:

This change addresses a compatibility issue arising from the use of the macOS-specific `-X` flag in the `cp` command withing a shell script called during the `npm run ios` command.

The `-X` flag prevents the copying of Extended Attributes and resource forks, which indeed prevents possible issues on macOS. However the flag is not supported by GNU's `cp`, commonly installed via homebrew on macOS systems, and usually added to the user's PATH.

This fix basically does a feature test to figure out if the `-X` flag is available, and only uses it is the test is positive.

The intended behavior of not copying Extended Attributes and resources forks is still preserved in the script even if GNU's `cp` is in the path, as GNU's `cp` doesn't copy these by default.

In short, the script will behave correctly regardless of the `cp` version installed, but the script will now be more POSIX compatible.

The fix helps prevent unnecessary debugging time as, in my experience, the source of this error is not always displayed in the output of `npm run ios`.

As mentioned in: 
- https://github.com/facebook/react-native/issues/42112#issuecomment-1922990774
- https://github.com/facebook/react-native/issues/39734#issuecomment-1932644315

### Relevant Documentation
- [GNU's cp documentation](https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html#cp-invocation)
- [macOS's cp man page](https://ss64.com/mac/cp.html)

## Changelog:

[IOS] [FIXED] - Fix compatibility issue with 'cp' command in shell script.

## Test Plan:

```
# with GNU's cp in path
npm run ios
# observe build passing (this is the fix)

# remove GNU's cp from path
npm run ios
# observe build passing (no regression)
```

