### PR TITLE
Remove deprecated Pressability methods

### DIFF
--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -136,33 +136,6 @@ export type PressabilityConfig = $ReadOnly<{|
    * while this pressable is responder.
    */
   blockNativeResponder?: ?boolean,
-
-  /**
-   * Returns whether a long press gesture should cancel the press gesture.
-   * Defaults to true.
-   *
-   * @deprecated
-   */
-  onLongPressShouldCancelPress_DEPRECATED?: ?() => boolean,
-
-  /**
-   * If `cancelable` is set, this will be ignored.
-   *
-   * Returns whether to yield to a lock termination request (e.g. if a native
-   * scroll gesture attempts to steal the responder lock).
-   *
-   * @deprecated
-   */
-  onResponderTerminationRequest_DEPRECATED?: ?() => boolean,
-
-  /**
-   * If `disabled` is set, this will be ignored.
-   *
-   * Returns whether to start a press gesture.
-   *
-   * @deprecated
-   */
-  onStartShouldSetResponder_DEPRECATED?: ?() => boolean,
 |}>;
 
 export type EventHandlers = $ReadOnly<{|
@@ -475,13 +448,7 @@ export default class Pressability {
     const responderEventHandlers = {
       onStartShouldSetResponder: (): boolean => {
         const {disabled} = this._config;
-        if (disabled == null) {
-          const {onStartShouldSetResponder_DEPRECATED} = this._config;
-          return onStartShouldSetResponder_DEPRECATED == null
-            ? true
-            : onStartShouldSetResponder_DEPRECATED();
-        }
-        return !disabled;
+        return !disabled ?? true;
       },
 
       onResponderGrant: (event: PressEvent): void | boolean => {
@@ -559,13 +526,7 @@ export default class Pressability {
 
       onResponderTerminationRequest: (): boolean => {
         const {cancelable} = this._config;
-        if (cancelable == null) {
-          const {onResponderTerminationRequest_DEPRECATED} = this._config;
-          return onResponderTerminationRequest_DEPRECATED == null
-            ? true
-            : onResponderTerminationRequest_DEPRECATED();
-        }
-        return cancelable;
+        return cancelable ?? true;
       },
 
       onClick: (event: PressEvent): void => {
@@ -789,9 +750,7 @@ export default class Pressability {
       const {onLongPress, onPress, android_disableSound} = this._config;
       if (onPress != null) {
         const isPressCanceledByLongPress =
-          onLongPress != null &&
-          prevState === 'RESPONDER_ACTIVE_LONG_PRESS_IN' &&
-          this._shouldLongPressCancelPress();
+          onLongPress != null && prevState === 'RESPONDER_ACTIVE_LONG_PRESS_IN';
         if (!isPressCanceledByLongPress) {
           if (Platform.OS === 'android' && android_disableSound !== true) {
             SoundManager.playTouchSound();
@@ -923,13 +882,6 @@ export default class Pressability {
     ) {
       this._receiveSignal('LONG_PRESS_DETECTED', event);
     }
-  }
-
-  _shouldLongPressCancelPress(): boolean {
-    return (
-      this._config.onLongPressShouldCancelPress_DEPRECATED == null ||
-      this._config.onLongPressShouldCancelPress_DEPRECATED()
-    );
   }
 
   _cancelHoverInDelayTimeout(): void {

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -118,9 +118,6 @@ const Text: React.AbstractComponent<
               setHighlighted(false);
               onPressOut?.(event);
             },
-            onResponderTerminationRequest_DEPRECATED:
-              onResponderTerminationRequest,
-            onStartShouldSetResponder_DEPRECATED: onStartShouldSetResponder,
           }
         : null,
     [
@@ -131,8 +128,6 @@ const Text: React.AbstractComponent<
       onPress,
       onPressIn,
       onPressOut,
-      onResponderTerminationRequest,
-      onStartShouldSetResponder,
       suppressHighlighting,
     ],
   );
@@ -169,8 +164,13 @@ const Text: React.AbstractComponent<
             },
             onClick: eventHandlers.onClick,
             onResponderTerminationRequest:
-              eventHandlers.onResponderTerminationRequest,
-            onStartShouldSetResponder: eventHandlers.onStartShouldSetResponder,
+              onResponderTerminationRequest != null
+                ? onResponderTerminationRequest
+                : eventHandlers.onResponderTerminationRequest,
+            onStartShouldSetResponder:
+              onStartShouldSetResponder != null
+                ? onStartShouldSetResponder
+                : eventHandlers.onStartShouldSetResponder,
           },
     [
       eventHandlers,
@@ -178,6 +178,8 @@ const Text: React.AbstractComponent<
       onResponderMove,
       onResponderRelease,
       onResponderTerminate,
+      onResponderTerminationRequest,
+      onStartShouldSetResponder,
     ],
   );
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6192,9 +6192,6 @@ exports[`public API should not change unintentionally Libraries/Pressability/Pre
   onPressMove?: ?(event: PressEvent) => mixed,
   onPressOut?: ?(event: PressEvent) => mixed,
   blockNativeResponder?: ?boolean,
-  onLongPressShouldCancelPress_DEPRECATED?: ?() => boolean,
-  onResponderTerminationRequest_DEPRECATED?: ?() => boolean,
-  onStartShouldSetResponder_DEPRECATED?: ?() => boolean,
 |}>;
 export type EventHandlers = $ReadOnly<{|
   onBlur: (event: BlurEvent) => void,
@@ -6269,7 +6266,6 @@ declare export default class Pressability {
     |}>
   ): boolean;
   _handleLongPress(event: PressEvent): void;
-  _shouldLongPressCancelPress(): boolean;
   _cancelHoverInDelayTimeout(): void;
   _cancelHoverOutDelayTimeout(): void;
   _cancelLongPressDelayTimeout(): void;

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -36,7 +36,6 @@ const FILES_WITH_KNOWN_ERRORS = new Set([
   'Libraries/Components/RefreshControl/RefreshControl.js',
   'Libraries/Components/ScrollView/ScrollView.js',
   'Libraries/Components/StatusBar/StatusBar.js',
-  'Libraries/Components/TextInput/InputAccessoryView.js',
   'Libraries/Components/StaticRenderer.js',
   'Libraries/Components/Touchable/TouchableNativeFeedback.js',
   'Libraries/Components/Touchable/TouchableWithoutFeedback.js',


### PR DESCRIPTION
Summary:
These have been deprecated since 2019 (D18742620), probably time we remove them.

Changelog: [General][Removed] Removed deprecated methods from Pressability.

Differential Revision: D54535029


