### PR TITLE
Implement getJSCallInvokerHolder for BridgelessCatalystInstance

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3582,7 +3582,7 @@ public abstract class com/facebook/react/runtime/BindingsInstaller {
 }
 
 public final class com/facebook/react/runtime/BridgelessCatalystInstance : com/facebook/react/bridge/CatalystInstance {
-	public fun <init> ()V
+	public fun <init> (Lcom/facebook/react/runtime/ReactHostImpl;)V
 	public fun addBridgeIdleDebugListener (Lcom/facebook/react/bridge/NotThreadSafeBridgeIdleDebugListener;)V
 	public fun addJSIModules (Ljava/util/List;)V
 	public fun callFunction (Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/bridge/NativeArray;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -32,7 +32,8 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
 
 @DoNotStrip
 @DeprecatedInNewArchitecture
-public class BridgelessCatalystInstance : CatalystInstance {
+public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : CatalystInstance {
+
   override fun handleMemoryPressure(level: Int) {
     throw UnsupportedOperationException("Unimplemented method 'handleMemoryPressure'")
   }
@@ -161,8 +162,8 @@ public class BridgelessCatalystInstance : CatalystInstance {
     throw UnsupportedOperationException("Unimplemented method 'addJSIModules'")
   }
 
-  override fun getJSCallInvokerHolder(): CallInvokerHolder {
-    throw UnsupportedOperationException("Unimplemented method 'getJSCallInvokerHolder'")
+  override fun getJSCallInvokerHolder(): CallInvokerHolder? {
+    return reactHost.getJSCallInvokerHolder()
   }
 
   override fun getNativeMethodCallInvokerHolder(): NativeMethodCallInvokerHolder {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -8,6 +8,7 @@
 package com.facebook.react.runtime;
 
 import android.content.Context;
+import android.util.Log;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -18,8 +19,6 @@ import com.facebook.react.bridge.JavaScriptModuleRegistry;
 import com.facebook.react.bridge.NativeArray;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException;
-import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableNativeArray;
@@ -84,11 +83,10 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
 
   @Override
   public CatalystInstance getCatalystInstance() {
-    ReactSoftExceptionLogger.logSoftExceptionVerbose(
+    Log.w(
         TAG,
-        new ReactNoCrashBridgeNotAllowedSoftException(
-            "getCatalystInstance() cannot be called when the bridge is disabled"));
-    throw new UnsupportedOperationException("There is no Catalyst instance in bridgeless mode.");
+        "[WARNING] Bridgeless doesn't support CatalystInstance. Accessing an API that's not part of the new architecture is not encouraged usage.");
+    return new BridgelessCatalystInstance(mReactHost);
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -61,6 +61,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.runtime.internal.bolts.Continuation;
 import com.facebook.react.runtime.internal.bolts.Task;
 import com.facebook.react.runtime.internal.bolts.TaskCompletionSource;
+import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.BlackHoleEventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcher;
@@ -601,6 +602,20 @@ public class ReactHostImpl implements ReactHost {
     ReactSoftExceptionLogger.logSoftException(
         TAG,
         new ReactNoCrashSoftException("Tried to get runtime executor while instance is not ready"));
+    return null;
+  }
+
+  /* package */
+  @Nullable
+  CallInvokerHolder getJSCallInvokerHolder() {
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance != null) {
+      return reactInstance.getJSCallInvokerHolder();
+    }
+    ReactSoftExceptionLogger.logSoftException(
+        TAG,
+        new ReactNoCrashSoftException(
+            "Tried to get JSCallInvokerHolder while instance is not ready"));
     return null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -478,7 +478,7 @@ final class ReactInstance {
 
   private native void loadJSBundleFromAssets(AssetManager assetManager, String assetURL);
 
-  private native CallInvokerHolderImpl getJSCallInvokerHolder();
+  /* package */ native CallInvokerHolderImpl getJSCallInvokerHolder();
 
   private native NativeMethodCallInvokerHolderImpl getNativeMethodCallInvokerHolder();
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
@@ -55,9 +55,11 @@ class BridgelessReactContextTest {
     Assertions.assertThat(bridgelessReactContext.getFabricUIManager()).isEqualTo(fabricUiManager)
   }
 
-  @Test(expected = UnsupportedOperationException::class)
-  fun getCatalystInstance_throwsException() {
-    // Disable this test for now due to mocking FabricUIManager fails
-    bridgelessReactContext.catalystInstance
+  @Test
+  fun getCatalystInstanceTest() {
+    val bridgelessCatalystInstance = BridgelessCatalystInstance(reactHost)
+    doReturn(bridgelessCatalystInstance).`when`(bridgelessReactContext).getCatalystInstance()
+    Assertions.assertThat(bridgelessReactContext.getCatalystInstance())
+        .isEqualTo(bridgelessCatalystInstance)
   }
 }


### PR DESCRIPTION
Summary:
Implement `getJSCallInvokerHolder()` for BridgelessCatalystInstance

Changelog:
[Android][Breaking] Implement `getJSCallInvokerHolder()` for Bridgeless Catalyst Instance

Reviewed By: cortinico

Differential Revision: D54650305


