### PR TITLE
Fix build from source for hermes-engine

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -211,6 +211,8 @@ android {
   }
   if (rootProject.hasProperty("ndkVersion") && rootProject.properties["ndkVersion"] != null) {
     ndkVersion = rootProject.properties["ndkVersion"].toString()
+  } else {
+    ndkVersion = libs.versions.ndkVersion.get()
   }
 
   defaultConfig {


### PR DESCRIPTION
Summary:
When users are building from source for React Native they don't have an ndkVersion variable specified. So we want to fallback to the global NDK version we set for the whole build here.

Changelog:
[Android] [Fixed] - Fix build from source for hermes-engine

Reviewed By: dmytrorykun

Differential Revision: D55240603


