### PR TITLE
Allow accessing common feature flags before setting overrides for JS-only overrides

### DIFF
--- a/packages/react-native/scripts/featureflags/generateFiles.js
+++ b/packages/react-native/scripts/featureflags/generateFiles.js
@@ -14,6 +14,7 @@ import generateAndroidModules from './generateAndroidModules';
 import generateCommonCxxModules from './generateCommonCxxModules';
 import generateJavaScriptModules from './generateJavaScriptModules';
 import fs from 'fs';
+import path from 'path';
 
 export default function generateFiles(
   generatorConfig: GeneratorConfig,
@@ -65,6 +66,7 @@ export default function generateFiles(
   }
 
   for (const [modulePath, moduleContents] of Object.entries(generatedFiles)) {
-    fs.writeFileSync(modulePath, moduleContents, 'utf8');
+    fs.mkdirSync(path.dirname(modulePath), {recursive: true});
+    fs.writeFileSync(modulePath, moduleContents, {encoding: 'utf8'});
   }
 }

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -29,7 +29,6 @@ function createGetter<T: boolean | number | string>(
 
   return () => {
     if (cachedValue == null) {
-      accessedFeatureFlags.add(configName);
       cachedValue = customValueGetter() ?? defaultValue;
     }
     return cachedValue;
@@ -44,7 +43,10 @@ export function createJavaScriptFlagGetter<
 ): Getter<ReturnType<ReactNativeFeatureFlagsJsOnly[K]>> {
   return createGetter(
     configName,
-    () => overrides?.[configName]?.(),
+    () => {
+      accessedFeatureFlags.add(configName);
+      return overrides?.[configName]?.();
+    },
     defaultValue,
   );
 }

--- a/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
+++ b/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
@@ -84,18 +84,32 @@ describe('ReactNativeFeatureFlags', () => {
     expect(jsOnlyTestFlagFn).toHaveBeenCalledTimes(1);
   });
 
-  it('should throw an error if any of the flags has been accessed before overridding', () => {
+  it('should throw an error if any of the JS flags has been accessed before overridding', () => {
     const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
 
-    ReactNativeFeatureFlags.commonTestFlag();
+    ReactNativeFeatureFlags.jsOnlyTestFlag();
 
     expect(() =>
       ReactNativeFeatureFlags.override({
         jsOnlyTestFlag: () => true,
       }),
     ).toThrow(
-      'Feature flags were accessed before being overridden: commonTestFlag',
+      'Feature flags were accessed before being overridden: jsOnlyTestFlag',
     );
+  });
+
+  it('should NOT throw an error if any of the common flags has been accessed before overridding', () => {
+    const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
+
+    ReactNativeFeatureFlags.commonTestFlag();
+
+    expect(() => {
+      ReactNativeFeatureFlags.override({
+        jsOnlyTestFlag: () => true,
+      });
+    }).not.toThrow();
+
+    expect(ReactNativeFeatureFlags.jsOnlyTestFlag()).toBe(true);
   });
 
   it('should throw an error when trying to set overrides twice', () => {


### PR DESCRIPTION
Summary:
Changelog: [internal]

When we built the new feature flag system we added a constraint in the JS API to prevent calling `override` if any of the flags was already accessed from JS.

This is very restrictive because it doesn't allow us to access common flags (like `enableMicrotasks`) set up from native during the initialization of the framework because then applications wouldn't be able to set JS-only overrides.

This relaxes the constraint to disallow accessing JS-only flags before setting JS-only overrides, but accessing common (native) flags before that is ok.

Differential Revision: D54687055


