### PR TITLE
[Android] Support `onActivityResult` on bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -139,7 +139,7 @@ public class ReactDelegate {
   public void onActivityResult(
       int requestCode, int resultCode, Intent data, boolean shouldForwardToReactInstance) {
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      // TODO T156475655: Implement onActivityResult for Bridgeless
+      mReactHost.onActivityResult(mActivity, requestCode, resultCode, data);
     } else {
       if (getReactNativeHost().hasInstance() && shouldForwardToReactInstance) {
         getReactNativeHost()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -9,6 +9,7 @@ package com.facebook.react
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
@@ -71,6 +72,9 @@ public interface ReactHost {
 
   /** To be called when the host activity is destroyed. */
   public fun onHostDestroy(activity: Activity?)
+
+  /** To be called when the host activity receives a result . */
+  public fun onActivityResult(activity: Activity?, requestCode: Int, resultCode: Int, data: Intent)
 
   /** To be called to create and setup an ReactSurface. */
   public fun createSurface(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -15,6 +15,7 @@ import static java.lang.Boolean.TRUE;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -354,6 +355,19 @@ public class ReactHostImpl implements ReactHost {
     // TODO(T137233065): Disable DevSupportManager here
     if (currentActivity == activity) {
       moveToHostDestroy(getCurrentReactContext());
+    }
+  }
+
+  /** To be called when the host activity receives a result. */
+  @ThreadConfined(UI)
+  @Override
+  public void onActivityResult(@Nullable Activity activity, int requestCode, int resultCode, @Nullable Intent data) {
+    final String method = "onActivityResult(activity, requestCode, resultCode, data)";
+    log(method);
+
+    ReactContext currentContext = this.getCurrentReactContext();
+    if (currentContext != null) {
+      currentContext.onActivityResult(activity, requestCode, resultCode, data);
     }
   }
 


### PR DESCRIPTION
## Summary:
I was migrating a library that makes use of `onActivityResult` to the new arch and realised it hasn't been implemented in bridgeless yet. I'm not sure if we need a lifecycle transition here. It's guaranteed to be called before `onResume`.

## Changelog:
[Android][ADDED] - Implement `onActivityResult` on bridgeless.

## Test Plan:
Patched the example project in the migrated lib and it works as expected.
