### PR TITLE
fix(dev-middleware): create custom message handler for synthetic page

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -176,14 +176,7 @@ export default class Device {
 
   getPagesList(): $ReadOnlyArray<Page> {
     if (this.#lastConnectedLegacyReactNativePage) {
-      const reactNativeReloadablePage = {
-        id: REACT_NATIVE_RELOADABLE_PAGE_ID,
-        title: 'React Native Experimental (Improved Chrome Reloads)',
-        vm: "don't use",
-        app: this.#app,
-        capabilities: {},
-      };
-      return [...this.#pages.values(), reactNativeReloadablePage];
+      return [...this.#pages.values(), this.#createSyntheticPage()];
     } else {
       return [...this.#pages.values()];
     }
@@ -224,7 +217,10 @@ export default class Device {
 
     // TODO(moti): Handle null case explicitly, e.g. refuse to connect to
     // unknown pages.
-    const page: ?Page = this.#pages.get(pageId);
+    const page: ?Page =
+      pageId === REACT_NATIVE_RELOADABLE_PAGE_ID
+        ? this.#createSyntheticPage()
+        : this.#pages.get(pageId);
 
     this.#debuggerConnection = debuggerInfo;
 
@@ -377,6 +373,19 @@ export default class Device {
    */
   #pageHasCapability(page: Page, flag: $Keys<TargetCapabilityFlags>): boolean {
     return page.capabilities[flag] === true;
+  }
+
+  /**
+   * Returns the synthetic "React Native Experimental (Improved Chrome Reloads)" page.
+   */
+  #createSyntheticPage(): Page {
+    return {
+      id: REACT_NATIVE_RELOADABLE_PAGE_ID,
+      title: 'React Native Experimental (Improved Chrome Reloads)',
+      vm: "don't use",
+      app: this.#app,
+      capabilities: {},
+    };
   }
 
   // Handles messages received from device:


### PR DESCRIPTION
## Summary:

This is a follow-up bugfix for expo/expo#27425, related to:
 - #43291
 - #43307
 - #43310
 - #43364

The middleware API works as intended and can run our extended CDP events. Unfortunately, this only applies to an actual `Page` from the device, not for the `React Native Experimental (Improved Chrome Reloads)` synthetic / virtual page.

That's because the middleware instantiation gets aborted when the page can't be found in `this.#pages.get(pageId)`, which always returns `null` for this synthetic page.

## Changelog:

[GENERAL] [FIXED] Create custom message handler for synthetic page

## Test Plan:

See added test case.
