### PR TITLE
fix(rn-tester): prevent alert example from crashing

### DIFF
--- a/packages/rn-tester/js/examples/Alert/AlertExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertExample.js
@@ -227,7 +227,9 @@ const AlertWithStylesPreferred = () => {
 };
 
 const PromptOptions = () => {
-  const [promptValue, setPromptValue] = React.useState<string>('');
+  const [promptValue, setPromptValue] = React.useState<
+    string | {login: string, password: string},
+  >('');
 
   const customButtons = [
     {
@@ -243,7 +245,8 @@ const PromptOptions = () => {
   return (
     <View>
       <Text style={styles.promptValue}>
-        <Text style={styles.bold}>Prompt value:</Text> {promptValue}
+        <Text style={styles.bold}>Prompt value:</Text>
+        {JSON.stringify(promptValue, null, 2)}
       </Text>
 
       <Pressable


### PR DESCRIPTION
## Summary:

This small PR fixes issue causing `AlertExample` to crash on `login-password` prompt example, as it was trying to render object in `<Text>`

## Changelog:

[INTERNAL] [FIXED] - Prevent alert example from crashing

## Test Plan:

`login-password` prompt example in `AlertExample` doesn't crash when pressing `OK`
