### PR TITLE
Update INTERNAL_CALLSITES_REGEX

### DIFF
--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -56,6 +56,12 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
       ],
       // $FlowFixMe[untyped-import]
       getPolyfills: () => require('@react-native/js-polyfills')(),
+      isThirdPartyModule({path: modulePath}: $ReadOnly<{path: string, ...}>) {
+        return (
+          INTERNAL_CALLSITES_REGEX.test(modulePath) ||
+          /(?:^|[/\\])node_modules[/\\]/.test(modulePath)
+        );
+      },
     },
     server: {
       port: Number(process.env.RCT_METRO_PORT) || 8081,

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -27,6 +27,7 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
     '/Libraries/YellowBox/.+\\.js$',
     '/metro-runtime/.+\\.js$',
     '/node_modules/@babel/runtime/.+\\.js$',
+    '/node_modules/@react-native/js-polyfills/.+\\.js$',
     '/node_modules/event-target-shim/.+\\.js$',
     '/node_modules/invariant/.+\\.js$',
     '/node_modules/react-devtools-core/.+\\.js$',


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Syncs the internal and OSS versions of `INTERNAL_CALLSITES_REGEX` in the default RN Metro config.

Differential Revision: D55237394


