### PR TITLE
Add JSI test for queueMicrotask and drainMicrotasks

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -87,10 +87,6 @@ NativeState::~NativeState() {}
 
 Runtime::~Runtime() {}
 
-void Runtime::queueMicrotask(const jsi::Function& /*callback*/) {
-  throw JSINativeException("queueMicrotask is not implemented in this runtime");
-}
-
 Instrumentation& Runtime::instrumentation() {
   class NoInstrumentation : public Instrumentation {
     std::string getRecordedGCStats() override {

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -214,7 +214,7 @@ class JSI_EXPORT Runtime {
   /// its event loop implementation.
   ///
   /// \param callback a function to be executed as a microtask.
-  virtual void queueMicrotask(const jsi::Function& callback);
+  virtual void queueMicrotask(const jsi::Function& callback) = 0;
 
   /// Drain the JavaScript VM internal Microtask (a.k.a. Job in ECMA262) queue.
   ///

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -1358,6 +1358,38 @@ TEST_P(JSITest, JSErrorTest) {
       JSIException);
 }
 
+TEST_P(JSITest, MicrotasksTest) {
+  try {
+    rt.global().setProperty(rt, "globalValue", String::createFromAscii(rt, ""));
+
+    auto microtask1 =
+        function("function microtask1() { globalValue += 'hello'; }");
+    auto microtask2 =
+        function("function microtask2() { globalValue += ' world' }");
+
+    rt.queueMicrotask(microtask1);
+    rt.queueMicrotask(microtask2);
+
+    EXPECT_EQ(
+        rt.global().getProperty(rt, "globalValue").asString(rt).utf8(rt), "");
+
+    rt.drainMicrotasks();
+
+    EXPECT_EQ(
+        rt.global().getProperty(rt, "globalValue").asString(rt).utf8(rt),
+        "hello world");
+
+    // Microtasks shouldn't run again
+    rt.drainMicrotasks();
+
+    EXPECT_EQ(
+        rt.global().getProperty(rt, "globalValue").asString(rt).utf8(rt),
+        "hello world");
+  } catch (const JSINativeException& ex) {
+    // queueMicrotask() is unimplemented by some runtimes, ignore such failures.
+  }
+}
+
 //----------------------------------------------------------------------
 // Test that multiple levels of delegation in DecoratedHostObjects works.
 


### PR DESCRIPTION
Differential Revision: D54484771

Add JSI test verifying the behavior of `queueMicrotask` and `drainMicrotasks` in the runtimes that support them.


