### PR TITLE
Avoid generation of RNCore component if they have been generated already

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -415,7 +415,33 @@ function generateSchemaInfo(library, platform) {
   };
 }
 
+function shouldSkipGenerationForRncore(schemaInfo, platform) {
+  if (platform !== 'ios' || schemaInfo.library.config.name !== 'rncore') {
+    return false;
+  }
+  const rncoreOutputPath = path.join(
+    RNCORE_CONFIGS.ios,
+    'react',
+    'renderer',
+    'components',
+    'rncore',
+  );
+  const rncoreAbsolutePath = path.resolve(rncoreOutputPath);
+  return (
+    rncoreAbsolutePath.includes('node_modules') &&
+    fs.existsSync(rncoreAbsolutePath) &&
+    fs.readdirSync(rncoreAbsolutePath).length > 0
+  );
+}
+
 function generateCode(outputPath, schemaInfo, includesGeneratedCode, platform) {
+  if (shouldSkipGenerationForRncore(schemaInfo, platform)) {
+    console.log(
+      '[Codegen - rncore] Skipping iOS code generation for rncore as it has been generated already.',
+    );
+    return;
+  }
+
   const libraryName = schemaInfo.library.config.name;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), libraryName));
   const tmpOutputDir = path.join(tmpDir, 'out');

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -416,19 +416,20 @@ function generateSchemaInfo(library, platform) {
 }
 
 function generateCode(outputPath, schemaInfo, includesGeneratedCode, platform) {
-  const tmpDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), schemaInfo.library.config.name),
-  );
+  const libraryName = schemaInfo.library.config.name;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), libraryName));
   const tmpOutputDir = path.join(tmpDir, 'out');
   fs.mkdirSync(tmpOutputDir, {recursive: true});
 
-  console.log(`[Codegen] Generating Native Code for ${platform}`);
+  console.log(
+    `[Codegen] Generating Native Code for ${libraryName} - ${platform}`,
+  );
   const useLocalIncludePaths = includesGeneratedCode;
   generateSpecsCLIExecutor.generateSpecFromInMemorySchema(
     platform,
     schemaInfo.schema,
     tmpOutputDir,
-    schemaInfo.library.config.name,
+    libraryName,
     'com.facebook.fbreact.specs',
     schemaInfo.library.config.type,
     useLocalIncludePaths,
@@ -436,10 +437,7 @@ function generateCode(outputPath, schemaInfo, includesGeneratedCode, platform) {
 
   // Finally, copy artifacts to the final output directory.
   const outputDir =
-    reactNativeCoreLibraryOutputPath(
-      schemaInfo.library.config.name,
-      platform,
-    ) ?? outputPath;
+    reactNativeCoreLibraryOutputPath(libraryName, platform) ?? outputPath;
   fs.mkdirSync(outputDir, {recursive: true});
   // TODO: Fix this. This will not work on Windows.
   execSync(`cp -R ${tmpOutputDir}/* "${outputDir}"`);

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -34,18 +34,19 @@ const REACT_NATIVE_REPOSITORY_ROOT = path.join(
 );
 const REACT_NATIVE_PACKAGE_ROOT_FOLDER = path.join(__dirname, '..', '..');
 const CODEGEN_REPO_PATH = `${REACT_NATIVE_REPOSITORY_ROOT}/packages/react-native-codegen`;
+const RNCORE_CONFIGS = {
+  ios: path.join(REACT_NATIVE_PACKAGE_ROOT_FOLDER, 'ReactCommon'),
+  android: path.join(
+    REACT_NATIVE_PACKAGE_ROOT_FOLDER,
+    'ReactAndroid',
+    'build',
+    'generated',
+    'source',
+    'codegen',
+  ),
+};
 const CORE_LIBRARIES_WITH_OUTPUT_FOLDER = {
-  rncore: {
-    ios: path.join(REACT_NATIVE_PACKAGE_ROOT_FOLDER, 'ReactCommon'),
-    android: path.join(
-      REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-      'ReactAndroid',
-      'build',
-      'generated',
-      'source',
-      'codegen',
-    ),
-  },
+  rncore: RNCORE_CONFIGS,
   FBReactNativeSpec: {
     ios: null,
     android: path.join(

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -593,6 +593,22 @@ function cleanupEmptyFilesAndFolders(filepath) {
   }
 }
 
+function generateRNCoreComponentsIOS(projectRoot /*: string */) /*: void*/ {
+  const ios = 'ios';
+  buildCodegenIfNeeded();
+  const pkgJson = readPkgJsonInDirectory(projectRoot);
+  const rncoreLib = findProjectRootLibraries(pkgJson, projectRoot).filter(
+    library => library.config.name === 'rncore',
+  )[0];
+  if (!rncoreLib) {
+    throw new Error(
+      "[Codegen] Can't find rncore library. Failed to generate rncore artifacts",
+    );
+  }
+  const rncoreSchemaInfo = generateSchemaInfo(rncoreLib, ios);
+  generateCode('', rncoreSchemaInfo, false, ios);
+}
+
 // Execute
 
 /**
@@ -686,7 +702,8 @@ function execute(projectRoot, targetPlatform, baseOutputPath) {
 }
 
 module.exports = {
-  execute: execute,
+  execute,
+  generateRNCoreComponentsIOS,
   // exported for testing purposes only:
   _extractLibrariesFromJSON: extractLibrariesFromJSON,
   _cleanupEmptyFilesAndFolders: cleanupEmptyFilesAndFolders,


### PR DESCRIPTION
Summary:
Added a check to avoid the regeneration of RNCore components in case they have been generated already.
In order to maintain backward compatibility and to make sure not to break internal use cases, I think we should still keep the possibility to generate these components at `pod install` time.

Internal users of RNTester, for example, will not run `yarn prepack` before building react-native using OSS technology.
Notice that, in this specific case, the Codegen generates the file in a path that is not `node_modules`.

## Changelog:
[General][Added] - Skip generation of RNCore if the files have been already generated

Differential Revision: D54308832


