### PR TITLE
Add conditional return in `handleRemoveView`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -518,11 +518,10 @@ public class ReactViewGroup extends ViewGroup
   private void handleRemoveView(View view) {
     UiThreadUtil.assertOnUiThread();
 
-    if (indexOfChild(view) == -1){
-      return;
-    }
-
     if (!customDrawOrderDisabled()) {
+      if (indexOfChild(view) == -1){
+        return;
+      }
       getDrawingOrderHelper().handleRemoveView(view);
       setChildrenDrawingOrderEnabled(getDrawingOrderHelper().shouldEnableCustomDrawingOrder());
     } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -518,6 +518,10 @@ public class ReactViewGroup extends ViewGroup
   private void handleRemoveView(View view) {
     UiThreadUtil.assertOnUiThread();
 
+    if (indexOfChild(view) == -1){
+      return;
+    }
+
     if (!customDrawOrderDisabled()) {
       getDrawingOrderHelper().handleRemoveView(view);
       setChildrenDrawingOrderEnabled(getDrawingOrderHelper().shouldEnableCustomDrawingOrder());


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I was recently working on an [issue](https://github.com/software-mansion/react-native-reanimated/issues/5715) in Reanimated where z-index of some views was broken after a Layout Animation was used. The issue was that in some cases we were calling the `removeView` function on a already removed view. On plain Android this wouldn't be an issue, since the `removeView` function ignores such calls. Unfortunately, the `ReactViewGroup.java` implementation maintains a counter of views with user defined z-index. This counter is decremented whenever a call to `removeView` is made, even if the view is not a child of this `ViewGroup`. This PR adds an additional check in the `handleRemoveView` function to unify the `removeView` behavior between Android and react-native.

## Changelog:
[ANDROID] [CHANGED] - Changed the `handleRemoveView` function in `ReactViewGroup.java` to ignore calls for `Views` that are not children of this `ViewGroup`

## Test Plan:

I tested if the `rn-tester` app behaves correctly after those changes.
