### PR TITLE
Fixes Android/iOS build break

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -203,7 +203,7 @@ Pod::Spec.new do |s|
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/textinput/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/textinput/platform/android"
-      sss.header_dir           = "react/renderer/components/iostextinput"
+      sss.header_dir           = "react/renderer/components/textinput"
 
     end
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -14,7 +14,7 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS platform/android/react/renderer/components/androidtextinput/*.cpp)
+file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_textinput STATIC ${rrc_textinput_SRC})
 
 target_include_directories(rrc_textinput PUBLIC . ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/)

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -14,10 +14,13 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS *.cpp)
+file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS 
+	*.cpp
+	platform/android/react/renderer/components/textinput/*.cpp)
+
 add_library(rrc_textinput STATIC ${rrc_textinput_SRC})
 
-target_include_directories(rrc_textinput PUBLIC . ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/)
+target_include_directories(rrc_textinput PUBLIC ${REACT_COMMON_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/)
 
 target_link_libraries(rrc_textinput
         glog

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
@@ -9,9 +9,9 @@
 
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
-#include <react/renderer/components/iostextinput/BaseTextInputProps.h>
 #include <react/renderer/components/iostextinput/conversions.h>
 #include <react/renderer/components/iostextinput/primitives.h>
+#include <react/renderer/components/textinput/BaseTextInputProps.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>


### PR DESCRIPTION
## Summary:

Seems Android / iOS broke by https://github.com/facebook/react-native/pull/43431.

## Changelog:

[IOS] [FIXED] - Fixes Android/iOS build break


## Test Plan:

CI greened.
