### PR TITLE
fix(iOS): fix rendering `RCTRedBoxExtraData`

### DIFF
--- a/packages/react-native/React/Modules/RCTRedBoxExtraDataViewController.m
+++ b/packages/react-native/React/Modules/RCTRedBoxExtraDataViewController.m
@@ -6,6 +6,7 @@
  */
 
 #import "RCTRedBoxExtraDataViewController.h"
+#import "React/RCTUtils.h"
 
 @interface RCTRedBoxExtraDataCell : UITableViewCell
 
@@ -24,26 +25,27 @@
 
     self.keyLabel = [UILabel new];
     [self.contentView addSubview:self.keyLabel];
-
     self.keyLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.keyLabel.leadingAnchor constraintEqualToAnchor:contentLayout.leadingAnchor].active = YES;
-    [self.keyLabel.topAnchor constraintEqualToAnchor:contentLayout.topAnchor].active = YES;
-    [self.keyLabel.bottomAnchor constraintEqualToAnchor:contentLayout.bottomAnchor].active = YES;
-    [self.keyLabel.widthAnchor constraintEqualToAnchor:contentLayout.widthAnchor multiplier:0.3].active = YES;
-
+    [NSLayoutConstraint activateConstraints:@[
+      [self.keyLabel.leadingAnchor constraintEqualToAnchor:contentLayout.leadingAnchor],
+      [self.keyLabel.topAnchor constraintEqualToAnchor:contentLayout.topAnchor],
+      [self.keyLabel.bottomAnchor constraintEqualToAnchor:contentLayout.bottomAnchor],
+      [self.keyLabel.widthAnchor constraintEqualToAnchor:contentLayout.widthAnchor multiplier:0.3]
+    ]];
     self.keyLabel.textColor = [UIColor whiteColor];
     self.keyLabel.numberOfLines = 0;
     self.keyLabel.lineBreakMode = NSLineBreakByWordWrapping;
     self.keyLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:12.0f];
+    
     self.valueLabel = [UILabel new];
     [self.contentView addSubview:self.valueLabel];
-
     self.valueLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.valueLabel.leadingAnchor constraintEqualToAnchor:self.keyLabel.trailingAnchor constant:10.f].active = YES;
-    [self.valueLabel.trailingAnchor constraintEqualToAnchor:contentLayout.trailingAnchor].active = YES;
-    [self.valueLabel.topAnchor constraintEqualToAnchor:contentLayout.topAnchor].active = YES;
-    [self.valueLabel.bottomAnchor constraintEqualToAnchor:contentLayout.bottomAnchor].active = YES;
-
+    [NSLayoutConstraint activateConstraints:@[
+      [self.valueLabel.leadingAnchor constraintEqualToAnchor:self.keyLabel.trailingAnchor constant:10.f],
+      [self.valueLabel.trailingAnchor constraintEqualToAnchor:contentLayout.trailingAnchor],
+      [self.valueLabel.topAnchor constraintEqualToAnchor:contentLayout.topAnchor],
+      [self.valueLabel.bottomAnchor constraintEqualToAnchor:contentLayout.bottomAnchor]
+    ]];
     self.valueLabel.textColor = [UIColor whiteColor];
     self.valueLabel.numberOfLines = 0;
     self.valueLabel.lineBreakMode = NSLineBreakByWordWrapping;
@@ -71,72 +73,82 @@
   if (self = [super init]) {
     _extraData = [NSMutableArray new];
     _extraDataTitle = [NSMutableArray new];
-    self.view.backgroundColor = [UIColor colorWithRed:0.8 green:0 blue:0 alpha:1];
-
-    _tableView = [UITableView new];
-    _tableView.delegate = self;
-    _tableView.dataSource = self;
-    _tableView.backgroundColor = [UIColor clearColor];
-    _tableView.estimatedRowHeight = 200;
-    _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
-    _tableView.rowHeight = UITableViewAutomaticDimension;
-    _tableView.allowsSelection = NO;
-
-#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
-    NSString *reloadText = @"Reload JS (\u2318R)";
-    NSString *dismissText = @"Dismiss (ESC)";
-#else
-    NSString *reloadText = @"Reload JS";
-    NSString *dismissText = @"Dismiss";
-#endif
-
-    UIButton *dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    dismissButton.translatesAutoresizingMaskIntoConstraints = NO;
-    dismissButton.accessibilityIdentifier = @"redbox-extra-data-dismiss";
-    dismissButton.titleLabel.font = [UIFont systemFontOfSize:13];
-    [dismissButton setTitle:dismissText forState:UIControlStateNormal];
-    [dismissButton setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateNormal];
-    [dismissButton setTitleColor:[UIColor whiteColor] forState:UIControlStateHighlighted];
-    [dismissButton addTarget:self action:@selector(dismiss) forControlEvents:UIControlEventTouchUpInside];
-
-    UIButton *reloadButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    reloadButton.accessibilityIdentifier = @"redbox-reload";
-    reloadButton.titleLabel.font = [UIFont systemFontOfSize:13];
-    [reloadButton setTitle:reloadText forState:UIControlStateNormal];
-    [reloadButton setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateNormal];
-    [reloadButton setTitleColor:[UIColor whiteColor] forState:UIControlStateHighlighted];
-    [reloadButton addTarget:self action:@selector(reload) forControlEvents:UIControlEventTouchUpInside];
-
-    UIStackView *buttonStackView = [UIStackView new];
-    buttonStackView.axis = UILayoutConstraintAxisHorizontal;
-    buttonStackView.distribution = UIStackViewDistributionEqualSpacing;
-    buttonStackView.alignment = UIStackViewAlignmentFill;
-    buttonStackView.spacing = 20;
-
-    [buttonStackView addArrangedSubview:dismissButton];
-    [buttonStackView addArrangedSubview:reloadButton];
-    buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
-
-    UIStackView *mainStackView = [UIStackView new];
-    mainStackView.axis = UILayoutConstraintAxisVertical;
-    mainStackView.backgroundColor = [UIColor colorWithRed:0.8 green:0 blue:0 alpha:1];
-    [mainStackView addArrangedSubview:_tableView];
-    [mainStackView addArrangedSubview:buttonStackView];
-    mainStackView.translatesAutoresizingMaskIntoConstraints = NO;
-
-    [self.view addSubview:mainStackView];
-
-    CGFloat tableHeight = self.view.bounds.size.height - 60.f;
-    [_tableView.heightAnchor constraintEqualToConstant:tableHeight].active = YES;
-    [_tableView.widthAnchor constraintEqualToAnchor:self.view.widthAnchor].active = YES;
-
-    CGFloat buttonWidth = self.view.bounds.size.width / 4;
-    [dismissButton.heightAnchor constraintEqualToConstant:60].active = YES;
-    [dismissButton.widthAnchor constraintEqualToConstant:buttonWidth].active = YES;
-    [reloadButton.heightAnchor constraintEqualToConstant:60].active = YES;
-    [reloadButton.widthAnchor constraintEqualToConstant:buttonWidth].active = YES;
   }
   return self;
+}
+
+- (UIButton *)redBoxButtonWithTitle:(NSString *)title accessibilityIdentifier:(NSString *)accessibilityIdentifier action:(SEL)action {
+  UIButton *button = [UIButton buttonWithType: UIButtonTypeCustom];
+  button.accessibilityIdentifier = accessibilityIdentifier;
+  
+  button.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
+  
+  button.titleLabel.font = [UIFont systemFontOfSize:13];
+  
+  [button setTitle:title forState:UIControlStateNormal];
+  [button setTitleColor:[UIColor colorWithWhite:1 alpha:1] forState:UIControlStateNormal];
+  [button setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateHighlighted];
+  
+  [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+  return button;
+}
+
+-(void)viewDidLoad {
+  CGFloat bottomSafeAreaInset = RCTSharedApplication().delegate.window.safeAreaInsets.bottom;
+  
+  CGFloat buttonHeight = 60;
+  CGFloat buttonWidth = self.view.bounds.size.width / 2;
+  
+  CGRect frame = self.view.bounds;
+  frame.size.height -= buttonHeight + bottomSafeAreaInset;
+  
+  _tableView = [[UITableView alloc] initWithFrame:frame style:UITableViewStylePlain];
+  _tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _tableView.delegate = self;
+  _tableView.dataSource = self;
+  _tableView.backgroundColor = [UIColor colorWithRed:0.8 green:0 blue:0 alpha:1];
+  _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+  _tableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
+  _tableView.allowsSelection = NO;
+  
+  [self.view addSubview:_tableView];
+  
+#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
+  NSString *reloadText = @"Reload JS (\u2318R)";
+  NSString *dismissText = @"Dismiss (ESC)";
+#else
+  NSString *reloadText = @"Reload JS";
+  NSString *dismissText = @"Dismiss";
+#endif
+  
+  UIButton *dismissButton = [self redBoxButtonWithTitle:dismissText accessibilityIdentifier:@"redbox-extra-data-dismiss" action:@selector(dismiss)];
+  UIButton *reloadButton = [self redBoxButtonWithTitle:reloadText accessibilityIdentifier:@"redbox-reload" action:@selector(reload)];
+  
+  UIStackView *buttonStackView = [[UIStackView alloc] init];
+  buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
+  buttonStackView.axis = UILayoutConstraintAxisHorizontal;
+  buttonStackView.distribution = UIStackViewDistributionFillEqually;
+  buttonStackView.alignment = UIStackViewAlignmentTop;
+  buttonStackView.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
+  
+  [buttonStackView addArrangedSubview:dismissButton];
+  [buttonStackView addArrangedSubview:reloadButton];
+  
+  [NSLayoutConstraint activateConstraints:@[
+    [dismissButton.heightAnchor constraintEqualToConstant:buttonHeight],
+    [dismissButton.widthAnchor constraintEqualToConstant:buttonWidth],
+    [reloadButton.heightAnchor constraintEqualToConstant:buttonHeight],
+    [reloadButton.widthAnchor constraintEqualToConstant:buttonWidth],
+  ]];
+  
+  [self.view addSubview:buttonStackView];
+  
+  [NSLayoutConstraint activateConstraints:@[
+    [buttonStackView.heightAnchor constraintEqualToConstant:buttonHeight + bottomSafeAreaInset],
+    [buttonStackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [buttonStackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [buttonStackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+  ]];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -157,23 +169,25 @@
 
 - (UIView *)tableView:(__unused UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-  UIView *view = [UIView new];
-  view.backgroundColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:1];
-
-  UILabel *header = [UILabel new];
-  [view addSubview:header];
-
-  header.translatesAutoresizingMaskIntoConstraints = NO;
-  [header.leadingAnchor constraintEqualToAnchor:view.leadingAnchor constant:5].active = YES;
-  [header.trailingAnchor constraintEqualToAnchor:view.trailingAnchor].active = YES;
-  [header.topAnchor constraintEqualToAnchor:view.topAnchor].active = YES;
-  [header.bottomAnchor constraintEqualToAnchor:view.bottomAnchor].active = YES;
-
-  header.textColor = [UIColor whiteColor];
-  header.font = [UIFont fontWithName:@"Menlo-Bold" size:14.0f];
-  header.text = [_extraDataTitle[section] uppercaseString];
-
-  return view;
+  UIView *header = [UIView new];
+  header.backgroundColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:1];
+  
+  UILabel *headerLabel = [UILabel new];
+  [header addSubview:headerLabel];
+  
+  headerLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  [NSLayoutConstraint activateConstraints:@[
+    [headerLabel.leadingAnchor constraintEqualToAnchor:header.leadingAnchor constant:5],
+    [headerLabel.trailingAnchor constraintEqualToAnchor:header.trailingAnchor],
+    [headerLabel.topAnchor constraintEqualToAnchor:header.topAnchor],
+    [headerLabel.bottomAnchor constraintEqualToAnchor:header.bottomAnchor],
+  ]];
+  
+  headerLabel.textColor = [UIColor whiteColor];
+  headerLabel.font = [UIFont fontWithName:@"Menlo-Bold" size:14.0f];
+  headerLabel.text = [_extraDataTitle[section] uppercaseString];
+  
+  return header;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/packages/react-native/React/Modules/RCTRedBoxExtraDataViewController.m
+++ b/packages/react-native/React/Modules/RCTRedBoxExtraDataViewController.m
@@ -94,23 +94,19 @@
 }
 
 -(void)viewDidLoad {
-  CGFloat bottomSafeAreaInset = RCTSharedApplication().delegate.window.safeAreaInsets.bottom;
+  CGFloat bottomSafeAreaInset = RCTKeyWindow().safeAreaInsets.bottom;
   
   CGFloat buttonHeight = 60;
   CGFloat buttonWidth = self.view.bounds.size.width / 2;
   
-  CGRect frame = self.view.bounds;
-  frame.size.height -= buttonHeight + bottomSafeAreaInset;
-  
-  _tableView = [[UITableView alloc] initWithFrame:frame style:UITableViewStylePlain];
-  _tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _tableView = [UITableView new];
+  _tableView.translatesAutoresizingMaskIntoConstraints = NO;
   _tableView.delegate = self;
   _tableView.dataSource = self;
   _tableView.backgroundColor = [UIColor colorWithRed:0.8 green:0 blue:0 alpha:1];
   _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
   _tableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
   _tableView.allowsSelection = NO;
-  
   [self.view addSubview:_tableView];
   
 #if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
@@ -134,17 +130,20 @@
   [buttonStackView addArrangedSubview:dismissButton];
   [buttonStackView addArrangedSubview:reloadButton];
   
+  [self.view addSubview:buttonStackView];
+  
   [NSLayoutConstraint activateConstraints:@[
+    [_tableView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+    [_tableView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [_tableView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [_tableView.bottomAnchor constraintEqualToAnchor:buttonStackView.topAnchor],
+    
     [dismissButton.heightAnchor constraintEqualToConstant:buttonHeight],
     [dismissButton.widthAnchor constraintEqualToConstant:buttonWidth],
     [reloadButton.heightAnchor constraintEqualToConstant:buttonHeight],
     [reloadButton.widthAnchor constraintEqualToConstant:buttonWidth],
-  ]];
-  
-  [self.view addSubview:buttonStackView];
-  
-  [NSLayoutConstraint activateConstraints:@[
     [buttonStackView.heightAnchor constraintEqualToConstant:buttonHeight + bottomSafeAreaInset],
+    
     [buttonStackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
     [buttonStackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
     [buttonStackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],


### PR DESCRIPTION
## Summary:

This PR fixes rendering of `RCTRedBoxExtraData`

I noticed that it wasn't displaying the `reload` and `dismiss` buttons, which made it impossible to close modal and to reload JS on e.g. `visionOS` (on `iOS` it could only be closed by swiping).

PR adds these buttons back and also introduces some refactoring

Before & After:

<img width="1118" alt="pr-img" src="https://github.com/facebook/react-native/assets/56474758/50e22499-9df0-45f0-84ac-2118ab7a8e6c">

## Changelog:

[IOS] [FIXED] - Fix rendering `RCTRedBoxExtraData`

## Test Plan:

Make sure that `RCTRedBoxExtraData`  displays and works as expected
