### PR TITLE
Move lifecycle listener inside JavaTimerManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -21,7 +21,6 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JSBundleLoaderDelegate;
 import com.facebook.react.bridge.JavaScriptContextHolder;
-import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.NativeArray;
 import com.facebook.react.bridge.NativeMap;
 import com.facebook.react.bridge.NativeModule;
@@ -143,6 +142,7 @@ final class ReactInstance {
     if (useDevSupport) {
       devSupportManager.startInspector();
     }
+
     JSTimerExecutor jsTimerExecutor = createJSTimerExecutor();
     mJavaTimerManager =
         new JavaTimerManager(
@@ -150,24 +150,6 @@ final class ReactInstance {
             jsTimerExecutor,
             ReactChoreographer.getInstance(),
             devSupportManager);
-
-    mBridgelessReactContext.addLifecycleEventListener(
-        new LifecycleEventListener() {
-          @Override
-          public void onHostResume() {
-            mJavaTimerManager.onHostResume();
-          }
-
-          @Override
-          public void onHostPause() {
-            mJavaTimerManager.onHostPause();
-          }
-
-          @Override
-          public void onHostDestroy() {
-            mJavaTimerManager.onHostDestroy();
-          }
-        });
 
     JSRuntimeFactory jsRuntimeFactory = mDelegate.getJsRuntimeFactory();
     BindingsInstaller bindingsInstaller = mDelegate.getBindingsInstaller();
@@ -448,6 +430,7 @@ final class ReactInstance {
     mQueueConfiguration.destroy();
     mTurboModuleManager.invalidate();
     mFabricUIManager.invalidate();
+    mJavaTimerManager.onInstanceDestroy();
     mHybridData.resetNative();
     mComponentNameResolverManager = null;
     mUIConstantsProviderManager = null;

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.kt
@@ -7,14 +7,19 @@
 
 package com.facebook.react.modules.timing
 
+import android.content.Context
 import android.view.Choreographer.FrameCallback
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.common.SystemClock
 import com.facebook.react.devsupport.interfaces.DevSupportManager
+import com.facebook.react.jstasks.HeadlessJsTaskConfig
+import com.facebook.react.jstasks.HeadlessJsTaskContext
+import com.facebook.react.modules.appregistry.AppRegistry
 import com.facebook.react.modules.core.JSTimers
 import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.modules.core.ReactChoreographer.CallbackType
@@ -27,9 +32,12 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.MockedStatic
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.reset
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.`when` as whenever
@@ -43,12 +51,14 @@ class TimingModuleTest {
     const val FRAME_TIME_NS = 17 * 1000 * 1000
   }
 
+  private lateinit var reactContext: ReactApplicationContext
+  private lateinit var headlessContext: HeadlessJsTaskContext
   private lateinit var timingModule: TimingModule
   private lateinit var reactChoreographerMock: ReactChoreographer
   private lateinit var postFrameCallbackHandler: PostFrameCallbackHandler
   private lateinit var idlePostFrameCallbackHandler: PostFrameCallbackHandler
   private var currentTimeNs = 0L
-  private lateinit var jSTimersMock: JSTimers
+  private lateinit var jsTimersMock: JSTimers
   private lateinit var arguments: MockedStatic<Arguments>
   private lateinit var systemClock: MockedStatic<SystemClock>
   private lateinit var reactChoreographer: MockedStatic<ReactChoreographer>
@@ -82,9 +92,11 @@ class TimingModuleTest {
         .thenAnswer { reactChoreographerMock }
 
     val reactInstance = mock(CatalystInstance::class.java)
-    val reactContext = mock(ReactApplicationContext::class.java)
-    whenever(reactContext.catalystInstance).thenReturn(reactInstance)
-    whenever(reactContext.hasActiveReactInstance()).thenReturn(true)
+    reactContext = spy(ReactApplicationContext(mock(Context::class.java)))
+    doReturn(reactInstance).`when`(reactContext).catalystInstance
+    doReturn(true).`when`(reactContext).hasActiveReactInstance()
+
+    headlessContext = HeadlessJsTaskContext.getInstance(reactContext)
 
     postFrameCallbackHandler = PostFrameCallbackHandler()
     idlePostFrameCallbackHandler = PostFrameCallbackHandler()
@@ -95,7 +107,6 @@ class TimingModuleTest {
         .thenAnswer {
           return@thenAnswer postFrameCallbackHandler.answer(it)
         }
-
     whenever(
             reactChoreographerMock.postFrameCallback(
                 eq(CallbackType.IDLE_EVENT), any(FrameCallback::class.java)))
@@ -104,12 +115,17 @@ class TimingModuleTest {
         }
 
     timingModule = TimingModule(reactContext, mock(DevSupportManager::class.java))
-    jSTimersMock = mock(JSTimers::class.java)
-    whenever(reactContext.getJSModule(JSTimers::class.java)).thenReturn(jSTimersMock)
-    whenever(reactContext.runOnJSQueueThread(any(Runnable::class.java))).thenAnswer { invocation ->
-      (invocation.arguments[0] as Runnable).run()
-      return@thenAnswer true
-    }
+    jsTimersMock = mock(JSTimers::class.java)
+    doReturn(jsTimersMock).`when`(reactContext).getJSModule(JSTimers::class.java)
+    doReturn(mock(AppRegistry::class.java))
+        .`when`(reactContext)
+        .getJSModule(AppRegistry::class.java)
+    doAnswer({ invocation ->
+          (invocation.arguments[0] as Runnable).run()
+          return@doAnswer true
+        })
+        .`when`(reactContext)
+        .runOnJSQueueThread(any(Runnable::class.java))
 
     timingModule.initialize()
   }
@@ -134,111 +150,113 @@ class TimingModuleTest {
 
   @Test
   fun testSimpleTimer() {
-    timingModule.onHostResume()
+    reactContext.onHostResume(null)
     timingModule.createTimer(1.0, 1.0, 0.0, false)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(1.0))
-    reset(jSTimersMock)
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(1.0))
+    reset(jsTimersMock)
     stepChoreographerFrame()
-    verifyNoMoreInteractions(jSTimersMock)
+    verifyNoMoreInteractions(jsTimersMock)
   }
 
   @Test
   fun testSimpleRecurringTimer() {
     timingModule.createTimer(100.0, 1.0, 0.0, true)
-    timingModule.onHostResume()
+    reactContext.onHostResume(null)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(100.0))
-    reset(jSTimersMock)
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(100.0))
+    reset(jsTimersMock)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(100.0))
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(100.0))
   }
 
   @Test
   fun testCancelRecurringTimer() {
-    timingModule.onHostResume()
+    reactContext.onHostResume(null)
     timingModule.createTimer(105.0, 1.0, 0.0, true)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(105.0))
-    reset(jSTimersMock)
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(105.0))
+    reset(jsTimersMock)
     timingModule.deleteTimer(105.0)
     stepChoreographerFrame()
-    verifyNoMoreInteractions(jSTimersMock)
+    verifyNoMoreInteractions(jsTimersMock)
   }
 
   @Test
   fun testPausingAndResuming() {
-    timingModule.onHostResume()
+    reactContext.onHostResume(null)
     timingModule.createTimer(41.0, 1.0, 0.0, true)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(41.0))
-    reset(jSTimersMock)
-    timingModule.onHostPause()
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(41.0))
+    reset(jsTimersMock)
+    reactContext.onHostPause()
     stepChoreographerFrame()
-    verifyNoMoreInteractions(jSTimersMock)
-    reset(jSTimersMock)
-    timingModule.onHostResume()
+    verifyNoMoreInteractions(jsTimersMock)
+    reset(jsTimersMock)
+    reactContext.onHostResume(null)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(41.0))
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(41.0))
   }
 
   @Test
   fun testHeadlessJsTaskInBackground() {
-    timingModule.onHostPause()
-    timingModule.onHeadlessJsTaskStart(42)
+    reactContext.onHostPause()
+    val taskConfig = HeadlessJsTaskConfig("foo", JavaOnlyMap())
+    val taskId = headlessContext.startTask(taskConfig)
     timingModule.createTimer(41.0, 1.0, 0.0, true)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(41.0))
-    reset(jSTimersMock)
-    timingModule.onHeadlessJsTaskFinish(42)
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(41.0))
+    reset(jsTimersMock)
+    headlessContext.finishTask(taskId)
     stepChoreographerFrame()
-    verifyNoMoreInteractions(jSTimersMock)
+    verifyNoMoreInteractions(jsTimersMock)
   }
 
   @Test
   fun testHeadlessJsTaskInForeground() {
-    timingModule.onHostResume()
-    timingModule.onHeadlessJsTaskStart(42)
+    val taskConfig = HeadlessJsTaskConfig("foo", JavaOnlyMap())
+    val taskId = headlessContext.startTask(taskConfig)
+    reactContext.onHostResume(null)
     timingModule.createTimer(41.0, 1.0, 0.0, true)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(41.0))
-    reset(jSTimersMock)
-    timingModule.onHeadlessJsTaskFinish(42)
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(41.0))
+    reset(jsTimersMock)
+    headlessContext.finishTask(taskId)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(41.0))
-    reset(jSTimersMock)
-    timingModule.onHostPause()
-    verifyNoMoreInteractions(jSTimersMock)
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(41.0))
+    reset(jsTimersMock)
+    reactContext.onHostPause()
+    verifyNoMoreInteractions(jsTimersMock)
   }
 
   @Test
   fun testHeadlessJsTaskIntertwine() {
-    timingModule.onHostResume()
-    timingModule.onHeadlessJsTaskStart(42)
     timingModule.createTimer(41.0, 1.0, 0.0, true)
-    timingModule.onHostPause()
+    reactContext.onHostPause()
+    val taskConfig = HeadlessJsTaskConfig("foo", JavaOnlyMap())
+    val taskId = headlessContext.startTask(taskConfig)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(41.0))
-    reset(jSTimersMock)
-    timingModule.onHostResume()
-    timingModule.onHeadlessJsTaskFinish(42)
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(41.0))
+    reset(jsTimersMock)
+    reactContext.onHostResume(null)
+    headlessContext.finishTask(taskId)
     stepChoreographerFrame()
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(41.0))
-    reset(jSTimersMock)
-    timingModule.onHostPause()
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(41.0))
+    reset(jsTimersMock)
+    reactContext.onHostPause()
     stepChoreographerFrame()
-    verifyNoMoreInteractions(jSTimersMock)
+    verifyNoMoreInteractions(jsTimersMock)
   }
 
   @Test
   fun testSetTimeoutZero() {
     timingModule.createTimer(100.0, 0.0, 0.0, false)
-    verify(jSTimersMock).callTimers(JavaOnlyArray.of(100.0))
+    verify(jsTimersMock).callTimers(JavaOnlyArray.of(100.0))
   }
 
   @Test
   fun testActiveTimersInRange() {
-    timingModule.onHostResume()
+    reactContext.onHostResume(null)
     assertThat(timingModule.hasActiveTimersInRange(100)).isFalse
     timingModule.createTimer(41.0, 1.0, 0.0, true)
     assertThat(timingModule.hasActiveTimersInRange(100)).isFalse // Repeating
@@ -250,13 +268,12 @@ class TimingModuleTest {
   @Test
   fun testIdleCallback() {
     timingModule.setSendIdleEvents(true)
-    timingModule.onHostResume()
+    reactContext.onHostResume(null)
     stepChoreographerFrame()
-    verify(jSTimersMock).callIdleCallbacks(SystemClock.currentTimeMillis().toDouble())
+    verify(jsTimersMock).callIdleCallbacks(SystemClock.currentTimeMillis().toDouble())
   }
 
   private class PostFrameCallbackHandler : Answer<Unit> {
-
     private var frameCallback: FrameCallback? = null
 
     override fun answer(invocation: InvocationOnMock) {


### PR DESCRIPTION
Summary:
Reafactor JavaTimerManager so more code is shared between bridge and bridgeless.

Note that HeadlessJSTaskContext is not currently configured when using bridgeless.

Changelog: [Internal]

Differential Revision: D54496604


