### PR TITLE
Move the generation of module registration in its own file

### DIFF
--- a/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderH.js
@@ -38,7 +38,7 @@ const FileTemplate = ({lookupFuncs}: {lookupFuncs: string}) => `
 extern "C" {
 #endif
 
-Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name);
+Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name) __attribute__((deprecated("please ask to 3rd party library maintainer to use the 'package.json'")));
 #if RCT_NEW_ARCH_ENABLED
 #ifndef RCT_DYNAMIC_FRAMEWORKS
 

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderH-test.js.snap
@@ -21,7 +21,7 @@ Map {
 extern \\"C\\" {
 #endif
 
-Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name);
+Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name) __attribute__((deprecated(\\"please ask to 3rd party library maintainer to use the 'package.json'\\")));
 #if RCT_NEW_ARCH_ENABLED
 #ifndef RCT_DYNAMIC_FRAMEWORKS
 

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -17,6 +17,10 @@
 #import "RCTAppDelegate+Protected.h"
 #import "RCTAppSetupUtils.h"
 
+#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
+#import <ReactCodegen/RCTFabricComponentsProvider.h>
+#endif
+
 #if RN_DISABLE_OSS_PLUGIN_HEADER
 #import <RCTTurboModulePlugin/RCTTurboModulePlugin.h>
 #else
@@ -263,7 +267,11 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
 {
+#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
+  return [RCTFabricComponentsProvider fabricComponents];
+#else
   return @{};
+#endif
 }
 
 #pragma mark - RCTTurboModuleManagerDelegate

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -17,6 +17,7 @@
  */
 
 const utils = require('./codegen-utils');
+const {generateCustomURLHandlers} = require('./generate-modules-protocols.js');
 const generateSpecsCLIExecutor = require('./generate-specs-cli-executor');
 const {execSync} = require('child_process');
 const fs = require('fs');
@@ -60,22 +61,6 @@ const CORE_LIBRARIES_WITH_OUTPUT_FOLDER = {
   },
 };
 const REACT_NATIVE = 'react-native';
-
-const MODULES_PROTOCOLS_H_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
-  'RCTModulesConformingToProtocolsProviderH.template',
-);
-
-const MODULES_PROTOCOLS_MM_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
-  'RCTModulesConformingToProtocolsProviderMM.template',
-);
 
 const COMPONENTS_MAPPING_H_TEMPLATE_PATH = path.join(
   REACT_NATIVE_PACKAGE_ROOT_FOLDER,
@@ -554,52 +539,6 @@ function findCodegenEnabledLibraries(pkgJson, projectRoot) {
       ...findLibrariesFromReactNativeConfig(projectRoot),
     ];
   }
-}
-
-function generateCustomURLHandlers(libraries, outputDir) {
-  const customImageURLLoaderClasses = libraries
-    .flatMap(
-      library =>
-        library?.config?.ios?.modulesConformingToProtocol?.RCTImageURLLoader,
-    )
-    .filter(Boolean)
-    .map(className => `@"${className}"`)
-    .join(',\n\t\t');
-
-  const customImageDataDecoderClasses = libraries
-    .flatMap(
-      library =>
-        library?.config?.ios?.modulesConformingToProtocol?.RCTImageDataDecoder,
-    )
-    .filter(Boolean)
-    .map(className => `@"${className}"`)
-    .join(',\n\t\t');
-
-  const customURLHandlerClasses = libraries
-    .flatMap(
-      library =>
-        library?.config?.ios?.modulesConformingToProtocol?.RCTURLRequestHandler,
-    )
-    .filter(Boolean)
-    .map(className => `@"${className}"`)
-    .join(',\n\t\t');
-
-  const template = fs.readFileSync(MODULES_PROTOCOLS_MM_TEMPLATE_PATH, 'utf8');
-  const finalMMFile = template
-    .replace(/{imageURLLoaderClassNames}/, customImageURLLoaderClasses)
-    .replace(/{imageDataDecoderClassNames}/, customImageDataDecoderClasses)
-    .replace(/{requestHandlersClassNames}/, customURLHandlerClasses);
-
-  fs.writeFileSync(
-    path.join(outputDir, 'RCTModulesConformingToProtocolsProvider.mm'),
-    finalMMFile,
-  );
-
-  const templateH = fs.readFileSync(MODULES_PROTOCOLS_H_TEMPLATE_PATH, 'utf8');
-  fs.writeFileSync(
-    path.join(outputDir, 'RCTModulesConformingToProtocolsProvider.h'),
-    templateH,
-  );
 }
 
 function generateLocalComponentProvider(libraries, outputDir) {

--- a/packages/react-native/scripts/codegen/generate-modules-protocols.js
+++ b/packages/react-native/scripts/codegen/generate-modules-protocols.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const REACT_NATIVE_PACKAGE_ROOT_FOLDER = path.join(__dirname, '..', '..');
+
+const MODULES_PROTOCOLS_H_TEMPLATE_PATH = path.join(
+  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
+  'scripts',
+  'codegen',
+  'templates',
+  'RCTModulesConformingToProtocolsProviderH.template',
+);
+
+const MODULES_PROTOCOLS_MM_TEMPLATE_PATH = path.join(
+  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
+  'scripts',
+  'codegen',
+  'templates',
+  'RCTModulesConformingToProtocolsProviderMM.template',
+);
+
+/*::
+type Library = $ReadOnly<{
+  config?: {
+    ios?: {
+      modulesConformingToProtocol?: {
+        RCTImageURLLoader?: $ReadOnlyArray<string>,
+        RCTImageDataDecoder?: $ReadOnlyArray<string>,
+        RCTURLRequestHandler?: $ReadOnlyArray<string>,
+      }
+    }
+  }
+}>
+*/
+
+function generateCustomURLHandlers(
+  libraries /*: Library[]*/,
+  outputDir /*: string */,
+) /*: void*/ {
+  const customImageURLLoaderClasses = libraries
+    .flatMap(
+      library =>
+        library?.config?.ios?.modulesConformingToProtocol?.RCTImageURLLoader,
+    )
+    .filter(Boolean)
+    .map(className => `@"${className}"`)
+    .join(',\n\t\t');
+
+  const customImageDataDecoderClasses = libraries
+    .flatMap(
+      library =>
+        library?.config?.ios?.modulesConformingToProtocol?.RCTImageDataDecoder,
+    )
+    .filter(Boolean)
+    .map(className => `@"${className}"`)
+    .join(',\n\t\t');
+
+  const customURLHandlerClasses = libraries
+    .flatMap(
+      library =>
+        library?.config?.ios?.modulesConformingToProtocol?.RCTURLRequestHandler,
+    )
+    .filter(Boolean)
+    .map(className => `@"${className}"`)
+    .join(',\n\t\t');
+
+  const template = fs.readFileSync(MODULES_PROTOCOLS_MM_TEMPLATE_PATH, 'utf8');
+  const finalMMFile = template
+    .replace(/{imageURLLoaderClassNames}/, customImageURLLoaderClasses)
+    .replace(/{imageDataDecoderClassNames}/, customImageDataDecoderClasses)
+    .replace(/{requestHandlersClassNames}/, customURLHandlerClasses);
+
+  fs.writeFileSync(
+    path.join(outputDir, 'RCTModulesConformingToProtocolsProvider.mm'),
+    finalMMFile,
+  );
+
+  const templateH = fs.readFileSync(MODULES_PROTOCOLS_H_TEMPLATE_PATH, 'utf8');
+  fs.writeFileSync(
+    path.join(outputDir, 'RCTModulesConformingToProtocolsProvider.h'),
+    templateH,
+  );
+}
+
+module.exports = {
+  generateCustomURLHandlers,
+};

--- a/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderH.template
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RCTFabricComponentsProvider: NSObject
+
++ (NSDictionary<NSString *, Class> *)fabricComponents;
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTFabricComponentsProviderMM.template
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTFabricComponentsProvider.h"
+
+static NSDictionary<NSString *, Class> * _fabricComponents;
+
+@implementation RCTFabricComponentsProvider
+
++ (void)initialize
+{
+  _fabricComponents = @{
+    {componentNameClassMap}
+  };
+}
+
++ (NSDictionary<NSString *, Class> *)fabricComponents
+{
+  if (!_fabricComponents) {
+    [self initialize];
+  }
+
+  return _fabricComponents;
+}
+
+@end

--- a/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
+++ b/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
@@ -29,14 +29,6 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<RNTMyNativeViewComponentDescriptor>();
 }
 
-// Load is not invoked if it is not defined, therefore, we must ask to update this.
-// See the Apple documentation: https://developer.apple.com/documentation/objectivec/nsobject/1418815-load?language=objc
-// "[...] but only if the newly loaded class or category implements a method that can respond."
-+ (void)load
-{
-  [super load];
-}
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -146,13 +146,6 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 
 #pragma mark - RCTComponentViewFactoryComponentProvider
 
-#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
-- (nonnull NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
-{
-  return @{@"RNTMyNativeView" : RNTMyNativeViewComponentView.class};
-}
-#endif
-
 - (NSURL *)bundleURL
 {
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:kBundlePath];

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -38,6 +38,11 @@
     "jsSrcsDir": ".",
     "android": {
       "javaPackageName": "com.facebook.fbreact.specs"
+    },
+    "ios": {
+      "componentsMapping": {
+        "RNTMyNativeView": "RNTMyNativeViewComponentView"
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
This change is a refactor that moves a generation function in its own file, adding flow types.
This allows to incremental typing the scripts plus simplify them, hiding implementation details in dedicated files.

## Changelog:
[Internal] - Move generation of module registration for custom protocol in its own file + add flow types

Differential Revision: D54414403


