### PR TITLE
Correctly pass Image.source attribute to the C++ side

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -171,7 +171,11 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
       ...restProps,
       style,
       shouldNotifyLoadEvents: !!(onLoadStart || onLoad || onLoadEnd || onError),
+      // Both iOS and C++ sides expect to have "source" prop, whereas on Android it's "src"
+      // (for historical reasons). So in the latter case we populate both "src" and "source",
+      // in order to have a better alignment between platforms in the future.
       src: sources,
+      source: sources,
       /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
        * when making Flow check .android.js files. */
       headers: (source?.[0]?.headers || source?.headers: ?{[string]: string}),


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

C++ side expects "source" property to be an up to date, correctly resolved Image source inside `ImageProps`.

Incidentally, it wasn't the case when:
* we build for an Android platform
* the asset is a "packager asset", i.e. bundled by Metro and included in APK

It hasn't been an issue in the case of "pure" Android platform, as it instead uses "src" prop, instead of source on the Java implementation side, ignoring "source" completely, so the fact that "source" wasn't propagated correctly to C++ in some cases didn't affect Android.

However, there are some new use cases where we'd like to have correct "source" value in C++ as well (and ultimately align this between all the platforms, so it's "source" everywhere, but this is a matter of a separate discussion).

Differential Revision: D54000899


