### PR TITLE
Stop catching IllegalArgumentException in ReactPackageTurboModuleManagerDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -8,14 +8,12 @@
 package com.facebook.react;
 
 import androidx.annotation.Nullable;
-import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.jni.HybridData;
 import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.common.ReactConstants;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.internal.turbomodule.core.TurboModuleManagerDelegate;
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModule;
@@ -164,25 +162,15 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
     NativeModule resolvedModule = null;
 
     for (final ModuleProvider moduleProvider : mModuleProviders) {
-      try {
-        final ReactModuleInfo moduleInfo = mPackageModuleInfos.get(moduleProvider).get(moduleName);
-        if (moduleInfo != null
-            && moduleInfo.isTurboModule()
-            && (resolvedModule == null || moduleInfo.canOverrideExistingModule())) {
+      final ReactModuleInfo moduleInfo = mPackageModuleInfos.get(moduleProvider).get(moduleName);
+      if (moduleInfo != null
+          && moduleInfo.isTurboModule()
+          && (resolvedModule == null || moduleInfo.canOverrideExistingModule())) {
 
-          final NativeModule module = moduleProvider.getModule(moduleName);
-          if (module != null) {
-            resolvedModule = module;
-          }
+        final NativeModule module = moduleProvider.getModule(moduleName);
+        if (module != null) {
+          resolvedModule = module;
         }
-
-      } catch (IllegalArgumentException ex) {
-        // TODO T170570617: remove this catch statement and let exception bubble up
-        FLog.e(
-            ReactConstants.TAG,
-            ex,
-            "Caught exception while constructing module '%s'. This was previously ignored but will not be caught in the future.",
-            moduleName);
       }
     }
 
@@ -227,24 +215,15 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
     NativeModule resolvedModule = null;
 
     for (final ModuleProvider moduleProvider : mModuleProviders) {
-      try {
-        final ReactModuleInfo moduleInfo = mPackageModuleInfos.get(moduleProvider).get(moduleName);
-        if (moduleInfo != null
-            && !moduleInfo.isTurboModule()
-            && (resolvedModule == null || moduleInfo.canOverrideExistingModule())) {
+      final ReactModuleInfo moduleInfo = mPackageModuleInfos.get(moduleProvider).get(moduleName);
+      if (moduleInfo != null
+          && !moduleInfo.isTurboModule()
+          && (resolvedModule == null || moduleInfo.canOverrideExistingModule())) {
 
-          final NativeModule module = moduleProvider.getModule(moduleName);
-          if (module != null) {
-            resolvedModule = module;
-          }
+        final NativeModule module = moduleProvider.getModule(moduleName);
+        if (module != null) {
+          resolvedModule = module;
         }
-      } catch (IllegalArgumentException ex) {
-        // TODO T170570617: remove this catch statement and let exception bubble up
-        FLog.e(
-            ReactConstants.TAG,
-            ex,
-            "Caught exception while constructing module '%s'. This was previously ignored but will not be caught in the future.",
-            moduleName);
       }
     }
 


### PR DESCRIPTION
Summary:
Now that 0.74 has been cut, we can drop this warning and let the exception bubble up.

In https://github.com/facebook/react-native/pull/41509 we stopped masking this.

Changelog: [Android][Changed] Throwing IllegalArgumentException from ReactPackage is no longer suppressed

Reviewed By: cortinico, cipolleschi

Differential Revision: D54068429


