### PR TITLE
Adjust version parsing in release scripts, fix release dry runs in CI

### DIFF
--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -8,7 +8,7 @@
           name: "prepare_release (dry run test)"
           version: "0.0.0"
           monorepo_packages_version: "0.0.0"
-          tag: latest
+          tag: test
           dry_run: true
       - prepare_hermes_workspace
       - build_android:

--- a/.circleci/configurations/test_workflows/testAndroid.yml
+++ b/.circleci/configurations/test_workflows/testAndroid.yml
@@ -8,7 +8,7 @@
           name: "prepare_release (dry run test)"
           version: "0.0.0"
           monorepo_packages_version: "0.0.0"
-          tag: latest
+          tag: test
           dry_run: true
       - prepare_hermes_workspace
       - build_android:

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -8,7 +8,7 @@
           name: "prepare_release (dry run test)"
           version: "0.0.0"
           monorepo_packages_version: "0.0.0"
-          tag: latest
+          tag: test
           dry_run: true
       - prepare_hermes_workspace
       - build_android:

--- a/scripts/releases/utils/version-utils.js
+++ b/scripts/releases/utils/version-utils.js
@@ -135,14 +135,17 @@ function validatePrealpha(version /*: Version */) {
 
 function isStableRelease(version /*: Version */) /*: boolean */ {
   return (
-    version.major === '0' && version.minor !== '0' && version.prerelease == null
+    version.major === '0' &&
+    !!version.minor.match(/^\d+$/) &&
+    !!version.patch.match(/^\d+$/) &&
+    version.prerelease == null
   );
 }
 
 function isStablePrerelease(version /*: Version */) /*: boolean */ {
   return !!(
     version.major === '0' &&
-    version.minor !== '0' &&
+    version.minor.match(/^\d+$/) &&
     version.patch.match(/^\d+$/) &&
     (version.prerelease?.startsWith('rc.') ||
       version.prerelease?.startsWith('rc-') ||


### PR DESCRIPTION
Summary:
Fixes to restore passing CI checks on main after D55027120.

- Widen validation checks in version utils to accept `0.x.x` (as opposed to `0.[not-'0'].x`).
- Use `tag: test` instead of `tag: latest` for dry run job params.

Changelog: [Internal]

Differential Revision: D55123739


