### PR TITLE
Fix path to node in .xcode.env.local

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -228,7 +228,21 @@ class ReactNativePodsUtils
         end
 
         if !file_manager.exist?("#{file_path}.local")
-            node_binary = `command -v node`
+            # When installing pods with a yarn alias, yarn creates a fake yarn and node executables
+            # in a temporary folder.
+            # Using `type -a` we are able to retrieve all the paths of an executable and we can
+            # exclude the temporary ones.
+            # see https://github.com/facebook/react-native/issues/43285 for more info
+            node_binary = `type -a node`.split("\n").map { |path|
+                path.gsub!("node is ", "")
+            }
+
+            if (!node_binary[0].start_with?("/var"))
+                node_binary = node_binary[0]
+            else
+                node_binary = node_binary[1]
+            end
+
             system("echo 'export NODE_BINARY=#{node_binary}' > #{file_path}.local")
         end
     end


### PR DESCRIPTION
Summary:
This change fixes https://github.com/facebook/react-native/issues/43285.
Basically, when using a `yarn` alias to install pods, yarn creates a copy of the `node` and `yarn` executables and the `command -v node` command will return the path to that executable.

Differential Revision: D54542774


