### PR TITLE
Expose ReactDelegate for react-native-restart

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -83,6 +83,7 @@ public abstract class com/facebook/react/ReactActivity : androidx/appcompat/app/
 	protected fun <init> ()V
 	protected fun createReactActivityDelegate ()Lcom/facebook/react/ReactActivityDelegate;
 	protected fun getMainComponentName ()Ljava/lang/String;
+	public fun getReactDelegate ()V
 	protected final fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	protected final fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 	public fun invokeDefaultOnBackPressed ()V
@@ -113,6 +114,7 @@ public class com/facebook/react/ReactActivityDelegate {
 	protected fun getLaunchOptions ()Landroid/os/Bundle;
 	public fun getMainComponentName ()Ljava/lang/String;
 	protected fun getPlainActivity ()Landroid/app/Activity;
+	protected fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;
 	public fun getReactHost ()Lcom/facebook/react/ReactHost;
 	public fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	protected fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -65,6 +65,10 @@ public abstract class ReactActivity extends AppCompatActivity
     mDelegate.onDestroy();
   }
 
+  public void getReactDelegate() {
+    mDelegate.getReactDelegate();
+  }
+
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -87,6 +87,10 @@ public class ReactActivityDelegate {
     return ((ReactApplication) getPlainActivity().getApplication()).getReactHost();
   }
 
+  protected @Nullable ReactDelegate getReactDelegate() {
+    return mReactDelegate;
+  }
+
   public ReactInstanceManager getReactInstanceManager() {
     return mReactDelegate.getReactInstanceManager();
   }


### PR DESCRIPTION
Summary:
Supported `reload()` in Bridgeless through ReactDelegate in https://github.com/facebook/react-native/pull/43521 in order to unblock react-native-restart

https://github.com/avishayil/react-native-restart/blob/134cabd5b3f355ffe551e5dd1be1dd46d870fe13/android/src/main/java/com/reactnativerestart/RestartModule.java#L54

which can access React Delegate through :
```
if(currentActivity instanceof ReactActivity) {
    ReactActivity reactActivity = (ReactActivity) currentActivity;
    ReactDelegate reactDelegate = reactActivity.getReactDelegate();
    reactDelegate.reload()
}
```

Changelog:
[Android][Added] Expose ReactDelegate in ReactActivity

Differential Revision: D55166962


