### PR TITLE
Expose `rrc_textinput` via prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -126,6 +126,11 @@ val preparePrefab by
                       Pair("../ReactCommon/react/renderer/components/view/platform/android/", ""),
                   )),
               PrefabPreprocessingEntry(
+                  "rrc_textinput",
+                  Pair(
+                      "../ReactCommon/react/renderer/components/textinput/",
+                      "react/renderer/components/androidtextinput/")),
+              PrefabPreprocessingEntry(
                   "rrc_legacyviewmanagerinterop",
                   Pair(
                       "../ReactCommon/react/renderer/components/legacyviewmanagerinterop/",
@@ -540,6 +545,7 @@ android {
             "rrc_image",
             "rrc_root",
             "rrc_view",
+            "rrc_textinput",
             "rrc_legacyviewmanagerinterop",
             "jsi",
             "glog",
@@ -664,6 +670,7 @@ android {
     create("rrc_image") { headers = File(prefabHeadersDir, "rrc_image").absolutePath }
     create("rrc_root") { headers = File(prefabHeadersDir, "rrc_root").absolutePath }
     create("rrc_view") { headers = File(prefabHeadersDir, "rrc_view").absolutePath }
+    create("rrc_textinput") { headers = File(prefabHeadersDir, "rrc_textinput").absolutePath }
     create("rrc_legacyviewmanagerinterop") {
       headers = File(prefabHeadersDir, "rrc_legacyviewmanagerinterop").absolutePath
     }

--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -74,6 +74,7 @@ add_library(react_cxxreactpackage ALIAS ReactAndroid::react_cxxreactpackage)
 add_library(react_render_core ALIAS ReactAndroid::react_render_core)
 add_library(react_render_graphics ALIAS ReactAndroid::react_render_graphics)
 add_library(rrc_view ALIAS ReactAndroid::rrc_view)
+add_library(rrc_textinput ALIAS ReactAndroid::rrc_textinput)
 add_library(jsi ALIAS ReactAndroid::jsi)
 add_library(glog ALIAS ReactAndroid::glog)
 add_library(fabricjni ALIAS ReactAndroid::fabricjni)
@@ -108,6 +109,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         react_render_mapbuffer              # prefab ready
         rrc_image                           # prefab ready
         rrc_view                            # prefab ready
+        rrc_textinput                       # prefab ready
         rrc_legacyviewmanagerinterop        # prefab ready
         runtimeexecutor                     # prefab ready
         turbomodulejsijni                   # prefab ready


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The `rrc_textinput` was not exposed via prefab. I'm adding it to make possible for react-native-live-markdown to integrate on top of React Native via prefab. Based on #36166.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [CHANGED] - Expose `rrc_textinput` via prefab.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
