### PR TITLE
Support onKeyDown in Bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -154,6 +154,7 @@ public class com/facebook/react/ReactDelegate {
 	public fun onHostDestroy ()V
 	public fun onHostPause ()V
 	public fun onHostResume ()V
+	public fun onKeyDown (ILandroid/view/KeyEvent;)Z
 	public fun onNewIntent (Landroid/content/Intent;)Z
 	public fun onWindowFocusChanged (Z)V
 	public fun shouldShowDevMenuOrReload (ILandroid/view/KeyEvent;)Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -147,17 +147,7 @@ public class ReactActivityDelegate {
   }
 
   public boolean onKeyDown(int keyCode, KeyEvent event) {
-    if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      // TODO T156475655: support onKeyDown
-    } else {
-      if (getReactNativeHost().hasInstance()
-          && getReactNativeHost().getUseDeveloperSupport()
-          && keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
-        event.startTracking();
-        return true;
-      }
-    }
-    return false;
+    return mReactDelegate.onKeyDown(keyCode, event);
   }
 
   public boolean onKeyUp(int keyCode, KeyEvent event) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -184,6 +184,19 @@ public class ReactDelegate {
     }
   }
 
+  public boolean onKeyDown(int keyCode, KeyEvent event) {
+    if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD
+        && ((ReactFeatureFlags.enableBridgelessArchitecture
+                && mReactHost != null
+                && mReactHost.getDevSupportManager() != null)
+            || (getReactNativeHost().hasInstance()
+                && getReactNativeHost().getUseDeveloperSupport()))) {
+      event.startTracking();
+      return true;
+    }
+    return false;
+  }
+
   public void loadApp() {
     loadApp(mMainComponentName);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -138,7 +138,7 @@ public class ReactDelegate {
   }
 
   public boolean onNewIntent(Intent intent) {
-    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+    if (ReactFeatureFlags.enableBridgelessArchitecture && mReactHost != null) {
       mReactHost.onNewIntent(intent);
       return true;
     } else {
@@ -152,7 +152,7 @@ public class ReactDelegate {
 
   public void onActivityResult(
       int requestCode, int resultCode, Intent data, boolean shouldForwardToReactInstance) {
-    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+    if (ReactFeatureFlags.enableBridgelessArchitecture && mReactHost != null) {
       mReactHost.onActivityResult(mActivity, requestCode, resultCode, data);
     } else {
       if (getReactNativeHost().hasInstance() && shouldForwardToReactInstance) {
@@ -164,7 +164,7 @@ public class ReactDelegate {
   }
 
   public void onWindowFocusChanged(boolean hasFocus) {
-    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+    if (ReactFeatureFlags.enableBridgelessArchitecture && mReactHost != null) {
       mReactHost.onWindowFocusChange(hasFocus);
     } else {
       if (getReactNativeHost().hasInstance()) {
@@ -174,7 +174,7 @@ public class ReactDelegate {
   }
 
   public void onConfigurationChanged(Configuration newConfig) {
-    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+    if (ReactFeatureFlags.enableBridgelessArchitecture && mReactHost != null) {
       mReactHost.onConfigurationChanged(Assertions.assertNotNull(mActivity));
     } else {
       if (getReactNativeHost().hasInstance()) {


### PR DESCRIPTION
Summary:
Implement `onKeyDown` in Bridgeless by adding it to ReactHostImpl

Changelog:
[Android][Breaking] Implement `onKeyDown` in Bridgeless

Differential Revision: D54870966


