### PR TITLE
Update feature flag generator to create directories for generated files before writing

### DIFF
--- a/packages/react-native/scripts/featureflags/generateFiles.js
+++ b/packages/react-native/scripts/featureflags/generateFiles.js
@@ -14,6 +14,7 @@ import generateAndroidModules from './generateAndroidModules';
 import generateCommonCxxModules from './generateCommonCxxModules';
 import generateJavaScriptModules from './generateJavaScriptModules';
 import fs from 'fs';
+import path from 'path';
 
 export default function generateFiles(
   generatorConfig: GeneratorConfig,
@@ -65,6 +66,7 @@ export default function generateFiles(
   }
 
   for (const [modulePath, moduleContents] of Object.entries(generatedFiles)) {
-    fs.writeFileSync(modulePath, moduleContents, 'utf8');
+    fs.mkdirSync(path.dirname(modulePath), {recursive: true});
+    fs.writeFileSync(modulePath, moduleContents, {encoding: 'utf8'});
   }
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

The generator doesn't create intermediate directories, which is causing issues now that we're moving the generated native module spec to a new directory.

This fixes that.

Differential Revision: D54690126


