### PR TITLE
Implement previouslyExportedState on HermesRuntimeAgentDelegateNew

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -92,7 +92,7 @@ references:
     # Cocoapods - RNTester
     pods_cache_key: &pods_cache_key v11-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
     cocoapods_cache_key: &cocoapods_cache_key v11-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
-    rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v9-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v10-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
 
     # Cocoapods - Template
     template_cocoapods_cache_key: &template_cocoapods_cache_key v6-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: packages/rn-tester/Pods
-          key: v2-${{ runner.os }}-RNTesterPods-${{ hashFiles('packages/rn-tester/Podfile.lock') }}-${{ hashFiles('packages/rn-tester/Podfile') }}-${{ hashFiles('tmp/hermes/hermesversion') }}
+          key: v3-${{ runner.os }}-RNTesterPods-${{ hashFiles('packages/rn-tester/Podfile.lock') }}-${{ hashFiles('packages/rn-tester/Podfile') }}-${{ hashFiles('tmp/hermes/hermesversion') }}
       - name: Pod Install
         run: |
           cd packages/rn-tester

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.h
@@ -66,6 +66,9 @@ class HermesRuntimeAgentDelegateNew : public RuntimeAgentDelegate {
    */
   bool handleRequest(const cdp::PreparsedRequest& req) override;
 
+  std::unique_ptr<RuntimeAgentDelegate::ExportedState> getExportedState()
+      override;
+
  private:
   class Impl;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -557,16 +557,23 @@ TYPED_TEST(
       std::to_string(executionContextId)));
 }
 
-// TODO(T178858701): Restore breakpoint reload persistence under
-// HermesRuntimeAgentDelegateNew
-TYPED_TEST(JsiIntegrationHermesLegacyTest, ResolveBreakpointAfterReload) {
+TYPED_TEST(JsiIntegrationHermesTest, ResolveBreakpointAfterReload) {
   this->connect();
 
   InSequence s;
 
-  this->expectMessageFromPage(JsonParsed(AtJsonPtr("/id", 1)));
+  this->expectMessageFromPage(JsonEq(R"({
+                                         "id": 1,
+                                         "result": {}
+                                       })"));
   this->toPage_->sendMessage(R"({
                                  "id": 1,
+                                 "method": "Debugger.enable"
+                               })");
+
+  this->expectMessageFromPage(JsonParsed(AtJsonPtr("/id", 2)));
+  this->toPage_->sendMessage(R"({
+                                 "id": 2,
                                  "method": "Debugger.setBreakpointByUrl",
                                  "params": {"lineNumber": 2, "url": "breakpointTest.js"}
                                })");
@@ -574,11 +581,11 @@ TYPED_TEST(JsiIntegrationHermesLegacyTest, ResolveBreakpointAfterReload) {
   this->reload();
 
   this->expectMessageFromPage(JsonEq(R"({
-                                         "id": 2,
+                                         "id": 3,
                                          "result": {}
                                        })"));
   this->toPage_->sendMessage(R"({
-                                 "id": 2,
+                                 "id": 3,
                                  "method": "Debugger.enable"
                                })");
 


### PR DESCRIPTION
Summary:
## Context

We are migrating to the new Hermes `CDPAgent` and `CDPDebugAPI` APIs in the modern CDP server (previously `HermesCDPHandler`).

## This diff

Wires up `previouslyExportedState` with `CDPAgent`, and re-enables the `ResolveBreakpointAfterReload` integration test.

Changelog: [Internal]

Differential Revision: D54369985


