### PR TITLE
Prototype symbolicating component stacks

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/__tests__/parseLogBoxLog-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/parseLogBoxLog-test.js
@@ -609,6 +609,53 @@ Please follow the instructions at: fburl.com/rn-remote-assets`,
     });
   });
 
+  it('parses an error log with a component stack in the message without debug source', () => {
+    const error = {
+      id: 0,
+      isFatal: true,
+      isComponentError: true,
+      message:
+        'Error: Some kind of message\n\nThis error is located at:\n    in MyComponent (created by MyOtherComponent)\n',
+      originalMessage: 'Some kind of message',
+      name: '',
+      componentStack: '\n    in MyComponent (created by MyOtherComponent)\n',
+      stack: [
+        {
+          column: 1,
+          file: 'foo.js',
+          lineNumber: 1,
+          methodName: 'bar',
+          collapse: false,
+        },
+      ],
+    };
+    expect(parseLogBoxException(error)).toEqual({
+      level: 'fatal',
+      isComponentError: true,
+      stack: [
+        {
+          collapse: false,
+          column: 1,
+          file: 'foo.js',
+          lineNumber: 1,
+          methodName: 'bar',
+        },
+      ],
+      componentStack: [
+        {
+          content: 'MyComponent',
+          fileName: '',
+          location: null,
+        },
+      ],
+      category: 'Some kind of message',
+      message: {
+        content: 'Some kind of message',
+        substitutions: [],
+      },
+    });
+  });
+
   it('parses a fatal exception', () => {
     const error = {
       id: 0,

--- a/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
@@ -193,16 +193,26 @@ export function parseComponentStack(message: string): ComponentStack {
         return null;
       }
       const match = s.match(/(.*) \(at (.*\.js):([\d]+)\)/);
-      if (!match) {
-        return null;
+      if (match) {
+        let [content, fileName, row] = match.slice(1);
+        return {
+          content,
+          fileName,
+          location: {column: -1, row: parseInt(row, 10)},
+        };
       }
 
-      let [content, fileName, row] = match.slice(1);
-      return {
-        content,
-        fileName,
-        location: {column: -1, row: parseInt(row, 10)},
-      };
+      // In some cases, the component stack doesn't have a source.
+      const matchWithoutSource = s.match(/(.*) \(created by .*\)/);
+      if (matchWithoutSource) {
+        return {
+          content: matchWithoutSource[1],
+          fileName: '',
+          location: null,
+        };
+      }
+
+      return null;
     })
     .filter(Boolean);
 }

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
@@ -50,24 +50,24 @@ function getPrettyFileName(path: string) {
 }
 function LogBoxInspectorReactFrames(props: Props): React.Node {
   const [collapsed, setCollapsed] = React.useState(true);
-  if (props.log.componentStack == null || props.log.componentStack.length < 1) {
+  if (props.log.getAvailableComponentStack() == null || props.log.getAvailableComponentStack().length < 1) {
     return null;
   }
 
   function getStackList() {
     if (collapsed) {
-      return props.log.componentStack.slice(0, 3);
+      return props.log.getAvailableComponentStack().slice(0, 3);
     } else {
       return props.log.componentStack;
     }
   }
 
   function getCollapseMessage() {
-    if (props.log.componentStack.length <= 3) {
+    if (props.log.getAvailableComponentStack().length <= 3) {
       return;
     }
 
-    const count = props.log.componentStack.length - 3;
+    const count = props.log.getAvailableComponentStack().length - 3;
     if (collapsed) {
       return `See ${count} more components`;
     } else {


### PR DESCRIPTION
## Summary
TODO:
- [ ] Clean up code
- [ ] Figure out frames without location
- [ ] Make backwards compatible
- [ ] Figure out code frames (should component frames take prioity?)
- [ ] Add out collapsing

## Screen

<img width="565" alt="Screenshot 2024-02-21 at 12 39 57 PM" src="https://github.com/facebook/react-native/assets/2440089/dddb5852-f757-4ba5-9945-a91d8e0239dd">


Changelog:
[General][Fixed] - Support component stacks without source info.

Differential Revision: D53984570


