### PR TITLE
Synchronize access to LongLivedObjectCollection instances

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/LongLivedObject.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/LongLivedObject.cpp
@@ -16,6 +16,9 @@ LongLivedObjectCollection& LongLivedObjectCollection::get(
     jsi::Runtime& runtime) {
   static std::unordered_map<void*, std::shared_ptr<LongLivedObjectCollection>>
       instances;
+  static std::mutex instancesMutex;
+
+  std::scoped_lock lock(instancesMutex);
   void* key = static_cast<void*>(&runtime);
   auto entry = instances.find(key);
   if (entry == instances.end()) {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This is just to make sure that all instances of `LongLivedObjectCollection` map can be safely accessed by multiple threads.

Reviewed By: RSNara

Differential Revision: D54801015


