### PR TITLE
feat: allow use of RCTRootViewFactory from Swift

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -152,6 +152,8 @@ typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *modu
 - (instancetype)initWithConfiguration:(RCTRootViewFactoryConfiguration *)configuration
         andTurboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate;
 
+- (instancetype)initWithConfiguration:(RCTRootViewFactoryConfiguration *)configuration;
+
 /**
  * This method can be used to create new RCTRootViews on demand.
  *

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -113,6 +113,11 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
   return self;
 }
 
+- (instancetype)initWithConfiguration:(RCTRootViewFactoryConfiguration *)configuration
+{
+  return [self initWithConfiguration:configuration andTurboModuleManagerDelegate:nil];
+}
+
 - (UIView *)viewWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties
 {
   return [self viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:nil];


### PR DESCRIPTION
## Summary:

The goal of this PR is to allow the usage of `RCTRootViewFactory` from Swift. The issue with `RCTTurboModuleManager.h` is that it uses C++ in its header file, which is not allowed in Swift, making this initializer unavailable. 

This PR allows users to just pass configuration + adds a nullable annotation to bundleURL.

Example usage: 

```swift
import Foundation
import UIKit
import React
import React_RCTAppDelegate

@main
class AppDelegate: NSObject, UIApplicationDelegate {
  var window: UIWindow?
  private var rootViewFactory: RCTRootViewFactory?
  
  func application(
    _ application: UIApplication,
    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
  ) -> Bool {
   
    // Create config
    let config = RCTRootViewFactoryConfiguration(
      bundleURL: self.bundleURL(),
      newArchEnabled: true,
      turboModuleEnabled: true,
      bridgelessEnabled: false
    )
    
    // Create rootview factory
    rootViewFactory = RCTRootViewFactory(configuration: config)
    
    // Create rootview
    let rootView = rootViewFactory?.view(withModuleName: "RN0740RC4")
    let rootViewController = UIViewController()
    rootViewController.view = rootView
    
    // Create window and assign view controller
    window = UIWindow(frame: UIScreen.main.bounds)
    window?.rootViewController = rootViewController;
    window?.makeKeyAndVisible()
    
    return true
  }
  
  func bundleURL() -> URL? {
    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
  }
}
```

## Changelog:

[IOS] [FIXED] - Allow usage of `RCTRootViewFactory` from Swift

## Test Plan:

CI Green, check usage of initializer without turbo module delegate