### PR TITLE
Fix missing imports in React Native files.

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoaderLoggable.h
+++ b/packages/react-native/Libraries/Image/RCTImageLoaderLoggable.h
@@ -5,10 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * The image loader (i.e. RCTImageLoader) implement this to declare whether image performance should be logged.
  */
-@protocol RCTImageLoaderLoggableProtocol
+@protocol RCTImageLoaderLoggableProtocol <NSObject>
 
 /**
  * Image instrumentation - declares whether its caller should log images

--- a/packages/react-native/Libraries/NativeAnimation/RCTAnimationUtils.h
+++ b/packages/react-native/Libraries/NativeAnimation/RCTAnimationUtils.h
@@ -7,6 +7,7 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import <React/RCTDefines.h>
 

--- a/packages/react-native/React/Base/RCTBundleManager.h
+++ b/packages/react-native/React/Base/RCTBundleManager.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <Foundation/Foundation.h>
+
 @class RCTBridge;
 
 typedef NSURL * (^RCTBridgelessBundleURLGetter)(void);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTRuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTRuntimeExecutor.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <Foundation/Foundation.h>
+
 #import <ReactCommon/RuntimeExecutor.h>
 #import <jsi/jsi.h>
 


### PR DESCRIPTION
Summary:
While debugging issues with precompiled_headers in Instagram, it became apparent that these RN files don't correctly import the necessary files to make them build on their own. Fix that!

Changelog: [iOS][Fixed] Fixed missing header imports

Reviewed By: fkgozali

Differential Revision: D53963676


