### PR TITLE
fix(ios) use condensed system font

### DIFF
--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -407,7 +407,7 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
     fontSize = font.pointSize ?: defaultFontSize;
     fontWeight = weightOfFont(font);
     isItalic = isItalicFont(font);
-    isCondensed = isCondensedFont(font) || [familyName isEqualToString:@"SystemCondensed"];
+    isCondensed = isCondensedFont(font);
   }
 
   // Get font attributes
@@ -418,6 +418,7 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
   familyName = [RCTConvert NSString:family] ?: familyName;
   isItalic = style ? [RCTConvert RCTFontStyle:style] : isItalic;
   fontWeight = weight ? [RCTConvert RCTFontWeight:weight] : fontWeight;
+  isCondensed = isCondensed || [familyName isEqualToString:@"SystemCondensed"];
 
   BOOL didFindFont = NO;
 

--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -407,7 +407,7 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
     fontSize = font.pointSize ?: defaultFontSize;
     fontWeight = weightOfFont(font);
     isItalic = isItalicFont(font);
-    isCondensed = isCondensedFont(font);
+    isCondensed = isCondensedFont(font) || [familyName isEqualToString:@"SystemCondensed"];
   }
 
   // Get font attributes
@@ -423,7 +423,11 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
 
   // Handle system font as special case. This ensures that we preserve
   // the specific metrics of the standard system font as closely as possible.
-  if ([familyName isEqual:defaultFontFamily] || [familyName isEqualToString:@"System"]) {
+  if (
+    [familyName isEqual:defaultFontFamily] ||
+    [familyName isEqualToString:@"System"] ||
+    [familyName isEqualToString:@"SystemCondensed"]
+  ) {
     font = cachedSystemFont(fontSize, fontWeight);
     if (font) {
       didFindFont = YES;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
The current implementation does not support System font variants. Currently the isCondensed variable is always returning false. This pr adds an extra check to support the 'SystemCondensed' font variant on iOS.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS][ADDED] - Update font to handle system condensed variant

## Test Plan:

```
<Text style={{ fontSize: 28, fontFamily: 'System' }}>System</Text>
<Text style={{ fontSize: 28, fontFamily: 'SystemCondensed' }}>SystemCondensed</Text>
<Text style={{ fontSize: 28, fontFamily: 'AmericanTypewriter-Condensed' }}>AmericanTypewriter-Condensed</Text>
<Text style={{ fontSize: 28, fontFamily: 'HelveticaNeue' }}>HelveticaNeue</Text>
<Text style={{ fontSize: 28, fontFamily: 'HelveticaNeue-CondensedBold' }}>HelveticaNeue-CondensedBold</Text>
```
![Simulator Screenshot - iPhone 15 Pro - 2024-02-26 at 17 56 40](https://github.com/facebook/react-native/assets/63480001/36daea22-2e75-4526-8b2d-f0555fbf2441)
