### PR TITLE
TextInput[Android]: Fixes Cursor End Scroll on First Render on Default Value

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -129,6 +129,7 @@ public class ReactEditText extends AppCompatEditText {
 
   private static final KeyListener sKeyListener = QwertyKeyListener.getInstanceForFullKeyboard();
   private @Nullable EventDispatcher mEventDispatcher;
+  public boolean isFirstRender = true;
 
   public ReactEditText(Context context) {
     super(context);
@@ -677,6 +678,9 @@ public class ReactEditText extends AppCompatEditText {
     // text so, we have to set text to null, which will clear the currently composing text.
     if (reactTextUpdate.getText().length() == 0) {
       setText(null);
+      } else if (isFirstRender && !hasFocus()) {
+      setText(spannableStringBuilder);
+      isFirstRender = false;
     } else {
       // When we update text, we trigger onChangeText code that will
       // try to update state if the wrapper is available. Temporarily disable

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -368,7 +368,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       boolean isCurrentSelectionEmpty = view.getSelectionStart() == view.getSelectionEnd();
       int selectionStart = UNSET;
       int selectionEnd = UNSET;
-      if (isCurrentSelectionEmpty) {
+      if (isCurrentSelectionEmpty && !view.isFirstRender) {
         // if selection is not set by state, shift current selection to ensure constant gap to
         // text end
         int textLength = view.getText() == null ? 0 : view.getText().length();

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-import type { RNTesterModuleExample } from '../../types/RNTesterTypes';
-import type { TextStyle } from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import type {TextStyle} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import RNTesterButton from '../../components/RNTesterButton';
-import { RNTesterThemeContext } from '../../components/RNTesterTheme';
+import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 import * as React from 'react';
-import { useContext, useState } from 'react';
+import {useContext, useState} from 'react';
 import {
   Button,
   Platform,
@@ -107,7 +107,7 @@ class WithLabel extends React.Component<$FlowFixMeProps> {
 class RewriteExample extends React.Component<$FlowFixMeProps, any> {
   constructor(props: any | void) {
     super(props);
-    this.state = { text: '' };
+    this.state = {text: ''};
   }
   render(): React.Node {
     const limit = 20;
@@ -122,12 +122,12 @@ class RewriteExample extends React.Component<$FlowFixMeProps, any> {
           maxLength={limit}
           onChangeText={text => {
             text = text.replace(/ /g, '_');
-            this.setState({ text });
+            this.setState({text});
           }}
           style={styles.default}
           value={this.state.text}
         />
-        <Text style={[styles.remainder, { color: remainderColor }]}>
+        <Text style={[styles.remainder, {color: remainderColor}]}>
           {remainder}
         </Text>
       </View>
@@ -141,7 +141,7 @@ class RewriteExampleInvalidCharacters extends React.Component<
 > {
   constructor(props: any | void) {
     super(props);
-    this.state = { text: '' };
+    this.state = {text: ''};
   }
   render(): React.Node {
     return (
@@ -151,7 +151,7 @@ class RewriteExampleInvalidCharacters extends React.Component<
           autoCorrect={false}
           multiline={false}
           onChangeText={text => {
-            this.setState({ text: text.replace(/\s/g, '') });
+            this.setState({text: text.replace(/\s/g, '')});
           }}
           style={styles.default}
           value={this.state.text}
@@ -169,7 +169,7 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
 
   constructor(props: any | void) {
     super(props);
-    this.state = { text: '' };
+    this.state = {text: ''};
   }
   render(): React.Node {
     return (
@@ -182,7 +182,7 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
           }}
           multiline={true}
           onChangeText={text => {
-            this.setState({ text: text.replace(/ /g, '') });
+            this.setState({text: text.replace(/ /g, '')});
           }}
           style={styles.default}
           value={this.state.text}
@@ -201,7 +201,7 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
   }
 }
 
-type ExampleRef = { current: null | { focus(): void, ... } };
+type ExampleRef = {current: null | {focus(): void, ...}};
 
 class BlurOnSubmitExample extends React.Component<{...}> {
   ref1: ExampleRef = React.createRef();
@@ -343,72 +343,72 @@ class SubmitBehaviorExample extends React.Component<{...}> {
   }
 }
 
-class TextEventsExample extends React.Component<{...}, $FlowFixMeState > {
+class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
   state:
     | any
     | {
-      curText: string,
-      prev2Text: string,
-      prev3Text: string,
-      prevText: string,
-    } = {
-  curText: '<No Event>',
+        curText: string,
+        prev2Text: string,
+        prev3Text: string,
+        prevText: string,
+      } = {
+    curText: '<No Event>',
     prevText: '<No Event>',
-      prev2Text: '<No Event>',
-        prev3Text: '<No Event>',
+    prev2Text: '<No Event>',
+    prev3Text: '<No Event>',
   };
 
-updateText = (text: string) => {
-  this.setState(state => {
-    return {
-      curText: text,
-      prevText: state.curText,
-      prev2Text: state.prevText,
-      prev3Text: state.prev2Text,
-    };
-  });
-};
+  updateText = (text: string) => {
+    this.setState(state => {
+      return {
+        curText: text,
+        prevText: state.curText,
+        prev2Text: state.prevText,
+        prev3Text: state.prev2Text,
+      };
+    });
+  };
 
-render(): React.Node {
-  return (
-    <View>
-      <TextInput
-        autoCapitalize="none"
-        placeholder="Enter text to see events"
-        autoCorrect={false}
-        multiline
-        onFocus={() => this.updateText('onFocus')}
-        onBlur={() => this.updateText('onBlur')}
-        onChange={event =>
-          this.updateText('onChange text: ' + event.nativeEvent.text)
-        }
-        onContentSizeChange={event =>
-          this.updateText(
-            'onContentSizeChange size: ' +
-            JSON.stringify(event.nativeEvent.contentSize),
-          )
-        }
-        onEndEditing={event =>
-          this.updateText('onEndEditing text: ' + event.nativeEvent.text)
-        }
-        onSubmitEditing={event =>
-          this.updateText('onSubmitEditing text: ' + event.nativeEvent.text)
-        }
-        onKeyPress={event =>
-          this.updateText('onKeyPress key: ' + event.nativeEvent.key)
-        }
-        style={styles.singleLine}
-      />
-      <Text style={styles.eventLabel}>
-        {this.state.curText}
-        {'\n'}
-        (prev: {this.state.prevText}){'\n'}
-        (prev2: {this.state.prev2Text}){'\n'}
-        (prev3: {this.state.prev3Text})
-      </Text>
-    </View>
-  );
-}
+  render(): React.Node {
+    return (
+      <View>
+        <TextInput
+          autoCapitalize="none"
+          placeholder="Enter text to see events"
+          autoCorrect={false}
+          multiline
+          onFocus={() => this.updateText('onFocus')}
+          onBlur={() => this.updateText('onBlur')}
+          onChange={event =>
+            this.updateText('onChange text: ' + event.nativeEvent.text)
+          }
+          onContentSizeChange={event =>
+            this.updateText(
+              'onContentSizeChange size: ' +
+                JSON.stringify(event.nativeEvent.contentSize),
+            )
+          }
+          onEndEditing={event =>
+            this.updateText('onEndEditing text: ' + event.nativeEvent.text)
+          }
+          onSubmitEditing={event =>
+            this.updateText('onSubmitEditing text: ' + event.nativeEvent.text)
+          }
+          onKeyPress={event =>
+            this.updateText('onKeyPress key: ' + event.nativeEvent.key)
+          }
+          style={styles.singleLine}
+        />
+        <Text style={styles.eventLabel}>
+          {this.state.curText}
+          {'\n'}
+          (prev: {this.state.prevText}){'\n'}
+          (prev2: {this.state.prev2Text}){'\n'}
+          (prev3: {this.state.prev3Text})
+        </Text>
+      </View>
+    );
+  }
 }
 
 class TokenizedTextExample extends React.Component<
@@ -417,7 +417,7 @@ class TokenizedTextExample extends React.Component<
 > {
   constructor(props: any | void) {
     super(props);
-    this.state = { text: 'Hello #World' };
+    this.state = {text: 'Hello #World'};
   }
   render(): React.Node {
     //define delimiter
@@ -459,13 +459,13 @@ class TokenizedTextExample extends React.Component<
     });
 
     return (
-      <View style={{ flexDirection: 'row' }}>
+      <View style={{flexDirection: 'row'}}>
         <TextInput
           testID="text-input"
           multiline={true}
           style={styles.multiline}
           onChangeText={text => {
-            this.setState({ text });
+            this.setState({text});
           }}>
           <Text>{parts}</Text>
         </TextInput>
@@ -477,7 +477,7 @@ class TokenizedTextExample extends React.Component<
 type SelectionExampleState = {
   selection: $ReadOnly<{|
     start: number,
-  end: number,
+    end: number,
   |}>,
   value: string,
   ...
@@ -494,15 +494,15 @@ class SelectionExample extends React.Component<
   constructor(props) {
     super(props);
     this.state = {
-      selection: { start: 0, end: 0 },
+      selection: {start: 0, end: 0},
       value: props.value,
     };
   }
 
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
-  onSelectionChange({ nativeEvent: { selection } }) {
-    this.setState({ selection });
+  onSelectionChange({nativeEvent: {selection}}) {
+    this.setState({selection});
   }
 
   getRandomPosition(): number {
@@ -512,7 +512,7 @@ class SelectionExample extends React.Component<
 
   select(start: number, end: number) {
     this._textInput?.focus();
-    this.setState({ selection: { start, end } });
+    this.setState({selection: {start, end}});
     if (this.props.imperative) {
       this._textInput?.setSelection(start, end);
     }
@@ -539,11 +539,11 @@ class SelectionExample extends React.Component<
 
     return (
       <View>
-        <View style={{ flexDirection: 'row' }}>
+        <View style={{flexDirection: 'row'}}>
           <TextInput
             testID={`${this.props.testID}-text-input`}
             multiline={this.props.multiline}
-            onChangeText={value => this.setState({ value })}
+            onChangeText={value => this.setState({value})}
             // $FlowFixMe[method-unbinding] added when improving typing for this parameters
             onSelectionChange={this.onSelectionChange.bind(this)}
             ref={textInput => (this._textInput = textInput)}
@@ -610,87 +610,87 @@ const TextStylesExample = React.memo(() => {
         {
           name: 'backgroundColor',
           textStyles: [
-            { backgroundColor: theme.SystemBackgroundColor },
-            { backgroundColor: 'red' },
-            { backgroundColor: 'orange' },
-            { backgroundColor: 'yellow' },
-            { backgroundColor: 'green' },
-            { backgroundColor: 'blue' },
+            {backgroundColor: theme.SystemBackgroundColor},
+            {backgroundColor: 'red'},
+            {backgroundColor: 'orange'},
+            {backgroundColor: 'yellow'},
+            {backgroundColor: 'green'},
+            {backgroundColor: 'blue'},
           ],
         },
         {
           name: 'color',
           textStyles: [
-            { color: theme.LabelColor },
-            { color: 'red' },
-            { color: 'orange' },
-            { color: 'yellow' },
-            { color: 'green' },
-            { color: 'blue' },
+            {color: theme.LabelColor},
+            {color: 'red'},
+            {color: 'orange'},
+            {color: 'yellow'},
+            {color: 'green'},
+            {color: 'blue'},
           ],
         },
         {
           name: 'fontFamily',
           textStyles: [
-            { fontFamily: 'sans-serif' },
-            { fontFamily: 'serif' },
-            { fontFamily: 'monospace' },
+            {fontFamily: 'sans-serif'},
+            {fontFamily: 'serif'},
+            {fontFamily: 'monospace'},
           ],
         },
         {
           name: 'fontSize',
           textStyles: [
-            { fontSize: 8 },
-            { fontSize: 10 },
-            { fontSize: 12 },
-            { fontSize: 14 },
-            { fontSize: 16 },
-            { fontSize: 18 },
+            {fontSize: 8},
+            {fontSize: 10},
+            {fontSize: 12},
+            {fontSize: 14},
+            {fontSize: 16},
+            {fontSize: 18},
           ],
         },
         {
           name: 'fontStyle',
-          textStyles: [{ fontStyle: 'normal' }, { fontStyle: 'italic' }],
+          textStyles: [{fontStyle: 'normal'}, {fontStyle: 'italic'}],
         },
         {
           name: 'fontWeight',
           textStyles: [
-            { fontWeight: 'normal' },
-            { fontWeight: 'bold' },
-            { fontWeight: '200' },
-            { fontWeight: '400' },
-            { fontWeight: '600' },
-            { fontWeight: '800' },
+            {fontWeight: 'normal'},
+            {fontWeight: 'bold'},
+            {fontWeight: '200'},
+            {fontWeight: '400'},
+            {fontWeight: '600'},
+            {fontWeight: '800'},
           ],
         },
         {
           name: 'letterSpacing',
           textStyles: [
-            { letterSpacing: 0 },
-            { letterSpacing: 1 },
-            { letterSpacing: 2 },
-            { letterSpacing: 3 },
-            { letterSpacing: 4 },
-            { letterSpacing: 5 },
+            {letterSpacing: 0},
+            {letterSpacing: 1},
+            {letterSpacing: 2},
+            {letterSpacing: 3},
+            {letterSpacing: 4},
+            {letterSpacing: 5},
           ],
         },
         {
           name: 'lineHeight',
           multiline: true,
           textStyles: [
-            { lineHeight: 4 },
-            { lineHeight: 8 },
-            { lineHeight: 16 },
-            { lineHeight: 24 },
+            {lineHeight: 4},
+            {lineHeight: 8},
+            {lineHeight: 16},
+            {lineHeight: 24},
           ],
         },
         {
           name: 'textDecorationLine',
           textStyles: [
-            { textDecorationLine: 'none' },
-            { textDecorationLine: 'underline' },
-            { textDecorationLine: 'line-through' },
-            { textDecorationLine: 'underline line-through' },
+            {textDecorationLine: 'none'},
+            {textDecorationLine: 'underline'},
+            {textDecorationLine: 'line-through'},
+            {textDecorationLine: 'underline line-through'},
           ],
         },
         {
@@ -698,32 +698,32 @@ const TextStylesExample = React.memo(() => {
           textStyles: [
             {
               textShadowColor: 'black',
-              textShadowOffset: { width: 0, height: 0 },
+              textShadowOffset: {width: 0, height: 0},
               textShadowRadius: 0,
             },
             {
               textShadowColor: 'black',
-              textShadowOffset: { width: 0, height: 0 },
+              textShadowOffset: {width: 0, height: 0},
               textShadowRadius: 5,
             },
             {
               textShadowColor: 'red',
-              textShadowOffset: { width: 0, height: 0 },
+              textShadowOffset: {width: 0, height: 0},
               textShadowRadius: 5,
             },
             {
               textShadowColor: 'blue',
-              textShadowOffset: { width: 0, height: -5 },
+              textShadowOffset: {width: 0, height: -5},
               textShadowRadius: 5,
             },
             {
               textShadowColor: 'green',
-              textShadowOffset: { width: 0, height: 5 },
+              textShadowOffset: {width: 0, height: 5},
               textShadowRadius: 5,
             },
             {
               textShadowColor: 'orange',
-              textShadowOffset: { width: 10, height: 0 },
+              textShadowOffset: {width: 10, height: 0},
               textShadowRadius: 5,
             },
           ],
@@ -741,7 +741,7 @@ type TextStylesContainerProps = {
   }>,
 };
 
-function TextStylesContainer({ examples }: TextStylesContainerProps) {
+function TextStylesContainer({examples}: TextStylesContainerProps) {
   const [offset, setOffset] = useState(0);
 
   const MAX_CYCLES = 6;
@@ -756,7 +756,7 @@ function TextStylesContainer({ examples }: TextStylesContainerProps) {
       </RNTesterButton>
       <View>
         <View testID="styles-screenshot-area" style={styles.screenshotArea} />
-        {examples.map(({ name, multiline, textStyles }) => (
+        {examples.map(({name, multiline, textStyles}) => (
           <WithLabel label={name} key={name}>
             {multiline ? (
               <MultilineStyledTextInput
@@ -1034,32 +1034,32 @@ module.exports = ([
       return (
         <View>
           <TextInput
-            style={[styles.singleLine, { fontFamily: fontFamilyA }]}
+            style={[styles.singleLine, {fontFamily: fontFamilyA}]}
             placeholder={`Custom fonts like ${fontFamilyA} are supported`}
           />
           <TextInput
             style={[
               styles.singleLine,
-              { fontFamily: fontFamilyA, fontWeight: 'bold' },
+              {fontFamily: fontFamilyA, fontWeight: 'bold'},
             ]}
             placeholder={`${fontFamilyA} bold`}
           />
           <TextInput
             style={[
               styles.singleLine,
-              { fontFamily: fontFamilyA, fontWeight: '500' },
+              {fontFamily: fontFamilyA, fontWeight: '500'},
             ]}
             placeholder={`${fontFamilyA} 500`}
           />
           <TextInput
             style={[
               styles.singleLine,
-              { fontFamily: fontFamilyA, fontStyle: 'italic' },
+              {fontFamily: fontFamilyA, fontStyle: 'italic'},
             ]}
             placeholder={`${fontFamilyA} italic`}
           />
           <TextInput
-            style={[styles.singleLine, { fontFamily: fontFamilyB }]}
+            style={[styles.singleLine, {fontFamily: fontFamilyB}]}
             placeholder={fontFamilyB}
           />
         </View>
@@ -1127,4 +1127,4 @@ module.exports = ([
     name: 'textStyles',
     render: () => <TextStylesExample />,
   },
-]: Array < RNTesterModuleExample >);
+]: Array<RNTesterModuleExample>);

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-import type {TextStyle} from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type { RNTesterModuleExample } from '../../types/RNTesterTypes';
+import type { TextStyle } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import RNTesterButton from '../../components/RNTesterButton';
-import {RNTesterThemeContext} from '../../components/RNTesterTheme';
+import { RNTesterThemeContext } from '../../components/RNTesterTheme';
 import * as React from 'react';
-import {useContext, useState} from 'react';
+import { useContext, useState } from 'react';
 import {
   Button,
   Platform,
@@ -107,7 +107,7 @@ class WithLabel extends React.Component<$FlowFixMeProps> {
 class RewriteExample extends React.Component<$FlowFixMeProps, any> {
   constructor(props: any | void) {
     super(props);
-    this.state = {text: ''};
+    this.state = { text: '' };
   }
   render(): React.Node {
     const limit = 20;
@@ -122,12 +122,12 @@ class RewriteExample extends React.Component<$FlowFixMeProps, any> {
           maxLength={limit}
           onChangeText={text => {
             text = text.replace(/ /g, '_');
-            this.setState({text});
+            this.setState({ text });
           }}
           style={styles.default}
           value={this.state.text}
         />
-        <Text style={[styles.remainder, {color: remainderColor}]}>
+        <Text style={[styles.remainder, { color: remainderColor }]}>
           {remainder}
         </Text>
       </View>
@@ -141,7 +141,7 @@ class RewriteExampleInvalidCharacters extends React.Component<
 > {
   constructor(props: any | void) {
     super(props);
-    this.state = {text: ''};
+    this.state = { text: '' };
   }
   render(): React.Node {
     return (
@@ -151,7 +151,7 @@ class RewriteExampleInvalidCharacters extends React.Component<
           autoCorrect={false}
           multiline={false}
           onChangeText={text => {
-            this.setState({text: text.replace(/\s/g, '')});
+            this.setState({ text: text.replace(/\s/g, '') });
           }}
           style={styles.default}
           value={this.state.text}
@@ -169,7 +169,7 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
 
   constructor(props: any | void) {
     super(props);
-    this.state = {text: ''};
+    this.state = { text: '' };
   }
   render(): React.Node {
     return (
@@ -182,7 +182,7 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
           }}
           multiline={true}
           onChangeText={text => {
-            this.setState({text: text.replace(/ /g, '')});
+            this.setState({ text: text.replace(/ /g, '') });
           }}
           style={styles.default}
           value={this.state.text}
@@ -201,7 +201,7 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
   }
 }
 
-type ExampleRef = {current: null | {focus(): void, ...}};
+type ExampleRef = { current: null | { focus(): void, ... } };
 
 class BlurOnSubmitExample extends React.Component<{...}> {
   ref1: ExampleRef = React.createRef();
@@ -343,72 +343,72 @@ class SubmitBehaviorExample extends React.Component<{...}> {
   }
 }
 
-class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
+class TextEventsExample extends React.Component<{...}, $FlowFixMeState > {
   state:
     | any
     | {
-        curText: string,
-        prev2Text: string,
-        prev3Text: string,
-        prevText: string,
-      } = {
-    curText: '<No Event>',
+      curText: string,
+      prev2Text: string,
+      prev3Text: string,
+      prevText: string,
+    } = {
+  curText: '<No Event>',
     prevText: '<No Event>',
-    prev2Text: '<No Event>',
-    prev3Text: '<No Event>',
+      prev2Text: '<No Event>',
+        prev3Text: '<No Event>',
   };
 
-  updateText = (text: string) => {
-    this.setState(state => {
-      return {
-        curText: text,
-        prevText: state.curText,
-        prev2Text: state.prevText,
-        prev3Text: state.prev2Text,
-      };
-    });
-  };
+updateText = (text: string) => {
+  this.setState(state => {
+    return {
+      curText: text,
+      prevText: state.curText,
+      prev2Text: state.prevText,
+      prev3Text: state.prev2Text,
+    };
+  });
+};
 
-  render(): React.Node {
-    return (
-      <View>
-        <TextInput
-          autoCapitalize="none"
-          placeholder="Enter text to see events"
-          autoCorrect={false}
-          multiline
-          onFocus={() => this.updateText('onFocus')}
-          onBlur={() => this.updateText('onBlur')}
-          onChange={event =>
-            this.updateText('onChange text: ' + event.nativeEvent.text)
-          }
-          onContentSizeChange={event =>
-            this.updateText(
-              'onContentSizeChange size: ' +
-                JSON.stringify(event.nativeEvent.contentSize),
-            )
-          }
-          onEndEditing={event =>
-            this.updateText('onEndEditing text: ' + event.nativeEvent.text)
-          }
-          onSubmitEditing={event =>
-            this.updateText('onSubmitEditing text: ' + event.nativeEvent.text)
-          }
-          onKeyPress={event =>
-            this.updateText('onKeyPress key: ' + event.nativeEvent.key)
-          }
-          style={styles.singleLine}
-        />
-        <Text style={styles.eventLabel}>
-          {this.state.curText}
-          {'\n'}
-          (prev: {this.state.prevText}){'\n'}
-          (prev2: {this.state.prev2Text}){'\n'}
-          (prev3: {this.state.prev3Text})
-        </Text>
-      </View>
-    );
-  }
+render(): React.Node {
+  return (
+    <View>
+      <TextInput
+        autoCapitalize="none"
+        placeholder="Enter text to see events"
+        autoCorrect={false}
+        multiline
+        onFocus={() => this.updateText('onFocus')}
+        onBlur={() => this.updateText('onBlur')}
+        onChange={event =>
+          this.updateText('onChange text: ' + event.nativeEvent.text)
+        }
+        onContentSizeChange={event =>
+          this.updateText(
+            'onContentSizeChange size: ' +
+            JSON.stringify(event.nativeEvent.contentSize),
+          )
+        }
+        onEndEditing={event =>
+          this.updateText('onEndEditing text: ' + event.nativeEvent.text)
+        }
+        onSubmitEditing={event =>
+          this.updateText('onSubmitEditing text: ' + event.nativeEvent.text)
+        }
+        onKeyPress={event =>
+          this.updateText('onKeyPress key: ' + event.nativeEvent.key)
+        }
+        style={styles.singleLine}
+      />
+      <Text style={styles.eventLabel}>
+        {this.state.curText}
+        {'\n'}
+        (prev: {this.state.prevText}){'\n'}
+        (prev2: {this.state.prev2Text}){'\n'}
+        (prev3: {this.state.prev3Text})
+      </Text>
+    </View>
+  );
+}
 }
 
 class TokenizedTextExample extends React.Component<
@@ -417,7 +417,7 @@ class TokenizedTextExample extends React.Component<
 > {
   constructor(props: any | void) {
     super(props);
-    this.state = {text: 'Hello #World'};
+    this.state = { text: 'Hello #World' };
   }
   render(): React.Node {
     //define delimiter
@@ -459,13 +459,13 @@ class TokenizedTextExample extends React.Component<
     });
 
     return (
-      <View style={{flexDirection: 'row'}}>
+      <View style={{ flexDirection: 'row' }}>
         <TextInput
           testID="text-input"
           multiline={true}
           style={styles.multiline}
           onChangeText={text => {
-            this.setState({text});
+            this.setState({ text });
           }}>
           <Text>{parts}</Text>
         </TextInput>
@@ -477,7 +477,7 @@ class TokenizedTextExample extends React.Component<
 type SelectionExampleState = {
   selection: $ReadOnly<{|
     start: number,
-    end: number,
+  end: number,
   |}>,
   value: string,
   ...
@@ -494,15 +494,15 @@ class SelectionExample extends React.Component<
   constructor(props) {
     super(props);
     this.state = {
-      selection: {start: 0, end: 0},
+      selection: { start: 0, end: 0 },
       value: props.value,
     };
   }
 
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
-  onSelectionChange({nativeEvent: {selection}}) {
-    this.setState({selection});
+  onSelectionChange({ nativeEvent: { selection } }) {
+    this.setState({ selection });
   }
 
   getRandomPosition(): number {
@@ -512,7 +512,7 @@ class SelectionExample extends React.Component<
 
   select(start: number, end: number) {
     this._textInput?.focus();
-    this.setState({selection: {start, end}});
+    this.setState({ selection: { start, end } });
     if (this.props.imperative) {
       this._textInput?.setSelection(start, end);
     }
@@ -539,11 +539,11 @@ class SelectionExample extends React.Component<
 
     return (
       <View>
-        <View style={{flexDirection: 'row'}}>
+        <View style={{ flexDirection: 'row' }}>
           <TextInput
             testID={`${this.props.testID}-text-input`}
             multiline={this.props.multiline}
-            onChangeText={value => this.setState({value})}
+            onChangeText={value => this.setState({ value })}
             // $FlowFixMe[method-unbinding] added when improving typing for this parameters
             onSelectionChange={this.onSelectionChange.bind(this)}
             ref={textInput => (this._textInput = textInput)}
@@ -610,87 +610,87 @@ const TextStylesExample = React.memo(() => {
         {
           name: 'backgroundColor',
           textStyles: [
-            {backgroundColor: theme.SystemBackgroundColor},
-            {backgroundColor: 'red'},
-            {backgroundColor: 'orange'},
-            {backgroundColor: 'yellow'},
-            {backgroundColor: 'green'},
-            {backgroundColor: 'blue'},
+            { backgroundColor: theme.SystemBackgroundColor },
+            { backgroundColor: 'red' },
+            { backgroundColor: 'orange' },
+            { backgroundColor: 'yellow' },
+            { backgroundColor: 'green' },
+            { backgroundColor: 'blue' },
           ],
         },
         {
           name: 'color',
           textStyles: [
-            {color: theme.LabelColor},
-            {color: 'red'},
-            {color: 'orange'},
-            {color: 'yellow'},
-            {color: 'green'},
-            {color: 'blue'},
+            { color: theme.LabelColor },
+            { color: 'red' },
+            { color: 'orange' },
+            { color: 'yellow' },
+            { color: 'green' },
+            { color: 'blue' },
           ],
         },
         {
           name: 'fontFamily',
           textStyles: [
-            {fontFamily: 'sans-serif'},
-            {fontFamily: 'serif'},
-            {fontFamily: 'monospace'},
+            { fontFamily: 'sans-serif' },
+            { fontFamily: 'serif' },
+            { fontFamily: 'monospace' },
           ],
         },
         {
           name: 'fontSize',
           textStyles: [
-            {fontSize: 8},
-            {fontSize: 10},
-            {fontSize: 12},
-            {fontSize: 14},
-            {fontSize: 16},
-            {fontSize: 18},
+            { fontSize: 8 },
+            { fontSize: 10 },
+            { fontSize: 12 },
+            { fontSize: 14 },
+            { fontSize: 16 },
+            { fontSize: 18 },
           ],
         },
         {
           name: 'fontStyle',
-          textStyles: [{fontStyle: 'normal'}, {fontStyle: 'italic'}],
+          textStyles: [{ fontStyle: 'normal' }, { fontStyle: 'italic' }],
         },
         {
           name: 'fontWeight',
           textStyles: [
-            {fontWeight: 'normal'},
-            {fontWeight: 'bold'},
-            {fontWeight: '200'},
-            {fontWeight: '400'},
-            {fontWeight: '600'},
-            {fontWeight: '800'},
+            { fontWeight: 'normal' },
+            { fontWeight: 'bold' },
+            { fontWeight: '200' },
+            { fontWeight: '400' },
+            { fontWeight: '600' },
+            { fontWeight: '800' },
           ],
         },
         {
           name: 'letterSpacing',
           textStyles: [
-            {letterSpacing: 0},
-            {letterSpacing: 1},
-            {letterSpacing: 2},
-            {letterSpacing: 3},
-            {letterSpacing: 4},
-            {letterSpacing: 5},
+            { letterSpacing: 0 },
+            { letterSpacing: 1 },
+            { letterSpacing: 2 },
+            { letterSpacing: 3 },
+            { letterSpacing: 4 },
+            { letterSpacing: 5 },
           ],
         },
         {
           name: 'lineHeight',
           multiline: true,
           textStyles: [
-            {lineHeight: 4},
-            {lineHeight: 8},
-            {lineHeight: 16},
-            {lineHeight: 24},
+            { lineHeight: 4 },
+            { lineHeight: 8 },
+            { lineHeight: 16 },
+            { lineHeight: 24 },
           ],
         },
         {
           name: 'textDecorationLine',
           textStyles: [
-            {textDecorationLine: 'none'},
-            {textDecorationLine: 'underline'},
-            {textDecorationLine: 'line-through'},
-            {textDecorationLine: 'underline line-through'},
+            { textDecorationLine: 'none' },
+            { textDecorationLine: 'underline' },
+            { textDecorationLine: 'line-through' },
+            { textDecorationLine: 'underline line-through' },
           ],
         },
         {
@@ -698,32 +698,32 @@ const TextStylesExample = React.memo(() => {
           textStyles: [
             {
               textShadowColor: 'black',
-              textShadowOffset: {width: 0, height: 0},
+              textShadowOffset: { width: 0, height: 0 },
               textShadowRadius: 0,
             },
             {
               textShadowColor: 'black',
-              textShadowOffset: {width: 0, height: 0},
+              textShadowOffset: { width: 0, height: 0 },
               textShadowRadius: 5,
             },
             {
               textShadowColor: 'red',
-              textShadowOffset: {width: 0, height: 0},
+              textShadowOffset: { width: 0, height: 0 },
               textShadowRadius: 5,
             },
             {
               textShadowColor: 'blue',
-              textShadowOffset: {width: 0, height: -5},
+              textShadowOffset: { width: 0, height: -5 },
               textShadowRadius: 5,
             },
             {
               textShadowColor: 'green',
-              textShadowOffset: {width: 0, height: 5},
+              textShadowOffset: { width: 0, height: 5 },
               textShadowRadius: 5,
             },
             {
               textShadowColor: 'orange',
-              textShadowOffset: {width: 10, height: 0},
+              textShadowOffset: { width: 10, height: 0 },
               textShadowRadius: 5,
             },
           ],
@@ -741,7 +741,7 @@ type TextStylesContainerProps = {
   }>,
 };
 
-function TextStylesContainer({examples}: TextStylesContainerProps) {
+function TextStylesContainer({ examples }: TextStylesContainerProps) {
   const [offset, setOffset] = useState(0);
 
   const MAX_CYCLES = 6;
@@ -756,7 +756,7 @@ function TextStylesContainer({examples}: TextStylesContainerProps) {
       </RNTesterButton>
       <View>
         <View testID="styles-screenshot-area" style={styles.screenshotArea} />
-        {examples.map(({name, multiline, textStyles}) => (
+        {examples.map(({ name, multiline, textStyles }) => (
           <WithLabel label={name} key={name}>
             {multiline ? (
               <MultilineStyledTextInput
@@ -843,6 +843,17 @@ module.exports = ([
           autoFocus={true}
           style={styles.default}
           accessibilityLabel="I am the accessibility label for text input"
+        />
+      );
+    },
+  },
+  {
+    title: 'Long text behavior',
+    render: function (): React.Node {
+      return (
+        <TextInput
+          style={styles.default}
+          defaultValue="It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout."
         />
       );
     },
@@ -1023,32 +1034,32 @@ module.exports = ([
       return (
         <View>
           <TextInput
-            style={[styles.singleLine, {fontFamily: fontFamilyA}]}
+            style={[styles.singleLine, { fontFamily: fontFamilyA }]}
             placeholder={`Custom fonts like ${fontFamilyA} are supported`}
           />
           <TextInput
             style={[
               styles.singleLine,
-              {fontFamily: fontFamilyA, fontWeight: 'bold'},
+              { fontFamily: fontFamilyA, fontWeight: 'bold' },
             ]}
             placeholder={`${fontFamilyA} bold`}
           />
           <TextInput
             style={[
               styles.singleLine,
-              {fontFamily: fontFamilyA, fontWeight: '500'},
+              { fontFamily: fontFamilyA, fontWeight: '500' },
             ]}
             placeholder={`${fontFamilyA} 500`}
           />
           <TextInput
             style={[
               styles.singleLine,
-              {fontFamily: fontFamilyA, fontStyle: 'italic'},
+              { fontFamily: fontFamilyA, fontStyle: 'italic' },
             ]}
             placeholder={`${fontFamilyA} italic`}
           />
           <TextInput
-            style={[styles.singleLine, {fontFamily: fontFamilyB}]}
+            style={[styles.singleLine, { fontFamily: fontFamilyB }]}
             placeholder={fontFamilyB}
           />
         </View>
@@ -1116,4 +1127,4 @@ module.exports = ([
     name: 'textStyles',
     render: () => <TextStylesExample />,
   },
-]: Array<RNTesterModuleExample>);
+]: Array < RNTesterModuleExample >);


### PR DESCRIPTION
## Summary:

On rendering The `TextInput` with `defaultValue`  at a case when the text string is longer than the screen size , a weird behaviour follows on android, where the leftmost text characters gets cut off and hidden, the reason is the cursor which moves to the end.

The cause of the same to my understanding is how the text is getting updated inside the `ReactEditText`. it has a range which it replaces with the text provided, if the cursor is in close proximity , the same is moved to the end for the replaced text.

the solution that i used is pretty straightforward, we need to make sure our cursor's position should be at the start of the text for the first render, we can just simply use the `setText()` method from the `EditText`, while we create the editText for the first time in the render cycle. 
I have introduced a flag variable of `isFirstRender` initialised to `true`, this would allow us to call the `EditText` method and then eventually toggling it to false.

## Changelog:

[ANDROID] [Fixed] - Fixes The Position of cursor on Overflowing Text on Android Text Input


## Test Plan:

All Test Passing
Checked on RN TESTER
Long Text Behaviour section has been added to demonstrate the same

Before
![Screenshot_1709111184](https://github.com/facebook/react-native/assets/72331432/3ba07875-1e1c-4907-b879-8b991984f230)

After

![Screenshot_1709111606](https://github.com/facebook/react-native/assets/72331432/7fa8d510-65ef-4013-90c0-0baed62859ee)
