### PR TITLE
Support component stacks without debug source in LogBox

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
@@ -193,16 +193,26 @@ export function parseComponentStack(message: string): ComponentStack {
         return null;
       }
       const match = s.match(/(.*) \(at (.*\.js):([\d]+)\)/);
-      if (!match) {
-        return null;
+      if (match) {
+        let [content, fileName, row] = match.slice(1);
+        return {
+          content,
+          fileName,
+          location: {column: -1, row: parseInt(row, 10)},
+        };
       }
 
-      let [content, fileName, row] = match.slice(1);
-      return {
-        content,
-        fileName,
-        location: {column: -1, row: parseInt(row, 10)},
-      };
+      // In some cases, the component stack doesn't have a source.
+      const matchWithoutSource = s.match(/(.*) \(created by .*\)/);
+      if (matchWithoutSource) {
+        return {
+          content: matchWithoutSource[1],
+          fileName: '',
+          location: null,
+        };
+      }
+
+      return null;
     })
     .filter(Boolean);
 }


### PR DESCRIPTION
## Summary
Fixes component stacks without source info, and duplication in the error message string.

### Before
No component stacks, and error message duplication:

<img width="565" alt="Screenshot 2024-02-21 at 11 20 17 AM" src="https://github.com/facebook/react-native/assets/2440089/8fb5835d-36ab-4b69-8578-7ffcce250bc2">


### After
Back to normal, albeit without the component source location:

<img width="565" alt="Screenshot 2024-02-21 at 11 20 28 AM" src="https://github.com/facebook/react-native/assets/2440089/78262de1-8181-4b78-8970-2396b3a9243f">

## Misc
Changelog:
[General][Fixed] - Support component stacks without source info.

Reviewed By: yungsters

Differential Revision: D53981672


