### PR TITLE
Migrate back to chromium-edge-launcher since Windows fix was merged

### DIFF
--- a/flow-typed/npm/chromium-edge-launcher_v0.2.x.js
+++ b/flow-typed/npm/chromium-edge-launcher_v0.2.x.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-declare module '@rnx-kit/chromium-edge-launcher' {
+declare module 'chromium-edge-launcher' {
   import typeof fs from 'fs';
   import typeof childProcess from 'child_process';
   import type {ChildProcess} from 'child_process';

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@isaacs/ttlcache": "^1.4.1",
     "@react-native/debugger-frontend": "0.75.0-main",
-    "@rnx-kit/chromium-edge-launcher": "^1.0.0",
     "chrome-launcher": "^0.15.2",
+    "chromium-edge-launcher": "^0.2.0",
     "connect": "^3.6.5",
     "debug": "^2.2.0",
     "node-fetch": "^2.2.0",

--- a/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
@@ -15,8 +15,8 @@ import {promises as fs} from 'fs';
 import path from 'path';
 import osTempDir from 'temp-dir';
 
-const {Launcher: EdgeLauncher} = require('@rnx-kit/chromium-edge-launcher');
 const ChromeLauncher = require('chrome-launcher');
+const {Launcher: EdgeLauncher} = require('chromium-edge-launcher');
 
 /**
  * Default `BrowserLauncher` implementation which opens URLs on the host

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,18 +2537,6 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
-"@rnx-kit/chromium-edge-launcher@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz#c0df8ea00a902c7a417cd9655aab06de398b939c"
-  integrity sha512-lzD84av1ZQhYUS+jsGqJiCMaJO2dn9u+RTT9n9q6D3SaKVwWqv+7AoRKqBu19bkwyE+iFRl1ymr40QS90jVFYg==
-  dependencies:
-    "@types/node" "^18.0.0"
-    escape-string-regexp "^4.0.0"
-    is-wsl "^2.2.0"
-    lighthouse-logger "^1.0.0"
-    mkdirp "^1.0.4"
-    rimraf "^3.0.2"
-
 "@rnx-kit/rn-changelog-generator@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@rnx-kit/rn-changelog-generator/-/rn-changelog-generator-0.4.0.tgz#637d87bcf8de6e87599930ed88d9375010277660"
@@ -3846,6 +3834,18 @@ chrome-launcher@^0.15.0, chrome-launcher@^0.15.2:
     escape-string-regexp "^4.0.0"
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
+
+chromium-edge-launcher@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz#0c378f28c99aefc360705fa155de0113997f62fc"
+  integrity sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==
+  dependencies:
+    "@types/node" "*"
+    escape-string-regexp "^4.0.0"
+    is-wsl "^2.2.0"
+    lighthouse-logger "^1.0.0"
+    mkdirp "^1.0.4"
+    rimraf "^3.0.2"
 
 ci-info@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary:

The [Windows fix](https://github.com/cezaraugusto/chromium-edge-launcher/pull/1) was merged and published. We no longer need to use the fork.

## Changelog:

[INTERNAL] [FIXED] - Fix experimental debugger launch flow with Edge on Windows

## Test Plan:

n/a