### PR TITLE
Register ReactInstanceManager with modern CDP backend

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1140,6 +1140,15 @@ public class com/facebook/react/bridge/ReactIgnorableMountingException : java/la
 	public static fun isIgnorable (Ljava/lang/Throwable;)Z
 }
 
+public class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget : java/lang/AutoCloseable {
+	public fun <init> (Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;)V
+	public fun close ()V
+}
+
+public abstract interface class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate {
+	public abstract fun onReload ()V
+}
+
 public class com/facebook/react/bridge/ReactMarker {
 	public fun <init> ()V
 	public static fun addFabricListener (Lcom/facebook/react/bridge/ReactMarker$FabricMarkerListener;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -64,6 +64,7 @@ import com.facebook.react.bridge.ProxyJavaScriptExecutor;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactCxxErrorHandler;
+import com.facebook.react.bridge.ReactInstanceManagerInspectorTarget;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
@@ -80,6 +81,7 @@ import com.facebook.react.common.annotations.StableReactNativeAPI;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
+import com.facebook.react.devsupport.InspectorFlags;
 import com.facebook.react.devsupport.ReactInstanceDevHelper;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
@@ -173,6 +175,7 @@ public class ReactInstanceManager {
   private final Context mApplicationContext;
   private @Nullable @ThreadConfined(UI) DefaultHardwareBackBtnHandler mDefaultBackButtonImpl;
   private @Nullable Activity mCurrentActivity;
+  private @Nullable ReactInstanceManagerInspectorTarget mInspectorTarget;
   private final Collection<com.facebook.react.ReactInstanceEventListener>
       mReactInstanceEventListeners =
           Collections.synchronizedList(
@@ -689,6 +692,7 @@ public class ReactInstanceManager {
   @Deprecated
   public void onHostDestroy() {
     UiThreadUtil.assertOnUiThread();
+    destroyInspectorTarget();
 
     if (mUseDeveloperSupport) {
       mDevSupportManager.setDevSupportEnabled(false);
@@ -737,6 +741,7 @@ public class ReactInstanceManager {
     }
 
     mHasStartedDestroying = true;
+    destroyInspectorTarget();
 
     if (mUseDeveloperSupport) {
       mDevSupportManager.setDevSupportEnabled(false);
@@ -1349,6 +1354,8 @@ public class ReactInstanceManager {
 
     NativeModuleRegistry nativeModuleRegistry = processPackages(reactContext, mPackages);
 
+    getOrCreateInspectorTarget();
+
     CatalystInstanceImpl.Builder catalystInstanceBuilder =
         new CatalystInstanceImpl.Builder()
             .setReactQueueConfigurationSpec(ReactQueueConfigurationSpec.createDefault())
@@ -1470,5 +1477,28 @@ public class ReactInstanceManager {
       ((ReactPackageLogger) reactPackage).endProcessPackage();
     }
     SystraceMessage.endSection(TRACE_TAG_REACT_JAVA_BRIDGE).flush();
+  }
+
+  private @Nullable ReactInstanceManagerInspectorTarget getOrCreateInspectorTarget() {
+    if (mInspectorTarget == null && InspectorFlags.getEnableModernCDPRegistry()) {
+
+      mInspectorTarget =
+          new ReactInstanceManagerInspectorTarget(
+              new ReactInstanceManagerInspectorTarget.TargetDelegate() {
+                @Override
+                public void onReload() {
+                  UiThreadUtil.runOnUiThread(() -> mDevSupportManager.handleReloadJS());
+                }
+              });
+    }
+
+    return mInspectorTarget;
+  }
+
+  private void destroyInspectorTarget() {
+    if (mInspectorTarget != null) {
+      mInspectorTarget.close();
+      mInspectorTarget = null;
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge;
+
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStripAny;
+import java.util.concurrent.Executor;
+
+@DoNotStripAny
+public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
+  public interface TargetDelegate {
+    public void onReload();
+  }
+
+  private final HybridData mHybridData;
+
+  public ReactInstanceManagerInspectorTarget(TargetDelegate delegate) {
+    mHybridData =
+        initHybrid(
+            new Executor() {
+              @Override
+              public void execute(Runnable command) {
+                if (UiThreadUtil.isOnUiThread()) {
+                  command.run();
+                } else {
+                  UiThreadUtil.runOnUiThread(command);
+                }
+              }
+            },
+            delegate);
+  }
+
+  private native HybridData initHybrid(Executor executor, TargetDelegate delegate);
+
+  public void close() {
+    mHybridData.resetNative();
+  }
+
+  static {
+    ReactBridge.staticInit();
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -19,6 +19,7 @@
 #include "JReactMarker.h"
 #include "JavaScriptExecutorHolder.h"
 #include "ProxyExecutor.h"
+#include "ReactInstanceManagerInspectorTarget.h"
 #include "WritableNativeArray.h"
 #include "WritableNativeMap.h"
 
@@ -90,6 +91,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     WritableNativeMap::registerNatives();
     JReactMarker::registerNatives();
     JInspector::registerNatives();
+    ReactInstanceManagerInspectorTarget::registerNatives();
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ReactInstanceManagerInspectorTarget.h"
+
+#include <fbjni/NativeRunnable.h>
+#include <jsinspector-modern/InspectorFlags.h>
+
+using namespace facebook::jni;
+using namespace facebook::react::jsinspector_modern;
+
+namespace facebook::react {
+
+void ReactInstanceManagerInspectorTarget::TargetDelegate::onReload() const {
+  auto method = javaClassStatic()->getMethod<void()>("onReload");
+  method(self());
+}
+
+ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
+    jni::alias_ref<ReactInstanceManagerInspectorTarget::jhybridobject> jobj,
+    jni::alias_ref<JExecutor::javaobject> executor,
+    const ReactInstanceManagerInspectorTarget::TargetDelegate& delegate)
+    : javaPart_(make_global(jobj)), delegate_(delegate) {
+  auto& inspectorFlags = InspectorFlags::getInstance();
+
+  if (inspectorFlags.getEnableModernCDPRegistry()) {
+    inspectorTarget_ = HostTarget::create(
+        *this, [javaExecutor = executor](auto callback) mutable {
+          auto jrunnable =
+              JNativeRunnable::newObjectCxxArgs(std::move(callback));
+          javaExecutor->execute(jrunnable);
+        });
+
+    inspectorPageId_ = getInspectorInstance().addPage(
+        "React Native Bridge (Experimental)",
+        /* vm */ "",
+        [inspectorTarget =
+             inspectorTarget_](std::unique_ptr<IRemoteConnection> remote)
+            -> std::unique_ptr<ILocalConnection> {
+          return inspectorTarget->connect(
+              std::move(remote),
+              {
+                  .integrationName =
+                      "Android Bridge (ReactInstanceManagerInspectorTarget)",
+              });
+        },
+        {.nativePageReloads = true});
+  }
+}
+
+ReactInstanceManagerInspectorTarget::~ReactInstanceManagerInspectorTarget() {
+  if (inspectorPageId_.has_value()) {
+    getInspectorInstance().removePage(*inspectorPageId_);
+  }
+}
+
+jni::local_ref<ReactInstanceManagerInspectorTarget::jhybriddata>
+ReactInstanceManagerInspectorTarget::initHybrid(
+    jni::alias_ref<jhybridobject> jobj,
+    jni::alias_ref<JExecutor::javaobject> executor,
+    const ReactInstanceManagerInspectorTarget::TargetDelegate& delegate) {
+  return makeCxxInstance(jobj, executor, delegate);
+}
+
+void ReactInstanceManagerInspectorTarget::registerNatives() {
+  registerHybrid({
+      makeNativeMethod(
+          "initHybrid", ReactInstanceManagerInspectorTarget::initHybrid),
+  });
+}
+
+void ReactInstanceManagerInspectorTarget::onReload(
+    const PageReloadRequest& /*request*/) {
+  delegate_.onReload();
+}
+
+HostTarget* ReactInstanceManagerInspectorTarget::getInspectorTarget() {
+  return inspectorTarget_.get();
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fb/fbjni.h>
+#include <jsinspector-modern/HostTarget.h>
+#include <react/jni/JExecutor.h>
+
+namespace facebook::react {
+
+class ReactInstanceManagerInspectorTarget
+    : public jni::HybridClass<ReactInstanceManagerInspectorTarget>,
+      public jsinspector_modern::HostTargetDelegate {
+ private:
+  class TargetDelegate : public facebook::jni::JavaClass<TargetDelegate> {
+   public:
+    static constexpr auto kJavaDescriptor =
+        "Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;";
+
+    void onReload() const;
+  };
+
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget;";
+
+  ReactInstanceManagerInspectorTarget(
+      const ReactInstanceManagerInspectorTarget&) = delete;
+  ReactInstanceManagerInspectorTarget& operator=(
+      const ReactInstanceManagerInspectorTarget&) = delete;
+
+  ~ReactInstanceManagerInspectorTarget() override;
+
+  static jni::local_ref<jhybriddata> initHybrid(
+      jni::alias_ref<jhybridobject> jobj,
+      jni::alias_ref<JExecutor::javaobject> executor,
+      const ReactInstanceManagerInspectorTarget::TargetDelegate& delegate);
+
+  static void registerNatives();
+
+  void onReload(const PageReloadRequest& request) override;
+  jsinspector_modern::HostTarget* getInspectorTarget();
+
+ private:
+  friend HybridBase;
+
+  ReactInstanceManagerInspectorTarget(
+      jni::alias_ref<ReactInstanceManagerInspectorTarget::jhybridobject> jobj,
+      jni::alias_ref<JExecutor::javaobject> executor,
+      const ReactInstanceManagerInspectorTarget::TargetDelegate& delegate);
+
+  jni::global_ref<ReactInstanceManagerInspectorTarget::javaobject> javaPart_;
+
+  const ReactInstanceManagerInspectorTarget::TargetDelegate& delegate_;
+  std::shared_ptr<jsinspector_modern::HostTarget> inspectorTarget_;
+  std::optional<int> inspectorPageId_;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Integrates the modern CDP backend with `ReactInstanceManager` on Android.

`ReactInstanceManager` is equivalent to the CDP page / `HostTarget` concept, therefore we register the `addPage`/`removePage` calls with this object's lifecycle.

Implementation notes:
- `ReactInstanceManagerInspectorTarget` is created to avoid converting `ReactInstanceManager` to JNI (impacting tests).
- Its constructor receives a `TargetDelegate` object, so that we avoid passing the entire `ReactInstanceManager` class through (avoids cyclic dependency from `com.facebook.react.bridge` to `com.facebook.react`).

Changelog:
[Internal] - Register `ReactInstanceManager` with modern CDP backend

Differential Revision: D51456960


