### PR TITLE
fix(iOS) [0.74]: properly warn about createRootViewWithBridge

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -116,6 +116,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
     }
     rootView = [self createRootViewWithBridge:self.bridge moduleName:self.moduleName initProps:initProps];
   }
+  [self _logWarnIfCreateRootViewWithBridgeIsOverridden];
   [self customizeRootView:(RCTRootView *)rootView];
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [self createRootViewController];
@@ -158,7 +159,6 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
                           moduleName:(NSString *)moduleName
                            initProps:(NSDictionary *)initProps
 {
-  [self _logWarnIfCreateRootViewWithBridgeIsOverridden];
   BOOL enableFabric = self.fabricEnabled;
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, enableFabric);
 


### PR DESCRIPTION
## Summary:

This PR fixes an issue that `_logWarnIfCreateRootViewWithBridgeIsOverridden` was called in wrong place. 

Assuming user overrides this method and call to `[super]`: 

```objc
- (UIView *)createRootViewWithBridge:(RCTBridge *)bridge moduleName:(NSString *)moduleName initProps:(NSDictionary *)initProps {
  UIView *view = [super createRootViewWithBridge:bridge moduleName:moduleName initProps:initProps];
  view.backgroundColor = [UIColor redColor];
  return view;
}
```

This method still wasn't called in bridgeless (and not showing the error). 

Checking if user overrides this method in `appDidFinishWithLaunching` works every time

![simulator_screenshot_0E22557C-CE37-4617-A25A-F39A6ED4D3D0](https://github.com/facebook/react-native/assets/52801365/d7865f37-32f0-40ad-a252-74ab7c5b7757)

## Changelog:

[IOS] [FIXED] - Properly warn about `createRootViewWithBridge` being deprecated 


## Test Plan:

Check if warning is shown when message is overridden 
