### PR TITLE
Add missing text and eventCount fields to TextInput focus and blur events

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -618,6 +618,10 @@ public class ReactEditText extends AppCompatEditText {
     return ++mNativeEventCount;
   }
 
+  public int getEventCounter() {
+    return mNativeEventCount;
+  }
+
   public void maybeSetTextFromJS(ReactTextUpdate reactTextUpdate) {
     mIsSettingTextFromJS = true;
     maybeSetText(reactTextUpdate);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputBlurEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputBlurEvent.java
@@ -18,13 +18,18 @@ import com.facebook.react.uimanager.events.Event;
 
   private static final String EVENT_NAME = "topBlur";
 
+  private String mText;
+  private int mEventCount;
+
   @Deprecated
-  public ReactTextInputBlurEvent(int viewId) {
-    this(ViewUtil.NO_SURFACE_ID, viewId);
+  public ReactTextInputBlurEvent(int viewId, String text, int eventCount) {
+    this(ViewUtil.NO_SURFACE_ID, viewId, text, eventCount);
   }
 
-  public ReactTextInputBlurEvent(int surfaceId, int viewId) {
+  public ReactTextInputBlurEvent(int surfaceId, int viewId, String text, int eventCount) {
     super(surfaceId, viewId);
+    mText = text;
+    mEventCount = eventCount;
   }
 
   @Override
@@ -42,6 +47,8 @@ import com.facebook.react.uimanager.events.Event;
   protected WritableMap getEventData() {
     WritableMap eventData = Arguments.createMap();
     eventData.putInt("target", getViewTag());
+    eventData.putString("text", mText);
+    eventData.putInt("eventCount", mEventCount);
     return eventData;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputFocusEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputFocusEvent.java
@@ -18,13 +18,18 @@ import com.facebook.react.uimanager.events.Event;
 
   private static final String EVENT_NAME = "topFocus";
 
+  private String mText;
+  private int mEventCount;
+
   @Deprecated
-  public ReactTextInputFocusEvent(int viewId) {
-    this(ViewUtil.NO_SURFACE_ID, viewId);
+  public ReactTextInputFocusEvent(int viewId, String text, int eventCount) {
+    this(ViewUtil.NO_SURFACE_ID, viewId, text, eventCount);
   }
 
-  public ReactTextInputFocusEvent(int surfaceId, int viewId) {
+  public ReactTextInputFocusEvent(int surfaceId, int viewId, String text, int eventCount) {
     super(surfaceId, viewId);
+    mText = text;
+    mEventCount = eventCount;
   }
 
   @Override
@@ -37,6 +42,8 @@ import com.facebook.react.uimanager.events.Event;
   protected WritableMap getEventData() {
     WritableMap eventData = Arguments.createMap();
     eventData.putInt("target", getViewTag());
+    eventData.putString("text", mText);
+    eventData.putInt("eventCount", mEventCount);
     return eventData;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1150,9 +1150,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
           EventDispatcher eventDispatcher = getEventDispatcher(reactContext, editText);
           if (hasFocus) {
             eventDispatcher.dispatchEvent(
-                new ReactTextInputFocusEvent(surfaceId, editText.getId()));
+                new ReactTextInputFocusEvent(
+                  surfaceId, editText.getId(), editText.getText().toString(), editText.getEventCounter()));
           } else {
-            eventDispatcher.dispatchEvent(new ReactTextInputBlurEvent(surfaceId, editText.getId()));
+            eventDispatcher.dispatchEvent(
+                new ReactTextInputBlurEvent(
+                  surfaceId, editText.getId(), editText.getText().toString(), editText.getEventCounter()));
 
             eventDispatcher.dispatchEvent(
                 new ReactTextInputEndEditingEvent(


### PR DESCRIPTION
## Summary:

It turned out that on Android `onFocus` and `onBlur` callbacks on `TextInput` component were missing `text` and `eventCount` fields on `nativeEvent` object. In order to retrieve information about `eventCount` I had to introduce new method `getEventCounter` to `ReactEditText.java` to just read the number without incrementing it.

## Changelog:

[ANDROID] [FIXED] - Add missing text and eventCount fields to TextInput focus and blur events

