### PR TITLE
Save exported state across RuntimeAgent instances

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
@@ -39,6 +39,7 @@ std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
 JSExecutor::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState,
+    std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>,
     const jsinspector_modern::ExecutionContextDescription&
         executionContextDescription) {
   (void)executionContextDescription;

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
@@ -147,6 +147,8 @@ class RN_EXPORT JSExecutor : public jsinspector_modern::RuntimeTargetDelegate {
   createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState,
+      std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const jsinspector_modern::ExecutionContextDescription&
           executionContextDescription) override;
 };

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -261,6 +261,8 @@ std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
 HermesExecutor::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState,
+    std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
+        previouslyExportedState,
     const jsinspector_modern::ExecutionContextDescription&
         executionContextDescription) {
   std::shared_ptr<HermesRuntime> hermesRuntimeShared(runtime_, &hermesRuntime_);
@@ -268,6 +270,7 @@ HermesExecutor::createAgentDelegate(
       new jsinspector_modern::HermesRuntimeAgentDelegate(
           frontendChannel,
           sessionState,
+          std::move(previouslyExportedState),
           executionContextDescription,
           hermesRuntimeShared,
           [jsQueueWeak = std::weak_ptr(jsQueue_),

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -58,6 +58,8 @@ class HermesExecutor : public JSIExecutor {
   createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState,
+      std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const jsinspector_modern::ExecutionContextDescription&
           executionContextDescription) override;
 

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.cpp
@@ -67,6 +67,26 @@ class HermesRuntimeAgentDelegate::Impl final : public RuntimeAgentDelegate {
   using HermesCDPHandler = hermes::inspector_modern::chrome::CDPHandler;
   using HermesExecutionContextDescription =
       hermes::inspector_modern::chrome::CDPHandlerExecutionContextDescription;
+  using HermesState = hermes::inspector_modern::chrome::State;
+
+  struct HermesStateWrapper : public ExportedState {
+    explicit HermesStateWrapper(std::unique_ptr<HermesState> state)
+        : state_(std::move(state)) {}
+
+    static std::unique_ptr<HermesState> unwrapDestructively(
+        ExportedState* wrapper) {
+      if (!wrapper) {
+        return nullptr;
+      }
+      if (auto* typedWrapper = dynamic_cast<HermesStateWrapper*>(wrapper)) {
+        return std::move(typedWrapper->state_);
+      }
+      return nullptr;
+    }
+
+   private:
+    std::unique_ptr<HermesState> state_;
+  };
 
  public:
   /**
@@ -75,6 +95,10 @@ class HermesRuntimeAgentDelegate::Impl final : public RuntimeAgentDelegate {
    * \param sessionState The state of the current CDP session. This will only
    * be accessed on the main thread (during the constructor, in handleRequest,
    * etc).
+   * \param previouslyExportedState The exported state from a previous instance
+   * of RuntimeAgentDelegate (NOT necessarily HermesRuntimeAgentDelegate). This
+   * may be nullptr, and if not nullptr it may be of any concrete type that
+   * implements RuntimeAgentDelegate::ExportedState.
    * \param executionContextDescription A description of the execution context
    * represented by this runtime. This is used for disambiguating the
    * source/destination of CDP messages when there are multiple runtimes
@@ -87,6 +111,8 @@ class HermesRuntimeAgentDelegate::Impl final : public RuntimeAgentDelegate {
   Impl(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const ExecutionContextDescription& executionContextDescription,
       std::shared_ptr<hermes::HermesRuntime> runtime,
       RuntimeExecutor runtimeExecutor)
@@ -96,7 +122,9 @@ class HermesRuntimeAgentDelegate::Impl final : public RuntimeAgentDelegate {
                 runtimeExecutor),
             /* waitForDebugger */ false,
             /* enableConsoleAPICapturing */ false,
-            /* state */ nullptr,
+            /* state */
+            HermesStateWrapper::unwrapDestructively(
+                previouslyExportedState.get()),
             {.isRuntimeDomainEnabled = sessionState.isRuntimeDomainEnabled},
             HermesExecutionContextDescription{
                 .id = executionContextDescription.id,
@@ -139,6 +167,10 @@ class HermesRuntimeAgentDelegate::Impl final : public RuntimeAgentDelegate {
     return true;
   }
 
+  virtual std::unique_ptr<ExportedState> getExportedState() override {
+    return std::make_unique<HermesStateWrapper>(hermes_->getState());
+  }
+
  private:
   std::shared_ptr<HermesCDPHandler> hermes_;
 };
@@ -155,6 +187,7 @@ class HermesRuntimeAgentDelegate::Impl final
   Impl(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
       const ExecutionContextDescription&,
       std::shared_ptr<hermes::HermesRuntime> runtime,
       RuntimeExecutor)
@@ -169,12 +202,15 @@ class HermesRuntimeAgentDelegate::Impl final
 HermesRuntimeAgentDelegate::HermesRuntimeAgentDelegate(
     FrontendChannel frontendChannel,
     SessionState& sessionState,
+    std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+        previouslyExportedState,
     const ExecutionContextDescription& executionContextDescription,
     std::shared_ptr<hermes::HermesRuntime> runtime,
     RuntimeExecutor runtimeExecutor)
     : impl_(std::make_unique<Impl>(
           std::move(frontendChannel),
           sessionState,
+          std::move(previouslyExportedState),
           executionContextDescription,
           std::move(runtime),
           std::move(runtimeExecutor))) {}
@@ -182,6 +218,11 @@ HermesRuntimeAgentDelegate::HermesRuntimeAgentDelegate(
 bool HermesRuntimeAgentDelegate::handleRequest(
     const cdp::PreparsedRequest& req) {
   return impl_->handleRequest(req);
+}
+
+std::unique_ptr<HermesRuntimeAgentDelegate::ExportedState>
+HermesRuntimeAgentDelegate::getExportedState() {
+  return impl_->getExportedState();
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h
@@ -26,6 +26,10 @@ class HermesRuntimeAgentDelegate : public RuntimeAgentDelegate {
    * \param sessionState The state of the current CDP session. This will only
    * be accessed on the main thread (during the constructor, in handleRequest,
    * etc).
+   * \param previouslyExportedState The exported state from a previous instance
+   * of RuntimeAgentDelegate (NOT necessarily HermesRuntimeAgentDelegate). This
+   * may be nullptr, and if not nullptr it may be of any concrete type that
+   * implements RuntimeAgentDelegate::ExportedState.
    * \param executionContextDescription A description of the execution context
    * represented by this runtime. This is used for disambiguating the
    * source/destination of CDP messages when there are multiple runtimes
@@ -38,6 +42,8 @@ class HermesRuntimeAgentDelegate : public RuntimeAgentDelegate {
   HermesRuntimeAgentDelegate(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const ExecutionContextDescription& executionContextDescription,
       std::shared_ptr<hermes::HermesRuntime> runtime,
       RuntimeExecutor runtimeExecutor);
@@ -51,6 +57,8 @@ class HermesRuntimeAgentDelegate : public RuntimeAgentDelegate {
    * agent expects another agent to respond to the request instead.
    */
   bool handleRequest(const cdp::PreparsedRequest& req) override;
+
+  virtual std::unique_ptr<ExportedState> getExportedState() override;
 
  private:
   // We use the private implementation idiom to keep HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ExecutionContext.h"
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+template <class>
+inline constexpr bool always_false_v = false;
+
+} // namespace
+
+bool ExecutionContextSelector::matches(
+    const ExecutionContextDescription& context) const noexcept {
+  // Exhaustiveness checking based on the example in
+  // https://en.cppreference.com/w/cpp/utility/variant/visit.
+  return std::visit(
+      [&context](auto&& arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, AllContexts>) {
+          return true;
+        } else if constexpr (std::is_same_v<T, ContextId>) {
+          return context.id == arg;
+        } else if constexpr (std::is_same_v<T, ContextName>) {
+          return context.name == arg;
+        } else {
+          static_assert(always_false_v<T>, "non-exhaustive visitor");
+        }
+      },
+      value_);
+
+  // Prevent the compiler from thinking always_false_v is unused when the
+  // visitor is (correctly) exhaustive.
+  (void)always_false_v<void>;
+}
+
+ExecutionContextSelector ExecutionContextSelector::byId(int32_t id) {
+  return ExecutionContextSelector{id};
+}
+
+ExecutionContextSelector ExecutionContextSelector::byName(std::string name) {
+  return ExecutionContextSelector{std::move(name)};
+}
+
+ExecutionContextSelector ExecutionContextSelector::all() {
+  return ExecutionContextSelector{AllContexts{}};
+}
+
+bool matchesAny(
+    const ExecutionContextDescription& context,
+    const ExecutionContextSelectorSet& selectors) {
+  for (const auto& selector : selectors) {
+    if (selector.matches(context)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
@@ -7,9 +7,13 @@
 
 #pragma once
 
+#include "UniqueMonostate.h"
+
 #include <cinttypes>
 #include <optional>
 #include <string>
+#include <unordered_set>
+#include <variant>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -20,4 +24,86 @@ struct ExecutionContextDescription {
   std::optional<std::string> uniqueId;
 };
 
+/**
+ * A type-safe selector for execution contexts.
+ */
+class ExecutionContextSelector {
+ public:
+  /**
+   * Returns true iff this selector matches \c context.
+   */
+  bool matches(const ExecutionContextDescription& context) const noexcept;
+
+  /**
+   * Returns a new selector that matches only the given execution context ID.
+   */
+  static ExecutionContextSelector byId(int32_t id);
+
+  /**
+   * Returns a new selector that matches only the given execution context name.
+   */
+  static ExecutionContextSelector byName(std::string name);
+
+  /**
+   * Returns a new selector that matches any execution context.
+   */
+  static ExecutionContextSelector all();
+
+  ExecutionContextSelector() = delete;
+  ExecutionContextSelector(const ExecutionContextSelector& other) = default;
+  ExecutionContextSelector(ExecutionContextSelector&& other) noexcept = default;
+  ExecutionContextSelector& operator=(const ExecutionContextSelector& other) =
+      default;
+  ExecutionContextSelector& operator=(
+      ExecutionContextSelector&& other) noexcept = default;
+  ~ExecutionContextSelector() = default;
+
+  inline bool operator==(const ExecutionContextSelector& other) const noexcept {
+    return value_ == other.value_;
+  }
+
+ private:
+  /**
+   * Marker type used to represent "all execution contexts".
+   *
+   * Q: What is a UniqueMonostate?
+   * A: std::monostate, but it's distinct from other UniqueMonostate<...>s, so
+   *    you can use multiple of them in the same variant without ambiguity.
+   */
+  using AllContexts = UniqueMonostate<0>;
+  using ContextId = int32_t;
+  using ContextName = std::string;
+
+  using Representation = std::variant<AllContexts, ContextId, ContextName>;
+
+  explicit inline ExecutionContextSelector(Representation&& r) : value_(r) {}
+
+  Representation value_;
+
+  friend struct std::hash<
+      facebook::react::jsinspector_modern::ExecutionContextSelector>;
+};
+
+using ExecutionContextSelectorSet =
+    std::unordered_set<ExecutionContextSelector>;
+
+bool matchesAny(
+    const ExecutionContextDescription& context,
+    const ExecutionContextSelectorSet& selectors);
+
 } // namespace facebook::react::jsinspector_modern
+
+namespace std {
+
+template <>
+struct hash<::facebook::react::jsinspector_modern::ExecutionContextSelector> {
+  size_t operator()(
+      const ::facebook::react::jsinspector_modern::ExecutionContextSelector&
+          selector) const {
+    return hash<::facebook::react::jsinspector_modern::
+                    ExecutionContextSelector::Representation>{}(
+        selector.value_);
+  }
+};
+
+} // namespace std

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RuntimeAgent.h"
+#include "SessionState.h"
 
 namespace facebook::react::jsinspector_modern {
 
@@ -118,6 +119,20 @@ void RuntimeAgent::notifyBindingCalled(
           folly::dynamic::object(
               "executionContextId", executionContextDescription_.id)(
               "name", bindingName)("payload", payload))));
+}
+
+RuntimeAgent::ExportedState RuntimeAgent::getExportedState() {
+  return {
+      .delegateState = delegate_ ? delegate_->getExportedState() : nullptr,
+  };
+}
+
+RuntimeAgent::~RuntimeAgent() {
+  // TODO: Eventually, there may be more than one Runtime per Page, and we'll
+  // need to store multiple agent states here accordingly. For now let's do
+  // the simple thing and assume (as we do elsewhere) that only one Runtime
+  // per Page can exist at a time.
+  sessionState_.lastRuntimeAgentExportedState = getExportedState();
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -10,13 +10,13 @@
 #include "InspectorInterfaces.h"
 #include "RuntimeAgentDelegate.h"
 #include "RuntimeTarget.h"
-#include "SessionState.h"
 
 #include <jsinspector-modern/Parsing.h>
 
 namespace facebook::react::jsinspector_modern {
 
 class RuntimeTargetController;
+struct SessionState;
 
 /**
  * An Agent that handles requests from the Chrome DevTools Protocol
@@ -48,6 +48,8 @@ class RuntimeAgent final {
       SessionState& sessionState,
       std::unique_ptr<RuntimeAgentDelegate> delegate);
 
+  ~RuntimeAgent();
+
   /**
    * Handle a CDP request. The response will be sent over the provided
    * \c FrontendChannel synchronously or asynchronously. Performs any
@@ -68,6 +70,17 @@ class RuntimeAgent final {
   void notifyBindingCalled(
       const std::string& bindingName,
       const std::string& payload);
+
+  struct ExportedState {
+    std::unique_ptr<RuntimeAgentDelegate::ExportedState> delegateState;
+  };
+
+  /**
+   * Export the RuntimeAgent's state, if available. This will be called
+   * shortly before the RuntimeAgent is destroyed to preserve state that may be
+   * needed when constructin a new RuntimeAgent.
+   */
+  ExportedState getExportedState();
 
  private:
   FrontendChannel frontendChannel_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgentDelegate.h
@@ -19,6 +19,11 @@ namespace facebook::react::jsinspector_modern {
  */
 class RuntimeAgentDelegate {
  public:
+  class ExportedState {
+   public:
+    virtual ~ExportedState() = default;
+  };
+
   virtual ~RuntimeAgentDelegate() = default;
 
   /**
@@ -30,6 +35,17 @@ class RuntimeAgentDelegate {
    * agent expects another agent to respond to the request instead.
    */
   virtual bool handleRequest(const cdp::PreparsedRequest& req) = 0;
+
+  /**
+   * Export RuntimeAgentDelegate-specific state that should persist across
+   * consecutive RuntimeTargets in this session.
+   * If the RuntimeTarget is destroyed and later logically replaced by a new
+   * one (e.g. as part of an Instance reload), the state returned here will be
+   * passed to \ref RuntimeTargetDelegate::createAgentDelegate.
+   */
+  inline virtual std::unique_ptr<ExportedState> getExportedState() {
+    return std::make_unique<ExportedState>();
+  }
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "SessionState.h"
+
 #include <jsinspector-modern/RuntimeTarget.h>
 
 using namespace facebook::jsi;
@@ -33,13 +35,18 @@ RuntimeTarget::RuntimeTarget(
 std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
     FrontendChannel channel,
     SessionState& sessionState) {
+  auto runtimeAgentState =
+      std::move(sessionState.lastRuntimeAgentExportedState);
   auto runtimeAgent = std::make_shared<RuntimeAgent>(
       channel,
       controller_,
       executionContextDescription_,
       sessionState,
       delegate_.createAgentDelegate(
-          channel, sessionState, executionContextDescription_));
+          channel,
+          sessionState,
+          std::move(runtimeAgentState.delegateState),
+          executionContextDescription_));
   agents_.insert(runtimeAgent);
   return runtimeAgent;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -13,7 +13,6 @@
 #include "InspectorInterfaces.h"
 #include "RuntimeAgent.h"
 #include "ScopedExecutor.h"
-#include "SessionState.h"
 #include "WeakList.h"
 
 #include <memory>
@@ -35,6 +34,7 @@ namespace facebook::react::jsinspector_modern {
 class RuntimeAgent;
 class RuntimeAgentDelegate;
 class RuntimeTarget;
+struct SessionState;
 
 /**
  * Receives events from a RuntimeTarget. This is a shared interface that
@@ -47,6 +47,8 @@ class RuntimeTargetDelegate {
   virtual std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
       FrontendChannel channel,
       SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const ExecutionContextDescription& executionContextDescription) = 0;
 };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -7,8 +7,11 @@
 
 #pragma once
 
+#include "ExecutionContext.h"
+
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace facebook::react::jsinspector_modern {
@@ -20,13 +23,16 @@ struct SessionState {
   bool isRuntimeDomainEnabled{false};
 
   /**
-   * The set of bindings registered during this session using @cdp
-   * Runtime.addBinding. Even though bindings get added to the global scope as
+   * A map from binding names (registered during this session using @cdp
+   * Runtime.addBinding) to execution context selectors.
+   *
+   * Even though bindings get added to the global scope as
    * functions that can outlive a session, they are treated as session state,
    * matching Chrome's behaviour (a binding not added by the current session
    * will not emit events on it).
    */
-  std::unordered_set<std::string> subscribedBindingNames;
+  std::unordered_map<std::string, ExecutionContextSelectorSet>
+      subscribedBindings;
 
   // Here, we will eventually allow RuntimeAgents to store their own arbitrary
   // state (e.g. some sort of K/V storage of folly::dynamic?)

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "ExecutionContext.h"
+#include "RuntimeAgent.h"
 
 #include <string>
 #include <string_view>
@@ -33,6 +34,12 @@ struct SessionState {
    */
   std::unordered_map<std::string, ExecutionContextSelectorSet>
       subscribedBindings;
+
+  /**
+   * Stores the state object exported from the last main RuntimeAgent, if any,
+   * before it was destroyed.
+   */
+  RuntimeAgent::ExportedState lastRuntimeAgentExportedState;
 
   // Here, we will eventually allow RuntimeAgents to store their own arbitrary
   // state (e.g. some sort of K/V storage of folly::dynamic?)

--- a/packages/react-native/ReactCommon/jsinspector-modern/UniqueMonostate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/UniqueMonostate.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A template for easily creating empty types that are distinct from one
+ * another. Useful if you need to generate marker types for use in an
+ * std::variant, and a single std::monostate won't do.
+ */
+template <size_t key>
+struct UniqueMonostate {
+  constexpr bool operator==(const UniqueMonostate<key>&) const noexcept {
+    return true;
+  }
+  constexpr bool operator!=(const UniqueMonostate<key>&) const noexcept {
+    return false;
+  }
+  constexpr bool operator<(const UniqueMonostate<key>&) const noexcept {
+    return false;
+  }
+  constexpr bool operator>(const UniqueMonostate<key>&) const noexcept {
+    return false;
+  }
+  constexpr bool operator<=(const UniqueMonostate<key>&) const noexcept {
+    return true;
+  }
+  constexpr bool operator>=(const UniqueMonostate<key>&) const noexcept {
+    return true;
+  }
+};
+
+} // namespace facebook::react::jsinspector_modern
+
+namespace std {
+
+template <size_t key>
+struct hash<::facebook::react::jsinspector_modern::UniqueMonostate<key>> {
+  size_t operator()(
+      const ::facebook::react::jsinspector_modern::UniqueMonostate<key>&)
+      const noexcept {
+    return key;
+  }
+};
+
+} // namespace std

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -131,6 +131,8 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
       createAgentDelegate,
       (FrontendChannel channel,
        SessionState& sessionState,
+       std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+           previouslyExportedState,
        const ExecutionContextDescription&),
       (override));
 };
@@ -140,6 +142,7 @@ class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {
   inline MockRuntimeAgentDelegate(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
       const ExecutionContextDescription& executionContextDescription)
       : frontendChannel(std::move(frontendChannel)),
         sessionState(sessionState),

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/PageTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/PageTargetTest.cpp
@@ -31,10 +31,11 @@ class PageTargetTest : public Test {
 
  protected:
   PageTargetTest() {
-    EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _))
+    EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _, _))
         .WillRepeatedly(runtimeAgentDelegates_.lazily_make_unique<
                         FrontendChannel,
                         SessionState&,
+                        std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
                         const ExecutionContextDescription&>());
   }
 
@@ -444,7 +445,7 @@ TEST_F(PageTargetProtocolTest, MessageRoutingWhileNoRuntimeAgentDelegate) {
 TEST_F(PageTargetProtocolTest, InstanceWithNullRuntimeAgentDelegate) {
   InSequence s;
 
-  EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _))
+  EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _, _))
       .WillRepeatedly(ReturnNull());
 
   auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.cpp
@@ -24,6 +24,7 @@ std::unique_ptr<RuntimeAgentDelegate>
 JsiIntegrationTestGenericEngineAdapter::createAgentDelegate(
     FrontendChannel frontendChannel,
     SessionState& sessionState,
+    std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
     const ExecutionContextDescription&) {
   return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
       new FallbackRuntimeAgentDelegate(

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.h
@@ -28,6 +28,8 @@ class JsiIntegrationTestGenericEngineAdapter : public RuntimeTargetDelegate {
   virtual std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const ExecutionContextDescription& executionContextDescription) override;
 
   jsi::Runtime& getRuntime() const noexcept;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
@@ -23,11 +23,14 @@ std::unique_ptr<RuntimeAgentDelegate>
 JsiIntegrationTestHermesEngineAdapter::createAgentDelegate(
     FrontendChannel frontendChannel,
     SessionState& sessionState,
+    std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+        previouslyExportedState,
     const ExecutionContextDescription& executionContextDescription) {
   return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
       new HermesRuntimeAgentDelegate(
           frontendChannel,
           sessionState,
+          std::move(previouslyExportedState),
           executionContextDescription,
           runtime_,
           getRuntimeExecutor()));

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
@@ -28,6 +28,8 @@ class JsiIntegrationTestHermesEngineAdapter : public RuntimeTargetDelegate {
   virtual std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const ExecutionContextDescription& executionContextDescription) override;
 
   jsi::Runtime& getRuntime() const noexcept;

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
@@ -22,6 +22,7 @@ std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
 JSIRuntimeHolder::createAgentDelegate(
     jsinspector_modern::FrontendChannel frontendChannel,
     jsinspector_modern::SessionState& sessionState,
+    std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>,
     const jsinspector_modern::ExecutionContextDescription&
         executionContextDescription) {
   (void)executionContextDescription;

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
@@ -44,6 +44,8 @@ class JSIRuntimeHolder : public JSRuntime {
   std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate> createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState,
+      std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const jsinspector_modern::ExecutionContextDescription&
           executionContextDescription) override;
 

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -107,12 +107,15 @@ class HermesJSRuntime : public JSRuntime {
   std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate> createAgentDelegate(
       jsinspector_modern::FrontendChannel frontendChannel,
       jsinspector_modern::SessionState& sessionState,
+      std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
       const jsinspector_modern::ExecutionContextDescription&
           executionContextDescription) override {
     return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
         new jsinspector_modern::HermesRuntimeAgentDelegate(
             frontendChannel,
             sessionState,
+            std::move(previouslyExportedState),
             executionContextDescription,
             runtime_,
             [msgQueueThreadWeak = std::weak_ptr(msgQueueThread_),


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Wraps Hermes's `CDPHandler::getState()` API in an engine-agnostic abstraction (`RuntimeAgentDelegate::getExportedState`).

An Agent's lifetime ends when its Target is destroyed, but it can occasionally be useful to persist some state for the "next" Target+Agent of the same type (in the same session) to read. 

`RuntimeAgentDelegate` is polymorphic and can't just write arbitrary data to SessionState. Instead, it can now *export* a state object that we'll store and pass to the next `RuntimeTargetDelegate::createAgentDelegate` call.

Differential Revision: D53919696


