### PR TITLE
Rename React-Codegen to ReactCodegen

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -27,12 +27,9 @@
 // jsinspector-modern
 #import <jsinspector-modern/InspectorFlags.h>
 
-#if __has_include(<React-Codegen/RCTModulesConformingToProtocolsProvider.h>)
+#if __has_include(<ReactCodegen/RCTModulesConformingToProtocolsProvider.h>)
 #define USE_OSS_CODEGEN 1
-#import <React-Codegen/RCTModulesConformingToProtocolsProvider.h>
-#elif __has_include(<React_Codegen/RCTModulesConformingToProtocolsProvider.h>)
-#define USE_OSS_CODEGEN 1
-#import <React_Codegen/RCTModulesConformingToProtocolsProvider.h>
+#import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
 #else
 // Meta internal system do not generate the RCTModulesConformingToProtocolsProvider.h file
 #define USE_OSS_CODEGEN 0

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -76,7 +76,7 @@ Pod::Spec.new do |s|
   s.dependency "React-RCTImage"
   s.dependency "React-CoreModules"
   s.dependency "React-nativeconfig"
-  s.dependency "React-Codegen"
+  s.dependency "ReactCodegen"
 
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")

--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -25,7 +25,7 @@ header_search_paths = [
   "\"$(PODS_ROOT)/boost\"",
   "\"$(PODS_ROOT)/DoubleConversion\"",
   "\"$(PODS_ROOT)/fmt/include\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 Pod::Spec.new do |s|
@@ -55,7 +55,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTWebSocket"
   s.dependency "React-RCTNetwork"
 
-  add_dependency(s, "React-Codegen")
+  add_dependency(s, "ReactCodegen")
   add_dependency(s, "React-NativeModulesApple")
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])

--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 
 header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 
@@ -53,7 +53,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTImageHeaders"
   s.dependency "React-RCTNetwork"
 
-  add_dependency(s, "React-Codegen")
+  add_dependency(s, "ReactCodegen")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 

--- a/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 
 header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 Pod::Spec.new do |s|
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
 
-  add_dependency(s, "React-Codegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 end

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 
 header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 Pod::Spec.new do |s|
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTAnimationHeaders"
 
-  add_dependency(s, "React-Codegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 end

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 
 header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 Pod::Spec.new do |s|
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTNetworkHeaders"
 
-  add_dependency(s, "React-Codegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 end

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 
 header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 Pod::Spec.new do |s|
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTPushNotificationHeaders"
   s.dependency "React-jsi"
 
-  add_dependency(s, "React-Codegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 end

--- a/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
+++ b/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 
 header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 Pod::Spec.new do |s|
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTSettingsHeaders"
 
-  add_dependency(s, "React-Codegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 end

--- a/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
+++ b/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 
 header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 Pod::Spec.new do |s|
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTVibrationHeaders"
 
-  add_dependency(s, "React-Codegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 end

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -27,7 +27,7 @@ header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"$(PODS_ROOT)/DoubleConversion\"",
   "\"$(PODS_ROOT)/fmt/include\"",
-  "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
 Pod::Spec.new do |s|
@@ -59,7 +59,7 @@ Pod::Spec.new do |s|
   s.dependency "SocketRocket", socket_rocket_version
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
-  add_dependency(s, "React-Codegen")
+  add_dependency(s, "ReactCodegen")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 end

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -30,7 +30,7 @@ header_search_paths = [
   "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"$(PODS_ROOT)/Headers/Private/React-Core\"",
   "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
-  "\"$(PODS_ROOT)/Headers/Public/React-Codegen\"",
+  "\"$(PODS_ROOT)/Headers/Public/ReactCodegen\"",
 ]
 
 if ENV['USE_FRAMEWORKS']

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -38,7 +38,7 @@ if ENV['USE_FRAMEWORKS']
     "\"$(PODS_TARGET_SRCROOT)\"",
     "\"$(PODS_TARGET_SRCROOT)/react/renderer/textlayoutmanager/platform/ios\"",
     "\"$(PODS_TARGET_SRCROOT)/react/renderer/components/textinput/platform/ios\"",
-    # "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-Codegen/React_Codegen.framework/Headers\"",
+    # "\"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCodegen/ReactCodegen.framework/Headers\"",
   ]
 end
 

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -64,7 +64,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency "React-cxxreact"
   s.dependency "React-jsi"
-  add_dependency(s, "React-Codegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -64,7 +64,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         CodegenUtils.new().generate_react_codegen_podspec!(spec, codegen_output_dir, file_manager: FileMock)
 
         # Assert
-        assert_equal(Pod::UI.collected_messages, ["[Codegen] Skipping React-Codegen podspec generation."])
+        assert_equal(Pod::UI.collected_messages, ["[Codegen] Skipping ReactCodegen podspec generation."])
         assert_equal(Pathname.pwd_invocation_count, 0)
         assert_equal(Pod::Executable.executed_commands, [])
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 0)
@@ -83,8 +83,8 @@ class CodegenUtilsTests < Test::Unit::TestCase
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(Pod::Executable.executed_commands, [{ "command" => 'mkdir', "arguments" => ["-p", "~/app/ios/build"]}])
-        assert_equal(Pod::UI.collected_messages, ["[Codegen] Generating ~/app/ios/build/React-Codegen.podspec.json"])
-        assert_equal(FileMock.open_files_with_mode["~/app/ios/build/React-Codegen.podspec.json"], 'w')
+        assert_equal(Pod::UI.collected_messages, ["[Codegen] Generating ~/app/ios/build/ReactCodegen.podspec.json"])
+        assert_equal(FileMock.open_files_with_mode["~/app/ios/build/ReactCodegen.podspec.json"], 'w')
         assert_equal(FileMock.open_files[0].collected_write, ['{"name":"Test Podspec"}'])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
 
@@ -108,7 +108,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
 
         # Assert
         assert_equal(podspec, get_podspec_fabric_and_script_phases("echo Test Script Phase"))
-        assert_equal(Pod::UI.collected_messages, ["[Codegen] Adding script_phases to React-Codegen."])
+        assert_equal(Pod::UI.collected_messages, ["[Codegen] Adding script_phases to ReactCodegen."])
     end
 
     def testGetReactCodegenSpec_whenUseFrameworksAndNewArch_generatesAPodspec
@@ -337,7 +337,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         # Arrange
         app_path = "~/app"
         computed_script = "echo TestScript"
-        codegen_spec = {"name" => "React-Codegen"}
+        codegen_spec = {"name" => "ReactCodegen"}
 
         codegen_utils_mock = CodegenUtilsMock.new(
             :react_codegen_script_phases => computed_script,
@@ -370,7 +370,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         }])
         assert_equal(codegen_utils_mock.generate_react_codegen_spec_params,  [{
             :codegen_output_dir=>"build/generated/ios",
-            :react_codegen_spec=>{"name"=>"React-Codegen"}
+            :react_codegen_spec=>{"name"=>"ReactCodegen"}
         }])
         assert_equal(Pod::Executable.executed_commands, [
             {
@@ -501,7 +501,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
 
     def get_podspec_no_fabric_no_script
         spec = {
-          'name' => "React-Codegen",
+          'name' => "ReactCodegen",
           'version' => "99.98.97",
           'summary' => 'Temp pod for generated files for React Native',
           'homepage' => 'https://facebook.com/',
@@ -522,7 +522,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
                 "\"$(PODS_ROOT)/RCT-Folly\"",
                 "\"$(PODS_ROOT)/DoubleConversion\"",
                 "\"$(PODS_ROOT)/fmt/include\"",
-                "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+                "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
                 "\"$(PODS_ROOT)/Headers/Private/React-Fabric\"",
                 "\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\"",
                 "\"$(PODS_ROOT)/Headers/Private/Yoga\"",

--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -161,7 +161,7 @@ class NewArchitectureTests < Test::Unit::TestCase
                 { :dependency_name => "RCT-Folly", "version"=>"2024.01.01.00" },
                 { :dependency_name => "glog" },
                 { :dependency_name => "React-RCTFabric" },
-                { :dependency_name => "React-Codegen" },
+                { :dependency_name => "ReactCodegen" },
                 { :dependency_name => "RCTRequired" },
                 { :dependency_name => "RCTTypeSafety" },
                 { :dependency_name => "ReactCommon/turbomodule/bridging" },
@@ -184,7 +184,7 @@ class NewArchitectureTests < Test::Unit::TestCase
         #  Arrange
         spec = SpecMock.new
         spec.compiler_flags = ''
-        other_flags = "\"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Codegen/React_Codegen.framework/Headers\""
+        other_flags = "\"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\""
         spec.pod_target_xcconfig = {
             "HEADER_SEARCH_PATHS" => other_flags
         }
@@ -203,7 +203,7 @@ class NewArchitectureTests < Test::Unit::TestCase
                 { :dependency_name => "RCT-Folly", "version"=>"2024.01.01.00" },
                 { :dependency_name => "glog" },
                 { :dependency_name => "React-RCTFabric" },
-                { :dependency_name => "React-Codegen" },
+                { :dependency_name => "ReactCodegen" },
                 { :dependency_name => "RCTRequired" },
                 { :dependency_name => "RCTTypeSafety" },
                 { :dependency_name => "ReactCommon/turbomodule/bridging" },

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -764,7 +764,7 @@ class UtilsTests < Test::Unit::TestCase
         first_target = prepare_target("FirstTarget")
         second_target = prepare_target("SecondTarget", nil, [
             DependencyMock.new("RCT-Folly"),
-            DependencyMock.new("React-Codegen"),
+            DependencyMock.new("ReactCodegen"),
             DependencyMock.new("ReactCommon"),
             DependencyMock.new("React-RCTFabric"),
             DependencyMock.new("React-ImageManager"),
@@ -798,7 +798,7 @@ class UtilsTests < Test::Unit::TestCase
             if pod_name == "SecondTarget"
                 target_installation_result.native_target.build_configurations.each do |config|
                     received_search_path = config.build_settings["HEADER_SEARCH_PATHS"]
-                    expected_Search_path = "$(inherited) \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Codegen/React_Codegen.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Graphics/React_graphics.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/imagemanager/platform/ios\""
+                    expected_Search_path = "$(inherited) \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Graphics/React_graphics.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/imagemanager/platform/ios\""
                     assert_equal(received_search_path, expected_Search_path)
                 end
             else

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -43,7 +43,7 @@ class CodegenUtils
         # This podspec file should only be create once in the session/pod install.
         # This happens when multiple targets are calling use_react_native!.
         if @@REACT_CODEGEN_PODSPEC_GENERATED
-          Pod::UI.puts "[Codegen] Skipping React-Codegen podspec generation."
+          Pod::UI.puts "[Codegen] Skipping ReactCodegen podspec generation."
           return
         end
 
@@ -51,7 +51,7 @@ class CodegenUtils
         output_dir = "#{relative_installation_root}/#{codegen_output_dir}"
         Pod::Executable.execute_command("mkdir", ["-p", output_dir]);
 
-        podspec_path = file_manager.join(output_dir, 'React-Codegen.podspec.json')
+        podspec_path = file_manager.join(output_dir, 'ReactCodegen.podspec.json')
         Pod::UI.puts "[Codegen] Generating #{podspec_path}"
 
         file_manager.open(podspec_path, 'w') do |f|
@@ -62,7 +62,7 @@ class CodegenUtils
         @@REACT_CODEGEN_PODSPEC_GENERATED = true
     end
 
-    # It generates the podspec object that represents the `React-Codegen.podspec` file
+    # It generates the podspec object that represents the `ReactCodegen.podspec` file
     #
     # Parameters
     # - package_json_file: the path to the `package.json`, required to extract the proper React Native version
@@ -81,7 +81,7 @@ class CodegenUtils
           "\"$(PODS_ROOT)/RCT-Folly\"",
           "\"$(PODS_ROOT)/DoubleConversion\"",
           "\"$(PODS_ROOT)/fmt/include\"",
-          "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+          "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
           "\"$(PODS_ROOT)/Headers/Private/React-Fabric\"",
           "\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\"",
           "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
@@ -108,7 +108,7 @@ class CodegenUtils
         end
 
         spec = {
-          'name' => "React-Codegen",
+          'name' => "ReactCodegen",
           'version' => version,
           'summary' => 'Temp pod for generated files for React Native',
           'homepage' => 'https://facebook.com/',
@@ -156,7 +156,7 @@ class CodegenUtils
         end
 
         if script_phases
-          Pod::UI.puts "[Codegen] Adding script_phases to React-Codegen."
+          Pod::UI.puts "[Codegen] Adding script_phases to ReactCodegen."
           spec[:'script_phases'] = script_phases
         end
 
@@ -298,7 +298,7 @@ class CodegenUtils
       Pod::UI.warn '[Codegen] warn: using experimental new codegen integration'
       relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
 
-      # Generate React-Codegen podspec here to add the script phases.
+      # Generate ReactCodegen podspec here to add the script phases.
       script_phases = codegen_utils.get_react_codegen_script_phases(
         app_path,
         :fabric_enabled => fabric_enabled,

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -114,7 +114,7 @@ class NewArchitectureHelper
         ReactNativePodsUtils.add_flag_to_map_with_inheritance(current_config, "OTHER_CPLUSPLUSFLAGS", self.computeFlags(new_arch_enabled))
 
         spec.dependency "React-RCTFabric" # This is for Fabric Component
-        spec.dependency "React-Codegen"
+        spec.dependency "ReactCodegen"
 
         spec.dependency "RCTRequired"
         spec.dependency "RCTTypeSafety"

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -529,9 +529,9 @@ class ReactNativePodsUtils
     end
 
     def self.set_codegen_search_paths(target_installation_result)
-        header_search_paths = ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-Codegen", "React_Codegen", [])
+        header_search_paths = ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "ReactCodegen", "ReactCodegen", [])
             .map { |search_path| "\"#{search_path}\"" }
-        ReactNativePodsUtils.update_header_paths_if_depends_on(target_installation_result, "React-Codegen", header_search_paths)
+        ReactNativePodsUtils.update_header_paths_if_depends_on(target_installation_result, "ReactCodegen", header_search_paths)
     end
 
     def self.set_reactcommon_searchpaths(target_installation_result)
@@ -564,7 +564,7 @@ class ReactNativePodsUtils
             "RCTRequired",
             "RCTTypeSafety",
             "React",
-            "React-Codegen",
+            "ReactCodegen",
             "React-Core",
             "React-CoreModules",
             "React-Fabric",

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -169,7 +169,7 @@ def use_react_native! (
     :folly_version => folly_config[:version]
   )
 
-  pod 'React-Codegen', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
+  pod 'ReactCodegen', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
 
   # Always need fabric to access the RCTSurfacePresenterBridgeAdapter which allow to enable the RuntimeScheduler
   # If the New Arch is turned off, we will use the Old Renderer, though.
@@ -286,7 +286,7 @@ def react_native_post_install(
   ReactNativePodsUtils.set_use_hermes_build_setting(installer, hermes_enabled)
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
   ReactNativePodsUtils.set_ccache_compiler_and_linker_build_settings(installer, react_native_path, ccache_enabled)
-  ReactNativePodsUtils.apply_xcode_15_patch(installer) 
+  ReactNativePodsUtils.apply_xcode_15_patch(installer)
   ReactNativePodsUtils.updateOSDeploymentTarget(installer)
   ReactNativePodsUtils.set_dynamic_frameworks_flags(installer)
   ReactNativePodsUtils.add_ndebug_flag_to_pods_in_release(installer)

--- a/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
+++ b/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/my-native-view.git", :tag => "#{s.version}" }
   s.pod_target_xcconfig    = {
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Codegen/React_Codegen.framework/Headers\"",
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20"
   }
 

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#if __has_include(<React-Codegen/AppSpecsJSI.h>) // CocoaPod headers on Apple
-#include <React-Codegen/AppSpecsJSI.h>
+#if __has_include(<ReactCodegen/AppSpecsJSI.h>) // CocoaPod headers on Apple
+#include <ReactCodegen/AppSpecsJSI.h>
 #elif __has_include("AppSpecsJSI.h") // Cmake headers on Android
 #include "AppSpecsJSI.h"
 #else // BUCK headers


### PR DESCRIPTION
Summary:
This diff renames React-Codegen to ReactCodegen. This way we'll no longer have to try both
```
#include <React-Codegen/MyModule.h>
```
and additionally 
```
#include <React_Codegen/MyModule.h>
```
for cases with `use_frameworks`.

Differential Revision: D54068492


