### PR TITLE
Reduce warning level of distributed Yoga builds

### DIFF
--- a/packages/react-native/ReactCommon/yoga/cmake/project-defaults.cmake
+++ b/packages/react-native/ReactCommon/yoga/cmake/project-defaults.cmake
@@ -33,9 +33,7 @@ add_compile_options(
     -fexceptions
     # Enable warnings and warnings as errors
     -Wall
-    -Wextra
     -Werror
-    -Wconversion
     # Disable RTTI
     $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
     # Use -O2 (prioritize speed)


### PR DESCRIPTION
Summary:
Yoga may be built with a high warning level. This is helpful in letting Yoga be used in more places, and finding defects. We currently set these in the internal BUCK build, the CMake reference build, and the Yoga Standalone (not RN) CocoaPods build.

Yoga's reference CMake build and spec are consumed today by users of Yoga, instead of just Yoga developers. Here, it makes more sense to avoid anything that could break compiler-to-compiler compatibility.

We default these to a less intense (`-Wall -Werror`). I kept `/W4`, for pragmatic reasons, and since it is relatively standard for MSVC. 

We continue to build with strict flags on Buck build on Clang.


Fixes https://github.com/facebook/yoga/issues/1590

Differential Revision: D54735661


