### PR TITLE
Manual: Codemod initializeWithInstance() callers to BridgeReactContext

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -532,6 +532,10 @@ public abstract class com/facebook/react/bridge/BaseJavaModule : com/facebook/re
 	public fun invalidate ()V
 }
 
+public final class com/facebook/react/bridge/BridgeReactContext : com/facebook/react/bridge/ReactApplicationContext {
+	public fun <init> (Landroid/content/Context;)V
+}
+
 public abstract interface class com/facebook/react/bridge/Callback {
 	public abstract fun invoke ([Ljava/lang/Object;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -51,6 +51,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.infer.annotation.ThreadSafe;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.BridgeReactContext;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.CatalystInstanceImpl;
 import com.facebook.react.bridge.JSBundleLoader;
@@ -1346,7 +1347,7 @@ public class ReactInstanceManager {
       JavaScriptExecutor jsExecutor, JSBundleLoader jsBundleLoader) {
     FLog.d(ReactConstants.TAG, "ReactInstanceManager.createReactContext()");
     ReactMarker.logMarker(CREATE_REACT_CONTEXT_START, jsExecutor.getName());
-    final ReactApplicationContext reactContext = new ReactApplicationContext(mApplicationContext);
+    final BridgeReactContext reactContext = new BridgeReactContext(mApplicationContext);
 
     JSExceptionHandler exceptionHandler =
         mJSExceptionHandler != null ? mJSExceptionHandler : mDevSupportManager;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+import android.content.Context
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
+
+/**
+ * This is the bridge-specific concrete subclass of ReactContext. ReactContext has many methods that
+ * delegate to the react instance. This subclass will implement those methods, by delegating to the
+ * CatalystInstance. If you need to create a ReactContext within an "bridge context", please create
+ * BridgeReactContext.
+ */
+@DeprecatedInNewArchitecture
+class BridgeReactContext(base: Context) : ReactApplicationContext(base) {}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.kt
@@ -7,8 +7,8 @@
 
 package com.facebook.react.modules.deviceinfo
 
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactTestHelper
 import com.facebook.react.bridge.WritableMap
@@ -32,7 +32,7 @@ class DeviceInfoModuleTest : TestCase() {
   private lateinit var deviceInfoModule: DeviceInfoModule
   private lateinit var fakePortraitDisplayMetrics: WritableMap
   private lateinit var fakeLandscapeDisplayMetrics: WritableMap
-  private lateinit var reactContext: ReactApplicationContext
+  private lateinit var reactContext: BridgeReactContext
   private lateinit var displayMetricsHolder: MockedStatic<DisplayMetricsHolder>
 
   @Before
@@ -45,7 +45,7 @@ class DeviceInfoModuleTest : TestCase() {
     fakeLandscapeDisplayMetrics.putInt("height", 100)
 
     displayMetricsHolder = mockStatic(DisplayMetricsHolder::class.java)
-    reactContext = spy(ReactApplicationContext(RuntimeEnvironment.getApplication()))
+    reactContext = spy(BridgeReactContext(RuntimeEnvironment.getApplication()))
     val catalystInstanceMock = ReactTestHelper.createMockCatalystInstance()
     reactContext.initializeWithInstance(catalystInstanceMock)
     deviceInfoModule = DeviceInfoModule(reactContext)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.kt
@@ -11,10 +11,10 @@ import android.content.Context
 import android.os.Looper
 import android.view.Choreographer.FrameCallback
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.common.SystemClock
 import com.facebook.react.devsupport.interfaces.DevSupportManager
@@ -53,7 +53,7 @@ class TimingModuleTest {
     const val FRAME_TIME_NS = 17 * 1000 * 1000
   }
 
-  private lateinit var reactContext: ReactApplicationContext
+  private lateinit var reactContext: BridgeReactContext
   private lateinit var headlessContext: HeadlessJsTaskContext
   private lateinit var timingModule: TimingModule
   private lateinit var reactChoreographerMock: ReactChoreographer
@@ -94,7 +94,7 @@ class TimingModuleTest {
         .thenAnswer { reactChoreographerMock }
 
     val reactInstance = mock(CatalystInstance::class.java)
-    reactContext = spy(ReactApplicationContext(mock(Context::class.java)))
+    reactContext = spy(BridgeReactContext(mock(Context::class.java)))
     doReturn(reactInstance).`when`(reactContext).catalystInstance
     doReturn(true).`when`(reactContext).hasActiveReactInstance()
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.kt
@@ -9,9 +9,9 @@ package com.facebook.react.uimanager
 
 import android.graphics.drawable.ColorDrawable
 import android.view.View
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactTestHelper.createMockCatalystInstance
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.touch.JSResponderHandler
@@ -45,14 +45,14 @@ class SimpleViewPropertyTest {
     }
   }
 
-  private lateinit var context: ReactApplicationContext
+  private lateinit var context: BridgeReactContext
   private lateinit var catalystInstanceMock: CatalystInstance
   private lateinit var themedContext: ThemedReactContext
   private lateinit var manager: ConcreteViewManager
 
   @Before
   fun setup() {
-    context = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    context = BridgeReactContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
     context.initializeWithInstance(catalystInstanceMock)
     themedContext = ThemedReactContext(context, context, null, surfaceId)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
@@ -12,10 +12,10 @@ import android.util.DisplayMetrics
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.drawable.ScalingUtils
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactTestHelper.createMockCatalystInstance
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
@@ -41,7 +41,7 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class ReactImagePropertyTest {
 
-  private var context: ReactApplicationContext? = null
+  private var context: BridgeReactContext? = null
   private var catalystInstanceMock: CatalystInstance? = null
   private var themeContext: ThemedReactContext? = null
   private lateinit var arguments: MockedStatic<Arguments>
@@ -57,7 +57,7 @@ class ReactImagePropertyTest {
     rnLog.`when`<Boolean> { RNLog.w(any(), anyString()) }.thenAnswer {}
 
     SoLoader.setInTestMode()
-    context = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    context = BridgeReactContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
     context!!.initializeWithInstance(catalystInstanceMock)
     themeContext = ThemedReactContext(context, context, null, -1)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
@@ -17,9 +17,9 @@ import android.util.DisplayMetrics
 import android.view.Gravity
 import android.view.inputmethod.EditorInfo
 import androidx.core.content.res.ResourcesCompat.ID_NULL
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactTestHelper.createMockCatalystInstance
 import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.uimanager.ReactStylesDiffMap
@@ -36,7 +36,7 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class ReactTextInputPropertyTest {
 
-  private lateinit var context: ReactApplicationContext
+  private lateinit var context: BridgeReactContext
   private lateinit var catalystInstanceMock: CatalystInstance
   private lateinit var themedContext: ThemedReactContext
   private lateinit var manager: ReactTextInputManager
@@ -54,7 +54,7 @@ class ReactTextInputPropertyTest {
 
   @Before
   fun setup() {
-    context = ReactApplicationContext(RuntimeEnvironment.getApplication())
+    context = BridgeReactContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
     context.initializeWithInstance(catalystInstanceMock)
     themedContext = ThemedReactContext(context, context.baseContext, null, ID_NULL)


### PR DESCRIPTION
Summary:
Eventaully, ReactApplicationContext.initailizeWithInstance() will be moved to BridgeReactContext.

Doing the migration up-front to remove noise from the eventual diff.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D55218593
