### PR TITLE
Mark UIManagerListener interface as UnstableReactNativeAPI

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1448,14 +1448,6 @@ public abstract interface class com/facebook/react/bridge/UIManager : com/facebo
 	public abstract fun updateRootLayoutSpecs (IIIII)V
 }
 
-public abstract interface class com/facebook/react/bridge/UIManagerListener {
-	public abstract fun didDispatchMountItems (Lcom/facebook/react/bridge/UIManager;)V
-	public abstract fun didMountItems (Lcom/facebook/react/bridge/UIManager;)V
-	public abstract fun didScheduleMountItems (Lcom/facebook/react/bridge/UIManager;)V
-	public abstract fun willDispatchViewUpdates (Lcom/facebook/react/bridge/UIManager;)V
-	public abstract fun willMountItems (Lcom/facebook/react/bridge/UIManager;)V
-}
-
 public abstract interface class com/facebook/react/bridge/UIManagerProvider {
 	public abstract fun createUIManager (Lcom/facebook/react/bridge/ReactApplicationContext;)Lcom/facebook/react/bridge/UIManager;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerListener.kt
@@ -7,7 +7,10 @@
 
 package com.facebook.react.bridge
 
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+
 /** Listener used to hook into the UIManager update process. */
+@UnstableReactNativeAPI
 public interface UIManagerListener {
   /**
    * Called right before view updates are dispatched at the end of a batch. This is useful if a

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -11,6 +11,7 @@ package com.facebook.react.fabric.internal.interop
 
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.bridge.UIManagerListener
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.interop.UIBlock
 import com.facebook.react.fabric.interop.UIBlockViewResolver
 
@@ -21,6 +22,7 @@ import com.facebook.react.fabric.interop.UIBlockViewResolver
  * class effectively re-implements this logic by using a [UIManagerListener] and exposing the two
  * methods that the user intend to call.
  */
+@OptIn(UnstableReactNativeAPI::class)
 internal class InteropUIBlockListener : UIManagerListener {
 
   internal val beforeUIBlocks: MutableList<UIBlock> = mutableListOf()


### PR DESCRIPTION
Summary:
UIManagerListener interface is unstable and not recommended to be consumed externally, this API is likely to change in the future



changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D54028407


