### PR TITLE
Fix RCTPerfMonitor not showing up in scene based app

### DIFF
--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -298,7 +298,12 @@ RCT_EXPORT_MODULE()
 
   [self updateStats];
 
-  UIWindow *window = RCTSharedApplication().delegate.window;
+  UIWindow *window = [self getUIWindowFromScene];
+
+  if (!window) {
+    window = RCTSharedApplication().delegate.window;
+  }
+
   [window addSubview:self.container];
 
   _uiDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(threadUpdate:)];
@@ -488,6 +493,21 @@ RCT_EXPORT_MODULE()
     i += 2;
   }
   _perfLoggerMarks = [data copy];
+}
+
+- (UIWindow *)getUIWindowFromScene
+{
+  for (UIScene *scene in RCTSharedApplication().connectedScenes) {
+    // In app supports CarPlay, the active scene may be a CPTemplateApplicationScene instance, we should check the class.
+    if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
+      if (@available(iOS 15.0, *)) {
+        return ((UIWindowScene *)scene).keyWindow;
+      } else {
+        return ((UIWindowScene *)scene).windows.firstObject;
+      }
+    }
+  }
+  return nil;
 }
 
 #pragma mark - UITableViewDataSource

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -298,11 +298,7 @@ RCT_EXPORT_MODULE()
 
   [self updateStats];
 
-  UIWindow *window = [self getUIWindowFromScene];
-
-  if (!window) {
-    window = RCTSharedApplication().delegate.window;
-  }
+  UIWindow *window = RCTKeyWindow();
 
   [window addSubview:self.container];
 
@@ -493,21 +489,6 @@ RCT_EXPORT_MODULE()
     i += 2;
   }
   _perfLoggerMarks = [data copy];
-}
-
-- (UIWindow *)getUIWindowFromScene
-{
-  for (UIScene *scene in RCTSharedApplication().connectedScenes) {
-    // In app supports CarPlay, the active scene may be a CPTemplateApplicationScene instance, we should check the class.
-    if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
-      if (@available(iOS 15.0, *)) {
-        return ((UIWindowScene *)scene).keyWindow;
-      } else {
-        return ((UIWindowScene *)scene).windows.firstObject;
-      }
-    }
-  }
-  return nil;
 }
 
 #pragma mark - UITableViewDataSource


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Currently RCTPerfMonitor won't show up in scene based app, we should first try to extract the window from the connected scenes, and fallback to the window in `UIApplicationDelegate`.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Fix RCTPerfMonitor not showing up in scene based app

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Tested RCTPerfMonitor in app not using scenes;
- Tested RCTPerfMonitor in app using scenes in iOS 13 & 14;
- Tested RCTPerfMonitor in app using scenes in iOS 15+.
