### PR TITLE
Fix VirtualizedList-test.js

### DIFF
--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -14,6 +14,8 @@ import VirtualizedList from '../VirtualizedList';
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
+jest.useFakeTimers();
+
 describe('VirtualizedList', () => {
   it('renders simple list', () => {
     const component = ReactTestRenderer.create(


### PR DESCRIPTION
Summary:
Fixes `VirtualizedList-test.js`, which assumes fake timers (e.g. using `jest.runAllTimers()` and `jest.runOnlyPendingTimers()`) but did not actually use fake timers.

Changelog:
[Internal]

Differential Revision: D54668281


