### PR TITLE
Fix findLibrariesFromReactNativeConfig

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -283,11 +283,7 @@ function findLibrariesFromReactNativeConfig(projectRoot) {
       return [];
     }
 
-    return extractLibrariesFromJSON(
-      configFile,
-      configFile.name,
-      codegenConfigFileDir,
-    );
+    return extractLibrariesFromJSON(configFile, codegenConfigFileDir);
   });
 }
 


### PR DESCRIPTION
Summary:
This diff removes extra argument from the `extractLibrariesFromJSON` call inside `findLibrariesFromReactNativeConfig`.
This should fix the iOS failurte discribed in https://github.com/facebook/react-native/issues/43204
Changelog: [iOS][Fixed] - Codegen correctly handles react-native.config.js.

Reviewed By: cipolleschi

Differential Revision: D54248400


