### PR TITLE
Create a universal way to force-enable Fusebox at Buck build time

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -37,10 +37,19 @@ void InspectorFlags::dangerouslyResetFlags() {
 const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
     const {
   InspectorFlags::Values newValues = {
-      .enableCxxInspectorPackagerConnection = ReactNativeFeatureFlags::
-          inspectorEnableCxxInspectorPackagerConnection(),
+      .enableCxxInspectorPackagerConnection =
+#ifdef REACT_NATIVE_FORCE_ENABLE_FUSEBOX
+          true,
+#else
+          ReactNativeFeatureFlags::
+              inspectorEnableCxxInspectorPackagerConnection(),
+#endif
       .enableModernCDPRegistry =
+#ifdef REACT_NATIVE_FORCE_ENABLE_FUSEBOX
+          true,
+#else
           ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry(),
+#endif
   };
 
   if (cachedValues_.has_value() && !inconsistentFlagsStateLogged_) {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a way of enabling the Fusebox backend in React Native regardless of the corresponding feature flags. This is only supported in the Buck build and not intended for use in OSS.

Differential Revision: D55144502


