### PR TITLE
Add registerCallableModule types

### DIFF
--- a/packages/react-native/Libraries/Core/registerCallableModule.d.ts
+++ b/packages/react-native/Libraries/Core/registerCallableModule.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+type Module = Object;
+type RegisterCallableModule = (
+  name: string,
+  moduleOrFactory: Module | (() => Module),
+) => void;
+
+export const registerCallableModule: RegisterCallableModule;

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -103,6 +103,7 @@ export * from '../Libraries/Components/View/View';
 export * from '../Libraries/Components/View/ViewAccessibility';
 export * from '../Libraries/Components/View/ViewPropTypes';
 export * from '../Libraries/Components/Button';
+export * from '../Libraries/Core/registerCallableModule';
 export * from '../Libraries/DevToolsSettings/DevToolsSettingsManager';
 export * from '../Libraries/EventEmitter/NativeEventEmitter';
 export * from '../Libraries/EventEmitter/RCTDeviceEventEmitter';


### PR DESCRIPTION
## Summary:

`registerCallableModule()` was added from 7f549ec7bebe but no typescript types there. this pr tries to add the corresponding types.
 
## Changelog:

[GENERAL] [FIXED] - Add missing `registerCallableModule` TypeScript definitions

## Test Plan:

patch locally and try to `import { registerCallableModule } from 'react-native';` in a 0.74.0-rc.2 project 
