### PR TITLE
delete passthroughAnimatedPropExplicitValues from animated component

### DIFF
--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -8,19 +8,12 @@
  * @format
  */
 
-import View from '../Components/View/View';
 import useMergeRefs from '../Utilities/useMergeRefs';
 import useAnimatedProps from './useAnimatedProps';
 import * as React from 'react';
 
 // $FlowFixMe[deprecated-type]
-export type AnimatedProps<Props: {...}> = $ObjMap<
-  Props &
-    $ReadOnly<{
-      passthroughAnimatedPropExplicitValues?: React.ElementConfig<typeof View>,
-    }>,
-  () => any,
->;
+export type AnimatedProps<Props: {...}> = $ObjMap<Props, () => any>;
 
 export type AnimatedComponentType<
   Props: {...},
@@ -43,19 +36,9 @@ export default function createAnimatedComponent<TProps: {...}, TInstance>(
       // transformed and Pressable, onPress will not work after transform
       // without these passthrough values.
       // $FlowFixMe[prop-missing]
-      const {passthroughAnimatedPropExplicitValues, style} = reducedProps;
-      const {style: passthroughStyle, ...passthroughProps} =
-        passthroughAnimatedPropExplicitValues ?? {};
-      const mergedStyle = {...style, ...passthroughStyle};
+      const {style} = reducedProps;
 
-      return (
-        <Component
-          {...reducedProps}
-          {...passthroughProps}
-          style={mergedStyle}
-          ref={ref}
-        />
-      );
+      return <Component {...reducedProps} style={style} ref={ref} />;
     },
   );
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -810,13 +810,7 @@ exports[`public API should not change unintentionally Libraries/Animated/compone
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/createAnimatedComponent.js 1`] = `
-"export type AnimatedProps<Props: { ... }> = $ObjMap<
-  Props &
-    $ReadOnly<{
-      passthroughAnimatedPropExplicitValues?: React.ElementConfig<typeof View>,
-    }>,
-  () => any,
->;
+"export type AnimatedProps<Props: { ... }> = $ObjMap<Props, () => any>;
 export type AnimatedComponentType<
   Props: { ... },
   +Instance = mixed,


### PR DESCRIPTION
Summary:
changelog: [internal]

`passthroughAnimatedPropExplicitValues` is not used. Let's remove it.

Reviewed By: yungsters

Differential Revision: D54583470


