### PR TITLE
Do not crash on onJSBundleLoadedFromServer when fast-refreshing on bridgeless mode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessDevSupportManager.java
@@ -119,7 +119,7 @@ class BridgelessDevSupportManager extends DevSupportManagerBase {
 
       @Override
       public void onJSBundleLoadedFromServer() {
-        throw new IllegalStateException("Not implemented for bridgeless mode");
+        // Not implemented
       }
 
       @Override


### PR DESCRIPTION
Summary:
RN-Tester is currently instacrashing on fast-refresh (pressing r on Metro) as it ends up on `onJSBundleLoadedFromServer`
which throws an exception on Bridgeless mode. I'm fixing it by following the same logic as `onReloadWithJSDebugger`.

Changelog:
[Android] [Fixed] - Do not crash on onJSBundleLoadedFromServer when fast-refreshing on bridgeless mode

Differential Revision: D54121838


