### PR TITLE
Merge all core codegen into FBReactNativeSpec

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
@@ -63,7 +63,8 @@ std::shared_ptr<TurboModule> ${libraryName}_ModuleProvider(const std::string &mo
 // Note: this CMakeLists.txt template includes dependencies for both NativeModule and components.
 const CMakeListsTemplate = ({
   libraryName,
-}: $ReadOnly<{libraryName: string}>) => {
+  targetName,
+}: $ReadOnly<{libraryName: string, targetName: string}>) => {
   return `# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
@@ -75,20 +76,20 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 file(GLOB react_codegen_SRCS CONFIGURE_DEPENDS *.cpp react/renderer/components/${libraryName}/*.cpp)
 
 add_library(
-  react_codegen_${libraryName}
+  react_codegen_${targetName}
   SHARED
   \${react_codegen_SRCS}
 )
 
-target_include_directories(react_codegen_${libraryName} PUBLIC . react/renderer/components/${libraryName})
+target_include_directories(react_codegen_${targetName} PUBLIC . react/renderer/components/${libraryName})
 
 target_link_libraries(
-  react_codegen_${libraryName}
+  react_codegen_${targetName}
   fbjni
   folly_runtime
   glog
   jsi
-  ${libraryName !== 'rncore' ? 'react_codegen_rncore' : ''}
+  ${targetName !== 'rncore' ? 'react_codegen_rncore' : ''}
   react_debug
   react_nativemodule_core
   react_render_componentregistry
@@ -105,7 +106,7 @@ target_link_libraries(
 )
 
 target_compile_options(
-  react_codegen_${libraryName}
+  react_codegen_${targetName}
   PRIVATE
   -DLOG_TAG=\\"ReactNative\\"
   -fexceptions
@@ -142,9 +143,12 @@ module.exports = {
       modules: modules,
       libraryName: libraryName.replace(/-/g, '_'),
     });
+    // Use rncore as target name for backwards compat
+    const targetName =
+      libraryName === 'FBReactNativeSpec' ? 'rncore' : libraryName;
     return new Map([
       [`jni/${fileName}`, replacedTemplate],
-      ['jni/CMakeLists.txt', CMakeListsTemplate({libraryName: libraryName})],
+      ['jni/CMakeLists.txt', CMakeListsTemplate({libraryName, targetName})],
     ]);
   },
 };

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.mm
@@ -9,9 +9,9 @@
 
 #import <React/RCTConversions.h>
 
-#import <react/renderer/components/rncore/ComponentDescriptors.h>
-#import <react/renderer/components/rncore/EventEmitters.h>
-#import <react/renderer/components/rncore/Props.h>
+#import <react/renderer/components/FBReactNativeSpec/ComponentDescriptors.h>
+#import <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/FBReactNativeSpec/Props.h>
 
 #import "RCTFabricComponentsPlugins.h"
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/DebuggingOverlay/RCTDebuggingOverlayComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/DebuggingOverlay/RCTDebuggingOverlayComponentView.h
@@ -9,7 +9,7 @@
 
 #import <React/RCTViewComponentView.h>
 
-#import <react/renderer/components/rncore/RCTComponentViewHelpers.h>
+#import <react/renderer/components/FBReactNativeSpec/RCTComponentViewHelpers.h>
 
 @interface RCTDebuggingOverlayComponentView : RCTViewComponentView <RCTDebuggingOverlayViewProtocol>
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/DebuggingOverlay/RCTDebuggingOverlayComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/DebuggingOverlay/RCTDebuggingOverlayComponentView.mm
@@ -11,10 +11,10 @@
 #import <React/RCTDefines.h>
 #import <React/RCTLog.h>
 
-#import <react/renderer/components/rncore/ComponentDescriptors.h>
-#import <react/renderer/components/rncore/EventEmitters.h>
-#import <react/renderer/components/rncore/Props.h>
-#import <react/renderer/components/rncore/RCTComponentViewHelpers.h>
+#import <react/renderer/components/FBReactNativeSpec/ComponentDescriptors.h>
+#import <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/FBReactNativeSpec/Props.h>
+#import <react/renderer/components/FBReactNativeSpec/RCTComponentViewHelpers.h>
 
 #import "RCTFabricComponentsPlugins.h"
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -12,8 +12,8 @@
 #import <React/RCTSurfaceTouchHandler.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
+#import <react/renderer/components/FBReactNativeSpec/Props.h>
 #import <react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h>
-#import <react/renderer/components/rncore/Props.h>
 #import "RCTInputAccessoryContentView.h"
 
 #import "RCTFabricComponentsPlugins.h"

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -10,10 +10,10 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTModalManager.h>
 #import <React/UIView+React.h>
+#import <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/FBReactNativeSpec/Props.h>
 #import <react/renderer/components/modal/ModalHostViewComponentDescriptor.h>
 #import <react/renderer/components/modal/ModalHostViewState.h>
-#import <react/renderer/components/rncore/EventEmitters.h>
-#import <react/renderer/components/rncore/Props.h>
 
 #import "RCTConversions.h"
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -7,10 +7,10 @@
 
 #import "RCTPullToRefreshViewComponentView.h"
 
-#import <react/renderer/components/rncore/ComponentDescriptors.h>
-#import <react/renderer/components/rncore/EventEmitters.h>
-#import <react/renderer/components/rncore/Props.h>
-#import <react/renderer/components/rncore/RCTComponentViewHelpers.h>
+#import <react/renderer/components/FBReactNativeSpec/ComponentDescriptors.h>
+#import <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/FBReactNativeSpec/Props.h>
+#import <react/renderer/components/FBReactNativeSpec/RCTComponentViewHelpers.h>
 
 #import <React/RCTConversions.h>
 #import <React/RCTRefreshableProtocol.h>

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -9,10 +9,10 @@
 
 #import <React/RCTConversions.h>
 
-#import <react/renderer/components/rncore/ComponentDescriptors.h>
-#import <react/renderer/components/rncore/EventEmitters.h>
-#import <react/renderer/components/rncore/Props.h>
-#import <react/renderer/components/rncore/RCTComponentViewHelpers.h>
+#import <react/renderer/components/FBReactNativeSpec/ComponentDescriptors.h>
+#import <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/FBReactNativeSpec/Props.h>
+#import <react/renderer/components/FBReactNativeSpec/RCTComponentViewHelpers.h>
 
 #import "RCTFabricComponentsPlugins.h"
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.mm
@@ -7,9 +7,9 @@
 
 #import "RCTUnimplementedNativeComponentView.h"
 
-#import <react/renderer/components/rncore/ComponentDescriptors.h>
-#import <react/renderer/components/rncore/EventEmitters.h>
-#import <react/renderer/components/rncore/Props.h>
+#import <react/renderer/components/FBReactNativeSpec/ComponentDescriptors.h>
+#import <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/FBReactNativeSpec/Props.h>
 
 using namespace facebook::react;
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.mm
@@ -7,9 +7,9 @@
 
 #import "RCTUnimplementedViewComponentView.h"
 
-#import <react/renderer/components/rncore/ComponentDescriptors.h>
-#import <react/renderer/components/rncore/EventEmitters.h>
-#import <react/renderer/components/rncore/Props.h>
+#import <react/renderer/components/FBReactNativeSpec/ComponentDescriptors.h>
+#import <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/FBReactNativeSpec/Props.h>
 
 #import <react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h>
 #import <react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h>

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -778,9 +778,7 @@ dependencies {
 }
 
 react {
-  // TODO: The library name is chosen for parity with Fabric components & iOS
-  // This should be changed to a more generic name, e.g. `ReactCoreSpec`.
-  libraryName = "rncore"
+  libraryName = "FBReactNativeSpec"
   jsRootDir = file("../src")
 }
 

--- a/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp
@@ -29,10 +29,10 @@
 
 #include <DefaultComponentsRegistry.h>
 #include <DefaultTurboModuleManagerDelegate.h>
+#include <FBReactNativeSpec.h>
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <rncli.h>
-#include <rncore.h>
 
 #ifdef REACT_NATIVE_APP_CODEGEN_HEADER
 #include REACT_NATIVE_APP_CODEGEN_HEADER
@@ -97,7 +97,7 @@ std::shared_ptr<TurboModule> javaModuleProvider(
 #endif
 
   // We first try to look up core modules
-  if (auto module = rncore_ModuleProvider(name, params)) {
+  if (auto module = FBReactNativeSpec_ModuleProvider(name, params)) {
     return module;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
@@ -12,12 +12,12 @@
 #include <fbjni/fbjni.h>
 
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
+#include <react/renderer/components/FBReactNativeSpec/ComponentDescriptors.h>
 #include <react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h>
 #include <react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h>
 #include <react/renderer/components/image/ImageComponentDescriptor.h>
 #include <react/renderer/components/modal/ModalHostViewComponentDescriptor.h>
 #include <react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h>
-#include <react/renderer/components/rncore/ComponentDescriptors.h>
 #include <react/renderer/components/scrollview/ScrollViewComponentDescriptor.h>
 #include <react/renderer/components/text/ParagraphComponentDescriptor.h>
 #include <react/renderer/components/text/RawTextComponentDescriptor.h>

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
@@ -11,7 +11,7 @@
 #include <fbjni/fbjni.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
-#include <react/renderer/components/rncore/ComponentDescriptors.h>
+#include <react/renderer/components/FBReactNativeSpec/ComponentDescriptors.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 
+#include <FBReactNativeSpec.h>
 #include <react/nativemodule/dom/NativeDOM.h>
 #include <react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h>
 #include <react/nativemodule/microtasks/NativeMicrotasks.h>
@@ -100,7 +101,7 @@ std::shared_ptr<TurboModule> DefaultTurboModuleManagerDelegate::getTurboModule(
     }
   }
 
-  return nullptr;
+  return FBReactNativeSpec_ModuleProvider(name, params);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -95,6 +95,7 @@ Pod::Spec.new do |s|
       "\"$(PODS_TARGET_SRCROOT)\"",
       "\"$(PODS_ROOT)/DoubleConversion\"",
       "\"$(PODS_ROOT)/fmt/include\"",
+      "\"$(PODS_ROOT)/Headers/Public/ReactCodegen\""
     ]
 
     if ENV['USE_FRAMEWORKS']
@@ -130,7 +131,6 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "components" do |ss|
-
     ss.subspec "inputaccessory" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
@@ -156,11 +156,11 @@ Pod::Spec.new do |s|
       sss.header_dir           = "react/renderer/components/modal"
     end
 
-    ss.subspec "rncore" do |sss|
+    ss.subspec "FBReactNativeSpec" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/rncore/**/*.{m,mm,cpp,h}"
-      sss.header_dir           = "react/renderer/components/rncore"
+      sss.source_files         = "react/renderer/components/FBReactNativeSpec/**/*.{m,mm,cpp,h}"
+      sss.header_dir           = "react/renderer/components/FBReactNativeSpec"
     end
 
     ss.subspec "root" do |sss|
@@ -177,7 +177,6 @@ Pod::Spec.new do |s|
       sss.source_files         = "react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/safeareaview/tests"
       sss.header_dir           = "react/renderer/components/safeareaview"
-
     end
 
     ss.subspec "scrollview" do |sss|
@@ -186,7 +185,6 @@ Pod::Spec.new do |s|
       sss.source_files         = "react/renderer/components/scrollview/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/scrollview/tests"
       sss.header_dir           = "react/renderer/components/scrollview"
-
     end
 
     ss.subspec "text" do |sss|
@@ -195,7 +193,6 @@ Pod::Spec.new do |s|
       sss.source_files         = "react/renderer/components/text/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/text/tests"
       sss.header_dir           = "react/renderer/components/text"
-
     end
 
     ss.subspec "iostextinput" do |sss|
@@ -203,7 +200,6 @@ Pod::Spec.new do |s|
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/iostextinput"
-
     end
 
     ss.subspec "textinput" do |sss|
@@ -211,7 +207,6 @@ Pod::Spec.new do |s|
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/textinput"
-
     end
 
     ss.subspec "unimplementedview" do |sss|
@@ -220,7 +215,6 @@ Pod::Spec.new do |s|
       sss.source_files         = "react/renderer/components/unimplementedview/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/unimplementedview/tests"
       sss.header_dir           = "react/renderer/components/unimplementedview"
-
     end
 
     ss.subspec "view" do |sss|
@@ -310,7 +304,6 @@ Pod::Spec.new do |s|
     ss.source_files         = "react/renderer/telemetry/**/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/telemetry/tests"
     ss.header_dir           = "react/renderer/telemetry"
-
   end
 
   s.subspec "leakchecker" do |ss|
@@ -321,20 +314,4 @@ Pod::Spec.new do |s|
     ss.header_dir           = "react/renderer/leakchecker"
     ss.pod_target_xcconfig  = { "GCC_WARN_PEDANTIC" => "YES" }
   end
-
-  s.script_phases = [
-    {
-      :name => '[RN]Check rncore',
-      :execution_position => :before_compile,
-      :script => <<-EOS
-echo "Checking whether Codegen has run..."
-rncorePath="$REACT_NATIVE_PATH/ReactCommon/react/renderer/components/rncore"
-
-if [[ ! -d "$rncorePath" ]]; then
-  echo 'error: Codegen did not run properly in your project. Please reinstall cocoapods with `bundle exec pod install`.'
-  exit 1
-fi
-      EOS
-    }
-  ]
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
@@ -9,9 +9,7 @@
 
 #include <string>
 
-#if __has_include("rncoreJSI.h") // Cmake headers on Android
-#include "rncoreJSI.h"
-#elif __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
+#if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0dcfc928ff0eca1cb37766170d9b4379>>
+ * @generated SignedSource<<dd6da4bece7d5bc8be176f12c7132638>>
  */
 
 /**
@@ -19,9 +19,7 @@
 
 #pragma once
 
-#if __has_include("rncoreJSI.h") // Cmake headers on Android
-#include "rncoreJSI.h"
-#elif __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
+#if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/NativeMicrotasks.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/NativeMicrotasks.h
@@ -7,9 +7,7 @@
 
 #pragma once
 
-#if __has_include("rncoreJSI.h") // Cmake headers on Android
-#include "rncoreJSI.h"
-#elif __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
+#if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -45,4 +45,6 @@ Pod::Spec.new do |s|
   install_modules_dependencies(s)
 
   s.dependency "ReactCommon/turbomodule/core"
+
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
 end

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
+#include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/inputaccessory/InputAccessoryState.h>
-#include <react/renderer/components/rncore/EventEmitters.h>
-#include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
+#include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/modal/ModalHostViewState.h>
-#include <react/renderer/components/rncore/EventEmitters.h>
-#include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
@@ -9,6 +9,7 @@
 
 #include <fbjni/fbjni.h>
 #include <react/jni/ReadableNativeMap.h>
+#include <react/renderer/components/progressbar/conversions.h>
 #include <react/renderer/core/conversions.h>
 
 using namespace facebook::jni;

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-#include <react/renderer/components/progressbar/conversions.h>
-#include <react/renderer/components/rncore/Props.h>
+#include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ContextContainer.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
+#include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h>
-#include <react/renderer/components/rncore/EventEmitters.h>
-#include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <folly/dynamic.h>
-#include <react/renderer/components/rncore/Props.h>
+#include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/core/propsConversions.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <react/renderer/components/rncore/EventEmitters.h>
-#include <react/renderer/components/rncore/Props.h>
+#include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/safeareaview/SafeAreaViewState.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
@@ -9,8 +9,8 @@
 
 #include "AndroidSwitchMeasurementsManager.h"
 
-#include <react/renderer/components/rncore/EventEmitters.h>
-#include <react/renderer/components/rncore/Props.h>
+#include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+#include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
 namespace facebook::react {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -147,21 +147,8 @@
     "yargs": "^17.6.2"
   },
   "codegenConfig": {
-    "libraries": [
-      {
-        "name": "FBReactNativeSpec",
-        "type": "modules",
-        "ios": {},
-        "android": {},
-        "jsSrcsDir": "src"
-      },
-      {
-        "name": "rncore",
-        "type": "components",
-        "ios": {},
-        "android": {},
-        "jsSrcsDir": "src"
-      }
-    ]
+    "name": "FBReactNativeSpec",
+    "type": "all",
+    "jsSrcsDir": "src"
   }
 }

--- a/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.h-template.js
@@ -27,9 +27,7 @@ ${DO_NOT_MODIFY_COMMENT}
 
 #pragma once
 
-#if __has_include("rncoreJSI.h") // Cmake headers on Android
-#include "rncoreJSI.h"
-#elif __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
+#if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -528,11 +528,11 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
+    - React-Fabric/components/FBReactNativeSpec (= 1000.0.0)
     - React-Fabric/components/inputaccessory (= 1000.0.0)
     - React-Fabric/components/iostextinput (= 1000.0.0)
     - React-Fabric/components/legacyviewmanagerinterop (= 1000.0.0)
     - React-Fabric/components/modal (= 1000.0.0)
-    - React-Fabric/components/rncore (= 1000.0.0)
     - React-Fabric/components/root (= 1000.0.0)
     - React-Fabric/components/safeareaview (= 1000.0.0)
     - React-Fabric/components/scrollview (= 1000.0.0)
@@ -540,6 +540,26 @@ PODS:
     - React-Fabric/components/textinput (= 1000.0.0)
     - React-Fabric/components/unimplementedview (= 1000.0.0)
     - React-Fabric/components/view (= 1000.0.0)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/FBReactNativeSpec (1000.0.0):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -610,26 +630,6 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
   - React-Fabric/components/modal (1000.0.0):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (1000.0.0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1660,7 +1660,7 @@ SPEC CHECKSUMS:
   FBLazyVector: f4492a543c5a8fa1502d3a5867e3f7252497cfe8
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 221c62bc31d84593845e639e3288c6f64abc75ac
+  hermes-engine: 5b94fb45e6d9786e0c57b116e815a9c0e6d47f59
   MyNativeView: 1314dd52cc27c4a26957a5185aae6ecac6e4e2ff
   NativeCxxModuleExample: 65632ba6e8c216048f7af7d3c7bb1431d22bc2d0
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
@@ -1675,7 +1675,7 @@ SPEC CHECKSUMS:
   React-cxxreact: 73a61f1e212fa084d3ae19a4ee4e3531aff646a9
   React-debug: 296b501a90c41f83961f58c6d96a01330d499da5
   React-domnativemodule: d38559c0807e0694565b806f347a465a2486a30e
-  React-Fabric: 1ea5efc1cd04fd179021a481a82773bb6574f46a
+  React-Fabric: 7d229abbab5c2adc238c196c2155c8de84e54ea3
   React-FabricImage: da62cc5089fe6bdaa6ec0ab6ccca75c7d679065d
   React-featureflags: 23f83a12963770bf3cff300e8990678192436b36
   React-featureflagsnativemodule: 7f69e5d1ddaf2dacd69ba0d75faf396c5f148508
@@ -1689,7 +1689,7 @@ SPEC CHECKSUMS:
   React-jsitracing: dd08057dd5b74119cb406beb42028da85ed5b8a5
   React-logger: 8486d7a1d32b972414b1d34a93470ee2562c6ee2
   React-Mapbuffer: fd0d0306c1c4326be5f18a61e978d32a66b20a85
-  React-microtasksnativemodule: 0f4976afa97a9e6cac7e8ec7bf15b856c690c4d9
+  React-microtasksnativemodule: f4d71bde5f51a1a17bd3438caefedacdbee0f95e
   React-nativeconfig: 40a2c848083ef4065c163c854e1c82b5f9e9db84
   React-NativeModulesApple: 48f0205edc54b8a1c24328f2deeb74b4f1570418
   React-perflogger: 70d009f755dd10002183454cdf5ad9b22de4a1d7
@@ -1720,7 +1720,7 @@ SPEC CHECKSUMS:
   ReactCommon-Samples: e2bf03c8237c461fa36bda8e4638368fa82b633c
   ScreenshotManager: 16fcf9cbbee5b261ac46641a0f502fc1cb73a089
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: f58ba5e0ac1e7eb3ef4caedcf80c5aa39985b039
+  Yoga: 6699d976569a643bf13b139446612adfa2ce7ac6
 
 PODFILE CHECKSUM: 60b84dd598fc04e9ed84dbc82e2cb3b99b1d7adf
 

--- a/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
+++ b/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
@@ -7,11 +7,11 @@
 
 #include <DefaultComponentsRegistry.h>
 #include <DefaultTurboModuleManagerDelegate.h>
+#include <FBReactNativeSpec.h>
 #include <NativeCxxModuleExample.h>
 #include <ReactCommon/SampleTurboModuleSpec.h>
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
-#include <rncore.h>
 
 #ifdef REACT_NATIVE_APP_CODEGEN_HEADER
 #include REACT_NATIVE_APP_CODEGEN_HEADER
@@ -54,7 +54,7 @@ std::shared_ptr<TurboModule> javaModuleProvider(
 #endif
 
   // We first try to look up core modules
-  if (auto module = rncore_ModuleProvider(name, params)) {
+  if (auto module = FBReactNativeSpec_ModuleProvider(name, params)) {
     return module;
   }
 


### PR DESCRIPTION
Summary:
`rncore`, `FBReactNativeSpec` and `FBReactNativeComponentSpec` contain the same symbols, which leads to conflicts when we try to merge them into a single shared library. Cleanup the duplication and standardize on `FBReactNativeSpec` everywhere. I've left the Android OSS targets names as is, to avoid breaking deps.

This aligns react-native's package.json with the codegen tooling supported across iOS and Android, which is a single target for all all type-derived codegen.

Changelog: [Internal]

Differential Revision: D55037569


