### PR TITLE
Mark classes of package uimanager as @Nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.java
@@ -11,6 +11,7 @@ import android.view.MotionEvent;
 import android.view.ViewGroup;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.TouchEvent;
@@ -22,6 +23,7 @@ import com.facebook.react.uimanager.events.TouchEventType;
  * need to call handleTouchEvent from onTouchEvent and onInterceptTouchEvent. It will correctly find
  * the right view to handle the touch and also dispatch the appropriate event to JS
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class JSTouchDispatcher {
 
   private int mTargetTag = -1;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.java
@@ -8,11 +8,13 @@
 package com.facebook.react.uimanager;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * Provides helper methods for converting transform operations into a matrix and then into a list of
  * translate, scale and rotate commands.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MatrixMathHelper {
 
   private static final double EPSILON = .00001d;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MeasureSpecAssertions.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MeasureSpecAssertions.java
@@ -8,8 +8,10 @@
 package com.facebook.react.uimanager;
 
 import android.view.View;
+import com.facebook.infer.annotation.Nullsafe;
 
 /** Shared utility for asserting on MeasureSpecs. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MeasureSpecAssertions {
 
   public static final void assertExplicitMeasureSpec(int widthMeasureSpec, int heightMeasureSpec) {


### PR DESCRIPTION
Summary:
All these classes are NullSafe, let's mark them as NullSafe(Local) to ensure lint detect errors in the future

changelog: [internal] internal

bypass-github-export-checks

Reviewed By: javache

Differential Revision: D54027182


