### PR TITLE
[Android] update text to support color longs

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.java
@@ -72,6 +72,10 @@ public class ReactStylesDiffMap {
     return mBackingMap.isNull(name) ? restoreNullToDefaultValue : mBackingMap.getInt(name);
   }
 
+  public long getLong(String name, long restoreNullToDefaultValue) {
+    return mBackingMap.isNull(name) ? restoreNullToDefaultValue : mBackingMap.getLong(name);
+  }
+
   @Nullable
   public String getString(String name) {
     return mBackingMap.getString(name);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/BasicTextAttributeProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/BasicTextAttributeProvider.kt
@@ -20,11 +20,11 @@ internal interface BasicTextAttributeProvider {
 
   val isBackgroundColorSet: Boolean
 
-  val backgroundColor: Int
+  val backgroundColor: Long
 
   val isColorSet: Boolean
 
-  val color: Int
+  val color: Long
 
   val fontStyle: Int
 
@@ -44,5 +44,5 @@ internal interface BasicTextAttributeProvider {
 
   val textShadowRadius: Float
 
-  val textShadowColor: Int
+  val textShadowColor: Long
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -427,9 +427,9 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode
   protected TextAttributes mTextAttributes;
 
   protected boolean mIsColorSet = false;
-  protected int mColor;
+  protected long mColor;
   protected boolean mIsBackgroundColorSet = false;
-  protected int mBackgroundColor;
+  protected long mBackgroundColor;
 
   protected @Nullable AccessibilityRole mAccessibilityRole = null;
   protected @Nullable Role mRole = null;
@@ -444,7 +444,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode
   protected float mTextShadowOffsetDx = 0;
   protected float mTextShadowOffsetDy = 0;
   protected float mTextShadowRadius = 0;
-  protected int mTextShadowColor = DEFAULT_TEXT_SHADOW_COLOR;
+  protected long mTextShadowColor = Color.pack(DEFAULT_TEXT_SHADOW_COLOR);
 
   protected boolean mIsUnderlineTextDecorationSet = false;
   protected boolean mIsLineThroughTextDecorationSet = false;
@@ -583,12 +583,12 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode
   }
 
   @Override
-  public int getColor() {
+  public long getColor() {
     return mColor;
   }
 
   @ReactProp(name = ViewProps.COLOR, customType = "Color")
-  public void setColor(@Nullable Integer color) {
+  public void setColor(@Nullable Long color) {
     mIsColorSet = (color != null);
     if (mIsColorSet) {
       mColor = color;
@@ -602,12 +602,12 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode
   }
 
   @Override
-  public int getBackgroundColor() {
+  public long getBackgroundColor() {
     return mBackgroundColor;
   }
 
   @ReactProp(name = ViewProps.BACKGROUND_COLOR, customType = "Color")
-  public void setBackgroundColor(@Nullable Integer color) {
+  public void setBackgroundColor(@Nullable Long color) {
     // Background color needs to be handled here for virtual nodes so it can be incorporated into
     // the span. However, it doesn't need to be applied to non-virtual nodes because non-virtual
     // nodes get mapped to native views and native views get their background colors get set via
@@ -798,12 +798,12 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode
   }
 
   @Override
-  public int getTextShadowColor() {
+  public long getTextShadowColor() {
     return mTextShadowColor;
   }
 
   @ReactProp(name = PROP_SHADOW_COLOR, defaultInt = DEFAULT_TEXT_SHADOW_COLOR, customType = "Color")
-  public void setTextShadowColor(int textShadowColor) {
+  public void setTextShadowColor(long textShadowColor) {
     if (textShadowColor != mTextShadowColor) {
       mTextShadowColor = textShadowColor;
       markUpdated();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.text;
 
+import android.graphics.Color;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.TextUtils;
@@ -106,12 +107,12 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
   }
 
   @ReactProp(name = "selectionColor", customType = "Color")
-  public void setSelectionColor(ReactTextView view, @Nullable Integer color) {
+  public void setSelectionColor(ReactTextView view, @Nullable Long color) {
     if (color == null) {
       view.setHighlightColor(
           DefaultStyleValuesUtil.getDefaultTextColorHighlight(view.getContext()));
     } else {
-      view.setHighlightColor(color);
+      view.setHighlightColor(Color.toArgb(color));
     }
   }
 
@@ -180,11 +181,9 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
         "borderBottomColor"
       },
       customType = "Color")
-  public void setBorderColor(ReactTextView view, int index, Integer color) {
-    float rgbComponent =
-        color == null ? YogaConstants.UNDEFINED : (float) ((int) color & 0x00FFFFFF);
-    float alphaComponent = color == null ? YogaConstants.UNDEFINED : (float) ((int) color >>> 24);
-    view.setBorderColor(SPACING_TYPES[index], rgbComponent, alphaComponent);
+  public void setBorderColor(ReactTextView view, int index, Long color) {
+    long borderColor = color == null ? 0 : color;
+    view.setBorderColor(SPACING_TYPES[index], borderColor);
   }
 
   @ReactProp(name = ViewProps.INCLUDE_FONT_PADDING, defaultBoolean = true)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -626,12 +626,16 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     mReactBackgroundManager.setBackgroundColor(color);
   }
 
+  public void setBackgroundColor(long color) {
+    mReactBackgroundManager.setBackgroundColor(color);
+  }
+
   public void setBorderWidth(int position, float width) {
     mReactBackgroundManager.setBorderWidth(position, width);
   }
 
-  public void setBorderColor(int position, float color, float alpha) {
-    mReactBackgroundManager.setBorderColor(position, color, alpha);
+  public void setBorderColor(int position, long color) {
+    mReactBackgroundManager.setBorderColor(position, color);
   }
 
   public void setBorderRadius(float borderRadius) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.text;
 
+import android.graphics.Color;
 import android.os.Build;
 import android.text.Layout;
 import android.text.TextUtils;
@@ -72,7 +73,7 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
 
   private static final String PROP_TEXT_TRANSFORM = "textTransform";
 
-  private static final int DEFAULT_TEXT_SHADOW_COLOR = 0x55000000;
+  private static final long DEFAULT_TEXT_SHADOW_COLOR = Color.pack(0x55000000);
   private static final int DEFAULT_JUSTIFICATION_MODE =
       (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE;
   private static final int DEFAULT_BREAK_STRATEGY = Layout.BREAK_STRATEGY_HIGH_QUALITY;
@@ -81,9 +82,9 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
   protected float mLineHeight = Float.NaN;
   protected boolean mIsColorSet = false;
   protected boolean mAllowFontScaling = true;
-  protected int mColor;
+  protected long mColor;
   protected boolean mIsBackgroundColorSet = false;
-  protected int mBackgroundColor;
+  protected long mBackgroundColor;
 
   protected int mNumberOfLines = ReactConstants.UNSET;
   protected int mFontSize = ReactConstants.UNSET;
@@ -100,7 +101,7 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
   protected float mTextShadowOffsetDx = 0;
   protected float mTextShadowOffsetDy = 0;
   protected float mTextShadowRadius = 0;
-  protected int mTextShadowColor = DEFAULT_TEXT_SHADOW_COLOR;
+  protected long mTextShadowColor = DEFAULT_TEXT_SHADOW_COLOR;
 
   protected boolean mIsUnderlineTextDecorationSet = false;
   protected boolean mIsLineThroughTextDecorationSet = false;
@@ -155,10 +156,10 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
       MapBuffer.Entry entry = iterator.next();
       switch (entry.getKey()) {
         case TA_KEY_FOREGROUND_COLOR:
-          result.setColor(entry.getIntValue());
+          result.setColor(entry.getLongValue());
           break;
         case TA_KEY_BACKGROUND_COLOR:
-          result.setBackgroundColor(entry.getIntValue());
+          result.setBackgroundColor(entry.getLongValue());
           break;
         case TA_KEY_OPACITY:
           break;
@@ -203,7 +204,7 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
           result.setTextShadowRadius((float) entry.getDoubleValue());
           break;
         case TA_KEY_TEXT_SHADOW_COLOR:
-          result.setTextShadowColor(entry.getIntValue());
+          result.setTextShadowColor(entry.getLongValue());
           break;
         case TA_KEY_TEXT_SHADOW_OFFSET_DX:
           result.setTextShadowOffsetDx((float) entry.getDoubleValue());
@@ -242,14 +243,14 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
     result.setLetterSpacing(getFloatProp(props, ViewProps.LETTER_SPACING, Float.NaN));
     result.setAllowFontScaling(getBooleanProp(props, ViewProps.ALLOW_FONT_SCALING, true));
     result.setFontSize(getFloatProp(props, ViewProps.FONT_SIZE, ReactConstants.UNSET));
-    result.setColor(props.hasKey(ViewProps.COLOR) ? props.getInt(ViewProps.COLOR, 0) : null);
+    result.setColor(props.hasKey(ViewProps.COLOR) ? props.getLong(ViewProps.COLOR, 0) : null);
     result.setColor(
         props.hasKey(ViewProps.FOREGROUND_COLOR)
-            ? props.getInt(ViewProps.FOREGROUND_COLOR, 0)
+            ? props.getLong(ViewProps.FOREGROUND_COLOR, 0)
             : null);
     result.setBackgroundColor(
         props.hasKey(ViewProps.BACKGROUND_COLOR)
-            ? props.getInt(ViewProps.BACKGROUND_COLOR, 0)
+            ? props.getLong(ViewProps.BACKGROUND_COLOR, 0)
             : null);
     result.setFontFamily(getStringProp(props, ViewProps.FONT_FAMILY));
     result.setFontWeight(getStringProp(props, ViewProps.FONT_WEIGHT));
@@ -260,7 +261,7 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
     result.setTextShadowOffset(
         props.hasKey(PROP_SHADOW_OFFSET) ? props.getMap(PROP_SHADOW_OFFSET) : null);
     result.setTextShadowRadius(getFloatProp(props, PROP_SHADOW_RADIUS, 1));
-    result.setTextShadowColor(getIntProp(props, PROP_SHADOW_COLOR, DEFAULT_TEXT_SHADOW_COLOR));
+    result.setTextShadowColor(getLongProp(props, PROP_SHADOW_COLOR, DEFAULT_TEXT_SHADOW_COLOR));
     result.setTextTransform(getStringProp(props, PROP_TEXT_TRANSFORM));
     result.setLayoutDirection(getStringProp(props, ViewProps.LAYOUT_DIRECTION));
     result.setAccessibilityRole(getStringProp(props, ViewProps.ACCESSIBILITY_ROLE));
@@ -324,6 +325,14 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
   private static int getIntProp(ReactStylesDiffMap mProps, String name, int defaultvalue) {
     if (mProps.hasKey(name)) {
       return mProps.getInt(name, defaultvalue);
+    } else {
+      return defaultvalue;
+    }
+  }
+
+  private static long getLongProp(ReactStylesDiffMap mProps, String name, long defaultvalue) {
+    if (mProps.hasKey(name)) {
+      return mProps.getLong(name, defaultvalue);
     } else {
       return defaultvalue;
     }
@@ -428,11 +437,11 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
   }
 
   @Override
-  public int getColor() {
+  public long getColor() {
     return mColor;
   }
 
-  private void setColor(@Nullable Integer color) {
+  private void setColor(@Nullable Long color) {
     mIsColorSet = (color != null);
     if (mIsColorSet) {
       mColor = color;
@@ -445,11 +454,11 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
   }
 
   @Override
-  public int getBackgroundColor() {
+  public long getBackgroundColor() {
     return mBackgroundColor;
   }
 
-  private void setBackgroundColor(Integer color) {
+  private void setBackgroundColor(Long color) {
     // TODO: Don't apply background color to anchor TextView since it will be applied on the View
     // directly
     // if (!isVirtualAnchor()) {
@@ -690,11 +699,11 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
   }
 
   @Override
-  public int getTextShadowColor() {
+  public long getTextShadowColor() {
     return mTextShadowColor;
   }
 
-  private void setTextShadowColor(int textShadowColor) {
+  private void setTextShadowColor(long textShadowColor) {
     if (textShadowColor != mTextShadowColor) {
       mTextShadowColor = textShadowColor;
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutUtils.kt
@@ -339,7 +339,7 @@ internal object TextLayoutUtils {
         textAttributeProvider.textShadowOffsetDx != 0f ||
             textAttributeProvider.textShadowOffsetDy != 0f
     val hasTextShadowRadius = textAttributeProvider.textShadowRadius != 0f
-    val hasTextShadowColorAlpha = Color.alpha(textAttributeProvider.textShadowColor) != 0
+    val hasTextShadowColorAlpha = Color.alpha(textAttributeProvider.textShadowColor) != 0f
 
     if ((hasTextShadowOffset || hasTextShadowRadius) && hasTextShadowColorAlpha) {
       ops.add(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundColorSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundColorSpan.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.text.internal.span;
 
+import android.graphics.Color;
 import android.text.style.BackgroundColorSpan;
 import com.facebook.infer.annotation.Nullsafe;
 
@@ -17,5 +18,9 @@ import com.facebook.infer.annotation.Nullsafe;
 public class ReactBackgroundColorSpan extends BackgroundColorSpan implements ReactSpan {
   public ReactBackgroundColorSpan(int color) {
     super(color);
+  }
+
+  public ReactBackgroundColorSpan(long color) {
+    super(Color.toArgb(color));
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactForegroundColorSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactForegroundColorSpan.java
@@ -7,15 +7,33 @@
 
 package com.facebook.react.views.text.internal.span;
 
+import android.graphics.Color;
 import android.text.style.ForegroundColorSpan;
 import com.facebook.infer.annotation.Nullsafe;
+import android.text.TextPaint;
+import androidx.annotation.NonNull;
 
 /*
  * Wraps {@link ForegroundColorSpan} as a {@link ReactSpan}.
  */
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactForegroundColorSpan extends ForegroundColorSpan implements ReactSpan {
+  private long mColor = 0;
+
   public ReactForegroundColorSpan(int color) {
     super(color);
+  }
+
+  public ReactForegroundColorSpan(long color) {
+    super(Color.toArgb(color));
+    this.mColor = color;
+  }
+
+  @Override
+  public void updateDrawState(@NonNull TextPaint tp) {
+    super.updateDrawState(tp);
+    if (mColor != 0) {
+      tp.setColor(mColor);
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ShadowStyleSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ShadowStyleSpan.java
@@ -7,6 +7,8 @@
 
 package com.facebook.react.views.text.internal.span;
 
+import android.graphics.Color;
+import android.graphics.ColorSpace;
 import android.text.TextPaint;
 import android.text.style.CharacterStyle;
 import com.facebook.infer.annotation.Nullsafe;
@@ -14,9 +16,16 @@ import com.facebook.infer.annotation.Nullsafe;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class ShadowStyleSpan extends CharacterStyle implements ReactSpan {
   private final float mDx, mDy, mRadius;
-  private final int mColor;
+  private final long mColor;
 
   public ShadowStyleSpan(float dx, float dy, float radius, int color) {
+    mDx = dx;
+    mDy = dy;
+    mRadius = radius;
+    mColor = Color.pack(color);
+  }
+
+  public ShadowStyleSpan(float dx, float dy, float radius, long color) {
     mDx = dx;
     mDy = dy;
     mRadius = radius;


### PR DESCRIPTION
## Summary:

This builds on previous PRs for the wide gamut color [RFC](https://github.com/react-native-community/discussions-and-proposals/pull/738) and extends Android text with support for DisplayP3 color.

## Changelog:

[ANDROID] [ADDED] - Add DisplayP3 color support to Text

## Test Plan:

1. Pull changes from these previous PRs:
https://github.com/facebook/react-native/pull/42831
https://github.com/facebook/react-native/pull/43030
https://github.com/facebook/react-native/pull/43031
https://github.com/facebook/react-native/pull/43036
https://github.com/facebook/react-native/pull/43158
https://github.com/facebook/react-native/pull/43163
2. Follow the test steps for each PR
3. Pull these changes and build RNTester for Android: `cd packages/rn-tester && yarn android`
4. Navigate to ViewExample and observe DisplayP3 text color

![Screenshot_20240131-100112](https://github.com/facebook/react-native/assets/1944151/9f242212-05d1-4858-af7d-d62f21cc3cbe)
