### PR TITLE
Add build script to check that codegen run properly in the project

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -292,4 +292,20 @@ Pod::Spec.new do |s|
     ss.header_dir           = "react/renderer/leakchecker"
     ss.pod_target_xcconfig  = { "GCC_WARN_PEDANTIC" => "YES" }
   end
+
+  s.script_phases = [
+    {
+      :name => '[RN]Check rncore',
+      :execution_position => :before_compile,
+      :script => <<-EOS
+echo "Checking whether Codegen has run..."
+rncorePath="$REACT_NATIVE_PATH/ReactCommon/react/renderer/components/rncore"
+
+if [[ ! -d "$rncorePath" ]]; then
+  echo 'error: Codegen did not run properly in your project. Please reinstall cocoapods with `bundle exec pod install`.'
+  exit 1
+fi
+      EOS
+    }
+  ]
 end


### PR DESCRIPTION
Summary:
This is a quality of like improvement for the project we create for the final users.
Codegen generates code in `rncore`, within `node_modules`. This is not the perfect approach but it is working so far.

To make it more robust, we added a small script in React-Fabric podspec to check that codegen run properly when building.
In this way, if a user run `yarn install` and, for any reason, react-native is regenerated, we can provide a better DevX to our users with an actionable message on how to fix the build problem.

##Changelog
[iOS][Added] - Add error message if codegen has not run properly

Differential Revision: D53927788


