### PR TITLE
Adjust output package.json formatting in scripts

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -184,10 +184,7 @@ async function rewritePackageExports(packageName /*: string */) {
 
   pkg.exports = rewriteExportsField(pkg.exports);
 
-  await fs.writeFile(
-    packageJsonPath,
-    prettier.format(JSON.stringify(pkg), {parser: 'json'}),
-  );
+  await fs.writeFile(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
 }
 
 /*::

--- a/scripts/releases/__tests__/__snapshots__/set-rn-version-test.js.snap
+++ b/scripts/releases/__tests__/__snapshots__/set-rn-version-test.js.snap
@@ -128,7 +128,8 @@ exports[`setReactNativeVersion should set nightly version: packages/react-native
   \\"dependencies\\": {
     \\"@react-native/package-a\\": \\"0.81.0-nightly-29282302-abcd1234\\"
   }
-}"
+}
+"
 `;
 
 exports[`setReactNativeVersion should set release version: packages/react-native/Libraries/Core/ReactNativeVersion.js 1`] = `
@@ -259,5 +260,6 @@ exports[`setReactNativeVersion should set release version: packages/react-native
   \\"dependencies\\": {
     \\"@react-native/package-a\\": \\"1000.0.0\\"
   }
-}"
+}
+"
 `;

--- a/scripts/releases/set-rn-version.js
+++ b/scripts/releases/set-rn-version.js
@@ -110,8 +110,7 @@ async function setReactNativePackageVersion(
 
   await fs.writeFile(
     path.join(REPO_ROOT, 'packages/react-native/package.json'),
-    JSON.stringify(packageJson, null, 2),
-    'utf-8',
+    JSON.stringify(packageJson, null, 2) + '\n',
   );
 }
 

--- a/scripts/releases/set-version/__tests__/__snapshots__/set-version-test.js.snap
+++ b/scripts/releases/set-version/__tests__/__snapshots__/set-version-test.js.snap
@@ -176,7 +176,8 @@ exports[`setVersion updates monorepo for nightly: packages/react-native/package.
     \\"metro-config\\": \\"^0.80.3\\",
     \\"metro-runtime\\": \\"^0.80.3\\"
   }
-}"
+}
+"
 `;
 
 exports[`setVersion updates monorepo for nightly: packages/react-native/template/package.json 1`] = `
@@ -374,7 +375,8 @@ exports[`setVersion updates monorepo for release-candidate: packages/react-nativ
     \\"metro-config\\": \\"^0.80.3\\",
     \\"metro-runtime\\": \\"^0.80.3\\"
   }
-}"
+}
+"
 `;
 
 exports[`setVersion updates monorepo for release-candidate: packages/react-native/template/package.json 1`] = `
@@ -572,7 +574,8 @@ exports[`setVersion updates monorepo for stable version: packages/react-native/p
     \\"metro-config\\": \\"^0.80.3\\",
     \\"metro-runtime\\": \\"^0.80.3\\"
   }
-}"
+}
+"
 `;
 
 exports[`setVersion updates monorepo for stable version: packages/react-native/template/package.json 1`] = `
@@ -770,7 +773,8 @@ exports[`setVersion updates monorepo on main after release cut: packages/react-n
     \\"metro-config\\": \\"^0.80.3\\",
     \\"metro-runtime\\": \\"^0.80.3\\"
   }
-}"
+}
+"
 `;
 
 exports[`setVersion updates monorepo on main after release cut: packages/react-native/template/package.json 1`] = `

--- a/scripts/releases/set-version/index.js
+++ b/scripts/releases/set-version/index.js
@@ -49,7 +49,6 @@ async function updatePackageJson(
   return fs.writeFile(
     path.join(packagePath, 'package.json'),
     JSON.stringify(packageJson, null, 2) + '\n',
-    'utf-8',
   );
 }
 


### PR DESCRIPTION
Summary:
I noticed inconsistent handling of terminating newlines in D54006327@V1, and had also been noticing `yarn build` reformatting unrelated sections of `package.json` files.

For now, this logic isn't moved to a shared util, since there will likely be a higher level abstraction for the release scripts in the next batch of improvements.

Changelog: [Internal]

Reviewed By: lunaleaps

Differential Revision: D54007565


