### PR TITLE
Add uiThreadConditionalSync executor to AndroidExecutors

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3673,6 +3673,7 @@ public abstract interface class com/facebook/react/runtime/internal/bolts/Contin
 
 public class com/facebook/react/runtime/internal/bolts/Task : com/facebook/react/interfaces/TaskInterface {
 	public static final field BACKGROUND_EXECUTOR Ljava/util/concurrent/ExecutorService;
+	public static final field UI_THREAD_CONDITIONAL_SYNC_EXECUTOR Ljava/util/concurrent/Executor;
 	public static final field UI_THREAD_EXECUTOR Ljava/util/concurrent/Executor;
 	public static fun call (Ljava/util/concurrent/Callable;)Lcom/facebook/react/runtime/internal/bolts/Task;
 	public static fun call (Ljava/util/concurrent/Callable;Lcom/facebook/react/runtime/internal/bolts/CancellationToken;)Lcom/facebook/react/runtime/internal/bolts/Task;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
@@ -42,6 +42,10 @@ public class Task<TResult> implements TaskInterface<TResult> {
   /** An {@link java.util.concurrent.Executor} that executes tasks on the UI thread. */
   public static final Executor UI_THREAD_EXECUTOR = AndroidExecutors.uiThread();
 
+  /** An {@link java.util.concurrent.Executor} that executes tasks on the UI thread. */
+  public static final Executor UI_THREAD_CONDITIONAL_SYNC_EXECUTOR =
+      AndroidExecutors.uiThreadConditionalSync();
+
   /**
    * Interface for handlers invoked when a failed {@code Task} is about to be finalized, but the
    * exception has not been consumed.


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a new type of executor in AndroidExecutors to execute runnables on the UI thread.

If the caller is already on the UI thread it'd call the runnable immediately. Otherwise it'd be scheduled in the UI thread to execute asynchronously.

Reviewed By: huntie

Differential Revision: D53941120


