### PR TITLE
Update test to validate Debugger domain persistence

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -92,7 +92,7 @@ references:
     # Cocoapods - RNTester
     pods_cache_key: &pods_cache_key v11-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
     cocoapods_cache_key: &cocoapods_cache_key v11-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
-    rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v9-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v10-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
 
     # Cocoapods - Template
     template_cocoapods_cache_key: &template_cocoapods_cache_key v6-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: packages/rn-tester/Pods
-          key: v2-${{ runner.os }}-RNTesterPods-${{ hashFiles('packages/rn-tester/Podfile.lock') }}-${{ hashFiles('packages/rn-tester/Podfile') }}-${{ hashFiles('tmp/hermes/hermesversion') }}
+          key: v3-${{ runner.os }}-RNTesterPods-${{ hashFiles('packages/rn-tester/Podfile.lock') }}-${{ hashFiles('packages/rn-tester/Podfile') }}-${{ hashFiles('tmp/hermes/hermesversion') }}
       - name: Pod Install
         run: |
           cd packages/rn-tester

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.cpp
@@ -74,6 +74,12 @@ class HermesRuntimeAgentDelegateNew::Impl final : public RuntimeAgentDelegate {
     if (sessionState.isLogDomainEnabled) {
       sendHermesIntegrationDescription();
     }
+    if (sessionState.isRuntimeDomainEnabled) {
+      hermes_->enableRuntimeDomain();
+    }
+    if (sessionState.isDebuggerDomainEnabled) {
+      hermes_->enableDebuggerDomain();
+    }
   }
 
   bool handleRequest(const cdp::PreparsedRequest& req) override {

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegateNew.h
@@ -66,6 +66,9 @@ class HermesRuntimeAgentDelegateNew : public RuntimeAgentDelegate {
    */
   bool handleRequest(const cdp::PreparsedRequest& req) override;
 
+  std::unique_ptr<RuntimeAgentDelegate::ExportedState> getExportedState()
+      override;
+
  private:
   class Impl;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -76,6 +76,16 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = false;
+  } else if (req.method == "Debugger.enable") {
+    sessionState_.isDebuggerDomainEnabled = true;
+
+    shouldSendOKResponse = true;
+    isFinishedHandlingRequest = false;
+  } else if (req.method == "Debugger.disable") {
+    sessionState_.isDebuggerDomainEnabled = false;
+
+    shouldSendOKResponse = true;
+    isFinishedHandlingRequest = false;
   }
   // Methods other than domain enables/disables: handle anything we know how
   // to handle, and delegate to the InstanceAgent otherwise.

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -20,6 +20,7 @@ namespace facebook::react::jsinspector_modern {
 struct SessionState {
  public:
   // TODO: Generalise this to arbitrary domains
+  bool isDebuggerDomainEnabled{false};
   bool isLogDomainEnabled{false};
   bool isRuntimeDomainEnabled{false};
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -179,6 +179,8 @@ using AllHermesVariants = Types<
     JsiIntegrationTestHermesEngineAdapter,
     JsiIntegrationTestHermesWithCDPAgentEngineAdapter>;
 
+using ModernHermesVariants =
+    Types<JsiIntegrationTestHermesWithCDPAgentEngineAdapter>;
 using LegacyHermesVariants = Types<JsiIntegrationTestHermesEngineAdapter>;
 
 TYPED_TEST_SUITE(JsiIntegrationPortableTest, AllEngines);
@@ -192,7 +194,12 @@ using JsiIntegrationHermesLegacyTest =
     JsiIntegrationPortableTest<EngineAdapter>;
 TYPED_TEST_SUITE(JsiIntegrationHermesLegacyTest, LegacyHermesVariants);
 
-#pragma region JsiIntegrationPortableTest
+template <typename EngineAdapter>
+using JsiIntegrationHermesModernTest =
+    JsiIntegrationPortableTest<EngineAdapter>;
+TYPED_TEST_SUITE(JsiIntegrationHermesModernTest, ModernHermesVariants);
+
+#pragma region AllEngines
 
 TYPED_TEST(JsiIntegrationPortableTest, ConnectWithoutCrashing) {
   this->connect();
@@ -472,8 +479,8 @@ TYPED_TEST(JsiIntegrationPortableTest, ExceptionDuringAddBindingIsIgnored) {
   EXPECT_TRUE(this->eval("globalThis.foo === 42").getBool());
 }
 
-#pragma endregion
-#pragma region JsiIntegrationHermesTest
+#pragma endregion // AllEngines
+#pragma region AllHermesVariants
 
 TYPED_TEST(JsiIntegrationHermesTest, EvaluateExpression) {
   this->connect();
@@ -559,7 +566,10 @@ TYPED_TEST(JsiIntegrationHermesTest, EvaluateExpressionInExecutionContext) {
       std::to_string(executionContextId)));
 }
 
-TYPED_TEST(JsiIntegrationHermesTest, ResolveBreakpointAfterReload) {
+#pragma endregion // AllHermesVariants
+#pragma region ModernHermesVariants
+
+TYPED_TEST(JsiIntegrationHermesModernTest, ResolveBreakpointAfterReload) {
   this->connect();
 
   InSequence s;
@@ -610,6 +620,6 @@ TYPED_TEST(JsiIntegrationHermesTest, ResolveBreakpointAfterReload) {
       scriptInfo->value()["params"]["scriptId"]);
 }
 
-#pragma endregion
+#pragma endregion // ModernHermesVariants
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -557,16 +557,23 @@ TYPED_TEST(
       std::to_string(executionContextId)));
 }
 
-// TODO(T178858701): Restore breakpoint reload persistence under
-// HermesRuntimeAgentDelegateNew
-TYPED_TEST(JsiIntegrationHermesLegacyTest, ResolveBreakpointAfterReload) {
+TYPED_TEST(JsiIntegrationHermesTest, ResolveBreakpointAfterReload) {
   this->connect();
 
   InSequence s;
 
-  this->expectMessageFromPage(JsonParsed(AtJsonPtr("/id", 1)));
+  this->expectMessageFromPage(JsonEq(R"({
+                                         "id": 1,
+                                         "result": {}
+                                       })"));
   this->toPage_->sendMessage(R"({
                                  "id": 1,
+                                 "method": "Debugger.enable"
+                               })");
+
+  this->expectMessageFromPage(JsonParsed(AtJsonPtr("/id", 2)));
+  this->toPage_->sendMessage(R"({
+                                 "id": 2,
                                  "method": "Debugger.setBreakpointByUrl",
                                  "params": {"lineNumber": 2, "url": "breakpointTest.js"}
                                })");
@@ -574,11 +581,11 @@ TYPED_TEST(JsiIntegrationHermesLegacyTest, ResolveBreakpointAfterReload) {
   this->reload();
 
   this->expectMessageFromPage(JsonEq(R"({
-                                         "id": 2,
+                                         "id": 3,
                                          "result": {}
                                        })"));
   this->toPage_->sendMessage(R"({
-                                 "id": 2,
+                                 "id": 3,
                                  "method": "Debugger.enable"
                                })");
 


### PR DESCRIPTION
Summary:
## Context

We are migrating to the new Hermes `CDPAgent` and `CDPDebugAPI` APIs in the modern CDP server (previously `HermesCDPHandler`).

## This diff

Following D54712525, add a test case that validates `"Debugger.enable"` is persisted between reloads. This has been actioned by creating a further test group, `ModernHermesVariants`, and scoping the existing `ResolveBreakpointAfterReload` to this, with the removed second `"Debugger.enable"` message.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D54808212
