### PR TITLE
Allow the app to control the Activity Indicator in Bridgeless mode

### DIFF
--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -56,6 +56,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) RCTSurfaceHostingViewActivityIndicatorViewFactory activityIndicatorViewFactory;
 
+/**
+ * When set to `YES`, the activity indicator is not automatically hidden when the Surface stage changes.
+ * In this scenario, users should invoke `hideActivityIndicator` to remove it.
+ *
+ * @param disabled: if `YES`, the auto-hide is disabled. Otherwise the loading view will be hidden automatically
+ */
+- (void)disableActivityIndicatorAutoHide:(BOOL)disabled;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Summary:
Right now, the activity indicator is automatically hidden when the view is ready to be shown in bridgeless mode.
There is no way to prevent that the activity indicator is automatically removed.

In OSS, we have libraries (e.g.: `react-native-bootsplash`) that will allow the app to control when and how dismiss the splashscreen, but due to the current automatic behavior on Bridgeless, they stopped working.

***Note:** In the previous implementation, they were working because instead of using the `loadingView` property, they were adding the splashscreen view on top of the existing one. However, with the lazy behavior of the bridgeless mode, this is not working anymore because the RCTMountingManager [expect not to have any subview](https://www.internalfb.com/code/fbsource/[6962fa457dbc74ab3a760cf6090d9643c6748781]/xplat/js/react-native-github/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm?lines=176) when the first surface is mounted.*

## Changelog
[iOS][Added] - Allow the activityIndicator to be controlled from JS in bridgeless mode

Differential Revision: D54191856


