### PR TITLE
Check whether _bridge and surfacePresenter are not nil to prevent crashes.

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -370,7 +370,10 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
 - (UIView *)viewForReactTag:(NSNumber *)reactTag
 {
   RCTAssertMainQueue();
-  UIView *view = [_bridge.surfacePresenter findComponentViewWithTag_DO_NOT_USE_DEPRECATED:reactTag.integerValue];
+  UIView *view = nil;
+  if (_bridge && _bridge.surfacePresenter) {
+    view = [_bridge.surfacePresenter findComponentViewWithTag_DO_NOT_USE_DEPRECATED:reactTag.integerValue];
+  }
   if (!view) {
     view = _viewRegistry[reactTag];
   }
@@ -1674,8 +1677,8 @@ static UIView *_jsResponder;
 {
   self = [super init];
   if (self) {
-    self->_uiManager = uiManager;
-    self->_registry = registry;
+    _uiManager = uiManager;
+    _registry = registry;
   }
   return self;
 }
@@ -1683,19 +1686,19 @@ static UIView *_jsResponder;
 - (id)objectForKey:(id)key
 {
   if (![key isKindOfClass:[NSNumber class]]) {
-    return [super objectForKeyedSubscript:key];
+    return [super objectForKey:key];
   }
 
   NSNumber *index = (NSNumber *)key;
-  UIView *view = [_uiManager viewForReactTag:index];
+  UIView *view = _registry[index];
   if (view) {
     return [RCTUIManager paperViewOrCurrentView:view];
   }
-  view = _registry[index];
+  view = [_uiManager viewForReactTag:index];
   if (view) {
     return [RCTUIManager paperViewOrCurrentView:view];
   }
-  return [super objectForKeyedSubscript:key];
+  return [super objectForKey:key];
 }
 
 - (void)removeObjectForKey:(id)key


### PR DESCRIPTION
Summary:
Add some nil checks to make sure that the objects are there before calling methods on it.
Ususally,in ObjectiveC, this should not be a problem, but the surfacePresenter is an associated object, so I"m not sure that behaves as normal properties for the runtime.

## Changelog:
[Internal] - Add nil check to verify that the app is not crashing

## Facebook:
See S397861 and T180527210 for more information.

Differential Revision: D54246220


