### PR TITLE
avoid merging unrelated props into ShadowNodeFamily::nativeProps

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicPropsUtilities.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicPropsUtilities.cpp
@@ -31,4 +31,28 @@ folly::dynamic mergeDynamicProps(
   return result;
 }
 
+folly::dynamic overrideDynamicProps(
+    const folly::dynamic& source,
+    const folly::dynamic& patch) {
+  auto result = source;
+
+  if (!result.isObject()) {
+    result = folly::dynamic::object();
+  }
+
+  if (!patch.isObject()) {
+    return result;
+  }
+
+  // Note, here we have to preserve sub-prop objects with `null` value as
+  // an indication for the legacy mounting layer that it needs to clean them up.
+  for (const auto& pair : patch.items()) {
+    if (source.find(pair.first) != source.items().end()) {
+      result[pair.first] = pair.second;
+    }
+  }
+
+  return result;
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicPropsUtilities.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicPropsUtilities.h
@@ -21,4 +21,13 @@ folly::dynamic mergeDynamicProps(
     const folly::dynamic& source,
     const folly::dynamic& patch);
 
+/*
+ * Accepts two `folly::dynamic` objects as arguments. Both arguments need to
+ * represent a dictionary. It updates `source` with key/value pairs from
+ * `patch`, overriding existing keys only if they are not null.
+ */
+folly::dynamic overrideDynamicProps(
+    const folly::dynamic& source,
+    const folly::dynamic& patch);
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/DynamicPropsUtilitiesTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/DynamicPropsUtilitiesTest.cpp
@@ -64,3 +64,17 @@ TEST(DynamicPropsUtilitiesTest, handleNull) {
 
   EXPECT_TRUE(result["height"].isNull());
 }
+
+TEST(DynamicPropsUtilitiesTest, testOverrideDynamicProps) {
+  dynamic map1 = dynamic::object;
+  map1["height"] = 100;
+
+  dynamic map2 = dynamic::object;
+  map2["width"] = 200;
+  map2["height"] = 101;
+
+  auto result = overrideDynamicProps(map1, map2);
+
+  EXPECT_EQ(result["height"], 101);
+  EXPECT_TRUE(result["width"].isNull());
+}

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -128,7 +128,7 @@ std::shared_ptr<ShadowNode> UIManager::cloneNode(
       // and `rawProps` contain key 'A'. Value from `rawProps` overrides what
       // was previously in `nativeProps_DEPRECATED`.
       family.nativeProps_DEPRECATED =
-          std::make_unique<folly::dynamic>(mergeDynamicProps(
+          std::make_unique<folly::dynamic>(overrideDynamicProps(
               *family.nativeProps_DEPRECATED, (folly::dynamic)rawProps));
 
       props = componentDescriptor.cloneProps(


### PR DESCRIPTION
Summary:
changelog: [internal]

Originally when I built setNativeProps, I assumed a node is either controlled by handled directly or it is controlled by React. But we can't make sure that's the case, users can do both and control one prop with setNativeProps and the others with React. Additionally, Suspense uses display: none to hide a subtree.

Therefore, React controlled props must not be copied into `ShadowNodeFamily::nativeProps_DEPRECATED`

Reviewed By: javache

Differential Revision: D54453820


