### PR TITLE
Plug the codegen of RCTFabricComponents to The AppDelegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -17,6 +17,10 @@
 #import "RCTAppDelegate+Protected.h"
 #import "RCTAppSetupUtils.h"
 
+#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
+#import <ReactCodegen/RCTFabricComponentsProvider.h>
+#endif
+
 #if RN_DISABLE_OSS_PLUGIN_HEADER
 #import <RCTTurboModulePlugin/RCTTurboModulePlugin.h>
 #else
@@ -263,7 +267,11 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
 {
+#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
+  return [RCTFabricComponentsProvider fabricComponents];
+#else
   return @{};
+#endif
 }
 
 #pragma mark - RCTTurboModuleManagerDelegate

--- a/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderH.template
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RCTFabricComponentsProvider: NSObject
+
++ (NSDictionary<NSString *, Class> *)fabricComponents;
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderMM.template
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTFabricComponentsProvider.h"
+
+static NSDictionary<NSString *, Class> * _fabricComponents;
+
+@implementation RCTFabricComponentsProvider
+
++ (void)initialize
+{
+  _fabricComponents = @{
+    {componentNameClassMap}
+  };
+}
+
++ (NSDictionary<NSString *, Class> *)fabricComponents
+{
+  if (!_fabricComponents) {
+    [self initialize];
+  }
+
+  return _fabricComponents;
+}
+
+@end

--- a/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
+++ b/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
@@ -29,14 +29,6 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<RNTMyNativeViewComponentDescriptor>();
 }
 
-// Load is not invoked if it is not defined, therefore, we must ask to update this.
-// See the Apple documentation: https://developer.apple.com/documentation/objectivec/nsobject/1418815-load?language=objc
-// "[...] but only if the newly loaded class or category implements a method that can respond."
-+ (void)load
-{
-  [super load];
-}
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -146,13 +146,6 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 
 #pragma mark - RCTComponentViewFactoryComponentProvider
 
-#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
-- (nonnull NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
-{
-  return @{@"RNTMyNativeView" : RNTMyNativeViewComponentView.class};
-}
-#endif
-
 - (NSURL *)bundleURL
 {
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:kBundlePath];

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -38,6 +38,11 @@
     "jsSrcsDir": ".",
     "android": {
       "javaPackageName": "com.facebook.fbreact.specs"
+    },
+    "ios": {
+      "componentsMapping": {
+        "RNTMyNativeView": "RNTMyNativeViewComponentView"
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
This change puts together the codegen of the new RCTFabricComponents class with the actual code, testing it.

This approach allow us also to cleanup the code the RNTester AppDelegate given that now we can rely on an automated way to achieve the same result.

## Changelog:
[iOS][Changed] - Plug the RCTFabricComponents to the RCTAppDelegate

Differential Revision: D54364789
