### PR TITLE
fix: [TypeScript] Remove non-existent methods from `<ImageBackground/>`

### DIFF
--- a/packages/react-native/Libraries/Image/Image.d.ts
+++ b/packages/react-native/Libraries/Image/Image.d.ts
@@ -379,16 +379,4 @@ export interface ImageBackgroundProps extends ImagePropsBase {
 declare class ImageBackgroundComponent extends React.Component<ImageBackgroundProps> {}
 declare const ImageBackgroundBase: Constructor<NativeMethods> &
   typeof ImageBackgroundComponent;
-export class ImageBackground extends ImageBackgroundBase {
-  resizeMode: ImageResizeMode;
-  getSize(
-    uri: string,
-    success: (width: number, height: number) => void,
-    failure: (error: any) => void,
-  ): any;
-  prefetch(url: string): any;
-  abortPrefetch?(requestId: number): void;
-  queryCache?(
-    urls: string[],
-  ): Promise<{[url: string]: 'memory' | 'disk' | 'disk/memory'}>;
-}
+export class ImageBackground extends ImageBackgroundBase {}


### PR DESCRIPTION

## Summary:

Using the code from `Test Plan` you will see that `ImageBackground` component doesn't have methods that declared on TypeScript side. 

I checked the source code and there is also nothing:

https://github.com/facebook/react-native/blob/d9b0f15c844abce5e97edfd401656d84d0c84133/packages/react-native/Libraries/Image/ImageBackground.js#L47-L69

```tsx
// runtime (React Native 0.73)
 {
  "abortPrefetch": undefined,
  "getSize": undefined, 
  "prefetch": undefined, 
  "queryCache": undefined, 
  "resizeMode": undefined
}
```

## Changelog:

[GENERAL] [REMOVED] - Remove non-existent methods from `<ImageBackground/>` component

## Test Plan:

```tsx
      <ImageBackground
        resizeMode={'contain'}
        ref={ref => {
          if (ref) {
            console.log(' --- xdebug', {
              resizeMode: ref.resizeMode,
              queryCache: ref.queryCache,
              getSize: ref.getSize,
              prefetch: ref.prefetch,
              abortPrefetch: ref.abortPrefetch,
            });
          }
        }}
        style={{
          width: '100%',
          height: '100%',
        }}
        source={{
          uri: 'https://upload.wikimedia.org/wikipedia/commons/8/87/Arturo_Nieto-Dorantes.webp',
        }}
      />
```
