### PR TITLE
[TextInput][Android] :-fixes Text scroll Issue on first render in android with default Value

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -129,6 +129,7 @@ public class ReactEditText extends AppCompatEditText {
 
   private static final KeyListener sKeyListener = QwertyKeyListener.getInstanceForFullKeyboard();
   private @Nullable EventDispatcher mEventDispatcher;
+  public boolean isFirstRender = true;
 
   public ReactEditText(Context context) {
     super(context);
@@ -677,6 +678,9 @@ public class ReactEditText extends AppCompatEditText {
     // text so, we have to set text to null, which will clear the currently composing text.
     if (reactTextUpdate.getText().length() == 0) {
       setText(null);
+       } else if (isFirstRender && !hasFocus()) {
+      setText(spannableStringBuilder);
+      isFirstRender = false;
     } else {
       // When we update text, we trigger onChangeText code that will
       // try to update state if the wrapper is available. Temporarily disable

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -368,7 +368,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       boolean isCurrentSelectionEmpty = view.getSelectionStart() == view.getSelectionEnd();
       int selectionStart = UNSET;
       int selectionEnd = UNSET;
-      if (isCurrentSelectionEmpty) {
+      if (isCurrentSelectionEmpty && !view.isFirstRender) {
         // if selection is not set by state, shift current selection to ensure constant gap to
         // text end
         int textLength = view.getText() == null ? 0 : view.getText().length();

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -848,6 +848,17 @@ module.exports = ([
     },
   },
   {
+    title: 'Long text behavior',
+    render: function (): React.Node {
+      return (
+        <TextInput
+          style={styles.default}
+          defaultValue="It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout."
+        />
+      );
+    },
+  },
+  {
     name: 'maxLength',
     title: "Live Re-Write (<sp>  ->  '_') + maxLength",
     render: function (): React.Node {


### PR DESCRIPTION
## Summary:

On rendering The `TextInput` with `defaultValue`  at a case when the text string is longer than the screen size , a weird behaviour follows on android, where the leftmost text characters gets cut off and hidden, the reason is the cursor which moves to the end.

The cause of the same to my understanding is how the text is getting updated inside the `ReactEditText`. it has a range which it replaces with the text provided, if the cursor is in close proximity , the same is moved to the end for the replaced text.

the solution that i used is pretty straightforward, we need to make sure our cursor's position should be at the start of the text for the first render, we can just simply use the `setText()` method from the `EditText`, while we create the editText for the first time in the render cycle. 
I have introduced a flag variable of `isFirstRender` initialised to `true`, this would allow us to call the `EditText` method and then eventually toggling it to false.

## Changelog:

[ANDROID] [Fixed] - Fixes The Position of cursor on Overflowing Text on Android Text Input


## Test Plan:

All Test Passing
Checked on RN TESTER
Long Text Behaviour section has been added to demonstrate the same

Before
![Screenshot_1709111184](https://github.com/facebook/react-native/assets/72331432/3ba07875-1e1c-4907-b879-8b991984f230)

After

![Screenshot_1709111606](https://github.com/facebook/react-native/assets/72331432/7fa8d510-65ef-4013-90c0-0baed62859ee)
