### PR TITLE
Make queueMicrotask pure virtual

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -87,10 +87,6 @@ NativeState::~NativeState() {}
 
 Runtime::~Runtime() {}
 
-void Runtime::queueMicrotask(const jsi::Function& /*callback*/) {
-  throw JSINativeException("queueMicrotask is not implemented in this runtime");
-}
-
 Instrumentation& Runtime::instrumentation() {
   class NoInstrumentation : public Instrumentation {
     std::string getRecordedGCStats() override {

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -214,7 +214,7 @@ class JSI_EXPORT Runtime {
   /// its event loop implementation.
   ///
   /// \param callback a function to be executed as a microtask.
-  virtual void queueMicrotask(const jsi::Function& callback);
+  virtual void queueMicrotask(const jsi::Function& callback) = 0;
 
   /// Drain the JavaScript VM internal Microtask (a.k.a. Job in ECMA262) queue.
   ///


### PR DESCRIPTION
Summary:
Changelog: [internal]

We've done this in a separate diff because the changes in Hermes don't propagate immediately to the React Native repository. We need to land the changes in JSI and Hermes first (in a backwards-compatible way) and then land this in a separate commit to make the method mandatory.

Reviewed By: neildhar

Differential Revision: D54413830


