### PR TITLE
change: replace twitter with x

### DIFF
--- a/packages/react-native/Libraries/NewAppScreen/components/LearnMoreLinks.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/LearnMoreLinks.js
@@ -74,10 +74,10 @@ const links = [
   },
   {
     id: 9,
-    title: 'Follow us on Twitter',
-    link: 'https://twitter.com/reactnative',
+    title: 'Follow us on X',
+    link: 'https://x.com/reactnative',
     description:
-      'Stay in touch with the community, join in on Q&As and more by following React Native on Twitter.',
+      'Stay in touch with the community, join in on Q&As and more by following React Native on X.',
   },
 ];
 


### PR DESCRIPTION
## Summary:
When users create a new app, there is an option: Follow us on Twitter with the description. Twitter is X now.
![twitter](https://github.com/facebook/react-native/assets/8622007/7565a692-0e83-4549-a688-08f3ba28c76b)


## Changelog: [Internal]
Replace the Twitter link, title, and description with X. 

## Test Plan:
Set the environment for React Native app and then `npx react-native@latest init AwesomeProject`, `npm start`, and `npm run ios` 
