### PR TITLE
Add enableHermesCDPAgent case to ReactInstanceIntegrationTest

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
@@ -17,9 +17,11 @@
 #include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
 #include <react/runtime/hermes/HermesInstance.h>
 
+using namespace ::testing;
+
 namespace facebook::react::jsinspector_modern {
 
-using namespace ::testing;
+#pragma region ReactInstanceIntegrationTest
 
 ReactInstanceIntegrationTest::ReactInstanceIntegrationTest()
     : runtime(nullptr),
@@ -179,6 +181,8 @@ bool ReactInstanceIntegrationTest::verbose(bool isVerbose) {
   return previous;
 }
 
+#pragma endregion
+
 TEST_F(ReactInstanceIntegrationTest, RuntimeEvalTest) {
   auto val = run("1 + 2");
   EXPECT_EQ(val.asNumber(), 3);
@@ -218,13 +222,20 @@ INSTANTIATE_TEST_SUITE_P(
     ReactInstanceIntegrationTestWithFlags,
     ::testing::Values(
         InspectorFlagOverrides{
-            .enableCxxInspectorPackagerConnection = true,
-            .enableModernCDPRegistry = true},
-        InspectorFlagOverrides{
             .enableCxxInspectorPackagerConnection = false,
+            .enableHermesCDPAgent = false,
             .enableModernCDPRegistry = false},
         InspectorFlagOverrides{
             .enableCxxInspectorPackagerConnection = true,
-            .enableModernCDPRegistry = false}));
+            .enableHermesCDPAgent = false,
+            .enableModernCDPRegistry = false},
+        InspectorFlagOverrides{
+            .enableCxxInspectorPackagerConnection = true,
+            .enableHermesCDPAgent = false,
+            .enableModernCDPRegistry = true},
+        InspectorFlagOverrides{
+            .enableCxxInspectorPackagerConnection = false,
+            .enableHermesCDPAgent = true,
+            .enableModernCDPRegistry = true}));
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.cpp
@@ -27,15 +27,19 @@ class ReactNativeFeatureFlagsOverrides
       : overrides_(overrides) {}
 
   bool inspectorEnableCxxInspectorPackagerConnection() override {
-    return overrides_.enableCxxInspectorPackagerConnection;
+    return overrides_.enableCxxInspectorPackagerConnection.value_or(
+        ReactNativeFeatureFlagsDefaults::
+            inspectorEnableCxxInspectorPackagerConnection());
   }
 
   bool inspectorEnableHermesCDPAgent() override {
-    return overrides_.enableHermesCDPAgent;
+    return overrides_.enableHermesCDPAgent.value_or(
+        ReactNativeFeatureFlagsDefaults::inspectorEnableHermesCDPAgent());
   }
 
   bool inspectorEnableModernCDPRegistry() override {
-    return overrides_.enableModernCDPRegistry;
+    return overrides_.enableModernCDPRegistry.value_or(
+        ReactNativeFeatureFlagsDefaults::inspectorEnableModernCDPRegistry());
   }
 
  private:

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
@@ -9,6 +9,8 @@
 
 #include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
 
+#include <optional>
+
 namespace facebook::react::jsinspector_modern {
 
 /**
@@ -17,9 +19,9 @@ namespace facebook::react::jsinspector_modern {
 struct InspectorFlagOverrides {
   // NOTE: Keep these entries in sync with ReactNativeFeatureFlagsOverrides in
   // the implementation file.
-  bool enableCxxInspectorPackagerConnection = false;
-  bool enableHermesCDPAgent = false;
-  bool enableModernCDPRegistry = false;
+  std::optional<bool> enableCxxInspectorPackagerConnection;
+  std::optional<bool> enableHermesCDPAgent;
+  std::optional<bool> enableModernCDPRegistry;
 };
 
 /**


### PR DESCRIPTION
Summary:
## Context

We are migrating to the new Hermes `CDPAgent` and `CDPDebugAPI` APIs in the modern CDP server (previously `HermesCDPHandler`).

## This diff

Expands test coverage for the Hermes `CDPAgent` implementation by enabling in `ReactInstanceIntegrationTest`.

Changelog: [Internal]

bypass-github-export-checks

Reviewed By: motiz88

Differential Revision: D54801168


