### PR TITLE
support unstable extra params for /open-debugger

### DIFF
--- a/packages/dev-middleware/src/__tests__/getDevToolsFrontendUrl-test.js
+++ b/packages/dev-middleware/src/__tests__/getDevToolsFrontendUrl-test.js
@@ -11,6 +11,10 @@
 
 import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';
 
+function makeRandomString() {
+  return (Math.random() * 10000).toFixed(0);
+}
+
 describe('getDevToolsFrontendUrl', () => {
   const webSocketDebuggerUrl =
     'ws://localhost:8081/inspector/debug?device=1a9372c&page=-1';
@@ -52,6 +56,28 @@ describe('getDevToolsFrontendUrl', () => {
       expect(url.host).toBe('localhost:8081');
       expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
       expect(url.searchParams.get('unstable_enableNetworkPanel')).toBe('true');
+      expect(url.searchParams.get('ws')).toBe(
+        'localhost:8081/inspector/debug?device=1a9372c&page=-1',
+      );
+    });
+
+    it('should pass unstable_extras param to the returned url', async () => {
+      const experiments = {
+        enableNetworkInspector: false,
+        enableNewDebugger: false,
+        enableOpenDebuggerRedirect: false,
+      };
+      const unstableExtras = makeRandomString();
+      const actual = getDevToolsFrontendUrl(
+        experiments,
+        webSocketDebuggerUrl,
+        devServerUrl,
+        unstableExtras,
+      );
+      const url = new URL(actual);
+      expect(url.host).toBe('localhost:8081');
+      expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
+      expect(url.searchParams.get('unstable_extras')).toBe(unstableExtras);
       expect(url.searchParams.get('ws')).toBe(
         'localhost:8081/inspector/debug?device=1a9372c&page=-1',
       );
@@ -103,6 +129,27 @@ describe('getDevToolsFrontendUrl', () => {
       const url = assertValidRelativeURL(actual);
       expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
       expect(url.searchParams.get('unstable_enableNetworkPanel')).toBe('true');
+      expect(url.searchParams.get('ws')).toBe(
+        'localhost:8081/inspector/debug?device=1a9372c&page=-1',
+      );
+    });
+
+    it('should pass unstable_extras param to the returned url', async () => {
+      const experiments = {
+        enableNetworkInspector: false,
+        enableNewDebugger: false,
+        enableOpenDebuggerRedirect: false,
+      };
+      const unstableExtras = makeRandomString();
+      const actual = getDevToolsFrontendUrl(
+        experiments,
+        webSocketDebuggerUrl,
+        relativeDevServerUrl,
+        unstableExtras,
+      );
+      const url = assertValidRelativeURL(actual);
+      expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
+      expect(url.searchParams.get('unstable_extras')).toBe(unstableExtras);
       expect(url.searchParams.get('ws')).toBe(
         'localhost:8081/inspector/debug?device=1a9372c&page=-1',
       );

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -57,7 +57,12 @@ export default function openDebuggerMiddleware({
       (experiments.enableOpenDebuggerRedirect && req.method === 'GET')
     ) {
       const {query} = url.parse(req.url, true);
-      const {appId, device}: {appId?: string, device?: string, ...} = query;
+      const {
+        appId,
+        device,
+        unstable_extras,
+      }: {appId?: string, device?: string, unstable_extras?: string, ...} =
+        query;
 
       const targets = inspectorProxy.getPageDescriptions().filter(
         // Only use targets with better reloading support
@@ -122,6 +127,7 @@ export default function openDebuggerMiddleware({
                   experiments,
                   target.webSocketDebuggerUrl,
                   serverBaseUrl,
+                  unstable_extras,
                 ),
               ),
             );
@@ -134,6 +140,7 @@ export default function openDebuggerMiddleware({
                 target.webSocketDebuggerUrl,
                 // Use a relative URL.
                 '',
+                unstable_extras,
               ),
             });
             res.end();

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -18,6 +18,7 @@ export default function getDevToolsFrontendUrl(
   experiments: Experiments,
   webSocketDebuggerUrl: string,
   devServerUrl: string,
+  unstable_extras?: string,
 ): string {
   const scheme = new URL(webSocketDebuggerUrl).protocol.slice(0, -1);
   const webSocketUrlWithoutProtocol = webSocketDebuggerUrl.replace(
@@ -32,6 +33,9 @@ export default function getDevToolsFrontendUrl(
   ]);
   if (experiments.enableNetworkInspector) {
     searchParams.append('unstable_enableNetworkPanel', 'true');
+  }
+  if (unstable_extras != null && unstable_extras.trim() !== '') {
+    searchParams.append('unstable_extras', unstable_extras);
   }
 
   return appUrl + '?' + searchParams.toString();


### PR DESCRIPTION
Summary:
Changelog: [internal]

Add support for an unstable query param. Arbitrary string supported as we anticipate multiple values.

Differential Revision: D53824155


