### PR TITLE
Add prepare_release_new workflow, configure via flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,15 @@ parameters:
     default: false
     type: boolean
 
+  # Experimental unified release workflow
+  run_new_release_workflow:
+    default: false
+    type: boolean
+
+  run_nightly_workflow:
+    default: false
+    type: boolean
+
   release_latest:
     default: false
     type: boolean
@@ -20,7 +29,15 @@ parameters:
     default: ""
     type: string
 
-  run_nightly_workflow:
+  release_monorepo_packages_version:
+    default: ""
+    type: string
+
+  release_tag:
+    default: ""
+    type: string
+
+  release_dry_run:
     default: false
     type: boolean
 

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -1107,6 +1107,71 @@ jobs:
 
             node ./scripts/releases-ci/prepare-package-for-release.js -v "$VERSION" -l << parameters.latest >> --dry-run << parameters.dryrun >>
 
+  # Experimental unified release workflow
+  # Replaces `prepare_package_for_release`
+  #
+  # Writes a new commit and tag(s), which will trigger the `publish_release`
+  # and `publish_bumped_packages` workflows.
+  prepare_release_new:
+    parameters:
+      version:
+        type: string
+      # TODO(T182538198): Required for 0.74.x, where workspace packages are out
+      # of sync with react-native. This will be removed for 0.75+.
+      monorepo_packages_version:
+        type: string
+      tag:
+        type: string
+      dry_run:
+        type: boolean
+        default: false
+    executor: reactnativeios
+    steps:
+      - checkout_code_with_cache
+      - run_yarn
+      - add_ssh_keys:
+          fingerprints:
+            - "1f:c7:61:c4:e2:ff:77:e3:cc:ca:a7:34:c2:79:e3:3c"
+      - brew_install:
+          package: cmake
+      - run:
+          name: Versioning workspace packages
+          command: |
+            node scripts/releases/set-version "<< parameters.monorepo_packages_version >>" --skip-react-native-version
+      - run:
+          name: Versioning react-native package
+          command: |
+            node scripts/releases/set-rn-version.js -v "<< parameters.version >>" --build-type "release"
+      - run:
+          name: Updating RNTester Podfile.lock
+          command: |
+            cd packages/rn-tester/
+            bundle install
+            bundle exec pod install
+      - run:
+          name: Creating release commit
+          command: |
+            git commit -a -m "Release << parameters.version >>\n\n#publish-packages-to-npm&<< parameters.tag >>"
+            git tag -a "v<< parameters.version >>" -m "v<< parameters.version >>"
+            git show HEAD
+      - when:
+          condition:
+            equal: ["latest", << parameters.tag >>]
+          steps:
+            - run:
+                name: Updating "latest" tag
+                command: |
+                  git tag -d "latest"
+                  git push origin :latest
+                  git tag -a "latest" -m "latest"
+      - unless:
+          condition: << parameters.dry_run >>
+          steps:
+            run:
+              name: Pushing release commit
+              command: |
+                git push origin $CIRCLE_BRANCH --follow-tags
+
   build_npm_package:
     parameters:
       release_type:

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -129,14 +129,30 @@ parameters:
     default: false
     type: boolean
 
+  run_new_release_workflow:
+    default: false
+    type: boolean
+
+  run_nightly_workflow:
+    default: false
+    type: boolean
+
   release_latest:
     default: false
     type: boolean
 
   release_version:
-    default: "9999"
+    default: ""
     type: string
 
-  run_nightly_workflow:
+  release_monorepo_packages_version:
+    default: ""
+    type: string
+
+  release_tag:
+    default: ""
+    type: string
+
+  release_dry_run:
     default: false
     type: boolean

--- a/.circleci/configurations/workflows.yml
+++ b/.circleci/configurations/workflows.yml
@@ -6,6 +6,7 @@
 #  when:
 #    and:
 #      - equal: [ false, << pipeline.parameters.run_release_workflow >> ]
+#      - equal: [ false, << pipeline.parameters.run_new_release_workflow >> ]
 #      - equal: [ false, << pipeline.parameters.run_nightly_workflow >> ]
 #
 #  It's setup this way so we can trigger a release via a POST
@@ -24,6 +25,17 @@ workflows:
           name: prepare_package_for_release
           version: << pipeline.parameters.release_version >>
           latest : << pipeline.parameters.release_latest >>
+
+  # Experimental unified release workflow
+  create_release_new:
+    when: << pipeline.parameters.run_new_release_workflow >>
+    jobs:
+      - prepare_release_new:
+          name: prepare_release_new
+          version: << pipeline.parameters.release_version >>
+          monorepo_packages_version: << pipeline.parameters.release_monorepo_packages_version >>
+          tag: << pipeline.parameters.release_tag >>
+          dry_run: << pipeline.parameters.release_dry_run >>
 
   # This job will run only when a tag is published due to all the jobs being filtered.
   publish_release:
@@ -79,6 +91,7 @@ workflows:
     when:
       and:
         - equal: [ false, << pipeline.parameters.run_release_workflow >> ]
+        - equal: [ false, << pipeline.parameters.run_new_release_workflow >> ]
         - equal: [ false, << pipeline.parameters.run_nightly_workflow >> ]
     jobs:
       # Run lints on every commit
@@ -128,6 +141,7 @@ workflows:
     when:
       and:
         - equal: [ false, << pipeline.parameters.run_release_workflow >> ]
+        - equal: [ false, << pipeline.parameters.run_new_release_workflow >> ]
         - equal: [ false, << pipeline.parameters.run_nightly_workflow >> ]
     jobs:
       - find_and_publish_bumped_packages:


### PR DESCRIPTION
Summary:
This is a minimum approach to achieve a **single-command publish flow** for React Native, unifying the previous `yarn bump-all-updated-packages` and `yarn trigger-react-native-release` workflow entry points, which we are able to do after the resequencing of release testing infra in #42899.

This diff aims to change as little as possible to achieve the above — introducing a new job that merges operations to create the versioning commit. The triggered publish jobs are unchanged. In future, we may follow this change with further simplifications down the workflow tree.

**Key changes**

- Adds a new CircleCI workflow, `prepare_release_new`, which versions **all packages** and writes a single release commit.
- This replaces `yarn bump-all-updated-packages`, now implemented with the newer `set-version` script.
- Wires this up as an experiment within `trigger-react-native-release.js`, conditionally running the new workflow when `--use-new-workflow` is passed.

**Not changed**

- The single release commit written will continue to trigger both of the existing CI workflows on push (`publish_release` and `publish_bumped_packages`), which are unchanged.
    - The commit summary now includes the `#publish-packages-to-npm` marker, in order to trigger `publish_bumped_packages`.
- Usage: Release Crew members will continue to use the existing local script entry point (as [documented in the releases repo](https://github.com/reactwg/react-native-releases/blob/main/docs/guide-release-process.md#step-7-publish-react-native)), with the opt in flag.
    ```
    yarn trigger-react-native-release --use-new-workflow [...args]
    ```

After we're happy with the E2E behaviour of this workflow in the next 0.74 RC, I will follow up by dropping the `--use-new-workflow` flag and removing the old scripts.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D54956345


