### PR TITLE
fix: add compiler conditional to hover style

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -597,6 +597,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     layer.shadowPath = nil;
   }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000 /* __IPHONE_17_0 */
   // Stage 1.5. Cursor / Hover Effects
   if (@available(iOS 17.0, *)) {
     UIHoverStyle *hoverStyle = nil;
@@ -621,6 +622,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     }
     [self setHoverStyle:hoverStyle];
   }
+#endif
 
   // Stage 2. Border Rendering
   const bool useCoreAnimationBorderRendering =

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -896,6 +896,7 @@ static void RCTUpdateShadowPathForView(RCTView *view)
 
 static void RCTUpdateHoverStyleForView(RCTView *view)
 {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000 /* __IPHONE_17_0 */
   if (@available(iOS 17.0, *)) {
     UIHoverStyle *hoverStyle = nil;
     if ([view cursor] == RCTCursorPointer) {
@@ -917,6 +918,7 @@ static void RCTUpdateHoverStyleForView(RCTView *view)
     }
     [view setHoverStyle:hoverStyle];
   }
+#endif
 }
 
 - (void)updateClippingForLayer:(CALayer *)layer


### PR DESCRIPTION
## Summary:

Commit https://github.com/facebook/react-native/commit/73664f576aaa472d5c8fb2a02e0ddd017bbb2ea4 broke two jobs in CircleCI that we run using Xcode 14.3.1 because the commit introduced some types that are available only to iOS 17.
The code was wrapped around if(@available()) statement, but this does not compile out the code. It is a runtime check and the code needs to build anyway.

This takes effect at compile time as well. However, unlike with #available, the method must type check and compile. The code will always be emitted into your binary: however, it will only be used when the binary is executed on platforms that meet the availability requirements.

source: [forums.swift.org/t/if-vs-available-vs-if-available/40266/2](https://forums.swift.org/t/if-vs-available-vs-if-available/40266/2)

This change should fix it, introducing some compile time pragmas that removes the code if we build with older versions of Xcode


## Changelog:

[IOS] [ADDED] - Compiler conditionals for hover style (cursor: pointer)

## Test Plan:

CI Green
