### PR TITLE
Fix broken RNTester build in OSS (Android)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -14,7 +14,7 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS platform/android/react/renderer/components/androidtextinput/*.cpp)
+file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS *.cpp platform/android/react/renderer/components/androidtextinput/*.cpp)
 add_library(rrc_textinput STATIC ${rrc_textinput_SRC})
 
 target_include_directories(rrc_textinput PUBLIC . ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/)


### PR DESCRIPTION
Summary:
Fixes build regression of RNTester on  OSS, coming from D54764898.

NOTE: This is only Android bit for now, looking into the iOS one.

Differential Revision: D54908736


