### PR TITLE
Implement multiple view manager lookup for the interop layer on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerRegistry.java
@@ -53,13 +53,27 @@ public final class ViewManagerRegistry implements ComponentCallbacks2 {
    * @return the {@link ViewManager} registered to the className received as a parameter
    */
   public synchronized ViewManager get(String className) {
+    // 1. Try to get the manager without the prefix.
     ViewManager viewManager = mViewManagers.get(className);
     if (viewManager != null) {
       return viewManager;
     }
+
+    // 2. Try to get the manager with the RCT prefix.
+    String rctViewManagerName = "RCT" + className;
+    viewManager = mViewManagers.get(rctViewManagerName);
+    if (viewManager != null) {
+      return viewManager;
+    }
     if (mViewManagerResolver != null) {
+      // 1. Try to get the manager without the prefix.
       viewManager = getViewManagerFromResolver(className);
       if (viewManager != null) return viewManager;
+
+      // 2. Try to get the manager with the RCT prefix.
+      viewManager = getViewManagerFromResolver(rctViewManagerName);
+      if (viewManager != null) return viewManager;
+
       throw new IllegalViewOperationException(
           "ViewManagerResolver returned null for "
               + className


### PR DESCRIPTION
## Summary:

When running with the new architurece and using the renderer interop layer on Android, view managers don't work if their names start with `RCT`. This happens because the `RCT` prefix is automatically removed from the component name, and inside the internal `mViewManagers` we store view managers with the `RCT` prefix.

Using the `RCT` pattern as a prefix works fine with the old architecture and is actually used on the [Android Native UI Components](https://reactnative.dev/docs/next/native-components-android) tutorial in the docs, making me believe that this same patterns is used across many community libraries. 

This diff adds a secondary lookup logic for view managers:

1. We look for the XXXViewManager.
2. If not found, we look for RCTXXXViewManager. 


Quite similar to the iOS implementation introduced in  https://github.com/facebook/react-native/pull/38093

--- 

With this change we can also remove most of the entries from FabricNameComponentMapping (I can address this in a follow up PR)

https://github.com/facebook/react-native/blob/4e6eba7a2dedaa855af0bff5df3bec73a95f0fc4/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/FabricNameComponentMapping.java#L22-L45
 

## Changelog:

[ANDROID] [ADDED] - Implement multiple view manager lookup for the interop layer 


## Test Plan:

Tested installing a library such as [react-native-fbsdk-next](https://github.com/thebergamo/react-native-fbsdk-next) that names its view managers starting with `RCT`

<table>
<tr>
  <th>Before</th>
  <th>After</th>
</tr>
<tr>
<td> 
<img width="519" alt="image" src="https://github.com/facebook/react-native/assets/11707729/123de1d6-f018-424b-b6ce-38221af9d83e">
</td>
<td><img width="519" alt="image" src="https://github.com/facebook/react-native/assets/11707729/0f35b369-e2e4-4bbf-b880-6471fbc05d38">
</td>
</tr>
</table>



