### PR TITLE
Bring back the UNSET constant to TextAttributeProps

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -62,6 +62,8 @@ public class TextAttributeProps implements EffectiveTextAttributeProvider {
   public static final short TA_KEY_ROLE = 26;
   public static final short TA_KEY_TEXT_TRANSFORM = 27;
 
+  public static final int UNSET = -1;
+
   private static final String PROP_SHADOW_OFFSET = "textShadowOffset";
   private static final String PROP_SHADOW_OFFSET_WIDTH = "width";
   private static final String PROP_SHADOW_OFFSET_HEIGHT = "height";


### PR DESCRIPTION
Summary:
This diff brings back the `UNSET` constant to `TextAttributeProps`.
The removal of this constant was an unnecessary breaking change, that has broken several third-party libraries.

Changelog: [Android][Fixed] - Bring back the UNSET constant to TextAttributeProps.

Differential Revision: D54899524


