### PR TITLE
Support onConfigurationChanged in Bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -150,6 +150,7 @@ public class com/facebook/react/ReactDelegate {
 	public fun loadApp (Ljava/lang/String;)V
 	public fun onActivityResult (IILandroid/content/Intent;Z)V
 	public fun onBackPressed ()Z
+	public fun onConfigurationChanged (Landroid/content/res/Configuration;)V
 	public fun onHostDestroy ()V
 	public fun onHostPause ()V
 	public fun onHostResume ()V
@@ -199,6 +200,7 @@ public abstract interface class com/facebook/react/ReactHost {
 	public abstract fun getReactQueueConfiguration ()Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;
 	public abstract fun onActivityResult (Landroid/app/Activity;IILandroid/content/Intent;)V
 	public abstract fun onBackPressed ()Z
+	public abstract fun onConfigurationChanged (Landroid/content/Context;)V
 	public abstract fun onHostDestroy ()V
 	public abstract fun onHostDestroy (Landroid/app/Activity;)V
 	public abstract fun onHostPause ()V
@@ -3639,6 +3641,7 @@ public class com/facebook/react/runtime/ReactHostImpl : com/facebook/react/React
 	public fun getReactQueueConfiguration ()Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;
 	public fun onActivityResult (Landroid/app/Activity;IILandroid/content/Intent;)V
 	public fun onBackPressed ()Z
+	public fun onConfigurationChanged (Landroid/content/Context;)V
 	public fun onHostDestroy ()V
 	public fun onHostDestroy (Landroid/app/Activity;)V
 	public fun onHostPause ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -191,13 +191,7 @@ public class ReactActivityDelegate {
   }
 
   public void onConfigurationChanged(Configuration newConfig) {
-    if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      // TODO T156475655: support onConfigurationChanged
-    } else {
-      if (getReactNativeHost().hasInstance()) {
-        getReactInstanceManager().onConfigurationChanged(getContext(), newConfig);
-      }
-    }
+    mReactDelegate.onConfigurationChanged(newConfig);
   }
 
   public void requestPermissions(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -9,6 +9,7 @@ package com.facebook.react;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.annotation.Nullable;
@@ -167,6 +168,17 @@ public class ReactDelegate {
     } else {
       if (getReactNativeHost().hasInstance()) {
         getReactNativeHost().getReactInstanceManager().onWindowFocusChange(hasFocus);
+      }
+    }
+  }
+
+  public void onConfigurationChanged(Configuration newConfig) {
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      mReactHost.onConfigurationChanged(Assertions.assertNotNull(mActivity));
+    } else {
+      if (getReactNativeHost().hasInstance()) {
+        getReactInstanceManager()
+            .onConfigurationChanged(Assertions.assertNotNull(mActivity), newConfig);
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -126,6 +126,8 @@ public interface ReactHost {
   /* This method will give JS the opportunity to receive intents via Linking. */
   public fun onNewIntent(intent: Intent)
 
+  public fun onConfigurationChanged(context: Context)
+
   public fun addBeforeDestroyListener(onBeforeDestroy: () -> Unit)
 
   public fun removeBeforeDestroyListener(onBeforeDestroy: () -> Unit)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -58,6 +58,7 @@ import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.interfaces.TaskInterface;
 import com.facebook.react.interfaces.exceptionmanager.ReactJsExceptionHandler;
 import com.facebook.react.interfaces.fabric.ReactSurface;
+import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.runtime.internal.bolts.Continuation;
@@ -697,6 +698,20 @@ public class ReactHostImpl implements ReactHost {
     ReactSoftExceptionLogger.logSoftException(
         TAG,
         new ReactNoCrashSoftException("Tried to access onNewIntent while context is not ready"));
+  }
+
+  @ThreadConfined(UI)
+  @Override
+  public void onConfigurationChanged(Context updatedContext) {
+    ReactContext currentReactContext = getCurrentReactContext();
+    if (currentReactContext != null) {
+      AppearanceModule appearanceModule =
+          currentReactContext.getNativeModule(AppearanceModule.class);
+
+      if (appearanceModule != null) {
+        appearanceModule.onConfigurationChanged(updatedContext);
+      }
+    }
   }
 
   @Nullable


### PR DESCRIPTION
Summary:
Implement `onConfigurationChanged` in Bridgeless by adding it to ReactHostImpl

Changelog:
[Android][Breaking] Implement onConfigurationChanged in Bridgeless

Reviewed By: cortinico, RSNara

Differential Revision: D54792399
