### PR TITLE
fix: [TypeScript] Allow to pass empty string as style

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
@@ -14,7 +14,7 @@ export interface StyleSheetProperties {
   flatten<T extends string>(style: T): T;
 }
 
-type Falsy = undefined | null | false;
+type Falsy = undefined | null | false | '';
 interface RecursiveArray<T>
   extends Array<T | ReadonlyArray<T> | RecursiveArray<T>> {}
 /** Keep a brand of 'T' so that calls to `StyleSheet.flatten` can take `RegisteredStyle<T>` and return `T`. */

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -411,7 +411,9 @@ class CustomView extends React.Component {
   }
 }
 
-class Welcome extends React.Component<ElementProps<View> & {color: string}> {
+class Welcome extends React.Component<
+  ElementProps<View> & {color: string; bgColor?: null | undefined | string}
+> {
   rootViewRef = React.useRef<View>(null);
   customViewRef = React.useRef<CustomView>(null);
 
@@ -436,12 +438,18 @@ class Welcome extends React.Component<ElementProps<View> & {color: string}> {
   }
 
   render() {
-    const {color, ...props} = this.props;
+    const {color, bgColor, ...props} = this.props;
     return (
       <View
         {...props}
         ref={this.rootViewRef}
-        style={[[styles.container], undefined, null, false]}>
+        style={[
+          [styles.container],
+          undefined,
+          null,
+          false,
+          bgColor && {backgroundColor: bgColor},
+        ]}>
         <Text style={styles.welcome}>Welcome to React Native</Text>
         <Text style={styles.instructions}>
           To get started, edit index.ios.js


### PR DESCRIPTION
## Summary:

```tsx
import {Text} from 'react-native'

interface Props {
  foregroundColor?: string | undefined | null
}

function Test({foregroundColor}: Props){
  return <Text style=[styles.icon, foregroundColor && { color: foregroundColor }] />
  // ^^^ Error: Type "" is not assignable to type TextStyle | Falsy | RegisteredStyle<TextStyle> | RecursiveArray<TextStyle...
}
```


## Changelog:

[GENERAL] [ADDED] - [TypeScript] Allow to pass empty string as style

## Test Plan:

Change `Falsy` type locally and test it on the next code 

```tsx
const styles = StyleSheet.create({
  text: {
    color: 'red',
  },
});
export const a = <Text style={[styles.text, null, '', undefined, false]} />;
```
