### PR TITLE
Add new systrace sections in MountingCoordinator

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
@@ -106,6 +106,8 @@ std::optional<MountingTransaction> MountingCoordinator::pullTransaction()
       mountingOverrideDelegate->shouldOverridePullTransaction();
 
   if (shouldOverridePullTransaction) {
+    SystraceSection section2("MountingCoordinator::overridePullTransaction");
+
     auto mutations = ShadowViewMutation::List{};
     auto telemetry = TransactionTelemetry{};
 
@@ -128,6 +130,9 @@ std::optional<MountingTransaction> MountingCoordinator::pullTransaction()
 
 #ifdef RN_SHADOW_TREE_INTROSPECTION
   if (transaction.has_value()) {
+    SystraceSection section2(
+        "MountingCoordinator::verifyMutationsForDebugging");
+
     // We have something to validate.
     auto mutations = transaction->getMutations();
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

I think mount operations are taking longer than expected because of a debugging block (that we might remove). This adds some systrace sections to distinguish that from the overall time and confirm this only happens in debug builds.

Differential Revision: D54746491


