### PR TITLE
Improve reusability for RCTRootViewFactory

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -172,7 +172,7 @@ typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *modu
 
 #pragma mark - RCTRootViewFactory Helpers
 
-- (RCTHost *)createReactHost;
+- (RCTHost *)createReactHost:(NSDictionary *)launchOptions;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -172,7 +172,7 @@ typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *modu
 
 #pragma mark - RCTRootViewFactory Helpers
 
-- (RCTHost *)createReactHost:(NSDictionary *)launchOptions;
+- (RCTHost *)createReactHost:(NSDictionary *__nullable)launchOptions;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -13,6 +13,7 @@
 @protocol RCTComponentViewFactoryComponentProvider;
 @protocol RCTTurboModuleManagerDelegate;
 @class RCTBridge;
+@class RCTHost;
 @class RCTRootView;
 @class RCTSurfacePresenterBridgeAdapter;
 
@@ -147,6 +148,7 @@ typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *modu
 @interface RCTRootViewFactory : NSObject
 
 @property (nonatomic, strong, nullable) RCTBridge *bridge;
+@property (nonatomic, strong, nullable) RCTHost *reactHost;
 @property (nonatomic, strong, nullable) RCTSurfacePresenterBridgeAdapter *bridgeAdapter;
 
 - (instancetype)initWithConfiguration:(RCTRootViewFactoryConfiguration *)configuration

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -170,6 +170,10 @@ typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *modu
 
 - (UIView *_Nonnull)viewWithModuleName:(NSString *)moduleName;
 
+#pragma mark - RCTRootViewFactory Helpers
+
+- (RCTHost *)createReactHost;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -95,7 +95,6 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 @end
 
 @implementation RCTRootViewFactory {
-  RCTHost *_reactHost;
   RCTRootViewFactoryConfiguration *_configuration;
   __weak id<RCTTurboModuleManagerDelegate> _turboModuleManagerDelegate;
 }
@@ -139,7 +138,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
     [self createReactHostIfNeeded:launchOptions];
 
-    RCTFabricSurface *surface = [_reactHost createSurfaceWithModuleName:moduleName initialProperties:initProps];
+    RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName initialProperties:initProps];
 
     RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView = [[RCTSurfaceHostingProxyRootView alloc]
         initWithSurface:surface
@@ -223,23 +222,28 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (void)createReactHostIfNeeded:(NSDictionary *)launchOptions
 {
-  if (_reactHost) {
+  if (self.reactHost) {
     return;
   }
+  self.reactHost = [self createReactHost];
+}
 
+- (RCTHost *)createReactHost
+{
   __weak __typeof(self) weakSelf = self;
-  _reactHost = [[RCTHost alloc] initWithBundleURLProvider:self->_configuration.bundleURLBlock
-                                             hostDelegate:nil
-                               turboModuleManagerDelegate:_turboModuleManagerDelegate
-                                         jsEngineProvider:^std::shared_ptr<facebook::react::JSRuntimeFactory>() {
-                                           return [weakSelf createJSRuntimeFactory];
-                                         }
-                                            launchOptions:launchOptions];
-  [_reactHost setBundleURLProvider:^NSURL *() {
+  RCTHost *reactHost = [[RCTHost alloc] initWithBundleURLProvider:self->_configuration.bundleURLBlock
+                                                     hostDelegate:nil
+                                       turboModuleManagerDelegate:_turboModuleManagerDelegate
+                                                 jsEngineProvider:^std::shared_ptr<facebook::react::JSRuntimeFactory>() {
+                                                   return [weakSelf createJSRuntimeFactory];
+                                                 }
+                                                    launchOptions:launchOptions];
+  [reactHost setBundleURLProvider:^NSURL *() {
     return [weakSelf bundleURL];
   }];
-  [_reactHost setContextContainerHandler:self];
-  [_reactHost start];
+  [reactHost setContextContainerHandler:self];
+  [reactHost start];
+  return reactHost;
 }
 
 - (std::shared_ptr<facebook::react::JSRuntimeFactory>)createJSRuntimeFactory

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -225,10 +225,10 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
   if (self.reactHost) {
     return;
   }
-  self.reactHost = [self createReactHost];
+  self.reactHost = [self createReactHost:launchOptions];
 }
 
-- (RCTHost *)createReactHost
+- (RCTHost *)createReactHost:(NSDictionary *)launchOptions
 {
   __weak __typeof(self) weakSelf = self;
   RCTHost *reactHost = [[RCTHost alloc] initWithBundleURLProvider:self->_configuration.bundleURLBlock


### PR DESCRIPTION
## Summary:

RCTRootViewFactory is a great work for creating react binding view. we want to reuse the factory inside expo and would be good to have these improvements.
- exposing `reactHost` property so that we can update the RCTHost instance without recreate a factory.
- break bridgeless creation logic to a specific `createReactHost`, so that we can reuse the method for RCTHost creation
 
## Changelog:

[IOS][CHANGED] - Improve reusability for RCTRootViewFactory

## Test Plan:

this pr should not introduce any regression and getting all ci passed
