### PR TITLE
Prevent reporting mount when FabricUIManager has been destroyed

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1231,6 +1231,10 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
                   public void run() {
                     mMountNotificationScheduled.set(false);
 
+                    if (mDestroyed) {
+                      return;
+                    }
+
                     final @Nullable Binding binding = mBinding;
                     if (mountItems == null || binding == null) {
                       return;


### PR DESCRIPTION
Summary:
In all methods of FabricUIManager we check whether it's been destroyed before doing any logic, but we don't in this asynchronous method we're scheduling to report mounts.

This adds the check in that case as well to potentially fix some crashes we're seeing in current experiments for mount hooks on Android.

Changelog: [internal]

Differential Revision: D53920863


