### PR TITLE
Integrate CDPAgent into HermesRuntimeTargetDelegate behind flag

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6d6fd79bdd221b3aeed0057ac756ee92>>
+ * @generated SignedSource<<6fcdb57f2695ee9fcee85044356dd694>>
  */
 
 /**
@@ -75,6 +75,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun inspectorEnableCxxInspectorPackagerConnection(): Boolean = accessor.inspectorEnableCxxInspectorPackagerConnection()
+
+  /**
+   * Flag determining if the new Hermes CDPAgent API should be enabled in the modern CDP backend. This flag is global and should not be changed across React Host lifetimes.
+   */
+  @JvmStatic
+  public fun inspectorEnableHermesCDPAgent(): Boolean = accessor.inspectorEnableHermesCDPAgent()
 
   /**
    * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<45776de0416f833eed9bb84d6b7d1052>>
+ * @generated SignedSource<<d2150b26a6c41705c94f29719d4a40cd>>
  */
 
 /**
@@ -28,6 +28,7 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
   private var enableMicrotasksCache: Boolean? = null
   private var enableSpannableBuildingUnificationCache: Boolean? = null
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
+  private var inspectorEnableHermesCDPAgentCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
 
@@ -99,6 +100,15 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.inspectorEnableCxxInspectorPackagerConnection()
       inspectorEnableCxxInspectorPackagerConnectionCache = cached
+    }
+    return cached
+  }
+
+  override fun inspectorEnableHermesCDPAgent(): Boolean {
+    var cached = inspectorEnableHermesCDPAgentCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.inspectorEnableHermesCDPAgent()
+      inspectorEnableHermesCDPAgentCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f9c16b18d93c786db2c5a90c0c4340f6>>
+ * @generated SignedSource<<541da25ec42ee80213568cb42a3938ff>>
  */
 
 /**
@@ -43,6 +43,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun enableSpannableBuildingUnification(): Boolean
 
   @DoNotStrip @JvmStatic public external fun inspectorEnableCxxInspectorPackagerConnection(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun inspectorEnableHermesCDPAgent(): Boolean
 
   @DoNotStrip @JvmStatic public external fun inspectorEnableModernCDPRegistry(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4f72683fb2a832d5b77ee2cb37343526>>
+ * @generated SignedSource<<651851c7106c97b59669b5eff93934cc>>
  */
 
 /**
@@ -38,6 +38,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun enableSpannableBuildingUnification(): Boolean = false
 
   override fun inspectorEnableCxxInspectorPackagerConnection(): Boolean = false
+
+  override fun inspectorEnableHermesCDPAgent(): Boolean = false
 
   override fun inspectorEnableModernCDPRegistry(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5fd54183222961f5557dbe0ac111a6ec>>
+ * @generated SignedSource<<6882df78b616c5a898109434511ba6f8>>
  */
 
 /**
@@ -32,6 +32,7 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
   private var enableMicrotasksCache: Boolean? = null
   private var enableSpannableBuildingUnificationCache: Boolean? = null
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
+  private var inspectorEnableHermesCDPAgentCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
 
@@ -111,6 +112,16 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
       cached = currentProvider.inspectorEnableCxxInspectorPackagerConnection()
       accessedFeatureFlags.add("inspectorEnableCxxInspectorPackagerConnection")
       inspectorEnableCxxInspectorPackagerConnectionCache = cached
+    }
+    return cached
+  }
+
+  override fun inspectorEnableHermesCDPAgent(): Boolean {
+    var cached = inspectorEnableHermesCDPAgentCache
+    if (cached == null) {
+      cached = currentProvider.inspectorEnableHermesCDPAgent()
+      accessedFeatureFlags.add("inspectorEnableHermesCDPAgent")
+      inspectorEnableHermesCDPAgentCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c4f4d28210d5437839616d49120eb921>>
+ * @generated SignedSource<<82995bf53483afabf765e45ff6836294>>
  */
 
 /**
@@ -38,6 +38,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun enableSpannableBuildingUnification(): Boolean
 
   @DoNotStrip public fun inspectorEnableCxxInspectorPackagerConnection(): Boolean
+
+  @DoNotStrip public fun inspectorEnableHermesCDPAgent(): Boolean
 
   @DoNotStrip public fun inspectorEnableModernCDPRegistry(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5b40c18d94331e9ec3fdd1a8814b1292>>
+ * @generated SignedSource<<2c7012cc44b84ea9668b5ff3edacc3ff>>
  */
 
 /**
@@ -87,6 +87,12 @@ class ReactNativeFeatureFlagsProviderHolder
     return method(javaProvider_);
   }
 
+  bool inspectorEnableHermesCDPAgent() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("inspectorEnableHermesCDPAgent");
+    return method(javaProvider_);
+  }
+
   bool inspectorEnableModernCDPRegistry() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("inspectorEnableModernCDPRegistry");
@@ -143,6 +149,11 @@ bool JReactNativeFeatureFlagsCxxInterop::inspectorEnableCxxInspectorPackagerConn
   return ReactNativeFeatureFlags::inspectorEnableCxxInspectorPackagerConnection();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::inspectorEnableHermesCDPAgent(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::inspectorEnableHermesCDPAgent();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::inspectorEnableModernCDPRegistry(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry();
@@ -194,6 +205,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "inspectorEnableCxxInspectorPackagerConnection",
         JReactNativeFeatureFlagsCxxInterop::inspectorEnableCxxInspectorPackagerConnection),
+      makeNativeMethod(
+        "inspectorEnableHermesCDPAgent",
+        JReactNativeFeatureFlagsCxxInterop::inspectorEnableHermesCDPAgent),
       makeNativeMethod(
         "inspectorEnableModernCDPRegistry",
         JReactNativeFeatureFlagsCxxInterop::inspectorEnableModernCDPRegistry),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<514446a9fd1351df1f7f3b307de54b56>>
+ * @generated SignedSource<<f65471fe98a6dfff31d021724adbbd85>>
  */
 
 /**
@@ -52,6 +52,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool inspectorEnableCxxInspectorPackagerConnection(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool inspectorEnableHermesCDPAgent(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool inspectorEnableModernCDPRegistry(

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HermesRuntimeAgentDelegateNew.h"
+
+// If HERMES_ENABLE_DEBUGGER isn't defined, we can't access any Hermes
+// CDP headers or types.
+
+#ifdef HERMES_ENABLE_DEBUGGER
+#include <hermes/AsyncDebuggerAPI.h>
+#include <hermes/cdp/CDPAgent.h>
+#include <hermes/inspector/RuntimeAdapter.h>
+#else // HERMES_ENABLE_DEBUGGER
+#include <jsinspector-modern/FallbackRuntimeAgentDelegate.h>
+#endif // HERMES_ENABLE_DEBUGGER
+
+#include <hermes/hermes.h>
+#include <jsinspector-modern/ReactCdp.h>
+
+using namespace facebook::hermes;
+
+namespace facebook::react::jsinspector_modern {
+
+#ifdef HERMES_ENABLE_DEBUGGER
+
+class HermesRuntimeAgentDelegateNew::Impl final : public RuntimeAgentDelegate {
+ public:
+  Impl(
+      FrontendChannel frontendChannel,
+      SessionState& /*unused*/,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
+      const ExecutionContextDescription& executionContextDescription,
+      HermesRuntime& runtime,
+      HermesRuntimeTargetDelegate& runtimeTargetDelegate,
+      const RuntimeExecutor runtimeExecutor)
+      : hermes_(hermes::cdp::CDPAgent::create(
+            executionContextDescription.id,
+            runtimeTargetDelegate.getCDPDebugAPI(),
+            // RuntimeTask takes a HermesRuntime whereas our RuntimeExecutor
+            // takes a jsi::Runtime.
+            [runtimeExecutor,
+             &runtime](facebook::hermes::debugger::RuntimeTask fn) {
+              runtimeExecutor(
+                  [&runtime, fn = std::move(fn)](auto&) { fn(runtime); });
+            },
+            std::move(frontendChannel))) {
+    // TODO(T178858701): Pass previouslyExportedState to CDPAgent
+    (void)previouslyExportedState;
+  }
+
+  /**
+   * Handle a CDP request. The response will be sent over the provided
+   * \c FrontendChannel synchronously or asynchronously.
+   * \param req The parsed request.
+   * \returns true if this agent has responded, or will respond asynchronously,
+   * to the request (with either a success or error message). False if the
+   * agent expects another agent to respond to the request instead.
+   */
+  bool handleRequest(const cdp::PreparsedRequest& req) override {
+    // TODO: Change to string::starts_with when we're on C++20.
+    if (req.method.rfind("Log.", 0) == 0) {
+      // Since we know Hermes doesn't do anything useful with Log messages, but
+      // our containing PageAgent will, just bail out early.
+      // TODO: We need a way to negotiate this more dynamically with Hermes
+      // through the API.
+      return false;
+    }
+    // Forward everything else to Hermes's CDPAgent.
+    hermes_->handleCommand(req.toJson());
+    // Let the call know that this request is handled (i.e. it is Hermes's
+    // responsibility to respond with either success or an error).
+    return true;
+  }
+
+ private:
+  std::unique_ptr<hermes::cdp::CDPAgent> hermes_;
+};
+
+#else // !HERMES_ENABLE_DEBUGGER
+
+/**
+ * A stub for HermesRuntimeAgentDelegateNew when Hermes is compiled without
+ * debugging support.
+ */
+class HermesRuntimeAgentDelegateNew::Impl final
+    : public FallbackRuntimeAgentDelegate {
+ public:
+  Impl(
+      FrontendChannel frontendChannel,
+      SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
+      const ExecutionContextDescription&,
+      HermesRuntime& runtime,
+      HermesRuntimeTargetDelegate& runtimeTargetDelegate,
+      RuntimeExecutor)
+      : FallbackRuntimeAgentDelegate(
+            std::move(frontendChannel),
+            sessionState,
+            runtime.description()) {}
+};
+
+#endif // HERMES_ENABLE_DEBUGGER
+
+HermesRuntimeAgentDelegateNew::HermesRuntimeAgentDelegateNew(
+    FrontendChannel frontendChannel,
+    SessionState& sessionState,
+    std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+        previouslyExportedState,
+    const ExecutionContextDescription& executionContextDescription,
+    HermesRuntime& runtime,
+    HermesRuntimeTargetDelegate& runtimeTargetDelegate,
+    RuntimeExecutor runtimeExecutor)
+    : impl_(std::make_unique<Impl>(
+          std::move(frontendChannel),
+          sessionState,
+          std::move(previouslyExportedState),
+          executionContextDescription,
+          runtime,
+          runtimeTargetDelegate,
+          std::move(runtimeExecutor))) {}
+
+bool HermesRuntimeAgentDelegateNew::handleRequest(
+    const cdp::PreparsedRequest& req) {
+  return impl_->handleRequest(req);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "HermesRuntimeTargetDelegate.h"
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <hermes/hermes.h>
+#include <jsinspector-modern/ReactCdp.h>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A RuntimeAgentDelegate that handles requests from the Chrome DevTools
+ * Protocol for an instance of Hermes, using the new CDPAgent API.
+ */
+class HermesRuntimeAgentDelegateNew : public RuntimeAgentDelegate {
+ public:
+  /**
+   * \param frontendChannel A channel used to send responses and events to the
+   * frontend.
+   * \param sessionState The state of the current CDP session. This will only
+   * be accessed on the main thread (during the constructor, in handleRequest,
+   * etc).
+   * \param previouslyExportedState The exported state from a previous instance
+   * of RuntimeAgentDelegate (NOT necessarily HermesRuntimeAgentDelegateNew).
+   * This may be nullptr, and if not nullptr it may be of any concrete type that
+   * implements RuntimeAgentDelegate::ExportedState.
+   * \param executionContextDescription A description of the execution context
+   * represented by this runtime. This is used for disambiguating the
+   * source/destination of CDP messages when there are multiple runtimes
+   * (concurrently or over the life of a Page).
+   * \param runtime The HermesRuntime that this agent is attached to. The caller
+   * is responsible for keeping this object alive for the duration of the
+   * \c HermesRuntimeAgentDelegateNew lifetime.
+   * \param runtimeTargetDelegate The \c HermesRuntimeTargetDelegate object
+   * object for the passed runtime.
+   * \param runtimeExecutor A callback for scheduling work on the JS thread.
+   * \c runtimeExecutor may drop scheduled work if the runtime is destroyed
+   * first.
+   */
+  HermesRuntimeAgentDelegateNew(
+      FrontendChannel frontendChannel,
+      SessionState& sessionState,
+      std::unique_ptr<RuntimeAgentDelegate::ExportedState>
+          previouslyExportedState,
+      const ExecutionContextDescription& executionContextDescription,
+      hermes::HermesRuntime& runtime,
+      HermesRuntimeTargetDelegate& runtimeTargetDelegate,
+      RuntimeExecutor runtimeExecutor);
+
+  /**
+   * Handle a CDP request. The response will be sent over the provided
+   * \c FrontendChannel synchronously or asynchronously.
+   * \param req The parsed request.
+   * \returns true if this agent has responded, or will respond asynchronously,
+   * to the request (with either a success or error message). False if the
+   * agent expects another agent to respond to the request instead.
+   */
+  bool handleRequest(const cdp::PreparsedRequest& req) override;
+
+ private:
+  // We use the private implementation idiom to keep HERMES_ENABLE_DEBUGGER
+  // checks out of the header.
+  class Impl;
+
+  const std::unique_ptr<Impl> impl_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -13,6 +13,10 @@
 #include <hermes/hermes.h>
 #include <jsinspector-modern/ReactCdp.h>
 
+#ifdef HERMES_ENABLE_DEBUGGER
+#include <hermes/cdp/CDPDebugAPI.h>
+#endif
+
 #include <memory>
 
 namespace facebook::react::jsinspector_modern {
@@ -42,7 +46,19 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
       RuntimeExecutor runtimeExecutor) override;
 
  private:
+  // We use the private implementation idiom to ensure this class has the same
+  // layout regardless of whether HERMES_ENABLE_DEBUGGER is defined. The net
+  // effect is that callers can include HermesRuntimeTargetDelegate.h without
+  // setting HERMES_ENABLE_DEBUGGER one way or the other.
   class Impl;
+
+// Callers within this library may set HERMES_ENABLE_DEBUGGER to see this extra
+// API.
+#ifdef HERMES_ENABLE_DEBUGGER
+  friend class HermesRuntimeAgentDelegateNew;
+
+  hermes::cdp::CDPDebugAPI& getCDPDebugAPI();
+#endif
 
   std::unique_ptr<Impl> impl_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -22,7 +22,9 @@ InspectorFlags::InspectorFlags()
           ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry()),
       enableCxxInspectorPackagerConnection_(
           ReactNativeFeatureFlags::
-              inspectorEnableCxxInspectorPackagerConnection()) {}
+              inspectorEnableCxxInspectorPackagerConnection()),
+      enableHermesCDPAgent_(
+          ReactNativeFeatureFlags::inspectorEnableHermesCDPAgent()) {}
 
 bool InspectorFlags::getEnableModernCDPRegistry() const {
   assertFlagsMatchUpstream();
@@ -35,6 +37,11 @@ bool InspectorFlags::getEnableCxxInspectorPackagerConnection() const {
       // If we are using the modern CDP registry, then we must also use the C++
       // InspectorPackagerConnection implementation.
       enableModernCDPRegistry_;
+}
+
+bool InspectorFlags::getEnableHermesCDPAgent() const {
+  assertFlagsMatchUpstream();
+  return enableHermesCDPAgent_;
 }
 
 void InspectorFlags::dangerouslyResetFlags() {
@@ -50,7 +57,9 @@ void InspectorFlags::assertFlagsMatchUpstream() const {
           ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry() ||
       enableCxxInspectorPackagerConnection_ !=
           ReactNativeFeatureFlags::
-              inspectorEnableCxxInspectorPackagerConnection()) {
+              inspectorEnableCxxInspectorPackagerConnection() ||
+      ReactNativeFeatureFlags::inspectorEnableHermesCDPAgent() !=
+          enableHermesCDPAgent_) {
     LOG(ERROR)
         << "[InspectorFlags] Error: One or more ReactNativeFeatureFlags values "
         << "have changed during the global app lifetime. This may lead to "

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -31,6 +31,11 @@ class InspectorFlags {
   bool getEnableCxxInspectorPackagerConnection() const;
 
   /**
+   * Flag determining if the new Hermes CDPAgent API should be enabled.
+   */
+  bool getEnableHermesCDPAgent() const;
+
+  /**
    * Reset flags to their upstream values. The caller must ensure any resources
    * that have read previous flag values have been cleaned up.
    */
@@ -44,6 +49,7 @@ class InspectorFlags {
 
   bool enableModernCDPRegistry_;
   bool enableCxxInspectorPackagerConnection_;
+  bool enableHermesCDPAgent_;
 
   mutable bool inconsistentFlagsStateLogged_{false};
   void assertFlagsMatchUpstream() const;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<59573653a5f37505d9a52ac76a9dbcff>>
+ * @generated SignedSource<<55b2c569a265eee897d5d75bcd16c47f>>
  */
 
 /**
@@ -51,6 +51,10 @@ bool ReactNativeFeatureFlags::enableSpannableBuildingUnification() {
 
 bool ReactNativeFeatureFlags::inspectorEnableCxxInspectorPackagerConnection() {
   return getAccessor().inspectorEnableCxxInspectorPackagerConnection();
+}
+
+bool ReactNativeFeatureFlags::inspectorEnableHermesCDPAgent() {
+  return getAccessor().inspectorEnableHermesCDPAgent();
 }
 
 bool ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<036e7f3ee4def5b955ed61c707bbc8f8>>
+ * @generated SignedSource<<9f5013f209f3c12dcb43f4f12ef63d57>>
  */
 
 /**
@@ -72,6 +72,11 @@ class ReactNativeFeatureFlags {
    * Flag determining if the C++ implementation of InspectorPackagerConnection should be used instead of the per-platform one. This flag is global and should not be changed across React Host lifetimes.
    */
   static bool inspectorEnableCxxInspectorPackagerConnection();
+
+  /**
+   * Flag determining if the new Hermes CDPAgent API should be enabled in the modern CDP backend. This flag is global and should not be changed across React Host lifetimes.
+   */
+  static bool inspectorEnableHermesCDPAgent();
 
   /**
    * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d7a724033028f9edc2b0f9a6714a554d>>
+ * @generated SignedSource<<7584a3cf3bcc8eb8fc53a1af82db0f2e>>
  */
 
 /**
@@ -173,6 +173,24 @@ bool ReactNativeFeatureFlagsAccessor::inspectorEnableCxxInspectorPackagerConnect
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::inspectorEnableHermesCDPAgent() {
+  auto flagValue = inspectorEnableHermesCDPAgent_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(8, "inspectorEnableHermesCDPAgent");
+
+    flagValue = currentProvider_->inspectorEnableHermesCDPAgent();
+    inspectorEnableHermesCDPAgent_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::inspectorEnableModernCDPRegistry() {
   auto flagValue = inspectorEnableModernCDPRegistry_.load();
 
@@ -182,7 +200,7 @@ bool ReactNativeFeatureFlagsAccessor::inspectorEnableModernCDPRegistry() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(8, "inspectorEnableModernCDPRegistry");
+    markFlagAsAccessed(9, "inspectorEnableModernCDPRegistry");
 
     flagValue = currentProvider_->inspectorEnableModernCDPRegistry();
     inspectorEnableModernCDPRegistry_ = flagValue;
@@ -200,7 +218,7 @@ bool ReactNativeFeatureFlagsAccessor::useModernRuntimeScheduler() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(9, "useModernRuntimeScheduler");
+    markFlagAsAccessed(10, "useModernRuntimeScheduler");
 
     flagValue = currentProvider_->useModernRuntimeScheduler();
     useModernRuntimeScheduler_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2fa6a12c1d9b10483d8e2e23125d231e>>
+ * @generated SignedSource<<6960a406278e4dc4a9fa54156ba87dbb>>
  */
 
 /**
@@ -39,6 +39,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool enableMicrotasks();
   bool enableSpannableBuildingUnification();
   bool inspectorEnableCxxInspectorPackagerConnection();
+  bool inspectorEnableHermesCDPAgent();
   bool inspectorEnableModernCDPRegistry();
   bool useModernRuntimeScheduler();
 
@@ -51,7 +52,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 10> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 11> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> batchRenderingUpdatesInEventLoop_;
@@ -61,6 +62,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enableMicrotasks_;
   std::atomic<std::optional<bool>> enableSpannableBuildingUnification_;
   std::atomic<std::optional<bool>> inspectorEnableCxxInspectorPackagerConnection_;
+  std::atomic<std::optional<bool>> inspectorEnableHermesCDPAgent_;
   std::atomic<std::optional<bool>> inspectorEnableModernCDPRegistry_;
   std::atomic<std::optional<bool>> useModernRuntimeScheduler_;
 };

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<927bc1410a5baadf3a4005e50067c4df>>
+ * @generated SignedSource<<ca46f6cafdedcd8ab3e84f673cdb678d>>
  */
 
 /**
@@ -56,6 +56,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool inspectorEnableCxxInspectorPackagerConnection() override {
+    return false;
+  }
+
+  bool inspectorEnableHermesCDPAgent() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74b4ca674d50bda5fb18d74568024399>>
+ * @generated SignedSource<<58280914deb0933b181a1336c2bb6763>>
  */
 
 /**
@@ -33,6 +33,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enableMicrotasks() = 0;
   virtual bool enableSpannableBuildingUnification() = 0;
   virtual bool inspectorEnableCxxInspectorPackagerConnection() = 0;
+  virtual bool inspectorEnableHermesCDPAgent() = 0;
   virtual bool inspectorEnableModernCDPRegistry() = 0;
   virtual bool useModernRuntimeScheduler() = 0;
 };

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1a785df8b045c1340d3139bd85add42b>>
+ * @generated SignedSource<<93488ca4d00dfb07cb209a17ff06dcc3>>
  */
 
 /**
@@ -75,6 +75,11 @@ bool NativeReactNativeFeatureFlags::enableSpannableBuildingUnification(
 bool NativeReactNativeFeatureFlags::inspectorEnableCxxInspectorPackagerConnection(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::inspectorEnableCxxInspectorPackagerConnection();
+}
+
+bool NativeReactNativeFeatureFlags::inspectorEnableHermesCDPAgent(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::inspectorEnableHermesCDPAgent();
 }
 
 bool NativeReactNativeFeatureFlags::inspectorEnableModernCDPRegistry(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c9ed3da29eba982bc9cbc122e077e04c>>
+ * @generated SignedSource<<48b75b37734bfa54dcbddac2f7e69605>>
  */
 
 /**
@@ -51,6 +51,8 @@ class NativeReactNativeFeatureFlags
   bool enableSpannableBuildingUnification(jsi::Runtime& runtime);
 
   bool inspectorEnableCxxInspectorPackagerConnection(jsi::Runtime& runtime);
+
+  bool inspectorEnableHermesCDPAgent(jsi::Runtime& runtime);
 
   bool inspectorEnableModernCDPRegistry(jsi::Runtime& runtime);
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -67,6 +67,11 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'Flag determining if the C++ implementation of InspectorPackagerConnection should be used instead of the per-platform one. This flag is global and should not be changed across React Host lifetimes.',
     },
+    inspectorEnableHermesCDPAgent: {
+      defaultValue: false,
+      description:
+        'Flag determining if the new Hermes CDPAgent API should be enabled in the modern CDP backend. This flag is global and should not be changed across React Host lifetimes.',
+    },
     inspectorEnableModernCDPRegistry: {
       defaultValue: false,
       description:

--- a/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fd6c4691a532a520ba08ef0ed2ae297c>>
+ * @generated SignedSource<<2f601f8841edc10f34e5c435bdcf9118>>
  * @flow strict-local
  */
 
@@ -31,6 +31,7 @@ export interface Spec extends TurboModule {
   +enableMicrotasks?: () => boolean;
   +enableSpannableBuildingUnification?: () => boolean;
   +inspectorEnableCxxInspectorPackagerConnection?: () => boolean;
+  +inspectorEnableHermesCDPAgent?: () => boolean;
   +inspectorEnableModernCDPRegistry?: () => boolean;
   +useModernRuntimeScheduler?: () => boolean;
 }

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c055b3ee44111eb5e3367c664befc685>>
+ * @generated SignedSource<<fcb0314c6eae04ea1a24922c00a7de62>>
  * @flow strict-local
  */
 
@@ -48,6 +48,7 @@ export type ReactNativeFeatureFlags = {
   enableMicrotasks: Getter<boolean>,
   enableSpannableBuildingUnification: Getter<boolean>,
   inspectorEnableCxxInspectorPackagerConnection: Getter<boolean>,
+  inspectorEnableHermesCDPAgent: Getter<boolean>,
   inspectorEnableModernCDPRegistry: Getter<boolean>,
   useModernRuntimeScheduler: Getter<boolean>,
 }
@@ -124,6 +125,10 @@ export const enableSpannableBuildingUnification: Getter<boolean> = createNativeF
  * Flag determining if the C++ implementation of InspectorPackagerConnection should be used instead of the per-platform one. This flag is global and should not be changed across React Host lifetimes.
  */
 export const inspectorEnableCxxInspectorPackagerConnection: Getter<boolean> = createNativeFlagGetter('inspectorEnableCxxInspectorPackagerConnection', false);
+/**
+ * Flag determining if the new Hermes CDPAgent API should be enabled in the modern CDP backend. This flag is global and should not be changed across React Host lifetimes.
+ */
+export const inspectorEnableHermesCDPAgent: Getter<boolean> = createNativeFlagGetter('inspectorEnableHermesCDPAgent', false);
 /**
  * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
  */


### PR DESCRIPTION
Summary:
## Context

We are migrating to the new Hermes `CDPAgent` and `CDPDebugAPI` APIs in the modern CDP server (previously `HermesCDPHandler`).

## This diff

Integrates `HermesRuntimeAgentDelegateNew` (using the new Hermes `CDPAgent` setup) into `HermesRuntimeTargetDelegate` behind a new feature flag, `inspectorEnableHermesCDPAgent`. This completes the initial integration for all platforms.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D54586162


