### PR TITLE
feat: RCTConvert to support UIModalPresentationStyle

### DIFF
--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -80,6 +80,7 @@ typedef NSURL RCTFileURL;
 + (UIReturnKeyType)UIReturnKeyType:(id)json;
 + (UIUserInterfaceStyle)UIUserInterfaceStyle:(id)json API_AVAILABLE(ios(12));
 + (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(NSString *)orientation;
++ (UIModalPresentationStyle)UIModalPresentationStyle:(id)json;
 
 #if !TARGET_OS_TV
 + (UIDataDetectorTypes)UIDataDetectorTypes:(id)json;

--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -511,6 +511,17 @@ RCT_ENUM_CONVERTER(
     unsignedIntegerValue)
 
 RCT_ENUM_CONVERTER(
+    UIModalPresentationStyle,
+    (@{
+      @"fullScreen" : @(UIModalPresentationFullScreen),
+      @"pageSheet" : @(UIModalPresentationPageSheet),
+      @"formSheet" : @(UIModalPresentationFormSheet),
+      @"overFullScreen" : @(UIModalPresentationOverFullScreen),
+    }),
+    UIModalPresentationFullScreen,
+    integerValue)
+
+RCT_ENUM_CONVERTER(
     UIViewContentMode,
     (@{
       @"scale-to-fill" : @(UIViewContentModeScaleToFill),

--- a/packages/react-native/React/Views/RCTModalHostViewManager.h
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.h
@@ -5,15 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <React/RCTConvert.h>
 #import <React/RCTInvalidating.h>
 #import <React/RCTViewManager.h>
-
-@interface RCTConvert (RCTModalHostView)
-
-+ (UIModalPresentationStyle)UIModalPresentationStyle:(id)json;
-
-@end
 
 typedef void (^RCTModalViewInteractionBlock)(
     UIViewController *reactViewController,

--- a/packages/react-native/React/Views/RCTModalHostViewManager.h
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <React/RCTConvert.h>
 #import <React/RCTInvalidating.h>
 #import <React/RCTViewManager.h>
 

--- a/packages/react-native/React/Views/RCTModalHostViewManager.m
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.m
@@ -13,7 +13,6 @@
 #import "RCTModalManager.h"
 #import "RCTShadowView.h"
 #import "RCTUtils.h"
-#import <React/RCTConvert.h>
 
 @interface RCTModalHostShadowView : RCTShadowView
 

--- a/packages/react-native/React/Views/RCTModalHostViewManager.m
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.m
@@ -13,21 +13,7 @@
 #import "RCTModalManager.h"
 #import "RCTShadowView.h"
 #import "RCTUtils.h"
-
-@implementation RCTConvert (RCTModalHostView)
-
-RCT_ENUM_CONVERTER(
-    UIModalPresentationStyle,
-    (@{
-      @"fullScreen" : @(UIModalPresentationFullScreen),
-      @"pageSheet" : @(UIModalPresentationPageSheet),
-      @"formSheet" : @(UIModalPresentationFormSheet),
-      @"overFullScreen" : @(UIModalPresentationOverFullScreen),
-    }),
-    UIModalPresentationFullScreen,
-    integerValue)
-
-@end
+#import <React/RCTConvert.h>
 
 @interface RCTModalHostShadowView : RCTShadowView
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Currently, the ability to convert JS values to `UIModalPresentationStyle` is not present directly on `RCTConvert`.

In the RN code base itself, there's not a lot of need to do this type of conversion, but in community modules, presenting ViewControllers can be a fairly common scenario and it'd be nice to be able to use this conversion directly from `RCTConvert`, rather than from `RCTModalHostViewManager`, as it'd improve its "discoverability" and consistency.

If someone relied on this, then it's technically speaking a breaking change but I'd say it's for the better, and searching `#import <React/RCTModalHostViewManager.h>` on github doesn't reveal a lot of results.
 
## Changelog:



[IOS] [ADDED] - RCTConvert to support UIModalPresentationStyle

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests

## Test Plan:

Tested using RN Tester


https://github.com/facebook/react-native/assets/1566403/6e62df86-dde3-47b0-b2e9-bb6b483cadf6


