### PR TITLE
Gate inspector target creation and destruction behind inspector feature flags

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -115,7 +115,7 @@ final class ReactInstance {
       QueueThreadExceptionHandler exceptionHandler,
       ReactJsExceptionHandler reactExceptionManager,
       boolean useDevSupport,
-      ReactHostInspectorTarget reactHostInspectorTarget) {
+      @Nullable ReactHostInspectorTarget reactHostInspectorTarget) {
     mBridgelessReactContext = bridgelessReactContext;
     mDelegate = delegate;
 
@@ -466,7 +466,7 @@ final class ReactInstance {
       ReactJsExceptionHandler jReactExceptionsManager,
       @Nullable BindingsInstaller jBindingsInstaller,
       boolean isProfiling,
-      ReactHostInspectorTarget reactHostInspectorTarget);
+      @Nullable ReactHostInspectorTarget reactHostInspectorTarget);
 
   @DoNotStrip
   private static native JSTimerExecutor createJSTimerExecutor();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -67,7 +67,9 @@ JReactInstance::JReactInstance(
       sharedJSMessageQueueThread,
       timerManager,
       std::move(jsErrorHandlingFunc),
-      jReactHostInspectorTarget->cthis()->getInspectorTarget());
+      jReactHostInspectorTarget
+          ? jReactHostInspectorTarget->cthis()->getInspectorTarget()
+          : nullptr);
 
   auto bufferedRuntimeExecutor = instance_->getBufferedRuntimeExecutor();
   timerManager->setRuntimeExecutor(bufferedRuntimeExecutor);

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -131,15 +131,15 @@ ReactInstance::ReactInstance(
 }
 
 void ReactInstance::unregisterFromInspector() {
-  assert(inspectorTarget_);
+  if (inspectorTarget_) {
+    assert(runtimeInspectorTarget_);
+    inspectorTarget_->unregisterRuntime(*runtimeInspectorTarget_);
 
-  assert(runtimeInspectorTarget_);
-  inspectorTarget_->unregisterRuntime(*runtimeInspectorTarget_);
+    assert(parentInspectorTarget_);
+    parentInspectorTarget_->unregisterInstance(*inspectorTarget_);
 
-  assert(parentInspectorTarget_);
-  parentInspectorTarget_->unregisterInstance(*inspectorTarget_);
-
-  inspectorTarget_ = nullptr;
+    inspectorTarget_ = nullptr;
+  }
 }
 
 RuntimeExecutor ReactInstance::getUnbufferedRuntimeExecutor() noexcept {


### PR DESCRIPTION
Summary:
This fixes a crashes during logout on Android and iOS caused by trying to unregister the inspector from instances that were not previously registered. This is because I removed a check in D51459050 that was necessary when the inspector was disabled via the flag (and we call the `unregisterFromInspector` method unconditionally).

This also gates the registration/unregistration on Android properly.

Differential Revision: D54357554


