### PR TITLE
fix(android): fix `ndkVersion` is unset when building from source

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -470,6 +470,8 @@ android {
   }
   if (rootProject.hasProperty("ndkVersion") && rootProject.properties["ndkVersion"] != null) {
     ndkVersion = rootProject.properties["ndkVersion"].toString()
+  } else {
+    ndkVersion = libs.versions.ndkVersion.get()
   }
 
   compileOptions {


### PR DESCRIPTION
## Summary:

`ndkVersion` is unset when building from source using this guide: https://reactnative.dev/contributing/how-to-build-from-source

## Changelog:

[ANDROID] [FIXED] - Fix `ndkVersion` is unset when building from source

## Test Plan:

```
git clone https://github.com/microsoft/react-native-test-app.git
cd react-native-test-app
npm run set-react-version nightly
yarn

# Manually apply the patch in node_modules/react-native/ReactAndroid/build.gradle.kts
# Enable building from source
sed -i '' 's/#react.buildFromSource/react.buildFromSource/' example/android/gradle.properties

# Build
cd example/android
./gradlew assembleDebug
```