### PR TITLE
Unmount view from the reactsubviews in the Interop Layer

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -179,8 +179,8 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  if (_adapter) {
-    [_adapter.paperView removeReactSubview:childComponentView];
+  if (_adapter && index < _adapter.paperView.reactSubviews.count) {
+    [_adapter.paperView removeReactSubview:_adapter.paperView.reactSubviews[index]];
   } else {
     [_viewsToBeUnmounted addObject:childComponentView];
   }


### PR DESCRIPTION
Summary:
When mounting views in the interop layer, we register them in an array `reactSubview` that is added to `UIView`. However, when unmounting them, we were just removing them from the parent view.

This worked fine while the view we were adding to reactSubview was the same that we were adding to hierarchy. However, there are instances where libraries might wrap those views in some custom wrappers. This break the assumption that the same view we are adding to the UI hierarchy is the same view we will remove.

With this change, we make sure to use the same semantic when we add some view and when we remove it.

This also fixes a crash that happens with Mobile home when navigating away from the Ride's Map, using Fabric.

## Changelog
[internal] - Remove views from hierarchy using the view that is added to the `reactSubviews`

Differential Revision: D53943728


