### PR TITLE
Allow importing RCTAppDelegate in Swift

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate+Protected.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate+Protected.h
@@ -4,9 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+#if defined(__cplusplus)
 
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import "RCTAppDelegate.h"
 
 @interface RCTAppDelegate () <RCTTurboModuleManagerDelegate>
 @end
+
+#endif

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -7,41 +7,28 @@
 
 #import "RCTAppDelegate.h"
 #import <React/RCTColorSpaceUtils.h>
-#import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTLog.h>
 #import <React/RCTRootView.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 #import <React/RCTUtils.h>
 #import <react/renderer/graphics/ColorComponents.h>
-#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import "RCTAppDelegate+Protected.h"
 #import "RCTAppSetupUtils.h"
+#import <objc/runtime.h>
 
 #if RN_DISABLE_OSS_PLUGIN_HEADER
 #import <RCTTurboModulePlugin/RCTTurboModulePlugin.h>
 #else
 #import <React/CoreModulesPlugins.h>
 #endif
-#import <React/RCTBundleURLProvider.h>
 #import <React/RCTComponentViewFactory.h>
 #import <React/RCTComponentViewProtocol.h>
-#import <React/RCTFabricSurface.h>
-#import <React/RCTSurfaceHostingProxyRootView.h>
-#import <React/RCTSurfacePresenter.h>
-#import <ReactCommon/RCTContextContainerHandling.h>
 #if USE_HERMES
 #import <ReactCommon/RCTHermesInstance.h>
 #else
 #import <ReactCommon/RCTJscInstance.h>
 #endif
-#import <ReactCommon/RCTHost+Internal.h>
-#import <ReactCommon/RCTHost.h>
-#import <ReactCommon/RCTTurboModuleManager.h>
-#import <react/config/ReactNativeConfig.h>
 #import <react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h>
-#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
-#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
-#import <react/runtime/JSRuntimeFactory.h>
 
 @interface RCTAppDelegate () <RCTComponentViewFactoryComponentProvider>
 @end

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -131,6 +131,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
         initWithSurface:surface
         sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact];
 
+    surfaceHostingProxyRootView.backgroundColor = [UIColor systemBackgroundColor];
     return surfaceHostingProxyRootView;
   }
 


### PR DESCRIPTION
## Summary:

This PR fixes importing RCTAppDelegate, cleans up the imports, and properly sets the background color for bridgeless mode when using `RCTRootViewFactory`.

The issue with importing to Swift was that `RCTTurboModuleManager` has C++ in headers which caused Swift to error out. 

## Changelog:

[IOS] [FIXED] - Allow importing RCTAppDelegate in Swift
[INTERNAL] [REMOVED] - Remove unnecessary imports in AppDelegate
[INTERNAL] [FIXED] - Properly set background color for bridgeless

## Test Plan:

- CI Green
- Check if background color is correct
