### PR TITLE
Delete deprecated didReceiveLocal/RemoteNotification

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -45,9 +45,4 @@ typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
  */
 + (void)setInitialNotification:(UNNotification *)notification;
 
-/** DEPRECATED. Use didReceiveNotification instead. */
-+ (void)didReceiveLocalNotification:(UILocalNotification *)notification RCT_DEPRECATED;
-/** DEPRECATED. Use didReceiveNotification instead. */
-+ (void)didReceiveRemoteNotification:(NSDictionary *)notification RCT_DEPRECATED;
-
 @end

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -97,26 +97,6 @@ RCT_ENUM_CONVERTER(
 
 @implementation RCTPushNotificationManager
 
-/** DEPRECATED. UILocalNotification was deprecated in iOS 10. Please don't add new callsites. */
-static NSDictionary *RCTFormatLocalNotification(UILocalNotification *notification)
-{
-  NSMutableDictionary *formattedLocalNotification = [NSMutableDictionary dictionary];
-  if (notification.fireDate) {
-    NSDateFormatter *formatter = [NSDateFormatter new];
-    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
-    NSString *fireDateString = [formatter stringFromDate:notification.fireDate];
-    formattedLocalNotification[@"fireDate"] = fireDateString;
-  }
-  formattedLocalNotification[@"alertAction"] = RCTNullIfNil(notification.alertAction);
-  formattedLocalNotification[@"alertBody"] = RCTNullIfNil(notification.alertBody);
-  formattedLocalNotification[@"applicationIconBadgeNumber"] = @(notification.applicationIconBadgeNumber);
-  formattedLocalNotification[@"category"] = RCTNullIfNil(notification.category);
-  formattedLocalNotification[@"soundName"] = RCTNullIfNil(notification.soundName);
-  formattedLocalNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(notification.userInfo));
-  formattedLocalNotification[@"remote"] = @NO;
-  return formattedLocalNotification;
-}
-
 /** For delivered notifications */
 static NSDictionary<NSString *, id> *RCTFormatUNNotification(UNNotification *notification)
 {
@@ -265,23 +245,6 @@ RCT_EXPORT_MODULE()
 + (void)setInitialNotification:(UNNotification *)notification
 {
   kInitialNotification = notification;
-}
-
-// Deprecated
-+ (void)didReceiveLocalNotification:(UILocalNotification *)notification
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:kLocalNotificationReceived
-                                                      object:self
-                                                    userInfo:RCTFormatLocalNotification(notification)];
-}
-
-// Deprecated
-+ (void)didReceiveRemoteNotification:(NSDictionary *)notification
-{
-  NSDictionary *userInfo = @{@"notification" : notification};
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
-                                                      object:self
-                                                    userInfo:userInfo];
 }
 
 - (void)invalidate


### PR DESCRIPTION
Summary:
Changelog:
[iOS][Breaking] Deleting deprecated didReceiveLocalNotification & didReceiveRemoteNotification callbacks on RCTPushNotificationManager

Differential Revision: D52883365


