### PR TITLE
feat(cli): warn underlying command when using `npx react-native init`

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -40,6 +40,16 @@ async function getLatestVersion(registryHost = DEFAULT_REGISTRY_HOST) {
 }
 
 /**
+ * Warn when users are using `npx react-native init`, to raise awareness of the changes from RFC 0759.
+ * @see https://github.com/react-native-community/discussions-and-proposals/tree/main/proposals/0759-react-native-frameworks.md
+ */
+function warnWhenRunningInit() {
+  if (process.argv[2] === 'init') {
+    console.warn('\nRunning: npx @react-native-community/cli init\n');
+  }
+}
+
+/**
  * npx react-native -> @react-native-community/cli
  *
  * Will perform a version check and warning if you're not running the latest community cli when executed using npx. If
@@ -66,6 +76,9 @@ async function main() {
       // Ignore errors, since it's a nice to have warning
     }
   }
+
+  warnWhenRunningInit();
+
   return cli.run(name);
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This adds a new warning for React Native 0.74, implementing the [RFC 0759](https://github.com/react-native-community/discussions-and-proposals/blob/nc/rnf/proposals/0759-react-native-frameworks.md#the-init-command) init command changes.

- It's added inside `react-native/cli.js` to avoid warning users when actually executing `npx @react-native-community/cli` commands.
- The check is fairly simple: `process.argv[2] === 'init'`. The first two args are the Node bin and the actual script bin paths.
- The message is sent over `console.warn` to avoid potentially mixing JSON with non-JSON output.

## Changelog:

[GENERAL] [ADDED] - Warn with future command when using `npx react-native init`

## Test Plan:

Any command other than `init` must not warn.

- `$ node ./path/to/react-native/cli.js init`
- `$ node ./path/to/react-native/cli.js init --help`
  - Should warn with `Running: npx @react-native-community/cli init`
    ![image](https://github.com/facebook/react-native/assets/1203991/a3f5e3d2-7b59-41fe-9a53-bc9ce5a21fd1)
- `$ node ./path/to/react-native/cli.js --help`
  - Must not warn 
    ![image](https://github.com/facebook/react-native/assets/1203991/97679429-db35-47f8-bdeb-33187bb167cf)

