### PR TITLE
[Fabric] iOS: Fixes textinput onscroll event payload

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -168,12 +168,9 @@ void TextInputEventEmitter::onKeyPress(
 
 void TextInputEventEmitter::onScroll(
     const TextInputMetrics& textInputMetrics) const {
-  dispatchEvent(
-      "scroll",
-      [textInputMetrics](jsi::Runtime& runtime) {
-        return textInputMetricsScrollPayload(runtime, textInputMetrics);
-      },
-      EventPriority::AsynchronousBatched);
+  dispatchEvent("scroll", [textInputMetrics](jsi::Runtime& runtime) {
+    return textInputMetricsScrollPayload(runtime, textInputMetrics);
+  });
 }
 
 void TextInputEventEmitter::dispatchTextInputEvent(

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -36,6 +36,53 @@ static jsi::Value textInputMetricsPayload(
   return payload;
 };
 
+static jsi::Value textInputMetricsScrollPayload(
+    jsi::Runtime& runtime,
+    const TextInputMetrics& textInputMetrics) {
+  auto payload = jsi::Object(runtime);
+
+  {
+    auto contentOffset = jsi::Object(runtime);
+    contentOffset.setProperty(runtime, "x", textInputMetrics.contentOffset.x);
+    contentOffset.setProperty(runtime, "y", textInputMetrics.contentOffset.y);
+    payload.setProperty(runtime, "contentOffset", contentOffset);
+  }
+
+  {
+    auto contentInset = jsi::Object(runtime);
+    contentInset.setProperty(runtime, "top", textInputMetrics.contentInset.top);
+    contentInset.setProperty(
+        runtime, "left", textInputMetrics.contentInset.left);
+    contentInset.setProperty(
+        runtime, "bottom", textInputMetrics.contentInset.bottom);
+    contentInset.setProperty(
+        runtime, "right", textInputMetrics.contentInset.right);
+    payload.setProperty(runtime, "contentInset", contentInset);
+  }
+
+  {
+    auto contentSize = jsi::Object(runtime);
+    contentSize.setProperty(
+        runtime, "width", textInputMetrics.contentSize.width);
+    contentSize.setProperty(
+        runtime, "height", textInputMetrics.contentSize.height);
+    payload.setProperty(runtime, "contentSize", contentSize);
+  }
+
+  {
+    auto layoutMeasurement = jsi::Object(runtime);
+    layoutMeasurement.setProperty(
+        runtime, "width", textInputMetrics.layoutMeasurement.width);
+    layoutMeasurement.setProperty(
+        runtime, "height", textInputMetrics.layoutMeasurement.height);
+    payload.setProperty(runtime, "layoutMeasurement", layoutMeasurement);
+  }
+
+  payload.setProperty(runtime, "zoomScale", textInputMetrics.zoomScale ?: 1);
+
+  return payload;
+};
+
 static jsi::Value textInputMetricsContentSizePayload(
     jsi::Runtime& runtime,
     const TextInputMetrics& textInputMetrics) {
@@ -121,7 +168,12 @@ void TextInputEventEmitter::onKeyPress(
 
 void TextInputEventEmitter::onScroll(
     const TextInputMetrics& textInputMetrics) const {
-  dispatchTextInputEvent("scroll", textInputMetrics);
+  dispatchEvent(
+      "scroll",
+      [textInputMetrics](jsi::Runtime& runtime) {
+        return textInputMetricsScrollPayload(runtime, textInputMetrics);
+      },
+      EventPriority::AsynchronousBatched);
 }
 
 void TextInputEventEmitter::dispatchTextInputEvent(


### PR DESCRIPTION
## Summary:

Fixes #43428 . cc @cortinico .

## Changelog:

[IOS] [FIXED] - [Fabric] iOS: Fixes textinput onscroll event payload

## Test Plan:

```
    const onInputScroll = (e) => {
      if (Platform.OS !== "web") {
        const {
          nativeEvent: {
            contentOffset: { x, y },
          },
        } = e;
        console.log('onInputScroll ====', e?.nativeEvent)
      }
    };  

<TextInput
          onScroll={onInputScroll}
          // ref={inputRef}
          multiline
  />
```
