### PR TITLE
Fix use-after-free in AsyncEventBeat

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
@@ -38,12 +38,12 @@ void AsyncEventBeat::tick() const {
   isBeatCallbackScheduled_ = true;
 
   runtimeExecutor_([this, ownerBox = ownerBox_](jsi::Runtime& runtime) {
-    isBeatCallbackScheduled_ = false;
     auto owner = ownerBox->owner.lock();
     if (!owner) {
       return;
     }
 
+    isBeatCallbackScheduled_ = false;
     if (beatCallback_) {
       beatCallback_(runtime);
     }

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/AsynchronousEventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/AsynchronousEventBeat.cpp
@@ -43,13 +43,12 @@ void AsynchronousEventBeat::induce() const {
   isBeatCallbackScheduled_ = true;
 
   runtimeExecutor_([this, weakOwner](jsi::Runtime& runtime) {
-    isBeatCallbackScheduled_ = false;
-
     auto owner = weakOwner.lock();
     if (!owner) {
       return;
     }
 
+    isBeatCallbackScheduled_ = false;
     if (beatCallback_) {
       beatCallback_(runtime);
     }


### PR DESCRIPTION
Summary:
Both common and Android implementations of AsyncEventBeat use weak_ptrs
to determine if the object is still valid before invoking the callback.
Move the write to `isBeatCallbackScheduled_` down so it's protected by
that same check.

Changelog: [Internal]

Reviewed By: javache, NickGerleman

Differential Revision: D55226529


