### PR TITLE
Warn users if XCode is too old

### DIFF
--- a/.circleci/configurations/executors.yml
+++ b/.circleci/configurations/executors.yml
@@ -39,7 +39,7 @@ executors:
   reactnativeios-lts:
     <<: *defaults
     macos:
-      xcode: '14.3.1'
+      xcode: '14.2.0'
     resource_class: macos.x86.medium.gen2
     environment:
       - RCT_BUILD_HERMES_FROM_SOURCE: true

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -74,7 +74,7 @@ references:
     gems_cache_key: &gems_cache_key v1-gems-{{ checksum "Gemfile.lock" }}
     gradle_cache_key: &gradle_cache_key v3-gradle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "packages/react-native/ReactAndroid/gradle.properties" }}
     yarn_cache_key: &yarn_cache_key v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}
-    rbenv_cache_key: &rbenv_cache_key v1-rbenv-{{ checksum "/tmp/required_ruby" }}
+    rbenv_cache_key: &rbenv_cache_key v2-rbenv-{{ checksum "/tmp/required_ruby" }}
     hermes_workspace_cache_key: &hermes_workspace_cache_key v5-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
     hermes_workspace_debug_cache_key: &hermes_workspace_debug_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_workspace_release_cache_key: &hermes_workspace_release_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
@@ -95,8 +95,8 @@ references:
     rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v10-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
 
     # Cocoapods - Template
-    template_cocoapods_cache_key: &template_cocoapods_cache_key v6-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
-    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v6-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
+    template_cocoapods_cache_key: &template_cocoapods_cache_key v7-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
+    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v7-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
 
   cache_paths:
     hermes_workspace_macos_cache_paths: &hermes_workspace_macos_cache_paths

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -41,6 +41,10 @@ module Helpers
             return '13.4'
         end
 
+        def self.min_xcode_version_supported
+            return '14.3'
+        end
+
         def self.folly_config
             return {
                 :version => '2024.01.01.00',

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -407,19 +407,39 @@ class ReactNativePodsUtils
     def self.is_using_xcode15_0(xcodebuild_manager: Xcodebuild)
         xcodebuild_version = xcodebuild_manager.version
 
+        if version = self.parse_xcode_version(xcodebuild_version)
+            return version["major"] == 15 && version["minor"] == 0
+        end
+
+        return false
+    end
+
+    def self.parse_xcode_version(version_string)
         # The output of xcodebuild -version is something like
         # Xcode 15.0
         # or
         # Xcode 14.3.1
         # We want to capture the version digits
-        regex = /(\d+)\.(\d+)(?:\.(\d+))?/
-        if match_data = xcodebuild_version.match(regex)
-            major = match_data[1].to_i
-            minor = match_data[2].to_i
-            return major == 15 && minor == 0
+        match = version_string.match(/(\d+)\.(\d+)(?:\.(\d+))?/)
+        return nil if match.nil?
+
+        return {"str" => match[0], "major" => match[1].to_i, "minor" => match[2].to_i};
+    end
+
+    def self.check_minimum_required_xcode(xcodebuild_manager: Xcodebuild)
+        version = self.parse_xcode_version(xcodebuild_manager.version)
+        if (version.nil? || !Gem::Version::correct?(version["str"]))
+            Pod::UI.warn "Unexpected XCode version string '#{xcodebuild_manager.version}'"
+            return
         end
 
-        return false
+        current = version["str"]
+        min_required = Helpers::Constants.min_xcode_version_supported
+
+        if Gem::Version::new(current) < Gem::Version::new(min_required)
+            Pod::UI.puts "React Native requires XCode >= #{min_required}. Found #{current}.".red
+            raise "Please upgrade XCode"
+        end
     end
 
     def self.add_compiler_flag_to_project(installer, flag, configuration: nil)

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -80,6 +80,8 @@ def use_react_native! (
   ENV['APP_PATH'] = app_path
   ENV['REACT_NATIVE_PATH'] = path
 
+  ReactNativePodsUtils.check_minimum_required_xcode()
+
   # Current target definition is provided by Cocoapods and it refers to the target
   # that has invoked the `use_react_native!` function.
   ReactNativePodsUtils.detect_use_frameworks(current_target_definition)


### PR DESCRIPTION
Summary:
Fail the build early if user's version of XCode is too old to avoid cryptic errors.

Changelog:
[iOS][Changed] - Warn users if XCode is too old

Differential Revision: D55149636


