### PR TITLE
Add codegen for mapping between componentName and componentClass

### DIFF
--- a/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderH.template
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#import <React/RCTComponentViewProtocol.h>
+
+@interface RCTFabricComponentsProvider: NSObject
+
++ (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)fabricComponents;
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderMM.template
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTFabricComponents.h"
+
+static NSDictionary<NSString *, Class<RCTComponentViewProtocol>> * _fabricComponents;
+
+@implementation RCTFabricComponentsProvider
+
++ (void)initialize
+{
+  _fabricComponents = @{
+    {componentNameClassMap}
+  };
+}
+
++ (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)fabricComponents
+{
+  if (!_fabricComponents) {
+    [self initialize];
+  }
+
+  return _fabricComponents;
+}
+
+@end


### PR DESCRIPTION
Summary:
The current approach of generating the RCTThirdPartyFabricComponentsProvider is flawed:
- The file depends on RCTFabric to get access to a specific protocol.
- The file rely on some floating functions that should be implemented by the third party libraries. This approach don't work with `use_frameworks` because the RCTFabric framework should be able to build in isolation and those symbols will be missing.
- The file should also depends on all the libraries because of the above floating functions. This creates implicit dependencies which are circular (Codegen -> Library and Library -> Codegen)
- The file is generated in `node_modules` for the users.

The solution is to generate the registration of components leveraging the objc runtime and using `NSClassFromString`. Unfortunately, in OSS, we have all sort of mappings. To make some examples, I [found instances](https://github.com/search?q=ViewCls%28void%29+NOT+repo%3Afacebook%2Freact-native+NOT+is%3Afork&type=code&p=3) of these classes:

- ComponetName -> ComponentNameComponentView
- ComponetName -> ComponentName
- ComponetName -> RNTComponetName
- ComponetName -> RNTComponetNameComponentView
- ComponetName -> ComponetNameView

This makes it impossible to create an heuristic that might work in all the cases. It is also impossible to leverage the existing `<ComponentName>Cls` function we asked to create to library authors, because we will fall back again in the problems above.

So, library authors must specify in their `package.json` the association between `componentName` --> `componentClass` so that we can generate the dictionary appropriately.

This requires a migration for the OSS ecosystem, so we will now only deprecate the `RCTThirdPartyComponentProvider` and we will remove it after 0.75-stable will be released.
The deprecation will happen in a following diff.

## Changelog:
[iOS][Added] - Generate the RCTFabricComponentsProvider in Reactcodegen

Differential Revision: D54363904


