### PR TITLE
Update debugger-frontend from a96803a...72fb914

### DIFF
--- a/packages/debugger-frontend/BUILD_INFO
+++ b/packages/debugger-frontend/BUILD_INFO
@@ -1,5 +1,5 @@
-@generated SignedSource<<5739e6306143ffbb6531f901e19506c9>>
-Git revision: a96803a5b999d2ddbc62f8b9a12019db00019b17
+@generated SignedSource<<d37dc53384b5afb76950f44f0370f4bd>>
+Git revision: 72fb914269e341fcd4782384f56532d68f6ffd24
 Built with --nohooks: false
 Is local checkout: false
 Remote URL: https://github.com/facebookexperimental/rn-chrome-devtools-frontend


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Update `react-native/debugger-frontend` from a96803a...72fb914

Resyncs `react-native/debugger-frontend` from GitHub - see `rn-chrome-devtools-frontend` [changelog](https://github.com/facebookexperimental/rn-chrome-devtools-frontend/compare/a96803a5b999d2ddbc62f8b9a12019db00019b17...72fb914269e341fcd4782384f56532d68f6ffd24).

Differential Revision: D55263007


