### PR TITLE
Mark classes of package uimanager as @Nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolverManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolverManager.java
@@ -7,12 +7,14 @@
 
 package com.facebook.react.uimanager;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.proguard.annotations.DoNotStripAny;
 import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.soloader.SoLoader;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStripAny
 public class ComponentNameResolverManager {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FabricViewStateManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FabricViewStateManager.java
@@ -9,6 +9,7 @@ package com.facebook.react.uimanager;
 
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
@@ -24,6 +25,7 @@ import com.facebook.react.bridge.WritableMap;
  * retrying the UpdateState call until it succeeds; or you call setState again; or the View layer is
  * updated with a newer StateWrapper.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @Deprecated(
     since =
         "Deprecated class since v0.73.0, please use com.facebook.react.uimanager.StateWrapper instead.",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FloatUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FloatUtil.java
@@ -7,6 +7,9 @@
 
 package com.facebook.react.uimanager;
 
+import com.facebook.infer.annotation.Nullsafe;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class FloatUtil {
 
   private static final float EPSILON = .00001f;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/fragments/BridgeTextFragment.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/fragments/BridgeTextFragment.kt
@@ -15,8 +15,12 @@ import com.facebook.react.views.text.TextAttributeProps
 /** A [TextFragment] implementation backed by a a [ReadableMap] */
 internal class BridgeTextFragment(private val fragment: ReadableMap) : TextFragment {
   override val textAttributeProps: TextAttributeProps
-    get() =
-        TextAttributeProps.fromReadableMap(ReactStylesDiffMap(fragment.getMap("textAttributes")))
+    get() {
+      val textAttributesMap =
+          fragment.getMap("textAttributes")
+              ?: throw IllegalStateException("Missing required field `textAttributes`")
+      return TextAttributeProps.fromReadableMap(ReactStylesDiffMap(textAttributesMap))
+    }
 
   override val string: String?
     get() = fragment.getString("string")


### PR DESCRIPTION
Summary:
All these classes are NullSafe, let's mark them as NullSafe(Local) to ensure lint detect errors in the future

changelog: [internal] internal

Reviewed By: arushikesarwani94

Differential Revision: D54027178


