### PR TITLE
refactor metrics for ScrollViewEventEmitter

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -389,14 +389,15 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   return NO;
 }
 
-- (ScrollViewMetrics)_scrollViewMetrics
+- (ScrollViewEventEmitter::Metrics)_scrollViewMetrics
 {
-  ScrollViewMetrics metrics;
-  metrics.contentSize = RCTSizeFromCGSize(_scrollView.contentSize);
-  metrics.contentOffset = RCTPointFromCGPoint(_scrollView.contentOffset);
-  metrics.contentInset = RCTEdgeInsetsFromUIEdgeInsets(_scrollView.contentInset);
-  metrics.containerSize = RCTSizeFromCGSize(_scrollView.bounds.size);
-  metrics.zoomScale = _scrollView.zoomScale;
+  auto metrics = ScrollViewEventEmitter::Metrics{
+      .contentSize = RCTSizeFromCGSize(_scrollView.contentSize),
+      .contentOffset = RCTPointFromCGPoint(_scrollView.contentOffset),
+      .contentInset = RCTEdgeInsetsFromUIEdgeInsets(_scrollView.contentInset),
+      .containerSize = RCTSizeFromCGSize(_scrollView.bounds.size),
+      .zoomScale = _scrollView.zoomScale,
+  };
 
   if (_layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
     metrics.contentOffset.x = metrics.contentSize.width - metrics.containerSize.width - metrics.contentOffset.x;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.cpp
@@ -11,7 +11,7 @@ namespace facebook::react {
 
 static jsi::Value scrollViewMetricsPayload(
     jsi::Runtime& runtime,
-    const ScrollViewMetrics& scrollViewMetrics) {
+    const ScrollViewEventEmitter::Metrics& scrollViewMetrics) {
   auto payload = jsi::Object(runtime);
 
   {
@@ -57,15 +57,14 @@ static jsi::Value scrollViewMetricsPayload(
   return payload;
 }
 
-void ScrollViewEventEmitter::onScroll(
-    const ScrollViewMetrics& scrollViewMetrics) const {
+void ScrollViewEventEmitter::onScroll(const Metrics& scrollViewMetrics) const {
   dispatchUniqueEvent("scroll", [scrollViewMetrics](jsi::Runtime& runtime) {
     return scrollViewMetricsPayload(runtime, scrollViewMetrics);
   });
 }
 
 void ScrollViewEventEmitter::onScrollToTop(
-    const ScrollViewMetrics& scrollViewMetrics) const {
+    const Metrics& scrollViewMetrics) const {
   dispatchUniqueEvent(
       "scrollToTop", [scrollViewMetrics](jsi::Runtime& runtime) {
         return scrollViewMetricsPayload(runtime, scrollViewMetrics);
@@ -73,28 +72,28 @@ void ScrollViewEventEmitter::onScrollToTop(
 }
 
 void ScrollViewEventEmitter::onScrollBeginDrag(
-    const ScrollViewMetrics& scrollViewMetrics) const {
+    const Metrics& scrollViewMetrics) const {
   dispatchScrollViewEvent("scrollBeginDrag", scrollViewMetrics);
 }
 
 void ScrollViewEventEmitter::onScrollEndDrag(
-    const ScrollViewMetrics& scrollViewMetrics) const {
+    const Metrics& scrollViewMetrics) const {
   dispatchScrollViewEvent("scrollEndDrag", scrollViewMetrics);
 }
 
 void ScrollViewEventEmitter::onMomentumScrollBegin(
-    const ScrollViewMetrics& scrollViewMetrics) const {
+    const Metrics& scrollViewMetrics) const {
   dispatchScrollViewEvent("momentumScrollBegin", scrollViewMetrics);
 }
 
 void ScrollViewEventEmitter::onMomentumScrollEnd(
-    const ScrollViewMetrics& scrollViewMetrics) const {
+    const Metrics& scrollViewMetrics) const {
   dispatchScrollViewEvent("momentumScrollEnd", scrollViewMetrics);
 }
 
 void ScrollViewEventEmitter::dispatchScrollViewEvent(
     std::string name,
-    const ScrollViewMetrics& scrollViewMetrics) const {
+    const Metrics& scrollViewMetrics) const {
   dispatchEvent(std::move(name), [scrollViewMetrics](jsi::Runtime& runtime) {
     return scrollViewMetricsPayload(runtime, scrollViewMetrics);
   });

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
@@ -15,30 +15,29 @@
 
 namespace facebook::react {
 
-class ScrollViewMetrics {
- public:
-  Size contentSize;
-  Point contentOffset;
-  EdgeInsets contentInset;
-  Size containerSize;
-  Float zoomScale;
-};
-
 class ScrollViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
-  void onScroll(const ScrollViewMetrics& scrollViewMetrics) const;
-  void onScrollBeginDrag(const ScrollViewMetrics& scrollViewMetrics) const;
-  void onScrollEndDrag(const ScrollViewMetrics& scrollViewMetrics) const;
-  void onMomentumScrollBegin(const ScrollViewMetrics& scrollViewMetrics) const;
-  void onMomentumScrollEnd(const ScrollViewMetrics& scrollViewMetrics) const;
-  void onScrollToTop(const ScrollViewMetrics& scrollViewMetrics) const;
+  struct Metrics {
+    Size contentSize;
+    Point contentOffset;
+    EdgeInsets contentInset;
+    Size containerSize;
+    Float zoomScale{};
+  };
+
+  void onScroll(const Metrics& scrollViewMetrics) const;
+  void onScrollBeginDrag(const Metrics& scrollViewMetrics) const;
+  void onScrollEndDrag(const Metrics& scrollViewMetrics) const;
+  void onMomentumScrollBegin(const Metrics& scrollViewMetrics) const;
+  void onMomentumScrollEnd(const Metrics& scrollViewMetrics) const;
+  void onScrollToTop(const Metrics& scrollViewMetrics) const;
 
  private:
   void dispatchScrollViewEvent(
       std::string name,
-      const ScrollViewMetrics& scrollViewMetrics) const;
+      const Metrics& scrollViewMetrics) const;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]


- use designated initializers.
- make ScrollViewMetrics a struct.
- move ScrollViewMetrics inside of ScrollViewEventEmitter.

This is to be more consistent with other event emitters.

Reviewed By: rubennorte

Differential Revision: D54896331


