### PR TITLE
[Android] update scroll views to support wide gamut color

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -17,6 +17,7 @@ import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -96,7 +97,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   private @Nullable FpsListener mFpsListener = null;
   private @Nullable String mScrollPerfTag;
   private @Nullable Drawable mEndBackground;
-  private int mEndFillColor = Color.TRANSPARENT;
+  private long mEndFillColor = Color.pack(Color.TRANSPARENT);
   private boolean mDisableIntervalMomentum = false;
   private int mSnapInterval = 0;
   private @Nullable List<Integer> mSnapOffsets;
@@ -780,7 +781,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     return getChildAt(0);
   }
 
-  public void setEndFillColor(int color) {
+  public void setEndFillColor(long color) {
     if (color != mEndFillColor) {
       mEndFillColor = color;
       mEndBackground = new ColorDrawable(mEndFillColor);
@@ -857,9 +858,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   public void draw(Canvas canvas) {
     if (mEndFillColor != Color.TRANSPARENT) {
       final View content = getContentView();
-      if (mEndBackground != null && content != null && content.getRight() < getWidth()) {
-        mEndBackground.setBounds(content.getRight(), 0, getWidth(), getHeight());
-        mEndBackground.draw(canvas);
+      if (content != null && content.getRight() < getWidth()) {
+        Paint paint = new Paint();
+        paint.setColor(mEndFillColor);
+        canvas.drawRect(content.getRight(), 0, getWidth(), getHeight(), paint);
       }
     }
     super.draw(canvas);
@@ -1273,12 +1275,16 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     mReactBackgroundManager.setBackgroundColor(color);
   }
 
+  public void setBackgroundColor(long color) {
+    mReactBackgroundManager.setBackgroundColor(color);
+  }
+
   public void setBorderWidth(int position, float width) {
     mReactBackgroundManager.setBorderWidth(position, width);
   }
 
-  public void setBorderColor(int position, float color, float alpha) {
-    mReactBackgroundManager.setBorderColor(position, color, alpha);
+  public void setBorderColor(int position, long color) {
+    mReactBackgroundManager.setBorderColor(position, color);
   }
 
   public void setBorderRadius(float borderRadius) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -96,7 +96,6 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   private boolean mSendMomentumEvents;
   private @Nullable FpsListener mFpsListener = null;
   private @Nullable String mScrollPerfTag;
-  private @Nullable Drawable mEndBackground;
   private long mEndFillColor = Color.pack(Color.TRANSPARENT);
   private boolean mDisableIntervalMomentum = false;
   private int mSnapInterval = 0;
@@ -784,7 +783,6 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   public void setEndFillColor(long color) {
     if (color != mEndFillColor) {
       mEndFillColor = color;
-      mEndBackground = new ColorDrawable(mEndFillColor);
     }
   }
 
@@ -856,7 +854,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
   @Override
   public void draw(Canvas canvas) {
-    if (mEndFillColor != Color.TRANSPARENT) {
+    if (mEndFillColor != Color.pack(Color.TRANSPARENT)) {
       final View content = getContentView();
       if (content != null && content.getRight() < getWidth()) {
         Paint paint = new Paint();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -236,7 +236,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
    * @param color
    */
   @ReactProp(name = "endFillColor", defaultInt = Color.TRANSPARENT, customType = "Color")
-  public void setBottomFillColor(ReactHorizontalScrollView view, int color) {
+  public void setBottomFillColor(ReactHorizontalScrollView view, long color) {
     view.setEndFillColor(color);
   }
 
@@ -291,11 +291,9 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
         "borderBottomColor"
       },
       customType = "Color")
-  public void setBorderColor(ReactHorizontalScrollView view, int index, Integer color) {
-    float rgbComponent =
-        color == null ? YogaConstants.UNDEFINED : (float) ((int) color & 0x00FFFFFF);
-    float alphaComponent = color == null ? YogaConstants.UNDEFINED : (float) ((int) color >>> 24);
-    view.setBorderColor(SPACING_TYPES[index], rgbComponent, alphaComponent);
+  public void setBorderColor(ReactHorizontalScrollView view, int index, Long color) {
+    long borderColor = color == null ? 0 : color;
+    view.setBorderColor(SPACING_TYPES[index], borderColor);
   }
 
   @ReactProp(name = "overflow")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -97,7 +97,6 @@ public class ReactScrollView extends ScrollView
   private boolean mSendMomentumEvents;
   private @Nullable FpsListener mFpsListener = null;
   private @Nullable String mScrollPerfTag;
-  private @Nullable Drawable mEndBackground;
   private long mEndFillColor = Color.pack(Color.TRANSPARENT);
   private boolean mDisableIntervalMomentum = false;
   private int mSnapInterval = 0;
@@ -621,7 +620,7 @@ public class ReactScrollView extends ScrollView
 
   @Override
   public void draw(Canvas canvas) {
-    if (mEndFillColor != Color.TRANSPARENT) {
+    if (mEndFillColor != Color.pack(Color.TRANSPARENT)) {
       final View contentView = getContentView();
       if (contentView != null && contentView.getBottom() < getHeight()) {
         Paint paint = new Paint();
@@ -1008,7 +1007,6 @@ public class ReactScrollView extends ScrollView
   public void setEndFillColor(long color) {
     if (color != mEndFillColor) {
       mEndFillColor = color;
-      mEndBackground = new ColorDrawable(mEndFillColor);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -17,6 +17,7 @@ import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -97,7 +98,7 @@ public class ReactScrollView extends ScrollView
   private @Nullable FpsListener mFpsListener = null;
   private @Nullable String mScrollPerfTag;
   private @Nullable Drawable mEndBackground;
-  private int mEndFillColor = Color.TRANSPARENT;
+  private long mEndFillColor = Color.pack(Color.TRANSPARENT);
   private boolean mDisableIntervalMomentum = false;
   private int mSnapInterval = 0;
   private @Nullable List<Integer> mSnapOffsets;
@@ -622,9 +623,10 @@ public class ReactScrollView extends ScrollView
   public void draw(Canvas canvas) {
     if (mEndFillColor != Color.TRANSPARENT) {
       final View contentView = getContentView();
-      if (mEndBackground != null && contentView != null && contentView.getBottom() < getHeight()) {
-        mEndBackground.setBounds(0, contentView.getBottom(), getWidth(), getHeight());
-        mEndBackground.draw(canvas);
+      if (contentView != null && contentView.getBottom() < getHeight()) {
+        Paint paint = new Paint();
+        paint.setColor(mEndFillColor);
+        canvas.drawRect(0, contentView.getBottom(), getWidth(), getHeight(), paint);
       }
     }
     getDrawingRect(mRect);
@@ -1003,7 +1005,7 @@ public class ReactScrollView extends ScrollView
     return getHeight();
   }
 
-  public void setEndFillColor(int color) {
+  public void setEndFillColor(long color) {
     if (color != mEndFillColor) {
       mEndFillColor = color;
       mEndBackground = new ColorDrawable(mEndFillColor);
@@ -1198,12 +1200,16 @@ public class ReactScrollView extends ScrollView
     mReactBackgroundManager.setBackgroundColor(color);
   }
 
+  public void setBackgroundColor(long color) {
+    mReactBackgroundManager.setBackgroundColor(color);
+  }
+
   public void setBorderWidth(int position, float width) {
     mReactBackgroundManager.setBorderWidth(position, width);
   }
 
-  public void setBorderColor(int position, float color, float alpha) {
-    mReactBackgroundManager.setBorderColor(position, color, alpha);
+  public void setBorderColor(int position, long color) {
+    mReactBackgroundManager.setBorderColor(position, color);
   }
 
   public void setBorderRadius(float borderRadius) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -173,7 +173,7 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
    * @param color
    */
   @ReactProp(name = "endFillColor", defaultInt = Color.TRANSPARENT, customType = "Color")
-  public void setBottomFillColor(ReactScrollView view, int color) {
+  public void setBottomFillColor(ReactScrollView view, long color) {
     view.setEndFillColor(color);
   }
 
@@ -272,10 +272,9 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
         "borderBottomColor"
       },
       customType = "Color")
-  public void setBorderColor(ReactScrollView view, int index, Integer color) {
-    float rgbComponent = color == null ? YogaConstants.UNDEFINED : (float) (color & 0x00FFFFFF);
-    float alphaComponent = color == null ? YogaConstants.UNDEFINED : (float) (color >>> 24);
-    view.setBorderColor(SPACING_TYPES[index], rgbComponent, alphaComponent);
+  public void setBorderColor(ReactScrollView view, int index, Long color) {
+    long borderColor = color == null ? 0 : color;
+    view.setBorderColor(SPACING_TYPES[index], borderColor);
   }
 
   @ReactProp(name = "overflow")


### PR DESCRIPTION
## Summary:

This builds on previous PRs for the wide gamut color [RFC](https://github.com/react-native-community/discussions-and-proposals/pull/738) and extends Android scroll views with support for DisplayP3 color.

## Changelog:

[ANDROID] [ADDED] - update scroll views to support wide gamut color

## Test Plan:

1. Pull changes from these previous PRs:
https://github.com/facebook/react-native/pull/42831
https://github.com/facebook/react-native/pull/43031
https://github.com/facebook/react-native/pull/43036
https://github.com/facebook/react-native/pull/43056
1. Follow the test steps for each PR
1. Pull these changes and build RNTester for Android: cd packages/rn-tester && yarn android
1. Navigate to ScrollViewExample and modify to set DisplayP3 background/borders/endFill