### PR TITLE
Remove unused forward declaration of RCTMountingManager

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -21,8 +21,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RCTMountingManager;
-
 /**
  * Exactly same semantic as `facebook::react::SchedulerDelegate`.
  */


### PR DESCRIPTION
Summary:
The forward declaration for RCTMountingManager doesn't appear to be used anywhere. It can be deleted.

## Changelog

[Internal]

Differential Revision: D54692764


