### PR TITLE
Correctly initialize default transformOrigin prop value to "center"

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -54,7 +54,14 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
   // Transform
   Transform transform{};
-  TransformOrigin transformOrigin{};
+  TransformOrigin transformOrigin{
+      {
+          ValueUnit{50.0f, UnitType::Percent},
+          ValueUnit{50.0f, UnitType::Percent},
+      },
+      0.0f,
+
+  };
   BackfaceVisibility backfaceVisibility{};
   bool shouldRasterize{};
   std::optional<int> zIndex{};


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

`view.transformOrigin` prop should be initialized to "center", since this is default [per documentaion](https://reactnative.dev/docs/next/transforms#transform-origin), and it should be treated this way even if the prop is not explicitly set from JS.

Differential Revision: D54229772


