### PR TITLE
Add missing #pragma once's in ReactCommon

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/ErrorUtils.h
+++ b/packages/react-native/ReactCommon/cxxreact/ErrorUtils.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <jsi/jsi.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/cxxreact/SharedProxyCxxModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/SharedProxyCxxModule.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <memory>
 
 #include <cxxreact/CxxModule.h>

--- a/packages/react-native/ReactCommon/react/debug/react_native_assert.h
+++ b/packages/react-native/ReactCommon/react/debug/react_native_assert.h
@@ -18,6 +18,8 @@
 // For recoverable conditions that can be violated by user mistake (e.g. JS
 // code passes an unexpected prop value), consider react_native_expect instead.
 
+#pragma once
+
 #include "flags.h"
 
 #undef react_native_assert

--- a/packages/react-native/ReactCommon/react/debug/react_native_expect.h
+++ b/packages/react-native/ReactCommon/react/debug/react_native_expect.h
@@ -20,6 +20,8 @@
 // will see a helpful diagnostic (beyond a low level log). That concern is the
 // caller's responsibility.
 
+#pragma once
+
 #include "flags.h"
 
 #undef react_native_expect

--- a/packages/react-native/ReactCommon/react/renderer/animations/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/conversions.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <glog/logging.h>
 #include <react/renderer/animations/primitives.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <folly/dynamic.h>
 #include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/conversions.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <folly/dynamic.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/text/ParagraphState.h>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/ErrorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/ErrorUtils.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <jsi/jsi.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/AsynchronousEventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/AsynchronousEventBeat.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <react/renderer/core/EventBeat.h>
 #include <react/utils/RunLoopObserver.h>

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/InspectorData.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/InspectorData.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <vector>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/runtime/BridgelessJSCallInvoker.h
+++ b/packages/react-native/ReactCommon/react/runtime/BridgelessJSCallInvoker.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <ReactCommon/CallInvoker.h>
 #include <ReactCommon/RuntimeExecutor.h>
 #include <functional>

--- a/packages/react-native/ReactCommon/react/runtime/BridgelessNativeMethodCallInvoker.h
+++ b/packages/react-native/ReactCommon/react/runtime/BridgelessNativeMethodCallInvoker.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <ReactCommon/CallInvoker.h>
 #include <cxxreact/MessageQueueThread.h>
 #include <functional>

--- a/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 #include <atomic>

--- a/packages/react-native/ReactCommon/react/utils/SimpleThreadSafeCache.h
+++ b/packages/react-native/ReactCommon/react/utils/SimpleThreadSafeCache.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <functional>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

Was writing some unit tests, accidentally included `ImageProps.h` twice (once directly and once transitively) and realized that we have a handful of files without `#pragma once`.

This fixes it for header files inside `ReactCommon`.

Differential Revision: D54258058


