### PR TITLE
Mark ViewGroupManager.getChildAt() as Nullable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewGroupManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewGroupManager.java
@@ -8,6 +8,7 @@
 package com.facebook.react.uimanager;
 
 import android.view.View;
+import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.UiThreadUtil;
 
@@ -19,6 +20,7 @@ public interface IViewGroupManager<T extends View> extends IViewManagerWithChild
   void addView(T parent, View child, int index);
 
   /** @return child of the parent view at the index specified as a parameter. */
+  @Nullable
   View getChildAt(T parent, int index);
 
   /** Removes View from the parent View at the index specified as a parameter. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
@@ -67,6 +67,7 @@ public abstract class ViewGroupManager<T extends ViewGroup>
   }
 
   @Override
+  @Nullable
   public View getChildAt(T parent, int index) {
     return parent.getChildAt(index);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.view;
 
 import android.view.View;
+import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -52,6 +53,7 @@ public abstract class ReactClippingViewManager<T extends ReactViewGroup>
   }
 
   @Override
+  @Nullable
   public View getChildAt(T parent, int index) {
     boolean removeClippedSubviews = parent.getRemoveClippedSubviews();
     if (removeClippedSubviews) {
@@ -68,10 +70,12 @@ public abstract class ReactClippingViewManager<T extends ReactViewGroup>
     boolean removeClippedSubviews = parent.getRemoveClippedSubviews();
     if (removeClippedSubviews) {
       View child = getChildAt(parent, index);
-      if (child.getParent() != null) {
-        parent.removeView(child);
+      if (child != null) {
+        if (child.getParent() != null) {
+          parent.removeView(child);
+        }
+        parent.removeViewWithSubviewClippingEnabled(child);
       }
-      parent.removeViewWithSubviewClippingEnabled(child);
     } else {
       parent.removeViewAt(index);
     }


### PR DESCRIPTION
Summary:
ViewGroup.getChildAt() is nullable, we should make ViewGroupManager.getChildAt() as well.

see https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/ViewGroup.java#6939


changelog: [internal] internal

Differential Revision: D54271529


