### PR TITLE
Remove deprecated alertAction and repeatInterval properties

### DIFF
--- a/packages/react-native/src/private/specs/modules/NativePushNotificationManagerIOS.js
+++ b/packages/react-native/src/private/specs/modules/NativePushNotificationManagerIOS.js
@@ -55,10 +55,6 @@ type Notification = {|
    * getScheduledLocalNotifications or getDeliveredNotifications.
    */
   +soundName?: ?string,
-  /** DEPRECATED. This was used for iOS's legacy UILocalNotification. */
-  +alertAction?: ?string,
-  /** DEPRECATED. Use `fireDate` or `fireIntervalSeconds` instead. */
-  +repeatInterval?: ?string,
 |};
 
 export interface Spec extends TurboModule {


### PR DESCRIPTION
Summary:
Changelog:
[iOS][Breaking] Deleting deprecated alertAction and repeatInterval in PushNotificationIOS

Reviewed By: philIip

Differential Revision: D53734569


