### PR TITLE
[TypeScript] Add missing `Headers` methods

### DIFF
--- a/packages/react-native/types/modules/globals.d.ts
+++ b/packages/react-native/types/modules/globals.d.ts
@@ -132,6 +132,10 @@ declare interface Headers {
   get(name: string): string | null;
   has(name: string): boolean;
   set(name: string, value: string): void;
+  entries(): IterableIterator<[string, string]>;
+  keys(): IterableIterator<string>;
+  values(): IterableIterator<string>;
+  [Symbol.iterator](): IterableIterator<[string, string]>;
 }
 
 declare var Headers: {


### PR DESCRIPTION

## Summary:

```tsx
// Hermes runtime (RN 73.x)
console.log({...Headers.prototype})
// result:
{ 
  "append": [Function anonymous], 
  "delete": [Function anonymous], 
  "entries": [Function anonymous], 
  "forEach": [Function anonymous], 
  "get": [Function anonymous], 
  "has": [Function anonymous], 
  "keys": [Function anonymous], 
  "set": [Function anonymous], 
  "values": [Function anonymous], 
  Symbol(Symbol.iterator): [Function anonymous]
}
```

But in typescript

```tsx
new Headers().entries() 
// ^^^ Error: Property entries does not exist on type Headers
Object.fromEntries(new Headers())
// ^^^ Error: Property [Symbol.iterator] is missing in type Headers but required in type Iterable<readonly any[]>
```


## Changelog:

[GENERAL] [ADDED] - [TypeScript] Add missing `Header` methods

## Test Plan:

Use code above in your RN project and run `yarn tsc --noEmit` 
