### PR TITLE
Register ReactHostImpl with modern CDP backend

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3673,6 +3673,7 @@ public abstract interface class com/facebook/react/runtime/internal/bolts/Contin
 
 public class com/facebook/react/runtime/internal/bolts/Task : com/facebook/react/interfaces/TaskInterface {
 	public static final field BACKGROUND_EXECUTOR Ljava/util/concurrent/ExecutorService;
+	public static final field UI_THREAD_CONDITIONAL_SYNC_EXECUTOR Ljava/util/concurrent/Executor;
 	public static final field UI_THREAD_EXECUTOR Ljava/util/concurrent/Executor;
 	public static fun call (Ljava/util/concurrent/Callable;)Lcom/facebook/react/runtime/internal/bolts/Task;
 	public static fun call (Ljava/util/concurrent/Callable;Lcom/facebook/react/runtime/internal/bolts/CancellationToken;)Lcom/facebook/react/runtime/internal/bolts/Task;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -108,6 +108,7 @@ public class ReactHostImpl implements ReactHost {
   private final MemoryPressureRouter mMemoryPressureRouter;
   private final boolean mAllowPackagerServerAccess;
   private final boolean mUseDevSupport;
+  private final ReactHostInspectorTarget mReactHostInspectorTarget;
   private final Collection<ReactInstanceEventListener> mReactInstanceEventListeners =
       Collections.synchronizedList(new ArrayList<>());
 
@@ -184,6 +185,7 @@ public class ReactHostImpl implements ReactHost {
       mDevSupportManager = new DisabledDevSupportManager();
     }
     mUseDevSupport = useDevSupport;
+    mReactHostInspectorTarget = new ReactHostInspectorTarget(this);
   }
 
   @Override
@@ -759,6 +761,7 @@ public class ReactHostImpl implements ReactHost {
   @ThreadConfined(UI)
   private void moveToHostDestroy(@Nullable ReactContext currentContext) {
     mReactLifecycleStateManager.moveToOnHostDestroy(currentContext);
+    mReactHostInspectorTarget.close();
     setCurrentActivity(null);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.runtime
+
+import com.facebook.jni.HybridData
+import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.react.runtime.internal.bolts.Task
+import com.facebook.soloader.SoLoader
+import java.io.Closeable
+import java.util.concurrent.Executor
+
+@DoNotStripAny
+internal class ReactHostInspectorTarget(private val reactHostImpl: ReactHostImpl) : Closeable {
+  // fbjni looks for the exact name "mHybridData":
+  // https://github.com/facebookincubator/fbjni/blob/5587a7fd2b191656be9391a3832ce04c034009a5/cxx/fbjni/detail/Hybrid.h#L310
+  @Suppress("NoHungarianNotation")
+  private val mHybridData: HybridData =
+      initHybrid(reactHostImpl, Task.UI_THREAD_CONDITIONAL_SYNC_EXECUTOR)
+
+  private external fun initHybrid(reactHostImpl: ReactHostImpl, executor: Executor): HybridData
+
+  override fun close() {
+    mHybridData.resetNative()
+  }
+
+  private companion object {
+    init {
+      SoLoader.loadLibrary("rninstance")
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
@@ -42,6 +42,10 @@ public class Task<TResult> implements TaskInterface<TResult> {
   /** An {@link java.util.concurrent.Executor} that executes tasks on the UI thread. */
   public static final Executor UI_THREAD_EXECUTOR = AndroidExecutors.uiThread();
 
+  /** An {@link java.util.concurrent.Executor} that executes tasks on the UI thread. */
+  public static final Executor UI_THREAD_CONDITIONAL_SYNC_EXECUTOR =
+      AndroidExecutors.uiThreadConditionalSync();
+
   /**
    * Interface for handlers invoked when a failed {@code Task} is about to be finalized, but the
    * exception has not been consumed.

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JReactHostInspectorTarget.h"
+#include <fbjni/NativeRunnable.h>
+#include <jsinspector-modern/InspectorFlags.h>
+
+using namespace facebook::jni;
+using namespace facebook::react::jsinspector_modern;
+
+namespace facebook::react {
+JReactHostInspectorTarget::JReactHostInspectorTarget(
+    alias_ref<JReactHostImpl::javaobject> reactHostImpl,
+    alias_ref<JExecutor::javaobject> executor)
+    : javaReactHostImpl_(make_global(reactHostImpl)),
+      javaExecutor_(make_global(executor)) {
+  auto& inspectorFlags = InspectorFlags::getInstance();
+  if (inspectorFlags.getEnableModernCDPRegistry()) {
+    inspectorTarget_ = HostTarget::create(
+        *this,
+        [javaExecutor =
+             javaExecutor_](std::function<void()>&& callback) mutable {
+          auto jrunnable =
+              JNativeRunnable::newObjectCxxArgs(std::move(callback));
+          javaExecutor->execute(jrunnable);
+        });
+
+    inspectorPageId_ = getInspectorInstance().addPage(
+        "React Native Bridgeless (Experimental)",
+        /* vm */ "",
+        [inspectorTargetWeak = std::weak_ptr(inspectorTarget_)](
+            std::unique_ptr<IRemoteConnection> remote)
+            -> std::unique_ptr<ILocalConnection> {
+          if (auto inspectorTarget = inspectorTargetWeak.lock()) {
+            return inspectorTarget->connect(
+                std::move(remote),
+                {
+                    .integrationName = "Android Bridgeless (ReactHostImpl)",
+                });
+          }
+          // Reject the connection.
+          return nullptr;
+        },
+        {.nativePageReloads = true});
+  }
+}
+
+JReactHostInspectorTarget::~JReactHostInspectorTarget() {
+  if (inspectorPageId_.has_value()) {
+    getInspectorInstance().removePage(*inspectorPageId_);
+  }
+}
+
+local_ref<JReactHostInspectorTarget::jhybriddata>
+JReactHostInspectorTarget::initHybrid(
+    alias_ref<JReactHostInspectorTarget::jhybridobject> self,
+    jni::alias_ref<JReactHostImpl::javaobject> reactHostImpl,
+    jni::alias_ref<JExecutor::javaobject> executor) {
+  return makeCxxInstance(reactHostImpl, executor);
+}
+
+void JReactHostInspectorTarget::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("initHybrid", JReactHostInspectorTarget::initHybrid),
+  });
+}
+
+void JReactHostInspectorTarget::onReload(const PageReloadRequest& request) {
+  javaReactHostImpl_->reload("CDP Page.reload");
+}
+
+HostTarget* JReactHostInspectorTarget::getInspectorTarget() {
+  return inspectorTarget_ ? inspectorTarget_.get() : nullptr;
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jsinspector-modern/HostTarget.h>
+#include <react/jni/JExecutor.h>
+#include <string>
+
+namespace facebook::react {
+
+struct JTaskInterface : public jni::JavaClass<JTaskInterface> {
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/interfaces/TaskInterface;";
+};
+
+struct JReactHostImpl : public jni::JavaClass<JReactHostImpl> {
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/runtime/ReactHostImpl;";
+
+  jni::local_ref<JTaskInterface::javaobject> reload(const std::string& reason) {
+    static auto method =
+        javaClassStatic()->getMethod<JTaskInterface::javaobject(std::string)>(
+            "reload");
+    return method(self(), reason);
+  }
+};
+
+class JReactHostInspectorTarget
+    : public jni::HybridClass<JReactHostInspectorTarget>,
+      public jsinspector_modern::HostTargetDelegate {
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/runtime/ReactHostInspectorTarget;";
+
+  ~JReactHostInspectorTarget() override;
+
+  static jni::local_ref<JReactHostInspectorTarget::jhybriddata> initHybrid(
+      jni::alias_ref<JReactHostInspectorTarget::jhybridobject> jThis,
+      jni::alias_ref<JReactHostImpl::javaobject> reactHost,
+      jni::alias_ref<JExecutor::javaobject>);
+
+  static void registerNatives();
+
+  void onReload(const PageReloadRequest& request) override;
+
+  jsinspector_modern::HostTarget* getInspectorTarget();
+
+ private:
+  JReactHostInspectorTarget(
+      jni::alias_ref<JReactHostImpl::javaobject> reactHostImpl,
+      jni::alias_ref<JExecutor::javaobject> executor);
+  jni::global_ref<JReactHostImpl::javaobject> javaReactHostImpl_;
+  jni::global_ref<JExecutor::javaobject> javaExecutor_;
+
+  std::shared_ptr<jsinspector_modern::HostTarget> inspectorTarget_;
+  std::optional<int> inspectorPageId_;
+
+  friend HybridBase;
+};
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/OnLoad.cpp
@@ -9,6 +9,7 @@
 #include <react/jni/JReactMarker.h>
 
 #include "JJSTimerExecutor.h"
+#include "JReactHostInspectorTarget.h"
 #include "JReactInstance.h"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*unused*/) {
@@ -16,5 +17,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*unused*/) {
     facebook::react::JReactMarker::setLogPerfMarkerIfNeeded();
     facebook::react::JReactInstance::registerNatives();
     facebook::react::JJSTimerExecutor::registerNatives();
+    facebook::react::JReactHostInspectorTarget::registerNatives();
   });
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactHostTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactHostTest.kt
@@ -56,6 +56,8 @@ class ReactHostTest {
   private lateinit var bridgelessReactContext: BridgelessReactContext
 
   private lateinit var mockedReactInstanceCtor: MockedConstruction<ReactInstance>
+  private lateinit var mockedReactHostInspectorTargetCtor:
+      MockedConstruction<ReactHostInspectorTarget>
   private lateinit var mockedDevSupportManagerCtor: MockedConstruction<BridgelessDevSupportManager>
   private lateinit var mockedBridgelessReactContextCtor: MockedConstruction<BridgelessReactContext>
   private lateinit var mockedMemoryPressureRouterCtor: MockedConstruction<MemoryPressureRouter>
@@ -73,6 +75,8 @@ class ReactHostTest {
     bridgelessReactContext = Mockito.mock(BridgelessReactContext::class.java)
 
     mockedReactInstanceCtor = Mockito.mockConstruction(ReactInstance::class.java)
+    mockedReactHostInspectorTargetCtor =
+        Mockito.mockConstruction(ReactHostInspectorTarget::class.java)
     mockedDevSupportManagerCtor = Mockito.mockConstruction(BridgelessDevSupportManager::class.java)
     mockedBridgelessReactContextCtor = Mockito.mockConstruction(BridgelessReactContext::class.java)
     mockedMemoryPressureRouterCtor = Mockito.mockConstruction(MemoryPressureRouter::class.java)
@@ -95,6 +99,7 @@ class ReactHostTest {
   @After
   fun tearDown() {
     mockedReactInstanceCtor.close()
+    mockedReactHostInspectorTargetCtor.close()
     mockedDevSupportManagerCtor.close()
     mockedBridgelessReactContextCtor.close()
     mockedMemoryPressureRouterCtor.close()

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactSurfaceTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactSurfaceTest.kt
@@ -12,7 +12,6 @@ import android.content.Context
 import android.view.View
 import com.facebook.react.bridge.NativeMap
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
-import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.interfaces.fabric.SurfaceHandler
 import com.facebook.react.runtime.internal.bolts.Task
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -34,7 +33,6 @@ import org.robolectric.shadows.ShadowInstrumentation
 @OptIn(UnstableReactNativeAPI::class)
 @Config(shadows = [ShadowSoLoader::class])
 class ReactSurfaceTest {
-  private lateinit var reactHostDelegate: ReactHostDelegate
   private lateinit var eventDispatcher: EventDispatcher
   private lateinit var reactHost: ReactHostImpl
   private lateinit var context: Context
@@ -43,12 +41,9 @@ class ReactSurfaceTest {
 
   @Before
   fun setUp() {
-    reactHostDelegate = mock(ReactHostDelegate::class.java)
     eventDispatcher = mock(EventDispatcher::class.java)
     context = Robolectric.buildActivity(Activity::class.java).create().get()
-    val componentFactory = Mockito.mock(ComponentFactory::class.java)
-    reactHost =
-        Mockito.spy(ReactHostImpl(context, reactHostDelegate, componentFactory, false, {}, false))
+    reactHost = Mockito.mock(ReactHostImpl::class.java)
     Mockito.doAnswer(mockedStartSurface())
         .`when`(reactHost)
         .startSurface(ArgumentMatchers.any(ReactSurfaceImpl::class.java))


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This implements the integration of `ReactHost` with the modern CDP backend. It handles the registration of pages in CDP when we create new instances of `ReactHost` (which is the equivalent concept in React Native).

The next PR will handle the registration of `ReactInstance` to complete the integration on bridgeless.

Differential Revision: D51459049


