### PR TITLE
Remove AutoFill from context menu when using `contextMenuHidden`

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -261,6 +261,15 @@ static UIColor *defaultPlaceholderColor(void)
   return [super canPerformAction:action withSender:sender];
 }
 
+-(void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder {
+    if (_contextMenuHidden) {
+        if (@available(iOS 17.0, *)) {
+            [builder removeMenuForIdentifier:UIMenuAutoFill];
+        }
+    }
+    [super buildMenuWithBuilder:builder];
+}
+
 #pragma mark - Dictation
 
 - (void)dictationRecordingDidEnd

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -142,6 +142,15 @@
   return [super canPerformAction:action withSender:sender];
 }
 
+-(void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder {
+    if (_contextMenuHidden) {
+        if (@available(iOS 17.0, *)) {
+            [builder removeMenuForIdentifier:UIMenuAutoFill];
+        }
+    }
+    [super buildMenuWithBuilder:builder];
+}
+
 #pragma mark - Dictation
 
 - (void)dictationRecordingDidEnd


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This pull request resolves the issue #43452 
Previously, when utilizing `contextMenuHidden`, the context menu wasn't entirely hidden as the "AutoFill" option remained visible. However, it's now possible to eliminate it using the menu builder.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - hide AutoFill from context menu when using `contextMenuHidden`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Manual tests in RNTester:


https://github.com/facebook/react-native/assets/39670088/dc0f828c-f613-412d-b560-f3b795dd3ffb


