### PR TITLE
feat(iOS): add all supported ReturnKeyTypes

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -692,6 +692,7 @@ switch (returnKeyType) {
         returnKeyTypesSet = [NSSet setWithObjects:
             @(UIReturnKeyDone),
             @(UIReturnKeyGo),
+            @(UIReturnKeyDefault),
             @(UIReturnKeyNext),
             @(UIReturnKeySearch),
             @(UIReturnKeySend),

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -502,6 +502,7 @@ switch (returnKeyType) {
         returnKeyTypesSet = [NSSet setWithObjects:
             @(UIReturnKeyDone),
             @(UIReturnKeyGo),
+            @(UIReturnKeyDefault),
             @(UIReturnKeyNext),
             @(UIReturnKeySearch),
             @(UIReturnKeySend),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Related issue: https://github.com/facebook/react-native/issues/43243
As [documentation](https://reactnative.dev/docs/textinput#returnkeytype) stated for the ReturnKeyType prop on the input there are different options, like "next", "go" and etc. They are actually supported on the iOS side but we can't use it in our react native app, because of the hardcoded version of DoneButton on existing code: 
<img width="887" alt="image" src="https://github.com/facebook/react-native/assets/53994979/9ecaf63b-675c-45f0-b737-7ae3e937584a">
So, I decided to add support for types which were in documentation


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[IOS] [ADDED]: ReturnKeyTypes
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

ran yarn jest react-native-codegen and yarn jest react-native, both successfully:
<img width="420" alt="image" src="https://github.com/facebook/react-native/assets/53994979/c36b61f7-ef45-4062-ac5b-1dd2d0a9e544">

<img width="420" alt="image" src="https://github.com/facebook/react-native/assets/53994979/af83c22c-d110-4c28-94c1-d48ee27bfcfe">


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
