### PR TITLE
Fix CI by adding explicit visibility modifier to BridgelessCatalystInstance

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -32,7 +32,7 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
 
 @DoNotStrip
 @DeprecatedInNewArchitecture
-class BridgelessCatalystInstance : CatalystInstance {
+public class BridgelessCatalystInstance : CatalystInstance {
   override fun handleMemoryPressure(level: Int) {
     throw UnsupportedOperationException("Unimplemented method 'handleMemoryPressure'")
   }


### PR DESCRIPTION
Summary:
Fix CI by adding explicit visibility modifier to the newly added `BridgelessCatalystInstance` class. In Kotlin, in explicit API mode, which is usually the default mode for Kotlin, we must explicitly specify one of the modifiers for every declaration to make it clear and explicit.

Changelog:
[Internal] internal

Differential Revision: D54442485


