### PR TITLE
Add installJSIBindings for turbo modules on android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/JSIBindingsInstaller.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/JSIBindingsInstaller.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core
+
+import com.facebook.jni.HybridData
+import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.proguard.annotations.DoNotStripAny
+
+/**
+ * A Java holder for a C++ JSIBindingsInstaller.
+ */
+@DoNotStripAny
+public class JSIBindingsInstaller(@field:DoNotStrip private val mHybridData: HybridData)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings.kt
@@ -7,18 +7,18 @@
 
 package com.facebook.react.turbomodule.core.interfaces
 
-import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.react.turbomodule.core.JSIBindingsInstaller
 
 /**
  * If a turbo module needs to install its custom JSI bindings, it should implement this interface.
  */
-@DoNotStrip
+@DoNotStripAny
 public interface TurboModuleWithJSIBindings {
   /**
-   * The method to install JSI bindings.
-   * The implementation will typically call into C++ for JSI setup through JNI.
-   * @param runtime The (facebook::jsi::Runtime *) pointer casted to Long type.
+   * Returns the [JSIBindingsInstaller] callback that the core will later invoke with
+   * an `facebook::jsi::Runtime` instance.
+   * The implementation will typically mix with JNI and C++.
    */
-  @DoNotStrip
-  public fun installJSIBindings(runtime: Long)
+  public fun getJSIBindingsInstaller(): JSIBindingsInstaller
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core.interfaces
+
+import com.facebook.proguard.annotations.DoNotStrip
+
+/**
+ * If a turbo module needs to install its custom JSI bindings, it should implement this interface.
+ */
+@DoNotStrip
+public interface TurboModuleWithJSIBindings {
+  /**
+   * The method to install JSI bindings.
+   * The implementation will typically call into C++ for JSI setup through JNI.
+   * @param runtime The (facebook::jsi::Runtime *) pointer casted to Long type.
+   */
+  @DoNotStrip
+  public fun installJSIBindings(runtime: Long)
+}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
         turbomodulejsijni
         SHARED
         ReactCommon/CompositeTurboModuleManagerDelegate.cpp
+        ReactCommon/JJSIBindingsInstaller.cpp
         ReactCommon/OnLoad.cpp
         ReactCommon/TurboModuleManager.cpp
 )

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/JJSIBindingsInstaller.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/JJSIBindingsInstaller.cpp
@@ -9,7 +9,8 @@
 
 namespace facebook::react {
 
-JJSIBindingsInstaller::JJSIBindingsInstaller(TurboModule::JSIBindingsInstaller jsiBindingsInstaller)
+JJSIBindingsInstaller::JJSIBindingsInstaller(
+    TurboModule::JSIBindingsInstaller jsiBindingsInstaller)
     : jsiBindingsInstaller_(jsiBindingsInstaller) {}
 
 TurboModule::JSIBindingsInstaller JJSIBindingsInstaller::get() {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/JJSIBindingsInstaller.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/JJSIBindingsInstaller.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JJSIBindingsInstaller.h"
+
+namespace facebook::react {
+
+JJSIBindingsInstaller::JJSIBindingsInstaller(TurboModule::JSIBindingsInstaller jsiBindingsInstaller)
+    : jsiBindingsInstaller_(jsiBindingsInstaller) {}
+
+TurboModule::JSIBindingsInstaller JJSIBindingsInstaller::get() {
+  return jsiBindingsInstaller_;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/JJSIBindingsInstaller.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/JJSIBindingsInstaller.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/TurboModule.h>
+#include <fbjni/fbjni.h>
+
+namespace facebook::react {
+
+class JJSIBindingsInstaller : public jni::HybridClass<JJSIBindingsInstaller> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/turbomodule/core/JSIBindingsInstaller;";
+
+  TurboModule::JSIBindingsInstaller get();
+
+ private:
+  friend HybridBase;
+  JJSIBindingsInstaller(TurboModule::JSIBindingsInstaller jsiBindingsInstaller);
+  TurboModule::JSIBindingsInstaller jsiBindingsInstaller_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -14,6 +14,7 @@
 
 #include <ReactCommon/CxxTurboModuleUtils.h>
 #include <ReactCommon/JavaInteropTurboModule.h>
+#include <ReactCommon/JJSIBindingsInstaller.h>
 #include <ReactCommon/TurboCxxModule.h>
 #include <ReactCommon/TurboModuleBinding.h>
 #include <ReactCommon/TurboModulePerfLogger.h>
@@ -212,8 +213,11 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
 
       auto turboModule = delegate->cthis()->getTurboModule(name, params);
       if (moduleInstance->isInstanceOf(JTurboModuleWithJSIBindings::javaClassStatic())) {
-        auto installJSIBindingsForModule = moduleInstance->getClass()->getMethod<void(jlong)>("installJSIBindings");
-        installJSIBindingsForModule(moduleInstance, reinterpret_cast<jlong>(runtime));
+        auto getJSIBindingsInstaller = moduleInstance->getClass()->getMethod<JJSIBindingsInstaller::javaobject ()>("getJSIBindingsInstaller");
+        auto installer = getJSIBindingsInstaller(moduleInstance);
+        if (installer) {
+          installer->cthis()->get()(*runtime);
+        }
       }
 
       turboModuleCache->insert({name, turboModule});

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -13,8 +13,8 @@
 #include <jsi/jsi.h>
 
 #include <ReactCommon/CxxTurboModuleUtils.h>
-#include <ReactCommon/JavaInteropTurboModule.h>
 #include <ReactCommon/JJSIBindingsInstaller.h>
+#include <ReactCommon/JavaInteropTurboModule.h>
 #include <ReactCommon/TurboCxxModule.h>
 #include <ReactCommon/TurboModuleBinding.h>
 #include <ReactCommon/TurboModulePerfLogger.h>
@@ -131,7 +131,8 @@ void TurboModuleManager::registerNatives() {
 }
 
 TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
-    jsi::Runtime *runtime, bool enableSyncVoidMethods) {
+    jsi::Runtime* runtime,
+    bool enableSyncVoidMethods) {
   return [turboModuleCache_ = std::weak_ptr<ModuleCache>(turboModuleCache_),
           runtime,
           jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
@@ -212,8 +213,12 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
           .shouldVoidMethodsExecuteSync = enableSyncVoidMethods};
 
       auto turboModule = delegate->cthis()->getTurboModule(name, params);
-      if (moduleInstance->isInstanceOf(JTurboModuleWithJSIBindings::javaClassStatic())) {
-        auto getJSIBindingsInstaller = moduleInstance->getClass()->getMethod<JJSIBindingsInstaller::javaobject ()>("getJSIBindingsInstaller");
+      if (moduleInstance->isInstanceOf(
+              JTurboModuleWithJSIBindings::javaClassStatic())) {
+        auto getJSIBindingsInstaller =
+            moduleInstance->getClass()
+                ->getMethod<JJSIBindingsInstaller::javaobject()>(
+                    "getJSIBindingsInstaller");
         auto installer = getJSIBindingsInstaller(moduleInstance);
         if (installer) {
           installer->cthis()->get()(*runtime);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -67,7 +67,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 
   TurboModuleProviderFunctionType createTurboModuleProvider(
-      bool enableSyncVoidMethods);
+      jsi::Runtime *runtime, bool enableSyncVoidMethods);
   TurboModuleProviderFunctionType createLegacyModuleProvider();
 };
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -67,7 +67,8 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 
   TurboModuleProviderFunctionType createTurboModuleProvider(
-      jsi::Runtime *runtime, bool enableSyncVoidMethods);
+      jsi::Runtime* runtime,
+      bool enableSyncVoidMethods);
   TurboModuleProviderFunctionType createLegacyModuleProvider();
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -48,6 +48,8 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
  public:
   TurboModule(std::string name, std::shared_ptr<CallInvoker> jsInvoker);
 
+  using JSIBindingsInstaller = std::function<void(jsi::Runtime& runtime)>;
+
   // Note: keep this method declared inline to avoid conflicts
   // between RTTI and non-RTTI compilation units
   facebook::jsi::Value get(

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
@@ -22,7 +22,8 @@ struct JTurboModule : jni::JavaClass<JTurboModule> {
       "Lcom/facebook/react/internal/turbomodule/core/interfaces/TurboModule;";
 };
 
-struct JTurboModuleWithJSIBindings : jni::JavaClass<JTurboModuleWithJSIBindings> {
+struct JTurboModuleWithJSIBindings
+    : jni::JavaClass<JTurboModuleWithJSIBindings> {
   static auto constexpr kJavaDescriptor =
       "Lcom/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings;";
 };

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
@@ -22,6 +22,11 @@ struct JTurboModule : jni::JavaClass<JTurboModule> {
       "Lcom/facebook/react/internal/turbomodule/core/interfaces/TurboModule;";
 };
 
+struct JTurboModuleWithJSIBindings : jni::JavaClass<JTurboModuleWithJSIBindings> {
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings;";
+};
+
 class JSI_EXPORT JavaTurboModule : public TurboModule {
  public:
   // TODO(T65603471): Should we unify this with a Fabric abstraction?

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
@@ -23,4 +23,5 @@ target_include_directories(sampleturbomodule PUBLIC .)
 target_link_libraries(sampleturbomodule
         fbjni
         jsi
-        react_nativemodule_core)
+        react_nativemodule_core
+        turbomodulejsijni)

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.cpp
@@ -12,15 +12,21 @@ namespace facebook::react {
 // static
 void SampleTurboModuleJSIBindings::registerNatives() {
   javaClassLocal()->registerNatives({
-    makeNativeMethod("getJSIBindingsInstallerCxx", SampleTurboModuleJSIBindings::getJSIBindingsInstallerCxx),
+      makeNativeMethod(
+          "getJSIBindingsInstallerCxx",
+          SampleTurboModuleJSIBindings::getJSIBindingsInstallerCxx),
   });
 }
 
 // static
-jni::local_ref<JJSIBindingsInstaller::javaobject> SampleTurboModuleJSIBindings::getJSIBindingsInstallerCxx(jni::alias_ref<jni::JClass> clazz) {
-  return jni::make_local(JJSIBindingsInstaller::newObjectCxxArgs([](jsi::Runtime &runtime) {
-    runtime.global().setProperty(runtime, "__SampleTurboModuleJSIBindings", "Hello JSI!");
-  }));
+jni::local_ref<JJSIBindingsInstaller::javaobject>
+SampleTurboModuleJSIBindings::getJSIBindingsInstallerCxx(
+    jni::alias_ref<jni::JClass> clazz) {
+  return jni::make_local(
+      JJSIBindingsInstaller::newObjectCxxArgs([](jsi::Runtime& runtime) {
+        runtime.global().setProperty(
+            runtime, "__SampleTurboModuleJSIBindings", "Hello JSI!");
+      }));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.cpp
@@ -12,14 +12,15 @@ namespace facebook::react {
 // static
 void SampleTurboModuleJSIBindings::registerNatives() {
   javaClassLocal()->registerNatives({
-    makeNativeMethod("installJSIBindingsCxx", SampleTurboModuleJSIBindings::installJSIBindingsCxx),
+    makeNativeMethod("getJSIBindingsInstallerCxx", SampleTurboModuleJSIBindings::getJSIBindingsInstallerCxx),
   });
 }
 
 // static
-void SampleTurboModuleJSIBindings::installJSIBindingsCxx(jni::alias_ref<jni::JClass> clazz, jlong runtimePtr) {
-  jsi::Runtime &runtime = *reinterpret_cast<jsi::Runtime *>(runtimePtr);
-  runtime.global().setProperty(runtime, "__SampleTurboModuleJSIBindings", "Hello JSI!");
+jni::local_ref<JJSIBindingsInstaller::javaobject> SampleTurboModuleJSIBindings::getJSIBindingsInstallerCxx(jni::alias_ref<jni::JClass> clazz) {
+  return jni::make_local(JJSIBindingsInstaller::newObjectCxxArgs([](jsi::Runtime &runtime) {
+    runtime.global().setProperty(runtime, "__SampleTurboModuleJSIBindings", "Hello JSI!");
+  }));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ReactCommon/SampleTurboModuleJSIBindings.h>
+
+namespace facebook::react {
+
+// static
+void SampleTurboModuleJSIBindings::registerNatives() {
+  javaClassLocal()->registerNatives({
+    makeNativeMethod("installJSIBindingsCxx", SampleTurboModuleJSIBindings::installJSIBindingsCxx),
+  });
+}
+
+// static
+void SampleTurboModuleJSIBindings::installJSIBindingsCxx(jni::alias_ref<jni::JClass> clazz, jlong runtimePtr) {
+  jsi::Runtime &runtime = *reinterpret_cast<jsi::Runtime *>(runtimePtr);
+  runtime.global().setProperty(runtime, "__SampleTurboModuleJSIBindings", "Hello JSI!");
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.h
@@ -7,13 +7,14 @@
 
 #pragma once
 
+#include <ReactCommon/JJSIBindingsInstaller.h>
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
-#include <ReactCommon/JJSIBindingsInstaller.h>
 
 namespace facebook::react {
 
-class SampleTurboModuleJSIBindings : public jni::JavaClass<SampleTurboModuleJSIBindings> {
+class SampleTurboModuleJSIBindings
+    : public jni::JavaClass<SampleTurboModuleJSIBindings> {
  public:
   static constexpr const char* kJavaDescriptor =
       "Lcom/facebook/fbreact/specs/SampleTurboModule;";
@@ -24,7 +25,8 @@ class SampleTurboModuleJSIBindings : public jni::JavaClass<SampleTurboModuleJSIB
 
  private:
   // Using static function as a simple demonstration
-  static jni::local_ref<JJSIBindingsInstaller::javaobject> getJSIBindingsInstallerCxx(jni::alias_ref<jni::JClass> clazz);
+  static jni::local_ref<JJSIBindingsInstaller::javaobject>
+  getJSIBindingsInstallerCxx(jni::alias_ref<jni::JClass> clazz);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+namespace facebook::react {
+
+class SampleTurboModuleJSIBindings : public jni::JavaClass<SampleTurboModuleJSIBindings> {
+ public:
+  static constexpr const char* kJavaDescriptor =
+      "Lcom/facebook/fbreact/specs/SampleTurboModule;";
+
+  SampleTurboModuleJSIBindings() = default;
+
+  static void registerNatives();
+
+ private:
+  // Using static function as a simple demonstration
+  static void installJSIBindingsCxx(jni::alias_ref<jni::JClass> clazz, jlong runtimePtr);
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.h
@@ -9,6 +9,7 @@
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
+#include <ReactCommon/JJSIBindingsInstaller.h>
 
 namespace facebook::react {
 
@@ -23,7 +24,7 @@ class SampleTurboModuleJSIBindings : public jni::JavaClass<SampleTurboModuleJSIB
 
  private:
   // Using static function as a simple demonstration
-  static void installJSIBindingsCxx(jni::alias_ref<jni::JClass> clazz, jlong runtimePtr);
+  static jni::local_ref<JJSIBindingsInstaller::javaobject> getJSIBindingsInstallerCxx(jni::alias_ref<jni::JClass> clazz);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.turbomodule.core.JSIBindingsInstaller;
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings;
 import java.util.HashMap;
 import java.util.Map;
@@ -249,9 +250,9 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec implements Tu
 
   @Override
   @DoNotStrip
-  public void installJSIBindings(long runtime) {
-    installJSIBindingsCxx(runtime);
+  public JSIBindingsInstaller getJSIBindingsInstaller() {
+    return getJSIBindingsInstallerCxx();
   }
 
-  private static native void installJSIBindingsCxx(long runtime);
+  private static native JSIBindingsInstaller getJSIBindingsInstallerCxx();
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -23,11 +23,12 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings;
 import java.util.HashMap;
 import java.util.Map;
 
 @ReactModule(name = SampleTurboModule.NAME)
-public class SampleTurboModule extends NativeSampleTurboModuleSpec {
+public class SampleTurboModule extends NativeSampleTurboModuleSpec implements TurboModuleWithJSIBindings {
 
   public static final String NAME = "SampleTurboModule";
 
@@ -245,4 +246,12 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec {
   public String getName() {
     return NAME;
   }
+
+  @Override
+  @DoNotStrip
+  public void installJSIBindings(long runtime) {
+    installJSIBindingsCxx(runtime);
+  }
+
+  private static native void installJSIBindingsCxx(long runtime);
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -29,7 +29,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 @ReactModule(name = SampleTurboModule.NAME)
-public class SampleTurboModule extends NativeSampleTurboModuleSpec implements TurboModuleWithJSIBindings {
+public class SampleTurboModule extends NativeSampleTurboModuleSpec
+    implements TurboModuleWithJSIBindings {
 
   public static final String NAME = "SampleTurboModule";
 

--- a/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
+++ b/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
@@ -9,6 +9,7 @@
 #include <DefaultTurboModuleManagerDelegate.h>
 #include <NativeCxxModuleExample.h>
 #include <ReactCommon/SampleTurboModuleSpec.h>
+#include <ReactCommon/SampleTurboModuleJSIBindings.h>
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 
@@ -66,5 +67,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
     facebook::react::DefaultComponentsRegistry::
         registerComponentDescriptorsFromEntryPoint =
             &facebook::react::registerComponents;
+    facebook::react::SampleTurboModuleJSIBindings::registerNatives();
   });
 }

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -14,6 +14,7 @@ import styles from './TurboModuleExampleCommon';
 import * as React from 'react';
 import {
   FlatList,
+  Platform,
   RootTagContext,
   Text,
   TouchableOpacity,
@@ -128,6 +129,9 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
           this._setResult('promiseAssert', e.message);
         });
     },
+    installJSIBindings: () => {
+      return global.__SampleTurboModuleJSIBindings;
+    },
   };
 
   _setResult(
@@ -192,6 +196,14 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
     if (global.__turboModuleProxy == null) {
       throw new Error(
         'Cannot load this example because TurboModule is not configured.',
+      );
+    }
+    if (
+      global.__SampleTurboModuleJSIBindings == null &&
+      Platform.OS === 'android' // TODO: Add iOS support
+    ) {
+      throw new Error(
+        'The JSI bindings for SampleTurboModule are not installed.',
       );
     }
   }


### PR DESCRIPTION
## Summary:

Add synchronous JSI installation for TurboModules on Android. That would help some 3rd party JSI based modules to get the `jsi::Runtime` on bridgeless mode.
The iOS implementation will be in a separate PR.
 
## Changelog:

[ANDROID] [ADDED] - Add installJSIBindings for TurboModules

## Test Plan:

Added test in RN-Tester TurboModule test case
