### PR TITLE
Make React-jsiinspector depends on hermes-engine to fix Dynamic Frameworks

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -53,4 +53,8 @@ Pod::Spec.new do |s|
   s.dependency "DoubleConversion"
   s.dependency "React-runtimeexecutor", version
   s.dependency "React-jsi"
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  end
+
 end


### PR DESCRIPTION
Summary:
When Hermes i used, it is hermes that provides JSI to React Native and not React-jsi.
This is required to fix the ODR violatons.
Dynamic frameworks requires that all the dependencies are declared explicitly, and missing the `hermes-engine` dependency was breaking the dependency graph.

## Changelog
[Internal] - Make JSIInspector depends o hermes-engine

Differential Revision: D53901016


