### PR TITLE
Fix RNTester OSS build

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -198,15 +198,22 @@ Pod::Spec.new do |s|
 
     end
 
-    ss.subspec "textinput" do |sss|
+    ss.subspec "iostextinput" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/textinput/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/textinput/platform/android"
+      sss.source_files         = "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/iostextinput"
 
     end
 
+    ss.subspec "textinput" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}"
+      sss.header_dir           = "react/renderer/components/textinput"
+
+    end
+    
     ss.subspec "unimplementedview" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
@@ -9,9 +9,9 @@
 
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
-#include <react/renderer/components/iostextinput/BaseTextInputProps.h>
 #include <react/renderer/components/iostextinput/conversions.h>
 #include <react/renderer/components/iostextinput/primitives.h>
+#include <react/renderer/components/textinput/BaseTextInputProps.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>


### PR DESCRIPTION
Summary:
This diff adds another sub-sub-spec to React-Fabric pod to fix import paths in `textinput`.

Changelog: [Internal]

Differential Revision: D54918454


