### PR TITLE
use structs instead of class for TextInputMetrics and KeyPressMetrics

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -336,12 +336,11 @@ using namespace facebook::react;
 
   if (!_backedTextInputView.textWasPasted) {
     if (_eventEmitter) {
-      KeyPressMetrics keyPressMetrics;
-      keyPressMetrics.text = RCTStringFromNSString(text);
-      keyPressMetrics.eventCount = _mostRecentEventCount;
-
       const auto &textInputEventEmitter = static_cast<const TextInputEventEmitter &>(*_eventEmitter);
-      textInputEventEmitter.onKeyPress(keyPressMetrics);
+      textInputEventEmitter.onKeyPress({
+          .text = RCTStringFromNSString(text),
+          .eventCount = static_cast<int>(_mostRecentEventCount),
+      });
     }
   }
 
@@ -515,29 +514,18 @@ using namespace facebook::react;
 
 #pragma mark - Other
 
-- (TextInputMetrics)_textInputMetrics
+- (TextInputEventEmitter::Metrics)_textInputMetrics
 {
-  TextInputMetrics metrics;
-  metrics.text = RCTStringFromNSString(_backedTextInputView.attributedText.string);
-  metrics.selectionRange = [self _selectionRange];
-  metrics.eventCount = _mostRecentEventCount;
-
-  CGPoint contentOffset = _backedTextInputView.contentOffset;
-  metrics.contentOffset = {contentOffset.x, contentOffset.y};
-
-  UIEdgeInsets contentInset = _backedTextInputView.contentInset;
-  metrics.contentInset = {contentInset.left, contentInset.top, contentInset.right, contentInset.bottom};
-
-  CGSize contentSize = _backedTextInputView.contentSize;
-  metrics.contentSize = {contentSize.width, contentSize.height};
-
-  CGSize layoutMeasurement = _backedTextInputView.bounds.size;
-  metrics.layoutMeasurement = {layoutMeasurement.width, layoutMeasurement.height};
-
-  CGFloat zoomScale = _backedTextInputView.zoomScale;
-  metrics.zoomScale = zoomScale;
-
-  return metrics;
+  return {
+      .text = RCTStringFromNSString(_backedTextInputView.attributedText.string),
+      .selectionRange = [self _selectionRange],
+      .eventCount = static_cast<int>(_mostRecentEventCount),
+      .contentOffset = RCTPointFromCGPoint(_backedTextInputView.contentOffset),
+      .contentInset = RCTEdgeInsetsFromUIEdgeInsets(_backedTextInputView.contentInset),
+      .contentSize = RCTSizeFromCGSize(_backedTextInputView.contentSize),
+      .layoutMeasurement = RCTSizeFromCGSize(_backedTextInputView.bounds.size),
+      .zoomScale = _backedTextInputView.zoomScale,
+  };
 }
 
 - (void)_updateState

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -11,7 +11,7 @@ namespace facebook::react {
 
 static jsi::Value textInputMetricsPayload(
     jsi::Runtime& runtime,
-    const TextInputMetrics& textInputMetrics) {
+    const TextInputEventEmitter::Metrics& textInputMetrics) {
   auto payload = jsi::Object(runtime);
 
   payload.setProperty(
@@ -38,7 +38,7 @@ static jsi::Value textInputMetricsPayload(
 
 static jsi::Value textInputMetricsScrollPayload(
     jsi::Runtime& runtime,
-    const TextInputMetrics& textInputMetrics) {
+    const TextInputEventEmitter::Metrics& textInputMetrics) {
   auto payload = jsi::Object(runtime);
 
   {
@@ -88,7 +88,7 @@ static jsi::Value textInputMetricsScrollPayload(
 
 static jsi::Value textInputMetricsContentSizePayload(
     jsi::Runtime& runtime,
-    const TextInputMetrics& textInputMetrics) {
+    const TextInputEventEmitter::Metrics& textInputMetrics) {
   auto payload = jsi::Object(runtime);
 
   {
@@ -105,7 +105,7 @@ static jsi::Value textInputMetricsContentSizePayload(
 
 static jsi::Value keyPressMetricsPayload(
     jsi::Runtime& runtime,
-    const KeyPressMetrics& keyPressMetrics) {
+    const TextInputEventEmitter::KeyPressMetrics& keyPressMetrics) {
   auto payload = jsi::Object(runtime);
   payload.setProperty(runtime, "eventCount", keyPressMetrics.eventCount);
 
@@ -126,39 +126,36 @@ static jsi::Value keyPressMetricsPayload(
   return payload;
 };
 
-void TextInputEventEmitter::onFocus(
-    const TextInputMetrics& textInputMetrics) const {
+void TextInputEventEmitter::onFocus(const Metrics& textInputMetrics) const {
   dispatchTextInputEvent("focus", textInputMetrics);
 }
 
-void TextInputEventEmitter::onBlur(
-    const TextInputMetrics& textInputMetrics) const {
+void TextInputEventEmitter::onBlur(const Metrics& textInputMetrics) const {
   dispatchTextInputEvent("blur", textInputMetrics);
 }
 
-void TextInputEventEmitter::onChange(
-    const TextInputMetrics& textInputMetrics) const {
+void TextInputEventEmitter::onChange(const Metrics& textInputMetrics) const {
   dispatchTextInputEvent("change", textInputMetrics);
 }
 
 void TextInputEventEmitter::onContentSizeChange(
-    const TextInputMetrics& textInputMetrics) const {
+    const Metrics& textInputMetrics) const {
   dispatchTextInputContentSizeChangeEvent(
       "contentSizeChange", textInputMetrics);
 }
 
 void TextInputEventEmitter::onSelectionChange(
-    const TextInputMetrics& textInputMetrics) const {
+    const Metrics& textInputMetrics) const {
   dispatchTextInputEvent("selectionChange", textInputMetrics);
 }
 
 void TextInputEventEmitter::onEndEditing(
-    const TextInputMetrics& textInputMetrics) const {
+    const Metrics& textInputMetrics) const {
   dispatchTextInputEvent("endEditing", textInputMetrics);
 }
 
 void TextInputEventEmitter::onSubmitEditing(
-    const TextInputMetrics& textInputMetrics) const {
+    const Metrics& textInputMetrics) const {
   dispatchTextInputEvent("submitEditing", textInputMetrics);
 }
 
@@ -169,8 +166,7 @@ void TextInputEventEmitter::onKeyPress(
   });
 }
 
-void TextInputEventEmitter::onScroll(
-    const TextInputMetrics& textInputMetrics) const {
+void TextInputEventEmitter::onScroll(const Metrics& textInputMetrics) const {
   dispatchEvent("scroll", [textInputMetrics](jsi::Runtime& runtime) {
     return textInputMetricsScrollPayload(runtime, textInputMetrics);
   });
@@ -178,7 +174,7 @@ void TextInputEventEmitter::onScroll(
 
 void TextInputEventEmitter::dispatchTextInputEvent(
     const std::string& name,
-    const TextInputMetrics& textInputMetrics) const {
+    const Metrics& textInputMetrics) const {
   dispatchEvent(name, [textInputMetrics](jsi::Runtime& runtime) {
     return textInputMetricsPayload(runtime, textInputMetrics);
   });
@@ -186,7 +182,7 @@ void TextInputEventEmitter::dispatchTextInputEvent(
 
 void TextInputEventEmitter::dispatchTextInputContentSizeChangeEvent(
     const std::string& name,
-    const TextInputMetrics& textInputMetrics) const {
+    const Metrics& textInputMetrics) const {
   dispatchEvent(name, [textInputMetrics](jsi::Runtime& runtime) {
     return textInputMetricsContentSizePayload(runtime, textInputMetrics);
   });

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
@@ -12,48 +12,46 @@
 
 namespace facebook::react {
 
-class TextInputMetrics {
- public:
-  std::string text;
-  AttributedString::Range selectionRange;
-  // ScrollView-like metrics
-  Size contentSize;
-  Point contentOffset;
-  EdgeInsets contentInset;
-  Size containerSize;
-  int eventCount;
-  Size layoutMeasurement;
-  float zoomScale;
-};
-
-class KeyPressMetrics {
- public:
-  std::string text;
-  int eventCount;
-};
-
 class TextInputEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
-  void onFocus(const TextInputMetrics& textInputMetrics) const;
-  void onBlur(const TextInputMetrics& textInputMetrics) const;
-  void onChange(const TextInputMetrics& textInputMetrics) const;
-  void onContentSizeChange(const TextInputMetrics& textInputMetrics) const;
-  void onSelectionChange(const TextInputMetrics& textInputMetrics) const;
-  void onEndEditing(const TextInputMetrics& textInputMetrics) const;
-  void onSubmitEditing(const TextInputMetrics& textInputMetrics) const;
+  struct Metrics {
+    std::string text;
+    AttributedString::Range selectionRange;
+    // ScrollView-like metrics
+    Size contentSize;
+    Point contentOffset;
+    EdgeInsets contentInset;
+    Size containerSize;
+    int eventCount;
+    Size layoutMeasurement;
+    Float zoomScale;
+  };
+
+  struct KeyPressMetrics {
+    std::string text;
+    int eventCount;
+  };
+
+  void onFocus(const Metrics& textInputMetrics) const;
+  void onBlur(const Metrics& textInputMetrics) const;
+  void onChange(const Metrics& textInputMetrics) const;
+  void onContentSizeChange(const Metrics& textInputMetrics) const;
+  void onSelectionChange(const Metrics& textInputMetrics) const;
+  void onEndEditing(const Metrics& textInputMetrics) const;
+  void onSubmitEditing(const Metrics& textInputMetrics) const;
   void onKeyPress(const KeyPressMetrics& keyPressMetrics) const;
-  void onScroll(const TextInputMetrics& textInputMetrics) const;
+  void onScroll(const Metrics& textInputMetrics) const;
 
  private:
   void dispatchTextInputEvent(
       const std::string& name,
-      const TextInputMetrics& textInputMetrics) const;
+      const Metrics& textInputMetrics) const;
 
   void dispatchTextInputContentSizeChangeEvent(
       const std::string& name,
-      const TextInputMetrics& textInputMetrics) const;
+      const Metrics& textInputMetrics) const;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

- use designated initializers.
- make TextInputMetrics and KeyPressMetrics structs.
- move TextInputMetrics and KeyPressMetrics inside of TextInputEventEmitter.
- Utilise RCTSizeFromCGSize, RCTEdgeInsetsFromUIEdgeInsets and RCTPointFromCGPoint when creating  TextInputMetrics.

Reviewed By: rshest

Differential Revision: D54895928


