### PR TITLE
Use new JSI method to queue microtasks in RuntimeSchedulerTest

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -13,8 +13,8 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdlib>
+#include <deque>
 #include <mutex>
-#include <queue>
 #include <sstream>
 #include <thread>
 
@@ -51,6 +51,12 @@ class JSCRuntime : public jsi::Runtime {
       const std::shared_ptr<const jsi::Buffer>& buffer,
       const std::string& sourceURL) override;
 
+  // If we use this interface to implement microtasks in the host we need to
+  // polyfill `Promise` to use these methods, because JSC doesn't currently
+  // support providing a custom queue for its built-in implementation.
+  // Not doing this would result in a non-compliant behavior, as microtasks
+  // wouldn't execute in the order in which they were queued.
+  void queueMicrotask(const jsi::Function& callback) override;
   bool drainMicrotasks(int maxMicrotasksHint = -1) override;
 
   jsi::Object global() override;
@@ -265,6 +271,7 @@ class JSCRuntime : public jsi::Runtime {
   std::atomic<bool> ctxInvalid_;
   std::string desc_;
   JSValueRef nativeStateSymbol_ = nullptr;
+  std::deque<jsi::Function> microtaskQueue_;
 #ifndef NDEBUG
   mutable std::atomic<intptr_t> objectCounter_;
   mutable std::atomic<intptr_t> symbolCounter_;
@@ -378,6 +385,10 @@ JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
 }
 
 JSCRuntime::~JSCRuntime() {
+  // We need to clear the microtask queue to remove all references to the
+  // callbacks, so objectCounter_ would be 0 below.
+  microtaskQueue_.clear();
+
   // On shutting down and cleaning up: when JSC is actually torn down,
   // it calls JSC::Heap::lastChanceToFinalize internally which
   // finalizes anything left over.  But at this point,
@@ -434,7 +445,24 @@ jsi::Value JSCRuntime::evaluateJavaScript(
   return createValue(res);
 }
 
-bool JSCRuntime::drainMicrotasks(int maxMicrotasksHint) {
+void JSCRuntime::queueMicrotask(const jsi::Function& callback) {
+  microtaskQueue_.emplace_back(
+      jsi::Value(*this, callback).asObject(*this).asFunction(*this));
+}
+
+bool JSCRuntime::drainMicrotasks(int /*maxMicrotasksHint*/) {
+  // Note that new jobs can be enqueued during the draining.
+  while (!microtaskQueue_.empty()) {
+    jsi::Function callback = std::move(microtaskQueue_.front());
+
+    // We need to pop before calling the callback because that might throw.
+    // When that happens, the host will call `drainMicrotasks` again to execute
+    // the remaining microtasks, and this one shouldn't run again.
+    microtaskQueue_.pop_front();
+
+    callback.call(*this);
+  }
+
   return true;
 }
 

--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -126,6 +126,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
       const std::shared_ptr<const PreparedJavaScript>& js) override {
     return plain().evaluatePreparedJavaScript(js);
   }
+  void queueMicrotask(const jsi::Function& callback) override {
+    return plain().queueMicrotask(callback);
+  }
   bool drainMicrotasks(int maxMicrotasksHint) override {
     return plain().drainMicrotasks(maxMicrotasksHint);
   }
@@ -543,6 +546,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
       const std::shared_ptr<const PreparedJavaScript>& js) override {
     Around around{with_};
     return RD::evaluatePreparedJavaScript(js);
+  }
+  void queueMicrotask(const Function& callback) override {
+    Around around{with_};
+    RD::queueMicrotask(callback);
   }
   bool drainMicrotasks(int maxMicrotasksHint) override {
     Around around{with_};

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -87,6 +87,10 @@ NativeState::~NativeState() {}
 
 Runtime::~Runtime() {}
 
+void Runtime::queueMicrotask(const jsi::Function& /*callback*/) {
+  throw JSINativeException("queueMicrotask is not implemented in this runtime");
+}
+
 Instrumentation& Runtime::instrumentation() {
   class NoInstrumentation : public Instrumentation {
     std::string getRecordedGCStats() override {

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -209,6 +209,13 @@ class JSI_EXPORT Runtime {
   virtual Value evaluatePreparedJavaScript(
       const std::shared_ptr<const PreparedJavaScript>& js) = 0;
 
+  /// Queues a microtask in the JavaScript VM internal Microtask (a.k.a. Job in
+  /// ECMA262) queue, to be executed when the host drains microtasks in
+  /// its event loop implementation.
+  ///
+  /// \param callback a function to be executed as a microtask.
+  virtual void queueMicrotask(const jsi::Function& callback);
+
   /// Drain the JavaScript VM internal Microtask (a.k.a. Job in ECMA262) queue.
   ///
   /// \param maxMicrotasksHint a hint to tell an implementation that it should

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -200,13 +200,7 @@ TEST_P(
           return jsi::Value::undefined();
         });
 
-    // Hermes doesn't expose a C++ API to schedule microtasks, so we just access
-    // the API that it exposes to JS.
-    auto global = runtime_->global();
-    auto enqueueJobFn = global.getPropertyAsObject(*runtime_, "HermesInternal")
-                            .getPropertyAsFunction(*runtime_, "enqueueJob");
-
-    enqueueJobFn.call(*runtime_, std::move(microtaskCallback));
+    runtime_->queueMicrotask(microtaskCallback);
 
     return jsi::Value::undefined();
   });


### PR DESCRIPTION
Summary:
Changelog: [internal]

Now that `jsi::Runtime::queueMicrotask` is available, we can use it instead of calling an internal Hermes API in `RuntimeSchedulerTest`.

Reviewed By: christophpurrer

Differential Revision: D54416245


