### PR TITLE
Avoid TextInput example styles causing non-deterministic rendering on iOS

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.BlendMode;
 import android.graphics.BlendModeColorFilter;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -34,6 +35,7 @@ import androidx.autofill.HintConstants;
 import androidx.core.content.ContextCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.R;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
@@ -589,6 +591,27 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   @ReactProp(name = "cursorColor", customType = "Color")
   public void setCursorColor(ReactEditText view, @Nullable Integer color) {
+    view.setTag(R.id.cursor_color, color);
+    updateCursorDrawable(view);
+  }
+
+  private void updateCursorDrawable(ReactEditText view) {
+    if (view.getStagedInputType() == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+        && shouldHideCursorForEmailTextInput()) {
+      return;
+    }
+
+    @Nullable Boolean caretHiddenTag = (Boolean) view.getTag(R.id.caret_hidden);
+    boolean caretHidden = caretHiddenTag != null && caretHiddenTag;
+    view.setCursorVisible(!caretHidden);
+
+    @Nullable
+    Integer cursorColor =
+        caretHidden ? Color.TRANSPARENT : (Integer) view.getTag(R.id.cursor_color);
+    setCursorDrawableColor(view, cursorColor);
+  }
+
+  private void setCursorDrawableColor(ReactEditText view, @Nullable Integer color) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       Drawable cursorDrawable = view.getTextCursorDrawable();
       if (cursorDrawable != null) {
@@ -650,11 +673,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   @ReactProp(name = "caretHidden", defaultBoolean = false)
   public void setCaretHidden(ReactEditText view, boolean caretHidden) {
-    if (view.getStagedInputType() == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
-        && shouldHideCursorForEmailTextInput()) {
-      return;
-    }
-    view.setCursorVisible(!caretHidden);
+    view.setTag(R.id.caret_hidden, caretHidden);
+    updateCursorDrawable(view);
   }
 
   @ReactProp(name = "contextMenuHidden", defaultBoolean = false)

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -56,4 +56,11 @@
 
   <!-- tag is used to invalidate transform style in view manager -->
   <item type="id" name="invalidate_transform"/>
+
+  <!-- tag is used to store cursor color-->
+  <item type="id" name="cursor_color"/>
+
+  <!-- tag is used to store whether caret is hidden-->
+  <item type="id" name="caret_hidden"/>
+
 </resources>

--- a/packages/rn-tester/js/components/RNTesterTextInput.js
+++ b/packages/rn-tester/js/components/RNTesterTextInput.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+import type {PressEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+
+const React = require('react');
+const {Pressable, StyleSheet, Text} = require('react-native');
+
+type Props = $ReadOnly<{|
+  testID?: string,
+  textTestID?: string,
+  children?: React.Node,
+  onPress?: ?(event: PressEvent) => mixed,
+|}>;
+
+class RNTesterButton extends React.Component<Props> {
+  render(): React.Node {
+    return (
+      <Pressable
+        testID={this.props.testID}
+        onPress={this.props.onPress}
+        style={({pressed}) => [styles.button, pressed && styles.pressed]}>
+        <Text testID={this.props.textTestID}>{this.props.children}</Text>
+      </Pressable>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  button: {
+    borderColor: '#696969',
+    borderRadius: 8,
+    borderWidth: 1,
+    padding: 10,
+    margin: 5,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#d3d3d3',
+  },
+  pressed: {
+    backgroundColor: '#a9a9a9',
+  },
+});
+
+module.exports = RNTesterButton;

--- a/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
+++ b/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {RNTesterThemeContext} from '../../components/RNTesterTheme';
+import React, {forwardRef, useContext} from 'react';
+import {StyleSheet, TextInput} from 'react-native';
+
+const ExampleTextInput: React.AbstractComponent<
+  React.ElementConfig<typeof TextInput>,
+  $ReadOnly<{|
+    ...React.ElementRef<typeof TextInput>,
+  |}>,
+> = forwardRef((props, ref) => {
+  const theme = useContext(RNTesterThemeContext);
+
+  return (
+    <TextInput
+      ref={ref}
+      {...props}
+      style={[
+        {
+          color: theme.LabelColor,
+          backgroundColor: theme.SecondaryGroupedBackgroundColor,
+          borderColor: theme.QuaternaryLabelColor,
+        },
+        styles.input,
+        props.style,
+      ]}
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  input: {
+    borderWidth: 1,
+    fontSize: 13,
+    flexGrow: 1,
+    flexShrink: 1,
+    padding: 4,
+  },
+});
+
+export default ExampleTextInput;

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -15,9 +15,11 @@ import type {
   RNTesterModuleExample,
 } from '../../types/RNTesterTypes';
 
+import ExampleTextInput from './ExampleTextInput';
+
 const TextInputSharedExamples = require('./TextInputSharedExamples.js');
 const React = require('react');
-const {StyleSheet, Switch, Text, TextInput, View} = require('react-native');
+const {StyleSheet, Switch, Text, View} = require('react-native');
 
 class ToggleDefaultPaddingExample extends React.Component<
   $FlowFixMeProps,
@@ -32,7 +34,7 @@ class ToggleDefaultPaddingExample extends React.Component<
   render(): React.Node {
     return (
       <View>
-        <TextInput style={this.state.hasPadding ? {padding: 0} : null} />
+        <ExampleTextInput style={this.state.hasPadding ? {padding: 0} : null} />
         <Text
           onPress={() => this.setState({hasPadding: !this.state.hasPadding})}>
           Toggle padding
@@ -103,7 +105,7 @@ class AutogrowingTextInputExample extends React.Component<{...}> {
         {/* $FlowFixMe(>=0.122.0 site=react_native_android_fb) This comment
          * suppresses an error found when Flow v0.122.0 was deployed. To see
          * the error, delete this comment and run Flow. */}
-        <TextInput
+        <ExampleTextInput
           /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was
            * found when making Flow check .android.js files. */
           multiline={this.state.multiline}
@@ -143,13 +145,6 @@ const styles = StyleSheet.create({
   singleLineWithHeightTextInput: {
     height: 30,
   },
-  default: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#0f0f0f',
-    flex: 1,
-    fontSize: 13,
-    padding: 4,
-  },
 });
 
 const examples: Array<RNTesterModuleExample> = [
@@ -159,33 +154,33 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             style={[styles.singleLine]}
             defaultValue="Default color text"
           />
-          <TextInput
+          <ExampleTextInput
             style={[styles.singleLine, {color: 'green'}]}
             defaultValue="Green Text"
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="Default placeholder text color"
             style={styles.singleLine}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="Red placeholder text color"
             placeholderTextColor="red"
             style={styles.singleLine}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="Default underline color"
             style={styles.singleLine}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="Blue underline color"
             style={styles.singleLine}
             underlineColorAndroid="blue"
           />
-          <TextInput
+          <ExampleTextInput
             defaultValue="Same BackgroundColor as View "
             style={[
               styles.singleLine,
@@ -194,18 +189,18 @@ const examples: Array<RNTesterModuleExample> = [
             <Text style={{backgroundColor: 'rgba(100, 100, 100, 0.3)'}}>
               Darker backgroundColor
             </Text>
-          </TextInput>
-          <TextInput
+          </ExampleTextInput>
+          <ExampleTextInput
             defaultValue="Selection Color is red"
             selectionColor={'red'}
             style={styles.singleLine}
           />
-          <TextInput
+          <ExampleTextInput
             defaultValue="Selection handles are red"
             selectionHandleColor={'red'}
             style={styles.singleLine}
           />
-          <TextInput
+          <ExampleTextInput
             defaultValue="Cursor Color is red"
             cursorColor={'red'}
             style={styles.singleLine}
@@ -219,7 +214,7 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             defaultValue="Font Weight (default)"
             style={[styles.singleLine]}
           />
@@ -236,7 +231,7 @@ const examples: Array<RNTesterModuleExample> = [
             '200',
             '100',
           ].map(fontWeight => (
-            <TextInput
+            <ExampleTextInput
               defaultValue={`Font Weight (${fontWeight})`}
               key={fontWeight}
               style={[styles.singleLine, {fontWeight}]}
@@ -250,7 +245,7 @@ const examples: Array<RNTesterModuleExample> = [
     title: 'Text input, themes and heights',
     render: function (): React.Node {
       return (
-        <TextInput
+        <ExampleTextInput
           placeholder="If you set height, beware of padding set from themes"
           style={[styles.singleLineWithHeightTextInput]}
         />
@@ -262,19 +257,19 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             style={[styles.singleLine, {letterSpacing: 0}]}
             placeholder="letterSpacing = 0"
           />
-          <TextInput
+          <ExampleTextInput
             style={[styles.singleLine, {letterSpacing: 2}]}
             placeholder="letterSpacing = 2"
           />
-          <TextInput
+          <ExampleTextInput
             style={[styles.singleLine, {letterSpacing: 9}]}
             placeholder="letterSpacing = 9"
           />
-          <TextInput
+          <ExampleTextInput
             style={[styles.singleLine, {letterSpacing: -1}]}
             placeholder="letterSpacing = -1"
           />
@@ -287,12 +282,12 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             defaultValue="iloveturtles"
             secureTextEntry={true}
             style={styles.singleLine}
           />
-          <TextInput
+          <ExampleTextInput
             secureTextEntry={true}
             style={[styles.singleLine, {color: 'red'}]}
             placeholder="color is supported too"
@@ -306,7 +301,7 @@ const examples: Array<RNTesterModuleExample> = [
     title: 'Editable',
     render: function (): React.Node {
       return (
-        <TextInput
+        <ExampleTextInput
           defaultValue="Can't touch this! (>'-')> ^(' - ')^ <('-'<) (>'-')> ^(' - ')^"
           editable={false}
           style={styles.singleLine}
@@ -319,7 +314,7 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             autoCorrect={true}
             placeholder="multiline, aligned top-left"
             placeholderTextColor="red"
@@ -329,7 +324,7 @@ const examples: Array<RNTesterModuleExample> = [
               {textAlign: 'left', textAlignVertical: 'top'},
             ]}
           />
-          <TextInput
+          <ExampleTextInput
             autoCorrect={true}
             placeholder="multiline, aligned center"
             placeholderTextColor="green"
@@ -339,7 +334,7 @@ const examples: Array<RNTesterModuleExample> = [
               {textAlign: 'center', textAlignVertical: 'center'},
             ]}
           />
-          <TextInput
+          <ExampleTextInput
             autoCorrect={true}
             multiline={true}
             style={[
@@ -350,7 +345,7 @@ const examples: Array<RNTesterModuleExample> = [
             <Text style={styles.multiline}>
               multiline with children, aligned bottom-right
             </Text>
-          </TextInput>
+          </ExampleTextInput>
         </View>
       );
     },
@@ -360,24 +355,20 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             placeholder="editable text input using editable prop"
-            style={styles.default}
             editable
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="uneditable text input using editable prop"
-            style={styles.default}
             editable={false}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="editable text input using readOnly prop"
-            style={styles.default}
             readOnly={false}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="uneditable text input using readOnly prop"
-            style={styles.default}
             readOnly
           />
         </View>
@@ -390,22 +381,22 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             numberOfLines={2}
             multiline={true}
             placeholder="Two line input using numberOfLines prop"
           />
-          <TextInput
+          <ExampleTextInput
             numberOfLines={5}
             multiline={true}
             placeholder="Five line input using numberOfLines prop"
           />
-          <TextInput
+          <ExampleTextInput
             rows={2}
             multiline={true}
             placeholder="Two line input using rows prop"
           />
-          <TextInput
+          <ExampleTextInput
             rows={5}
             multiline={true}
             placeholder="Five line input using rows prop"
@@ -443,26 +434,16 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
-            autoComplete="country"
-            placeholder="country"
-            style={styles.default}
-          />
-          <TextInput
+          <ExampleTextInput autoComplete="country" placeholder="country" />
+          <ExampleTextInput
             autoComplete="postal-address-country"
             placeholder="postal-address-country"
-            style={styles.default}
           />
-          <TextInput
+          <ExampleTextInput
             autoComplete="one-time-code"
             placeholder="one-time-code"
-            style={styles.default}
           />
-          <TextInput
-            autoComplete="sms-otp"
-            placeholder="sms-otp"
-            style={styles.default}
-          />
+          <ExampleTextInput autoComplete="sms-otp" placeholder="sms-otp" />
         </View>
       );
     },
@@ -482,7 +463,7 @@ const examples: Array<RNTesterModuleExample> = [
       const returnKeyLabels = ['Compile', 'React Native'];
       const returnKeyExamples = returnKeyTypes.map(type => {
         return (
-          <TextInput
+          <ExampleTextInput
             key={type}
             returnKeyType={type}
             placeholder={'returnKeyType: ' + type}
@@ -492,7 +473,7 @@ const examples: Array<RNTesterModuleExample> = [
       });
       const types = returnKeyLabels.map(type => {
         return (
-          <TextInput
+          <ExampleTextInput
             key={type}
             returnKeyLabel={type}
             placeholder={'returnKeyLabel: ' + type}
@@ -513,18 +494,18 @@ const examples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             inlineImageLeft="ic_menu_black_24dp"
             placeholder="This has drawableLeft set"
             style={styles.singleLine}
           />
-          <TextInput
+          <ExampleTextInput
             inlineImageLeft="ic_menu_black_24dp"
             inlineImagePadding={30}
             placeholder="This has drawableLeft and drawablePadding set"
             style={styles.singleLine}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="This does not have drawable props set"
             style={styles.singleLine}
           />

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -16,6 +16,8 @@ import type {
 } from '../../types/RNTesterTypes';
 import type {KeyboardType} from 'react-native/Libraries/Components/TextInput/TextInput';
 
+import ExampleTextInput from './ExampleTextInput';
+
 const TextInputSharedExamples = require('./TextInputSharedExamples.js');
 const React = require('react');
 const {
@@ -25,7 +27,6 @@ const {
   StyleSheet,
   Switch,
   Text,
-  TextInput,
   View,
 } = require('react-native');
 
@@ -56,8 +57,7 @@ class TextInputAccessoryViewChangeTextExample extends React.Component<
     return (
       <View>
         <Text>Set InputAccessoryView with ID & reset text:</Text>
-        <TextInput
-          style={styles.default}
+        <ExampleTextInput
           inputAccessoryViewID={inputAccessoryViewID}
           onChangeText={text => this.setState({text})}
           value={this.state.text}
@@ -97,8 +97,7 @@ class TextInputAccessoryViewChangeKeyboardExample extends React.Component<
       <View>
         <Text>Set InputAccessoryView with ID & switch keyboard:</Text>
         {/* $FlowFixMe[incompatible-use] */}
-        <TextInput
-          style={styles.default}
+        <ExampleTextInput
           inputAccessoryViewID={inputAccessoryViewID}
           onChangeText={text => this.setState({text})}
           value={this.state.text}
@@ -129,8 +128,7 @@ class TextInputAccessoryViewDefaultDoneButtonExample extends React.Component<
 
   render(): React.Node {
     return (
-      <TextInput
-        style={styles.default}
+      <ExampleTextInput
         onChangeText={text => this.setState({text})}
         value={this.state.text}
         keyboardType={this.props.keyboardType}
@@ -148,12 +146,11 @@ class RewriteExampleKana extends React.Component<$FlowFixMeProps, any> {
   render(): React.Node {
     return (
       <View style={styles.rewriteContainer}>
-        <TextInput
+        <ExampleTextInput
           multiline={false}
           onChangeText={text => {
             this.setState({text: text.replace(/ひ/g, '日')});
           }}
-          style={styles.default}
           value={this.state.text}
         />
       </View>
@@ -173,9 +170,8 @@ class SecureEntryExample extends React.Component<$FlowFixMeProps, any> {
   render(): React.Node {
     return (
       <View>
-        <TextInput
+        <ExampleTextInput
           secureTextEntry={true}
-          style={styles.default}
           defaultValue="abc"
           onChangeText={text => this.setState({text})}
           value={this.state.text}
@@ -186,8 +182,7 @@ class SecureEntryExample extends React.Component<$FlowFixMeProps, any> {
             flex: 1,
             flexDirection: 'row',
           }}>
-          <TextInput
-            style={styles.default}
+          <ExampleTextInput
             defaultValue="cde"
             onChangeText={text => this.setState({password: text})}
             secureTextEntry={this.state.isSecureTextEntry}
@@ -247,7 +242,7 @@ class AutogrowingTextInputExample extends React.Component<
         />
 
         <Text>TextInput:</Text>
-        <TextInput
+        <ExampleTextInput
           value="prop"
           multiline={this.state.multiline}
           style={[style, {width: this.state.fullWidth ? '100%' : '50%'}]}
@@ -266,20 +261,8 @@ class AutogrowingTextInputExample extends React.Component<
 }
 
 const styles = StyleSheet.create({
-  default: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#0f0f0f',
-    flex: 1,
-    fontSize: 13,
-    padding: 4,
-  },
   multiline: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#0f0f0f',
-    flex: 1,
-    fontSize: 13,
     height: 50,
-    padding: 4,
     marginBottom: 4,
   },
   multilinePlaceholderStyles: {
@@ -305,7 +288,6 @@ const styles = StyleSheet.create({
   labelContainer: {
     flexDirection: 'row',
     marginVertical: 2,
-    flex: 1,
   },
   label: {
     width: 115,
@@ -370,21 +352,18 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="singleline">
-            <TextInput style={styles.default} value="(value property)">
+            <ExampleTextInput value="(value property)">
               (first raw text node)
               <Text style={{color: 'red'}}>(internal raw text node)</Text>
               (last raw text node)
-            </TextInput>
+            </ExampleTextInput>
           </WithLabel>
           <WithLabel label="multiline">
-            <TextInput
-              style={styles.default}
-              multiline={true}
-              value="(value property)">
+            <ExampleTextInput multiline={true} value="(value property)">
               (first raw text node)
               <Text style={{color: 'red'}}>(internal raw text node)</Text>
               (last raw text node)
-            </TextInput>
+            </ExampleTextInput>
           </WithLabel>
         </View>
       );
@@ -397,7 +376,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       const examples = keyboardAppearance.map(type => {
         return (
           <WithLabel key={type} label={type}>
-            <TextInput keyboardAppearance={type} style={styles.default} />
+            <ExampleTextInput keyboardAppearance={type} />
           </WithLabel>
         );
       });
@@ -423,7 +402,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       const examples = returnKeyTypes.map(type => {
         return (
           <WithLabel key={type} label={type}>
-            <TextInput returnKeyType={type} style={styles.default} />
+            <ExampleTextInput returnKeyType={type} />
           </WithLabel>
         );
       });
@@ -436,10 +415,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="true">
-            <TextInput
-              enablesReturnKeyAutomatically={true}
-              style={styles.default}
-            />
+            <ExampleTextInput enablesReturnKeyAutomatically={true} />
           </WithLabel>
         </View>
       );
@@ -456,14 +432,8 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
-            style={[styles.default, {color: 'blue'}]}
-            defaultValue="Blue"
-          />
-          <TextInput
-            style={[styles.default, {color: 'green'}]}
-            defaultValue="Green"
-          />
+          <ExampleTextInput style={{color: 'blue'}} defaultValue="Blue" />
+          <ExampleTextInput style={{color: 'green'}} defaultValue="Green" />
         </View>
       );
     },
@@ -473,13 +443,11 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
-            style={styles.default}
+          <ExampleTextInput
             selectionColor={'green'}
             defaultValue="Highlight me"
           />
-          <TextInput
-            style={styles.default}
+          <ExampleTextInput
             selectionColor={'rgba(86, 76, 205, 1)'}
             defaultValue="Highlight me"
           />
@@ -499,11 +467,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       const examples = clearButtonModes.map(mode => {
         return (
           <WithLabel key={mode} label={mode}>
-            <TextInput
-              style={styles.default}
-              clearButtonMode={mode}
-              defaultValue={mode}
-            />
+            <ExampleTextInput clearButtonMode={mode} defaultValue={mode} />
           </WithLabel>
         );
       });
@@ -516,35 +480,31 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="clearTextOnFocus">
-            <TextInput
+            <ExampleTextInput
               placeholder="text is cleared on focus"
               defaultValue="text is cleared on focus"
-              style={styles.default}
               clearTextOnFocus={true}
             />
           </WithLabel>
           <WithLabel label="selectTextOnFocus">
-            <TextInput
+            <ExampleTextInput
               placeholder="text is selected on focus"
               defaultValue="text is selected on focus"
-              style={styles.default}
               selectTextOnFocus={true}
             />
           </WithLabel>
           <WithLabel label="clearTextOnFocus (multiline)">
-            <TextInput
+            <ExampleTextInput
               placeholder="text is cleared on focus"
               defaultValue="text is cleared on focus"
-              style={styles.default}
               clearTextOnFocus={true}
               multiline={true}
             />
           </WithLabel>
           <WithLabel label="selectTextOnFocus (multiline)">
-            <TextInput
+            <ExampleTextInput
               placeholder="text is selected on focus"
               defaultValue="text is selected on focus"
-              style={styles.default}
               selectTextOnFocus={true}
               multiline={true}
             />
@@ -558,7 +518,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             style={styles.multiline}
             placeholder="blurOnSubmit = true"
             returnKeyType="next"
@@ -577,12 +537,12 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             placeholder="multiline text input"
             multiline={true}
             style={styles.multiline}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="multiline text input with font styles and placeholder"
             multiline={true}
             clearTextOnFocus={true}
@@ -592,19 +552,19 @@ const textInputExamples: Array<RNTesterModuleExample> = [
             keyboardType="url"
             style={[styles.multiline, styles.multilineWithFontStyles]}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="multiline text input with max length"
             maxLength={5}
             multiline={true}
             style={styles.multiline}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="uneditable multiline text input"
             editable={false}
             multiline={true}
             style={styles.multiline}
           />
-          <TextInput
+          <ExampleTextInput
             defaultValue="uneditable multiline text input with phone number detection: 88888888."
             editable={false}
             multiline={true}
@@ -620,24 +580,20 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             placeholder="editable text input using editable prop"
-            style={styles.default}
             editable
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="uneditable text input using editable prop"
-            style={styles.default}
             editable={false}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="editable text input using readOnly prop"
-            style={styles.default}
             readOnly={false}
           />
-          <TextInput
+          <ExampleTextInput
             placeholder="uneditable text input using readOnly prop"
-            style={styles.default}
             readOnly
           />
         </View>
@@ -651,7 +607,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
         <View>
           <Text>Singleline TextInput</Text>
           <View style={{height: 80}}>
-            <TextInput
+            <ExampleTextInput
               style={{
                 position: 'absolute',
                 fontSize: 16,
@@ -670,7 +626,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
           </View>
           <Text>Multiline TextInput</Text>
           <View style={{height: 130}}>
-            <TextInput
+            <ExampleTextInput
               style={{
                 position: 'absolute',
                 fontSize: 16,
@@ -690,7 +646,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
             />
           </View>
           <View>
-            <TextInput
+            <ExampleTextInput
               style={{
                 fontSize: 16,
                 backgroundColor: '#eeeeee',
@@ -716,7 +672,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     render: function (): React.Node {
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             placeholder="height increases with content"
             defaultValue="React Native enables you to build world-class application experiences on native platforms using a consistent developer experience based on JavaScript and React. The focus of React Native is on developer efficiency across all the platforms you care about - learn once, write anywhere. Facebook uses React Native in multiple production apps and will continue investing in React Native."
             multiline={true}
@@ -765,28 +721,16 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="maxLength: 5">
-            <TextInput maxLength={5} style={styles.default} />
+            <ExampleTextInput maxLength={5} />
           </WithLabel>
           <WithLabel label="maxLength: 5 with placeholder">
-            <TextInput
-              maxLength={5}
-              placeholder="ZIP code entry"
-              style={styles.default}
-            />
+            <ExampleTextInput maxLength={5} placeholder="ZIP code entry" />
           </WithLabel>
           <WithLabel label="maxLength: 5 with default value already set">
-            <TextInput
-              maxLength={5}
-              defaultValue="94025"
-              style={styles.default}
-            />
+            <ExampleTextInput maxLength={5} defaultValue="94025" />
           </WithLabel>
           <WithLabel label="maxLength: 5 with very long default value already set">
-            <TextInput
-              maxLength={5}
-              defaultValue="9402512345"
-              style={styles.default}
-            />
+            <ExampleTextInput maxLength={5} defaultValue="9402512345" />
           </WithLabel>
         </View>
       );
@@ -798,16 +742,16 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="country">
-            <TextInput autoComplete="country" style={styles.default} />
+            <ExampleTextInput autoComplete="country" />
           </WithLabel>
           <WithLabel label="one-time-code">
-            <TextInput autoComplete="one-time-code" style={styles.default} />
+            <ExampleTextInput autoComplete="one-time-code" />
           </WithLabel>
           <WithLabel label="birthdate-full">
-            <TextInput autoComplete="birthdate-full" style={styles.default} />
+            <ExampleTextInput autoComplete="birthdate-full" />
           </WithLabel>
           <WithLabel label="cc-name">
-            <TextInput autoComplete="cc-name" style={styles.default} />
+            <ExampleTextInput autoComplete="cc-name" />
           </WithLabel>
         </View>
       );
@@ -819,26 +763,22 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="emailAddress">
-            <TextInput textContentType="emailAddress" style={styles.default} />
+            <ExampleTextInput textContentType="emailAddress" />
           </WithLabel>
           <WithLabel label="name">
-            <TextInput textContentType="name" style={styles.default} />
+            <ExampleTextInput textContentType="name" />
           </WithLabel>
           <WithLabel label="postalCode, when autoComplete set">
-            <TextInput
+            <ExampleTextInput
               textContentType="postalCode"
               autoComplete="email"
-              style={styles.default}
             />
           </WithLabel>
           <WithLabel label="creditCardExpiration">
-            <TextInput
-              textContentType="creditCardExpiration"
-              style={styles.default}
-            />
+            <ExampleTextInput textContentType="creditCardExpiration" />
           </WithLabel>
           <WithLabel label="birthdate">
-            <TextInput textContentType="birthdate" style={styles.default} />
+            <ExampleTextInput textContentType="birthdate" />
           </WithLabel>
         </View>
       );
@@ -850,16 +790,16 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="letterSpacing: 10 lineHeight: 20 textAlign: 'center'">
-            <TextInput
+            <ExampleTextInput
               placeholder="multiline text input"
               multiline={true}
               style={[styles.multiline, styles.multilinePlaceholderStyles]}
             />
           </WithLabel>
           <WithLabel label="letterSpacing: 10 textAlign: 'center'">
-            <TextInput
+            <ExampleTextInput
               placeholder="singleline"
-              style={[styles.default, styles.singlelinePlaceholderStyles]}
+              style={styles.singlelinePlaceholderStyles}
             />
           </WithLabel>
         </View>
@@ -872,7 +812,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="showSoftInputOnFocus: false">
-            <TextInput showSoftInputOnFocus={false} style={[styles.default]} />
+            <ExampleTextInput showSoftInputOnFocus={false} />
           </WithLabel>
         </View>
       );
@@ -901,10 +841,9 @@ const textInputExamples: Array<RNTesterModuleExample> = [
                   return (
                     <View key={code}>
                       <Text style={{fontWeight: 'bold'}}>{`[${code}]`}</Text>
-                      <TextInput
+                      <ExampleTextInput
                         multiline
                         lineBreakStrategyIOS={strategy}
-                        style={styles.default}
                         defaultValue={textByCode[code]}
                       />
                     </View>
@@ -923,12 +862,11 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <WithLabel label="smartInsertDelete: true | undefined">
-            <TextInput style={styles.default} defaultValue="CopyAndPaste" />
+            <ExampleTextInput defaultValue="CopyAndPaste" />
           </WithLabel>
           <WithLabel label="smartInsertDelete: false">
-            <TextInput
+            <ExampleTextInput
               smartInsertDelete={false}
-              style={styles.default}
               defaultValue="CopyAndPaste"
             />
           </WithLabel>
@@ -941,7 +879,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
 module.exports = ({
   displayName: (undefined: ?string),
   title: 'TextInput',
-  documentationURL: 'https://reactnative.dev/docs/textinput',
+  documentationURL: 'https://reactnative.dev/docs/ExampleTextInput',
   category: 'Basic',
   description: 'Single and multi-line text inputs.',
   examples: textInputExamples,

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -13,6 +13,8 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {TextStyle} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
+import ExampleTextInput from './ExampleTextInput';
+
 import RNTesterButton from '../../components/RNTesterButton';
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 import * as React from 'react';
@@ -27,20 +29,8 @@ import {
 } from 'react-native';
 
 const styles = StyleSheet.create({
-  default: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#0f0f0f',
-    flex: 1,
-    fontSize: 13,
-    padding: 4,
-  },
   multiline: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#0f0f0f',
-    flex: 1,
-    fontSize: 13,
     height: 50,
-    padding: 4,
     marginBottom: 4,
   },
   singleLine: {
@@ -78,11 +68,6 @@ const styles = StyleSheet.create({
   },
   focusedUncontrolled: {
     margin: -2,
-    borderWidth: 2,
-    borderColor: '#0a0a0a',
-    flex: 1,
-    fontSize: 13,
-    padding: 4,
   },
   screenshotArea: {
     position: 'absolute',
@@ -115,7 +100,7 @@ class RewriteExample extends React.Component<$FlowFixMeProps, any> {
     const remainderColor = remainder > 5 ? 'blue' : 'red';
     return (
       <View style={styles.rewriteContainer}>
-        <TextInput
+        <ExampleTextInput
           testID="rewrite_sp_underscore_input"
           autoCorrect={false}
           multiline={false}
@@ -124,7 +109,6 @@ class RewriteExample extends React.Component<$FlowFixMeProps, any> {
             text = text.replace(/ /g, '_');
             this.setState({text});
           }}
-          style={styles.default}
           value={this.state.text}
         />
         <Text style={[styles.remainder, {color: remainderColor}]}>
@@ -146,14 +130,13 @@ class RewriteExampleInvalidCharacters extends React.Component<
   render(): React.Node {
     return (
       <View style={styles.rewriteContainer}>
-        <TextInput
+        <ExampleTextInput
           testID="rewrite_no_sp_input"
           autoCorrect={false}
           multiline={false}
           onChangeText={text => {
             this.setState({text: text.replace(/\s/g, '')});
           }}
-          style={styles.default}
           value={this.state.text}
         />
       </View>
@@ -174,7 +157,7 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
   render(): React.Node {
     return (
       <View style={styles.rewriteContainer}>
-        <TextInput
+        <ExampleTextInput
           testID="rewrite_clear_input"
           autoCorrect={false}
           ref={ref => {
@@ -184,7 +167,6 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
           onChangeText={text => {
             this.setState({text: text.replace(/ /g, '')});
           }}
-          style={styles.default}
           value={this.state.text}
         />
         <Button
@@ -213,7 +195,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
   render(): React.Node {
     return (
       <View>
-        <TextInput
+        <ExampleTextInput
           ref={this.ref1}
           style={styles.singleLine}
           placeholder="blurOnSubmit = false"
@@ -221,7 +203,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
           blurOnSubmit={false}
           onSubmitEditing={() => this.ref2.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref2}
           style={styles.singleLine}
           keyboardType="email-address"
@@ -230,7 +212,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
           blurOnSubmit={false}
           onSubmitEditing={() => this.ref3.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref3}
           style={styles.singleLine}
           keyboardType="url"
@@ -239,7 +221,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
           blurOnSubmit={false}
           onSubmitEditing={() => this.ref4.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref4}
           style={styles.singleLine}
           keyboardType="numeric"
@@ -247,7 +229,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
           blurOnSubmit={false}
           onSubmitEditing={() => this.ref5.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref5}
           style={styles.singleLine}
           keyboardType="numbers-and-punctuation"
@@ -275,69 +257,73 @@ class SubmitBehaviorExample extends React.Component<{...}> {
   render(): React.Node {
     return (
       <View>
-        <TextInput
+        <ExampleTextInput
           ref={this.ref1}
           placeholder="single line submit"
           submitBehavior="submit"
           onSubmitEditing={() => this.ref2.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref2}
           placeholder="single line blurAndSubmit"
           submitBehavior="blurAndSubmit"
           onSubmitEditing={() => this.ref3.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref3}
           placeholder="single line default"
           onSubmitEditing={() => this.ref4.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref4}
           blurOnSubmit
           placeholder="single line blurOnSubmit true"
           onSubmitEditing={() => this.ref5.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref5}
           blurOnSubmit={false}
           placeholder="single line blurOnSubmit false"
           onSubmitEditing={() => this.ref6.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref6}
           multiline
           placeholder="multiline submit"
           submitBehavior="submit"
           onSubmitEditing={() => this.ref7.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref7}
           multiline
           placeholder="multiline blurAndSubmit"
           submitBehavior="blurAndSubmit"
           onSubmitEditing={() => this.ref8.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref8}
           multiline
           blurOnSubmit
           placeholder="multiline blurOnSubmit true"
           onSubmitEditing={() => this.ref9.current?.focus()}
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref9}
           multiline
           blurOnSubmit={false}
           placeholder="multiline blurOnSubmit false"
         />
-        <TextInput
+        <ExampleTextInput
           ref={this.ref10}
           multiline
           placeholder="multiline newline"
           submitBehavior="newline"
         />
-        <TextInput ref={this.ref11} multiline placeholder="multiline default" />
+        <ExampleTextInput
+          ref={this.ref11}
+          multiline
+          placeholder="multiline default"
+        />
       </View>
     );
   }
@@ -372,7 +358,7 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
   render(): React.Node {
     return (
       <View>
-        <TextInput
+        <ExampleTextInput
           autoCapitalize="none"
           placeholder="Enter text to see events"
           autoCorrect={false}
@@ -460,7 +446,7 @@ class TokenizedTextExample extends React.Component<
 
     return (
       <View style={{flexDirection: 'row'}}>
-        <TextInput
+        <ExampleTextInput
           testID="text-input"
           multiline={true}
           style={styles.multiline}
@@ -468,7 +454,7 @@ class TokenizedTextExample extends React.Component<
             this.setState({text});
           }}>
           <Text>{parts}</Text>
-        </TextInput>
+        </ExampleTextInput>
       </View>
     );
   }
@@ -540,7 +526,7 @@ class SelectionExample extends React.Component<
     return (
       <View>
         <View style={{flexDirection: 'row'}}>
-          <TextInput
+          <ExampleTextInput
             testID={`${this.props.testID}-text-input`}
             multiline={this.props.multiline}
             onChangeText={value => this.setState({value})}
@@ -591,10 +577,10 @@ function UncontrolledExample() {
   const [isFocused, setIsFocused] = React.useState(false);
 
   return (
-    <TextInput
+    <ExampleTextInput
       defaultValue="Hello World!"
       testID="uncontrolled-textinput"
-      style={isFocused ? styles.focusedUncontrolled : styles.default}
+      style={isFocused ? styles.focusedUncontrolled : undefined}
       onFocus={() => setIsFocused(true)}
       onBlur={() => setIsFocused(false)}
     />
@@ -790,11 +776,8 @@ function StyledTextInput({
   styleOffset,
 }: StyledTextInputProps) {
   return (
-    <TextInput
-      style={[
-        styles.default,
-        textStyles[(0 + styleOffset) % textStyles.length],
-      ]}
+    <ExampleTextInput
+      style={textStyles[(0 + styleOffset) % textStyles.length]}
       testID={`style-${name}`}>
       <Text>He</Text>
       <Text style={textStyles[(1 + styleOffset) % textStyles.length]}>ll</Text>
@@ -805,7 +788,7 @@ function StyledTextInput({
       <Text style={textStyles[(3 + styleOffset) % textStyles.length]}>Wo</Text>
       <Text style={textStyles[(4 + styleOffset) % textStyles.length]}>rl</Text>
       <Text style={textStyles[(5 + styleOffset) % textStyles.length]}>d!</Text>
-    </TextInput>
+    </ExampleTextInput>
   );
 }
 
@@ -815,12 +798,9 @@ function MultilineStyledTextInput({
   styleOffset,
 }: StyledTextInputProps) {
   return (
-    <TextInput
+    <ExampleTextInput
       multiline={true}
-      style={[
-        styles.default,
-        textStyles[(0 + styleOffset) % textStyles.length],
-      ]}
+      style={textStyles[(0 + styleOffset) % textStyles.length]}
       testID={`style-${name}`}>
       <Text>Hel{'\n'}</Text>
       <Text style={textStyles[(1 + styleOffset) % textStyles.length]}>
@@ -830,7 +810,7 @@ function MultilineStyledTextInput({
         Wor{'\n'}
       </Text>
       <Text style={textStyles[(3 + styleOffset) % textStyles.length]}>ld!</Text>
-    </TextInput>
+    </ExampleTextInput>
   );
 }
 
@@ -839,9 +819,8 @@ module.exports = ([
     title: 'Auto-focus',
     render: function (): React.Node {
       return (
-        <TextInput
+        <ExampleTextInput
           autoFocus={true}
-          style={styles.default}
           accessibilityLabel="I am the accessibility label for text input"
         />
       );
@@ -874,31 +853,24 @@ module.exports = ([
       return (
         <View>
           <WithLabel label="none">
-            <TextInput
-              testID="capitalize-none"
-              autoCapitalize="none"
-              style={styles.default}
-            />
+            <ExampleTextInput testID="capitalize-none" autoCapitalize="none" />
           </WithLabel>
           <WithLabel label="sentences">
-            <TextInput
+            <ExampleTextInput
               testID="capitalize-sentences"
               autoCapitalize="sentences"
-              style={styles.default}
             />
           </WithLabel>
           <WithLabel label="words">
-            <TextInput
+            <ExampleTextInput
               testID="capitalize-words"
               autoCapitalize="words"
-              style={styles.default}
             />
           </WithLabel>
           <WithLabel label="characters">
-            <TextInput
+            <ExampleTextInput
               testID="capitalize-characters"
               autoCapitalize="characters"
-              style={styles.default}
             />
           </WithLabel>
         </View>
@@ -911,10 +883,10 @@ module.exports = ([
       return (
         <View>
           <WithLabel label="true">
-            <TextInput autoCorrect={true} style={styles.default} />
+            <ExampleTextInput autoCorrect={true} />
           </WithLabel>
           <WithLabel label="false">
-            <TextInput autoCorrect={false} style={styles.default} />
+            <ExampleTextInput autoCorrect={false} />
           </WithLabel>
         </View>
       );
@@ -942,7 +914,7 @@ module.exports = ([
       const examples = keyboardTypes.map(type => {
         return (
           <WithLabel key={type} label={type}>
-            <TextInput keyboardType={type} style={styles.default} />
+            <ExampleTextInput keyboardType={type} />
           </WithLabel>
         );
       });
@@ -966,7 +938,7 @@ module.exports = ([
       const examples = inputMode.map(mode => {
         return (
           <WithLabel key={mode} label={mode}>
-            <TextInput inputMode={mode} style={styles.default} />
+            <ExampleTextInput inputMode={mode} />
           </WithLabel>
         );
       });
@@ -995,7 +967,7 @@ module.exports = ([
       const examples = enterKeyHintTypesHints.map(hint => {
         return (
           <WithLabel key={hint} label={hint}>
-            <TextInput enterKeyHint={hint} style={styles.default} />
+            <ExampleTextInput enterKeyHint={hint} />
           </WithLabel>
         );
       });
@@ -1022,32 +994,32 @@ module.exports = ([
 
       return (
         <View>
-          <TextInput
+          <ExampleTextInput
             style={[styles.singleLine, {fontFamily: fontFamilyA}]}
             placeholder={`Custom fonts like ${fontFamilyA} are supported`}
           />
-          <TextInput
+          <ExampleTextInput
             style={[
               styles.singleLine,
               {fontFamily: fontFamilyA, fontWeight: 'bold'},
             ]}
             placeholder={`${fontFamilyA} bold`}
           />
-          <TextInput
+          <ExampleTextInput
             style={[
               styles.singleLine,
               {fontFamily: fontFamilyA, fontWeight: '500'},
             ]}
             placeholder={`${fontFamilyA} 500`}
           />
-          <TextInput
+          <ExampleTextInput
             style={[
               styles.singleLine,
               {fontFamily: fontFamilyA, fontStyle: 'italic'},
             ]}
             placeholder={`${fontFamilyA} italic`}
           />
-          <TextInput
+          <ExampleTextInput
             style={[styles.singleLine, {fontFamily: fontFamilyB}]}
             placeholder={fontFamilyB}
           />
@@ -1070,7 +1042,6 @@ module.exports = ([
         <View>
           <SelectionExample
             testID="singleline"
-            style={styles.default}
             value="text selection can be changed"
           />
           <SelectionExample
@@ -1091,7 +1062,6 @@ module.exports = ([
         <View>
           <SelectionExample
             testID="singlelineImperative"
-            style={styles.default}
             value="text selection can be changed imperatively"
             imperative={true}
           />


### PR DESCRIPTION
Summary:
iOS E2E tests non-deterministic rendering happens around examples with a border set to `StyleSheet.hairlineWidth`. That value has special subpixel math, that doesn't seem to render consistently on iOS (this is its own bug).

To unblock adding some new E2E iOS TextInput tests, this removes usage of `hairlineWidth` in styles, and more generally, tries to unify TextInput styles in the examples.

This will break a whole bunch of RNTester Jest E2E baselines on different apps, which I will update from land-time runs or after continuous builds are available for different endpoints.

Changelog: [Internal]

Differential Revision: D55213090


