### PR TITLE
feature: [Image] Allow to use `Headers` interface

### DIFF
--- a/packages/react-native/Libraries/Image/AssetSourceResolver.js
+++ b/packages/react-native/Libraries/Image/AssetSourceResolver.js
@@ -16,6 +16,7 @@ export type ResolvedAssetSource = {|
   +height: ?number,
   +uri: string,
   +scale: number,
+  +headers?: ?{[string]: string},
 |};
 
 import type {PackagerAsset} from '@react-native/assets-registry/registry';

--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -67,11 +67,16 @@ function getSize(
  */
 function getSizeWithHeaders(
   url: string,
-  headers: {[string]: string, ...},
+  headers: {[string]: string, ...} | Headers,
   success?: (width: number, height: number) => void,
   failure?: (error: mixed) => void,
 ): void | Promise<ImageSize> {
-  const promise = NativeImageLoaderAndroid.getSizeWithHeaders(url, headers);
+  const promise = NativeImageLoaderAndroid.getSizeWithHeaders(
+    url,
+    headers instanceof Headers
+      ? Object.fromEntries(headers.entries())
+      : headers,
+  );
   if (typeof success !== 'function') {
     return promise;
   }

--- a/packages/react-native/Libraries/Image/Image.d.ts
+++ b/packages/react-native/Libraries/Image/Image.d.ts
@@ -342,11 +342,11 @@ export class Image extends ImageBase {
 
   static getSizeWithHeaders(
     uri: string,
-    headers: {[index: string]: string},
+    headers: {[index: string]: string} | Headers,
   ): Promise<ImageSize>;
   static getSizeWithHeaders(
     uri: string,
-    headers: {[index: string]: string},
+    headers: {[index: string]: string} | Headers,
     success: (width: number, height: number) => void,
     failure?: (error: any) => void,
   ): void;

--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -52,11 +52,16 @@ function getSize(
 
 function getSizeWithHeaders(
   uri: string,
-  headers: {[string]: string, ...},
+  headers: {[string]: string, ...} | Headers,
   success?: (width: number, height: number) => void,
   failure?: (error: mixed) => void,
 ): void | Promise<ImageSize> {
-  const promise = NativeImageLoaderIOS.getSizeWithHeaders(uri, headers);
+  const promise = NativeImageLoaderIOS.getSizeWithHeaders(
+    uri,
+    headers instanceof Headers
+      ? Object.fromEntries(headers.entries())
+      : headers,
+  );
   if (typeof success !== 'function') {
     return promise;
   }

--- a/packages/react-native/Libraries/Image/ImageSource.d.ts
+++ b/packages/react-native/Libraries/Image/ImageSource.d.ts
@@ -32,7 +32,7 @@ export interface ImageURISource {
    * `headers` is an object representing the HTTP headers to send along with the
    * request for a remote image.
    */
-  headers?: {[key: string]: string} | undefined;
+  headers?: Headers | {[key: string]: string} | undefined;
   /**
    * `cache` determines how the requests handles potentially cached
    * responses.

--- a/packages/react-native/Libraries/Image/ImageSource.js
+++ b/packages/react-native/Libraries/Image/ImageSource.js
@@ -39,7 +39,7 @@ export interface ImageURISource {
    * `headers` is an object representing the HTTP headers to send along with the
    * request for a remote image.
    */
-  +headers?: ?{[string]: string};
+  +headers?: ?{[string]: string} | ?Headers;
 
   /**
    * `body` is the HTTP body to send with the request. This must be a valid
@@ -116,7 +116,10 @@ export function getImageSourceProperties(
     object.cache = imageSource.cache;
   }
   if (imageSource.headers != null) {
-    object.headers = imageSource.headers;
+    object.headers =
+      imageSource.headers instanceof Headers
+        ? Object.fromEntries<string, string>(imageSource.headers.entries())
+        : imageSource.headers;
   }
   if (imageSource.height != null) {
     object.height = imageSource.height;

--- a/packages/react-native/Libraries/Image/ImageSourceUtils.js
+++ b/packages/react-native/Libraries/Image/ImageSourceUtils.js
@@ -24,6 +24,17 @@ export function getImageSourcesFromImageProps(
 ): ?ResolvedAssetSource | $ReadOnlyArray<{uri: string, ...}> {
   let source = resolveAssetSource(imageProps.source);
 
+  if (
+    typeof source === 'object' &&
+    source != null &&
+    source.headers instanceof Headers
+  ) {
+    source = {
+      ...source,
+      headers: Object.fromEntries<string, string>(source.headers.entries()),
+    };
+  }
+
   let sources;
 
   const {crossOrigin, referrerPolicy, src, srcSet, width, height} = imageProps;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4270,6 +4270,7 @@ exports[`public API should not change unintentionally Libraries/Image/AssetSourc
   +height: ?number,
   +uri: string,
   +scale: number,
+  +headers?: ?{ [string]: string },
 |};
 declare class AssetSourceResolver {
   serverUrl: ?string;
@@ -4446,7 +4447,7 @@ exports[`public API should not change unintentionally Libraries/Image/ImageSourc
   +uri?: ?string;
   +bundle?: ?string;
   +method?: ?string;
-  +headers?: ?{ [string]: string };
+  +headers?: ?{ [string]: string } | ?Headers;
   +body?: ?string;
   +cache?: ?(\\"default\\" | \\"reload\\" | \\"force-cache\\" | \\"only-if-cached\\");
   +width?: ?number;

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -1279,6 +1279,9 @@ export class ImageTest extends React.Component {
     const promise2: Promise<any> = Image.getSizeWithHeaders(uri, headers).then(
       ({width, height}) => console.log(width, height),
     );
+    Image.getSizeWithHeaders(uri, new Headers(headers)).then(
+      ({width, height}) => console.log(width, height),
+    );
     Image.getSizeWithHeaders(uri, headers, (width, height) =>
       console.log(width, height),
     );
@@ -1321,6 +1324,19 @@ export class ImageTest extends React.Component {
             uri: 'https://seeklogo.com/images/T/typescript-logo-B29A3F462D-seeklogo.com.png',
           }}
           resizeMode={resizeMode}
+        />
+
+        <Image
+          source={{
+            uri: 'https://seeklogo.com/images/T/typescript-logo-B29A3F462D-seeklogo.com.png',
+            headers: new Headers({Authorization: 'Bearer test'}),
+          }}
+        />
+        <Image
+          source={{
+            uri: 'https://seeklogo.com/images/T/typescript-logo-B29A3F462D-seeklogo.com.png',
+            headers: {Authorization: 'Bearer test'},
+          }}
         />
       </View>
     );


### PR DESCRIPTION
## Summary:

The `Headers` interface of the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) allows you to perform various actions on [HTTP request and response headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers). These actions include retrieving, setting, adding to, and removing headers from the list of the request's headers. Ant it will good candidate to use it for Image component  in React Native platform.

```tsx
        <Image
          source={{
            uri: '...',
            headers: new Headers({Authorization: 'Bearer test'}), // New way
          }}
        />
        <Image
          source={{
            uri: '...',
            headers: {Authorization: 'Bearer test'},
          }}
        />
```


- MDN Docs: https://developer.mozilla.org/en-US/docs/Web/API/Headers


## Changelog:

[GENERAL] [ADDED] - Image `source` allow to pass `Headers` interface

## Test Plan:

1. Create a new Project
2. Apply changes from this PR
3. Add an `Image` with `source={{ uri, headers: new Headers({ x-header-123: 'my-tests' }) }}`
<details>
  <summary>4. Create a simple static server (with a headers logger) </summary>

  ```javascript
    var path = require('path');
    var http = require('http');
    var fs = require('fs');

    var dir = path.join(__dirname, 'public');

    var mime = {
        html: 'text/html',
        txt: 'text/plain',
        css: 'text/css',
        gif: 'image/gif',
        jpg: 'image/jpeg',
        png: 'image/png',
        svg: 'image/svg+xml',
        js: 'application/javascript'
    };

    var server = http.createServer(function (req, res) {
        console.log(' --- xdebug', req.headers, req.url, req.method);
        var reqpath = req.url.toString().split('?')[0];
        if (req.method !== 'GET') {
            res.statusCode = 501;
            res.setHeader('Content-Type', 'text/plain');
            return res.end('Method not implemented');
        }
        var file = path.join(dir, reqpath.replace(/\/$/, '/index.html'));
        if (file.indexOf(dir + path.sep) !== 0) {
            res.statusCode = 403;
            res.setHeader('Content-Type', 'text/plain');
            return res.end('Forbidden');
        }
        var type = mime[path.extname(file).slice(1)] || 'text/plain';
        var s = fs.createReadStream(file);
        s.on('open', function () {
            res.setHeader('Content-Type', type);
            s.pipe(res);
        });
        s.on('error', function () {
            res.setHeader('Content-Type', 'text/plain');
            res.statusCode = 404;
            res.end('Not found');
        });
    });

    server.listen(3000, function () {
        console.log('Listening on http://localhost:3000/');
    });
  ```
  
</details>

5. Apply image `source.uri` from a static server created above
6. Add `headers: new Headers({ ... })` in source prop or `Image.getSizeWithHeaders`

**See Results ->**

<details>
  <summary> Image.getSizeWithHeaders  </summary>
  

  Android

<img width="578" alt="Screenshot 2024-03-01 at 19 19 11" src="https://github.com/facebook/react-native/assets/4661784/b05b11c5-dcf2-41c7-b54c-e8ca07b42043">


  iOS
  
<img width="583" alt="Screenshot 2024-03-01 at 19 16 54" src="https://github.com/facebook/react-native/assets/4661784/8d16316a-2033-48d6-abea-a04ac7b2f460">


</details>


<details>
  <summary> Image source={...}  </summary>
  

  Android

<img width="818" alt="Screenshot 2024-03-01 at 19 06 18" src="https://github.com/facebook/react-native/assets/4661784/cc0f9a47-f290-4003-a102-c80ff4672c37">


  iOS

<img width="960" alt="Screenshot 2024-03-01 at 19 10 48" src="https://github.com/facebook/react-native/assets/4661784/1c812652-6ec5-4b37-bdb5-744bf6c3b861">

  
</details>






