### PR TITLE
[Android] Update bridge to handle long values

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.java
@@ -97,6 +97,11 @@ public class JavaOnlyArray implements ReadableArray, WritableArray {
   }
 
   @Override
+  public long getLong(int index) {
+    return ((Number) mBackingList.get(index)).longValue();
+  }
+
+  @Override
   public @Nullable String getString(int index) {
     return (String) mBackingList.get(index);
   }
@@ -129,7 +134,7 @@ public class JavaOnlyArray implements ReadableArray, WritableArray {
       return ReadableType.Null;
     } else if (object instanceof Boolean) {
       return ReadableType.Boolean;
-    } else if (object instanceof Double || object instanceof Float || object instanceof Integer) {
+    } else if (object instanceof Double || object instanceof Float || object instanceof Integer || object instanceof Long) {
       return ReadableType.Number;
     } else if (object instanceof String) {
       return ReadableType.String;
@@ -154,6 +159,11 @@ public class JavaOnlyArray implements ReadableArray, WritableArray {
   @Override
   public void pushInt(int value) {
     mBackingList.add(new Double(value));
+  }
+
+  @Override
+  public void pushLong(long value) {
+    mBackingList.add(value);
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
@@ -111,6 +111,11 @@ public class JavaOnlyMap implements ReadableMap, WritableMap {
   }
 
   @Override
+  public long getLong(@NonNull String name) {
+    return ((Number) mBackingMap.get(name)).longValue();
+  }
+
+  @Override
   public String getString(@NonNull String name) {
     return (String) mBackingMap.get(name);
   }
@@ -188,6 +193,11 @@ public class JavaOnlyMap implements ReadableMap, WritableMap {
   @Override
   public void putInt(@NonNull String key, int value) {
     mBackingMap.put(key, new Double(value));
+  }
+
+  @Override
+  public void putLong(@NonNull String key, long value) {
+    mBackingMap.put(key, value);
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableArray.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableArray.java
@@ -26,6 +26,8 @@ public interface ReadableArray {
 
   int getInt(int index);
 
+  long getLong(int index);
+
   @NonNull
   String getString(int index);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.java
@@ -29,6 +29,8 @@ public interface ReadableMap {
 
   int getInt(@NonNull String name);
 
+  long getLong(@NonNull String name);
+
   @Nullable
   String getString(@NonNull String name);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
@@ -98,6 +98,11 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
   }
 
   @Override
+  public long getLong(int index) {
+    return ((Long) getLocalArray()[index]).longValue();
+  }
+
+  @Override
   public @NonNull String getString(int index) {
     return (String) getLocalArray()[index];
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
@@ -161,6 +161,11 @@ public class ReadableNativeMap extends NativeMap implements ReadableMap {
   }
 
   @Override
+  public long getLong(@NonNull String name) {
+    return getValue(name, Long.class).longValue();
+  }
+
+  @Override
   public @Nullable String getString(@NonNull String name) {
     return getNullableValue(name, String.class);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableArray.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableArray.java
@@ -20,6 +20,8 @@ public interface WritableArray extends ReadableArray {
 
   void pushInt(int value);
 
+  void pushLong(long value);
+
   void pushString(@Nullable String value);
 
   void pushArray(@Nullable ReadableArray array);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableMap.java
@@ -21,6 +21,8 @@ public interface WritableMap extends ReadableMap {
 
   void putInt(@NonNull String key, int value);
 
+  void putLong(@NonNull String key, long value);
+
   void putString(@NonNull String key, @Nullable String value);
 
   void putArray(@NonNull String key, @Nullable ReadableArray value);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeArray.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeArray.java
@@ -39,6 +39,9 @@ public class WritableNativeArray extends ReadableNativeArray implements Writable
   public native void pushInt(int value);
 
   @Override
+  public native void pushLong(long value);
+
+  @Override
   public native void pushString(@Nullable String value);
 
   // Note: this consumes the map so do not reuse it.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeMap.java
@@ -33,6 +33,9 @@ public class WritableNativeMap extends ReadableNativeMap implements WritableMap 
   public native void putInt(@NonNull String key, int value);
 
   @Override
+  public native void putLong(@NonNull String key, long value);
+
+  @Override
   public native void putNull(@NonNull String key);
 
   @Override

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyArrayTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyArrayTest.kt
@@ -15,15 +15,16 @@ class JavaOnlyArrayTest {
   @Test
   fun testGetType() {
     val values =
-        JavaOnlyArray.of(1, 2f, 3.0, "4", false, JavaOnlyArray.of(), JavaOnlyMap.of(), null)
+        JavaOnlyArray.of(1, 2f, 3.0, 4L, "5", false, JavaOnlyArray.of(), JavaOnlyMap.of(), null)
 
     assertThat(values.getType(0)).isEqualTo(ReadableType.Number)
     assertThat(values.getType(1)).isEqualTo(ReadableType.Number)
     assertThat(values.getType(2)).isEqualTo(ReadableType.Number)
-    assertThat(values.getType(3)).isEqualTo(ReadableType.String)
-    assertThat(values.getType(4)).isEqualTo(ReadableType.Boolean)
-    assertThat(values.getType(5)).isEqualTo(ReadableType.Array)
-    assertThat(values.getType(6)).isEqualTo(ReadableType.Map)
-    assertThat(values.getType(7)).isEqualTo(ReadableType.Null)
+    assertThat(values.getType(3)).isEqualTo(ReadableType.Number)
+    assertThat(values.getType(4)).isEqualTo(ReadableType.String)
+    assertThat(values.getType(5)).isEqualTo(ReadableType.Boolean)
+    assertThat(values.getType(6)).isEqualTo(ReadableType.Array)
+    assertThat(values.getType(7)).isEqualTo(ReadableType.Map)
+    assertThat(values.getType(8)).isEqualTo(ReadableType.Null)
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyArrayTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyArrayTest.kt
@@ -27,4 +27,11 @@ class JavaOnlyArrayTest {
     assertThat(values.getType(7)).isEqualTo(ReadableType.Map)
     assertThat(values.getType(8)).isEqualTo(ReadableType.Null)
   }
+
+  @Test
+  fun testLongValueNotTruncated() {
+    val values = JavaOnlyArray.of(1125899906842623L)
+
+    assertThat(values.getLong(0)).isEqualTo(1125899906842623L)
+  }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyMapTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyMapTest.kt
@@ -27,4 +27,11 @@ class JavaOnlyMapTest {
     assertThat(values.getType("map")).isEqualTo(ReadableType.Map)
     assertThat(values.getType("null")).isEqualTo(ReadableType.Null)
   }
+
+  @Test
+  fun testLongValueNotTruncated() {
+    val values = JavaOnlyMap.of("long", 1125899906842623L)
+
+    assertThat(values.getLong("long")).isEqualTo(1125899906842623L)
+  }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyMapTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyMapTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/** Tests for [JavaOnlyMap] */
+class JavaOnlyMapTest {
+  @Test
+  fun testGetType() {
+    val values =
+        JavaOnlyMap.of("int", 1, "float", 2f, "double", 3.0, "long", 4L, "string", "5", "boolean", false, "array", JavaOnlyArray.of(), "map", JavaOnlyMap.of(), "null", null)
+
+    assertThat(values.getType("int")).isEqualTo(ReadableType.Number)
+    assertThat(values.getType("float")).isEqualTo(ReadableType.Number)
+    assertThat(values.getType("double")).isEqualTo(ReadableType.Number)
+    assertThat(values.getType("long")).isEqualTo(ReadableType.Number)
+    assertThat(values.getType("string")).isEqualTo(ReadableType.String)
+    assertThat(values.getType("boolean")).isEqualTo(ReadableType.Boolean)
+    assertThat(values.getType("array")).isEqualTo(ReadableType.Array)
+    assertThat(values.getType("map")).isEqualTo(ReadableType.Map)
+    assertThat(values.getType("null")).isEqualTo(ReadableType.Null)
+  }
+}


### PR DESCRIPTION
## Summary:

This adds support for 64 bit integer (long) values to the Android bridge. Per the wide gamut color [RFC](https://github.com/react-native-community/discussions-and-proposals/pull/738) Android encodes wide gamut colors as long values so we need to update the bridge to support 64 bit integers as well since these classes will soon receive those values from native.

## Changelog:

[ANDROID] [ADDED] - Update bridge to handle long values

## Test Plan:

I added tests where I could for long types and truncation. I would like to add tests for ReadableNativeArray and ReadableNativeMap but I'm not sure how to go about mocking HybridData.
