### PR TITLE
Fix Bridgeless React Context test in OSS

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
@@ -57,9 +57,7 @@ class BridgelessReactContextTest {
 
   @Test
   fun getCatalystInstanceTest() {
-    val bridgelessCatalystInstance = BridgelessCatalystInstance(reactHost)
-    doReturn(bridgelessCatalystInstance).`when`(bridgelessReactContext).getCatalystInstance()
     Assertions.assertThat(bridgelessReactContext.getCatalystInstance())
-        .isEqualTo(bridgelessCatalystInstance)
+        .isInstanceOf(BridgelessCatalystInstance::class.java)
   }
 }


### PR DESCRIPTION
Summary: https://github.com/facebook/react-native/pull/43400/ caused a `getCatalystInstanceTest` to fail in OSS due to `bridgelessReactContext` not being a Mock object.

Differential Revision: D54781539


