### PR TITLE
Log a message identifying Fusebox based on a handshake with the frontend

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -71,7 +71,11 @@ class HostAgent final {
    * Runtime.consoleAPICalled is that the latter requires an execution context
    * ID, which does not exist at the Host level.
    */
-  void sendInfoLogEntry(std::string_view text);
+  void sendInfoLogEntry(
+      std::string_view text,
+      std::initializer_list<std::string_view> args = {});
+
+  void sendFuseboxNotice();
 
   FrontendChannel frontendChannel_;
   HostTargetController& targetController_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -36,6 +36,8 @@ struct SessionState {
   std::unordered_map<std::string, ExecutionContextSelectorSet>
       subscribedBindings;
 
+  bool isFuseboxClientDetected{false};
+
   /**
    * Stores the state object exported from the last main RuntimeAgent, if any,
    * before it was destroyed.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
@@ -155,8 +155,7 @@ TEST_F(HostTargetProtocolTest, InjectLogsToIdentifyBackend) {
       onMessage(JsonParsed(AllOf(
           AtJsonPtr("/method", "Log.entryAdded"),
           AtJsonPtr("/params/entry", Not(IsEmpty()))))))
-      .Times(2)
-      .RetiresOnSaturation();
+      .Times(AtLeast(1));
   EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
                                                "id": 1,
                                                "result": {}

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -317,6 +317,21 @@ TYPED_TEST(JsiIntegrationPortableTest, ExceptionDuringAddBindingIsIgnored) {
   EXPECT_TRUE(this->eval("globalThis.foo === 42").getBool());
 }
 
+TYPED_TEST(JsiIntegrationPortableTest, FuseboxSetClientMetadata) {
+  this->connect();
+
+  this->expectMessageFromPage(JsonEq(R"({
+                                          "id": 1,
+                                          "result": {}
+                                        })"));
+
+  this->toPage_->sendMessage(R"({
+                                 "id": 1,
+                                 "method": "FuseboxClient.setClientMetadata",
+                                 "params": {}
+                               })");
+}
+
 #pragma endregion // AllEngines
 #pragma region AllHermesVariants
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Uses https://github.com/facebookexperimental/rn-chrome-devtools-frontend/pull/24 to identify the Fusebox frontend and show a corresponding message in the logs.

Also tweaks the wording and formatting of other messages logged by the Fusebox backend - including removing the "you are using the modern CDP backend" one.

Reviewed By: huntie

Differential Revision: D55075645


