### PR TITLE
[RN][iOS][0.71] Fix flipper for Xcode 15.3

### DIFF
--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.71.16)
-  - FBReactNativeSpec (0.71.16):
+  - FBLazyVector (0.71.17)
+  - FBReactNativeSpec (0.71.17):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-Core (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-Core (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -73,9 +73,9 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.71.16):
-    - hermes-engine/Pre-built (= 0.71.16)
-  - hermes-engine/Pre-built (0.71.16)
+  - hermes-engine (0.71.17):
+    - hermes-engine/Pre-built (= 0.71.17)
+  - hermes-engine/Pre-built (0.71.17)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -100,26 +100,26 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.71.16)
-  - RCTTypeSafety (0.71.16):
-    - FBLazyVector (= 0.71.16)
-    - RCTRequired (= 0.71.16)
-    - React-Core (= 0.71.16)
-  - React (0.71.16):
-    - React-Core (= 0.71.16)
-    - React-Core/DevSupport (= 0.71.16)
-    - React-Core/RCTWebSocket (= 0.71.16)
-    - React-RCTActionSheet (= 0.71.16)
-    - React-RCTAnimation (= 0.71.16)
-    - React-RCTBlob (= 0.71.16)
-    - React-RCTImage (= 0.71.16)
-    - React-RCTLinking (= 0.71.16)
-    - React-RCTNetwork (= 0.71.16)
-    - React-RCTSettings (= 0.71.16)
-    - React-RCTText (= 0.71.16)
-    - React-RCTVibration (= 0.71.16)
-  - React-callinvoker (0.71.16)
-  - React-Codegen (0.71.16):
+  - RCTRequired (0.71.17)
+  - RCTTypeSafety (0.71.17):
+    - FBLazyVector (= 0.71.17)
+    - RCTRequired (= 0.71.17)
+    - React-Core (= 0.71.17)
+  - React (0.71.17):
+    - React-Core (= 0.71.17)
+    - React-Core/DevSupport (= 0.71.17)
+    - React-Core/RCTWebSocket (= 0.71.17)
+    - React-RCTActionSheet (= 0.71.17)
+    - React-RCTAnimation (= 0.71.17)
+    - React-RCTBlob (= 0.71.17)
+    - React-RCTImage (= 0.71.17)
+    - React-RCTLinking (= 0.71.17)
+    - React-RCTNetwork (= 0.71.17)
+    - React-RCTSettings (= 0.71.17)
+    - React-RCTText (= 0.71.17)
+    - React-RCTVibration (= 0.71.17)
+  - React-callinvoker (0.71.17)
+  - React-Codegen (0.71.17):
     - FBReactNativeSpec
     - hermes-engine
     - RCT-Folly
@@ -132,655 +132,655 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.71.16):
+  - React-Core (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.16)
-    - React-cxxreact (= 0.71.16)
+    - React-Core/Default (= 0.71.17)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.71.16):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.71.16)
-    - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-    - Yoga
-  - React-Core/Default (0.71.16):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.16)
-    - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-    - Yoga
-  - React-Core/DevSupport (0.71.16):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.16)
-    - React-Core/RCTWebSocket (= 0.71.16)
-    - React-cxxreact (= 0.71.16)
-    - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-jsinspector (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.71.16):
+  - React-Core/CoreModulesHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.71.16):
+  - React-Core/Default (0.71.17):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact (= 0.71.17)
+    - React-hermes
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+    - Yoga
+  - React-Core/DevSupport (0.71.17):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.71.17)
+    - React-Core/RCTWebSocket (= 0.71.17)
+    - React-cxxreact (= 0.71.17)
+    - React-hermes
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-jsinspector (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.71.16):
+  - React-Core/RCTAnimationHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTImageHeaders (0.71.16):
+  - React-Core/RCTBlobHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.71.16):
+  - React-Core/RCTImageHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.71.16):
+  - React-Core/RCTLinkingHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.71.16):
+  - React-Core/RCTNetworkHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.71.16):
+  - React-Core/RCTPushNotificationHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTTextHeaders (0.71.16):
+  - React-Core/RCTSettingsHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.71.16):
+  - React-Core/RCTTextHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-Core/RCTWebSocket (0.71.16):
+  - React-Core/RCTVibrationHeaders (0.71.17):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.16)
-    - React-cxxreact (= 0.71.16)
+    - React-Core/Default
+    - React-cxxreact (= 0.71.17)
     - React-hermes
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-perflogger (= 0.71.16)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
     - Yoga
-  - React-CoreModules (0.71.16):
+  - React-Core/RCTWebSocket (0.71.17):
+    - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.16)
-    - React-Codegen (= 0.71.16)
-    - React-Core/CoreModulesHeaders (= 0.71.16)
-    - React-jsi (= 0.71.16)
+    - React-Core/Default (= 0.71.17)
+    - React-cxxreact (= 0.71.17)
+    - React-hermes
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+    - Yoga
+  - React-CoreModules (0.71.17):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.71.17)
+    - React-Codegen (= 0.71.17)
+    - React-Core/CoreModulesHeaders (= 0.71.17)
+    - React-jsi (= 0.71.17)
     - React-RCTBlob
-    - React-RCTImage (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-cxxreact (0.71.16):
+    - React-RCTImage (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-cxxreact (0.71.17):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsinspector (= 0.71.16)
-    - React-logger (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-    - React-runtimeexecutor (= 0.71.16)
-  - React-Fabric (0.71.16):
+    - React-callinvoker (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsinspector (= 0.71.17)
+    - React-logger (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+    - React-runtimeexecutor (= 0.71.17)
+  - React-Fabric (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-Fabric/animations (= 0.71.16)
-    - React-Fabric/attributedstring (= 0.71.16)
-    - React-Fabric/butter (= 0.71.16)
-    - React-Fabric/componentregistry (= 0.71.16)
-    - React-Fabric/componentregistrynative (= 0.71.16)
-    - React-Fabric/components (= 0.71.16)
-    - React-Fabric/config (= 0.71.16)
-    - React-Fabric/core (= 0.71.16)
-    - React-Fabric/debug_core (= 0.71.16)
-    - React-Fabric/debug_renderer (= 0.71.16)
-    - React-Fabric/imagemanager (= 0.71.16)
-    - React-Fabric/leakchecker (= 0.71.16)
-    - React-Fabric/mapbuffer (= 0.71.16)
-    - React-Fabric/mounting (= 0.71.16)
-    - React-Fabric/runtimescheduler (= 0.71.16)
-    - React-Fabric/scheduler (= 0.71.16)
-    - React-Fabric/telemetry (= 0.71.16)
-    - React-Fabric/templateprocessor (= 0.71.16)
-    - React-Fabric/textlayoutmanager (= 0.71.16)
-    - React-Fabric/uimanager (= 0.71.16)
-    - React-Fabric/utils (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/animations (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-Fabric/animations (= 0.71.17)
+    - React-Fabric/attributedstring (= 0.71.17)
+    - React-Fabric/butter (= 0.71.17)
+    - React-Fabric/componentregistry (= 0.71.17)
+    - React-Fabric/componentregistrynative (= 0.71.17)
+    - React-Fabric/components (= 0.71.17)
+    - React-Fabric/config (= 0.71.17)
+    - React-Fabric/core (= 0.71.17)
+    - React-Fabric/debug_core (= 0.71.17)
+    - React-Fabric/debug_renderer (= 0.71.17)
+    - React-Fabric/imagemanager (= 0.71.17)
+    - React-Fabric/leakchecker (= 0.71.17)
+    - React-Fabric/mapbuffer (= 0.71.17)
+    - React-Fabric/mounting (= 0.71.17)
+    - React-Fabric/runtimescheduler (= 0.71.17)
+    - React-Fabric/scheduler (= 0.71.17)
+    - React-Fabric/telemetry (= 0.71.17)
+    - React-Fabric/templateprocessor (= 0.71.17)
+    - React-Fabric/textlayoutmanager (= 0.71.17)
+    - React-Fabric/uimanager (= 0.71.17)
+    - React-Fabric/utils (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/animations (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/attributedstring (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/attributedstring (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/butter (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/butter (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/componentregistry (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/componentregistry (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/componentregistrynative (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/componentregistrynative (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-Fabric/components/activityindicator (= 0.71.16)
-    - React-Fabric/components/image (= 0.71.16)
-    - React-Fabric/components/inputaccessory (= 0.71.16)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.71.16)
-    - React-Fabric/components/modal (= 0.71.16)
-    - React-Fabric/components/root (= 0.71.16)
-    - React-Fabric/components/safeareaview (= 0.71.16)
-    - React-Fabric/components/scrollview (= 0.71.16)
-    - React-Fabric/components/slider (= 0.71.16)
-    - React-Fabric/components/text (= 0.71.16)
-    - React-Fabric/components/textinput (= 0.71.16)
-    - React-Fabric/components/unimplementedview (= 0.71.16)
-    - React-Fabric/components/view (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/activityindicator (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-Fabric/components/activityindicator (= 0.71.17)
+    - React-Fabric/components/image (= 0.71.17)
+    - React-Fabric/components/inputaccessory (= 0.71.17)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.71.17)
+    - React-Fabric/components/modal (= 0.71.17)
+    - React-Fabric/components/root (= 0.71.17)
+    - React-Fabric/components/safeareaview (= 0.71.17)
+    - React-Fabric/components/scrollview (= 0.71.17)
+    - React-Fabric/components/slider (= 0.71.17)
+    - React-Fabric/components/text (= 0.71.17)
+    - React-Fabric/components/textinput (= 0.71.17)
+    - React-Fabric/components/unimplementedview (= 0.71.17)
+    - React-Fabric/components/view (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/activityindicator (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/image (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/image (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/inputaccessory (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/inputaccessory (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/legacyviewmanagerinterop (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/legacyviewmanagerinterop (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/modal (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/modal (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/root (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/root (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/safeareaview (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/safeareaview (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/scrollview (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/scrollview (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/slider (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/slider (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/text (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/text (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/textinput (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/textinput (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/unimplementedview (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/unimplementedview (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/components/view (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/components/view (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
     - Yoga
-  - React-Fabric/config (0.71.16):
+  - React-Fabric/config (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/core (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/core (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/debug_core (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/debug_core (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/debug_renderer (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/debug_renderer (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/imagemanager (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/imagemanager (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - React-RCTImage (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/leakchecker (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - React-RCTImage (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/leakchecker (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/mapbuffer (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/mapbuffer (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/mounting (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/mounting (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/runtimescheduler (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/runtimescheduler (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/scheduler (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/scheduler (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/telemetry (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/telemetry (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/templateprocessor (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/templateprocessor (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/textlayoutmanager (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/textlayoutmanager (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
     - React-Fabric/uimanager
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/uimanager (0.71.16):
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/uimanager (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-Fabric/utils (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-Fabric/utils (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.16)
-    - RCTTypeSafety (= 0.71.16)
-    - React-graphics (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-jsiexecutor (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-graphics (0.71.16):
+    - RCTRequired (= 0.71.17)
+    - RCTTypeSafety (= 0.71.17)
+    - React-graphics (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-jsiexecutor (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-graphics (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.16)
-  - React-hermes (0.71.16):
+    - React-Core/Default (= 0.71.17)
+  - React-hermes (0.71.17):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - RCT-Folly/Futures (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.16)
+    - React-cxxreact (= 0.71.17)
     - React-jsi
-    - React-jsiexecutor (= 0.71.16)
-    - React-jsinspector (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-  - React-jsi (0.71.16):
+    - React-jsiexecutor (= 0.71.17)
+    - React-jsinspector (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+  - React-jsi (0.71.17):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.71.16):
+  - React-jsiexecutor (0.71.17):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-  - React-jsinspector (0.71.16)
-  - React-logger (0.71.16):
+    - React-cxxreact (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+  - React-jsinspector (0.71.17)
+  - React-logger (0.71.17):
     - glog
-  - React-perflogger (0.71.16)
-  - React-RCTActionSheet (0.71.16):
-    - React-Core/RCTActionSheetHeaders (= 0.71.16)
-  - React-RCTAnimation (0.71.16):
+  - React-perflogger (0.71.17)
+  - React-RCTActionSheet (0.71.17):
+    - React-Core/RCTActionSheetHeaders (= 0.71.17)
+  - React-RCTAnimation (0.71.17):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.16)
-    - React-Codegen (= 0.71.16)
-    - React-Core/RCTAnimationHeaders (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-RCTAppDelegate (0.71.16):
+    - RCTTypeSafety (= 0.71.17)
+    - React-Codegen (= 0.71.17)
+    - React-Core/RCTAnimationHeaders (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-RCTAppDelegate (0.71.17):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
     - ReactCommon/turbomodule/core
-  - React-RCTBlob (0.71.16):
+  - React-RCTBlob (0.71.17):
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.71.16)
-    - React-Core/RCTBlobHeaders (= 0.71.16)
-    - React-Core/RCTWebSocket (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-RCTNetwork (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-RCTFabric (0.71.16):
+    - React-Codegen (= 0.71.17)
+    - React-Core/RCTBlobHeaders (= 0.71.17)
+    - React-Core/RCTWebSocket (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-RCTNetwork (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-RCTFabric (0.71.17):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core (= 0.71.16)
-    - React-Fabric (= 0.71.16)
-    - React-RCTImage (= 0.71.16)
-  - React-RCTImage (0.71.16):
+    - React-Core (= 0.71.17)
+    - React-Fabric (= 0.71.17)
+    - React-RCTImage (= 0.71.17)
+  - React-RCTImage (0.71.17):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.16)
-    - React-Codegen (= 0.71.16)
-    - React-Core/RCTImageHeaders (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-RCTNetwork (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-RCTLinking (0.71.16):
-    - React-Codegen (= 0.71.16)
-    - React-Core/RCTLinkingHeaders (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-RCTNetwork (0.71.16):
+    - RCTTypeSafety (= 0.71.17)
+    - React-Codegen (= 0.71.17)
+    - React-Core/RCTImageHeaders (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-RCTNetwork (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-RCTLinking (0.71.17):
+    - React-Codegen (= 0.71.17)
+    - React-Core/RCTLinkingHeaders (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-RCTNetwork (0.71.17):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.16)
-    - React-Codegen (= 0.71.16)
-    - React-Core/RCTNetworkHeaders (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-RCTPushNotification (0.71.16):
-    - RCTTypeSafety (= 0.71.16)
-    - React-Codegen (= 0.71.16)
-    - React-Core/RCTPushNotificationHeaders (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-RCTSettings (0.71.16):
+    - RCTTypeSafety (= 0.71.17)
+    - React-Codegen (= 0.71.17)
+    - React-Core/RCTNetworkHeaders (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-RCTPushNotification (0.71.17):
+    - RCTTypeSafety (= 0.71.17)
+    - React-Codegen (= 0.71.17)
+    - React-Core/RCTPushNotificationHeaders (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-RCTSettings (0.71.17):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.16)
-    - React-Codegen (= 0.71.16)
-    - React-Core/RCTSettingsHeaders (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-RCTTest (0.71.16):
+    - RCTTypeSafety (= 0.71.17)
+    - React-Codegen (= 0.71.17)
+    - React-Core/RCTSettingsHeaders (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-RCTTest (0.71.17):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core (= 0.71.16)
-    - React-CoreModules (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-RCTText (0.71.16):
-    - React-Core/RCTTextHeaders (= 0.71.16)
-  - React-RCTVibration (0.71.16):
+    - React-Core (= 0.71.17)
+    - React-CoreModules (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-RCTText (0.71.17):
+    - React-Core/RCTTextHeaders (= 0.71.17)
+  - React-RCTVibration (0.71.17):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.71.16)
-    - React-Core/RCTVibrationHeaders (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
-  - React-rncore (0.71.16)
-  - React-runtimeexecutor (0.71.16):
-    - React-jsi (= 0.71.16)
-  - ReactCommon/turbomodule/bridging (0.71.16):
+    - React-Codegen (= 0.71.17)
+    - React-Core/RCTVibrationHeaders (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
+  - React-rncore (0.71.17)
+  - React-runtimeexecutor (0.71.17):
+    - React-jsi (= 0.71.17)
+  - ReactCommon/turbomodule/bridging (0.71.17):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.16)
-    - React-Core (= 0.71.16)
-    - React-cxxreact (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-logger (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-  - ReactCommon/turbomodule/core (0.71.16):
+    - React-callinvoker (= 0.71.17)
+    - React-Core (= 0.71.17)
+    - React-cxxreact (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-logger (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+  - ReactCommon/turbomodule/core (0.71.17):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.16)
-    - React-Core (= 0.71.16)
-    - React-cxxreact (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-logger (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-  - ReactCommon/turbomodule/samples (0.71.16):
+    - React-callinvoker (= 0.71.17)
+    - React-Core (= 0.71.17)
+    - React-cxxreact (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-logger (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+  - ReactCommon/turbomodule/samples (0.71.17):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.16)
-    - React-Core (= 0.71.16)
-    - React-cxxreact (= 0.71.16)
-    - React-jsi (= 0.71.16)
-    - React-logger (= 0.71.16)
-    - React-perflogger (= 0.71.16)
-    - ReactCommon/turbomodule/core (= 0.71.16)
+    - React-callinvoker (= 0.71.17)
+    - React-Core (= 0.71.17)
+    - React-cxxreact (= 0.71.17)
+    - React-jsi (= 0.71.17)
+    - React-logger (= 0.71.17)
+    - React-perflogger (= 0.71.17)
+    - ReactCommon/turbomodule/core (= 0.71.17)
   - ScreenshotManager (0.0.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -964,9 +964,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: 9840513ec2766e31fb9e34c2dabb2c4671400fcd
-  FBReactNativeSpec: 510e811a56c257b4b1e3e9ea9ec0f4199f9be314
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
+  FBLazyVector: 719c60593e0a5b54cba28d1e50250581efff79d2
+  FBReactNativeSpec: 6b9f133bc3cfa4a32528e6d2d7bd981e7a7289bc
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -977,48 +977,48 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 2382506846564caf4152c45390dc24f08fce7057
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  hermes-engine: 7d82f250301e83c48ec0857c6810283d787b61da
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
-  RCTRequired: 44a3cda52ccac0be738fbf43fef90f3546a48c52
-  RCTTypeSafety: da7fbf9826fc898ca8b10dc840f2685562039a64
-  React: defd955b6d6ffb9791bb66dee08d90b87a8e2c0c
-  React-callinvoker: 39ea57213d56ec9c527d51bd0dfb45cbb12ef447
-  React-Codegen: 36395766ab7ae5f4e7a2b3d22909e71ea0589760
-  React-Core: 898cb2f7785640e21d381b23fc64a2904628b368
-  React-CoreModules: 7f71e7054395d61585048061a66d67b58d3d27b7
-  React-cxxreact: 57fca29dd6995de0ee360980709c4be82d40cda1
-  React-Fabric: 497eb843376544dfbe37cc6c334d8bd18cdff63b
-  React-graphics: 313d5aff65e62453b8bcd5c0c437448a4f01200b
-  React-hermes: 33229fc1867df496665b36b222a82a0f850bcae1
-  React-jsi: 3a55652789df6ddd777cce9601bf000e18d6b9df
-  React-jsiexecutor: 9b2a87f674f30da4706af52520e4860974cec149
-  React-jsinspector: b3b341764ccda14f3659c00a9bc5b098b334db2b
-  React-logger: dc96fadd2f7f6bc38efc3cfb5fef876d4e6290a2
-  React-perflogger: c944b06edad34f5ecded0f29a6e66290a005d365
-  React-RCTActionSheet: fa467f37777dacba2c72da4be7ae065da4482d7d
-  React-RCTAnimation: 0591ee5f9e3d8c864a0937edea2165fe968e7099
-  React-RCTAppDelegate: 8b7f60103a83ad1670bda690571e73efddba29a0
-  React-RCTBlob: 082e8612f48b0ec12ca6dc949fb7c310593eff83
-  React-RCTFabric: 71d180575130f799cc466ffd7b2a5ef7903ab1f8
-  React-RCTImage: 6300660ef04d0e8a710ad9ea5d2fb4d9521c200d
-  React-RCTLinking: 7703ee1b10d3568c143a489ae74adc419c3f3ef3
-  React-RCTNetwork: 5748c647e09c66b918f81ae15ed7474327f653be
-  React-RCTPushNotification: 550538bea1aa073efc706afa5749a6f3107484b0
-  React-RCTSettings: 8c8a84ee363db9cbc287c8b8f2fb782acf7ba414
-  React-RCTTest: 09d2227cadfb85cd29a608af540d2787b360b623
-  React-RCTText: d5e53c0741e3e2df91317781e993b5e42bd70448
-  React-RCTVibration: 052dd488ba95f461a37c992b9e01bd4bcc59a7b6
-  React-rncore: 5d2bb753849256d058b3986f96823102f6f7c21b
-  React-runtimeexecutor: b5abe02558421897cd9f73d4f4b6adb4bc297083
-  ReactCommon: a1a263d94f02a0dc8442f341d5a11b3d7a9cd44d
+  RCTRequired: 90f1bac0c9682cd0f725922a79fbc064836f06bb
+  RCTTypeSafety: 14a5fd9ec04e2807eff1fcd22a293befd68de90f
+  React: fcf49ebf29d43e90507c7aafaa59e97b2bb45def
+  React-callinvoker: 614178adcfb8b8a625f05fc5d9d4f41bef0537e2
+  React-Codegen: 8545c3b00c020ffb029ae8ee07d8d81863ae5556
+  React-Core: 8a82312634818407546aeef822d0d6bf6267d327
+  React-CoreModules: 1233334b72d7af5c6f8ab2fa25de6e7e86fdaaea
+  React-cxxreact: 937cae3d092ca0e1657b93adae3b09bf31c9a778
+  React-Fabric: 9d7ce66f79df9e300c7a0ef9893e89a2b250b9d0
+  React-graphics: 056af55a8e64435bc54efa696add444ca6cc37ac
+  React-hermes: 15043539bccf5cfd22c2de2fc9d4d234a6c78007
+  React-jsi: d7e4018b6e18e5607ab1c0a17c01dc85e904eefb
+  React-jsiexecutor: 62ec957dd5be4519b56c7965ee7156063ffcf765
+  React-jsinspector: aadc7a5f156f047800ab3d51f6a10ce5b009109d
+  React-logger: a41d4cad677e9726b71a45a4012431d2fb1edd80
+  React-perflogger: 2588b59d386dbbc1df392da9493a8baa690bc89c
+  React-RCTActionSheet: 057d6c6fc29e2a6d183d323ef35d9f6aedae936b
+  React-RCTAnimation: 4c25b2c7953ea5b983eda940922fb4036f03e3f1
+  React-RCTAppDelegate: 2cbd92fefacafd31283f02a46c2c0eb4c5ba5adf
+  React-RCTBlob: 7710e8c24a33c9a590f20dc81d1e7fed99dd4576
+  React-RCTFabric: e201a78951798c5f7a43646fd16c468e5b0d3b54
+  React-RCTImage: 7e13cfb10121d027d16b544b04e753c96c15d53e
+  React-RCTLinking: bee7bbe68fe4f758cfcadae113d47b44e86d6b1e
+  React-RCTNetwork: 1c4de789e12da8f892b6e1248192a20bac74db4c
+  React-RCTPushNotification: 007c31c4f26d556834f98bfa34a9cf5bc7003a0a
+  React-RCTSettings: 67929605cb023aab73fb6926f9e8ce5cc9ceedc7
+  React-RCTTest: 66d4377a6ad7daa1a0100e479810bff43b3d4182
+  React-RCTText: 8c793c96183e085fffb823cf49ecd3d247655d90
+  React-RCTVibration: 6bdf9ae4d6cada21ab251c5ec4ebbb53b2c442da
+  React-rncore: 55682fef05e969d6f65b6bc18b6ed83df4a85d75
+  React-runtimeexecutor: 304198fed11471da368cf5d1ce933b84e1288c0b
+  ReactCommon: 91850c06577766d9970edec2a6929a6e14865a21
   ScreenshotManager: e77ad8e427160ebce1f86313e2b21ea56b665285
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: e29645ec5a66fb00934fad85338742d1c247d4cb
+  Yoga: fb40589bb1a96e2573358586fc2903b3811ce254
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 8da43cb75927abd2bbb2fc21dcebfebb05b89963
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -144,6 +144,27 @@ class ReactNativePodsUtils
         end
     end
 
+    def self.fix_flipper_for_xcode_15_3(installer)
+        installer.pods_project.targets.each do |target|
+            if target.name == 'Flipper'
+                file_path = 'Pods/Flipper/xplat/Flipper/FlipperTransportTypes.h'
+                if !File.exist?(file_path)
+                    return
+                end
+
+                contents = File.read(file_path)
+                if contents.include?('#include <functional>')
+                    return
+                end
+                mod_content = contents.gsub("#pragma once", "#pragma once\n#include <functional>")
+                File.chmod(0755, file_path)
+                File.open(file_path, 'w') do |file|
+                    file.puts(mod_content)
+                end
+            end
+        end
+    end
+
     def self.apply_xcode_15_patch(installer, xcodebuild_manager: Xcodebuild)
         projects = self.extract_projects(installer)
 

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -226,6 +226,7 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
   ReactNativePodsUtils.apply_xcode_15_patch(installer)
   ReactNativePodsUtils.updateIphoneOSDeploymentTarget(installer)
+  ReactNativePodsUtils.fix_flipper_for_xcode_15_3(installer)
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   is_new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == "1"


### PR DESCRIPTION
## Summary
Following https://github.com/facebook/react-native/issues/43335, we implemented the fix suggested [here](https://github.com/facebook/react-native/issues/43335#issuecomment-1980708164).

The rationale of applying this fix rather then releasing a new version of Flipper is because we will have to release Flipper `0.248.0`, and the latest flipper version on Cocoapods is `0.233.0` (15 versions behind).

Plus, we have to port the fix to 0.73 and 0.72 and bumping Flipper there would be a major pain and it might require more time and introduce other bugs we don't want.

## Changelog
[iOS][Fixed] - Make 0.71 build with Xcode 15.3

## Test Plan
Tested locally + CircleCI is green
