### PR TITLE
Add internal call sites to x_google_ignoreList

### DIFF
--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -56,6 +56,12 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
       ],
       // $FlowFixMe[untyped-import]
       getPolyfills: () => require('@react-native/js-polyfills')(),
+      isThirdPartyModule({path: modulePath}: $ReadOnly<{path: string, ...}>) {
+        return (
+          INTERNAL_CALLSITES_REGEX.test(modulePath) ||
+          /(?:^|[/\\])node_modules[/\\]/.test(modulePath)
+        );
+      },
     },
     server: {
       port: Number(process.env.RCT_METRO_PORT) || 8081,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Leverages https://developer.chrome.com/docs/devtools/x-google-ignore-list to mark more internal files as "third party", thus collapsing them by default in stack traces in modern versions of Chrome DevTools. The list of modules to collapse is the same one used by LogBox.

This likely only affects Meta usage, since Metro's default for [`isThirdPartyModule`](https://metrobundler.dev/docs/configuration/#isthirdpartymodule) already excludes all `node_modules`, but I'm making this change across Meta and OSS for consistency and to signal intent.

Differential Revision: D55236653


