### PR TITLE
Console polyfill: preserve unknown methods from originalConsole if found

### DIFF
--- a/packages/polyfills/console.js
+++ b/packages/polyfills/console.js
@@ -554,6 +554,7 @@ if (global.nativeLoggingHook) {
   }
 
   global.console = {
+    ...(originalConsole ?? {}),
     error: getNativeLogFunction(LOG_LEVELS.error),
     info: getNativeLogFunction(LOG_LEVELS.info),
     log: getNativeLogFunction(LOG_LEVELS.info),
@@ -578,7 +579,10 @@ if (global.nativeLoggingHook) {
   if (__DEV__ && originalConsole) {
     Object.keys(console).forEach(methodName => {
       const reactNativeMethod = console[methodName];
-      if (originalConsole[methodName]) {
+      if (
+        originalConsole[methodName] &&
+        reactNativeMethod !== originalConsole[methodName]
+      ) {
         console[methodName] = function () {
           originalConsole[methodName](...arguments);
           reactNativeMethod.apply(console, arguments);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e59e70d753403b168558b0d2b9513b5c>>
+ * @generated SignedSource<<4fda339ba0682c3d729725e20a016d27>>
  */
 
 /**
@@ -41,9 +41,9 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun inspectorEnableCxxInspectorPackagerConnection(): Boolean = false
 
-  override fun inspectorEnableHermesCDPAgent(): Boolean = false
+  override fun inspectorEnableHermesCDPAgent(): Boolean = true
 
-  override fun inspectorEnableModernCDPRegistry(): Boolean = false
+  override fun inspectorEnableModernCDPRegistry(): Boolean = true
 
   override fun skipMountHookNotifications(): Boolean = false
 

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -125,6 +125,9 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
       case ConsoleAPIType::kTimeEnd:
         type = HermesConsoleAPIType::kTimeEnd;
         break;
+      case ConsoleAPIType::kCount:
+        type = HermesConsoleAPIType::kCount;
+        break;
       default:
         throw std::logic_error{"Unknown console message type"};
     }

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -73,6 +73,65 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
               std::move(runtimeExecutor)));
   }
 
+  void addConsoleMessage(jsi::Runtime& /*unused*/, ConsoleMessage message)
+      override {
+    using HermesConsoleMessage = facebook::hermes::cdp::ConsoleMessage;
+    using HermesConsoleAPIType = facebook::hermes::cdp::ConsoleAPIType;
+
+    HermesConsoleAPIType type{};
+    switch (message.type) {
+      case ConsoleAPIType::kLog:
+        type = HermesConsoleAPIType::kLog;
+        break;
+      case ConsoleAPIType::kDebug:
+        type = HermesConsoleAPIType::kDebug;
+        break;
+      case ConsoleAPIType::kInfo:
+        type = HermesConsoleAPIType::kInfo;
+        break;
+      case ConsoleAPIType::kError:
+        type = HermesConsoleAPIType::kError;
+        break;
+      case ConsoleAPIType::kWarning:
+        type = HermesConsoleAPIType::kWarning;
+        break;
+      case ConsoleAPIType::kDir:
+        type = HermesConsoleAPIType::kDir;
+        break;
+      case ConsoleAPIType::kDirXML:
+        type = HermesConsoleAPIType::kDirXML;
+        break;
+      case ConsoleAPIType::kTable:
+        type = HermesConsoleAPIType::kTable;
+        break;
+      case ConsoleAPIType::kTrace:
+        type = HermesConsoleAPIType::kTrace;
+        break;
+      case ConsoleAPIType::kStartGroup:
+        type = HermesConsoleAPIType::kStartGroup;
+        break;
+      case ConsoleAPIType::kStartGroupCollapsed:
+        type = HermesConsoleAPIType::kStartGroupCollapsed;
+        break;
+      case ConsoleAPIType::kEndGroup:
+        type = HermesConsoleAPIType::kEndGroup;
+        break;
+      case ConsoleAPIType::kClear:
+        type = HermesConsoleAPIType::kClear;
+        break;
+      case ConsoleAPIType::kAssert:
+        type = HermesConsoleAPIType::kAssert;
+        break;
+      case ConsoleAPIType::kTimeEnd:
+        type = HermesConsoleAPIType::kTimeEnd;
+        break;
+      default:
+        throw std::logic_error{"Unknown console message type"};
+    }
+    cdpDebugAPI_->addConsoleMessage(
+        HermesConsoleMessage{message.timestamp, type, std::move(message.args)});
+  }
+
  private:
   HermesRuntimeTargetDelegate& delegate_;
   std::shared_ptr<HermesRuntime> runtime_;
@@ -116,6 +175,12 @@ HermesRuntimeTargetDelegate::createAgentDelegate(
       std::move(previouslyExportedState),
       executionContextDescription,
       std::move(runtimeExecutor));
+}
+
+void HermesRuntimeTargetDelegate::addConsoleMessage(
+    jsi::Runtime& runtime,
+    ConsoleMessage message) {
+  impl_->addConsoleMessage(runtime, std::move(message));
 }
 
 #ifdef HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -45,6 +45,9 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
           executionContextDescription,
       RuntimeExecutor runtimeExecutor) override;
 
+  void addConsoleMessage(jsi::Runtime& runtime, ConsoleMessage message)
+      override;
+
  private:
   // We use the private implementation idiom to ensure this class has the same
   // layout regardless of whether HERMES_ENABLE_DEBUGGER is defined. The net

--- a/packages/react-native/ReactCommon/jsinspector-modern/ConsoleMessage.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ConsoleMessage.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <jsi/jsi.h>
+
+namespace facebook::react::jsinspector_modern {
+
+enum class ConsoleAPIType {
+  kLog,
+  kDebug,
+  kInfo,
+  kError,
+  kWarning,
+  kDir,
+  kDirXML,
+  kTable,
+  kTrace,
+  kStartGroup,
+  kStartGroupCollapsed,
+  kEndGroup,
+  kClear,
+  kAssert,
+  kTimeEnd,
+  kCount
+};
+
+struct ConsoleMessage {
+  double timestamp;
+  ConsoleAPIType type;
+  std::vector<jsi::Value> args;
+
+  ConsoleMessage(
+      double timestamp,
+      ConsoleAPIType type,
+      std::vector<jsi::Value> args)
+      : timestamp(timestamp), type(type), args(std::move(args)) {}
+
+  ConsoleMessage(const ConsoleMessage& other) = delete;
+  ConsoleMessage(ConsoleMessage&& other) noexcept = default;
+  ConsoleMessage& operator=(const ConsoleMessage& other) = delete;
+  ConsoleMessage& operator=(ConsoleMessage&& other) noexcept = default;
+  ~ConsoleMessage() = default;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
@@ -26,4 +26,10 @@ FallbackRuntimeTargetDelegate::createAgentDelegate(
       std::move(channel), sessionState, engineDescription_);
 }
 
+void FallbackRuntimeTargetDelegate::addConsoleMessage(
+    jsi::Runtime& /*unused*/,
+    ConsoleMessage /*unused*/) {
+  // TODO: Best-effort printing (without RemoteObjects)
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
@@ -31,6 +31,9 @@ class FallbackRuntimeTargetDelegate : public RuntimeTargetDelegate {
       const ExecutionContextDescription& executionContextDescription,
       RuntimeExecutor runtimeExecutor) override;
 
+  void addConsoleMessage(jsi::Runtime& runtime, ConsoleMessage message)
+      override;
+
  private:
   std::string engineDescription_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -21,6 +21,7 @@ std::shared_ptr<RuntimeTarget> RuntimeTarget::create(
   std::shared_ptr<RuntimeTarget> runtimeTarget{
       new RuntimeTarget(executionContextDescription, delegate, jsExecutor)};
   runtimeTarget->setExecutor(selfExecutor);
+  runtimeTarget->installGlobals();
   return runtimeTarget;
 }
 
@@ -31,6 +32,78 @@ RuntimeTarget::RuntimeTarget(
     : executionContextDescription_(executionContextDescription),
       delegate_(delegate),
       jsExecutor_(jsExecutor) {}
+
+void RuntimeTarget::installGlobals() {
+  installConsoleHandler();
+}
+
+void RuntimeTarget::installConsoleHandler() {
+  jsExecutor_([selfWeak = weak_from_this(),
+               selfExecutor = executorFromThis()](jsi::Runtime& runtime) {
+    // TODO(moti): Switch from implementing __inspectorLog to directly
+    // installing a `console` object.
+    runtime.global().setProperty(
+        runtime,
+        "__inspectorLog",
+        jsi::Function::createFromHostFunction(
+            runtime,
+            jsi::PropNameID::forAscii(runtime, "__inspectorLog"),
+            4,
+            [selfWeak, selfExecutor](
+                jsi::Runtime& rt,
+                const jsi::Value& /*thisVal*/,
+                const jsi::Value* args,
+                size_t count) {
+              if (count < 4) {
+                throw jsi::JSError(
+                    rt,
+                    "__inspectorLog requires at least 4 arguments: logLevel, str, args, framesToSkip");
+              }
+              std::chrono::time_point<std::chrono::system_clock> timestamp =
+                  std::chrono::system_clock::now();
+              std::string level = args[0].asString(rt).utf8(rt);
+              ConsoleAPIType type = ConsoleAPIType::kLog;
+              if (level == "debug") {
+                type = ConsoleAPIType::kDebug;
+              } else if (level == "log") {
+                type = ConsoleAPIType::kLog;
+              } else if (level == "warning") {
+                type = ConsoleAPIType::kWarning;
+              } else if (level == "error") {
+                type = ConsoleAPIType::kError;
+              }
+              // NOTE: args[1] is the processed string message - ignore it.
+              jsi::Array argsArray = args[2].asObject(rt).asArray(rt);
+              std::vector<jsi::Value> argsVec;
+              for (size_t i = 0, length = argsArray.length(rt); i != length;
+                   ++i) {
+                argsVec.emplace_back(argsArray.getValueAtIndex(rt, i));
+              }
+              // TODO(moti): Handle framesToSkip in some way. Note that the
+              // runtime doesn't even capture a stack trace at the moment.
+              ConsoleMessage consoleMessage{
+                  std::chrono::duration_cast<
+                      std::chrono::duration<double, std::milli>>(
+                      timestamp.time_since_epoch())
+                      .count(),
+                  type,
+                  std::move(argsVec)};
+              if (auto self = selfWeak.lock()) {
+                // Q: Why is it safe to use self->delegate_ here?
+                // A: Because the caller of InspectorTarget::registerRuntime
+                // is explicitly required to guarantee that the delegate not
+                // only outlives the target, but also outlives all JS code
+                // execution that occurs on the JS thread.
+                self->delegate_.addConsoleMessage(
+                    rt, std::move(consoleMessage));
+                // To ensure we never destroy `self` on the JS thread, send
+                // our shared_ptr back to the inspector thread.
+                selfExecutor([self = std::move(self)](auto&) { (void)self; });
+              }
+              return jsi::Value::undefined();
+            }));
+  });
+}
 
 std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
     FrontendChannel channel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetConsole.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetConsole.cpp
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <jsinspector-modern/RuntimeTarget.h>
+
+#include <deque>
+#include <string>
+
+using namespace facebook::jsi;
+using namespace std::string_literals;
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+struct ConsoleState {
+  /**
+   * https://console.spec.whatwg.org/#counting
+   */
+  std::unordered_map<std::string, int> countMap;
+
+  /**
+   * https://console.spec.whatwg.org/#timing
+   */
+  std::unordered_map<std::string, double> timerTable;
+
+  ConsoleState() = default;
+  ConsoleState(const ConsoleState&) = delete;
+  ConsoleState& operator=(const ConsoleState&) = delete;
+  ConsoleState(ConsoleState&&) = delete;
+  ConsoleState& operator=(ConsoleState&&) = delete;
+};
+
+/**
+ * `console` methods that have no behaviour other than emitting a
+ * Runtime.consoleAPICalled message.
+ */
+constexpr const std::pair<const char*, ConsoleAPIType>
+    kForwardingConsoleMethods[] = {
+        {"clear", ConsoleAPIType::kClear},
+        {"debug", ConsoleAPIType::kDebug},
+        {"dir", ConsoleAPIType::kDir},
+        {"dirxml", ConsoleAPIType::kDirXML},
+        {"error", ConsoleAPIType::kError},
+        {"group", ConsoleAPIType::kStartGroup},
+        {"groupCollapsed", ConsoleAPIType::kStartGroupCollapsed},
+        {"groupEnd", ConsoleAPIType::kEndGroup},
+        {"info", ConsoleAPIType::kInfo},
+        {"log", ConsoleAPIType::kLog},
+        {"table", ConsoleAPIType::kTable},
+        {"trace", ConsoleAPIType::kTrace},
+        {"warn", ConsoleAPIType::kWarning},
+};
+
+/**
+ * JS `Object.create()`
+ */
+jsi::Object objectCreate(jsi::Runtime& runtime, jsi::Value prototype) {
+  auto objectGlobal = runtime.global().getPropertyAsObject(runtime, "Object");
+  auto createFn = objectGlobal.getPropertyAsFunction(runtime, "create");
+  return createFn.callWithThis(runtime, objectGlobal, prototype)
+      .getObject(runtime);
+}
+
+bool toBoolean(jsi::Runtime& runtime, const jsi::Value& val) {
+  // Based on Operations.cpp:toBoolean in the Hermes VM.
+  if (val.isUndefined() || val.isNull()) {
+    return false;
+  }
+  if (val.isBool()) {
+    return val.getBool();
+  }
+  if (val.isNumber()) {
+    double m = val.getNumber();
+    return m != 0 && !std::isnan(m);
+  }
+  if (val.isSymbol() || val.isObject()) {
+    return true;
+  }
+  if (val.isString()) {
+    std::string s = val.getString(runtime).utf8(runtime);
+    return !s.empty();
+  }
+  assert(false && "All cases should be covered");
+  return false;
+}
+
+/**
+ * Get the current time in milliseconds as a double.
+ */
+double getTimestampMs() {
+  return std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+} // namespace
+
+void RuntimeTarget::installConsoleHandler() {
+  jsExecutor_([selfWeak = weak_from_this(),
+               selfExecutor = executorFromThis()](jsi::Runtime& runtime) {
+    jsi::Value consolePrototype = jsi::Value::null();
+    auto originalConsoleVal = runtime.global().getProperty(runtime, "console");
+    std::shared_ptr<jsi::Object> originalConsole;
+    if (originalConsoleVal.isObject()) {
+      originalConsole =
+          std::make_shared<jsi::Object>(originalConsoleVal.getObject(runtime));
+      consolePrototype = std::move(originalConsoleVal);
+    } else {
+      consolePrototype = jsi::Object(runtime);
+    }
+    auto console = objectCreate(runtime, std::move(consolePrototype));
+    auto state = std::make_shared<ConsoleState>();
+
+    /**
+     * An executor that runs synchronously and provides a safe reference to our
+     * RuntimeTargetDelegate for use on the JS thread.
+     * \see RuntimeTargetDelegate for information on which methods are safe to
+     * call on the JS thread.
+     * \warning The callback will not run if the RuntimeTarget has been
+     * destroyed.
+     */
+    auto delegateExecutorSync = [selfWeak, selfExecutor](auto&& func) {
+      if (auto self = selfWeak.lock()) {
+        // Q: Why is it safe to use self.delegate_ here?
+        // A: Because the caller of InspectorTarget::registerRuntime
+        // is explicitly required to guarantee that the delegate not
+        // only outlives the target, but also outlives all JS code
+        // execution that occurs on the JS thread.
+        func(self->delegate_);
+        // To ensure we never destroy `self` on the JS thread, send
+        // our shared_ptr back to the inspector thread.
+        selfExecutor([self = std::move(self)](auto&) { (void)self; });
+      }
+    };
+
+    /**
+     * Call \param innerFn and forward any arguments to the original console
+     * method named \param methodName, if possible.
+     */
+    auto forwardToOriginalConsole = [originalConsole, delegateExecutorSync](
+                                        const char* methodName,
+                                        auto&& innerFn) {
+      return [originalConsole,
+              delegateExecutorSync,
+              innerFn = std::move(innerFn),
+              methodName](
+                 jsi::Runtime& runtime,
+                 const jsi::Value& thisVal,
+                 const jsi::Value* args,
+                 size_t count) mutable {
+        jsi::Value retVal = innerFn(runtime, thisVal, args, count);
+        if (originalConsole) {
+          auto val = originalConsole->getProperty(runtime, methodName);
+          if (val.isObject()) {
+            auto obj = val.getObject(runtime);
+            if (obj.isFunction(runtime)) {
+              auto func = obj.getFunction(runtime);
+              func.callWithThis(runtime, *originalConsole, args, count);
+            }
+          }
+        }
+        return retVal;
+      };
+    };
+
+    /**
+     * Install a console method with the given name and body. The body receives
+     * the usual JSI host function parameters plus a ConsoleState reference, a
+     * reference to the RuntimeTargetDelegate for sending messages to the
+     * client, and the timestamp of the call. After the body runs (or is skipped
+     * due to RuntimeTarget having been destroyed), the method of the same name
+     * is also called on originalConsole (if it exists).
+     */
+    auto installConsoleMethod =
+        [&](const char* methodName,
+            std::function<void(
+                jsi::Runtime & runtime,
+                const jsi::Value* args,
+                size_t count,
+                RuntimeTargetDelegate& runtimeTargetDelegate,
+                ConsoleState& state,
+                double timestampMs)>&& body) {
+          console.setProperty(
+              runtime,
+              methodName,
+              jsi::Function::createFromHostFunction(
+                  runtime,
+                  jsi::PropNameID::forAscii(runtime, methodName),
+                  0,
+                  forwardToOriginalConsole(
+                      methodName,
+                      [body = std::move(body), state, delegateExecutorSync](
+                          jsi::Runtime& runtime,
+                          const jsi::Value& /*thisVal*/,
+                          const jsi::Value* args,
+                          size_t count) mutable {
+                        auto timestampMs = getTimestampMs();
+                        delegateExecutorSync(
+                            [&runtime,
+                             args,
+                             count,
+                             body = std::move(body),
+                             state,
+                             timestampMs](auto& runtimeTargetDelegate) {
+                              body(
+                                  runtime,
+                                  args,
+                                  count,
+                                  runtimeTargetDelegate,
+                                  *state,
+                                  timestampMs);
+                            });
+                        return jsi::Value::undefined();
+                      })));
+        };
+
+    /**
+     * console.count
+     */
+    installConsoleMethod(
+        "count",
+        [](jsi::Runtime& runtime,
+           const jsi::Value* args,
+           size_t count,
+           RuntimeTargetDelegate& runtimeTargetDelegate,
+           ConsoleState& state,
+           auto timestampMs) {
+          std::string label = "default";
+          if (count > 0 && !args[0].isUndefined()) {
+            label = args[0].toString(runtime).utf8(runtime);
+          }
+          auto it = state.countMap.find(label);
+          if (it == state.countMap.end()) {
+            it = state.countMap.insert({label, 1}).first;
+          } else {
+            it->second++;
+          }
+          std::vector<jsi::Value> vec;
+          vec.emplace_back(jsi::String::createFromUtf8(
+              runtime, label + ": "s + std::to_string(it->second)));
+          runtimeTargetDelegate.addConsoleMessage(
+              runtime, {timestampMs, ConsoleAPIType::kCount, std::move(vec)});
+        });
+
+    /**
+     * console.countReset
+     */
+    installConsoleMethod(
+        "countReset",
+        [](jsi::Runtime& runtime,
+           const jsi::Value* args,
+           size_t count,
+           RuntimeTargetDelegate& runtimeTargetDelegate,
+           ConsoleState& state,
+           auto timestampMs) {
+          std::string label = "default";
+          if (count > 0 && !args[0].isUndefined()) {
+            label = args[0].toString(runtime).utf8(runtime);
+          }
+          auto it = state.countMap.find(label);
+          if (it == state.countMap.end()) {
+            std::vector<jsi::Value> vec;
+            vec.emplace_back(jsi::String::createFromUtf8(
+                runtime, "Count for '"s + label + "' does not exist"));
+            runtimeTargetDelegate.addConsoleMessage(
+                runtime,
+                {timestampMs, ConsoleAPIType::kWarning, std::move(vec)});
+          } else {
+            it->second = 0;
+          }
+        });
+
+    /**
+     * console.time
+     */
+    installConsoleMethod(
+        "time",
+        [](jsi::Runtime& runtime,
+           const jsi::Value* args,
+           size_t count,
+           RuntimeTargetDelegate& runtimeTargetDelegate,
+           ConsoleState& state,
+           auto timestampMs) {
+          std::string label = "default";
+          if (count > 0 && !args[0].isUndefined()) {
+            label = args[0].toString(runtime).utf8(runtime);
+          }
+          auto it = state.timerTable.find(label);
+          if (it == state.timerTable.end()) {
+            state.timerTable.insert({label, timestampMs});
+          } else {
+            std::vector<jsi::Value> vec;
+            vec.emplace_back(jsi::String::createFromUtf8(
+                runtime, "Timer '"s + label + "' already exists"));
+            runtimeTargetDelegate.addConsoleMessage(
+                runtime,
+                {timestampMs, ConsoleAPIType::kWarning, std::move(vec)});
+          }
+        });
+
+    /**
+     * console.timeEnd
+     */
+    installConsoleMethod(
+        "timeEnd",
+        [](jsi::Runtime& runtime,
+           const jsi::Value* args,
+           size_t count,
+           RuntimeTargetDelegate& runtimeTargetDelegate,
+           ConsoleState& state,
+           auto timestampMs) {
+          std::string label = "default";
+          if (count > 0 && !args[0].isUndefined()) {
+            label = args[0].toString(runtime).utf8(runtime);
+          }
+          auto it = state.timerTable.find(label);
+          if (it == state.timerTable.end()) {
+            std::vector<jsi::Value> vec;
+            vec.emplace_back(jsi::String::createFromUtf8(
+                runtime, "Timer '"s + label + "' does not exist"));
+            runtimeTargetDelegate.addConsoleMessage(
+                runtime,
+                {timestampMs, ConsoleAPIType::kWarning, std::move(vec)});
+          } else {
+            std::vector<jsi::Value> vec;
+            vec.emplace_back(jsi::String::createFromUtf8(
+                runtime,
+                label + ": "s + std::to_string(timestampMs - it->second) +
+                    " ms"));
+            state.timerTable.erase(it);
+            runtimeTargetDelegate.addConsoleMessage(
+                runtime,
+                {timestampMs, ConsoleAPIType::kTimeEnd, std::move(vec)});
+          }
+        });
+
+    /**
+     * console.timeLog
+     */
+    installConsoleMethod(
+        "timeLog",
+        [](jsi::Runtime& runtime,
+           const jsi::Value* args,
+           size_t count,
+           RuntimeTargetDelegate& runtimeTargetDelegate,
+           ConsoleState& state,
+           auto timestampMs) {
+          std::string label = "default";
+          if (count > 0 && !args[0].isUndefined()) {
+            label = args[0].toString(runtime).utf8(runtime);
+          }
+          auto it = state.timerTable.find(label);
+          if (it == state.timerTable.end()) {
+            std::vector<jsi::Value> vec;
+            vec.emplace_back(jsi::String::createFromUtf8(
+                runtime, "Timer '"s + label + "' does not exist"));
+            runtimeTargetDelegate.addConsoleMessage(
+                runtime,
+                {timestampMs, ConsoleAPIType::kWarning, std::move(vec)});
+          } else {
+            std::vector<jsi::Value> vec;
+            vec.emplace_back(jsi::String::createFromUtf8(
+                runtime,
+                label + ": "s + std::to_string(timestampMs - it->second) +
+                    " ms"));
+            if (count > 1) {
+              for (size_t i = 1; i != count; ++i) {
+                vec.emplace_back(jsi::Value(runtime, args[i]));
+              }
+            }
+            runtimeTargetDelegate.addConsoleMessage(
+                runtime, {timestampMs, ConsoleAPIType::kLog, std::move(vec)});
+          }
+        });
+
+    /**
+     * console.assert
+     */
+    installConsoleMethod(
+        "assert",
+        [](jsi::Runtime& runtime,
+           const jsi::Value* args,
+           size_t count,
+           RuntimeTargetDelegate& runtimeTargetDelegate,
+           ConsoleState& /*state*/,
+           auto timestampMs) {
+          if (count >= 1 && toBoolean(runtime, args[0])) {
+            return;
+          }
+          std::deque<jsi::Value> data;
+
+          if (count > 1) {
+            for (size_t i = 1; i != count; ++i) {
+              data.emplace_back(jsi::Value(runtime, args[i]));
+            }
+          }
+          if (data.empty()) {
+            data.emplace_back(
+                jsi::String::createFromUtf8(runtime, "Assertion failed"));
+          } else if (data.front().isString()) {
+            data.front() = jsi::String::createFromUtf8(
+                runtime,
+                "Assertion failed: "s +
+                    data.front().asString(runtime).utf8(runtime));
+          } else {
+            data.emplace_front(
+                jsi::String::createFromUtf8(runtime, "Assertion failed"));
+          }
+          runtimeTargetDelegate.addConsoleMessage(
+              runtime,
+              {timestampMs,
+               ConsoleAPIType::kAssert,
+               std::vector<jsi::Value>(
+                   make_move_iterator(data.begin()),
+                   make_move_iterator(data.end()))});
+        });
+
+    for (auto& [name, type] : kForwardingConsoleMethods) {
+      installConsoleMethod(
+          name,
+          [type = type](
+              jsi::Runtime& runtime,
+              const jsi::Value* args,
+              size_t count,
+              RuntimeTargetDelegate& runtimeTargetDelegate,
+              ConsoleState& state,
+              auto timestampMs) {
+            std::vector<jsi::Value> argsVec;
+            for (size_t i = 0; i != count; ++i) {
+              argsVec.push_back(jsi::Value(runtime, args[i]));
+            }
+            runtimeTargetDelegate.addConsoleMessage(
+                runtime, {timestampMs, type, std::move(argsVec)});
+          });
+    }
+
+    runtime.global().setProperty(runtime, "console", console);
+  });
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -136,6 +136,11 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
        const ExecutionContextDescription&,
        RuntimeExecutor),
       (override));
+  MOCK_METHOD(
+      void,
+      addConsoleMessage,
+      (jsi::Runtime & runtime, ConsoleMessage message),
+      (override));
 };
 
 class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/prelude.js.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/prelude.js.h
@@ -553,6 +553,7 @@ if (global.nativeLoggingHook) {
   }
 
   global.console = {
+    ...(originalConsole ?? {}),
     error: getNativeLogFunction(LOG_LEVELS.error),
     info: getNativeLogFunction(LOG_LEVELS.info),
     log: getNativeLogFunction(LOG_LEVELS.info),
@@ -577,7 +578,10 @@ if (global.nativeLoggingHook) {
   if (__DEV__ && originalConsole) {
     Object.keys(console).forEach(methodName => {
       const reactNativeMethod = console[methodName];
-      if (originalConsole[methodName]) {
+      if (
+        originalConsole[methodName] &&
+        reactNativeMethod !== originalConsole[methodName]
+      ) {
         console[methodName] = function () {
           originalConsole[methodName](...arguments);
           reactNativeMethod.apply(console, arguments);

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c63cd0b38dfa9c4d6843a4b879f8f4df>>
+ * @generated SignedSource<<c1c58e483f6f6f0a16d615f7c2168b4b>>
  */
 
 /**
@@ -64,11 +64,11 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool inspectorEnableHermesCDPAgent() override {
-    return false;
+    return true;
   }
 
   bool inspectorEnableModernCDPRegistry() override {
-    return false;
+    return true;
   }
 
   bool skipMountHookNotifications() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -73,12 +73,12 @@ const definitions: FeatureFlagDefinitions = {
         'Flag determining if the C++ implementation of InspectorPackagerConnection should be used instead of the per-platform one. This flag is global and should not be changed across React Host lifetimes.',
     },
     inspectorEnableHermesCDPAgent: {
-      defaultValue: false,
+      defaultValue: true,
       description:
         'Flag determining if the new Hermes CDPAgent API should be enabled in the modern CDP backend. This flag is global and should not be changed across React Host lifetimes.',
     },
     inspectorEnableModernCDPRegistry: {
-      defaultValue: false,
+      defaultValue: true,
       description:
         'Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.',
     },

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<66678139be02293ff532e8e125ccc608>>
+ * @generated SignedSource<<fa6a02162b349234f40ba9d36b1f955f>>
  * @flow strict-local
  */
 
@@ -134,11 +134,11 @@ export const inspectorEnableCxxInspectorPackagerConnection: Getter<boolean> = cr
 /**
  * Flag determining if the new Hermes CDPAgent API should be enabled in the modern CDP backend. This flag is global and should not be changed across React Host lifetimes.
  */
-export const inspectorEnableHermesCDPAgent: Getter<boolean> = createNativeFlagGetter('inspectorEnableHermesCDPAgent', false);
+export const inspectorEnableHermesCDPAgent: Getter<boolean> = createNativeFlagGetter('inspectorEnableHermesCDPAgent', true);
 /**
  * Flag determining if the modern CDP backend should be enabled. This flag is global and should not be changed across React Host lifetimes.
  */
-export const inspectorEnableModernCDPRegistry: Getter<boolean> = createNativeFlagGetter('inspectorEnableModernCDPRegistry', false);
+export const inspectorEnableModernCDPRegistry: Getter<boolean> = createNativeFlagGetter('inspectorEnableModernCDPRegistry', true);
 /**
  * This is a temporary flag to disable part of the mount hooks pipeline to investigate a crash.
  */

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -133,7 +133,7 @@ class RNTesterApplication : Application(), ReactApplication {
     super.onCreate()
     SoLoader.init(this, /* native exopackage */ false)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      load()
+      load(bridgelessEnabled = false)
     }
   }
 }


### PR DESCRIPTION
Summary:
Changelog: [General][Changed] - Console polyfill now copies all properties from the existing `console` object

Fusebox now exposes a full WHATWG `console` object integrated directly with CDP debugging (D54826073). Some WHATWG `console` methods are missing from React Native's polyfill/shim, so let's pass those through unmodified so they can still be called.

(Long term, we shouldn't need most of `console.js`, but let's get there gradually as there are many RN users still depending on `nativeLoggingHook` etc.)

NOTE: We also update the "bundled" copy of `console.js` that lives in the jsinspector-modern C++ test suite.

Differential Revision: D54827902


