### PR TITLE
support jsCallInvoker in RCTBridgeProxy

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeProxy+Cxx.h
+++ b/packages/react-native/React/Base/RCTBridgeProxy+Cxx.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef __cplusplus
+#import <ReactCommon/CallInvoker.h>
+#endif
+
+#import "RCTBridgeProxy.h"
+
+@interface RCTBridgeProxy (Cxx)
+
+#ifdef __cplusplus
+@property (nonatomic, readwrite) std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker;
+#endif
+
+@end

--- a/packages/react-native/React/Base/RCTBridgeProxy.h
+++ b/packages/react-native/React/Base/RCTBridgeProxy.h
@@ -15,6 +15,7 @@
 @class RCTViewRegistry;
 
 @interface RCTBridgeProxy : NSProxy
+
 - (instancetype)initWithViewRegistry:(RCTViewRegistry *)viewRegistry
                       moduleRegistry:(RCTModuleRegistry *)moduleRegistry
                        bundleManager:(RCTBundleManager *)bundleManager
@@ -34,4 +35,5 @@
  */
 - (id)moduleForClass:(Class)moduleClass;
 - (id)moduleForName:(NSString *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad;
+
 @end

--- a/packages/react-native/React/Base/RCTBridgeProxy.mm
+++ b/packages/react-native/React/Base/RCTBridgeProxy.mm
@@ -6,10 +6,13 @@
  */
 
 #import "RCTBridgeProxy.h"
+#import "RCTBridgeProxy+Cxx.h"
+
 #import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
+#import <ReactCommon/CallInvoker.h>
 #import <jsi/jsi.h>
 
 using namespace facebook;
@@ -19,6 +22,12 @@ using namespace facebook;
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)sel;
 - (void)forwardInvocation:(NSInvocation *)invocation;
+@end
+
+@interface RCTBridgeProxy ()
+
+@property (nonatomic, readwrite) std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker;
+
 @end
 
 @implementation RCTBridgeProxy {
@@ -82,6 +91,12 @@ using namespace facebook;
 {
   [self logWarning:@"Please migrate to C++ TurboModule or RuntimeExecutor." cmd:_cmd];
   return _runtime;
+}
+
+- (std::shared_ptr<facebook::react::CallInvoker>)jsCallInvoker
+{
+  [self logWarning:@"Please migrate to RuntimeExecutor" cmd:_cmd];
+  return _jsCallInvoker;
 }
 
 /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -10,7 +10,6 @@
 #import <memory>
 
 #import <React/RCTBridgeModuleDecorator.h>
-#import <React/RCTBridgeProxy.h>
 #import <React/RCTDefines.h>
 #import <React/RCTTurboModuleRegistry.h>
 #import <ReactCommon/RuntimeExecutor.h>
@@ -18,6 +17,7 @@
 
 #import "RCTTurboModule.h"
 
+@class RCTBridgeProxy;
 @class RCTTurboModuleManager;
 
 @protocol RCTTurboModuleManagerDelegate <NSObject>


### PR DESCRIPTION
Summary:
Changelog: [Internal]

making call invoker a breaking change to runtime executor in 0.74 seems to be causing a lot of discourse. let's simplify things and first add the callinvoker to the backwards compat layer

Differential Revision: D54404845


