### PR TITLE
Restore Content-Length header in inspector-proxy JSON responses

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -167,6 +167,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
     response.writeHead(200, {
       'Content-Type': 'application/json; charset=UTF-8',
       'Cache-Control': 'no-cache',
+      'Content-Length': Buffer.byteLength(data).toString(),
       Connection: 'close',
     });
     response.end(data);


### PR DESCRIPTION
Summary:
Changelog: [General][Fixed] Re-enable listing Hermes debugger targets in chrome://inspect, broken in 0.74 RC

Fixes https://github.com/facebook/react-native/issues/43259.

Reverts https://github.com/facebook/react-native/pull/42590 and fixes the original `Content-Length` Unicode bug using a different approach.

Differential Revision: D54409847


