### PR TITLE
Fix E2E template install in CI jobs

### DIFF
--- a/scripts/e2e/init-template-e2e.js
+++ b/scripts/e2e/init-template-e2e.js
@@ -121,8 +121,8 @@ async function initNewProjectFromSource(
         --directory ${directory} \
         --template ${templatePath} \
         --verbose \
-        --skip-install \
-        --yarn-config-options npmRegistryServer="${VERDACCIO_SERVER_URL}"`,
+        --pm npm \
+        --skip-install`,
       {
         // Avoid loading packages/react-native/react-native.config.js
         cwd: REPO_ROOT,


### PR DESCRIPTION
This fixes a seemingly pre-existent misconfiguration within our `test_ios_template` E2E test setup in CircleCI.

**Background**

We call `npx @react-native-community/cli init` with the `--skip-install` flag, as part of the bootstrapping logic in `scripts/e2e/init-template-e2e.js`. This is necessary because we later want to explicitly call `npm install` with a custom `--registry` for our locally mirrored packages (via Verdaccio).

For some reason, we were observing unexpected differences when this was run under CircleCI:

1. Runs `yarn init`
2. Runs a `yarn add` (unknown pkg)

![image](https://github.com/facebook/react-native/assets/2547783/e3b1621b-e8c9-44cf-8491-9eb84f6c194a)

https://app.circleci.com/pipelines/github/facebook/react-native/42725/workflows/f648468b-e916-4501-887d-ad293aa6fccf/jobs/1398950


This is causing a Yarn-based install ahead of where we want — ignoring the `--skip-install` flag.

*I'm still unsure on the exact LOC cause in CLI* (but most likely, it's around the Yarn v3 move).

**Impact of this fix**

- The above meant that, when we were bootstrapping `test_ios_template` previously, packages weren't being read from Verdaccio, but **instead from npm** — using the `"0.74.0"` versions from the *previous branch cut* ❌.
- After https://github.com/facebook/react-native/pull/43132, this behaviour became breaking 💀 — since for the 0.74 -> 0.75 cut, we no longer physically published `"0.75.0-main"` (new format) packages to npm.

**This change**

I'm passing `--pm npm` to `npx @react-native-community/cli init` to skip around any Yarn behaviour. This appears to have removed the erroneous `yarn` invocations ✅.

Changelog: [Internal]

Differential Revision: D54536848


