### PR TITLE
Port: @react-native-community/cli#ios → @react-native/core-cli-utils#ios

### DIFF
--- a/packages/core-cli-utils/README.md
+++ b/packages/core-cli-utils/README.md
@@ -1,0 +1,52 @@
+# @react-native/core-cli-utils
+
+![npm package](https://img.shields.io/npm/v/@react-native/core-cli-utils?color=brightgreen&label=npm%20package)
+
+A collection of utilites to help Frameworks build their React Native CLI tooling. This is not intended to be used directly use users of React Native.
+
+## Usage
+
+```js
+import { Command } from 'commander';
+import cli from '@react-native/core-cli-utils';
+import debug from 'debug';
+
+const android = new Command('android');
+
+const frameworkFindsAndroidSrcDir = "...";
+const tasks = cli.clean.android(frameworkFindsAndroidSrcDir);
+const log = debug('fancy-framework:android');
+
+android
+    .command('clean')
+    .description(cli.clean.android)
+    .action(async () => {
+        const log = debug('fancy-framework:android:clean');
+        log(`🧹 let me clean your Android caches`);
+        // Add other caches your framework needs besides the normal React Native caches
+        // here.
+        for (const task of tasks) {
+            try {
+                log(`\t ${task.label}`);
+                // See: https://github.com/sindresorhus/execa#lines
+                const {stdout} = await task.action({ lines: true })
+                log(stdout.join('\n\tGradle: '));
+            } catch (e) {
+                log(`\t ⚠️ whoops: ${e.message}`);
+            }
+        }
+    });
+```
+
+And you'd be using it like this:
+
+```bash
+$ ./fancy-framework android clean
+🧹 let me clean your Android caches
+    Gradle: // a bunch of gradle output
+    Gradle: ....
+```
+
+## Contributing
+
+Changes to this package can be made locally and linked against your app. Please see the [Contributing guide](https://reactnative.dev/contributing/overview#contributing-code).

--- a/packages/core-cli-utils/index.js
+++ b/packages/core-cli-utils/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {tasks as clean} from './private/clean.js';
+
+export default {
+  clean,
+};

--- a/packages/core-cli-utils/package.json
+++ b/packages/core-cli-utils/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@react-native/core-cli-utils",
+  "version": "0.74.0",
+  "description": "React Native CLI library for Frameworks to build on",
+  "main": "index.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/react-native.git",
+    "directory": "packages/core-cli-utils"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/core-cli-utils#readme",
+  "keywords": [
+    "cli-utils",
+    "react-native"
+  ],
+  "bugs": "https://github.com/facebook/react-native/issues",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/core-cli-utils/private/clean.js
+++ b/packages/core-cli-utils/private/clean.js
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Task} from './types';
+import type {Options as ExecaOptions} from 'execa';
+
+import {isMacOS, isWindows, task} from './utils';
+// TODO: Remove execa dependency.
+import execa from 'execa';
+import {existsSync, readdirSync, rm} from 'fs';
+import os from 'os';
+import path from 'path';
+
+type CleanTasks = {
+  android: (androidSrcDir: ?string) => Task[],
+  metro: () => Task[],
+  npm: (projectRootDir: string, verifyCache?: boolean) => Task[],
+  bun: (projectRootDir: string) => Task[],
+  watchman: (projectRootDir: string) => Task[],
+  yarn: (projectRootDir: string) => Task[],
+  cocoapods?: (projectRootDir: string) => Task[],
+};
+
+const rmrf = (pathname: string) => {
+  if (!existsSync(pathname)) {
+    return;
+  }
+  rm(pathname, {maxRetries: 3, recursive: true, force: true});
+};
+
+export function cleanDir(
+  directory: string,
+  pattern: ?RegExp,
+): () => Promise<void> {
+  return async function cleanDirectory() {
+    if (pattern != null) {
+      const base = path.dirname(directory);
+      const files = readdirSync(base).filter((filename: string) =>
+        pattern.test(filename),
+      );
+      for (const filename of files) {
+        rmrf(path.join(base, filename));
+      }
+    } else {
+      rmrf(directory);
+    }
+  };
+}
+
+export function cleanTmpDir(filepattern: RegExp): ReturnType<typeof cleanDir> {
+  return cleanDir(os.tmpdir(), filepattern);
+}
+
+// The tasks that cleanup various build artefacts.
+export const tasks: CleanTasks = {
+  /**
+   * Cleans up the Android Gradle cache
+   */
+  android: (androidSrcDir: ?string) => [
+    task('Clean Gradle cache', async function gradle(opts?: ExecaOptions) {
+      const gradlew = path.join(
+        androidSrcDir ?? 'android',
+        isWindows ? 'gradlew.bat' : 'gradlew',
+      );
+
+      if (!existsSync(gradlew)) {
+        return;
+      }
+      const script = path.basename(gradlew);
+      const cwd = path.dirname(gradlew);
+      await execa(isWindows ? script : `./${script}`, ['clean'], {
+        cwd,
+        ...opts,
+      });
+    }),
+  ],
+
+  /**
+   * Agressively cleans up all Metro caches.
+   */
+  metro: () => [
+    task('Clean Metro cache', cleanTmpDir(/^metro-.+/)),
+    task('Clean Haste cache', cleanTmpDir(/^haste-map-.+/)),
+    task('Clean React Native cache', cleanTmpDir(/^react-.+/)),
+  ],
+
+  /**
+   * Cleans up the `node_modules` folder and optionally garbage collects the npm cache.
+   */
+  npm: (projectRootDir: string, verifyCache = false) => {
+    const _tasks = [
+      task(
+        'Remove node_modules',
+        cleanDir(path.join(projectRootDir, 'node_modules')),
+      ),
+    ];
+    if (verifyCache) {
+      _tasks.push(
+        task('Verify npm cache', (opts?: ExecaOptions) =>
+          execa('npm', ['cache', 'verify'], {cwd: projectRootDir, ...opts}),
+        ),
+      );
+    }
+    return _tasks;
+  },
+
+  /**
+   * Cleans up the Bun cache.
+   */
+  bun: (projectRootDir: string) => [
+    task('Clean Bun cache', (opts?: ExecaOptions) =>
+      execa('bun', ['pm', 'cache', 'rm'], {cwd: projectRootDir, ...opts}),
+    ),
+  ],
+
+  /**
+   * Stops Watchman and clears its cache
+   */
+  watchman: (projectRootDir: string) => [
+    task('Stop Watchman', (opts?: ExecaOptions) =>
+      execa(isWindows ? 'tskill' : 'killall', ['watchman'], {
+        cwd: projectRootDir,
+        ...opts,
+      }),
+    ),
+    task('Delete Watchman cache', (opts?: ExecaOptions) =>
+      execa('watchman', ['watch-del-all'], {cwd: projectRootDir, ...opts}),
+    ),
+  ],
+
+  /**
+   * Cleans up the Yarn cache
+   */
+  yarn: (projectRootDir: string) => [
+    task('Clean Yarn cache', (opts?: ExecaOptions) =>
+      execa('yarn', ['cache', 'clean'], {cwd: projectRootDir, ...opts}),
+    ),
+  ],
+};
+
+if (isMacOS) {
+  /**
+   * Cleans up the local and global CocoaPods cache
+   */
+  tasks.cocoapods = (projectRootDir: string) => [
+    // TODO: add project root
+    task('Clean CocoaPods pod cache', function removePodCache(opts?: ExecaOptions) {
+      return execa('pod', ['cache', 'clean', '--all'], {
+        cwd: projectRootDir,
+        ...opts,
+      });
+    }),
+    task('Remove installed CocoaPods', cleanDir('./ios/Pods')),
+    task('Remove CocoaPods spec cache', cleanDir('~/.cocoapods')),
+  ];
+}
+
+//
+// Internal CLI
+//

--- a/packages/core-cli-utils/private/ios.js
+++ b/packages/core-cli-utils/private/ios.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Task} from './types';
+import type {Result} from 'execa';
+
+import {assertDependencies, isOnPath, task} from './utils';
+import execa from 'execa';
+
+type iOSBuildMode = 'Debug' | 'Release';
+
+type iOSBuildOptions = {
+  isWorkspace: boolean,
+  name: string,
+  mode: iOSBuildMode,
+  scheme: string,
+  destination?: string, // Device or Simulator or UUID
+} & iOSOptions;
+
+type iOSBootstrapOption = {
+  // Enabled by default
+  newArchitecture: boolean,
+} & iOSOptions;
+
+type iOSInstallApp = {
+  device: string,
+  appPath: string,
+} & iOSOptions;
+
+type SemVer = string;
+
+type AutolinkPackage = {
+  name: string,
+  version: SemVer,
+};
+
+type iOSAutoLinkOptions = {
+  packages: Array<AutolinkPackage>,
+} & iOSOptions;
+
+type iOSOptions = {cwd: string, env?: {[key: string]: string | void, ...}};
+
+type iOSBuildTasks = {
+  bootstrap: (options: iOSBootstrapOption) => Task[],
+  build: (options: iOSBuildOptions, ...args: $ReadOnlyArray<string>) => Task[],
+  install: (options: iOSInstallApp) => Task[],
+  autolink: (options: iOSAutoLinkOptions) => Task[],
+};
+
+export const tasks: iOSBuildTasks = {
+  bootstrap: (options: iOSBootstrapOption) => [
+    task('Install CocoaPods dependencies', () => {
+      assertDependencies(
+        isOnPath('pod', 'CocoaPods'),
+        isOnPath('bundle', "Bundler to manage Ruby's gems"),
+      );
+      return execa('bundle', ['exec', 'pod', 'install'], {
+        cwd: options.cwd,
+        env: {RCT_NEW_ARCH_ENABLED: options.newArchitecture ? '1' : '0'},
+      });
+    }),
+  ],
+
+  build: (options: iOSBuildOptions, ...args: $ReadOnlyArray<string>) => [
+    task('build an iOS artifact', () => {
+      assertDependencies(isOnPath('xcodebuild', 'Xcode Commandline Tools'));
+      const _args = [
+        options.isWorkspace ? '-workspace' : '-project',
+        options.name,
+        '-scheme',
+        options.scheme,
+      ];
+      if (options.destination != null) {
+        _args.push('-destination', options.destination);
+      }
+      _args.push(...args);
+      return execa('xcodebuild', _args, {cwd: options.cwd, env: options.env});
+    }),
+  ],
+
+  install: (options: iOSInstallApp) => [
+    task('Install the app on a simulator', () => {
+      assertDependencies(isOnPath('xcrun', 'An Xcode Commandline tool: xcrun'));
+      return execa(
+        'xcrun',
+        ['simctl', 'install', options.device, options.appPath],
+        {cwd: options.cwd, env: options.env},
+      );
+    }),
+  ],
+
+  autolink: (options: iOSAutoLinkOptions) => [
+    task('Link packages', () => {
+      assertDependencies(
+        isOnPath('pod', 'CocoaPods'),
+        isOnPath('bundle', "Bundler to manage Ruby's gems"),
+      );
+      return execa(
+        'bundle',
+        ['exec', 'pod', 'install'],
+        {cwd: options.cwd, env: options.env},
+      );
+    }),
+  ],
+};

--- a/packages/core-cli-utils/private/types.js
+++ b/packages/core-cli-utils/private/types.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+export type Task = {
+  label: string,
+  action: () => Promise<mixed>,
+};

--- a/packages/core-cli-utils/private/utils.js
+++ b/packages/core-cli-utils/private/utils.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Task} from './types';
+
+import os from 'os';
+
+export function task(label: string, action: Task['action']): Task {
+  return {
+    label,
+    action,
+  };
+}
+
+export const isWindows = os.platform() === 'win32';
+export const isMacOS = os.platform() === 'darwin';

--- a/packages/core-cli-utils/private/utils.js
+++ b/packages/core-cli-utils/private/utils.js
@@ -11,6 +11,7 @@
 
 import type {Task} from './types';
 
+import execa from 'execa';
 import os from 'os';
 
 export function task(label: string, action: Task['action']): Task {
@@ -22,3 +23,28 @@ export function task(label: string, action: Task['action']): Task {
 
 export const isWindows = os.platform() === 'win32';
 export const isMacOS = os.platform() === 'darwin';
+
+type PathCheckResult = {
+  found: boolean,
+  dep: string,
+  description: string,
+};
+
+export function isOnPath(dep: string, description: string): PathCheckResult {
+  const result = execa.sync(isWindows ? 'where' : 'which', [dep]);
+  return {
+    found: result.exitCode === 0,
+    dep,
+    description,
+  };
+}
+
+export function assertDependencies(
+  ...deps: $ReadOnlyArray<ReturnType<typeof isOnPath>>
+) {
+  for (const {found, dep, description} of deps) {
+    if (!found) {
+      throw new Error(`"${dep}" not found, ${description}`);
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Move react-native-community/cli build-ios into core per RFC0759.  This provides:

- boostrap (triggers pod install & autolinking)
- build
- install

Changelog:
[General][Added] RFC-0759 Move cli iOS build into core

Differential Revision: D54112211


