### PR TITLE
Keep ES6Proxy enabled in bridgeless mode

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -137,7 +137,6 @@ std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
                             .withAllocInYoung(false)
                             .withRevertToYGAtTTI(true)
                             .build())
-          .withES6Proxy(false)
           .withEnableSampleProfiling(true)
           .withMicrotaskQueue(ReactNativeFeatureFlags::enableMicrotasks())
           .withVMExperimentFlags(vmExperimentFlags);


### PR DESCRIPTION
Summary:
The Hermes RuntimeConfig for bridgeless accidentally force-disabled ES6Proxy, resulting in https://github.com/facebook/react-native/issues/43523

To fix it, let's remove the incorrect override.

To test using RNTester, add the following change:

```
diff --git a/packages/rn-tester/js/RNTesterAppShared.js b/packages/rn-tester/js/RNTesterAppShared.js
index 87cb6b69dfe..f2512d09c5a 100644
--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -50,6 +50,8 @@ const RNTesterApp = ({
   );
   const colorScheme = useColorScheme();
+  new Proxy({}, {});
+
   const {
     activeModuleKey,
     activeModuleTitle,
```

Before this change, RNTester will get an error at start-up. After, the app loads correctly.

Changelog: [General][Fixed] Correctly keep ES6Proxy for bridgeless mode

Differential Revision: D55045780


