### PR TITLE
Remove console logs from Metro when native debugger console is available

### DIFF
--- a/packages/react-native/Libraries/Core/setUpDeveloperTools.js
+++ b/packages/react-native/Libraries/Core/setUpDeveloperTools.js
@@ -42,7 +42,9 @@ if (__DEV__) {
   if (!Platform.isTesting) {
     const HMRClient = require('../Utilities/HMRClient');
 
-    if (console._isPolyfilled) {
+    if (global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
+      HMRClient.unstable_notifyFuseboxConsoleEnabled();
+    } else if (console._isPolyfilled) {
       // We assume full control over the console and send JavaScript logs to Metro.
       [
         'trace',

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -122,6 +122,10 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
         HermesConsoleMessage{message.timestamp, type, std::move(message.args)});
   }
 
+  bool supportsConsole() const override {
+    return true;
+  }
+
  private:
   HermesRuntimeTargetDelegate& delegate_;
   std::shared_ptr<HermesRuntime> runtime_;
@@ -171,6 +175,10 @@ void HermesRuntimeTargetDelegate::addConsoleMessage(
     jsi::Runtime& runtime,
     ConsoleMessage message) {
   impl_->addConsoleMessage(runtime, std::move(message));
+}
+
+bool HermesRuntimeTargetDelegate::supportsConsole() const {
+  return impl_->supportsConsole();
 }
 
 #ifdef HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -48,6 +48,8 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
   void addConsoleMessage(jsi::Runtime& runtime, ConsoleMessage message)
       override;
 
+  bool supportsConsole() const override;
+
  private:
   // We use the private implementation idiom to ensure this class has the same
   // layout regardless of whether HERMES_ENABLE_DEBUGGER is defined. The net

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
@@ -32,4 +32,8 @@ void FallbackRuntimeTargetDelegate::addConsoleMessage(
   // TODO: Best-effort printing (without RemoteObjects)
 }
 
+bool FallbackRuntimeTargetDelegate::supportsConsole() const {
+  return false;
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
@@ -34,6 +34,8 @@ class FallbackRuntimeTargetDelegate : public RuntimeTargetDelegate {
   void addConsoleMessage(jsi::Runtime& runtime, ConsoleMessage message)
       override;
 
+  bool supportsConsole() const override;
+
  private:
   std::string engineDescription_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -67,6 +67,12 @@ class RuntimeTargetDelegate {
   virtual void addConsoleMessage(
       jsi::Runtime& runtime,
       ConsoleMessage message) = 0;
+
+  /**
+   * \returns true if the runtime supports reporting console API calls over CDP.
+   * \c addConsoleMessage MAY be called even if this method returns false.
+   */
+  virtual bool supportsConsole() const = 0;
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -141,6 +141,7 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
       addConsoleMessage,
       (jsi::Runtime & runtime, ConsoleMessage message),
       (override));
+  MOCK_METHOD(bool, supportsConsole, (), (override, const));
 };
 
 class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {


### PR DESCRIPTION
Summary: Changelog: [Internal] Remove console logs from Metro when native Fusebox debugger console is available

Differential Revision: D54829811


