### PR TITLE
[RN][Release] Fix release testing script

### DIFF
--- a/scripts/e2e/init-template-e2e.js
+++ b/scripts/e2e/init-template-e2e.js
@@ -22,6 +22,8 @@ const {
 const {parseArgs} = require('@pkgjs/parseargs');
 const chalk = require('chalk');
 const {execSync} = require('child_process');
+const {promises: fs} = require('fs');
+const path = require('path');
 
 const config = {
   options: {
@@ -64,6 +66,10 @@ async function main() {
   }
 
   await initNewProjectFromSource(options);
+
+  // TODO(T179377112): Fix memory leak from `spawn` in `setupVerdaccio` (above
+  // kill command does not wait for kill success).
+  process.exit(0);
 }
 
 async function initNewProjectFromSource(
@@ -119,48 +125,44 @@ async function initNewProjectFromSource(
       {
         // Avoid loading packages/react-native/react-native.config.js
         cwd: REPO_ROOT,
-        stdio: verbose ? 'inherit' : [process.stderr],
+        stdio: 'inherit',
       },
     );
     console.log('\nDone ✅');
 
     console.log('Installing project dependencies');
-    await runYarnUsingProxy(directory);
+    await installProjectUsingProxy(directory);
     console.log('Done ✅');
   } catch (e) {
     console.log('Failed ❌');
     throw e;
   } finally {
     console.log(`Cleanup: Killing Verdaccio process (PID: ${verdaccioPid})`);
-    execSync(`kill -9 ${verdaccioPid}`);
-    console.log('Done ✅');
+    try {
+      execSync(`kill -9 ${verdaccioPid}`);
+      console.log('Done ✅');
+    } catch {
+      console.warn('Failed to kill Verdaccio process');
+    }
 
     console.log('Cleanup: Removing Verdaccio storage directory');
     execSync(`rm -rf ${VERDACCIO_STORAGE_PATH}`);
     console.log('Done ✅');
-
-    // TODO(huntie): Fix memory leak from `spawn` in `setupVerdaccio` (above
-    // kill command does not wait for kill success).
-    process.exit(0);
   }
 }
 
-async function runYarnUsingProxy(cwd /*: string */) {
+async function installProjectUsingProxy(cwd /*: string */) {
   const execOptions = {
     cwd,
     stdio: 'inherit',
   };
-  execSync(
-    `yarn config set npmRegistryServer "${VERDACCIO_SERVER_URL}"`,
-    execOptions,
-  );
-  execSync(
-    'yarn config set unsafeHttpWhitelist --json \'["localhost"]\'',
-    execOptions,
-  );
 
   // TODO(huntie): Review pre-existing retry limit
-  const success = await retry('yarn', execOptions, 3, 500, ['install']);
+  const success = await retry('npm', execOptions, 3, 500, [
+    'install',
+    '--registry',
+    VERDACCIO_SERVER_URL,
+  ]);
 
   if (!success) {
     throw new Error('Failed to install project dependencies');

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -27,6 +27,7 @@ const {
   prepareArtifacts,
   setupCircleCIArtifacts,
 } = require('./utils/testing-utils');
+const chalk = require('chalk');
 const debug = require('debug')('test-e2e-local');
 const fs = require('fs');
 const path = require('path');
@@ -301,10 +302,10 @@ async function testRNTestProject(
     );
 
     cd('..');
-    exec('yarn ios');
+    exec('npm run ios');
   } else {
     // android
-    exec('yarn android');
+    exec('npm run android');
   }
   popd();
 }
@@ -329,7 +330,7 @@ async function main() {
 
   let circleCIArtifacts = await setupCircleCIArtifacts(
     // $FlowIgnoreError[prop-missing]
-    argv.circleCIToken,
+    argv.circleciToken,
     branchName,
   );
 
@@ -337,6 +338,15 @@ async function main() {
     await testRNTester(circleCIArtifacts, onReleaseBranch);
   } else {
     await testRNTestProject(circleCIArtifacts);
+
+    console.warn(
+      chalk.yellow(`
+================================================================================
+NOTE: Verdaccio may still be running on after this script has finished. Please
+Force Quit via Activity Monitor.
+================================================================================
+    `),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary:
This PR fixes the release testing script:
* Fix typo in variable name for circleciToken arg.
* Relocate erroneously positioned process.exit call (a force exit around Verdaccio, which we will remove in future).
* Add notice on exit around Verdaccio server not being killed successfully 
* Move from yarn to npm as yarn v3 does not work well with verdaccio

## Changelog:
[Internal] - Fix E2E testing script

## Test Plan:
Tested locally
