### PR TITLE
Make ReactActivityDelegate methods public

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -121,15 +121,15 @@ public class com/facebook/react/ReactActivityDelegate {
 	public fun onActivityResult (IILandroid/content/Intent;)V
 	public fun onBackPressed ()Z
 	public fun onConfigurationChanged (Landroid/content/res/Configuration;)V
-	protected fun onCreate (Landroid/os/Bundle;)V
-	protected fun onDestroy ()V
+	public fun onCreate (Landroid/os/Bundle;)V
+	public fun onDestroy ()V
 	public fun onKeyDown (ILandroid/view/KeyEvent;)Z
 	public fun onKeyLongPress (ILandroid/view/KeyEvent;)Z
 	public fun onKeyUp (ILandroid/view/KeyEvent;)Z
 	public fun onNewIntent (Landroid/content/Intent;)Z
-	protected fun onPause ()V
+	public fun onPause ()V
 	public fun onRequestPermissionsResult (I[Ljava/lang/String;[I)V
-	protected fun onResume ()V
+	public fun onResume ()V
 	public fun onWindowFocusChanged (Z)V
 	public fun requestPermissions ([Ljava/lang/String;ILcom/facebook/react/modules/core/PermissionListener;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -96,7 +96,7 @@ public class ReactActivityDelegate {
     return mMainComponentName;
   }
 
-  protected void onCreate(Bundle savedInstanceState) {
+  public void onCreate(Bundle savedInstanceState) {
     String mainComponentName = getMainComponentName();
     final Bundle launchOptions = composeLaunchOptions();
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
@@ -122,11 +122,11 @@ public class ReactActivityDelegate {
     getPlainActivity().setContentView(mReactDelegate.getReactRootView());
   }
 
-  protected void onPause() {
+  public void onPause() {
     mReactDelegate.onHostPause();
   }
 
-  protected void onResume() {
+  public void onResume() {
     mReactDelegate.onHostResume();
 
     if (mPermissionsCallback != null) {
@@ -135,7 +135,7 @@ public class ReactActivityDelegate {
     }
   }
 
-  protected void onDestroy() {
+  public void onDestroy() {
     mReactDelegate.onHostDestroy();
   }
 
@@ -220,14 +220,11 @@ public class ReactActivityDelegate {
   public void onRequestPermissionsResult(
       final int requestCode, final String[] permissions, final int[] grantResults) {
     mPermissionsCallback =
-        new Callback() {
-          @Override
-          public void invoke(Object... args) {
-            if (mPermissionListener != null
-                && mPermissionListener.onRequestPermissionsResult(
-                    requestCode, permissions, grantResults)) {
-              mPermissionListener = null;
-            }
+        args -> {
+          if (mPermissionListener != null
+              && mPermissionListener.onRequestPermissionsResult(
+                  requestCode, permissions, grantResults)) {
+            mPermissionListener = null;
           }
         };
   }


### PR DESCRIPTION
Summary:
Enable `ReactActivityDelegate` to be used outside of `ReactActivity` as well.

Changelog: [Internal]

Differential Revision: D54634339


