### PR TITLE
Scope LongLivedObjectCollection per runtime [2/n]

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/CallbackWrapper.h
+++ b/packages/react-native/ReactCommon/react/bridging/CallbackWrapper.h
@@ -24,12 +24,11 @@ class CallbackWrapper : public LongLivedObject {
       jsi::Function&& callback,
       jsi::Runtime& runtime,
       std::shared_ptr<CallInvoker> jsInvoker)
-      : callback_(std::move(callback)),
-        runtime_(runtime),
+      : LongLivedObject(runtime),
+        callback_(std::move(callback)),
         jsInvoker_(std::move(jsInvoker)) {}
 
   jsi::Function callback_;
-  jsi::Runtime& runtime_;
   std::shared_ptr<CallInvoker> jsInvoker_;
 
  public:

--- a/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
+++ b/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <jsi/jsi.h>
 #include <memory>
 #include <mutex>
 #include <unordered_set>
@@ -31,8 +32,9 @@ class LongLivedObject {
   virtual void allowRelease();
 
  protected:
-  LongLivedObject() = default;
+  explicit LongLivedObject(jsi::Runtime& runtime) : runtime_(runtime) {}
   virtual ~LongLivedObject() = default;
+  jsi::Runtime& runtime_;
 };
 
 /**

--- a/packages/react-native/ReactCommon/react/bridging/Promise.h
+++ b/packages/react-native/ReactCommon/react/bridging/Promise.h
@@ -34,7 +34,8 @@ class AsyncPromise {
             },
             jsInvoker));
 
-    auto promiseHolder = std::make_shared<PromiseHolder>(promise.asObject(rt));
+    auto promiseHolder =
+        std::make_shared<PromiseHolder>(rt, promise.asObject(rt));
     LongLivedObjectCollection::get().add(promiseHolder);
 
     // The shared state can retain the promise holder weakly now.
@@ -71,7 +72,8 @@ class AsyncPromise {
 
  private:
   struct PromiseHolder : LongLivedObject {
-    PromiseHolder(jsi::Object p) : promise(std::move(p)) {}
+    PromiseHolder(jsi::Runtime& runtime, jsi::Object p)
+        : LongLivedObject(runtime), promise(std::move(p)) {}
 
     jsi::Object promise;
   };

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.cpp
@@ -63,7 +63,9 @@ jsi::Array deepCopyJSIArray(jsi::Runtime& rt, const jsi::Array& arr) {
 }
 
 Promise::Promise(jsi::Runtime& rt, jsi::Function resolve, jsi::Function reject)
-    : runtime_(rt), resolve_(std::move(resolve)), reject_(std::move(reject)) {}
+    : LongLivedObject(rt),
+      resolve_(std::move(resolve)),
+      reject_(std::move(reject)) {}
 
 void Promise::resolve(const jsi::Value& result) {
   resolve_.call(runtime_, result);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
@@ -26,7 +26,6 @@ struct Promise : public LongLivedObject {
   void resolve(const jsi::Value& result);
   void reject(const std::string& error);
 
-  jsi::Runtime& runtime_;
   jsi::Function resolve_;
   jsi::Function reject_;
 };


### PR DESCRIPTION
Summary:
Changelog:
[General] [Breaking] - Make `LongLivedObject` constructor accept a `Runtime` reference.

# Context

Approach 1 as described in [RFC post](https://fb.workplace.com/groups/615693552291894/permalink/1693347124526526/).

# This diff

* Embed `Runtime` reference in `LongLivedObject` to keep supporting `allowRelease` method (and update extending classes accordingly)
* Update MSFT fork accordingly

Reviewed By: RSNara

Differential Revision: D54638813


