### PR TITLE
Add BridgelessCatalystInstance as a placeholder for backwards comptability of legacy APIs of CatalystInstance

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -949,6 +949,10 @@ public abstract class com/facebook/react/bridge/NativeArray : com/facebook/react
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/facebook/react/bridge/NativeArrayInterface {
+	public abstract fun toString ()Ljava/lang/String;
+}
+
 public abstract class com/facebook/react/bridge/NativeMap {
 	public fun <init> (Lcom/facebook/jni/HybridData;)V
 	public fun toString ()Ljava/lang/String;
@@ -3563,6 +3567,43 @@ public abstract class com/facebook/react/perflogger/NativeModulePerfLogger {
 
 public abstract class com/facebook/react/runtime/BindingsInstaller {
 	public fun <init> (Lcom/facebook/jni/HybridData;)V
+}
+
+public final class com/facebook/react/runtime/BridgelessCatalystInstance : com/facebook/react/bridge/CatalystInstance {
+	public fun <init> ()V
+	public fun addBridgeIdleDebugListener (Lcom/facebook/react/bridge/NotThreadSafeBridgeIdleDebugListener;)V
+	public fun addJSIModules (Ljava/util/List;)V
+	public fun callFunction (Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/bridge/NativeArray;)V
+	public fun destroy ()V
+	public fun extendNativeModules (Lcom/facebook/react/bridge/NativeModuleRegistry;)V
+	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
+	public fun getJSCallInvokerHolder ()Lcom/facebook/react/turbomodule/core/interfaces/CallInvokerHolder;
+	public fun getJSIModule (Lcom/facebook/react/bridge/JSIModuleType;)Lcom/facebook/react/bridge/JSIModule;
+	public fun getJSModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/JavaScriptModule;
+	public fun getJavaScriptContextHolder ()Lcom/facebook/react/bridge/JavaScriptContextHolder;
+	public fun getNativeMethodCallInvokerHolder ()Lcom/facebook/react/turbomodule/core/interfaces/NativeMethodCallInvokerHolder;
+	public fun getNativeModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/NativeModule;
+	public fun getNativeModule (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeModule;
+	public fun getNativeModules ()Ljava/util/Collection;
+	public fun getReactQueueConfiguration ()Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;
+	public fun getRuntimeExecutor ()Lcom/facebook/react/bridge/RuntimeExecutor;
+	public fun getRuntimeScheduler ()Lcom/facebook/react/bridge/RuntimeScheduler;
+	public fun getSourceURL ()Ljava/lang/String;
+	public fun handleMemoryPressure (I)V
+	public fun hasNativeModule (Ljava/lang/Class;)Z
+	public fun hasRunJSBundle ()Z
+	public fun invokeCallback (ILcom/facebook/react/bridge/NativeArrayInterface;)V
+	public fun isDestroyed ()Z
+	public fun loadScriptFromAssets (Landroid/content/res/AssetManager;Ljava/lang/String;Z)V
+	public fun loadScriptFromFile (Ljava/lang/String;Ljava/lang/String;Z)V
+	public fun loadSplitBundleFromFile (Ljava/lang/String;Ljava/lang/String;)V
+	public fun registerSegment (ILjava/lang/String;)V
+	public fun removeBridgeIdleDebugListener (Lcom/facebook/react/bridge/NotThreadSafeBridgeIdleDebugListener;)V
+	public fun runJSBundle ()V
+	public fun setFabricUIManager (Lcom/facebook/react/bridge/UIManager;)V
+	public fun setSourceURLs (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTurboModuleManager (Lcom/facebook/react/bridge/JSIModule;)V
+	public fun setTurboModuleRegistry (Lcom/facebook/react/internal/turbomodule/core/interfaces/TurboModuleRegistry;)V
 }
 
 public class com/facebook/react/runtime/CoreReactPackage$$ReactModuleInfoProvider : com/facebook/react/module/model/ReactModuleInfoProvider {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
@@ -120,7 +120,7 @@ public interface CatalystInstance
   RuntimeScheduler getRuntimeScheduler();
 
   @Deprecated
-  void addJSIModules(List<JSIModuleSpec> jsiModules);
+  <T extends JSIModule> void addJSIModules(List<JSIModuleSpec<T>> jsiModules);
 
   /**
    * Returns a hybrid object that contains a pointer to a JS CallInvoker, which is used to schedule

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -537,7 +537,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
   public native RuntimeScheduler getRuntimeScheduler();
 
   @Override
-  public void addJSIModules(List<JSIModuleSpec> jsiModules) {
+  @Deprecated
+  public <T extends JSIModule> void addJSIModules(List<JSIModuleSpec<T>> jsiModules) {
     mJSIModuleRegistry.registerModules(jsiModules);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSIModuleRegistry.java
@@ -26,8 +26,8 @@ class JSIModuleRegistry {
     return Assertions.assertNotNull(jsiModuleHolder.getJSIModule());
   }
 
-  public void registerModules(List<JSIModuleSpec> jsiModules) {
-    for (JSIModuleSpec spec : jsiModules) {
+  public <T extends JSIModule> void registerModules(List<JSIModuleSpec<T>> jsiModules) {
+    for (JSIModuleSpec<T> spec : jsiModules) {
       mModules.put(spec.getJSIModuleType(), new JSIModuleHolder(spec));
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArrayInterface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArrayInterface.java
@@ -7,7 +7,7 @@
 
 package com.facebook.react.bridge;
 
-interface NativeArrayInterface {
+public interface NativeArrayInterface {
   @Override
   String toString();
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.runtime
+
+import android.content.res.AssetManager
+import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.bridge.CatalystInstance
+import com.facebook.react.bridge.JSIModule
+import com.facebook.react.bridge.JSIModuleSpec
+import com.facebook.react.bridge.JSIModuleType
+import com.facebook.react.bridge.JavaScriptContextHolder
+import com.facebook.react.bridge.JavaScriptModule
+import com.facebook.react.bridge.NativeArray
+import com.facebook.react.bridge.NativeArrayInterface
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.NativeModuleRegistry
+import com.facebook.react.bridge.NotThreadSafeBridgeIdleDebugListener
+import com.facebook.react.bridge.RuntimeExecutor
+import com.facebook.react.bridge.RuntimeScheduler
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.queue.ReactQueueConfiguration
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
+import com.facebook.react.common.annotations.VisibleForTesting
+import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry
+import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
+import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder
+
+@DoNotStrip
+@DeprecatedInNewArchitecture
+class BridgelessCatalystInstance : CatalystInstance {
+  override fun handleMemoryPressure(level: Int) {
+    throw UnsupportedOperationException("Unimplemented method 'handleMemoryPressure'")
+  }
+
+  override fun loadScriptFromAssets(
+      assetManager: AssetManager,
+      assetURL: String,
+      loadSynchronously: Boolean
+  ) {
+    throw UnsupportedOperationException("Unimplemented method 'loadScriptFromAssets'")
+  }
+
+  override fun loadScriptFromFile(fileName: String, sourceURL: String, loadSynchronously: Boolean) {
+    throw UnsupportedOperationException("Unimplemented method 'loadScriptFromFile'")
+  }
+
+  override fun loadSplitBundleFromFile(fileName: String, sourceURL: String) {
+    throw UnsupportedOperationException("Unimplemented method 'loadSplitBundleFromFile'")
+  }
+
+  override fun setSourceURLs(deviceURL: String, remoteURL: String) {
+    throw UnsupportedOperationException("Unimplemented method 'setSourceURLs'")
+  }
+
+  override fun runJSBundle() {
+    throw UnsupportedOperationException("Unimplemented method 'runJSBundle'")
+  }
+
+  override fun hasRunJSBundle(): Boolean {
+    throw UnsupportedOperationException("Unimplemented method 'hasRunJSBundle'")
+  }
+
+  override fun getSourceURL(): String? {
+    throw UnsupportedOperationException("Unimplemented method 'getSourceURL'")
+  }
+
+  @DoNotStrip
+  override fun invokeCallback(callbackID: Int, arguments: NativeArrayInterface) {
+    throw UnsupportedOperationException("Unimplemented method 'invokeCallback'")
+  }
+
+  override fun callFunction(module: String, method: String, arguments: NativeArray) {
+    throw UnsupportedOperationException("Unimplemented method 'callFunction'")
+  }
+
+  override fun destroy() {
+    throw UnsupportedOperationException("Unimplemented method 'destroy'")
+  }
+
+  override fun isDestroyed(): Boolean {
+    throw UnsupportedOperationException("Unimplemented method 'isDestroyed'")
+  }
+
+  @VisibleForTesting
+  override fun initialize() {
+    throw UnsupportedOperationException("Unimplemented method 'initialize'")
+  }
+
+  override fun getReactQueueConfiguration(): ReactQueueConfiguration {
+    throw UnsupportedOperationException("Unimplemented method 'getReactQueueConfiguration'")
+  }
+
+  override fun <T : JavaScriptModule> getJSModule(jsInterface: Class<T>): T {
+    throw UnsupportedOperationException("Unimplemented method 'getJSModule'")
+  }
+
+  override fun <T : NativeModule> hasNativeModule(nativeModuleInterface: Class<T>): Boolean {
+    throw UnsupportedOperationException("Unimplemented method 'hasNativeModule'")
+  }
+
+  override fun <T : NativeModule> getNativeModule(nativeModuleInterface: Class<T>): T? {
+    throw UnsupportedOperationException("Unimplemented method 'getNativeModule'")
+  }
+
+  override fun getNativeModule(moduleName: String): NativeModule? {
+    throw UnsupportedOperationException("Unimplemented method 'getNativeModule'")
+  }
+
+  @Deprecated(
+      message =
+          "getJSIModule(JSIModuleType moduleType) is deprecated and will be deleted in the future. Please use ReactInstanceEventListener to subscribe for react instance events instead.")
+  override fun getJSIModule(moduleType: JSIModuleType): JSIModule {
+    throw UnsupportedOperationException("Unimplemented method 'getJSIModule'")
+  }
+
+  override fun getNativeModules(): Collection<NativeModule> {
+    throw UnsupportedOperationException("Unimplemented method 'getNativeModules'")
+  }
+
+  override fun extendNativeModules(modules: NativeModuleRegistry) {
+    throw UnsupportedOperationException("Unimplemented method 'extendNativeModules'")
+  }
+
+  override fun addBridgeIdleDebugListener(listener: NotThreadSafeBridgeIdleDebugListener) {
+    throw UnsupportedOperationException("Unimplemented method 'addBridgeIdleDebugListener'")
+  }
+
+  override fun removeBridgeIdleDebugListener(listener: NotThreadSafeBridgeIdleDebugListener) {
+    throw UnsupportedOperationException("Unimplemented method 'removeBridgeIdleDebugListener'")
+  }
+
+  override fun registerSegment(segmentId: Int, path: String) {
+    throw UnsupportedOperationException("Unimplemented method 'registerSegment'")
+  }
+
+  @VisibleForTesting
+  override fun setGlobalVariable(propName: String, jsonValue: String) {
+    throw UnsupportedOperationException("Unimplemented method 'setGlobalVariable'")
+  }
+
+  @Deprecated(message = "This API is unsupported in the New Architecture.")
+  override fun getJavaScriptContextHolder(): JavaScriptContextHolder {
+    throw UnsupportedOperationException("Unimplemented method 'getJavaScriptContextHolder'")
+  }
+
+  override fun getRuntimeExecutor(): RuntimeExecutor {
+    throw UnsupportedOperationException("Unimplemented method 'getRuntimeExecutor'")
+  }
+
+  override fun getRuntimeScheduler(): RuntimeScheduler {
+    throw UnsupportedOperationException("Unimplemented method 'getRuntimeScheduler'")
+  }
+
+  @Deprecated(message = "This API is unsupported in the New Architecture.")
+  override fun <T : JSIModule> addJSIModules(jsiModules: List<JSIModuleSpec<T>>) {
+    throw UnsupportedOperationException("Unimplemented method 'addJSIModules'")
+  }
+
+  override fun getJSCallInvokerHolder(): CallInvokerHolder {
+    throw UnsupportedOperationException("Unimplemented method 'getJSCallInvokerHolder'")
+  }
+
+  override fun getNativeMethodCallInvokerHolder(): NativeMethodCallInvokerHolder {
+    throw UnsupportedOperationException("Unimplemented method 'getNativeMethodCallInvokerHolder'")
+  }
+
+  @Deprecated(
+      message =
+          "setTurboModuleManager(JSIModule getter) is deprecated and will be deleted in the future. Please use setTurboModuleRegistry(TurboModuleRegistry turboModuleRegistry) instead.",
+      replaceWith = ReplaceWith("setTurboModuleRegistry(turboModuleRegistry)"))
+  override fun setTurboModuleManager(getter: JSIModule) {
+    throw UnsupportedOperationException("Unimplemented method 'setTurboModuleManager'")
+  }
+
+  @DeprecatedInNewArchitecture(
+      message =
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+  override fun setTurboModuleRegistry(turboModuleRegistry: TurboModuleRegistry) {
+    throw UnsupportedOperationException("Unimplemented method 'setTurboModuleRegistry'")
+  }
+
+  @DeprecatedInNewArchitecture(
+      message =
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+  override fun setFabricUIManager(fabricUIManager: UIManager) {
+    throw UnsupportedOperationException("Unimplemented method 'setFabricUIManager'")
+  }
+
+  @DeprecatedInNewArchitecture(
+      message =
+          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+  override fun getFabricUIManager(): UIManager {
+    throw UnsupportedOperationException("Unimplemented method 'getFabricUIManager'")
+  }
+}


### PR DESCRIPTION
Summary:
In order to make the legacy APIs of Catalyst Instance backwards compatible, introducing a regular class that implements CatalystInstance so as to make these APIs available for folks in Bridgeless mode as well.

Changelog:
[Internal] internal

Differential Revision: D54093013


