### PR TITLE
Create InspectorFlagOverridesGuard util, substitute in tests

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.h
@@ -10,6 +10,7 @@
 #include "InspectorMocks.h"
 #include "ReactNativeMocks.h"
 #include "UniquePtrFactory.h"
+#include "utils/InspectorFlagOverridesGuard.h"
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 #include <folly/json.h>
@@ -31,6 +32,7 @@ struct FeatureFlags {
 class ReactInstanceIntegrationTest : public Test {
  protected:
   ReactInstanceIntegrationTest();
+
   void SetUp() override;
   void TearDown() override;
 
@@ -46,7 +48,6 @@ class ReactInstanceIntegrationTest : public Test {
   std::unique_ptr<react::ReactInstance> instance;
   std::shared_ptr<MockMessageQueueThread> messageQueueThread;
   std::shared_ptr<ErrorUtils> errorHandler;
-  std::unique_ptr<FeatureFlags> featureFlags;
 
   MockRemoteConnection& getRemoteConnection() {
     EXPECT_EQ(mockRemoteConnections_.objectsVended(), 1);
@@ -68,10 +69,11 @@ class ReactInstanceIntegrationTest : public Test {
 
 class ReactInstanceIntegrationTestWithFlags
     : public ReactInstanceIntegrationTest,
-      public ::testing::WithParamInterface<FeatureFlags> {
-  void SetUp() override {
-    featureFlags = std::make_unique<FeatureFlags>(GetParam());
-    ReactInstanceIntegrationTest::SetUp();
-  }
+      public ::testing::WithParamInterface<InspectorFlagOverrides> {
+ protected:
+  ReactInstanceIntegrationTestWithFlags() : inspectorFlagsGuard_(GetParam()) {}
+
+ private:
+  InspectorFlagOverridesGuard inspectorFlagsGuard_;
 };
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "InspectorFlagOverridesGuard.h"
+
+#include <jsinspector-modern/InspectorFlags.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
+
+#include <memory>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Helper class that maps \c InspectorFlagOverrides to the shape of \c
+ * ReactNativeFeatureFlagsDefaults.
+ */
+class ReactNativeFeatureFlagsOverrides
+    : public ReactNativeFeatureFlagsDefaults {
+ public:
+  ReactNativeFeatureFlagsOverrides(const InspectorFlagOverrides& overrides)
+      : overrides_(overrides) {}
+
+  bool inspectorEnableCxxInspectorPackagerConnection() override {
+    return overrides_.enableCxxInspectorPackagerConnection;
+  }
+
+  bool inspectorEnableModernCDPRegistry() override {
+    return overrides_.enableModernCDPRegistry;
+  }
+
+ private:
+  InspectorFlagOverrides overrides_;
+};
+
+InspectorFlagOverridesGuard::InspectorFlagOverridesGuard(
+    const InspectorFlagOverrides& overrides) {
+  ReactNativeFeatureFlags::override(
+      std::make_unique<ReactNativeFeatureFlagsOverrides>(overrides));
+}
+
+InspectorFlagOverridesGuard::~InspectorFlagOverridesGuard() {
+  ReactNativeFeatureFlags::dangerouslyReset();
+  InspectorFlags::getInstance().dangerouslyResetFlags();
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Overridden \c InspectorFlags values for use in tests.
+ */
+struct InspectorFlagOverrides {
+  // NOTE: Keep these entries in sync with ReactNativeFeatureFlagsOverrides in
+  // the implementation file.
+  bool enableCxxInspectorPackagerConnection = false;
+  bool enableModernCDPRegistry = false;
+};
+
+/**
+ * A RAII helper to set up and tear down \c InspectorFlags (via \c
+ * ReactNativeFeatureFlags) with overrides for the lifetime of a test object.
+ */
+class InspectorFlagOverridesGuard {
+ public:
+  explicit InspectorFlagOverridesGuard(const InspectorFlagOverrides& overrides);
+
+  // Explicitly default move constructor and move-assignment operator,
+  // preventing copying.
+  InspectorFlagOverridesGuard(InspectorFlagOverridesGuard&&) = default;
+  InspectorFlagOverridesGuard& operator=(InspectorFlagOverridesGuard&&) =
+      default;
+
+  ~InspectorFlagOverridesGuard();
+};
+
+} // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Create a shared `InspectorFlagOverridesGuard` util for our `jsinspector-modern` tests, update `ReactInstanceIntegrationTestWithFlags` to reuse this.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D54639775


