### PR TITLE
Remove unused names in component mapping

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricComponents.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricComponents.java
@@ -28,20 +28,11 @@ public class FabricComponents {
     sComponentNames.put("View", "RCTView");
     sComponentNames.put("Image", "RCTImageView");
     sComponentNames.put("ScrollView", "RCTScrollView");
-    sComponentNames.put("Slider", "RCTSlider");
     sComponentNames.put("ModalHostView", "RCTModalHostView");
     sComponentNames.put("Paragraph", "RCTText");
     sComponentNames.put("Text", "RCText");
     sComponentNames.put("RawText", "RCTRawText");
     sComponentNames.put("ActivityIndicatorView", "AndroidProgressBar");
-    sComponentNames.put("ShimmeringView", "RKShimmeringView");
-    sComponentNames.put("TemplateView", "RCTTemplateView");
-    sComponentNames.put("AxialGradientView", "RCTAxialGradientView");
-    sComponentNames.put("Video", "RCTVideo");
-    sComponentNames.put("Map", "RCTMap");
-    sComponentNames.put("WebView", "RCTWebView");
-    sComponentNames.put("Keyframes", "RCTKeyframes");
-    sComponentNames.put("ImpressionTrackingView", "RCTImpressionTrackingView");
   }
 
   /** @return the name of component in the Fabric environment */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/FabricNameComponentMapping.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/FabricNameComponentMapping.java
@@ -28,20 +28,11 @@ class FabricNameComponentMapping {
     sComponentNames.put("View", "RCTView");
     sComponentNames.put("Image", "RCTImageView");
     sComponentNames.put("ScrollView", "RCTScrollView");
-    sComponentNames.put("Slider", "RCTSlider");
     sComponentNames.put("ModalHostView", "RCTModalHostView");
     sComponentNames.put("Paragraph", "RCTText");
     sComponentNames.put("Text", "RCText");
     sComponentNames.put("RawText", "RCTRawText");
     sComponentNames.put("ActivityIndicatorView", "AndroidProgressBar");
-    sComponentNames.put("ShimmeringView", "RKShimmeringView");
-    sComponentNames.put("TemplateView", "RCTTemplateView");
-    sComponentNames.put("AxialGradientView", "RCTAxialGradientView");
-    sComponentNames.put("Video", "RCTVideo");
-    sComponentNames.put("Map", "RCTMap");
-    sComponentNames.put("WebView", "RCTWebView");
-    sComponentNames.put("Keyframes", "RCTKeyframes");
-    sComponentNames.put("ImpressionTrackingView", "RCTImpressionTrackingView");
   }
 
   /** @return the name of component in the Fabric environment */

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/componentNameByReactViewName.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/componentNameByReactViewName.cpp
@@ -45,10 +45,6 @@ std::string componentNameByReactViewName(std::string viewName) {
     return "ScrollView";
   }
 
-  if (viewName == "RKShimmeringView") {
-    return "ShimmeringView";
-  }
-
   if (viewName == "RefreshControl") {
     return "PullToRefreshView";
   }


### PR DESCRIPTION
## Summary:

- `react-native-slider` use `RNCSlider` not `RCTSlider`: https://github.com/callstack/react-native-slider/blob/166ec7f3e7c853ab3be3da132c726dd8442b3874/package/ios/RNCSliderManager.m#L15-L20
- `react-native-video` doesn't support Fabric on stable release: https://github.com/react-native-video/react-native-video/issues/2650
- `react-native-maps` use `AIRMap` not `RCTMap`: https://github.com/react-native-maps/react-native-maps/blob/fca4ad7b2eb53a81814bdcd69d80f81620ea1a2a/ios/AirMaps/AIRMapManager.m#L36-L46
- `react-native-webview` use `RNCWebView` not `RCTWebView`: https://github.com/react-native-webview/react-native-webview/blob/4197bb42ce79406ff20c7e5637f78e44ca45474c/apple/RNCWebViewManager.mm#L44
- `Shimmer` is deprecated: https://github.com/facebookarchive/Shimmer

`TemplateView`, `AxialGradientView`, `Keyframes` and `ImpressionTrackingView` seem to be internal only and Google found nothing

## Changelog:

[GENERAL] [REMOVED] - Remove unused names in component mapping

## Test Plan:

none
