### PR TITLE
Use RuntimeExecutor consistently throughout the modern CDP backend

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
@@ -41,8 +41,10 @@ JSExecutor::createAgentDelegate(
     jsinspector_modern::SessionState& sessionState,
     std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>,
     const jsinspector_modern::ExecutionContextDescription&
-        executionContextDescription) {
+        executionContextDescription,
+    RuntimeExecutor runtimeExecutor) {
   (void)executionContextDescription;
+  (void)runtimeExecutor;
   return std::make_unique<jsinspector_modern::FallbackRuntimeAgentDelegate>(
       std::move(frontendChannel), sessionState, getDescription());
 }

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
@@ -150,7 +150,8 @@ class RN_EXPORT JSExecutor : public jsinspector_modern::RuntimeTargetDelegate {
       std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
           previouslyExportedState,
       const jsinspector_modern::ExecutionContextDescription&
-          executionContextDescription) override;
+          executionContextDescription,
+      RuntimeExecutor runtimeExecutor) override;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -15,7 +15,6 @@
 #include <jsi/decorator.h>
 #include <jsinspector-modern/InspectorFlags.h>
 
-#include <hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h>
 #include <hermes/inspector-modern/chrome/Registration.h>
 #include <hermes/inspector/RuntimeAdapter.h>
 
@@ -253,9 +252,10 @@ HermesExecutor::HermesExecutor(
     RuntimeInstaller runtimeInstaller,
     HermesRuntime& hermesRuntime)
     : JSIExecutor(runtime, delegate, timeoutInvoker, runtimeInstaller),
-      jsQueue_(jsQueue),
       runtime_(runtime),
-      hermesRuntime_(hermesRuntime) {}
+      targetDelegate_(
+          std::shared_ptr<HermesRuntime>(runtime_, &hermesRuntime),
+          std::move(jsQueue)) {}
 
 std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>
 HermesExecutor::createAgentDelegate(
@@ -265,28 +265,11 @@ HermesExecutor::createAgentDelegate(
         previouslyExportedState,
     const jsinspector_modern::ExecutionContextDescription&
         executionContextDescription) {
-  std::shared_ptr<HermesRuntime> hermesRuntimeShared(runtime_, &hermesRuntime_);
-  return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
-      new jsinspector_modern::HermesRuntimeAgentDelegate(
-          frontendChannel,
-          sessionState,
-          std::move(previouslyExportedState),
-          executionContextDescription,
-          hermesRuntimeShared,
-          [jsQueueWeak = std::weak_ptr(jsQueue_),
-           runtimeWeak = std::weak_ptr(runtime_)](auto fn) {
-            auto jsQueue = jsQueueWeak.lock();
-            if (!jsQueue) {
-              return;
-            }
-            jsQueue->runOnQueue([runtimeWeak, fn]() {
-              auto runtime = runtimeWeak.lock();
-              if (!runtime) {
-                return;
-              }
-              fn(*runtime);
-            });
-          }));
+  return targetDelegate_.createAgentDelegate(
+      std::move(frontendChannel),
+      sessionState,
+      std::move(previouslyExportedState),
+      executionContextDescription);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -62,7 +62,8 @@ class HermesExecutor : public JSIExecutor {
       std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
           previouslyExportedState,
       const jsinspector_modern::ExecutionContextDescription&
-          executionContextDescription) override;
+          executionContextDescription,
+      RuntimeExecutor runtimeExecutor) override;
 
  private:
   JSIScopedTimeoutInvoker timeoutInvoker_;

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hermes/hermes.h>
+#include <hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h>
 #include <jsireact/JSIExecutor.h>
 #include <utility>
 
@@ -65,9 +66,8 @@ class HermesExecutor : public JSIExecutor {
 
  private:
   JSIScopedTimeoutInvoker timeoutInvoker_;
-  std::shared_ptr<MessageQueueThread> jsQueue_;
   std::shared_ptr<jsi::Runtime> runtime_;
-  hermes::HermesRuntime& hermesRuntime_;
+  jsinspector_modern::HermesRuntimeTargetDelegate targetDelegate_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -14,30 +14,8 @@ namespace facebook::react::jsinspector_modern {
 
 class HermesRuntimeTargetDelegate::Impl : public RuntimeTargetDelegate {
  public:
-  Impl(
-      std::shared_ptr<HermesRuntime> hermesRuntime,
-      std::shared_ptr<MessageQueueThread> jsMessageQueueThread)
-      : Impl(
-            hermesRuntime,
-            [msgQueueThreadWeak = std::weak_ptr(jsMessageQueueThread),
-             runtimeWeak = std::weak_ptr(hermesRuntime)](auto fn) {
-              auto msgQueueThread = msgQueueThreadWeak.lock();
-              if (!msgQueueThread) {
-                return;
-              }
-              msgQueueThread->runOnQueue([runtimeWeak, fn]() {
-                auto runtime = runtimeWeak.lock();
-                if (!runtime) {
-                  return;
-                }
-                fn(*runtime);
-              });
-            }) {}
-
-  Impl(
-      std::shared_ptr<HermesRuntime> hermesRuntime,
-      RuntimeExecutor runtimeExecutor)
-      : runtime_(hermesRuntime), runtimeExecutor_(runtimeExecutor) {}
+  explicit Impl(std::shared_ptr<HermesRuntime> hermesRuntime)
+      : runtime_(hermesRuntime) {}
 
   // RuntimeTargetDelegate methods
 
@@ -46,30 +24,24 @@ class HermesRuntimeTargetDelegate::Impl : public RuntimeTargetDelegate {
       SessionState& sessionState,
       std::unique_ptr<RuntimeAgentDelegate::ExportedState>
           previouslyExportedState,
-      const ExecutionContextDescription& executionContextDescription) override {
+      const ExecutionContextDescription& executionContextDescription,
+      RuntimeExecutor runtimeExecutor) override {
     return std::unique_ptr<RuntimeAgentDelegate>(new HermesRuntimeAgentDelegate(
         frontendChannel,
         sessionState,
         std::move(previouslyExportedState),
         executionContextDescription,
         runtime_,
-        runtimeExecutor_));
+        std::move(runtimeExecutor)));
   }
 
  private:
   std::shared_ptr<HermesRuntime> runtime_;
-  RuntimeExecutor runtimeExecutor_;
 };
 
 HermesRuntimeTargetDelegate::HermesRuntimeTargetDelegate(
-    std::shared_ptr<HermesRuntime> hermesRuntime,
-    std::shared_ptr<MessageQueueThread> jsMessageQueueThread)
-    : impl_(std::make_unique<Impl>(hermesRuntime, jsMessageQueueThread)) {}
-
-HermesRuntimeTargetDelegate::HermesRuntimeTargetDelegate(
-    std::shared_ptr<HermesRuntime> hermesRuntime,
-    RuntimeExecutor runtimeExecutor)
-    : impl_(std::make_unique<Impl>(hermesRuntime, runtimeExecutor)) {}
+    std::shared_ptr<HermesRuntime> hermesRuntime)
+    : impl_(std::make_unique<Impl>(hermesRuntime)) {}
 
 HermesRuntimeTargetDelegate::~HermesRuntimeTargetDelegate() = default;
 
@@ -79,12 +51,14 @@ HermesRuntimeTargetDelegate::createAgentDelegate(
     SessionState& sessionState,
     std::unique_ptr<RuntimeAgentDelegate::ExportedState>
         previouslyExportedState,
-    const ExecutionContextDescription& executionContextDescription) {
+    const ExecutionContextDescription& executionContextDescription,
+    RuntimeExecutor runtimeExecutor) {
   return impl_->createAgentDelegate(
       frontendChannel,
       sessionState,
       std::move(previouslyExportedState),
-      executionContextDescription);
+      executionContextDescription,
+      std::move(runtimeExecutor));
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HermesRuntimeTargetDelegate.h"
+#include "HermesRuntimeAgentDelegate.h"
+
+using namespace facebook::hermes;
+
+namespace facebook::react::jsinspector_modern {
+
+class HermesRuntimeTargetDelegate::Impl : public RuntimeTargetDelegate {
+ public:
+  Impl(
+      std::shared_ptr<HermesRuntime> hermesRuntime,
+      std::shared_ptr<MessageQueueThread> jsMessageQueueThread)
+      : Impl(
+            hermesRuntime,
+            [msgQueueThreadWeak = std::weak_ptr(jsMessageQueueThread),
+             runtimeWeak = std::weak_ptr(hermesRuntime)](auto fn) {
+              auto msgQueueThread = msgQueueThreadWeak.lock();
+              if (!msgQueueThread) {
+                return;
+              }
+              msgQueueThread->runOnQueue([runtimeWeak, fn]() {
+                auto runtime = runtimeWeak.lock();
+                if (!runtime) {
+                  return;
+                }
+                fn(*runtime);
+              });
+            }) {}
+
+  Impl(
+      std::shared_ptr<HermesRuntime> hermesRuntime,
+      RuntimeExecutor runtimeExecutor)
+      : runtime_(hermesRuntime), runtimeExecutor_(runtimeExecutor) {}
+
+  // RuntimeTargetDelegate methods
+
+  std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
+      FrontendChannel frontendChannel,
+      SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
+      const ExecutionContextDescription& executionContextDescription) override {
+    return std::unique_ptr<RuntimeAgentDelegate>(new HermesRuntimeAgentDelegate(
+        frontendChannel,
+        sessionState,
+        std::move(previouslyExportedState),
+        executionContextDescription,
+        runtime_,
+        runtimeExecutor_));
+  }
+
+ private:
+  std::shared_ptr<HermesRuntime> runtime_;
+  RuntimeExecutor runtimeExecutor_;
+};
+
+HermesRuntimeTargetDelegate::HermesRuntimeTargetDelegate(
+    std::shared_ptr<HermesRuntime> hermesRuntime,
+    std::shared_ptr<MessageQueueThread> jsMessageQueueThread)
+    : impl_(std::make_unique<Impl>(hermesRuntime, jsMessageQueueThread)) {}
+
+HermesRuntimeTargetDelegate::HermesRuntimeTargetDelegate(
+    std::shared_ptr<HermesRuntime> hermesRuntime,
+    RuntimeExecutor runtimeExecutor)
+    : impl_(std::make_unique<Impl>(hermesRuntime, runtimeExecutor)) {}
+
+HermesRuntimeTargetDelegate::~HermesRuntimeTargetDelegate() = default;
+
+std::unique_ptr<RuntimeAgentDelegate>
+HermesRuntimeTargetDelegate::createAgentDelegate(
+    FrontendChannel frontendChannel,
+    SessionState& sessionState,
+    std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+        previouslyExportedState,
+    const ExecutionContextDescription& executionContextDescription) {
+  return impl_->createAgentDelegate(
+      frontendChannel,
+      sessionState,
+      std::move(previouslyExportedState),
+      executionContextDescription);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -23,19 +23,10 @@ namespace facebook::react::jsinspector_modern {
 class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
  public:
   /**
-   * Creates a HermesRuntimeTargetDelegate for the given runtime and message
-   * queue thread.
+   * Creates a HermesRuntimeTargetDelegate for the given runtime.
    */
-  HermesRuntimeTargetDelegate(
-      std::shared_ptr<hermes::HermesRuntime> hermesRuntime,
-      std::shared_ptr<MessageQueueThread> jsMessageQueueThread);
-
-  /**
-   * Creates a HermesRuntimeTargetDelegate for the given runtime and executor.
-   */
-  HermesRuntimeTargetDelegate(
-      std::shared_ptr<hermes::HermesRuntime> hermesRuntime,
-      RuntimeExecutor runtimeExecutor);
+  explicit HermesRuntimeTargetDelegate(
+      std::shared_ptr<hermes::HermesRuntime> hermesRuntime);
 
   ~HermesRuntimeTargetDelegate();
 
@@ -47,7 +38,8 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
       std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
           previouslyExportedState,
       const jsinspector_modern::ExecutionContextDescription&
-          executionContextDescription) override;
+          executionContextDescription,
+      RuntimeExecutor runtimeExecutor) override;
 
  private:
   class Impl;

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/RuntimeExecutor.h>
+
+#include <cxxreact/MessageQueueThread.h>
+#include <hermes/hermes.h>
+#include <jsinspector-modern/ReactCdp.h>
+
+#include <memory>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A RuntimeTargetDelegate that enables debugging a Hermes runtime over CDP.
+ */
+class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
+ public:
+  /**
+   * Creates a HermesRuntimeTargetDelegate for the given runtime and message
+   * queue thread.
+   */
+  HermesRuntimeTargetDelegate(
+      std::shared_ptr<hermes::HermesRuntime> hermesRuntime,
+      std::shared_ptr<MessageQueueThread> jsMessageQueueThread);
+
+  /**
+   * Creates a HermesRuntimeTargetDelegate for the given runtime and executor.
+   */
+  HermesRuntimeTargetDelegate(
+      std::shared_ptr<hermes::HermesRuntime> hermesRuntime,
+      RuntimeExecutor runtimeExecutor);
+
+  ~HermesRuntimeTargetDelegate();
+
+  // RuntimeTargetDelegate methods
+
+  std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate> createAgentDelegate(
+      jsinspector_modern::FrontendChannel frontendChannel,
+      jsinspector_modern::SessionState& sessionState,
+      std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
+      const jsinspector_modern::ExecutionContextDescription&
+          executionContextDescription) override;
+
+ private:
+  class Impl;
+
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -46,7 +46,8 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
           channel,
           sessionState,
           std::move(runtimeAgentState.delegateState),
-          executionContextDescription_));
+          executionContextDescription_,
+          jsExecutor_));
   agents_.insert(runtimeAgent);
   return runtimeAgent;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -49,7 +49,8 @@ class RuntimeTargetDelegate {
       SessionState& sessionState,
       std::unique_ptr<RuntimeAgentDelegate::ExportedState>
           previouslyExportedState,
-      const ExecutionContextDescription& executionContextDescription) = 0;
+      const ExecutionContextDescription& executionContextDescription,
+      RuntimeExecutor runtimeExecutor) = 0;
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
@@ -31,12 +31,13 @@ class HostTargetTest : public Test {
 
  protected:
   HostTargetTest() {
-    EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _, _))
+    EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _, _, _))
         .WillRepeatedly(runtimeAgentDelegates_.lazily_make_unique<
                         FrontendChannel,
                         SessionState&,
                         std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
-                        const ExecutionContextDescription&>());
+                        const ExecutionContextDescription&,
+                        RuntimeExecutor>());
   }
 
   void connect() {
@@ -445,7 +446,7 @@ TEST_F(HostTargetProtocolTest, MessageRoutingWhileNoRuntimeAgentDelegate) {
 TEST_F(HostTargetProtocolTest, InstanceWithNullRuntimeAgentDelegate) {
   InSequence s;
 
-  EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _, _))
+  EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _, _, _))
       .WillRepeatedly(ReturnNull());
 
   auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -133,7 +133,8 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
        SessionState& sessionState,
        std::unique_ptr<RuntimeAgentDelegate::ExportedState>
            previouslyExportedState,
-       const ExecutionContextDescription&),
+       const ExecutionContextDescription&,
+       RuntimeExecutor),
       (override));
 };
 
@@ -143,7 +144,8 @@ class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {
       FrontendChannel frontendChannel,
       SessionState& sessionState,
       std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
-      const ExecutionContextDescription& executionContextDescription)
+      const ExecutionContextDescription& executionContextDescription,
+      RuntimeExecutor)
       : frontendChannel(std::move(frontendChannel)),
         sessionState(sessionState),
         executionContextDescription(executionContextDescription) {}

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.cpp
@@ -25,7 +25,8 @@ JsiIntegrationTestGenericEngineAdapter::createAgentDelegate(
     FrontendChannel frontendChannel,
     SessionState& sessionState,
     std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
-    const ExecutionContextDescription&) {
+    const ExecutionContextDescription&,
+    RuntimeExecutor) {
   return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
       new FallbackRuntimeAgentDelegate(
           frontendChannel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.h
@@ -30,7 +30,8 @@ class JsiIntegrationTestGenericEngineAdapter : public RuntimeTargetDelegate {
       SessionState& sessionState,
       std::unique_ptr<RuntimeAgentDelegate::ExportedState>
           previouslyExportedState,
-      const ExecutionContextDescription& executionContextDescription) override;
+      const ExecutionContextDescription& executionContextDescription,
+      RuntimeExecutor runtimeExecutor) override;
 
   jsi::Runtime& getRuntime() const noexcept;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
@@ -17,7 +17,7 @@ JsiIntegrationTestHermesEngineAdapter::JsiIntegrationTestHermesEngineAdapter(
     folly::Executor& jsExecutor)
     : runtime_{hermes::makeHermesRuntime()},
       jsExecutor_{jsExecutor},
-      targetDelegate_(runtime_, getRuntimeExecutor()) {}
+      targetDelegate_{runtime_} {}
 
 std::unique_ptr<RuntimeAgentDelegate>
 JsiIntegrationTestHermesEngineAdapter::createAgentDelegate(
@@ -25,12 +25,14 @@ JsiIntegrationTestHermesEngineAdapter::createAgentDelegate(
     SessionState& sessionState,
     std::unique_ptr<RuntimeAgentDelegate::ExportedState>
         previouslyExportedState,
-    const ExecutionContextDescription& executionContextDescription) {
+    const ExecutionContextDescription& executionContextDescription,
+    RuntimeExecutor runtimeExecutor) {
   return targetDelegate_.createAgentDelegate(
       std::move(frontendChannel),
       sessionState,
       std::move(previouslyExportedState),
-      executionContextDescription);
+      executionContextDescription,
+      std::move(runtimeExecutor));
 }
 
 jsi::Runtime& JsiIntegrationTestHermesEngineAdapter::getRuntime()

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
@@ -7,8 +7,6 @@
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 
-#include <hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h>
-
 #include "JsiIntegrationTestHermesEngineAdapter.h"
 
 using facebook::hermes::makeHermesRuntime;
@@ -17,7 +15,9 @@ namespace facebook::react::jsinspector_modern {
 
 JsiIntegrationTestHermesEngineAdapter::JsiIntegrationTestHermesEngineAdapter(
     folly::Executor& jsExecutor)
-    : runtime_{hermes::makeHermesRuntime()}, jsExecutor_{jsExecutor} {}
+    : runtime_{hermes::makeHermesRuntime()},
+      jsExecutor_{jsExecutor},
+      targetDelegate_(runtime_, getRuntimeExecutor()) {}
 
 std::unique_ptr<RuntimeAgentDelegate>
 JsiIntegrationTestHermesEngineAdapter::createAgentDelegate(
@@ -26,14 +26,11 @@ JsiIntegrationTestHermesEngineAdapter::createAgentDelegate(
     std::unique_ptr<RuntimeAgentDelegate::ExportedState>
         previouslyExportedState,
     const ExecutionContextDescription& executionContextDescription) {
-  return std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate>(
-      new HermesRuntimeAgentDelegate(
-          frontendChannel,
-          sessionState,
-          std::move(previouslyExportedState),
-          executionContextDescription,
-          runtime_,
-          getRuntimeExecutor()));
+  return targetDelegate_.createAgentDelegate(
+      std::move(frontendChannel),
+      sessionState,
+      std::move(previouslyExportedState),
+      executionContextDescription);
 }
 
 jsi::Runtime& JsiIntegrationTestHermesEngineAdapter::getRuntime()

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
@@ -31,7 +31,8 @@ class JsiIntegrationTestHermesEngineAdapter : public RuntimeTargetDelegate {
       SessionState& sessionState,
       std::unique_ptr<RuntimeAgentDelegate::ExportedState>
           previouslyExportedState,
-      const ExecutionContextDescription& executionContextDescription) override;
+      const ExecutionContextDescription& executionContextDescription,
+      RuntimeExecutor runtimeExecutor) override;
 
   jsi::Runtime& getRuntime() const noexcept;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
@@ -11,6 +11,7 @@
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 #include <hermes/hermes.h>
+#include <hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h>
 #include <jsi/jsi.h>
 
 #include <memory>
@@ -39,6 +40,7 @@ class JsiIntegrationTestHermesEngineAdapter : public RuntimeTargetDelegate {
  private:
   std::shared_ptr<facebook::hermes::HermesRuntime> runtime_;
   folly::Executor& jsExecutor_;
+  HermesRuntimeTargetDelegate targetDelegate_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.cpp
@@ -24,8 +24,10 @@ JSIRuntimeHolder::createAgentDelegate(
     jsinspector_modern::SessionState& sessionState,
     std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>,
     const jsinspector_modern::ExecutionContextDescription&
-        executionContextDescription) {
+        executionContextDescription,
+    RuntimeExecutor runtimeExecutor) {
   (void)executionContextDescription;
+  (void)runtimeExecutor;
   return std::make_unique<jsinspector_modern::FallbackRuntimeAgentDelegate>(
       std::move(frontendChannel), sessionState, runtime_->description());
 }

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
@@ -47,7 +47,8 @@ class JSIRuntimeHolder : public JSRuntime {
       std::unique_ptr<jsinspector_modern::RuntimeAgentDelegate::ExportedState>
           previouslyExportedState,
       const jsinspector_modern::ExecutionContextDescription&
-          executionContextDescription) override;
+          executionContextDescription,
+      RuntimeExecutor runtimeExecutor) override;
 
   explicit JSIRuntimeHolder(std::unique_ptr<jsi::Runtime> runtime);
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The Hermes debugger integrations in Bridge/Bridgeless have so far used `MessageQueueThread` directly to schedule work on the JS thread, instead of the Instance-managed executor.

This was always a smell, but is now actively unsafe since the modern CDP backend requires `JSExecutor` / `JSRuntime` to remain alive while work is ongoing on the JS thread. This is not guaranteed when using `MessageQueueThread` directly like we do now, but *is* guaranteed by the Instance-managed `RuntimeExecutor` (see reasoning in D54493456).

We already have access to that executor in `RuntimeTarget`, so here we ensure that it's the one used by the AgentDelegate too and eliminate the direct use of `MessageQueueThread`.

NOTE: It would have been, perhaps, nice to just house the executor inside `JSExecutor` / `JSRuntime` to begin with, instead of adding a parameter to `createAgentDelegate()`. This would require some broader refactoring which I'm choosing to avoid for now.

Differential Revision: D54539429


