### PR TITLE
Remove dangerous "9999" version string default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
     type: boolean
 
   release_version:
-    default: "9999"
+    default: ""
     type: string
 
   run_nightly_workflow:


### PR DESCRIPTION
Summary:
As titled. This seems dangerous — removing with the motivation that we'd prefer this script to fail during execution than to succeed in publishing `9999`.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D54956661
