### PR TITLE
Fix syntax errors in view/conversions.h

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -14,6 +14,7 @@
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/RawProps.h>
 #include <react/renderer/graphics/Transform.h>
 #include <react/renderer/graphics/ValueUnit.h>
 #include <stdlib.h>


### PR DESCRIPTION
Summary:
This file always had a bunch of errors and made it so that actual errors do not show up (too many emitted). It was just because we are not including RawProps.h. I am not sure how it ever got compiled but I guess some header included something that included something etc. Maybe its a vs code issue but this seems like an obvious fix

Changelog: [Internal]

Differential Revision: D55041883


