### PR TITLE
[Fabric] iOS: Change image source url encode ascii to utf8

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
@@ -48,10 +48,10 @@ inline static NSURL *NSURLFromImageSource(const facebook::react::ImageSource &im
 {
   // `NSURL` has a history of crashing with bad input, so let's be safe.
   @try {
-    NSString *urlString = [NSString stringWithCString:imageSource.uri.c_str() encoding:NSASCIIStringEncoding];
+    NSString *urlString = [NSString stringWithUTF8String:imageSource.uri.c_str()];
 
     if (!imageSource.bundle.empty()) {
-      NSString *bundle = [NSString stringWithCString:imageSource.bundle.c_str() encoding:NSASCIIStringEncoding];
+      NSString *bundle = [NSString stringWithUTF8String:imageSource.bundle.c_str()];
       urlString = [NSString stringWithFormat:@"%@.bundle/%@", bundle, urlString];
     }
 


### PR DESCRIPTION
## Summary:

We should use utf8 to cover more characters.

## Changelog:

[IOS] [FIXED] - [Fabric] iOS: Change image source url encode ascii to utf8

## Test Plan:

Fixes #43462 
