### PR TITLE
Mark UIManagerModuleConstantsHelper.normalizeEventTypes as Nullable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -180,7 +180,7 @@ public class UIManagerModuleConstantsHelper {
   }
 
   @VisibleForTesting
-  /* package */ static void normalizeEventTypes(Map events) {
+  /* package */ static void normalizeEventTypes(@Nullable Map events) {
     if (events == null) {
       return;
     }


### PR DESCRIPTION
Summary:
Mark UIManagerModuleConstantsHelper.normalizeEventTypes as Nullable

changelog: [internal] internal

Differential Revision: D54327799


