### PR TITLE
Flag missing DefaultHardwareBackBtnHandler interface in bridgeless too

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -197,6 +197,7 @@ public abstract interface class com/facebook/react/ReactHost {
 	public abstract fun getDevSupportManager ()Lcom/facebook/react/devsupport/interfaces/DevSupportManager;
 	public abstract fun getJsEngineResolutionAlgorithm ()Lcom/facebook/react/JSEngineResolutionAlgorithm;
 	public abstract fun getLifecycleState ()Lcom/facebook/react/common/LifecycleState;
+	public abstract fun getMemoryPressureRouter ()Lcom/facebook/react/MemoryPressureRouter;
 	public abstract fun getReactQueueConfiguration ()Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;
 	public abstract fun onActivityResult (Landroid/app/Activity;IILandroid/content/Intent;)V
 	public abstract fun onBackPressed ()Z
@@ -1922,7 +1923,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field excludeYogaFromRawProps Z
 	public static field rejectTurboModulePromiseOnNativeError Z
 	public static field traceTurboModulePromiseRejections Z
-	public static field unstable_bridgelessArchitectureMemoryPressureHackyBoltsFix Z
 	public static field unstable_enableTurboModuleSyncVoidMethods Z
 	public static field unstable_useFabricInterop Z
 	public static field unstable_useTurboModuleInterop Z

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1909,7 +1909,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field dispatchPointerEvents Z
 	public static field enableBridgelessArchitecture Z
 	public static field enableBridgelessArchitectureNewCreateReloadDestroy Z
-	public static field enableBridgelessArchitectureSoftExceptions Z
 	public static field enableClonelessStateProgression Z
 	public static field enableCppPropsIteratorSetter Z
 	public static field enableEagerRootViewAttachment Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/MemoryPressureRouter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/MemoryPressureRouter.java
@@ -11,14 +11,12 @@ import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.res.Configuration;
 import com.facebook.react.bridge.MemoryPressureListener;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-/** Translates and routes memory pressure events to the current catalyst instance. */
+/** Translates and routes memory pressure events. */
 public class MemoryPressureRouter implements ComponentCallbacks2 {
-  private final Set<MemoryPressureListener> mListeners =
-      Collections.synchronizedSet(new LinkedHashSet<>());
+  private final CopyOnWriteArrayList<MemoryPressureListener> mListeners =
+      new CopyOnWriteArrayList();
 
   public MemoryPressureRouter(Context context) {
     context.getApplicationContext().registerComponentCallbacks(this);
@@ -30,7 +28,9 @@ public class MemoryPressureRouter implements ComponentCallbacks2 {
 
   /** Add a listener to be notified of memory pressure events. */
   public void addMemoryPressureListener(MemoryPressureListener listener) {
-    mListeners.add(listener);
+    if (!mListeners.contains(listener)) {
+      mListeners.add(listener);
+    }
   }
 
   /** Remove a listener previously added with {@link #addMemoryPressureListener}. */
@@ -50,11 +50,7 @@ public class MemoryPressureRouter implements ComponentCallbacks2 {
   public void onLowMemory() {}
 
   private void dispatchMemoryPressure(int level) {
-    // copy listeners array to avoid ConcurrentModificationException if any of the listeners remove
-    // themselves in handleMemoryPressure()
-    MemoryPressureListener[] listeners =
-        mListeners.toArray(new MemoryPressureListener[mListeners.size()]);
-    for (MemoryPressureListener listener : listeners) {
+    for (MemoryPressureListener listener : mListeners) {
       listener.handleMemoryPressure(level);
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -82,20 +82,17 @@ public class ReactDelegate {
   }
 
   public void onHostResume() {
+    if (!(mActivity instanceof DefaultHardwareBackBtnHandler)) {
+      throw new ClassCastException(
+          "Host Activity does not implement DefaultHardwareBackBtnHandler");
+    }
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      if (mActivity instanceof DefaultHardwareBackBtnHandler) {
-        mReactHost.onHostResume(mActivity, (DefaultHardwareBackBtnHandler) mActivity);
-      }
+      mReactHost.onHostResume(mActivity, (DefaultHardwareBackBtnHandler) mActivity);
     } else {
       if (getReactNativeHost().hasInstance()) {
-        if (mActivity instanceof DefaultHardwareBackBtnHandler) {
-          getReactNativeHost()
-              .getReactInstanceManager()
-              .onHostResume(mActivity, (DefaultHardwareBackBtnHandler) mActivity);
-        } else {
-          throw new ClassCastException(
-              "Host Activity does not implement DefaultHardwareBackBtnHandler");
-        }
+        getReactNativeHost()
+            .getReactInstanceManager()
+            .onHostResume(mActivity, (DefaultHardwareBackBtnHandler) mActivity);
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -48,6 +48,9 @@ public interface ReactHost {
   /** [JSEngineResolutionAlgorithm] used by this host. */
   public var jsEngineResolutionAlgorithm: JSEngineResolutionAlgorithm?
 
+  /** Routes memory pressure events to interested components */
+  public val memoryPressureRouter: MemoryPressureRouter
+
   /** To be called when back button is pressed */
   public fun onBackPressed(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -66,9 +66,6 @@ public class ReactFeatureFlags {
    */
   public static boolean enableBridgelessArchitecture = false;
 
-  /** Server-side gating for a hacky fix to an ANR in the bridgeless core, related to Bolts task. */
-  public static boolean unstable_bridgelessArchitectureMemoryPressureHackyBoltsFix = false;
-
   /**
    * Does the bridgeless architecture log soft exceptions. Could be useful for tracking down issues.
    */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -66,11 +66,6 @@ public class ReactFeatureFlags {
    */
   public static boolean enableBridgelessArchitecture = false;
 
-  /**
-   * Does the bridgeless architecture log soft exceptions. Could be useful for tracking down issues.
-   */
-  public static volatile boolean enableBridgelessArchitectureSoftExceptions = false;
-
   /** Does the bridgeless architecture use the new create/reload/destroy routines */
   public static volatile boolean enableBridgelessArchitectureNewCreateReloadDestroy = true;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -48,7 +48,6 @@ import com.facebook.react.bridge.queue.QueueThreadExceptionHandler;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.build.ReactBuildConfig;
-import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.DevSupportManagerBase;
 import com.facebook.react.devsupport.DisabledDevSupportManager;
 import com.facebook.react.devsupport.InspectorFlags;
@@ -879,16 +878,14 @@ public class ReactHostImpl implements ReactHost {
 
   private void raiseSoftException(String method, String message, @Nullable Throwable throwable) {
     log(method, message);
-    if (ReactFeatureFlags.enableBridgelessArchitectureSoftExceptions) {
-      if (throwable != null) {
-        ReactSoftExceptionLogger.logSoftException(
-            TAG, new ReactNoCrashSoftException(method + ": " + message, throwable));
-        return;
-      }
-
+    if (throwable != null) {
       ReactSoftExceptionLogger.logSoftException(
-          TAG, new ReactNoCrashSoftException(method + ": " + message));
+          TAG, new ReactNoCrashSoftException(method + ": " + message, throwable));
+      return;
     }
+
+    ReactSoftExceptionLogger.logSoftException(
+        TAG, new ReactNoCrashSoftException(method + ": " + message));
   }
 
   private Task<Boolean> callWithExistingReactInstance(


### PR DESCRIPTION
Summary:
Inconsistent between bridge and bridgeless, but if you forget to implement this interface, ReactDelegate will silently not do anything in bridgeless.

Changelog: [Android] Enforce Activities using ReactDelegate implement DefaultHardwareBackBtnHandler.

Differential Revision: D54900747


