### PR TITLE
Fix maintainVisibleContentPosition on Android during momentum scroll

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
@@ -118,7 +118,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
       int deltaX = newFrame.left - mPrevFirstVisibleFrame.left;
       if (deltaX != 0) {
         int scrollX = mScrollView.getScrollX();
-        mScrollView.scrollTo(scrollX + deltaX, mScrollView.getScrollY());
+        mScrollView.scrollToPreservingMomentum(scrollX + deltaX, mScrollView.getScrollY());
         mPrevFirstVisibleFrame = newFrame;
         if (mConfig.autoScrollToTopThreshold != null
             && scrollX <= mConfig.autoScrollToTopThreshold) {
@@ -129,7 +129,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
       int deltaY = newFrame.top - mPrevFirstVisibleFrame.top;
       if (deltaY != 0) {
         int scrollY = mScrollView.getScrollY();
-        mScrollView.scrollTo(mScrollView.getScrollX(), scrollY + deltaY);
+        mScrollView.scrollToPreservingMomentum(mScrollView.getScrollX(), scrollY + deltaY);
         mPrevFirstVisibleFrame = newFrame;
         if (mConfig.autoScrollToTopThreshold != null
             && scrollY <= mConfig.autoScrollToTopThreshold) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -1390,6 +1390,13 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
    * calculated against outdated scroll offsets.
    */
   private void recreateFlingAnimation(int scrollX, int maxX) {
+    // If we have any pending custom flings (e.g. from animated `scrollTo`, or flinging to a snap
+    // point), cancel them.
+    // TODO: Can we be more graceful (like OverScroller flings)?
+    if (getFlingAnimator().isRunning()) {
+      getFlingAnimator().cancel();
+    }
+
     if (mScroller != null && !mScroller.isFinished()) {
       // Calculate the velocity and position of the fling animation at the time of this layout
       // event, which may be later than the last ScrollView tick. These values are not commited to
@@ -1419,8 +1426,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   private void adjustPositionForContentChangeRTL(int left, int right, int oldLeft, int oldRight) {
-    // If we have any pending custon flings (e.g. from aninmated `scrollTo`, or flinging to a snap
-    // point), finish them, commiting the final `scrollX`.
+    // If we have any pending custom flings (e.g. from animated `scrollTo`, or flinging to a snap
+    // point), finish them, committing the final `scrollX`.
     // TODO: Can we be more graceful (like OverScroller flings)?
     if (getFlingAnimator().isRunning()) {
       getFlingAnimator().end();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -1323,6 +1323,25 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     setPendingContentOffsets(x, y);
   }
 
+  /**
+   * Scrolls to a new position preserving any momentum scrolling animation.
+   */
+  public void scrollToPreservingMomentum(int x, int y) {
+    float velocity = 0;
+    float direction = 0;
+    if (mScroller != null && !mScroller.isFinished()) {
+      velocity = mScroller.getCurrVelocity();
+      direction = Math.signum(mOnScrollDispatchHelper.getXFlingVelocity());
+      mScroller.abortAnimation();
+    }
+
+    scrollTo(x, y);
+
+    if (mScroller != null && velocity != 0) {
+      fling((int)(direction * velocity));
+    }
+  }
+
   private boolean isContentReady() {
     View child = getContentView();
     return child != null && child.getWidth() != 0 && child.getHeight() != 0;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1091,22 +1091,45 @@ public class ReactScrollView extends ScrollView
   }
 
   /**
+   * If we are in the middle of a fling animation from the user removing their finger
+   * (OverScroller is in `FLING_MODE`), recreate the existing fling animation since it was
+   * calculated against outdated scroll offsets.
+   */
+  private void recreateFlingAnimation(int scrollY) {
+    if (mScroller != null && !mScroller.isFinished()) {
+      // Calculate the velocity and position of the fling animation at the time of this layout
+      // event, which may be later than the last ScrollView tick. These values are not committed to
+      // the underlying ScrollView, which will recalculate positions on its next tick.
+      int scrollerYBeforeTick = mScroller.getCurrY();
+      boolean hasMoreTicks = mScroller.computeScrollOffset();
+
+      // Stop the existing animation at the current state of the scroller. We will then recreate
+      // it starting at the adjusted y offset.
+      mScroller.forceFinished(true);
+
+      if (hasMoreTicks) {
+        // OverScroller.getCurrVelocity() returns an absolute value of the velocity a current fling
+        // animation (only FLING_MODE animations). We derive direction along the Y axis from the
+        // start and end of the, animation assuming ScrollView never fires horizontal fling
+        // animations.
+        // TODO: This does not fully handle overscroll.
+        float direction = Math.signum(mScroller.getFinalY() - mScroller.getStartY());
+        float flingVelocityY = mScroller.getCurrVelocity() * direction;
+
+        mScroller.fling(
+          getScrollX(), scrollY, 0, (int) flingVelocityY, 0, 0, 0, Integer.MAX_VALUE);
+      } else {
+        scrollTo(getScrollX(), scrollY + (mScroller.getCurrX() - scrollerYBeforeTick));
+      }
+    }
+  }
+
+  /**
    * Scrolls to a new position preserving any momentum scrolling animation.
    */
   public void scrollToPreservingMomentum(int x, int y) {
-    float velocity = 0;
-    float direction = 0;
-    if (mScroller != null && !mScroller.isFinished()) {
-      velocity = mScroller.getCurrVelocity();
-      direction = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
-      mScroller.abortAnimation();
-    }
-
     scrollTo(x, y);
-
-    if (mScroller != null && velocity != 0) {
-      fling((int)(direction * velocity));
-    }
+    recreateFlingAnimation(y);
   }
 
   private boolean isContentReady() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1090,6 +1090,25 @@ public class ReactScrollView extends ScrollView
     setPendingContentOffsets(x, y);
   }
 
+  /**
+   * Scrolls to a new position preserving any momentum scrolling animation.
+   */
+  public void scrollToPreservingMomentum(int x, int y) {
+    float velocity = 0;
+    float direction = 0;
+    if (mScroller != null && !mScroller.isFinished()) {
+      velocity = mScroller.getCurrVelocity();
+      direction = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
+      mScroller.abortAnimation();
+    }
+
+    scrollTo(x, y);
+
+    if (mScroller != null && velocity != 0) {
+      fling((int)(direction * velocity));
+    }
+  }
+
   private boolean isContentReady() {
     View child = getContentView();
     return child != null && child.getWidth() != 0 && child.getHeight() != 0;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1096,6 +1096,13 @@ public class ReactScrollView extends ScrollView
    * calculated against outdated scroll offsets.
    */
   private void recreateFlingAnimation(int scrollY) {
+    // If we have any pending custom flings (e.g. from animated `scrollTo`, or flinging to a snap
+    // point), cancel them.
+    // TODO: Can we be more graceful (like OverScroller flings)?
+    if (getFlingAnimator().isRunning()) {
+      getFlingAnimator().cancel();
+    }
+
     if (mScroller != null && !mScroller.isFinished()) {
       // Calculate the velocity and position of the fling animation at the time of this layout
       // event, which may be later than the last ScrollView tick. These values are not committed to

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -597,5 +597,7 @@ public class ReactScrollViewHelper {
 
   public interface HasSmoothScroll {
     void reactSmoothScrollTo(int x, int y);
+
+    void scrollToPreservingMomentum(int x, int y);
   }
 }


### PR DESCRIPTION
## Summary:

When using maintainVisibleContentPosition (mvcp) on Android it doesn't work properly when items are added during a momentum scroll. This happens because the android scrollview momentum scroll animation overrides the scroll position that the mvcp implementation sets [here](https://github.com/facebook/react-native/blob/2d547a3252b328251e49dabfeec85f8d46c85411/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java#L132).

To fix this we need to cancel the momentum scroll animation, update the scroll position then restart the scroll animation with the previous animation remaining momentum.

## Changelog:

[ANDROID] [FIXED] - Fix maintainVisibleContentPosition during momentum scroll

## Test Plan:

Tested in RNTester on Android with both vertical and horizontal scrollviews using the following code:

```ts
// packages/rn-tester/js/RNTesterAppShared.js

import {
  Button,
  SafeAreaView,
  ScrollView,
  Text,
  View,
} from 'react-native';
import React, {useLayoutEffect, useRef, useState} from 'react';

const generateUniqueKey = () => `_${Math.random().toString(36).substr(2, 9)}`

const initialData = Array.from(Array(100).keys()).map(n => ({
  id: generateUniqueKey(),
  value: n,
}))

function ListItem({item}) {
  const color = `hsl(${item.value * 10}, 75%, 85%)`;

  return (
    <View
      style={{
        backgroundColor: color,
        height: 100,
      }}>
      <Text>List item: {item.value}</Text>
    </View>
  );
}

export default function FlatListRepro() {
  const numToAdd = 10;
  const [numbers, setNumbers] = useState(initialData);
  const ref = useRef();

  const addAbove = () => {
    setNumbers(prev => {
      const additionalNumbers = Array.from(Array(numToAdd).keys())
        .map(n => ({
          id: generateUniqueKey(),
          value: prev[0].value - n - 1,
        }))
        .reverse();

      return additionalNumbers.concat(prev);
    });
  };

  useLayoutEffect(() => {
    ref.current.scrollTo({y: numbers.length * 100, animated: false});
  // eslint-disable-next-line react-hooks/exhaustive-deps
  }, []);

  return (
    <SafeAreaView style={{flex: 1}}>
      <View style={{flexDirection: 'row', alignItems: 'center'}}>
        <Button title="Add Above" onPress={addAbove} />
      </View>
      <View>
        <ScrollView
          ref={ref}
          maintainVisibleContentPosition={{
            minIndexForVisible: 0,
          }}
        >
          {numbers.map((item) => (
            <ListItem key={item.id} item={item} />
          ))}
        </ScrollView>
      </View>
    </SafeAreaView>
  )
}
```

Before:

https://github.com/facebook/react-native/assets/2677334/a7102665-991e-449e-9d0a-ef06c370dc71

After:

https://github.com/facebook/react-native/assets/2677334/5430ecb1-26a9-4c92-9f16-c762d75685db




