### PR TITLE
fix(iOS): add extended check for content type application/javascript

### DIFF
--- a/packages/react-native/React/Base/RCTJavaScriptLoader.mm
+++ b/packages/react-native/React/Base/RCTJavaScriptLoader.mm
@@ -318,9 +318,11 @@ static void attemptAsynchronousLoadOfBundleAtURL(
         onComplete(nil, source);
       }
       progressHandler:^(NSDictionary *headers, NSNumber *loaded, NSNumber *total) {
+        NSString *contentType = headers[@"Content-Type"];
+        NSString *mimeType = [[contentType componentsSeparatedByString:@";"] firstObject];
         // Only care about download progress events for the javascript bundle part.
-        if ([headers[@"Content-Type"] isEqualToString:@"application/javascript"] ||
-            [headers[@"Content-Type"] isEqualToString:@"application/x-metro-bytecode-bundle"]) {
+        if ([mimeType isEqualToString:@"application/javascript"] ||
+            [mimeType isEqualToString:@"application/x-metro-bytecode-bundle"]) {
           onProgress(progressEventFromDownloadProgress(loaded, total));
         }
       }];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When used with expo, JS code content type is `application/javascript; charset=UTF-8` instead of just `application/javascript`, We have a really large bundle and the application shows stuck at "Bundling 100%" and does not show "Downloading 1..100%".

Here we improve the check for the content type to correctly show the progress.

## Changelog:

[IOS] [FIXED] - Fixed headers content type check for iOS bundle download

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:
For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
