### PR TITLE
Remove createRootView(initialProps) from ReactDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -105,10 +105,8 @@ public abstract class com/facebook/react/ReactActivity : androidx/appcompat/app/
 
 public class com/facebook/react/ReactActivityDelegate {
 	public fun <init> (Landroid/app/Activity;Ljava/lang/String;)V
-	public fun <init> (Lcom/facebook/react/ReactActivity;Ljava/lang/String;)V
 	protected fun composeLaunchOptions ()Landroid/os/Bundle;
 	protected fun createRootView ()Lcom/facebook/react/ReactRootView;
-	protected fun createRootView (Landroid/os/Bundle;)Lcom/facebook/react/ReactRootView;
 	protected fun getContext ()Landroid/content/Context;
 	protected fun getLaunchOptions ()Landroid/os/Bundle;
 	public fun getMainComponentName ()Ljava/lang/String;
@@ -1954,8 +1952,6 @@ public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/face
 	public fun <init> (Lcom/facebook/react/ReactActivity;Ljava/lang/String;Z)V
 	public synthetic fun <init> (Lcom/facebook/react/ReactActivity;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/facebook/react/ReactActivity;Ljava/lang/String;ZZ)V
-	protected fun createRootView ()Lcom/facebook/react/ReactRootView;
-	protected fun createRootView (Landroid/os/Bundle;)Lcom/facebook/react/ReactRootView;
 	protected fun isFabricEnabled ()Z
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -31,16 +31,9 @@ public class ReactActivityDelegate {
 
   private @Nullable PermissionListener mPermissionListener;
   private @Nullable Callback mPermissionsCallback;
-  private ReactDelegate mReactDelegate;
+  private @Nullable ReactDelegate mReactDelegate;
 
-  @Deprecated
   public ReactActivityDelegate(@Nullable Activity activity, @Nullable String mainComponentName) {
-    mActivity = activity;
-    mMainComponentName = mainComponentName;
-  }
-
-  public ReactActivityDelegate(
-      @Nullable ReactActivity activity, @Nullable String mainComponentName) {
     mActivity = activity;
     mMainComponentName = mainComponentName;
   }
@@ -56,21 +49,11 @@ public class ReactActivityDelegate {
   }
 
   protected @Nullable Bundle composeLaunchOptions() {
-    Bundle composedLaunchOptions = getLaunchOptions();
-    if (isFabricEnabled()) {
-      if (composedLaunchOptions == null) {
-        composedLaunchOptions = new Bundle();
-      }
-    }
-    return composedLaunchOptions;
+    return getLaunchOptions();
   }
 
   protected ReactRootView createRootView() {
-    return new ReactRootView(getContext());
-  }
-
-  protected ReactRootView createRootView(Bundle initialProps) {
-    return new ReactRootView(getContext());
+    return Assertions.assertNotNull(mReactDelegate).createRootView();
   }
 
   /**
@@ -108,7 +91,7 @@ public class ReactActivityDelegate {
               getPlainActivity(), getReactNativeHost(), mainComponentName, launchOptions) {
             @Override
             protected ReactRootView createRootView() {
-              return ReactActivityDelegate.this.createRootView(launchOptions);
+              return ReactActivityDelegate.this.createRootView();
             }
           };
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -11,7 +11,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.KeyEvent;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.config.ReactFeatureFlags;
@@ -75,7 +74,7 @@ public class ReactDelegate {
     mFabricEnabled = fabricEnabled;
     mActivity = activity;
     mMainComponentName = appKey;
-    mLaunchOptions = composeLaunchOptions(launchOptions);
+    mLaunchOptions = launchOptions;
     mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
     mReactNativeHost = reactNativeHost;
   }
@@ -181,6 +180,7 @@ public class ReactDelegate {
     }
   }
 
+  // Not used in bridgeless
   protected ReactRootView createRootView() {
     ReactRootView reactRootView = new ReactRootView(mActivity);
     reactRootView.setIsFabric(isFabricEnabled());
@@ -232,14 +232,5 @@ public class ReactDelegate {
    */
   protected boolean isFabricEnabled() {
     return mFabricEnabled;
-  }
-
-  private @NonNull Bundle composeLaunchOptions(Bundle composedLaunchOptions) {
-    if (isFabricEnabled()) {
-      if (composedLaunchOptions == null) {
-        composedLaunchOptions = new Bundle();
-      }
-    }
-    return composedLaunchOptions;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -452,7 +452,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   /**
    * Schedule rendering of the react component rendered by the JS application from the given JS
    * module (@{param moduleName}) using provided {@param reactInstanceManager} to attach to the JS
-   * context of that manager. Extra parameter {@param launchOptions} can be used to pass initial
+   * context of that manager. Extra parameter {@param initialProperties} can be used to pass initial
    * properties for the react component.
    */
   @ThreadConfined(UI)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
@@ -7,10 +7,8 @@
 
 package com.facebook.react.defaults
 
-import android.os.Bundle
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.ReactRootView
 
 /**
  * A utility class that allows you to simplify the setup of a [ReactActivityDelegate] for new apps
@@ -43,10 +41,4 @@ public open class DefaultReactActivityDelegate(
   ) : this(activity, mainComponentName, fabricEnabled)
 
   override fun isFabricEnabled(): Boolean = fabricEnabled
-
-  override fun createRootView(): ReactRootView =
-      ReactRootView(context).apply { setIsFabric(fabricEnabled) }
-
-  override fun createRootView(bundle: Bundle?): ReactRootView =
-      ReactRootView(context).apply { setIsFabric(fabricEnabled) }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
@@ -28,9 +28,7 @@ class ReactActivityDelegateTest {
             get() = composeLaunchOptions()
         }
 
-    assertNotNull(delegate.inspectLaunchOptions)
-    // False because oncurrentRoot is hardcoded to true for Fabric inside renderApplication
-    assertFalse(delegate.inspectLaunchOptions!!.containsKey("concurrentRoot"))
+    assertNull(delegate.inspectLaunchOptions)
   }
 
   @Test
@@ -60,9 +58,7 @@ class ReactActivityDelegateTest {
         }
 
     assertNotNull(delegate.inspectLaunchOptions)
-    // False because oncurrentRoot is hardcoded to true for Fabric inside renderApplication
-    assertFalse(delegate.inspectLaunchOptions!!.containsKey("concurrentRoot"))
-    assertTrue(delegate.inspectLaunchOptions!!.containsKey("test-property"))
-    assertEquals("test-value", delegate.inspectLaunchOptions!!.getString("test-property"))
+    assertTrue(delegate.inspectLaunchOptions?.containsKey("test-property") ?: false)
+    assertEquals("test-value", delegate.inspectLaunchOptions?.getString("test-property"))
   }
 }


### PR DESCRIPTION
Summary: Changelog: [Android][Changed] Simplified ReactActivityDelegate to expose a single createRootView method.

Differential Revision: D54434648


