### PR TITLE
Expose `react_render_textlayoutmanager` via prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -149,6 +149,12 @@ val preparePrefab by
                   "react_render_mapbuffer",
                   Pair("../ReactCommon/react/renderer/mapbuffer/", "react/renderer/mapbuffer/")),
               PrefabPreprocessingEntry(
+                  "react_render_textlayoutmanager",
+                  listOf(
+                      Pair("../ReactCommon/react/renderer/textlayoutmanager/", "react/renderer/textlayoutmanager/"),
+                      Pair("../ReactCommon/react/renderer/textlayoutmanager/platform/android/", ""),
+                  )),
+              PrefabPreprocessingEntry(
                   "yoga",
                   listOf(
                       Pair("../ReactCommon/yoga/", ""),
@@ -556,6 +562,7 @@ android {
             "glog",
             "fabricjni",
             "react_render_mapbuffer",
+            "react_render_textlayoutmanager",
             "yoga",
             "folly_runtime",
             "react_nativemodule_core",
@@ -685,6 +692,9 @@ android {
     create("fabricjni") { headers = File(prefabHeadersDir, "fabricjni").absolutePath }
     create("react_render_mapbuffer") {
       headers = File(prefabHeadersDir, "react_render_mapbuffer").absolutePath
+    }
+    create("react_render_textlayoutmanager") {
+      headers = File(prefabHeadersDir, "react_render_textlayoutmanager").absolutePath
     }
     create("yoga") { headers = File(prefabHeadersDir, "yoga").absolutePath }
     create("folly_runtime") { headers = File(prefabHeadersDir, "folly_runtime").absolutePath }

--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -80,6 +80,7 @@ add_library(jsi ALIAS ReactAndroid::jsi)
 add_library(glog ALIAS ReactAndroid::glog)
 add_library(fabricjni ALIAS ReactAndroid::fabricjni)
 add_library(react_render_mapbuffer ALIAS ReactAndroid::react_render_mapbuffer)
+add_library(react_render_textlayoutmanager ALIAS ReactAndroid::react_render_textlayoutmanager)
 add_library(yoga ALIAS ReactAndroid::yoga)
 add_library(folly_runtime ALIAS ReactAndroid::folly_runtime)
 add_library(react_nativemodule_core ALIAS ReactAndroid::react_nativemodule_core)
@@ -108,6 +109,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         react_render_graphics               # prefab ready
         react_render_imagemanager           # prefab ready
         react_render_mapbuffer              # prefab ready
+        react_render_textlayoutmanager      # prefab ready
         rrc_image                           # prefab ready
         rrc_view                            # prefab ready
         rrc_text                            # prefab ready


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The `react_render_textlayoutmanager` was not exposed via prefab. I'm adding it to make possible for react-native-live-markdown to integrate on top of React Native via prefab. Based on #36166.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [CHANGED] - Expose `react_render_textlayoutmanager` via prefab.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
