### PR TITLE
fix component stack symbolication in terminal

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
@@ -348,6 +348,26 @@ export function parseLogBoxException(
   };
 }
 
+export function formatComponentStack(componentStack: ComponentStack): string {
+  return componentStack
+    .map(frame => {
+      if (frame.fileName) {
+        location = frame.fileName;
+        if (frame.location) {
+          if (frame.location.row >= 0) {
+            location += `:${frame.location.row}`;
+            if (frame.location.column >= 0) {
+              location += `:${frame.location.column}`;
+            }
+          }
+        }
+      }
+
+      return `    in ${frame.content}` + (location ? ` (at ${location})` : '');
+    })
+    .join('\n');
+}
+
 export function parseLogBoxLog(args: $ReadOnlyArray<mixed>): {|
   componentStack: ComponentStack,
   category: Category,

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -34,7 +34,10 @@ interface ILogBox {
  */
 if (__DEV__) {
   const LogBoxData = require('./Data/LogBoxData');
-  const {parseLogBoxLog, parseInterpolation} = require('./Data/parseLogBoxLog');
+  const {
+    parseLogBoxLog,
+    formatComponentStack,
+  } = require('./Data/parseLogBoxLog');
 
   let originalConsoleError;
   let originalConsoleWarn;
@@ -207,8 +210,15 @@ if (__DEV__) {
 
       // Interpolate the message so they are formatted for adb and other CLIs.
       // This is different than the message.content above because it includes component stacks.
-      const interpolated = parseInterpolation(args);
-      originalConsoleError(interpolated.message.content);
+      let consoleMessage = message.content;
+
+      // If the component stack was parsed, format it for the console.
+      // This removes any unsymbolicated frames from the component stack.
+      if (componentStack) {
+        consoleMessage += formatComponentStack(componentStack);
+      }
+
+      originalConsoleError(consoleMessage);
 
       if (!LogBoxData.isMessageIgnored(message.content)) {
         LogBoxData.addLog({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Use the parsed component stack logic that's used for the logbox UI to generate the component stack logs in the terminal. This increases the correctness of the message between the terminal and the UI.

### Before

<img width="1190" alt="Screenshot 2024-02-20 at 5 49 34 PM" src="https://github.com/facebook/react-native/assets/9664363/f00f8ecc-0a14-41e0-95ec-4f3b97182b76">

### After

<img width="980" alt="Screenshot 2024-02-20 at 5 50 08 PM" src="https://github.com/facebook/react-native/assets/9664363/2c4fed9d-4f9a-4b8c-82ae-cc5d7f90e6b9">

### UI (unchanged)

Notice that `html.h1` is the first frame in the component stack in the UI:

![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-20 at 17 51 26](https://github.com/facebook/react-native/assets/9664363/7aa9445a-b783-4d28-a937-42b5be0cf97d)

Further work could figure out why component frames inside of certain node modules, in this case `react-native` Text, doesn't symbolicate correctly (at which point we can ignore the frame haha).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Fix component stack parsing for terminal logs.

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- New project: `bunx create-expo-app -t blank@50`
- Add dependency: `bun install react-strict-dom`
- `bunx expo --ios`
- Usage of invalid style should warn:

```tsx
import { StatusBar } from "expo-status-bar";
import { StyleSheet, View } from "react-native";
import { html } from "react-strict-dom";

export default function App() {
  return (
    <View style={styles.container}>
      <html.h1>Open up App.js to start working on your app!</html.h1>
      <StatusBar style="auto" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: "#fff",
    alignItems: "center",
    justifyContent: "center",
  },
});
```
- The terminal warning should now match the results in the LogBox UI.


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
