### PR TITLE
delete access to UIApplicationLaunchOptionsLocalNotificationKey

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -565,27 +565,6 @@ RCT_EXPORT_METHOD(getInitialNotification
     return;
   }
 
-  NSMutableDictionary<NSString *, id> *initialRemoteNotification =
-      [self.bridge.launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey] mutableCopy];
-
-  // The user actioned a remote notification to launch the app. This is a fallback that is deprecated
-  // in the new architecture.
-  if (initialRemoteNotification) {
-    initialRemoteNotification[@"remote"] = @YES;
-    resolve(initialRemoteNotification);
-    return;
-  }
-
-  UILocalNotification *initialLocalNotification =
-      self.bridge.launchOptions[UIApplicationLaunchOptionsLocalNotificationKey];
-
-  // The user actioned a local notification to launch the app. Notification is represented by UILocalNotification. This
-  // is deprecated.
-  if (initialLocalNotification) {
-    resolve(RCTFormatLocalNotification(initialLocalNotification));
-    return;
-  }
-
   resolve((id)kCFNull);
 }
 


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

PR#42628 introduced new behavior on how the react native infra tracks local notifications that start the app. in this PR, we are officially deleting the old implementation.

Reviewed By: ingridwang

Differential Revision: D52931617


