### PR TITLE
Do not invalidate RCTInstance if jsbundle failed to load

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -422,7 +422,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
         if (error) {
           // TODO(T91461138): Properly address bundle loading errors.
           RCTLogError(@"RCTInstance: Error while loading bundle: %@", error);
-          [strongSelf invalidate];
           return;
         }
         // DevSettings module is needed by _loadScriptFromSource's callback so prior initialization is required


### PR DESCRIPTION
Summary:
With this diff we will not be invalidating the `RCTInstance` in case of `jsbundle` loading error.
This change will allow us to to show the RedBox error message. We couldn't do that previously because we weren't able to instantiate the "RedBox" module for the the `RCTTurboModuleRegistry` that was in invalid state together with `RCTInstance`.

Changelog: [iOS][Fixed] - Show RedBox error message if Metro instance is not running.

Differential Revision: D54364278


