### PR TITLE
Trim invalid response blob msg

### DIFF
--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -250,7 +250,7 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): any) {
         } else {
           throw new Error(
             'Invalid response for blob - expecting object, was ' +
-              `${typeof this._response}: ${this._response}`,
+              `${typeof this._response}: ${this._response.trim()}`,
           );
         }
         break;


### PR DESCRIPTION
Summary:
Small tweak to #43069 - trim the message to avoid ending with a newline.

Changelog:
[General][Changed] - Trim invalid blob response error message

Differential Revision: D54422284


