### PR TITLE
Mark classes of package uimanager as @Nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolverManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolverManager.java
@@ -7,12 +7,14 @@
 
 package com.facebook.react.uimanager;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.proguard.annotations.DoNotStripAny;
 import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.soloader.SoLoader;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStripAny
 public class ComponentNameResolverManager {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FabricViewStateManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FabricViewStateManager.java
@@ -9,6 +9,7 @@ package com.facebook.react.uimanager;
 
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
@@ -24,6 +25,7 @@ import com.facebook.react.bridge.WritableMap;
  * retrying the UpdateState call until it succeeds; or you call setState again; or the View layer is
  * updated with a newer StateWrapper.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @Deprecated(
     since =
         "Deprecated class since v0.73.0, please use com.facebook.react.uimanager.StateWrapper instead.",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FloatUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FloatUtil.java
@@ -7,6 +7,9 @@
 
 package com.facebook.react.uimanager;
 
+import com.facebook.infer.annotation.Nullsafe;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class FloatUtil {
 
   private static final float EPSILON = .00001f;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/GuardedFrameCallback.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/GuardedFrameCallback.java
@@ -8,6 +8,7 @@
 package com.facebook.react.uimanager;
 
 import android.view.Choreographer;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JSExceptionHandler;
 import com.facebook.react.bridge.ReactContext;
 
@@ -15,6 +16,7 @@ import com.facebook.react.bridge.ReactContext;
  * Abstract base for a Choreographer FrameCallback that should have any RuntimeExceptions it throws
  * handled by the {@link JSExceptionHandler} registered if the app is in dev mode.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class GuardedFrameCallback implements Choreographer.FrameCallback {
 
   private final ReactContext mReactContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewGroupManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewGroupManager.java
@@ -8,9 +8,11 @@
 package com.facebook.react.uimanager;
 
 import android.view.View;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.UiThreadUtil;
 
 /** Interface providing children management API for view managers of classes extending ViewGroup. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public interface IViewGroupManager<T extends View> extends IViewManagerWithChildren {
 
   /** Adds a child view into the parent at the index specified as a parameter */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IllegalViewOperationException.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IllegalViewOperationException.java
@@ -9,9 +9,11 @@ package com.facebook.react.uimanager;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JSApplicationCausedNativeException;
 
 /** An exception caused by JS requesting the UI manager to perform an illegal view operation. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class IllegalViewOperationException extends JSApplicationCausedNativeException {
 
   @Nullable private View mView;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.java
@@ -11,6 +11,7 @@ import android.view.MotionEvent;
 import android.view.ViewGroup;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.TouchEvent;
@@ -22,6 +23,7 @@ import com.facebook.react.uimanager.events.TouchEventType;
  * need to call handleTouchEvent from onTouchEvent and onInterceptTouchEvent. It will correctly find
  * the right view to handle the touch and also dispatch the appropriate event to JS
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class JSTouchDispatcher {
 
   private int mTargetTag = -1;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.java
@@ -8,11 +8,13 @@
 package com.facebook.react.uimanager;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * Provides helper methods for converting transform operations into a matrix and then into a list of
  * translate, scale and rotate commands.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MatrixMathHelper {
 
   private static final double EPSILON = .00001d;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MeasureSpecAssertions.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MeasureSpecAssertions.java
@@ -8,8 +8,10 @@
 package com.facebook.react.uimanager;
 
 import android.view.View;
+import com.facebook.infer.annotation.Nullsafe;
 
 /** Shared utility for asserting on MeasureSpecs. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MeasureSpecAssertions {
 
   public static final void assertExplicitMeasureSpec(int widthMeasureSpec, int heightMeasureSpec) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeKind.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeKind.java
@@ -7,10 +7,13 @@
 
 package com.facebook.react.uimanager;
 
+import com.facebook.infer.annotation.Nullsafe;
+
 // Common conditionals:
 //   - `kind == PARENT` checks whether the node can host children in the native tree.
 //   - `kind != NONE` checks whether the node appears in the native tree.
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public enum NativeKind {
   // Node is in the native hierarchy and the HierarchyOptimizer should assume it can host children
   // (e.g. because it's a ViewGroup). Note that it's okay if the node doesn't support children. When

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.java
@@ -7,10 +7,13 @@
 
 package com.facebook.react.uimanager;
 
+import com.facebook.infer.annotation.Nullsafe;
+
 /**
  * Exception thrown when a class tries to access a native view by a tag that has no native view
  * associated with it.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class NoSuchNativeViewException extends IllegalViewOperationException {
 
   public NoSuchNativeViewException(String detailMessage) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.java
@@ -9,11 +9,13 @@ package com.facebook.react.uimanager;
 
 import androidx.annotation.Nullable;
 import androidx.core.util.Pools;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event used to notify JS component about changes of its position or dimensions */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class OnLayoutEvent extends Event<OnLayoutEvent> {
 
   private static final Pools.SynchronizedPool<OnLayoutEvent> EVENTS_POOL =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.java
@@ -9,8 +9,10 @@ package com.facebook.react.uimanager;
 
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
+import com.facebook.infer.annotation.Nullsafe;
 
 /** Android dp to pixel manipulation */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class PixelUtil {
 
   /** Convert from DIP to PX */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PointerEvents.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PointerEvents.java
@@ -7,12 +7,14 @@
 
 package com.facebook.react.uimanager;
 
+import com.facebook.infer.annotation.Nullsafe;
 import java.util.Locale;
 
 /**
  * Possible values for pointer events that a view and its descendants should receive. See
  * https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events for more info.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public enum PointerEvents {
 
   /** Neither the container nor its children receive events. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingViewGroupHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingViewGroupHelper.java
@@ -10,12 +10,14 @@ package com.facebook.react.uimanager;
 import android.graphics.Rect;
 import android.view.View;
 import android.view.ViewParent;
+import com.facebook.infer.annotation.Nullsafe;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * Provides implementation of common tasks for view and it's view manager supporting property {@code
  * removeClippedSubviews}.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @NotThreadSafe
 public class ReactClippingViewGroupHelper {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/fragments/BridgeTextFragment.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/fragments/BridgeTextFragment.kt
@@ -15,8 +15,12 @@ import com.facebook.react.views.text.TextAttributeProps
 /** A [TextFragment] implementation backed by a a [ReadableMap] */
 internal class BridgeTextFragment(private val fragment: ReadableMap) : TextFragment {
   override val textAttributeProps: TextAttributeProps
-    get() =
-        TextAttributeProps.fromReadableMap(ReactStylesDiffMap(fragment.getMap("textAttributes")))
+    get() {
+      val textAttributesMap =
+          fragment.getMap("textAttributes")
+              ?: throw IllegalStateException("Missing required field `textAttributes`")
+      return TextAttributeProps.fromReadableMap(ReactStylesDiffMap(textAttributesMap))
+    }
 
   override val string: String?
     get() = fragment.getString("string")


### PR DESCRIPTION
Summary:
All these classes are NullSafe, let's mark them as NullSafe(Local) to ensure lint detect errors in the future

changelog: [internal] internal

Reviewed By: javache

Differential Revision: D54027181


