### PR TITLE
Reset the autoresizing mask when the view is recycled

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -454,6 +454,7 @@ using namespace facebook::react;
   _eventEmitter.reset();
   _isJSResponder = NO;
   _removeClippedSubviews = NO;
+  self.autoresizingMask = UIViewAutoresizingNone;
   _reactSubviews = [NSMutableArray new];
 }
 


### PR DESCRIPTION
Summary:
Autoresizing mask is a native property of iOS views. When a veiw is created anew, the default value is `UIViewAutoresizingNone`. Libraries might create code that update this property and we need to make sure that it is reset when the view is recycled.

This should close: https://github.com/facebook/react-native/issues/42732

## Changelog:
[iOS][Changed] - Reset the autoresizing mask to `UIViewAutoresizingNone` when the view is recycled.

Differential Revision: D54263847


