### PR TITLE
Use CopyOnWriteArrayList in MemoryPressureRouter

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -197,6 +197,7 @@ public abstract interface class com/facebook/react/ReactHost {
 	public abstract fun getDevSupportManager ()Lcom/facebook/react/devsupport/interfaces/DevSupportManager;
 	public abstract fun getJsEngineResolutionAlgorithm ()Lcom/facebook/react/JSEngineResolutionAlgorithm;
 	public abstract fun getLifecycleState ()Lcom/facebook/react/common/LifecycleState;
+	public abstract fun getMemoryPressureRouter ()Lcom/facebook/react/MemoryPressureRouter;
 	public abstract fun getReactQueueConfiguration ()Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;
 	public abstract fun onActivityResult (Landroid/app/Activity;IILandroid/content/Intent;)V
 	public abstract fun onBackPressed ()Z
@@ -1922,7 +1923,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field excludeYogaFromRawProps Z
 	public static field rejectTurboModulePromiseOnNativeError Z
 	public static field traceTurboModulePromiseRejections Z
-	public static field unstable_bridgelessArchitectureMemoryPressureHackyBoltsFix Z
 	public static field unstable_enableTurboModuleSyncVoidMethods Z
 	public static field unstable_useFabricInterop Z
 	public static field unstable_useTurboModuleInterop Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/MemoryPressureRouter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/MemoryPressureRouter.java
@@ -11,14 +11,12 @@ import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.res.Configuration;
 import com.facebook.react.bridge.MemoryPressureListener;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-/** Translates and routes memory pressure events to the current catalyst instance. */
+/** Translates and routes memory pressure events. */
 public class MemoryPressureRouter implements ComponentCallbacks2 {
-  private final Set<MemoryPressureListener> mListeners =
-      Collections.synchronizedSet(new LinkedHashSet<>());
+  private final CopyOnWriteArrayList<MemoryPressureListener> mListeners =
+      new CopyOnWriteArrayList();
 
   public MemoryPressureRouter(Context context) {
     context.getApplicationContext().registerComponentCallbacks(this);
@@ -30,7 +28,9 @@ public class MemoryPressureRouter implements ComponentCallbacks2 {
 
   /** Add a listener to be notified of memory pressure events. */
   public void addMemoryPressureListener(MemoryPressureListener listener) {
-    mListeners.add(listener);
+    if (!mListeners.contains(listener)) {
+      mListeners.add(listener);
+    }
   }
 
   /** Remove a listener previously added with {@link #addMemoryPressureListener}. */
@@ -50,11 +50,7 @@ public class MemoryPressureRouter implements ComponentCallbacks2 {
   public void onLowMemory() {}
 
   private void dispatchMemoryPressure(int level) {
-    // copy listeners array to avoid ConcurrentModificationException if any of the listeners remove
-    // themselves in handleMemoryPressure()
-    MemoryPressureListener[] listeners =
-        mListeners.toArray(new MemoryPressureListener[mListeners.size()]);
-    for (MemoryPressureListener listener : listeners) {
+    for (MemoryPressureListener listener : mListeners) {
       listener.handleMemoryPressure(level);
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -48,6 +48,9 @@ public interface ReactHost {
   /** [JSEngineResolutionAlgorithm] used by this host. */
   public var jsEngineResolutionAlgorithm: JSEngineResolutionAlgorithm?
 
+  /** Routes memory pressure events to interested components */
+  public val memoryPressureRouter: MemoryPressureRouter
+
   /** To be called when back button is pressed */
   public fun onBackPressed(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -66,9 +66,6 @@ public class ReactFeatureFlags {
    */
   public static boolean enableBridgelessArchitecture = false;
 
-  /** Server-side gating for a hacky fix to an ANR in the bridgeless core, related to Bolts task. */
-  public static boolean unstable_bridgelessArchitectureMemoryPressureHackyBoltsFix = false;
-
   /**
    * Does the bridgeless architecture log soft exceptions. Could be useful for tracking down issues.
    */


### PR DESCRIPTION
Summary:
We use `CopyOnWriteArrayList` in other places across the React Native codebase, as it assumes that reading happens more frequently than updating. This saves us from needing to synchronize and copy when we access the list of listeners.

Changelog: [Internal]

Differential Revision: D54806272


