### PR TITLE
Fixes rendering smudges of elements with border for iOS New Architecture

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -49,6 +49,9 @@ static void RCTPerformMountInstructions(
 {
   SystraceSection s("RCTPerformMountInstructions");
 
+  [CATransaction begin];
+  [CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
+
   for (const auto &mutation : mutations) {
     switch (mutation.type) {
       case ShadowViewMutation::Create: {
@@ -146,6 +149,7 @@ static void RCTPerformMountInstructions(
       }
     }
   }
+  [CATransaction commit];
 }
 
 @implementation RCTMountingManager {


### PR DESCRIPTION
## Summary:

`0.73.0` introduced smudges appearing while rendering screen with elements, which use `borderWidth` styles as in https://github.com/facebook/react-native/issues/42604.

https://github.com/facebook/react-native/pull/38234 removed a feature flag `disableTransactionCommit`, which by default was `false`, meaning that prior to this `RCTMountingManager.mm` was using `CATransaction` for rendering (unless feature flag `react_fabric:disable_transaction_commit` was applied).

This change brings back `CATransaction` into  `RCTMountingManager.mm`


## Changelog:

[IOS] [FIXED] - Fix rendering issues of elements with `borderWidth` (issue 42604)

## Test Plan:

Download reproduction repository from linked issue and apply changes to the local version of react-native. 
Using `Reload` button or switching screen should not show any more smudges when rendering elements with `borderWidth`
