### PR TITLE
Fix Android Horizontal ScrollView OverScroll Fling when Content View Less Length than Scrolling View

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -808,7 +808,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
       // more information.
 
       if (!mScroller.isFinished() && mScroller.getCurrX() != mScroller.getFinalX()) {
-        int scrollRange = computeHorizontalScrollRange() - getWidth();
+        int scrollRange = Math.max(computeHorizontalScrollRange() - getWidth(), 0);
         if (scrollX >= scrollRange) {
           mScroller.abortAnimation();
           scrollX = scrollRange;


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/42874

## Sumary

D9405703 added some custom logic for Flings, to support FlatList scenarios where content is being added on the fly, during Fling animation. This works by allowing start Fling to not have bounds, then correcting/cancelling Fling when overscroll happens over a bound that would normally be allowed.

This has some math to try to determine max content length, and will clamp to this when scrolling over it. This logic is incorrect when content length is less than scrollview length, and we end up snapping to a negative offset.

This change adds clamping, so that we don't snap to negative position in horizontal scroll view. This clamping was already indirectly present on vertical scroll view. https://www.internalfb.com/code/fbsource/[b43cdf9b2fec71f5341ec8ff2d47e28a066f052e]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java?lines=609

## Test Plan

Above issue no longer reproes. Flinging while content is being added to horizontal FlatList still works correctly.

Changelog:
[Android][Fixed] - Fix Android Horizontal ScrollView OverScroll Fling when Content View Less Length than Scrolling View

Differential Revision: D55108818


