### PR TITLE
Fix RN tests in preparation for D54783723

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedNative-test.js
@@ -23,6 +23,7 @@ jest
   // findNodeHandle is imported from RendererProxy so mock that whole module.
   .setMock('../../ReactNative/RendererProxy', {findNodeHandle: () => 1});
 
+import {format} from 'node:util';
 import * as React from 'react';
 import TestRenderer from 'react-test-renderer';
 
@@ -295,11 +296,13 @@ describe('Native Animated', () => {
         useNativeDriver: true,
       });
 
+      const consoleError = console.error;
       jest.spyOn(console, 'error').mockImplementationOnce((...args) => {
-        if (args[0].startsWith('The above error occurred in the')) {
+        const message = format(args);
+        if (message.includes('The above error occurred in the')) {
           return;
         }
-        console.errorDebug(...args);
+        consoleError(...args);
       });
 
       expect(() => {

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import VirtualizedList from '../VirtualizedList';
+import {format} from 'node:util';
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
@@ -71,11 +72,12 @@ describe('VirtualizedList', () => {
   it('throws if no renderItem or ListItemComponent', () => {
     // Silence the React error boundary warning; we expect an uncaught error.
     const consoleError = console.error;
-    jest.spyOn(console, 'error').mockImplementation(message => {
-      if (message.startsWith('The above error occurred in the ')) {
+    jest.spyOn(console, 'error').mockImplementation((...args) => {
+      const message = format(...args);
+      if (message.includes('The above error occurred in the ')) {
         return;
       }
-      consoleError(message);
+      consoleError(...args);
     });
 
     const componentFactory = () =>


### PR DESCRIPTION
Summary:
The React sync in D54783723 was failing because some tests were relying on `console.error` being called as `console.error('Some message')` but it was refactored as `console.error('%s..', 'Some message')`, making them fail.

This fixes the tests by formatting the arguments passed to the console functions and checking against that instead.

Changelog: [internal]

Differential Revision: D54849485


