### PR TITLE
Mark classes of package uimanager as @Nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.java
@@ -9,6 +9,7 @@ package com.facebook.react.uimanager;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -32,6 +33,7 @@ import java.util.Map;
  * shouldn't be updated (whereas in all other cases it should be updated to the new value or the
  * property should be reset).
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactStylesDiffMap {
 
   /* package */ final ReadableMap mBackingMap;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.java
@@ -7,10 +7,12 @@
 
 package com.facebook.react.uimanager;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.yoga.YogaConfig;
 import com.facebook.yoga.YogaConfigFactory;
 import com.facebook.yoga.YogaErrata;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactYogaConfigProvider {
 
   private static YogaConfig YOGA_CONFIG;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewManager.java
@@ -9,8 +9,10 @@ package com.facebook.react.uimanager;
 
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import com.facebook.infer.annotation.Nullsafe;
 
 /** View manager for ReactRootView components. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class RootViewManager extends ViewGroupManager<ViewGroup> {
 
   public static final String REACT_CLASS = "RootView";


### PR DESCRIPTION
Summary:
All these classes are NullSafe, let's mark them as NullSafe(Local) to ensure lint detect errors in the future

bypass-github-export-checks

changelog: [internal] internal

Reviewed By: arushikesarwani94

Differential Revision: D54027177


