### PR TITLE
Prevent OSS build breakage due to unused-local-typedef

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++20
         -Wall
         -Wpedantic
+        -Wno-unused-local-typedef
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_uimanager_SRC CONFIGURE_DEPENDS *.cpp)


### PR DESCRIPTION
Summary:
Error:

```
react-native/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp:162:5: error: unused typedef 'INVALID_REQUESTED_LOG_SEVERITY' [-Werror,-Wunused-local-typedef]
      LOG_EVERY_N(INFO, 10) << "instanceHandle is null, event of type " << type
      ^
  react-native/packages/react-native/ReactAndroid/build/third-party-ndk/glog/exported/glog/logging.h:943:30: note: expanded from macro 'LOG_EVERY_N'
                               INVALID_REQUESTED_LOG_SEVERITY);           \
                               ^
  1 error generated.
  ninja: build stopped: subcommand failed.
```

This has been fixed upstream (https://github.com/google/glog/commit/8b3023f7e4ca46e0ecf5f660dd7340c79139bc34) but we're on an older glog version, so ignore the error.

Changelog: [Internal]

Differential Revision: D54811655


