### PR TITLE
Upgrade `@react-native-community/cli` to 13.6.3

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "dependencies": {
-    "@react-native-community/cli-server-api": "13.6.2",
-    "@react-native-community/cli-tools": "13.6.2",
+    "@react-native-community/cli-server-api": "13.6.3",
+    "@react-native-community/cli-tools": "13.6.3",
     "@react-native/dev-middleware": "0.74.75",
     "@react-native/metro-babel-transformer": "0.74.75",
     "chalk": "^4.0.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -98,9 +98,9 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.6.3",
-    "@react-native-community/cli": "13.6.2",
-    "@react-native-community/cli-platform-android": "13.6.2",
-    "@react-native-community/cli-platform-ios": "13.6.2",
+    "@react-native-community/cli": "13.6.3",
+    "@react-native-community/cli-platform-android": "13.6.3",
+    "@react-native-community/cli-platform-ios": "13.6.3",
     "@react-native/assets-registry": "0.74.75",
     "@react-native/codegen": "0.74.75",
     "@react-native/community-cli-plugin": "0.74.75",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,45 +2384,45 @@
   optionalDependencies:
     npmlog "2 || ^3.1.0 || ^4.0.0"
 
-"@react-native-community/cli-clean@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-13.6.2.tgz#073a9921392c0072691e29ef83f4e1b6d52d41ce"
-  integrity sha512-F05U//+DdsGUrFz3LOwNlaiVxv7W3jK38algZxHux/nQj4395LMQTtUMvTlk5CpptlJX3gJZRkjYJbpXSJbJag==
+"@react-native-community/cli-clean@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-13.6.3.tgz#976059a3be43b856bf06bee4b970b6b1b2054890"
+  integrity sha512-1+9G9oh2/Dhs5E/Ka2+bsdykg7vGvM+dZ7RcQvfYVuqhHVsIhQZ/9FmTS7r7UFcY1O7c/eqHbWVVWWCwN+a1kw==
   dependencies:
-    "@react-native-community/cli-tools" "13.6.2"
+    "@react-native-community/cli-tools" "13.6.3"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-glob "^3.3.2"
 
-"@react-native-community/cli-config@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-13.6.2.tgz#fb5a840293f8c175456a986c14e2fad22e551b74"
-  integrity sha512-a+mGYjAd5GuKHnaYjnJ03tXbo8pRCoWyzAGIfD5gZ2JOUuQu+d0JL6TRTXX0Vt31p9HhfUB3cSuS+cTNjNT49A==
+"@react-native-community/cli-config@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-13.6.3.tgz#526880a56443e07521f8c9cb6e5ad81142cc7b16"
+  integrity sha512-P2a/4YEw5LHjvOBCyexTfnPV4PLKGaqNfIjNHx0kGGy1TbDqR4cpTd+WImnTUeIuFb0U0fWb/4zcrIp02cUy9Q==
   dependencies:
-    "@react-native-community/cli-tools" "13.6.2"
+    "@react-native-community/cli-tools" "13.6.3"
     chalk "^4.1.2"
     cosmiconfig "^5.1.0"
     deepmerge "^4.3.0"
     fast-glob "^3.3.2"
     joi "^17.2.1"
 
-"@react-native-community/cli-debugger-ui@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.6.2.tgz#e35d33a74183a224cfb360c7f69512a9fec5e734"
-  integrity sha512-TQuTDauHyUIwn2f9dTnHnlVE26f8DWEw4reOrKWA7fZ4mqJ4MA3Ks424RD78aIcxkTqC4E3Z9nVsJfM42EMyyg==
+"@react-native-community/cli-debugger-ui@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.6.3.tgz#625a15dc5f420fe70d9788cfd16c7e0e59872d68"
+  integrity sha512-3hVgIecoThJm5jr0P3V5uO6JboGiAe19poarvHH8JEXb1cD9QVn3OreaeNYU98N4ZUMnvh0GVuYKtJIO/L7vAA==
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-13.6.2.tgz#77381bb2839bd4fd110a4c4f5ff86359520e81ec"
-  integrity sha512-5T2LC4Cvg/aJCLrh0FPKIjTnxc8GXwGYBBfQ8hAdXK3j2OgNRwwlii5NGDuvd4Gj1qdiEMgaZMm50R0kY2Qv+w==
+"@react-native-community/cli-doctor@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-13.6.3.tgz#415c4c5c6fc1c4a2489c6daf4b150a07efaee793"
+  integrity sha512-eM7/aIQJ/d5vL0sIB+oReaLLqUNtR3jYd+37scaYu5s/2GHkV6k6m9zLCXh5S9rulUtQ72/vInQfMCqMfozgtw==
   dependencies:
-    "@react-native-community/cli-config" "13.6.2"
-    "@react-native-community/cli-platform-android" "13.6.2"
-    "@react-native-community/cli-platform-apple" "13.6.2"
-    "@react-native-community/cli-platform-ios" "13.6.2"
-    "@react-native-community/cli-tools" "13.6.2"
+    "@react-native-community/cli-config" "13.6.3"
+    "@react-native-community/cli-platform-android" "13.6.3"
+    "@react-native-community/cli-platform-apple" "13.6.3"
+    "@react-native-community/cli-platform-ios" "13.6.3"
+    "@react-native-community/cli-tools" "13.6.3"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     deepmerge "^4.3.0"
@@ -2436,54 +2436,54 @@
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
-"@react-native-community/cli-hermes@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-13.6.2.tgz#980aa8895129dac51a68e25b1390219ff4e0875c"
-  integrity sha512-NEjyoUwlz/gsOmFkXYVm7glpc8tiJEPqNNRQhZzeTybcI9CSaBXcPpPj9ubuGwM3rzx+4hnwZGULrn1CQUYOfg==
+"@react-native-community/cli-hermes@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-13.6.3.tgz#ee1d5afddb5945ba8bde6989d031ed27c72bd5b4"
+  integrity sha512-QjKPnT0IvCeX8M1SX5gR+QrhGIwiIQxgpQoNtteBeBS5Bgr+h3bdQtyqI4NSxwHYTnWgPswghFH3yZgULTV8oA==
   dependencies:
-    "@react-native-community/cli-platform-android" "13.6.2"
-    "@react-native-community/cli-tools" "13.6.2"
+    "@react-native-community/cli-platform-android" "13.6.3"
+    "@react-native-community/cli-tools" "13.6.3"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
 
-"@react-native-community/cli-platform-android@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-13.6.2.tgz#b4bcf4e1af5a9633d49f9c735e33667d65ece32c"
-  integrity sha512-PYECUZACr25XDRngPtCfHLeiKBz+bV/P4xmLuUJHoS/8AjX8DTepi4dANVQ5kBsHueHayNYi7cLUG6Wuv/nf3Q==
+"@react-native-community/cli-platform-android@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-13.6.3.tgz#6cb77ca57ad949941eb0577b80c98fd80f853a3a"
+  integrity sha512-iDXqTWSuhX0KqMZJwbT2Wo8iJ5S5Z+LsQ+QgoV5L4cCKvH4wldybfPgLquZTCjaoY2BAMAnlES17yY7I1UD/wg==
   dependencies:
-    "@react-native-community/cli-tools" "13.6.2"
+    "@react-native-community/cli-tools" "13.6.3"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-glob "^3.3.2"
     fast-xml-parser "^4.2.4"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-apple@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-13.6.2.tgz#b7e53451c50ad3ac2e14352194281480f6b9d0ca"
-  integrity sha512-rzYNoo3f2hf6XksUCD2fC3DMchD01bXTekmsUscuB2UX6dIF0cDpn1mUYlOt4G2sppHNQTh8LIKsRd581k9H0g==
+"@react-native-community/cli-platform-apple@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-13.6.3.tgz#d71a593732ffcca597ec4a77b38b5a8fbb2701e0"
+  integrity sha512-XYr4/VFreVS8fcXVHpmpSa/0GZNWAcNM9SHBUReN2myANXUaZFZv9Ew1sh5AyvCDuyCQ4eTSeFhqavKuKgvVbQ==
   dependencies:
-    "@react-native-community/cli-tools" "13.6.2"
+    "@react-native-community/cli-tools" "13.6.3"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-glob "^3.3.2"
     fast-xml-parser "^4.0.12"
     ora "^5.4.1"
 
-"@react-native-community/cli-platform-ios@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.6.2.tgz#90ba76abb4cd5518495f25de13d4062dffb28eaa"
-  integrity sha512-DSL0HISKYTtyr9M2wdMQT89ZCWGfi7UbKYMXY7/B+PEcOXEUuOwcANqfNsO0nHLX9TGpoYYI9djk9YIsDDGqZQ==
+"@react-native-community/cli-platform-ios@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.6.3.tgz#24cac82b322ec1b3284d18031ddf4948deb3363f"
+  integrity sha512-Uf4IX33tcPPl0R4EUHcAISlcukr9GqQea6K6kBxRXK3orYexftrnUyJs3WsGEN3NPaQzxae8mWujBH2R5FtoHg==
   dependencies:
-    "@react-native-community/cli-platform-apple" "13.6.2"
+    "@react-native-community/cli-platform-apple" "13.6.3"
 
-"@react-native-community/cli-server-api@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-13.6.2.tgz#27ba135d90435c5af2af6c951b54acea61412e33"
-  integrity sha512-RKFx1s4vo+lLVQ7afiryCBfebLjvxF1HygcTchtWk0ttZQuT62/aMAf/LTxyHfBUNcqrYr+DAfD/Sd7VAfDO6Q==
+"@react-native-community/cli-server-api@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-13.6.3.tgz#b735b3c3aec9fe30c5e6861eee3728c138031ce1"
+  integrity sha512-3JEhMsGZrC+UCnYnj7le+mh4NRT2DmDcX8ZVWiDfKV3kJJ2KOUUSwyR9zdi0byJXIVkfiA2qleUXJVLHW8WqZg==
   dependencies:
-    "@react-native-community/cli-debugger-ui" "13.6.2"
-    "@react-native-community/cli-tools" "13.6.2"
+    "@react-native-community/cli-debugger-ui" "13.6.3"
+    "@react-native-community/cli-tools" "13.6.3"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.1"
@@ -2492,10 +2492,10 @@
     serve-static "^1.13.1"
     ws "^7.5.1"
 
-"@react-native-community/cli-tools@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-13.6.2.tgz#dec0351c381e33157b80aa59c842c465e0102476"
-  integrity sha512-wOU6Us3un3chrbkDzaREF/fGysVe8fJYwB8YJXUy+HfMDS9bpxHoxp9C7IXt3QmI/OZdKrEJSgauFYSpkYnKkQ==
+"@react-native-community/cli-tools@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-13.6.3.tgz#b2f8cf06dfa2687ca8a2a1d5b9159b783c98e23f"
+  integrity sha512-hWyjJAHignBNbBj1GZdDtzLGrmEkYwvmmFsedVJflm9aSqRHZ4my2gyRj54r5EhWK2DjCE1ZfO/5nmNpoIv7mQ==
   dependencies:
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
@@ -2509,26 +2509,26 @@
     shell-quote "^1.7.3"
     sudo-prompt "^9.0.0"
 
-"@react-native-community/cli-types@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-13.6.2.tgz#0ef977d5f032500a8f671da9683592871c0dc74a"
-  integrity sha512-kxbFqTW9+xOhzLZyl+zV6KW5vmHPKoYg3LPrt9sLv7/EqyTk/30PZeI8QlHjboj8r28idOrcCxR1raaSV2qkAA==
+"@react-native-community/cli-types@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-13.6.3.tgz#06215dee91b96d60d5e1a9e83669305c0bfac0d4"
+  integrity sha512-giiq+JJc5nO8DVDZKd8shWVdy/cGI1u2QHZhHmAYqBSkGfXYLel8YZKL9jpImUUWhm5dLcR9p5Oovq/ZDHB5vQ==
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@13.6.2":
-  version "13.6.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-13.6.2.tgz#3a44aa38a87a35f3b5933d8bad8e08e939405fd4"
-  integrity sha512-ghOJ4WqKb4+Q4Yqk2YagZVZGP2UbCsIB5fPaYUKp5Cc1ExoS517LmizZNKbBQJKSFz1Zu09lRHFTd7r6Ex32HA==
+"@react-native-community/cli@13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-13.6.3.tgz#acefe0a320d3ce372915f6a0c2360ae39a29efdc"
+  integrity sha512-zIKatLE5D45fnZAanWuzNhUJ7EAjeGV/i56K+B2zLkzlwRthobXjd2Jskq4/dOAd364Okl8/R6eK+pJzoVZPUQ==
   dependencies:
-    "@react-native-community/cli-clean" "13.6.2"
-    "@react-native-community/cli-config" "13.6.2"
-    "@react-native-community/cli-debugger-ui" "13.6.2"
-    "@react-native-community/cli-doctor" "13.6.2"
-    "@react-native-community/cli-hermes" "13.6.2"
-    "@react-native-community/cli-server-api" "13.6.2"
-    "@react-native-community/cli-tools" "13.6.2"
-    "@react-native-community/cli-types" "13.6.2"
+    "@react-native-community/cli-clean" "13.6.3"
+    "@react-native-community/cli-config" "13.6.3"
+    "@react-native-community/cli-debugger-ui" "13.6.3"
+    "@react-native-community/cli-doctor" "13.6.3"
+    "@react-native-community/cli-hermes" "13.6.3"
+    "@react-native-community/cli-server-api" "13.6.3"
+    "@react-native-community/cli-tools" "13.6.3"
+    "@react-native-community/cli-types" "13.6.3"
     chalk "^4.1.2"
     commander "^9.4.1"
     deepmerge "^4.3.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes `init` command when using older Yarn Classic versions: https://github.com/react-native-community/cli/pull/2329

## Changelog:


[GENERAL] [CHANGED] - Upgrade `@react-native-community/cli` to 13.6.3


## Test Plan:

CI