### PR TITLE
Make the New Architecture the default

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -419,10 +419,10 @@ class NewArchitectureTests < Test::Unit::TestCase
         assert_false(is_enabled)
     end
 
-    def test_newArchEnabled_whenRCTNewArchEnabledIsNotSet_returnFalse
+    def test_newArchEnabled_whenRCTNewArchEnabledIsNotSet_returnTrue
         ENV["RCT_NEW_ARCH_ENABLED"] = nil
         is_enabled = NewArchitectureHelper.new_arch_enabled
-        assert_false(is_enabled)
+        assert_true(is_enabled)
     end
 
 

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -186,6 +186,6 @@ class NewArchitectureHelper
     end
 
     def self.new_arch_enabled
-        return ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+        return ENV["RCT_NEW_ARCH_ENABLED"] == nil || ENV["RCT_NEW_ARCH_ENABLED"] == "1"
     end
 end

--- a/packages/react-native/template/android/gradle.properties
+++ b/packages/react-native/template/android/gradle.properties
@@ -34,7 +34,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.


### PR DESCRIPTION
Summary:
This change makes the New Architecture the default on both iOS and Android.
This means that new application will be created using the New Architecture by default.

It is still possible to opt out from it.

## Changelog
[General][Changed] - Make the new architecture the default

Reviewed By: cortinico, dmytrorykun

Differential Revision: D54006751


