### PR TITLE
react-native | Allow invoking a sync callback under AsyncCallback via 'unsafeCallSync'. (#43143)

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/Function.h
+++ b/packages/react-native/ReactCommon/react/bridging/Function.h
@@ -54,6 +54,15 @@ class AsyncCallback {
     callWithFunction(priority, std::move(callImpl));
   }
 
+  /// Invoke the function write-away as if it was a synchronous function
+  /// without any synchronization or delegating to JS context.
+  /// @note Caller is responsible for calling this from within JS context.
+  void unsafeCallSync(Args... args) const noexcept {
+    if (callback_) {
+      (*callback_)(std::forward<Args>(args)...);
+    }
+  }
+
  private:
   friend Bridging<AsyncCallback>;
 


### PR DESCRIPTION
Summary:

AsyncCallback allows storing SyncCallback and invoking it from any thread.
However, there are cases where if you have a mix of sync and async callbacks - you might want to invoke them together in one go, instead of spreading them out across thread invocations.

For those cases - allow invoking any AsyncCallback as a sync one, prefixing it with "unsafe", because it's inherently not a safe operation to perform.

Changelog:
[General][Changed] - Allow invoking the AsyncCallback synchronously to allow for tight performance optimization.

Reviewed By: s-rws

Differential Revision: D54028850
