### PR TITLE
Introduce BridgeReactContext < ReactApplicationContext

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -532,6 +532,10 @@ public abstract class com/facebook/react/bridge/BaseJavaModule : com/facebook/re
 	public fun invalidate ()V
 }
 
+public final class com/facebook/react/bridge/BridgeReactContext : com/facebook/react/bridge/ReactApplicationContext {
+	public fun <init> (Landroid/content/Context;)V
+}
+
 public abstract interface class com/facebook/react/bridge/Callback {
 	public abstract fun invoke ([Ljava/lang/Object;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+import android.content.Context
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
+
+/**
+ * This is the bridge-specific concrete subclass of ReactContext. ReactContext has many methods that
+ * delegate to the react instance. This subclass will implement those methods, by delegating to the
+ * CatalystInstance. If you need to create a ReactContext within an "bridge context", please create
+ * BridgeReactContext.
+ */
+@DeprecatedInNewArchitecture
+class BridgeReactContext(base: Context) : ReactApplicationContext(base) {}


### PR DESCRIPTION
Summary:
Eventually, we will move all bridge methods to BridgeReactContext.

Long-term, ReactApplicationContext and ReactContext will become abstract. And these two contexts will only contain methods common to both modes.

Changelog: [Android][Added] Introduce BridgeReactContext

Reviewed By: cortinico

Differential Revision: D55218592
