### PR TITLE
Factor out common parts of TextInputProps between Android/iOS

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -201,7 +201,8 @@ Pod::Spec.new do |s|
     ss.subspec "textinput" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
+      sss.source_files         = "react/renderer/components/textinput/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/textinput/platform/android"
       sss.header_dir           = "react/renderer/components/iostextinput"
 
     end

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "BaseTextInputProps.h"
+
+#include <react/renderer/core/propsConversions.h>
+
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsMacros.h>
+
+#include <react/renderer/graphics/Color.h>
+
+#include <react/renderer/attributedstring/TextAttributes.h>
+#include <react/renderer/attributedstring/conversions.h>
+#include <react/renderer/components/image/conversions.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/graphics/Color.h>
+#include <react/renderer/imagemanager/primitives.h>
+#include <react/utils/CoreFeatures.h>
+
+namespace facebook::react {
+
+BaseTextInputProps::BaseTextInputProps(
+    const PropsParserContext& context,
+    const BaseTextInputProps& sourceProps,
+    const RawProps& rawProps)
+    : ViewProps(context, sourceProps, rawProps),
+      BaseTextProps(context, sourceProps, rawProps),
+      paragraphAttributes(convertRawProp(
+          context,
+          rawProps,
+          sourceProps.paragraphAttributes,
+          {})),
+      defaultValue(convertRawProp(
+          context,
+          rawProps,
+          "defaultValue",
+          sourceProps.defaultValue,
+          {})),
+      placeholder(convertRawProp(
+          context,
+          rawProps,
+          "placeholder",
+          sourceProps.placeholder,
+          {})),
+      placeholderTextColor(convertRawProp(
+          context,
+          rawProps,
+          "placeholderTextColor",
+          sourceProps.placeholderTextColor,
+          {})),
+      cursorColor(convertRawProp(
+          context,
+          rawProps,
+          "cursorColor",
+          sourceProps.cursorColor,
+          {})),
+      selectionColor(convertRawProp(
+          context,
+          rawProps,
+          "selectionColor",
+          sourceProps.selectionColor,
+          {})),
+      selectionHandleColor(convertRawProp(
+          context,
+          rawProps,
+          "selectionHandleColor",
+          sourceProps.selectionHandleColor,
+          {})),
+      underlineColorAndroid(convertRawProp(
+          context,
+          rawProps,
+          "underlineColorAndroid",
+          sourceProps.underlineColorAndroid,
+          {})),
+      maxLength(convertRawProp(
+          context,
+          rawProps,
+          "maxLength",
+          sourceProps.maxLength,
+          {})),
+      text(convertRawProp(context, rawProps, "text", sourceProps.text, {})),
+      mostRecentEventCount(convertRawProp(
+          context,
+          rawProps,
+          "mostRecentEventCount",
+          sourceProps.mostRecentEventCount,
+          {})),
+      autoFocus(convertRawProp(
+          context,
+          rawProps,
+          "autoFocus",
+          sourceProps.autoFocus,
+          {})){};
+
+void BaseTextInputProps::setProp(
+    const PropsParserContext& context,
+    RawPropsPropNameHash hash,
+    const char* propName,
+    const RawValue& value) {
+  ViewProps::setProp(context, hash, propName, value);
+  BaseTextProps::setProp(context, hash, propName, value);
+
+  static auto defaults = BaseTextInputProps{};
+
+  // ParagraphAttributes has its own switch statement - to keep all
+  // of these fields together, and because there are some collisions between
+  // propnames parsed here and outside of ParagraphAttributes. For example,
+  // textBreakStrategy is duplicated.
+  // This code is also duplicated in ParagraphProps.
+  static auto paDefaults = ParagraphAttributes{};
+  switch (hash) {
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        maximumNumberOfLines,
+        "numberOfLines");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults, value, paragraphAttributes, ellipsizeMode, "ellipsizeMode");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        textBreakStrategy,
+        "textBreakStrategy");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        adjustsFontSizeToFit,
+        "adjustsFontSizeToFit");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        minimumFontSize,
+        "minimumFontSize");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        maximumFontSize,
+        "maximumFontSize");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        includeFontPadding,
+        "includeFontPadding");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        android_hyphenationFrequency,
+        "android_hyphenationFrequency");
+  }
+
+  switch (hash) {
+    RAW_SET_PROP_SWITCH_CASE_BASIC(underlineColorAndroid);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(autoFocus);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(maxLength);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(placeholder);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(placeholderTextColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(selectionColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(selectionHandleColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(defaultValue);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(cursorColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(text);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(mostRecentEventCount);
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/attributedstring/ParagraphAttributes.h>
+#include <react/renderer/components/text/BaseTextProps.h>
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/graphics/Color.h>
+#include <string>
+
+namespace facebook::react {
+
+class BaseTextInputProps : public ViewProps, public BaseTextProps {
+ public:
+  BaseTextInputProps() = default;
+  BaseTextInputProps(
+      const PropsParserContext& context,
+      const BaseTextInputProps& sourceProps,
+      const RawProps& rawProps);
+
+  void setProp(
+      const PropsParserContext& context,
+      RawPropsPropNameHash hash,
+      const char* propName,
+      const RawValue& value);
+
+#pragma mark - Props
+
+  /*
+   * Contains all prop values that affect visual representation of the
+   * paragraph.
+   */
+  ParagraphAttributes paragraphAttributes{};
+
+  std::string defaultValue{};
+
+  std::string placeholder{};
+  SharedColor placeholderTextColor{};
+
+  /*
+   * Tint colors
+   */
+  SharedColor cursorColor{};
+  SharedColor selectionColor{};
+  SharedColor selectionHandleColor{};
+  // TODO: Rename to `tintColor` and make universal.
+  SharedColor underlineColorAndroid{};
+
+  int maxLength{};
+
+  /*
+   * "Private" (only used by TextInput.js) props
+   */
+  std::string text{};
+  int mostRecentEventCount{0};
+
+  bool autoFocus{false};
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -17,10 +17,7 @@ add_compile_options(
 file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS platform/android/react/renderer/components/androidtextinput/*.cpp)
 add_library(rrc_textinput STATIC ${rrc_textinput_SRC})
 
-target_include_directories(rrc_textinput
-        PUBLIC
-          ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
-)
+target_include_directories(rrc_textinput PUBLIC . ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/)
 
 target_link_libraries(rrc_textinput
         glog

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -36,8 +36,7 @@ AndroidTextInputProps::AndroidTextInputProps(
     const PropsParserContext &context,
     const AndroidTextInputProps &sourceProps,
     const RawProps &rawProps)
-    : ViewProps(context, sourceProps, rawProps),
-      BaseTextProps(context, sourceProps, rawProps),
+    : BaseTextInputProps(context, sourceProps, rawProps),
       autoComplete(CoreFeatures::enablePropIteratorSetter? sourceProps.autoComplete : convertRawProp(
           context,
           rawProps,
@@ -59,10 +58,6 @@ AndroidTextInputProps::AndroidTextInputProps(
       textBreakStrategy(CoreFeatures::enablePropIteratorSetter? sourceProps.textBreakStrategy : convertRawProp(context, rawProps,
           "textBreakStrategy",
           sourceProps.textBreakStrategy,
-          {})),
-      underlineColorAndroid(CoreFeatures::enablePropIteratorSetter? sourceProps.underlineColorAndroid : convertRawProp(context, rawProps,
-          "underlineColorAndroid",
-          sourceProps.underlineColorAndroid,
           {})),
       inlineImageLeft(CoreFeatures::enablePropIteratorSetter? sourceProps.inlineImageLeft : convertRawProp(context, rawProps,
           "inlineImageLeft",
@@ -88,10 +83,6 @@ AndroidTextInputProps::AndroidTextInputProps(
           "autoCorrect",
           sourceProps.autoCorrect,
           {false})),
-      autoFocus(CoreFeatures::enablePropIteratorSetter? sourceProps.autoFocus : convertRawProp(context, rawProps,
-          "autoFocus",
-          sourceProps.autoFocus,
-          {false})),
       allowFontScaling(CoreFeatures::enablePropIteratorSetter? sourceProps.allowFontScaling : convertRawProp(context, rawProps,
           "allowFontScaling",
           sourceProps.allowFontScaling,
@@ -110,35 +101,15 @@ AndroidTextInputProps::AndroidTextInputProps(
           "returnKeyType",
           sourceProps.returnKeyType,
           {})),
-      maxLength(CoreFeatures::enablePropIteratorSetter? sourceProps.maxLength :
-          convertRawProp(context, rawProps, "maxLength", sourceProps.maxLength, {0})),
       multiline(CoreFeatures::enablePropIteratorSetter? sourceProps.multiline : convertRawProp(context, rawProps,
           "multiline",
           sourceProps.multiline,
           {false})),
-      placeholder(CoreFeatures::enablePropIteratorSetter? sourceProps.placeholder :
-          convertRawProp(context, rawProps, "placeholder", sourceProps.placeholder, {})),
-      placeholderTextColor(CoreFeatures::enablePropIteratorSetter? sourceProps.placeholderTextColor : convertRawProp(context, rawProps,
-          "placeholderTextColor",
-          sourceProps.placeholderTextColor,
-          {})),
       secureTextEntry(CoreFeatures::enablePropIteratorSetter? sourceProps.secureTextEntry : convertRawProp(context, rawProps,
           "secureTextEntry",
           sourceProps.secureTextEntry,
           {false})),
-      selectionColor(CoreFeatures::enablePropIteratorSetter? sourceProps.selectionColor : convertRawProp(context, rawProps,
-          "selectionColor",
-          sourceProps.selectionColor,
-          {})),
-      selectionHandleColor(CoreFeatures::enablePropIteratorSetter? sourceProps.selectionHandleColor : convertRawProp(context, rawProps,
-          "selectionHandleColor",
-          sourceProps.selectionHandleColor,
-          {})),
       value(CoreFeatures::enablePropIteratorSetter? sourceProps.value : convertRawProp(context, rawProps, "value", sourceProps.value, {})),
-      defaultValue(CoreFeatures::enablePropIteratorSetter? sourceProps.defaultValue : convertRawProp(context, rawProps,
-          "defaultValue",
-          sourceProps.defaultValue,
-          {})),
       selectTextOnFocus(CoreFeatures::enablePropIteratorSetter? sourceProps.selectTextOnFocus : convertRawProp(context, rawProps,
           "selectTextOnFocus",
           sourceProps.selectTextOnFocus,
@@ -202,15 +173,6 @@ AndroidTextInputProps::AndroidTextInputProps(
           "textAlignVertical",
           sourceProps.textAlignVertical,
           {})),
-      cursorColor(CoreFeatures::enablePropIteratorSetter? sourceProps.cursorColor :
-          convertRawProp(context, rawProps, "cursorColor", sourceProps.cursorColor, {})),
-      mostRecentEventCount(CoreFeatures::enablePropIteratorSetter? sourceProps.mostRecentEventCount : convertRawProp(context, rawProps,
-          "mostRecentEventCount",
-          sourceProps.mostRecentEventCount,
-          {0})),
-      text(CoreFeatures::enablePropIteratorSetter? sourceProps.text : convertRawProp(context, rawProps, "text", sourceProps.text, {})),
-      paragraphAttributes(CoreFeatures::enablePropIteratorSetter? sourceProps.paragraphAttributes :
-          convertRawProp(context, rawProps, sourceProps.paragraphAttributes, {})),
       // See AndroidTextInputComponentDescriptor for usage
       // TODO T63008435: can these, and this feature, be removed entirely?
       hasPadding(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPadding : hasValue(rawProps, sourceProps.hasPadding, "padding")),
@@ -252,63 +214,9 @@ void AndroidTextInputProps::setProp(
   // All Props structs setProp methods must always, unconditionally,
   // call all super::setProp methods, since multiple structs may
   // reuse the same values.
-  ViewProps::setProp(context, hash, propName, value);
-  BaseTextProps::setProp(context, hash, propName, value);
+  BaseTextInputProps::setProp(context, hash, propName, value);
 
   static auto defaults = AndroidTextInputProps{};
-
-  // ParagraphAttributes has its own switch statement - to keep all
-  // of these fields together, and because there are some collisions between
-  // propnames parsed here and outside of ParagraphAttributes. For example,
-  // textBreakStrategy is duplicated.
-  // This code is also duplicated in ParagraphProps.
-  static auto paDefaults = ParagraphAttributes{};
-  switch (hash) {
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        maximumNumberOfLines,
-        "numberOfLines");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults, value, paragraphAttributes, ellipsizeMode, "ellipsizeMode");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        textBreakStrategy,
-        "textBreakStrategy");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        adjustsFontSizeToFit,
-        "adjustsFontSizeToFit");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        minimumFontSize,
-        "minimumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        maximumFontSize,
-        "maximumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        includeFontPadding,
-        "includeFontPadding");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        android_hyphenationFrequency,
-        "android_hyphenationFrequency");
-  }
 
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE_BASIC(autoComplete);
@@ -316,27 +224,19 @@ void AndroidTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(numberOfLines);
     RAW_SET_PROP_SWITCH_CASE_BASIC(disableFullscreenUI);
     RAW_SET_PROP_SWITCH_CASE_BASIC(textBreakStrategy);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(underlineColorAndroid);
     RAW_SET_PROP_SWITCH_CASE_BASIC(inlineImageLeft);
     RAW_SET_PROP_SWITCH_CASE_BASIC(inlineImagePadding);
     RAW_SET_PROP_SWITCH_CASE_BASIC(importantForAutofill);
     RAW_SET_PROP_SWITCH_CASE_BASIC(showSoftInputOnFocus);
     RAW_SET_PROP_SWITCH_CASE_BASIC(autoCapitalize);
     RAW_SET_PROP_SWITCH_CASE_BASIC(autoCorrect);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(autoFocus);
     RAW_SET_PROP_SWITCH_CASE_BASIC(allowFontScaling);
     RAW_SET_PROP_SWITCH_CASE_BASIC(maxFontSizeMultiplier);
     RAW_SET_PROP_SWITCH_CASE_BASIC(editable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(keyboardType);
     RAW_SET_PROP_SWITCH_CASE_BASIC(returnKeyType);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(maxLength);
     RAW_SET_PROP_SWITCH_CASE_BASIC(multiline);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(placeholder);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(placeholderTextColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(secureTextEntry);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(selectionColor);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(selectionHandleColor);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(defaultValue);
     RAW_SET_PROP_SWITCH_CASE_BASIC(selectTextOnFocus);
     RAW_SET_PROP_SWITCH_CASE_BASIC(submitBehavior);
     RAW_SET_PROP_SWITCH_CASE_BASIC(caretHidden);
@@ -356,9 +256,6 @@ void AndroidTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(fontWeight);
     RAW_SET_PROP_SWITCH_CASE_BASIC(fontFamily);
     RAW_SET_PROP_SWITCH_CASE_BASIC(textAlignVertical);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(cursorColor);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(mostRecentEventCount);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(text);
 
     case CONSTEXPR_RAW_PROPS_KEY_HASH("value"): {
       fromRawValue(context, value, this->value, {});

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -12,8 +12,7 @@
 
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/attributedstring/conversions.h>
-#include <react/renderer/components/text/BaseTextProps.h>
-#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/components/textinput/BaseTextInputProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
@@ -58,7 +57,7 @@ inline folly::dynamic toDynamic(
   return dynamicValue;
 }
 
-class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
+class AndroidTextInputProps final : public BaseTextInputProps {
  public:
   AndroidTextInputProps() = default;
   AndroidTextInputProps(
@@ -81,28 +80,20 @@ class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
   int numberOfLines{0};
   bool disableFullscreenUI{false};
   std::string textBreakStrategy{};
-  SharedColor underlineColorAndroid{};
   std::string inlineImageLeft{};
   int inlineImagePadding{0};
   std::string importantForAutofill{};
   bool showSoftInputOnFocus{false};
   std::string autoCapitalize{};
   bool autoCorrect{false};
-  bool autoFocus{false};
   bool allowFontScaling{false};
   Float maxFontSizeMultiplier{0.0};
   bool editable{false};
   std::string keyboardType{};
   std::string returnKeyType{};
-  int maxLength{0};
   bool multiline{false};
-  std::string placeholder{};
-  SharedColor placeholderTextColor{};
   bool secureTextEntry{false};
-  SharedColor selectionColor{};
-  SharedColor selectionHandleColor{};
   std::string value{};
-  std::string defaultValue{};
   bool selectTextOnFocus{false};
   std::string submitBehavior{};
   bool caretHidden{false};
@@ -122,15 +113,6 @@ class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
   std::string fontWeight{};
   std::string fontFamily{};
   std::string textAlignVertical{};
-  SharedColor cursorColor{};
-  int mostRecentEventCount{0};
-  std::string text{};
-
-  /*
-   * Contains all prop values that affect visual representation of the
-   * paragraph.
-   */
-  ParagraphAttributes paragraphAttributes{};
 
   /**
    * Auxiliary information to detect if these props are set or not.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.cpp
@@ -18,75 +18,8 @@ TextInputProps::TextInputProps(
     const PropsParserContext& context,
     const TextInputProps& sourceProps,
     const RawProps& rawProps)
-    : ViewProps(context, sourceProps, rawProps),
-      BaseTextProps(context, sourceProps, rawProps),
+    : BaseTextInputProps(context, sourceProps, rawProps),
       traits(convertRawProp(context, rawProps, sourceProps.traits, {})),
-      paragraphAttributes(convertRawProp(
-          context,
-          rawProps,
-          sourceProps.paragraphAttributes,
-          {})),
-      defaultValue(convertRawProp(
-          context,
-          rawProps,
-          "defaultValue",
-          sourceProps.defaultValue,
-          {})),
-      placeholder(convertRawProp(
-          context,
-          rawProps,
-          "placeholder",
-          sourceProps.placeholder,
-          {})),
-      placeholderTextColor(convertRawProp(
-          context,
-          rawProps,
-          "placeholderTextColor",
-          sourceProps.placeholderTextColor,
-          {})),
-      maxLength(convertRawProp(
-          context,
-          rawProps,
-          "maxLength",
-          sourceProps.maxLength,
-          {})),
-      cursorColor(convertRawProp(
-          context,
-          rawProps,
-          "cursorColor",
-          sourceProps.cursorColor,
-          {})),
-      selectionColor(convertRawProp(
-          context,
-          rawProps,
-          "selectionColor",
-          sourceProps.selectionColor,
-          {})),
-      selectionHandleColor(convertRawProp(
-          context,
-          rawProps,
-          "selectionHandleColor",
-          sourceProps.selectionHandleColor,
-          {})),
-      underlineColorAndroid(convertRawProp(
-          context,
-          rawProps,
-          "underlineColorAndroid",
-          sourceProps.underlineColorAndroid,
-          {})),
-      text(convertRawProp(context, rawProps, "text", sourceProps.text, {})),
-      mostRecentEventCount(convertRawProp(
-          context,
-          rawProps,
-          "mostRecentEventCount",
-          sourceProps.mostRecentEventCount,
-          {})),
-      autoFocus(convertRawProp(
-          context,
-          rawProps,
-          "autoFocus",
-          sourceProps.autoFocus,
-          {})),
       selection(convertRawProp(
           context,
           rawProps,
@@ -111,15 +44,6 @@ TextInputProps::TextInputProps(
           "onChangeSync",
           sourceProps.onChangeSync,
           {})){};
-
-void TextInputProps::setProp(
-    const PropsParserContext& context,
-    RawPropsPropNameHash hash,
-    const char* propName,
-    const RawValue& value) {
-  ViewProps::setProp(context, hash, propName, value);
-  BaseTextProps::setProp(context, hash, propName, value);
-}
 
 TextAttributes TextInputProps::getEffectiveTextAttributes(
     Float fontSizeMultiplier) const {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
@@ -9,20 +9,18 @@
 
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
+#include <react/renderer/components/iostextinput/BaseTextInputProps.h>
 #include <react/renderer/components/iostextinput/conversions.h>
 #include <react/renderer/components/iostextinput/primitives.h>
-#include <react/renderer/components/text/BaseTextProps.h>
-#include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
-#include <react/renderer/graphics/Color.h>
 #include <react/renderer/imagemanager/primitives.h>
 #include <vector>
 
 namespace facebook::react {
 
-class TextInputProps final : public ViewProps, public BaseTextProps {
+class TextInputProps final : public BaseTextInputProps {
  public:
   TextInputProps() = default;
   TextInputProps(
@@ -30,40 +28,12 @@ class TextInputProps final : public ViewProps, public BaseTextProps {
       const TextInputProps& sourceProps,
       const RawProps& rawProps);
 
-  void setProp(
-      const PropsParserContext& context,
-      RawPropsPropNameHash hash,
-      const char* propName,
-      const RawValue& value);
-
 #pragma mark - Props
-
   const TextInputTraits traits{};
-  const ParagraphAttributes paragraphAttributes{};
-
-  std::string const defaultValue{};
-
-  std::string const placeholder{};
-  const SharedColor placeholderTextColor{};
-
-  int maxLength{};
-
-  /*
-   * Tint colors
-   */
-  const SharedColor cursorColor{};
-  const SharedColor selectionColor{};
-  const SharedColor selectionHandleColor{};
-  // TODO: Rename to `tintColor` and make universal.
-  const SharedColor underlineColorAndroid{};
 
   /*
    * "Private" (only used by TextInput.js) props
    */
-  std::string const text{};
-  const int mostRecentEventCount{0};
-
-  bool autoFocus{false};
   std::optional<Selection> selection{};
 
   std::string const inputAccessoryViewID{};


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] - 

This takes all the common props for TextInput between Android and iOS and factors them out into a single, platform independent props data structure, `BaseTextInputProps`.

This way it's both easier to manage the corresponding props, but also having this used on other platforms.

Differential Revision: D54764898


