### PR TITLE
refactor: Use `std::string_view` for prop conversions

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -321,7 +321,7 @@ namespace facebook::react {
 enum class EnumPropNativeComponentViewAlignment { Top, Center, BottomRight };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, EnumPropNativeComponentViewAlignment &result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == \\"top\\") { result = EnumPropNativeComponentViewAlignment::Top; return; }
   if (string == \\"center\\") { result = EnumPropNativeComponentViewAlignment::Center; return; }
   if (string == \\"bottom-right\\") { result = EnumPropNativeComponentViewAlignment::BottomRight; return; }
@@ -721,7 +721,7 @@ namespace facebook::react {
 enum class ObjectPropsNativeComponentStringEnumProp { Small, Large };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentStringEnumProp &result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == \\"small\\") { result = ObjectPropsNativeComponentStringEnumProp::Small; return; }
   if (string == \\"large\\") { result = ObjectPropsNativeComponentStringEnumProp::Large; return; }
   abort();

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -101,7 +101,7 @@ const EnumTemplate = ({
 enum class ${enumName} { ${values} };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ${enumName} &result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   ${fromCases}
   abort();
 }

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -1071,7 +1071,7 @@ namespace facebook::react {
 enum class ObjectPropsStringEnumProp { Option1 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsStringEnumProp &result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == \\"option1\\") { result = ObjectPropsStringEnumProp::Option1; return; }
   abort();
 }
@@ -1352,7 +1352,7 @@ namespace facebook::react {
 enum class StringEnumPropsNativeComponentAlignment { Top, Center, BottomRight };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, StringEnumPropsNativeComponentAlignment &result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == \\"top\\") { result = StringEnumPropsNativeComponentAlignment::Top; return; }
   if (string == \\"center\\") { result = StringEnumPropsNativeComponentAlignment::Center; return; }
   if (string == \\"bottom-right\\") { result = StringEnumPropsNativeComponentAlignment::BottomRight; return; }

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -73,7 +73,7 @@ inline void fromRawValue(
     DynamicTypeRamp& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "caption2") {
       result = DynamicTypeRamp::Caption2;
     } else if (string == "caption1") {
@@ -137,7 +137,7 @@ inline void fromRawValue(
     EllipsizeMode& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "clip") {
       result = EllipsizeMode::Clip;
     } else if (string == "head") {
@@ -183,7 +183,7 @@ inline void fromRawValue(
     TextBreakStrategy& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "simple") {
       result = TextBreakStrategy::Simple;
     } else if (string == "highQuality") {
@@ -210,7 +210,7 @@ inline void fromRawValue(
     FontWeight& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "normal") {
       result = FontWeight::Regular;
     } else if (string == "regular") {
@@ -259,7 +259,7 @@ inline void fromRawValue(
     FontStyle& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "normal") {
       result = FontStyle::Normal;
     } else if (string == "italic") {
@@ -360,7 +360,7 @@ inline void fromRawValue(
     TextTransform& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "none") {
       result = TextTransform::None;
     } else if (string == "uppercase") {
@@ -412,7 +412,7 @@ inline void fromRawValue(
     TextAlignment& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "auto") {
       result = TextAlignment::Natural;
     } else if (string == "left") {
@@ -462,7 +462,7 @@ inline void fromRawValue(
     WritingDirection& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "natural" || string == "auto") {
       result = WritingDirection::Natural;
     } else if (string == "ltr") {
@@ -504,7 +504,7 @@ inline void fromRawValue(
     LineBreakStrategy& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "none") {
       result = LineBreakStrategy::None;
     } else if (string == "push-out") {
@@ -550,7 +550,7 @@ inline void fromRawValue(
     TextDecorationLineType& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "none") {
       result = TextDecorationLineType::None;
     } else if (string == "underline") {
@@ -602,7 +602,7 @@ inline void fromRawValue(
     TextDecorationStyle& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "solid") {
       result = TextDecorationStyle::Solid;
     } else if (string == "double") {
@@ -664,7 +664,7 @@ inline void fromRawValue(
     HyphenationFrequency& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "none") {
       result = HyphenationFrequency::None;
     } else if (string == "normal") {

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -105,7 +105,7 @@ inline void fromRawValue(
     return;
   }
 
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "cover") {
     result = ImageResizeMode::Cover;
   } else if (stringValue == "contain") {

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
@@ -19,7 +19,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     ScrollViewSnapToAlignment& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "start") {
     result = ScrollViewSnapToAlignment::Start;
     return;
@@ -39,7 +39,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     ScrollViewIndicatorStyle& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "default") {
     result = ScrollViewIndicatorStyle::Default;
     return;
@@ -59,7 +59,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     ScrollViewKeyboardDismissMode& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "none") {
     result = ScrollViewKeyboardDismissMode::None;
     return;
@@ -79,7 +79,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     ContentInsetAdjustmentBehavior& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "never") {
     result = ContentInsetAdjustmentBehavior::Never;
     return;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/conversions.h
@@ -17,7 +17,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     AutocapitalizationType& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "none") {
     result = AutocapitalizationType::None;
     return;
@@ -41,7 +41,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     KeyboardAppearance& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "default") {
     result = KeyboardAppearance::Default;
     return;
@@ -61,7 +61,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     ReturnKeyType& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "default") {
     result = ReturnKeyType::Default;
     return;
@@ -129,7 +129,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     SubmitBehavior& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "newline") {
     result = SubmitBehavior::Newline;
     return;
@@ -149,7 +149,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     TextInputAccessoryVisibilityMode& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "never") {
     result = TextInputAccessoryVisibilityMode::Never;
     return;
@@ -173,7 +173,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     KeyboardType& result) {
-  auto string = (std::string)value;
+  auto string = std::string_view{(std::string)value};
   if (string == "default") {
     result = KeyboardType::Default;
     return;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -193,7 +193,7 @@ inline void fromRawValue(
   result = ImportantForAccessibility::Auto;
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "auto") {
       result = ImportantForAccessibility::Auto;
     } else if (string == "yes") {
@@ -284,7 +284,7 @@ inline void fromRawValue(
   result = AccessibilityLiveRegion::None;
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "none") {
       result = AccessibilityLiveRegion::None;
     } else if (string == "polite") {
@@ -396,7 +396,7 @@ inline void fromRawValue(
     AccessibilityRole& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "none") {
       result = AccessibilityRole::None;
     } else if (string == "button") {
@@ -636,7 +636,7 @@ inline void fromRawValue(
     Role& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
-    auto string = (std::string)value;
+    auto string = std::string_view{(std::string)value};
     if (string == "alert") {
       result = Role::Alert;
     } else if (string == "alertdialog") {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -173,7 +173,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "inherit") {
     result = yoga::Direction::Inherit;
     return;
@@ -199,7 +199,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "row") {
     result = yoga::FlexDirection::Row;
     return;
@@ -229,7 +229,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "flex-start") {
     result = yoga::Justify::FlexStart;
     return;
@@ -267,7 +267,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "auto") {
     result = yoga::Align::Auto;
     return;
@@ -317,7 +317,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "static") {
     result = yoga::PositionType::Static;
     return;
@@ -343,7 +343,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "nowrap") {
     result = yoga::Wrap::NoWrap;
     return;
@@ -369,7 +369,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "visible") {
     result = yoga::Overflow::Visible;
     return;
@@ -395,7 +395,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "flex") {
     result = yoga::Display::Flex;
     return;
@@ -416,7 +416,7 @@ inline void fromRawValue(
     result = yoga::value::points((float)value);
     return;
   } else if (value.hasType<std::string>()) {
-    const auto stringValue = (std::string)value;
+    const auto stringValue = std::string_view{(std::string)value};
     if (stringValue == "auto") {
       result = yoga::value::ofAuto();
       return;
@@ -467,7 +467,7 @@ inline Float toRadians(
   if (!value.hasType<std::string>() && defaultValue.has_value()) {
     return *defaultValue;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   char* suffixStart;
   double num = strtod(
       stringValue.c_str(), &suffixStart); // can't use std::stod, probably
@@ -610,7 +610,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "auto") {
     result = PointerEventsMode::Auto;
     return;
@@ -640,7 +640,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "auto") {
     result = BackfaceVisibility::Auto;
     return;
@@ -666,7 +666,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "circular") {
     result = BorderCurve::Circular;
     return;
@@ -688,7 +688,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "solid") {
     result = BorderStyle::Solid;
     return;
@@ -714,7 +714,7 @@ inline void fromRawValue(
   if (!value.hasType<std::string>()) {
     return;
   }
-  auto stringValue = (std::string)value;
+  auto stringValue = std::string_view{(std::string)value};
   if (stringValue == "classic") {
     result = LayoutConformance::Classic;
     return;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -470,7 +470,7 @@ inline Float toRadians(
   auto stringValue = std::string_view{(std::string)value};
   char* suffixStart;
   double num = strtod(
-      stringValue.c_str(), &suffixStart); // can't use std::stod, probably
+      stringValue.data(), &suffixStart); // can't use std::stod, probably
                                           // because of old Android NDKs
   if (0 == strncmp(suffixStart, "deg", 3)) {
     return static_cast<Float>(num * M_PI / 180.0f);


### PR DESCRIPTION
## Summary:

As pointed out by @tido64 in one of my [other PRs](https://github.com/microsoft/react-native-macos/pull/2080#discussion_r1504727104), we can be more efficient on prop conversions by using `std::string_view` instead of just casting to std::string, which may cause a copy. I thought I might as well do a Find+Replace for the whole codebase and see what breaks. 

## Changelog:

[GENERAL] [CHANGED] - Use `std::string_view` for prop conversions


## Test Plan:

CI should pass
