### PR TITLE
Fix retain cycle in ComponentNameResolverManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/ComponentNameResolverManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/ComponentNameResolverManager.h
@@ -7,11 +7,10 @@
 
 #pragma once
 
-#include <ReactCommon/CallInvokerHolder.h>
-#include <ReactCommon/RuntimeExecutor.h>
+#include <unordered_set>
+
 #include <fbjni/fbjni.h>
 #include <react/jni/JRuntimeExecutor.h>
-#include <set>
 
 namespace facebook::react {
 
@@ -20,9 +19,6 @@ class ComponentNameResolverManager
  public:
   static auto constexpr kJavaDescriptor =
       "Lcom/facebook/react/uimanager/ComponentNameResolverManager;";
-
-  constexpr static auto ComponentNameResolverJavaDescriptor =
-      "com/facebook/react/uimanager/ComponentNameResolver";
 
   static facebook::jni::local_ref<jhybriddata> initHybrid(
       facebook::jni::alias_ref<jhybridobject> jThis,
@@ -33,18 +29,14 @@ class ComponentNameResolverManager
 
  private:
   friend HybridBase;
-  facebook::jni::global_ref<ComponentNameResolverManager::javaobject> javaPart_;
+
   RuntimeExecutor runtimeExecutor_;
-
   facebook::jni::global_ref<jobject> componentNameResolver_;
-
-  std::set<std::string> componentNames_;
+  std::unordered_set<std::string> componentNames_;
 
   void installJSIBindings();
 
   explicit ComponentNameResolverManager(
-      facebook::jni::alias_ref<ComponentNameResolverManager::jhybridobject>
-          jThis,
       RuntimeExecutor runtimeExecutor,
       facebook::jni::alias_ref<jobject> componentNameResolver);
 };


### PR DESCRIPTION
Summary:
Storing a global_ref to `jThis` in a JNI hybrid object leads to a reference cycle which cannot be cleaned up by Java GC. The Java object will keep the C++ object alive and vice versa.

In this class, we didn't seem to need this reference anyway.

Changelog: [Internal]

Differential Revision: D55240490


