### PR TITLE
Update TypeScript types for `Libraries/Core/Devtools` to match implementation

### DIFF
--- a/packages/react-native/types/modules/Devtools.d.ts
+++ b/packages/react-native/types/modules/Devtools.d.ts
@@ -23,15 +23,17 @@ declare module 'react-native/Libraries/Core/Devtools/symbolicateStackTrace' {
 
   export type SymbolicatedStack = {
     stack: StackFrame[];
-    codeFrame?: CodeFrame;
+    codeFrame?: CodeFrame | undefined;
   };
 
   export type CodeFrame = {
     content: string;
-    location?: {
-      row: number;
-      column: number;
-    },
+    location?:
+      | {
+          row: number;
+          column: number;
+        }
+      | undefined;
     fileName: string;
   };
 

--- a/packages/react-native/types/modules/Devtools.d.ts
+++ b/packages/react-native/types/modules/Devtools.d.ts
@@ -15,11 +15,7 @@ declare module 'react-native/Libraries/Core/Devtools/parseErrorStack' {
     column: number | null;
   };
 
-  export interface ExtendedError extends Error {
-    framesToPop?: number | undefined;
-  }
-
-  export default function parseErrorStack(error: ExtendedError): StackFrame[];
+  export default function parseErrorStack(stack: string): StackFrame[];
 }
 
 declare module 'react-native/Libraries/Core/Devtools/symbolicateStackTrace' {

--- a/packages/react-native/types/modules/Devtools.d.ts
+++ b/packages/react-native/types/modules/Devtools.d.ts
@@ -21,8 +21,22 @@ declare module 'react-native/Libraries/Core/Devtools/parseErrorStack' {
 declare module 'react-native/Libraries/Core/Devtools/symbolicateStackTrace' {
   import {StackFrame} from 'react-native/Libraries/Core/Devtools/parseErrorStack';
 
+  export type SymbolicatedStack = {
+    stack: StackFrame[];
+    codeFrame?: CodeFrame;
+  };
+
+  export type CodeFrame = {
+    content: string;
+    location?: {
+      row: number;
+      column: number;
+    },
+    fileName: string;
+  };
+
   export default function symbolicateStackTrace(
     stack: ReadonlyArray<StackFrame>,
     extraData?: any,
-  ): Promise<StackFrame[]>;
+  ): Promise<SymbolicatedStack>;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The `parseErrorStack` function takes the stack as a string, as its only argument, not the `Error`: https://github.com/facebook/react-native/blob/ce4d8f2756841e1226cb1c773026413b63abdf85/packages/react-native/Libraries/Core/Devtools/parseErrorStack.js#L41

The `symbolicateStackTrace` returns a promise of an object containing a `codeFrame` and `stack`, not an array of frames:

https://github.com/facebook/react-native/blob/ce4d8f2756841e1226cb1c773026413b63abdf85/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js#L17-L30

## Changelog:

[GENERAL] [FIXED] - Fixed TypeScript type of the `parseErrorStack` and `symbolicateStackTrace` functions to match their implementation.

## Test Plan:

I patched the file locally and tested function to ensure its callable with a string.
