### PR TITLE
Fix DefaultReactNativeHost assuming lazyViewManagers are always available

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -998,6 +998,11 @@ public class ReactInstanceManager {
               if (names != null) {
                 uniqueNames.addAll(names);
               }
+            } else {
+              FLog.w(
+                  ReactConstants.TAG,
+                  "Package %s is not a ViewManagerOnDemandReactPackage, view managers will not be loaded",
+                  reactPackage.getClass().getSimpleName());
             }
             Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
           }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -49,13 +49,18 @@ protected constructor(
           DefaultComponentsRegistry.register(componentFactory)
 
           val viewManagerRegistry =
-              ViewManagerRegistry(
-                  object : ViewManagerResolver {
-                    override fun getViewManager(viewManagerName: String) =
-                        reactInstanceManager.createViewManager(viewManagerName)
+              if (lazyViewManagersEnabled) {
+                ViewManagerRegistry(
+                    object : ViewManagerResolver {
+                      override fun getViewManager(viewManagerName: String) =
+                          reactInstanceManager.createViewManager(viewManagerName)
 
-                    override fun getViewManagerNames() = reactInstanceManager.viewManagerNames
-                  })
+                      override fun getViewManagerNames() = reactInstanceManager.viewManagerNames
+                    })
+              } else {
+                ViewManagerRegistry(
+                    reactInstanceManager.getOrCreateViewManagers(reactApplicationContext))
+              }
 
           FabricUIManagerProviderImpl(
                   componentFactory, ReactNativeConfig.DEFAULT_CONFIG, viewManagerRegistry)


### PR DESCRIPTION
Summary:
cortinico flagged that bridge + fabric regressed in 0.74, likely due to D53406841. 

Changelog: [Android][Fixed] Fix registration of ViewManagers in new renderer when not using lazyViewManagers.

Differential Revision: D54551645


