### PR TITLE
Extract prepack tasks in a JS script and add codegen generation

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -89,7 +89,7 @@
     "types"
   ],
   "scripts": {
-    "prepack": "cp ../../README.md .",
+    "prepack": "node ./scripts/prepack.js",
     "featureflags-check": "node ./scripts/featureflags/index.js --verify-unchanged",
     "featureflags-update": "node ./scripts/featureflags/index.js"
   },

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -416,19 +416,20 @@ function generateSchemaInfo(library, platform) {
 }
 
 function generateCode(outputPath, schemaInfo, includesGeneratedCode, platform) {
-  const tmpDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), schemaInfo.library.config.name),
-  );
+  const libraryName = schemaInfo.library.config.name;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), libraryName));
   const tmpOutputDir = path.join(tmpDir, 'out');
   fs.mkdirSync(tmpOutputDir, {recursive: true});
 
-  console.log(`[Codegen] Generating Native Code for ${platform}`);
+  console.log(
+    `[Codegen] Generating Native Code for ${libraryName} - ${platform}`,
+  );
   const useLocalIncludePaths = includesGeneratedCode;
   generateSpecsCLIExecutor.generateSpecFromInMemorySchema(
     platform,
     schemaInfo.schema,
     tmpOutputDir,
-    schemaInfo.library.config.name,
+    libraryName,
     'com.facebook.fbreact.specs',
     schemaInfo.library.config.type,
     useLocalIncludePaths,
@@ -436,10 +437,7 @@ function generateCode(outputPath, schemaInfo, includesGeneratedCode, platform) {
 
   // Finally, copy artifacts to the final output directory.
   const outputDir =
-    reactNativeCoreLibraryOutputPath(
-      schemaInfo.library.config.name,
-      platform,
-    ) ?? outputPath;
+    reactNativeCoreLibraryOutputPath(libraryName, platform) ?? outputPath;
   fs.mkdirSync(outputDir, {recursive: true});
   // TODO: Fix this. This will not work on Windows.
   execSync(`cp -R ${tmpOutputDir}/* "${outputDir}"`);

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -34,18 +34,19 @@ const REACT_NATIVE_REPOSITORY_ROOT = path.join(
 );
 const REACT_NATIVE_PACKAGE_ROOT_FOLDER = path.join(__dirname, '..', '..');
 const CODEGEN_REPO_PATH = `${REACT_NATIVE_REPOSITORY_ROOT}/packages/react-native-codegen`;
+const RNCORE_CONFIGS = {
+  ios: path.join(REACT_NATIVE_PACKAGE_ROOT_FOLDER, 'ReactCommon'),
+  android: path.join(
+    REACT_NATIVE_PACKAGE_ROOT_FOLDER,
+    'ReactAndroid',
+    'build',
+    'generated',
+    'source',
+    'codegen',
+  ),
+};
 const CORE_LIBRARIES_WITH_OUTPUT_FOLDER = {
-  rncore: {
-    ios: path.join(REACT_NATIVE_PACKAGE_ROOT_FOLDER, 'ReactCommon'),
-    android: path.join(
-      REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-      'ReactAndroid',
-      'build',
-      'generated',
-      'source',
-      'codegen',
-    ),
-  },
+  rncore: RNCORE_CONFIGS,
   FBReactNativeSpec: {
     ios: null,
     android: path.join(

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -593,6 +593,22 @@ function cleanupEmptyFilesAndFolders(filepath) {
   }
 }
 
+function generateRNCoreComponentsIOS(projectRoot /*: string */) /*: void*/ {
+  const ios = 'ios';
+  buildCodegenIfNeeded();
+  const pkgJson = readPkgJsonInDirectory(projectRoot);
+  const rncoreLib = findProjectRootLibraries(pkgJson, projectRoot).filter(
+    library => library.config.name === 'rncore',
+  )[0];
+  if (!rncoreLib) {
+    throw new Error(
+      "[Codegen] Can't find rncore library. Failed to generate rncore artifacts",
+    );
+  }
+  const rncoreSchemaInfo = generateSchemaInfo(rncoreLib, ios);
+  generateCode('', rncoreSchemaInfo, false, ios);
+}
+
 // Execute
 
 /**
@@ -686,7 +702,8 @@ function execute(projectRoot, targetPlatform, baseOutputPath) {
 }
 
 module.exports = {
-  execute: execute,
+  execute,
+  generateRNCoreComponentsIOS,
   // exported for testing purposes only:
   _extractLibrariesFromJSON: extractLibrariesFromJSON,
   _cleanupEmptyFilesAndFolders: cleanupEmptyFilesAndFolders,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -415,7 +415,31 @@ function generateSchemaInfo(library, platform) {
   };
 }
 
+function shouldSkipGenerationForRncore(schemaInfo, platform) {
+  if (platform !== 'ios' || schemaInfo.library.config.name !== 'rncore') {
+    return false;
+  }
+  const rncoreOutputPath = path.join(
+    RNCORE_CONFIGS.ios,
+    'react',
+    'renderer',
+    'components',
+    'rncore',
+  );
+  return (
+    fs.existsSync(rncoreOutputPath) &&
+    fs.readdirSync(rncoreOutputPath).length > 0
+  );
+}
+
 function generateCode(outputPath, schemaInfo, includesGeneratedCode, platform) {
+  if (shouldSkipGenerationForRncore(schemaInfo, platform)) {
+    console.log(
+      '[Codegen - rncore] Skipping iOS code generation for rncore as it has been generated already.',
+    );
+    return;
+  }
+
   const libraryName = schemaInfo.library.config.name;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), libraryName));
   const tmpOutputDir = path.join(tmpDir, 'out');

--- a/packages/react-native/scripts/prepack.js
+++ b/packages/react-native/scripts/prepack.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+const {
+  generateRNCoreComponentsIOS,
+} = require('./codegen/generate-artifacts-executor');
+const fs = require('fs');
+
+console.info('[Prepack] Copying README.md');
+fs.copyFileSync('../../README.md', './README.md');
+generateRNCoreComponentsIOS('.');


### PR DESCRIPTION
Summary:
This change moves the prepack script of react-native in a separate script, so we can make sure we execute all the preprocessing we need before packing and publishing React Native to OSS.

## Changelog:
[General][Changed] - Moved the tasks of prepack in a separate node script

Differential Revision: D54308411


