### PR TITLE
Add scrollEventThrottle to validAttributes to ScrollView view config on Android

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -60,6 +60,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           sendMomentumEvents: true,
           borderRadius: true,
           nestedScrollEnabled: true,
+          scrollEventThrottle: true,
           borderStyle: true,
           borderRightColor: {
             process: require('../../StyleSheet/processColor').default,


### PR DESCRIPTION
Summary:
The `scrollEventThrottle` prop is missing in the ViewConfig for ScrollView for the Android platform. Because of that it was ignored by native in the New Architecture.
This diff fixes that.

Changelog: [Android][Fixed] - Add support for scrollEventThrottle for ScrollView on the New Architecture.

Differential Revision: D54303157


