### PR TITLE
Switch to Hermes lazy compilation mode in JsiIntegrationTest

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesWithCDPAgentEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesWithCDPAgentEngineAdapter.cpp
@@ -12,7 +12,14 @@ namespace facebook::react::jsinspector_modern {
 JsiIntegrationTestHermesWithCDPAgentEngineAdapter::
     JsiIntegrationTestHermesWithCDPAgentEngineAdapter(
         folly::Executor& jsExecutor)
-    : JsiIntegrationTestHermesEngineAdapter(jsExecutor) {}
+    : runtime_{hermes::makeHermesRuntime(
+          ::hermes::vm::RuntimeConfig::Builder()
+              .withEnableBlockScoping(true)
+              .withCompilationMode(
+                  ::hermes::vm::CompilationMode::ForceLazyCompilation)
+              .build())},
+      jsExecutor_{jsExecutor},
+      runtimeTargetDelegate_{runtime_} {}
 
 /* static */ InspectorFlagOverrides
 JsiIntegrationTestHermesWithCDPAgentEngineAdapter::
@@ -20,6 +27,31 @@ JsiIntegrationTestHermesWithCDPAgentEngineAdapter::
   return {
       .enableHermesCDPAgent = true,
       .enableModernCDPRegistry = true,
+  };
+}
+
+RuntimeTargetDelegate&
+JsiIntegrationTestHermesWithCDPAgentEngineAdapter::getRuntimeTargetDelegate() {
+  return runtimeTargetDelegate_;
+}
+
+jsi::Runtime& JsiIntegrationTestHermesWithCDPAgentEngineAdapter::getRuntime()
+    const noexcept {
+  return *runtime_;
+}
+
+RuntimeExecutor
+JsiIntegrationTestHermesWithCDPAgentEngineAdapter::getRuntimeExecutor()
+    const noexcept {
+  auto& jsExecutor = jsExecutor_;
+  return [runtimeWeak = std::weak_ptr(runtime_), &jsExecutor](auto fn) {
+    jsExecutor.add([runtimeWeak, fn]() {
+      auto runtime = runtimeWeak.lock();
+      if (!runtime) {
+        return;
+      }
+      fn(*runtime);
+    });
   };
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesWithCDPAgentEngineAdapter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesWithCDPAgentEngineAdapter.h
@@ -8,7 +8,15 @@
 #pragma once
 
 #include "../utils/InspectorFlagOverridesGuard.h"
-#include "JsiIntegrationTestHermesEngineAdapter.h"
+
+#include <jsinspector-modern/RuntimeTarget.h>
+
+#include <folly/executors/QueuedImmediateExecutor.h>
+#include <hermes/hermes.h>
+#include <hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h>
+#include <jsi/jsi.h>
+
+#include <memory>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -16,13 +24,23 @@ namespace facebook::react::jsinspector_modern {
  * An engine adapter for JsiIntegrationTest that uses Hermes (and Hermes's
  * new CDPAgent API).
  */
-class JsiIntegrationTestHermesWithCDPAgentEngineAdapter
-    : public JsiIntegrationTestHermesEngineAdapter {
+class JsiIntegrationTestHermesWithCDPAgentEngineAdapter {
  public:
   explicit JsiIntegrationTestHermesWithCDPAgentEngineAdapter(
       folly::Executor& jsExecutor);
 
   static InspectorFlagOverrides getInspectorFlagOverrides() noexcept;
+
+  RuntimeTargetDelegate& getRuntimeTargetDelegate();
+
+  jsi::Runtime& getRuntime() const noexcept;
+
+  RuntimeExecutor getRuntimeExecutor() const noexcept;
+
+ private:
+  std::shared_ptr<facebook::hermes::HermesRuntime> runtime_;
+  folly::Executor& jsExecutor_;
+  HermesRuntimeTargetDelegate runtimeTargetDelegate_;
 };
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Updates `JsiIntegrationTestHermesWithCDPAgentEngineAdapter` to align with `hermes::makeHermesRuntime()` creation since D54686192 (lazy compilation mode, related to recent repeat `Debugger.scriptParsed` bug).

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D54852326


