### PR TITLE
Add ReactDelegate to ReactApplication

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -134,6 +134,7 @@ public class com/facebook/react/ReactActivityDelegate {
 }
 
 public abstract interface class com/facebook/react/ReactApplication {
+	public fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;
 	public fun getReactHost ()Lcom/facebook/react/ReactHost;
 	public abstract fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactApplication.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactApplication.kt
@@ -18,4 +18,12 @@ public interface ReactApplication {
    */
   public val reactHost: ReactHost?
     get() = null
+
+  /**
+   * Get the default [ReactDelegate] for this app. This method will be used by the backwards
+   * compatibility layer as a delegate for selecting the appropriate ReactHost or ReactNativeHost
+   * instance based on the architecture in use.
+   */
+  public val reactDelegate: ReactDelegate?
+    get() = null
 }


### PR DESCRIPTION
Summary:
Adding ReactDelegate to ReactApplication so that it acts as an abstraction of ReactHost & ReactNativeHost for Bridgeless & Bridge correspondingly and product code can be agnostic of that.

Changelog:
[Internal] internal

Differential Revision: D54961909


