### PR TITLE
set to public access by default

### DIFF
--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -34,8 +34,9 @@ type PackageJSON = {
   ...
 }
 type NpmPackageOptions = {
-  tags: ?Array<string>,
+  tags: ?Array<string> | ?Array<?string>,
   otp: ?string,
+  access?: ?('public' | 'restricted')
 }
 */
 
@@ -131,14 +132,21 @@ function publishPackage(
   packageOptions /*: NpmPackageOptions */,
   execOptions /*: ?ExecOptsSync */,
 ) /*: ShellString */ {
-  const {otp, tags} = packageOptions;
-  const tagsFlag = tags != null ? tags.map(t => ` --tag ${t}`).join('') : '';
+  const {otp, tags, access} = packageOptions;
+  const tagsFlag =
+    tags != null
+      ? tags
+          .filter(Boolean)
+          .map(t => ` --tag ${t}`)
+          .join('')
+      : '';
   const otpFlag = otp != null ? ` --otp ${otp}` : '';
+  const accessFlag = access != null ? ` --access ${access}` : '';
   const options = execOptions
     ? {...execOptions, cwd: packagePath}
     : {cwd: packagePath};
 
-  return exec(`npm publish${tagsFlag}${otpFlag}`, options);
+  return exec(`npm publish${tagsFlag}${otpFlag}${accessFlag}`, options);
 }
 
 function diffPackages(

--- a/scripts/releases-ci/__tests__/publish-npm-test.js
+++ b/scripts/releases-ci/__tests__/publish-npm-test.js
@@ -160,8 +160,14 @@ describe('publish-npm', () => {
       expect(setVersionMock).toBeCalledWith(expectedVersion);
       expect(generateAndroidArtifactsMock).toHaveBeenCalled();
       expect(publishPackageMock.mock.calls).toEqual([
-        ['path/to/monorepo/pkg-a', {otp: undefined, tags: ['nightly']}],
-        ['path/to/monorepo/pkg-b', {otp: undefined, tags: ['nightly']}],
+        [
+          'path/to/monorepo/pkg-a',
+          {otp: undefined, tags: ['nightly'], access: 'public'},
+        ],
+        [
+          'path/to/monorepo/pkg-b',
+          {otp: undefined, tags: ['nightly'], access: 'public'},
+        ],
         [
           path.join(REPO_ROOT, 'packages', 'react-native'),
           {otp: undefined, tags: ['nightly']},
@@ -249,8 +255,14 @@ describe('publish-npm', () => {
 
       // Note that we don't call `publishPackage` for react-native, or monorepo/pkg-c
       expect(publishPackageMock.mock.calls).toEqual([
-        ['path/to/monorepo/pkg-a', {otp: undefined, tags: ['nightly']}],
-        ['path/to/monorepo/pkg-b', {otp: undefined, tags: ['nightly']}],
+        [
+          'path/to/monorepo/pkg-a',
+          {otp: undefined, tags: ['nightly'], access: 'public'},
+        ],
+        [
+          'path/to/monorepo/pkg-b',
+          {otp: undefined, tags: ['nightly'], access: 'public'},
+        ],
       ]);
 
       expect(consoleLogMock.mock.calls).toEqual([

--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -75,9 +75,9 @@ async function publishMonorepoPackages(tag /*: ?string */) {
   for (const packageInfo of Object.values(projectInfo)) {
     console.log(`Publishing ${packageInfo.name}...`);
     const result = publishPackage(packageInfo.path, {
-      // $FlowFixMe[incompatible-call]
       tags: [tag],
       otp: process.env.NPM_CONFIG_OTP,
+      access: 'public',
     });
 
     const spec = `${packageInfo.name}@${packageInfo.packageJson.version}`;
@@ -122,7 +122,6 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
 
   const packagePath = path.join(REPO_ROOT, 'packages', 'react-native');
   const result = publishPackage(packagePath, {
-    // $FlowFixMe[incompatible-call]
     tags: [tag],
     otp: process.env.NPM_CONFIG_OTP,
   });


### PR DESCRIPTION
Summary: Changelog: [Internal] - Specify `access` flag in publishing nightlies

Reviewed By: cipolleschi

Differential Revision: D54230208


