### PR TITLE
Port: @react-native-community/cli#android → @react-native/core-cli-utils#android

### DIFF
--- a/packages/core-cli-utils/private/android.js
+++ b/packages/core-cli-utils/private/android.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Task} from './types';
+import type {Result} from 'execa';
+
+import {isWindows, task, toPascalCase} from './utils';
+import execa from 'execa';
+
+type AndroidBuildMode = 'debug' | 'release';
+
+type AndroidBuild = {
+  sourceDir: string,
+  appName: string,
+  mode: AndroidBuildMode,
+  gradleArgs?: Array<string>,
+};
+
+type GradleReturn = ReturnType<typeof gradle>;
+
+async function gradle(cwd: string, ...args: string[]): Promise<Result> {
+  const gradlew = isWindows ? 'gradlew.bat' : './gradlew';
+  return execa(gradlew, args, {
+    stdio: 'inherit',
+    cwd,
+  });
+}
+
+//
+// Gradle Task wrappers
+//
+
+/**
+ * Assembles an Android app using Gradle
+ */
+export const assemble = (
+  cwd: string,
+  appName: string,
+  mode: AndroidBuildMode,
+  ...args: $ReadOnlyArray<string>
+): GradleReturn =>
+  gradle(cwd, `${appName}:assemble${toPascalCase(mode)}`, ...args);
+
+/**
+ * Assembles and tests an Android app using Gradle
+ */
+export const build = (
+  cwd: string,
+  appName: string,
+  mode: AndroidBuildMode,
+  ...args: $ReadOnlyArray<string>
+): GradleReturn =>
+  gradle(cwd, `${appName}:build${toPascalCase(mode)}`, ...args);
+
+/**
+ * Installs an Android app using Gradle
+ */
+export const install = (
+  cwd: string,
+  appName: string,
+  mode: AndroidBuildMode,
+  ...args: $ReadOnlyArray<string>
+): GradleReturn =>
+  gradle(cwd, `${appName}:install${toPascalCase(mode)}`, ...args);
+
+/**
+ * Runs a custom Gradle task if your frameworks needs aren't handled by assemble, build or install.
+ */
+export const customTask = (
+  cwd: string,
+  customTaskName: string,
+  ...args: $ReadOnlyArray<string>
+): GradleReturn => gradle(cwd, customTaskName, ...args);
+
+//
+// Android Tasks
+//
+
+type AndroidTasks = {
+  assemble: (options: AndroidBuild, ...args: $ReadOnlyArray<string>) => Task[],
+  build: (options: AndroidBuild, ...args: $ReadOnlyArray<string>) => Task[],
+  install: (options: AndroidBuild, ...args: $ReadOnlyArray<string>) => Task[],
+};
+
+export const tasks: AndroidTasks = {
+  assemble: (options: AndroidBuild, ...gradleArgs: $ReadOnlyArray<string>) => [
+    task('Assemble Android App', () =>
+      assemble(options.sourceDir, options.appName, options.mode, ...gradleArgs),
+    ),
+  ],
+  build: (options: AndroidBuild, ...gradleArgs: $ReadOnlyArray<string>) => [
+    task('Assembles and tests Android App', () =>
+      build(options.sourceDir, options.appName, options.mode, ...gradleArgs),
+    ),
+  ],
+  /**
+   * Useful extra gradle arguments:
+   *
+   * -PreactNativeDevServerPort=8081 sets the port for the installed app to point towards a Metro
+   *                                 server on (for example) 8081.
+   */
+  install: (options: AndroidBuild, ...gradleArgs: $ReadOnlyArray<string>) => [
+    task('Installs the assembled Android App', () =>
+      install(options.sourceDir, options.appName, options.mode, ...gradleArgs),
+    ),
+  ],
+
+  // We are not supporting launching the app and setting up the tunnel for metro <-> app, this is
+  // a framework concern. For an example of how one could do this, please look at the community
+  // CLI's code:
+  // https://github.com/react-native-community/cli/blob/54d48a4e08a1aef334ae6168788e0157a666b4f5/packages/cli-platform-android/src/commands/runAndroid/index.ts#L272C1-L290C2
+};

--- a/packages/core-cli-utils/private/ios.js
+++ b/packages/core-cli-utils/private/ios.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Task} from './types';
+
+import {assertDependencies, isOnPath, task} from './utils';
+import execa from 'execa';
+
+type iOSBuildMode = 'Debug' | 'Release';
+
+type iOSBuildOptions = {
+  isWorkspace: boolean,
+  name: string,
+  mode: iOSBuildMode,
+  scheme: string,
+  destination?: string, // Device or Simulator or UUID
+} & iOSOptions;
+
+type iOSBootstrapOption = {
+  // Enabled by default
+  newArchitecture: boolean,
+} & iOSOptions;
+
+type iOSInstallApp = {
+  device: string,
+  appPath: string,
+} & iOSOptions;
+
+type SemVer = string;
+
+type AutolinkPackage = {
+  name: string,
+  version: SemVer,
+};
+
+type iOSAutoLinkOptions = {
+  packages: Array<AutolinkPackage>,
+} & iOSOptions;
+
+type iOSOptions = {cwd: string, env?: {[key: string]: string | void, ...}};
+
+type iOSBuildTasks = {
+  bootstrap: (options: iOSBootstrapOption) => Task[],
+  build: (options: iOSBuildOptions, ...args: $ReadOnlyArray<string>) => Task[],
+  install: (options: iOSInstallApp) => Task[],
+  autolink: (options: iOSAutoLinkOptions) => Task[],
+};
+
+export const tasks: iOSBuildTasks = {
+  bootstrap: (options: iOSBootstrapOption) => [
+    task('Install CocoaPods dependencies', () => {
+      assertDependencies(
+        isOnPath('pod', 'CocoaPods'),
+        isOnPath('bundle', "Bundler to manage Ruby's gems"),
+      );
+      return execa('bundle', ['exec', 'pod', 'install'], {
+        cwd: options.cwd,
+        env: {RCT_NEW_ARCH_ENABLED: options.newArchitecture ? '1' : '0'},
+      });
+    }),
+  ],
+
+  build: (options: iOSBuildOptions, ...args: $ReadOnlyArray<string>) => [
+    task('build an iOS artifact', () => {
+      assertDependencies(isOnPath('xcodebuild', 'Xcode Commandline Tools'));
+      const _args = [
+        options.isWorkspace ? '-workspace' : '-project',
+        options.name,
+        '-scheme',
+        options.scheme,
+      ];
+      if (options.destination != null) {
+        _args.push('-destination', options.destination);
+      }
+      _args.push(...args);
+      return execa('xcodebuild', _args, {cwd: options.cwd, env: options.env});
+    }),
+  ],
+
+  install: (options: iOSInstallApp) => [
+    task('Install the app on a simulator', () => {
+      assertDependencies(isOnPath('xcrun', 'An Xcode Commandline tool: xcrun'));
+      return execa(
+        'xcrun',
+        ['simctl', 'install', options.device, options.appPath],
+        {cwd: options.cwd, env: options.env},
+      );
+    }),
+  ],
+
+  autolink: (options: iOSAutoLinkOptions) => [
+    task('Link packages', () => {
+      assertDependencies(
+        isOnPath('pod', 'CocoaPods'),
+        isOnPath('bundle', "Bundler to manage Ruby's gems"),
+      );
+      return execa('bundle', ['exec', 'pod', 'install'], {
+        cwd: options.cwd,
+        env: options.env,
+      });
+    }),
+  ],
+};

--- a/packages/core-cli-utils/private/utils.js
+++ b/packages/core-cli-utils/private/utils.js
@@ -24,6 +24,9 @@ export function task(label: string, action: Task['action']): Task {
 export const isWindows = os.platform() === 'win32';
 export const isMacOS = os.platform() === 'darwin';
 
+export const toPascalCase = (label: string): string =>
+  label.length === 0 ? '' : label[0].toUpperCase() + label.slice(1);
+
 type PathCheckResult = {
   found: boolean,
   dep: string,

--- a/packages/core-cli-utils/private/utils.js
+++ b/packages/core-cli-utils/private/utils.js
@@ -11,6 +11,7 @@
 
 import type {Task} from './types';
 
+import execa from 'execa';
 import os from 'os';
 
 export function task(label: string, action: Task['action']): Task {
@@ -22,3 +23,28 @@ export function task(label: string, action: Task['action']): Task {
 
 export const isWindows = os.platform() === 'win32';
 export const isMacOS = os.platform() === 'darwin';
+
+type PathCheckResult = {
+  found: boolean,
+  dep: string,
+  description: string,
+};
+
+export function isOnPath(dep: string, description: string): PathCheckResult {
+  const result = execa.sync(isWindows ? 'where' : 'which', [dep]);
+  return {
+    found: result.exitCode === 0,
+    dep,
+    description,
+  };
+}
+
+export function assertDependencies(
+  ...deps: $ReadOnlyArray<ReturnType<typeof isOnPath>>
+) {
+  for (const {found, dep, description} of deps) {
+    if (!found) {
+      throw new Error(`"${dep}" not found, ${description}`);
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Move react-native-community/cli build-android into core per RFC0759.  Provides:

- assemble
- build (assemble + tests)
- install

Changelog:
[General][Added] RFC-0759 Move cli Android build into core

Differential Revision: D54112210


