### PR TITLE
Add missing dependency from AndroidTextInput

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
@@ -29,6 +29,13 @@ TextMeasurement TextLayoutManager::measure(
   return TextMeasurement{{0, 0}, attachments};
 }
 
+TextMeasurement TextLayoutManager::measureCachedSpannableById(
+    int64_t /*cacheId*/,
+    const ParagraphAttributes& /*paragraphAttributes*/,
+    LayoutConstraints /*layoutConstraints*/) const {
+  return {};
+}
+
 LinesMeasurements TextLayoutManager::measureLines(
     AttributedString attributedString,
     ParagraphAttributes paragraphAttributes,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
@@ -42,6 +42,15 @@ class TextLayoutManager {
       LayoutConstraints layoutConstraints,
       std::shared_ptr<void>) const;
 
+  /**
+   * Measures an AttributedString on the platform, as identified by some
+   * opaque cache ID.
+   */
+  virtual TextMeasurement measureCachedSpannableById(
+      int64_t cacheId,
+      const ParagraphAttributes& paragraphAttributes,
+      LayoutConstraints layoutConstraints) const;
+
   /*
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] - 

This adds a stub for `TextLayoutManager.measureCachedSpannableById`, as well as a missing explicit dependency to `jni/react/jni` from the `TextInput` implementation on the Android platform.

This is required in order for certain build configurations to compile.

Differential Revision: D54807518


