### PR TITLE
Add UniquePtrFactory.back, use most recent remote connection in ReactInstanceIntegrationTest

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
@@ -70,7 +70,12 @@ void ReactInstanceIntegrationTest::SetUp() {
 }
 
 void ReactInstanceIntegrationTest::TearDown() {
+  ASSERT_NE(clientToVM_, nullptr);
   clientToVM_->disconnect();
+  // Expect the remote connection to have been destroyed.
+  EXPECT_EQ(mockRemoteConnections_.back(), nullptr);
+  // Destroy the local connection.
+  clientToVM_.reset();
 }
 
 void ReactInstanceIntegrationTest::initializeRuntime(std::string_view script) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.h
@@ -38,7 +38,9 @@ class ReactInstanceIntegrationTest : public ::testing::Test {
   std::shared_ptr<ErrorUtils> errorHandler;
 
   MockRemoteConnection& getRemoteConnection() {
-    return *mockRemoteConnections_[0];
+    auto rawPtr = mockRemoteConnections_.back();
+    ASSERT(rawPtr != nullptr);
+    return *rawPtr;
   }
 
  private:

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/UniquePtrFactory.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/UniquePtrFactory.h
@@ -75,6 +75,24 @@ class UniquePtrFactory {
   }
 
   /**
+   * Returns a pointer to the last object created by this factory, or nullptr if
+   * it has been destroyed or the factory has never created an object.
+   */
+  const T* back() const {
+    auto sz = objectPtrs_.size();
+    return sz > 0 ? objectPtrs_[sz - 1] : nullptr;
+  }
+
+  /**
+   * Returns a pointer to the last object created by this factory, or nullptr if
+   * it has been destroyed or the factory has never created an object.
+   */
+  T* back() {
+    auto sz = objectPtrs_.size();
+    return sz > 0 ? objectPtrs_[sz - 1] : nullptr;
+  }
+
+  /**
    * Returns the total number of objects created by this factory, including
    * those that have already been destroyed.
    */

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/UniquePtrFactoryTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/UniquePtrFactoryTest.cpp
@@ -81,4 +81,26 @@ TEST(UniquePtrFactoryTest, LazilyMakeUnique) {
   EXPECT_EQ(fooObjects.objectsVended(), 2);
 }
 
+TEST(UniquePtrFactoryTest, Back) {
+  UniquePtrFactory<Foo> fooObjects;
+  EXPECT_EQ(fooObjects.back(), nullptr)
+      << "back should return nullptr when empty";
+
+  auto foo0 = fooObjects.make_unique(100);
+  EXPECT_EQ(fooObjects.back(), fooObjects[0])
+      << "back should return the first object of one";
+
+  foo0.reset();
+  EXPECT_EQ(fooObjects.back(), fooObjects[0])
+      << "back should return nullptr if the last object was destroyed";
+
+  auto foo1 = fooObjects.make_unique(200);
+  EXPECT_EQ(fooObjects.back(), fooObjects[1])
+      << "back should return the second object of two";
+
+  foo1.reset();
+  EXPECT_EQ(fooObjects.back(), nullptr)
+      << "back should return nullptr if the last object was destroyed";
+}
+
 } // namespace facebook


### PR DESCRIPTION
Summary:
Because we use `mockRemoteConnections_.make_unique()` on each `ReactInstanceIntegrationTest::SetUp`, the current implementation of `getRemoteConnection` (which accesses `mockRemoteConnections_[0]`) is only correct after the test is set up *for the first time*, and fails in (e.g.) parameterised tests.

This modifies it to use the last `MockRemoteConnection` created by the factory, for which (for convenience+clarity) we add `back()` to `UniquePtrFactory`.

Changelog: [Internal]

Differential Revision: D54158008


