### PR TITLE
Enable JSI integration tests for Hermes CDPAgent

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.cpp
@@ -20,6 +20,11 @@ JsiIntegrationTestGenericEngineAdapter::JsiIntegrationTestGenericEngineAdapter(
     folly::Executor& jsExecutor)
     : runtime_{hermes::makeHermesRuntime()}, jsExecutor_{jsExecutor} {}
 
+InspectorFlagOverrides
+JsiIntegrationTestGenericEngineAdapter::getInspectorFlagOverrides() noexcept {
+  return {.enableModernCDPRegistry = true};
+}
+
 std::unique_ptr<RuntimeAgentDelegate>
 JsiIntegrationTestGenericEngineAdapter::createAgentDelegate(
     FrontendChannel frontendChannel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestGenericEngineAdapter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "../utils/InspectorFlagOverridesGuard.h"
+
 #include <jsinspector-modern/RuntimeTarget.h>
 
 #include <folly/executors/QueuedImmediateExecutor.h>
@@ -24,6 +26,8 @@ namespace facebook::react::jsinspector_modern {
 class JsiIntegrationTestGenericEngineAdapter : public RuntimeTargetDelegate {
  public:
   explicit JsiIntegrationTestGenericEngineAdapter(folly::Executor& jsExecutor);
+
+  static InspectorFlagOverrides getInspectorFlagOverrides() noexcept;
 
   virtual std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
       FrontendChannel frontendChannel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <folly/executors/QueuedImmediateExecutor.h>
-
 #include "JsiIntegrationTestHermesEngineAdapter.h"
+#include "../utils/InspectorFlagOverridesGuard.h"
+
+#include <folly/executors/QueuedImmediateExecutor.h>
 
 using facebook::hermes::makeHermesRuntime;
 
@@ -18,6 +19,11 @@ JsiIntegrationTestHermesEngineAdapter::JsiIntegrationTestHermesEngineAdapter(
     : runtime_{hermes::makeHermesRuntime()},
       jsExecutor_{jsExecutor},
       targetDelegate_{runtime_} {}
+
+InspectorFlagOverrides
+JsiIntegrationTestHermesEngineAdapter::getInspectorFlagOverrides() noexcept {
+  return {.enableModernCDPRegistry = true};
+}
 
 std::unique_ptr<RuntimeAgentDelegate>
 JsiIntegrationTestHermesEngineAdapter::createAgentDelegate(

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "../utils/InspectorFlagOverridesGuard.h"
+
 #include <jsinspector-modern/RuntimeTarget.h>
 
 #include <folly/executors/QueuedImmediateExecutor.h>
@@ -25,6 +27,8 @@ namespace facebook::react::jsinspector_modern {
 class JsiIntegrationTestHermesEngineAdapter : public RuntimeTargetDelegate {
  public:
   explicit JsiIntegrationTestHermesEngineAdapter(folly::Executor& jsExecutor);
+
+  static InspectorFlagOverrides getInspectorFlagOverrides() noexcept;
 
   virtual std::unique_ptr<RuntimeAgentDelegate> createAgentDelegate(
       FrontendChannel frontendChannel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesWithCDPAgentEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesWithCDPAgentEngineAdapter.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JsiIntegrationTestHermesWithCDPAgentEngineAdapter.h"
+
+namespace facebook::react::jsinspector_modern {
+
+JsiIntegrationTestHermesWithCDPAgentEngineAdapter::
+    JsiIntegrationTestHermesWithCDPAgentEngineAdapter(
+        folly::Executor& jsExecutor)
+    : JsiIntegrationTestHermesEngineAdapter(jsExecutor) {}
+
+InspectorFlagOverrides JsiIntegrationTestHermesWithCDPAgentEngineAdapter::
+    getInspectorFlagOverrides() noexcept {
+  return {
+      .enableHermesCDPAgent = true,
+      .enableModernCDPRegistry = true,
+  };
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesWithCDPAgentEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesWithCDPAgentEngineAdapter.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "../utils/InspectorFlagOverridesGuard.h"
+#include "JsiIntegrationTestHermesEngineAdapter.h"
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * An engine adapter for JsiIntegrationTest that uses Hermes (and Hermes's
+ * new CDPAgent API).
+ */
+class JsiIntegrationTestHermesWithCDPAgentEngineAdapter
+    : public JsiIntegrationTestHermesEngineAdapter {
+ public:
+  explicit JsiIntegrationTestHermesWithCDPAgentEngineAdapter(
+      folly::Executor& jsExecutor);
+
+  static InspectorFlagOverrides getInspectorFlagOverrides() noexcept;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.cpp
@@ -30,6 +30,10 @@ class ReactNativeFeatureFlagsOverrides
     return overrides_.enableCxxInspectorPackagerConnection;
   }
 
+  bool inspectorEnableHermesCDPAgent() override {
+    return overrides_.enableHermesCDPAgent;
+  }
+
   bool inspectorEnableModernCDPRegistry() override {
     return overrides_.enableModernCDPRegistry;
   }

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
@@ -18,6 +18,7 @@ struct InspectorFlagOverrides {
   // NOTE: Keep these entries in sync with ReactNativeFeatureFlagsOverrides in
   // the implementation file.
   bool enableCxxInspectorPackagerConnection = false;
+  bool enableHermesCDPAgent = false;
   bool enableModernCDPRegistry = false;
 };
 


### PR DESCRIPTION
Summary:
## Context

We are migrating to the new Hermes `CDPAgent` and `CDPDebugAPI` APIs in the modern CDP server (previously `HermesCDPHandler`).

## This diff

Bootstraps `HermesRuntimeAgentDelegateNew` within `JsiIntegrationTest.cpp`.

Test cases which currently do not pass with `HermesRuntimeAgentDelegateNew` are selectively matched against a new alias to exclude them: `JsiIntegrationHermesLegacyTest`.

Changelog: [Internal]

Differential Revision: D53810357


