### PR TITLE
Modify codegen to throw JS errors instead of crashing when passing  non-number arguments where RootTags are expected

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
@@ -147,7 +147,7 @@ function serializeArg(
     case 'ReservedTypeAnnotation':
       switch (realTypeAnnotation.name) {
         case 'RootTag':
-          return wrap(val => `${val}.getNumber()`);
+          return wrap(val => `${val}.asNumber()`);
         default:
           (realTypeAnnotation.name: empty);
           throw new Error(

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleCpp-test.js.snap
@@ -559,7 +559,7 @@ static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getObject(jsi
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
   return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getRootTag(
     rt,
-    args[0].getNumber()
+    args[0].asNumber()
   );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {


### PR DESCRIPTION
Summary:
Changelog: [internal]

## Context

Right now, if you have a native module using the codegen with a method like this:

```
someMethod(value: RootTag): void;
```

And you call it like this:

```
NativeModule.someMethod('');
```

The app crashes.

This happens because we cast the JS value to a C++ value using the method that asserts (`toNumber`) instead of the one that throws a JS error (`asNumber`).

## Changes

This fixes the crash by using `asNumber` instead of `toNumber`.

Differential Revision: D54206288


