### PR TITLE
Fix public-api-test "expected parse error" assertion

### DIFF
--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -87,18 +87,21 @@ describe('public API', () => {
           return;
         }
 
+        let success = false;
         try {
           expect(await translateFlowToExportedAPI(source)).toMatchSnapshot();
 
-          if (FILES_WITH_KNOWN_ERRORS.has(file)) {
+          success = true;
+        } catch (e) {
+          if (!FILES_WITH_KNOWN_ERRORS.has(file)) {
+            console.error('Unable to parse file:', file, '\n' + e);
+          }
+        } finally {
+          if (success && FILES_WITH_KNOWN_ERRORS.has(file)) {
             console.error(
               'Expected parse error, please remove file exclude from FILES_WITH_KNOWN_ERRORS:',
               file,
             );
-          }
-        } catch (e) {
-          if (!FILES_WITH_KNOWN_ERRORS.has(file)) {
-            console.error('Unable to parse file:', file, '\n' + e);
           }
         }
       } else {


### PR DESCRIPTION
Summary:
## Overview
I noticed while running this test, that there's an existing `console.error` to remove a file from the `FILES_WITH_KNOWN_ERRORS` list, but the tests pass despite the error. This happens because the `console.error` throws to fail the test, but this `console.error` is inside a try/catch, so the error is swallowed.

This diff moves the check to a finally, which fails the test.

I also fixed the `FILES_WITH_KNOWN_ERRORS` list.

Changelog: [Internal]

Reviewed By: yungsters

Differential Revision: D54587062


