### PR TITLE
Support limiting CDP bindings to specific contexts

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ExecutionContext.h"
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+template <class>
+inline constexpr bool always_false_v = false;
+
+} // namespace
+
+bool ExecutionContextSelector::matches(
+    const ExecutionContextDescription& context) const noexcept {
+  // Exhaustiveness checking based on the example in
+  // https://en.cppreference.com/w/cpp/utility/variant/visit.
+  return std::visit(
+      [&context](auto&& arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, AllContexts>) {
+          return true;
+        } else if constexpr (std::is_same_v<T, ContextId>) {
+          return context.id == arg;
+        } else if constexpr (std::is_same_v<T, ContextName>) {
+          return context.name == arg;
+        } else {
+          static_assert(always_false_v<T>, "non-exhaustive visitor");
+        }
+      },
+      value_);
+
+  // Prevent the compiler from thinking always_false_v is unused when the
+  // visitor is (correctly) exhaustive.
+  (void)always_false_v<void>;
+}
+
+ExecutionContextSelector ExecutionContextSelector::byId(int32_t id) {
+  return ExecutionContextSelector{id};
+}
+
+ExecutionContextSelector ExecutionContextSelector::byName(std::string name) {
+  return ExecutionContextSelector{std::move(name)};
+}
+
+ExecutionContextSelector ExecutionContextSelector::all() {
+  return ExecutionContextSelector{AllContexts{}};
+}
+
+bool matchesAny(
+    const ExecutionContextDescription& context,
+    const ExecutionContextSelectorSet& selectors) {
+  for (const auto& selector : selectors) {
+    if (selector.matches(context)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
@@ -7,9 +7,13 @@
 
 #pragma once
 
+#include "UniqueMonostate.h"
+
 #include <cinttypes>
 #include <optional>
 #include <string>
+#include <unordered_set>
+#include <variant>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -20,4 +24,86 @@ struct ExecutionContextDescription {
   std::optional<std::string> uniqueId;
 };
 
+/**
+ * A type-safe selector for execution contexts.
+ */
+class ExecutionContextSelector {
+ public:
+  /**
+   * Returns true iff this selector matches \c context.
+   */
+  bool matches(const ExecutionContextDescription& context) const noexcept;
+
+  /**
+   * Returns a new selector that matches only the given execution context ID.
+   */
+  static ExecutionContextSelector byId(int32_t id);
+
+  /**
+   * Returns a new selector that matches only the given execution context name.
+   */
+  static ExecutionContextSelector byName(std::string name);
+
+  /**
+   * Returns a new selector that matches any execution context.
+   */
+  static ExecutionContextSelector all();
+
+  ExecutionContextSelector() = delete;
+  ExecutionContextSelector(const ExecutionContextSelector& other) = default;
+  ExecutionContextSelector(ExecutionContextSelector&& other) noexcept = default;
+  ExecutionContextSelector& operator=(const ExecutionContextSelector& other) =
+      default;
+  ExecutionContextSelector& operator=(
+      ExecutionContextSelector&& other) noexcept = default;
+  ~ExecutionContextSelector() = default;
+
+  inline bool operator==(const ExecutionContextSelector& other) const noexcept {
+    return value_ == other.value_;
+  }
+
+ private:
+  /**
+   * Marker type used to represent "all execution contexts".
+   *
+   * Q: What is a UniqueMonostate?
+   * A: std::monostate, but it's distinct from other UniqueMonostate<...>s, so
+   *    you can use multiple of them in the same variant without ambiguity.
+   */
+  using AllContexts = UniqueMonostate<0>;
+  using ContextId = int32_t;
+  using ContextName = std::string;
+
+  using Representation = std::variant<AllContexts, ContextId, ContextName>;
+
+  explicit inline ExecutionContextSelector(Representation&& r) : value_(r) {}
+
+  Representation value_;
+
+  friend struct std::hash<
+      facebook::react::jsinspector_modern::ExecutionContextSelector>;
+};
+
+using ExecutionContextSelectorSet =
+    std::unordered_set<ExecutionContextSelector>;
+
+bool matchesAny(
+    const ExecutionContextDescription& context,
+    const ExecutionContextSelectorSet& selectors);
+
 } // namespace facebook::react::jsinspector_modern
+
+namespace std {
+
+template <>
+struct hash<::facebook::react::jsinspector_modern::ExecutionContextSelector> {
+  size_t operator()(
+      const ::facebook::react::jsinspector_modern::ExecutionContextSelector&
+          selector) const {
+    return hash<::facebook::react::jsinspector_modern::
+                    ExecutionContextSelector::Representation>{}(
+        selector.value_);
+  }
+};
+
+} // namespace std

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -7,8 +7,11 @@
 
 #pragma once
 
+#include "ExecutionContext.h"
+
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace facebook::react::jsinspector_modern {
@@ -20,13 +23,16 @@ struct SessionState {
   bool isRuntimeDomainEnabled{false};
 
   /**
-   * The set of bindings registered during this session using @cdp
-   * Runtime.addBinding. Even though bindings get added to the global scope as
+   * A map from binding names (registered during this session using @cdp
+   * Runtime.addBinding) to execution context selectors.
+   *
+   * Even though bindings get added to the global scope as
    * functions that can outlive a session, they are treated as session state,
    * matching Chrome's behaviour (a binding not added by the current session
    * will not emit events on it).
    */
-  std::unordered_set<std::string> subscribedBindingNames;
+  std::unordered_map<std::string, ExecutionContextSelectorSet>
+      subscribedBindings;
 
   // Here, we will eventually allow RuntimeAgents to store their own arbitrary
   // state (e.g. some sort of K/V storage of folly::dynamic?)

--- a/packages/react-native/ReactCommon/jsinspector-modern/UniqueMonostate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/UniqueMonostate.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A template for easily creating empty types that are distinct from one
+ * another. Useful if you need to generate marker types for use in an
+ * std::variant, and a single std::monostate won't do.
+ */
+template <size_t key>
+struct UniqueMonostate {
+  constexpr bool operator==(const UniqueMonostate<key>&) const noexcept {
+    return true;
+  }
+  constexpr bool operator!=(const UniqueMonostate<key>&) const noexcept {
+    return false;
+  }
+  constexpr bool operator<(const UniqueMonostate<key>&) const noexcept {
+    return false;
+  }
+  constexpr bool operator>(const UniqueMonostate<key>&) const noexcept {
+    return false;
+  }
+  constexpr bool operator<=(const UniqueMonostate<key>&) const noexcept {
+    return true;
+  }
+  constexpr bool operator>=(const UniqueMonostate<key>&) const noexcept {
+    return true;
+  }
+};
+
+} // namespace facebook::react::jsinspector_modern
+
+namespace std {
+
+template <size_t key>
+struct hash<::facebook::react::jsinspector_modern::UniqueMonostate<key>> {
+  size_t operator()(
+      const ::facebook::react::jsinspector_modern::UniqueMonostate<key>&)
+      const noexcept {
+    return key;
+  }
+};
+
+} // namespace std


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Completes React Native's support for the [`Runtime.addBinding`](https://cdpstatus.reactnative.dev/devtools-protocol/tot/Runtime#method-addBinding) and [`Runtime.removeBinding`](https://cdpstatus.reactnative.dev/devtools-protocol/tot/Runtime#method-removeBinding) methods (in the modern CDP backend) by handling the optional `executionContextId` and `executionContextName` params.

Reviewed By: huntie

Differential Revision: D53760393


