### PR TITLE
Deprecate `getSurfacePresenter` and `getModuleRegistry` in favor of their props

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -52,6 +52,10 @@ typedef std::shared_ptr<facebook::react::JSRuntimeFactory> (^RCTHostJSEngineProv
 
 @property (nonatomic, weak, nullable) id<RCTHostRuntimeDelegate> runtimeDelegate;
 
+@property (nonatomic, readonly) RCTSurfacePresenter *surfacePresenter;
+
+@property (nonatomic, readonly) RCTModuleRegistry *moduleRegistry;
+
 - (void)start;
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
@@ -64,11 +68,11 @@ typedef std::shared_ptr<facebook::react::JSRuntimeFactory> (^RCTHostJSEngineProv
 
 - (RCTFabricSurface *)createSurfaceWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)properties;
 
-- (RCTSurfacePresenter *)getSurfacePresenter;
+- (RCTSurfacePresenter *)getSurfacePresenter __attribute__((deprecated("Use `surfacePresenter` property instead.")));
 
 // Native module API
 
-- (RCTModuleRegistry *)getModuleRegistry;
+- (RCTModuleRegistry *)getModuleRegistry __attribute__((deprecated("Use `moduleRegistry` property instead.")));
 
 @end
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -212,7 +212,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                                              mode:(DisplayMode)displayMode
                                 initialProperties:(NSDictionary *)properties
 {
-  RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithSurfacePresenter:[self getSurfacePresenter]
+  RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
                                                                       moduleName:moduleName
                                                                initialProperties:properties];
   surface.surfaceHandler.setDisplayMode(displayMode);
@@ -235,14 +235,26 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   return [self createSurfaceWithModuleName:moduleName mode:DisplayMode::Visible initialProperties:properties];
 }
 
-- (RCTModuleRegistry *)getModuleRegistry
+- (RCTModuleRegistry *)moduleRegistry
 {
   return _moduleRegistry;
 }
 
-- (RCTSurfacePresenter *)getSurfacePresenter
+// Deprecated
+- (RCTModuleRegistry *)getModuleRegistry
+{
+  return self.moduleRegistry;
+}
+
+- (RCTSurfacePresenter *)surfacePresenter
 {
   return [_instance surfacePresenter];
+}
+
+// Deprecated
+- (RCTSurfacePresenter *)getSurfacePresenter
+{
+  return self.surfacePresenter;
 }
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
@@ -276,7 +288,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   [_hostDelegate hostDidStart:self];
 
   for (RCTFabricSurface *surface in [self _getAttachedSurfaces]) {
-    [surface resetWithSurfacePresenter:[self getSurfacePresenter]];
+    [surface resetWithSurfacePresenter:self.surfacePresenter];
   }
 }
 


### PR DESCRIPTION
Summary:
This change align the `getSurfacePresenter` and `getModuleRegistry` to the iOS convention for which these should be computed properties with no `get` prefix in their name.

We want to land this change and to pick it in 0.74 so we can remove the `get` versions in 0.75.

## Changelog:
[iOS][Deprecated] - Deprecate `getSurfacePresenter` and `getModuleRegistry` for `surfacePresenter` and moduleRegistry` props.

Reviewed By: javache

Differential Revision: D54253805


