### PR TITLE
Create new flag to disable the last part of the notifications for mount hooks on Android

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -265,10 +265,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
     CoreFeatures::enableGranularScrollViewStateUpdatesIOS = true;
   }
 
-  if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_mount_hooks_ios")) {
-    CoreFeatures::enableMountHooks = true;
-  }
-
   if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_cloneless_state_progression")) {
     CoreFeatures::enableClonelessStateProgression = true;
   }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1910,7 +1910,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field enableFabricPendingEventQueue Z
 	public static field enableFabricRenderer Z
 	public static field enableFabricRendererExclusively Z
-	public static field enableMountHooks Z
 	public static field enableRemoveDeleteTreeInstruction Z
 	public static field enableTextSpannableCache Z
 	public static field enableViewRecycling Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -109,9 +109,6 @@ public class ReactFeatureFlags {
    */
   public static boolean enableRemoveDeleteTreeInstruction = false;
 
-  /** Report mount operations from the host platform to notify mount hooks. */
-  public static boolean enableMountHooks = false;
-
   /** Use native view configs in bridgeless mode. */
   public static boolean useNativeViewConfigsInBridgelessMode = false;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -91,7 +91,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * We instruct ProGuard not to strip out any fields or methods, because many of these methods are
@@ -173,7 +172,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   @NonNull
   private final CopyOnWriteArrayList<UIManagerListener> mListeners = new CopyOnWriteArrayList<>();
 
-  @NonNull private final AtomicBoolean mMountNotificationScheduled = new AtomicBoolean(false);
+  private boolean mMountNotificationScheduled = false;
+  private final List<Integer> mMountedSurfaceIds = new ArrayList<>();
 
   @ThreadConfined(UI)
   @NonNull
@@ -1203,6 +1203,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   }
 
   private class MountItemDispatchListener implements MountItemDispatcher.ItemDispatchListener {
+    @UiThread
+    @ThreadConfined(UI)
     @Override
     public void willMountItems(@Nullable List<MountItem> mountItems) {
       for (UIManagerListener listener : mListeners) {
@@ -1210,18 +1212,26 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       }
     }
 
+    @UiThread
+    @ThreadConfined(UI)
     @Override
     public void didMountItems(@Nullable List<MountItem> mountItems) {
       for (UIManagerListener listener : mListeners) {
         listener.didMountItems(FabricUIManager.this);
       }
 
-      if (!ReactFeatureFlags.enableMountHooks) {
+      if (!ReactFeatureFlags.enableMountHooks || mountItems == null || mountItems.isEmpty()) {
         return;
       }
 
-      boolean mountNotificationScheduled = mMountNotificationScheduled.getAndSet(true);
-      if (!mountNotificationScheduled) {
+      // Collect surface IDs for all the mount items
+      for (MountItem mountItem : mountItems) {
+        if (mountItem != null && !mMountedSurfaceIds.contains(mountItem.getSurfaceId())) {
+          mMountedSurfaceIds.add(mountItem.getSurfaceId());
+        }
+      }
+
+      if (!mMountNotificationScheduled && !mMountedSurfaceIds.isEmpty()) {
         // Notify mount when the effects are visible and prevent mount hooks to
         // delay paint.
         UiThreadUtil.getUiThreadHandler()
@@ -1229,28 +1239,19 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
                 new Runnable() {
                   @Override
                   public void run() {
-                    mMountNotificationScheduled.set(false);
-
-                    if (mDestroyed) {
-                      return;
-                    }
+                    mMountNotificationScheduled = false;
 
                     final @Nullable Binding binding = mBinding;
-                    if (mountItems == null || binding == null) {
+                    if (binding == null || mDestroyed) {
+                      mMountedSurfaceIds.clear();
                       return;
                     }
 
-                    // Collect surface IDs for all the mount items
-                    List<Integer> surfaceIds = new ArrayList<>();
-                    for (MountItem mountItem : mountItems) {
-                      if (mountItem != null && !surfaceIds.contains(mountItem.getSurfaceId())) {
-                        surfaceIds.add(mountItem.getSurfaceId());
-                      }
-                    }
-
-                    for (int surfaceId : surfaceIds) {
+                    for (int surfaceId : mMountedSurfaceIds) {
                       binding.reportMount(surfaceId);
                     }
+
+                    mMountedSurfaceIds.clear();
                   }
                 });
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -65,6 +65,7 @@ import com.facebook.react.fabric.mounting.mountitems.DispatchCommandMountItem;
 import com.facebook.react.fabric.mounting.mountitems.MountItem;
 import com.facebook.react.fabric.mounting.mountitems.MountItemFactory;
 import com.facebook.react.interfaces.fabric.SurfaceHandler;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.internal.interop.InteropEventEmitter;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
@@ -1220,7 +1221,9 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
         listener.didMountItems(FabricUIManager.this);
       }
 
-      if (!ReactFeatureFlags.enableMountHooks || mountItems == null || mountItems.isEmpty()) {
+      if (!ReactNativeFeatureFlags.enableMountHooksAndroid()
+          || mountItems == null
+          || mountItems.isEmpty()) {
         return;
       }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6d6fd79bdd221b3aeed0057ac756ee92>>
+ * @generated SignedSource<<bdd9f28c6de15e64ce03c505a3f4f34b>>
  */
 
 /**
@@ -63,6 +63,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun enableMicrotasks(): Boolean = accessor.enableMicrotasks()
+
+  /**
+   * Enables the notification of mount operations to mount hooks on Android.
+   */
+  @JvmStatic
+  public fun enableMountHooksAndroid(): Boolean = accessor.enableMountHooksAndroid()
 
   /**
    * Uses new, deduplicated logic for constructing Android Spannables from text fragments

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bdd9f28c6de15e64ce03c505a3f4f34b>>
+ * @generated SignedSource<<a3cb24f7faddd86beb617c8314c1bfed>>
  */
 
 /**
@@ -87,6 +87,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun inspectorEnableModernCDPRegistry(): Boolean = accessor.inspectorEnableModernCDPRegistry()
+
+  /**
+   * This is a temporary flag to disable part of the mount hooks pipeline to investigate a crash.
+   */
+  @JvmStatic
+  public fun skipMountHookNotifications(): Boolean = accessor.skipMountHookNotifications()
 
   /**
    * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<45776de0416f833eed9bb84d6b7d1052>>
+ * @generated SignedSource<<7ae379135157666d9646f1d8eeec9989>>
  */
 
 /**
@@ -26,6 +26,7 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
   private var enableCustomDrawOrderFabricCache: Boolean? = null
   private var enableFixForClippedSubviewsCrashCache: Boolean? = null
   private var enableMicrotasksCache: Boolean? = null
+  private var enableMountHooksAndroidCache: Boolean? = null
   private var enableSpannableBuildingUnificationCache: Boolean? = null
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
@@ -81,6 +82,15 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.enableMicrotasks()
       enableMicrotasksCache = cached
+    }
+    return cached
+  }
+
+  override fun enableMountHooksAndroid(): Boolean {
+    var cached = enableMountHooksAndroidCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.enableMountHooksAndroid()
+      enableMountHooksAndroidCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7ae379135157666d9646f1d8eeec9989>>
+ * @generated SignedSource<<8539cf7ba13ab52ca878efd2c4858d7a>>
  */
 
 /**
@@ -30,6 +30,7 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
   private var enableSpannableBuildingUnificationCache: Boolean? = null
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
+  private var skipMountHookNotificationsCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
@@ -118,6 +119,15 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.inspectorEnableModernCDPRegistry()
       inspectorEnableModernCDPRegistryCache = cached
+    }
+    return cached
+  }
+
+  override fun skipMountHookNotifications(): Boolean {
+    var cached = skipMountHookNotificationsCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.skipMountHookNotifications()
+      skipMountHookNotificationsCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f9c16b18d93c786db2c5a90c0c4340f6>>
+ * @generated SignedSource<<244a0656beee8e018585bdd4bb4e5cd1>>
  */
 
 /**
@@ -39,6 +39,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun enableFixForClippedSubviewsCrash(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableMicrotasks(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun enableMountHooksAndroid(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableSpannableBuildingUnification(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<244a0656beee8e018585bdd4bb4e5cd1>>
+ * @generated SignedSource<<cd7257d4b1414f7aacd02a79b9295a46>>
  */
 
 /**
@@ -47,6 +47,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun inspectorEnableCxxInspectorPackagerConnection(): Boolean
 
   @DoNotStrip @JvmStatic public external fun inspectorEnableModernCDPRegistry(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun skipMountHookNotifications(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useModernRuntimeScheduler(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4f72683fb2a832d5b77ee2cb37343526>>
+ * @generated SignedSource<<d0985b19d61af8bdf47c322b7a59e203>>
  */
 
 /**
@@ -34,6 +34,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun enableFixForClippedSubviewsCrash(): Boolean = false
 
   override fun enableMicrotasks(): Boolean = false
+
+  override fun enableMountHooksAndroid(): Boolean = false
 
   override fun enableSpannableBuildingUnification(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d0985b19d61af8bdf47c322b7a59e203>>
+ * @generated SignedSource<<99263973c4a06fdc91e7c9edf4aa4e19>>
  */
 
 /**
@@ -42,6 +42,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun inspectorEnableCxxInspectorPackagerConnection(): Boolean = false
 
   override fun inspectorEnableModernCDPRegistry(): Boolean = false
+
+  override fun skipMountHookNotifications(): Boolean = false
 
   override fun useModernRuntimeScheduler(): Boolean = false
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5fd54183222961f5557dbe0ac111a6ec>>
+ * @generated SignedSource<<919eb0f27540e5dd7a1e028663c23264>>
  */
 
 /**
@@ -30,6 +30,7 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
   private var enableCustomDrawOrderFabricCache: Boolean? = null
   private var enableFixForClippedSubviewsCrashCache: Boolean? = null
   private var enableMicrotasksCache: Boolean? = null
+  private var enableMountHooksAndroidCache: Boolean? = null
   private var enableSpannableBuildingUnificationCache: Boolean? = null
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
@@ -91,6 +92,16 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
       cached = currentProvider.enableMicrotasks()
       accessedFeatureFlags.add("enableMicrotasks")
       enableMicrotasksCache = cached
+    }
+    return cached
+  }
+
+  override fun enableMountHooksAndroid(): Boolean {
+    var cached = enableMountHooksAndroidCache
+    if (cached == null) {
+      cached = currentProvider.enableMountHooksAndroid()
+      accessedFeatureFlags.add("enableMountHooksAndroid")
+      enableMountHooksAndroidCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<919eb0f27540e5dd7a1e028663c23264>>
+ * @generated SignedSource<<e8550b0c2494b223b82e6fab0a827d53>>
  */
 
 /**
@@ -34,6 +34,7 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
   private var enableSpannableBuildingUnificationCache: Boolean? = null
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
+  private var skipMountHookNotificationsCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
@@ -132,6 +133,16 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
       cached = currentProvider.inspectorEnableModernCDPRegistry()
       accessedFeatureFlags.add("inspectorEnableModernCDPRegistry")
       inspectorEnableModernCDPRegistryCache = cached
+    }
+    return cached
+  }
+
+  override fun skipMountHookNotifications(): Boolean {
+    var cached = skipMountHookNotificationsCache
+    if (cached == null) {
+      cached = currentProvider.skipMountHookNotifications()
+      accessedFeatureFlags.add("skipMountHookNotifications")
+      skipMountHookNotificationsCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c4f4d28210d5437839616d49120eb921>>
+ * @generated SignedSource<<ddbe652a9094bd6af4bdb741fc17ea7c>>
  */
 
 /**
@@ -34,6 +34,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun enableFixForClippedSubviewsCrash(): Boolean
 
   @DoNotStrip public fun enableMicrotasks(): Boolean
+
+  @DoNotStrip public fun enableMountHooksAndroid(): Boolean
 
   @DoNotStrip public fun enableSpannableBuildingUnification(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ddbe652a9094bd6af4bdb741fc17ea7c>>
+ * @generated SignedSource<<268a87860fea5f281567d2142f90b0d4>>
  */
 
 /**
@@ -42,6 +42,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun inspectorEnableCxxInspectorPackagerConnection(): Boolean
 
   @DoNotStrip public fun inspectorEnableModernCDPRegistry(): Boolean
+
+  @DoNotStrip public fun skipMountHookNotifications(): Boolean
 
   @DoNotStrip public fun useModernRuntimeScheduler(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<393c6cf93399cfe0b0533927877531d5>>
+ * @generated SignedSource<<d697a8ac9c347c63a5fd592bccbfb8b5>>
  */
 
 /**
@@ -99,6 +99,12 @@ class ReactNativeFeatureFlagsProviderHolder
     return method(javaProvider_);
   }
 
+  bool skipMountHookNotifications() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("skipMountHookNotifications");
+    return method(javaProvider_);
+  }
+
   bool useModernRuntimeScheduler() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useModernRuntimeScheduler");
@@ -159,6 +165,11 @@ bool JReactNativeFeatureFlagsCxxInterop::inspectorEnableModernCDPRegistry(
   return ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::skipMountHookNotifications(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::skipMountHookNotifications();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::useModernRuntimeScheduler(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useModernRuntimeScheduler();
@@ -211,6 +222,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "inspectorEnableModernCDPRegistry",
         JReactNativeFeatureFlagsCxxInterop::inspectorEnableModernCDPRegistry),
+      makeNativeMethod(
+        "skipMountHookNotifications",
+        JReactNativeFeatureFlagsCxxInterop::skipMountHookNotifications),
       makeNativeMethod(
         "useModernRuntimeScheduler",
         JReactNativeFeatureFlagsCxxInterop::useModernRuntimeScheduler),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5b40c18d94331e9ec3fdd1a8814b1292>>
+ * @generated SignedSource<<393c6cf93399cfe0b0533927877531d5>>
  */
 
 /**
@@ -75,6 +75,12 @@ class ReactNativeFeatureFlagsProviderHolder
     return method(javaProvider_);
   }
 
+  bool enableMountHooksAndroid() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableMountHooksAndroid");
+    return method(javaProvider_);
+  }
+
   bool enableSpannableBuildingUnification() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableSpannableBuildingUnification");
@@ -133,6 +139,11 @@ bool JReactNativeFeatureFlagsCxxInterop::enableMicrotasks(
   return ReactNativeFeatureFlags::enableMicrotasks();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::enableMountHooksAndroid(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::enableMountHooksAndroid();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::enableSpannableBuildingUnification(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::enableSpannableBuildingUnification();
@@ -188,6 +199,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "enableMicrotasks",
         JReactNativeFeatureFlagsCxxInterop::enableMicrotasks),
+      makeNativeMethod(
+        "enableMountHooksAndroid",
+        JReactNativeFeatureFlagsCxxInterop::enableMountHooksAndroid),
       makeNativeMethod(
         "enableSpannableBuildingUnification",
         JReactNativeFeatureFlagsCxxInterop::enableSpannableBuildingUnification),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e0466f307c37b0c46a09d3a792060fcd>>
+ * @generated SignedSource<<c3bb3615d6a32333f4f20e9d204b5dbb>>
  */
 
 /**
@@ -58,6 +58,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool inspectorEnableModernCDPRegistry(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool skipMountHookNotifications(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useModernRuntimeScheduler(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<514446a9fd1351df1f7f3b307de54b56>>
+ * @generated SignedSource<<e0466f307c37b0c46a09d3a792060fcd>>
  */
 
 /**
@@ -46,6 +46,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableMicrotasks(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool enableMountHooksAndroid(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableSpannableBuildingUnification(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<59573653a5f37505d9a52ac76a9dbcff>>
+ * @generated SignedSource<<cc7c7aa6ac71f94f8dd8fc8cc0c18308>>
  */
 
 /**
@@ -43,6 +43,10 @@ bool ReactNativeFeatureFlags::enableFixForClippedSubviewsCrash() {
 
 bool ReactNativeFeatureFlags::enableMicrotasks() {
   return getAccessor().enableMicrotasks();
+}
+
+bool ReactNativeFeatureFlags::enableMountHooksAndroid() {
+  return getAccessor().enableMountHooksAndroid();
 }
 
 bool ReactNativeFeatureFlags::enableSpannableBuildingUnification() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cc7c7aa6ac71f94f8dd8fc8cc0c18308>>
+ * @generated SignedSource<<fd7ff07ffc0f5f7b2d553a6b5064a1c0>>
  */
 
 /**
@@ -59,6 +59,10 @@ bool ReactNativeFeatureFlags::inspectorEnableCxxInspectorPackagerConnection() {
 
 bool ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry() {
   return getAccessor().inspectorEnableModernCDPRegistry();
+}
+
+bool ReactNativeFeatureFlags::skipMountHookNotifications() {
+  return getAccessor().skipMountHookNotifications();
 }
 
 bool ReactNativeFeatureFlags::useModernRuntimeScheduler() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<036e7f3ee4def5b955ed61c707bbc8f8>>
+ * @generated SignedSource<<a54f29c01ab4dc17de34a0b3ed3a509d>>
  */
 
 /**
@@ -62,6 +62,11 @@ class ReactNativeFeatureFlags {
    * Enables the use of microtasks in Hermes (scheduling) and RuntimeScheduler (execution).
    */
   static bool enableMicrotasks();
+
+  /**
+   * Enables the notification of mount operations to mount hooks on Android.
+   */
+  static bool enableMountHooksAndroid();
 
   /**
    * Uses new, deduplicated logic for constructing Android Spannables from text fragments

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a54f29c01ab4dc17de34a0b3ed3a509d>>
+ * @generated SignedSource<<f06d27ff4e4f35af5020d6a95aeb8343>>
  */
 
 /**
@@ -82,6 +82,11 @@ class ReactNativeFeatureFlags {
    * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
    */
   static bool inspectorEnableModernCDPRegistry();
+
+  /**
+   * This is a temporary flag to disable part of the mount hooks pipeline to investigate a crash.
+   */
+  static bool skipMountHookNotifications();
 
   /**
    * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f7d54fe8d458d80359a8d6e0e5816b1b>>
+ * @generated SignedSource<<6c1e6b6a51cd6fdddae40d3b61ae2b36>>
  */
 
 /**
@@ -209,6 +209,24 @@ bool ReactNativeFeatureFlagsAccessor::inspectorEnableModernCDPRegistry() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::skipMountHookNotifications() {
+  auto flagValue = skipMountHookNotifications_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(10, "skipMountHookNotifications");
+
+    flagValue = currentProvider_->skipMountHookNotifications();
+    skipMountHookNotifications_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::useModernRuntimeScheduler() {
   auto flagValue = useModernRuntimeScheduler_.load();
 
@@ -218,7 +236,7 @@ bool ReactNativeFeatureFlagsAccessor::useModernRuntimeScheduler() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(10, "useModernRuntimeScheduler");
+    markFlagAsAccessed(11, "useModernRuntimeScheduler");
 
     flagValue = currentProvider_->useModernRuntimeScheduler();
     useModernRuntimeScheduler_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d7a724033028f9edc2b0f9a6714a554d>>
+ * @generated SignedSource<<f7d54fe8d458d80359a8d6e0e5816b1b>>
  */
 
 /**
@@ -137,6 +137,24 @@ bool ReactNativeFeatureFlagsAccessor::enableMicrotasks() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::enableMountHooksAndroid() {
+  auto flagValue = enableMountHooksAndroid_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(6, "enableMountHooksAndroid");
+
+    flagValue = currentProvider_->enableMountHooksAndroid();
+    enableMountHooksAndroid_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::enableSpannableBuildingUnification() {
   auto flagValue = enableSpannableBuildingUnification_.load();
 
@@ -146,7 +164,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSpannableBuildingUnification() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(6, "enableSpannableBuildingUnification");
+    markFlagAsAccessed(7, "enableSpannableBuildingUnification");
 
     flagValue = currentProvider_->enableSpannableBuildingUnification();
     enableSpannableBuildingUnification_ = flagValue;
@@ -164,7 +182,7 @@ bool ReactNativeFeatureFlagsAccessor::inspectorEnableCxxInspectorPackagerConnect
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(7, "inspectorEnableCxxInspectorPackagerConnection");
+    markFlagAsAccessed(8, "inspectorEnableCxxInspectorPackagerConnection");
 
     flagValue = currentProvider_->inspectorEnableCxxInspectorPackagerConnection();
     inspectorEnableCxxInspectorPackagerConnection_ = flagValue;
@@ -182,7 +200,7 @@ bool ReactNativeFeatureFlagsAccessor::inspectorEnableModernCDPRegistry() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(8, "inspectorEnableModernCDPRegistry");
+    markFlagAsAccessed(9, "inspectorEnableModernCDPRegistry");
 
     flagValue = currentProvider_->inspectorEnableModernCDPRegistry();
     inspectorEnableModernCDPRegistry_ = flagValue;
@@ -200,7 +218,7 @@ bool ReactNativeFeatureFlagsAccessor::useModernRuntimeScheduler() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(9, "useModernRuntimeScheduler");
+    markFlagAsAccessed(10, "useModernRuntimeScheduler");
 
     flagValue = currentProvider_->useModernRuntimeScheduler();
     useModernRuntimeScheduler_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2fa6a12c1d9b10483d8e2e23125d231e>>
+ * @generated SignedSource<<d13ffc557c3874e9bdd78558cd309829>>
  */
 
 /**
@@ -37,6 +37,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool enableCustomDrawOrderFabric();
   bool enableFixForClippedSubviewsCrash();
   bool enableMicrotasks();
+  bool enableMountHooksAndroid();
   bool enableSpannableBuildingUnification();
   bool inspectorEnableCxxInspectorPackagerConnection();
   bool inspectorEnableModernCDPRegistry();
@@ -51,7 +52,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 10> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 11> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> batchRenderingUpdatesInEventLoop_;
@@ -59,6 +60,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enableCustomDrawOrderFabric_;
   std::atomic<std::optional<bool>> enableFixForClippedSubviewsCrash_;
   std::atomic<std::optional<bool>> enableMicrotasks_;
+  std::atomic<std::optional<bool>> enableMountHooksAndroid_;
   std::atomic<std::optional<bool>> enableSpannableBuildingUnification_;
   std::atomic<std::optional<bool>> inspectorEnableCxxInspectorPackagerConnection_;
   std::atomic<std::optional<bool>> inspectorEnableModernCDPRegistry_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d13ffc557c3874e9bdd78558cd309829>>
+ * @generated SignedSource<<4c5446d5b72429d090e17523f2d544a7>>
  */
 
 /**
@@ -41,6 +41,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool enableSpannableBuildingUnification();
   bool inspectorEnableCxxInspectorPackagerConnection();
   bool inspectorEnableModernCDPRegistry();
+  bool skipMountHookNotifications();
   bool useModernRuntimeScheduler();
 
   void override(std::unique_ptr<ReactNativeFeatureFlagsProvider> provider);
@@ -52,7 +53,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 11> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 12> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> batchRenderingUpdatesInEventLoop_;
@@ -64,6 +65,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enableSpannableBuildingUnification_;
   std::atomic<std::optional<bool>> inspectorEnableCxxInspectorPackagerConnection_;
   std::atomic<std::optional<bool>> inspectorEnableModernCDPRegistry_;
+  std::atomic<std::optional<bool>> skipMountHookNotifications_;
   std::atomic<std::optional<bool>> useModernRuntimeScheduler_;
 };
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<62de1b0e27590ad769296358a4f42c7a>>
+ * @generated SignedSource<<95e3fd7cf662623e3c09b093649d4ff2>>
  */
 
 /**
@@ -64,6 +64,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool inspectorEnableModernCDPRegistry() override {
+    return false;
+  }
+
+  bool skipMountHookNotifications() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<927bc1410a5baadf3a4005e50067c4df>>
+ * @generated SignedSource<<62de1b0e27590ad769296358a4f42c7a>>
  */
 
 /**
@@ -48,6 +48,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableMicrotasks() override {
+    return false;
+  }
+
+  bool enableMountHooksAndroid() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74b4ca674d50bda5fb18d74568024399>>
+ * @generated SignedSource<<3117fc0389416297369a47ee480eb906>>
  */
 
 /**
@@ -31,6 +31,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enableCustomDrawOrderFabric() = 0;
   virtual bool enableFixForClippedSubviewsCrash() = 0;
   virtual bool enableMicrotasks() = 0;
+  virtual bool enableMountHooksAndroid() = 0;
   virtual bool enableSpannableBuildingUnification() = 0;
   virtual bool inspectorEnableCxxInspectorPackagerConnection() = 0;
   virtual bool inspectorEnableModernCDPRegistry() = 0;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3117fc0389416297369a47ee480eb906>>
+ * @generated SignedSource<<26990a0a11bb2d7cf8510773b6ece099>>
  */
 
 /**
@@ -35,6 +35,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enableSpannableBuildingUnification() = 0;
   virtual bool inspectorEnableCxxInspectorPackagerConnection() = 0;
   virtual bool inspectorEnableModernCDPRegistry() = 0;
+  virtual bool skipMountHookNotifications() = 0;
   virtual bool useModernRuntimeScheduler() = 0;
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1a785df8b045c1340d3139bd85add42b>>
+ * @generated SignedSource<<27923a2dbf1dcbad238a4d06ebb54fb5>>
  */
 
 /**
@@ -65,6 +65,11 @@ bool NativeReactNativeFeatureFlags::enableFixForClippedSubviewsCrash(
 bool NativeReactNativeFeatureFlags::enableMicrotasks(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enableMicrotasks();
+}
+
+bool NativeReactNativeFeatureFlags::enableMountHooksAndroid(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::enableMountHooksAndroid();
 }
 
 bool NativeReactNativeFeatureFlags::enableSpannableBuildingUnification(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<27923a2dbf1dcbad238a4d06ebb54fb5>>
+ * @generated SignedSource<<4f7daa629ad90a9ab2fdc99e7c51e355>>
  */
 
 /**
@@ -85,6 +85,11 @@ bool NativeReactNativeFeatureFlags::inspectorEnableCxxInspectorPackagerConnectio
 bool NativeReactNativeFeatureFlags::inspectorEnableModernCDPRegistry(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry();
+}
+
+bool NativeReactNativeFeatureFlags::skipMountHookNotifications(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::skipMountHookNotifications();
 }
 
 bool NativeReactNativeFeatureFlags::useModernRuntimeScheduler(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c27f948d57ad70c7db8fd07a78ddd55f>>
+ * @generated SignedSource<<b10df028d57c3aebd1972bc4624d1b84>>
  */
 
 /**
@@ -55,6 +55,8 @@ class NativeReactNativeFeatureFlags
   bool inspectorEnableCxxInspectorPackagerConnection(jsi::Runtime& runtime);
 
   bool inspectorEnableModernCDPRegistry(jsi::Runtime& runtime);
+
+  bool skipMountHookNotifications(jsi::Runtime& runtime);
 
   bool useModernRuntimeScheduler(jsi::Runtime& runtime);
 };

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c9ed3da29eba982bc9cbc122e077e04c>>
+ * @generated SignedSource<<c27f948d57ad70c7db8fd07a78ddd55f>>
  */
 
 /**
@@ -47,6 +47,8 @@ class NativeReactNativeFeatureFlags
   bool enableFixForClippedSubviewsCrash(jsi::Runtime& runtime);
 
   bool enableMicrotasks(jsi::Runtime& runtime);
+
+  bool enableMountHooksAndroid(jsi::Runtime& runtime);
 
   bool enableSpannableBuildingUnification(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(react_render_uimanager
         folly_runtime
         jsi
         react_debug
+        react_featureflags
         react_render_componentregistry
         react_render_core
         react_render_debug

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -9,6 +9,7 @@
 
 #include <cxxreact/JSExecutor.h>
 #include <react/debug/react_native_assert.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/DynamicPropsUtilities.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/ShadowNodeFragment.h>
@@ -717,6 +718,14 @@ void UIManager::reportMount(SurfaceId surfaceId) const {
   SystraceSection s("UIManager::reportMount");
 
   auto time = JSExecutor::performanceNow();
+
+  // We are testing the impact of enabling mount hooks on Android and we're
+  // seeing some crashes that we didn't see on iOS. We'll run a test to enable
+  // the mount reporting pipeline excluding the logic below, to see if that
+  // logic is what's causing the issues. See T179749070.
+  if (ReactNativeFeatureFlags::skipMountHookNotifications()) {
+    return;
+  }
 
   auto rootShadowNode = RootShadowNode::Shared{};
   shadowTreeRegistry_.visit(surfaceId, [&](const ShadowTree& shadowTree) {

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
@@ -12,7 +12,6 @@ namespace facebook::react {
 bool CoreFeatures::enablePropIteratorSetter = false;
 bool CoreFeatures::cacheLastTextMeasurement = false;
 bool CoreFeatures::enableGranularScrollViewStateUpdatesIOS = false;
-bool CoreFeatures::enableMountHooks = false;
 bool CoreFeatures::enableGranularShadowTreeStateReconciliation = false;
 bool CoreFeatures::enableClonelessStateProgression = false;
 bool CoreFeatures::excludeYogaFromRawProps = false;

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
@@ -29,9 +29,6 @@ class CoreFeatures {
   // updates for all changes in scroll position.
   static bool enableGranularScrollViewStateUpdatesIOS;
 
-  // Report mount operations from the host platform to notify mount hooks.
-  static bool enableMountHooks;
-
   // When enabled, the renderer would only fail commits when they propagate
   // state and the last commit that updated state changed before committing.
   static bool enableGranularShadowTreeStateReconciliation;

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -77,6 +77,11 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.',
     },
+    skipMountHookNotifications: {
+      defaultValue: false,
+      description:
+        'This is a temporary flag to disable part of the mount hooks pipeline to investigate a crash.',
+    },
     useModernRuntimeScheduler: {
       defaultValue: false,
       description:

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -57,6 +57,11 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'Enables the use of microtasks in Hermes (scheduling) and RuntimeScheduler (execution).',
     },
+    enableMountHooksAndroid: {
+      defaultValue: false,
+      description:
+        'Enables the notification of mount operations to mount hooks on Android.',
+    },
     enableSpannableBuildingUnification: {
       defaultValue: false,
       description:

--- a/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fcbf05836bd9465c6a035669f6fc78f4>>
+ * @generated SignedSource<<ef52ae50a916af01ceaaaa6683f6ec5e>>
  * @flow strict-local
  */
 
@@ -33,6 +33,7 @@ export interface Spec extends TurboModule {
   +enableSpannableBuildingUnification?: () => boolean;
   +inspectorEnableCxxInspectorPackagerConnection?: () => boolean;
   +inspectorEnableModernCDPRegistry?: () => boolean;
+  +skipMountHookNotifications?: () => boolean;
   +useModernRuntimeScheduler?: () => boolean;
 }
 

--- a/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fd6c4691a532a520ba08ef0ed2ae297c>>
+ * @generated SignedSource<<fcbf05836bd9465c6a035669f6fc78f4>>
  * @flow strict-local
  */
 
@@ -29,6 +29,7 @@ export interface Spec extends TurboModule {
   +enableCustomDrawOrderFabric?: () => boolean;
   +enableFixForClippedSubviewsCrash?: () => boolean;
   +enableMicrotasks?: () => boolean;
+  +enableMountHooksAndroid?: () => boolean;
   +enableSpannableBuildingUnification?: () => boolean;
   +inspectorEnableCxxInspectorPackagerConnection?: () => boolean;
   +inspectorEnableModernCDPRegistry?: () => boolean;

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<aade6c478e09fb1f92319c3f46adaf13>>
+ * @generated SignedSource<<5d1eca67ace8cccc336a6c6f65b40c99>>
  * @flow strict-local
  */
 
@@ -50,6 +50,7 @@ export type ReactNativeFeatureFlags = {
   enableSpannableBuildingUnification: Getter<boolean>,
   inspectorEnableCxxInspectorPackagerConnection: Getter<boolean>,
   inspectorEnableModernCDPRegistry: Getter<boolean>,
+  skipMountHookNotifications: Getter<boolean>,
   useModernRuntimeScheduler: Getter<boolean>,
 }
 
@@ -133,6 +134,10 @@ export const inspectorEnableCxxInspectorPackagerConnection: Getter<boolean> = cr
  * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
  */
 export const inspectorEnableModernCDPRegistry: Getter<boolean> = createNativeFlagGetter('inspectorEnableModernCDPRegistry', false);
+/**
+ * This is a temporary flag to disable part of the mount hooks pipeline to investigate a crash.
+ */
+export const skipMountHookNotifications: Getter<boolean> = createNativeFlagGetter('skipMountHookNotifications', false);
 /**
  * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.
  */

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c055b3ee44111eb5e3367c664befc685>>
+ * @generated SignedSource<<aade6c478e09fb1f92319c3f46adaf13>>
  * @flow strict-local
  */
 
@@ -46,6 +46,7 @@ export type ReactNativeFeatureFlags = {
   enableCustomDrawOrderFabric: Getter<boolean>,
   enableFixForClippedSubviewsCrash: Getter<boolean>,
   enableMicrotasks: Getter<boolean>,
+  enableMountHooksAndroid: Getter<boolean>,
   enableSpannableBuildingUnification: Getter<boolean>,
   inspectorEnableCxxInspectorPackagerConnection: Getter<boolean>,
   inspectorEnableModernCDPRegistry: Getter<boolean>,
@@ -116,6 +117,10 @@ export const enableFixForClippedSubviewsCrash: Getter<boolean> = createNativeFla
  * Enables the use of microtasks in Hermes (scheduling) and RuntimeScheduler (execution).
  */
 export const enableMicrotasks: Getter<boolean> = createNativeFlagGetter('enableMicrotasks', false);
+/**
+ * Enables the notification of mount operations to mount hooks on Android.
+ */
+export const enableMountHooksAndroid: Getter<boolean> = createNativeFlagGetter('enableMountHooksAndroid', false);
 /**
  * Uses new, deduplicated logic for constructing Android Spannables from text fragments
  */


### PR DESCRIPTION
Summary:
Changelog: [internal]

We still haven't found the root cause of some of the crashes we're seeing in the experiments to enable mount hooks on Android.

This adds a new feature flag to skip part of the mount hooks pipeline to see if we can scope the investigation to that specific part (where we query the root tree in the base revision from the mounting coordinator).

Differential Revision: D54587739
