### PR TITLE
decouple RCTBridge+Private from jsinspector-modern

### DIFF
--- a/packages/react-native/React/Base/RCTBridge+Inspector.h
+++ b/packages/react-native/React/Base/RCTBridge+Inspector.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTBridge.h>
+
+#ifdef __cplusplus
+#import <jsinspector-modern/ReactCdp.h>
+#endif
+
+@interface RCTBridge (Inspector)
+
+/**
+ * The HostTarget for this bridge, if one has been created. Exposed for RCTCxxBridge only.
+ */
+@property (nonatomic, assign, readonly)
+#ifdef __cplusplus
+    facebook::react::jsinspector_modern::HostTarget *
+#else
+    // The inspector infrastructure cannot be used in C or Swift code.
+    void *
+#endif
+        inspectorTarget;
+
+@property (nonatomic, readonly, getter=isInspectable) BOOL inspectable;
+
+@end

--- a/packages/react-native/React/Base/RCTBridge+Private.h
+++ b/packages/react-native/React/Base/RCTBridge+Private.h
@@ -6,9 +6,6 @@
  */
 
 #import <React/RCTBridge.h>
-#ifdef __cplusplus
-#import <jsinspector-modern/ReactCdp.h>
-#endif
 
 @class RCTModuleRegistry;
 @class RCTModuleData;
@@ -73,17 +70,6 @@ RCT_EXTERN void RCTRegisterModule(Class);
  */
 @property (nonatomic, strong, readonly) RCTModuleRegistry *moduleRegistry;
 
-/**
- * The HostTarget for this bridge, if one has been created. Exposed for RCTCxxBridge only.
- */
-@property (nonatomic, assign, readonly)
-#ifdef __cplusplus
-    facebook::react::jsinspector_modern::HostTarget *
-#else
-    // The inspector infrastructure cannot be used in C code.
-    void *
-#endif
-        inspectorTarget;
 @end
 
 @interface RCTBridge (RCTCxxBridge)
@@ -152,12 +138,6 @@ RCT_EXTERN void RCTRegisterModule(Class);
  * Allow super fast, one time, timers to skip the queue and be directly executed
  */
 - (void)_immediatelyCallTimer:(NSNumber *)timer;
-
-@end
-
-@interface RCTBridge (Inspector)
-
-@property (nonatomic, readonly, getter=isInspectable) BOOL inspectable;
 
 @end
 

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTBridge.h"
+#import "RCTBridge+Inspector.h"
 #import "RCTBridge+Private.h"
 
 #import <objc/runtime.h>

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -10,6 +10,7 @@
 #import <objc/runtime.h>
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
+#import <React/RCTBridge+Inspector.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConstants.h>

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -9,6 +9,7 @@
 #include <future>
 
 #import <React/RCTAssert.h>
+#import <React/RCTBridge+Inspector.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeMethod.h>

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -11,6 +11,7 @@
 
 #import <React/NSDataBigString.h>
 #import <React/RCTAssert.h>
+#import <React/RCTBridge+Inspector.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>


### PR DESCRIPTION
Summary:
Changelog: [Internal]

fix for part of https://github.com/facebook/react-native/issues/43204

RCTBridge+Private is transitively bringing in boost in 0.74, which is causing build errors for some libs that were originally depending on it. this is because boost is a special pod that needs separate handling to link correctly.

let's simplify this problem by decoupling this header and moving the inspector specific logic into it's own category.

Differential Revision: D55228474


