### PR TITLE
Use fs.cpSync instead of execSync('cp ...

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -465,8 +465,7 @@ function generateCode(outputPath, schemaInfo, includesGeneratedCode, platform) {
   const outputDir =
     reactNativeCoreLibraryOutputPath(libraryName, platform) ?? outputPath;
   fs.mkdirSync(outputDir, {recursive: true});
-  // TODO: Fix this. This will not work on Windows.
-  execSync(`cp -R ${tmpOutputDir}/* "${outputDir}"`);
+  fs.cpSync(tmpOutputDir, outputDir, {recursive: true});
   console.log(`[Codegen] Generated artifacts: ${outputDir}`);
 }
 


### PR DESCRIPTION
Summary:
This diff replaces direct invocation of the `cp` command with the platform agnostic `fs.cpSync`.
Changelog: [Internal]

Differential Revision: D54634108


