### PR TITLE
Fix ReactEventEmitter on bridge-mode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.java
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.common.ViewUtil;
 
@@ -76,7 +77,8 @@ class ReactEventEmitter implements RCTModernEventEmitter {
 
     int reactTag = touches.getMap(0).getInt(TARGET_KEY);
     @UIManagerType int uiManagerType = ViewUtil.getUIManagerType(reactTag);
-    if (uiManagerType == UIManagerType.DEFAULT && getDefaultEventEmitter() != null) {
+    if ((uiManagerType == UIManagerType.DEFAULT || ReactFeatureFlags.unstable_useFabricInterop)
+        && getDefaultEventEmitter() != null) {
       mDefaultEventEmitter.receiveTouches(eventName, touches, changedIndices);
     }
   }
@@ -88,7 +90,9 @@ class ReactEventEmitter implements RCTModernEventEmitter {
     int uiManagerType = ViewUtil.getUIManagerType(event.getViewTag(), event.getSurfaceId());
     if (uiManagerType == UIManagerType.FABRIC && mFabricEventEmitter != null) {
       TouchesHelper.sendTouchEvent(mFabricEventEmitter, event);
-    } else if (uiManagerType == UIManagerType.DEFAULT && getDefaultEventEmitter() != null) {
+    } else if ((uiManagerType == UIManagerType.DEFAULT
+            || ReactFeatureFlags.unstable_useFabricInterop)
+        && getDefaultEventEmitter() != null) {
       TouchesHelper.sendTouchesLegacy(mDefaultEventEmitter, event);
     } else {
       ReactSoftExceptionLogger.logSoftException(
@@ -142,7 +146,11 @@ class ReactEventEmitter implements RCTModernEventEmitter {
           customCoalesceKey,
           event,
           category);
-    } else if (uiManagerType == UIManagerType.DEFAULT && getDefaultEventEmitter() != null) {
+    } else if ((uiManagerType == UIManagerType.DEFAULT
+            || ReactFeatureFlags.unstable_useFabricInterop)
+        && getDefaultEventEmitter() != null) {
+      // If you're on Paper or using Fabric Interop, we dispatch the event via the default event
+      // emitter
       mDefaultEventEmitter.receiveEvent(targetReactTag, eventName, event);
     } else {
       ReactSoftExceptionLogger.logSoftException(


### PR DESCRIPTION
Summary:
When on bridge-mode, users are reporting that events are not dispatched well on Android.
This is happening because `ReactEventEmitter` is checking wether the view is on Fabric or Paper,
and dispatching the event properly.

When on Bridge mode, on a Paper legacy view, the `uiManagerType` would be `UIManagerType.FABRIC` (as the RootView is set with Fabric Enabled),
but the `mFabricEventEmitter` will be null. So this results on events being completely ignored.

I've fixed this by checking if the user has enabled Fabric Interop mode, and if so, use the default event emitter.
Fixes #43635

Changelog:
[Android] [Fixed] - Fix ReactEventEmitter on bridge-mode

Differential Revision: D55317418


