### PR TITLE
fix flatlist props being undefined in ios

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -308,7 +308,6 @@ export type Props<ItemT> = {
  * Also inherits [ScrollView Props](docs/scrollview.html#props), unless it is nested in another FlatList of same orientation.
  */
 class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
-  props: Props<ItemT>;
   /**
    * Scrolls to the end of the content. May be janky without `getItemLayout` prop.
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
When using Flatlist on iOS and Android its failing because props are undefined

The problem is described on https://github.com/facebook/react-native/issues/34783

![Captura de pantalla 2024-02-22 a las 4 13 11](https://github.com/facebook/react-native/assets/1161455/325738d9-2e49-44a0-bb6a-077b2e02e9cd)

![Captura de pantalla 2024-02-22 a las 4 14 58](https://github.com/facebook/react-native/assets/1161455/118f76e1-a818-428e-938e-123b55536b49)


Fixed by setting constructor before any statement and removing unnecessary props declaration at the top of the class.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL] [FIXED] - Fix undefined props crash in FlatList

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
