### PR TITLE
Summary: minor fix found in nightly logs from `Publish NPM` job

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/assets"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/assets#readme",

--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/babel-plugin-codegen"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/babel-plugin-codegen#readme",

--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/facebook/react-native/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/community-cli-plugin"
   },
   "license": "MIT",

--- a/packages/core-cli-utils/package.json
+++ b/packages/core-cli-utils/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/core-cli-utils"
   },
   "exports": {

--- a/packages/debugger-frontend/package.json
+++ b/packages/debugger-frontend/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/facebook/react-native/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/debugger-frontend"
   },
   "license": "BSD-3-Clause",

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/facebook/react-native/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/dev-middleware"
   },
   "license": "MIT",

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/eslint-config-react-native"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/eslint-config-react-native#readme",

--- a/packages/eslint-plugin-react-native/package.json
+++ b/packages/eslint-plugin-react-native/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/eslint-plugin-react-native"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/eslint-plugin-react-native#readme",

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/eslint-plugin-specs"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/eslint-plugin-specs#readme",

--- a/packages/hermes-inspector-msggen/package.json
+++ b/packages/hermes-inspector-msggen/package.json
@@ -6,11 +6,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/hermes-inspector-msggen"
   },
   "bin": {
-    "msggen": "./bin/index.js"
+    "msggen": "bin/index.js"
   },
   "engines": {
     "node": ">=18"

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/metro-config"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/metro-config#readme",

--- a/packages/normalize-color/package.json
+++ b/packages/normalize-color/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/normalize-color"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/normalize-color#readme",

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/polyfills"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/polyfills#readme",

--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:facebook/react-native.git"
+    "url": "git+ssh://git@github.com/facebook/react-native.git"
   },
   "keywords": [
     "babel",

--- a/packages/react-native-babel-transformer/package.json
+++ b/packages/react-native-babel-transformer/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:facebook/react-native.git",
+    "url": "git+ssh://git@github.com/facebook/react-native.git",
     "directory": "packages/react-native-babel-transformer"
   },
   "keywords": [

--- a/packages/react-native-bots/package.json
+++ b/packages/react-native-bots/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/react-native-bots"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-bots#readme",

--- a/packages/react-native-codegen-typescript-test/package.json
+++ b/packages/react-native-codegen-typescript-test/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/react-native-codegen-typescript-test"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-typescript-test",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/react-native-codegen"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-codegen#readme",

--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/react-native-gradle-plugin"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-gradle-plugin#readme",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/react-native"
   },
   "homepage": "https://reactnative.dev/",
@@ -23,7 +23,9 @@
   "engines": {
     "node": ">=18"
   },
-  "bin": "./cli.js",
+  "bin": {
+    "react-native": "cli.js"
+  },
   "types": "types",
   "jest-junit": {
     "outputDirectory": "reports/junit",

--- a/packages/rn-tester-e2e/package.json
+++ b/packages/rn-tester-e2e/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/rn-tester-e2e",
   "repository": {
     "type": "git",
-    "url": "git@github.com:facebook/react-native.git",
+    "url": "git+ssh://git@github.com/facebook/react-native.git",
     "directory": "packages/rn-tester-e2e"
   },
   "scripts": {

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/rn-tester"
   },
   "engines": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/typescript-config"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/typescript-config#readme",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react-native.git",
+    "url": "git+https://github.com/facebook/react-native.git",
     "directory": "packages/virtualized-lists"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/virtualized-lists#readme",


### PR DESCRIPTION
## Summary:
Minor fix to package.json which newer version of npm warn about when publishing, after running `npm pkg fix -ws` on the workspace.

<img width="1174" alt="Screenshot 2024-03-15 at 22 10 35" src="https://github.com/facebook/react-native/assets/49578/9e1f55d5-0d83-469e-8c69-33f693e65991">


## Changelog: [Internal] npm pkg fix -ws

## Test Plan:

👀