### PR TITLE
getChildAtWithSubviewClippingEnabled should be @Nullable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -637,8 +637,11 @@ public class ReactViewGroup extends ViewGroup
     return mAllChildrenCount;
   }
 
-  /*package*/ View getChildAtWithSubviewClippingEnabled(int index) {
-    return Assertions.assertNotNull(mAllChildren)[index];
+  /*package*/ @Nullable
+  View getChildAtWithSubviewClippingEnabled(int index) {
+    return index >= 0 && index < mAllChildrenCount
+        ? Assertions.assertNotNull(mAllChildren)[index]
+        : null;
   }
 
   /*package*/ void addViewWithSubviewClippingEnabled(View child, int index) {


### PR DESCRIPTION
Summary:
The RemoveDeleteTree operation assumes it can safely call getChildAt with indices that are out of bounds to find all the children. `getChildAtWithSubviewClippingEnabled` was unnecessarily stricter than `getChildAt` and would crash in such cases.

Changelog: [Android][Fixed] - Fix crash in `getChildAtWithSubviewClippingEnabled`

Differential Revision: D54380975


