### PR TITLE
convert circleci workflows to github actions for android build and test

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,0 +1,14 @@
+name: Setup gradle
+description: 'Set up your GitHub Actions workflow with a specific version of gradle'
+inputs:
+  gradle-version:
+    description: 'The node.js version to use'
+    required: false
+    default: '8.6'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup gradle
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        gradle-version: ${{ inputs.gradle-version }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,19 @@
+name: Setup node.js
+description: 'Set up your GitHub Actions workflow with a specific version of node.js'
+inputs:
+  node-version:
+    description: 'The node.js version to use'
+    required: false
+    default: '18'
+  cache:
+    description: 'The package manager to use for caching dependencies'
+    required: false
+    default: 'yarn'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup node.js
+      uses: actions/setup-node@v4.0.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -6,6 +6,7 @@ on:
     push:
       tags:
         - 'v*'
+    # nightly build @ 2:15 AM UTC
     schedule:
       - cron: '15 2 * * *'
 
@@ -42,11 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4.0.0
-        with:
-          node-version: 18
-          cache: 'yarn'
+      - name: Setup node.js
+        uses: ./github/actions/setup-node
       - name: Setup hermes version
         id: hermes-version
         run: |
@@ -75,10 +73,9 @@ jobs:
           path: |
             /tmp/hermes/download/
             /tmp/hermes/hermes/
-          key: v5-hermes-${{ github.run_number }}-${{ steps.hermes-version.outputs.version }}
+          key: v1-hermes-${{ steps.hermes-version.outputs.version }}-${{ github.run_number }}
           enableCrossOsArchive: true
       - name: Yarn- Install Dependencies
-        if: ${{ ! contains(github.event.head_commit.message, 'Bump metro@') }}
         run: yarn install --non-interactive
       - name: Download Hermes tarball
         run: |
@@ -100,19 +97,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4.0.0
-        with:
-          node-version: 18
-          cache: 'yarn'
+      - name: Setup node.js
+        uses: ./github/actions/setup-node
       - name: Install dependencies
         run: yarn install --non-interactive
       - name: Set React Native Version
         run: node ./scripts/releases/set-rn-version.js --build-type ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       - name: Setup gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: 8.6
+        uses: ./github/actions/setup-gradle
       - name: Build and publish all the Android Artifacts to /tmp/maven-local
         run: |
           if [[ "${{ needs.set_release_type.outputs.RELEASE_TYPE }}" == "dry-run" ]]; then
@@ -157,11 +149,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4.0.0
-        with:
-          node-version: 18
-          cache: 'yarn'
+      - name: Setup node.js
+        uses: ./github/actions/setup-node
       - name: Install dependencies
         run: yarn install --non-interactive
       - name: Set React Native Version
@@ -187,11 +176,13 @@ jobs:
       - name: Build & Test React Native using Gradle
         run: ./gradlew build -PenableWarningsAsErrors=true
       - name: Upload test results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4.3.0
         with:
           name: android-test-results
           path: packages/react-native-gradle-plugin/build/test-results
       - name: Upload android package
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4.3.0
         with:
           name: rntester-apk

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -84,7 +84,7 @@ jobs:
           cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
 
           echo ${{ steps.hermes-version.outputs.version }}
-  build_andriod:
+  build_android:
     runs-on: ubuntu-latest
     needs: [set_release_type, prepare_hermes_workspace]
     container:
@@ -135,7 +135,7 @@ jobs:
           enableCrossOsArchive: true
   test_android:
     runs-on: ubuntu-latest
-    needs: [prepare_hermes_workspace, build_andriod]
+    needs: [prepare_hermes_workspace, build_android]
     container:
       image: reactnativecommunity/react-native-android:latest
       env:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Setup node.js
-        uses: ./github/actions/setup-node
+        uses: ./.github/actions/setup-node
       - name: Setup hermes version
         id: hermes-version
         run: |
@@ -98,13 +98,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Setup node.js
-        uses: ./github/actions/setup-node
+        uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: yarn install --non-interactive
       - name: Set React Native Version
         run: node ./scripts/releases/set-rn-version.js --build-type ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       - name: Setup gradle
-        uses: ./github/actions/setup-gradle
+        uses: ./.github/actions/setup-gradle
       - name: Build and publish all the Android Artifacts to /tmp/maven-local
         run: |
           if [[ "${{ needs.set_release_type.outputs.RELEASE_TYPE }}" == "dry-run" ]]; then
@@ -150,7 +150,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Setup node.js
-        uses: ./github/actions/setup-node
+        uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: yarn install --non-interactive
       - name: Set React Native Version

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,0 +1,199 @@
+name: test-all
+
+on:
+    workflow_dispatch:
+    pull_request:
+    push:
+      tags:
+        - 'v*'
+    schedule:
+      - cron: '15 2 * * *'
+
+jobs:
+  set_release_type:
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_TYPE: ${{ steps.set_release_type.outputs.RELEASE_TYPE }}
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      REF: ${{ github.ref }}
+    steps:
+      - id: set_release_type
+        run: |
+          if [[ $EVENT_NAME == "schedule" ]]; then
+            echo "Setting release type to nightly"
+            echo "RELEASE_TYPE=nightly" >> $GITHUB_OUTPUT
+          elif [[ $EVENT_NAME == "push" && $REF == refs/tags/v* ]]; then
+            echo "Setting release type to release"
+            echo "RELEASE_TYPE=release" >> $GITHUB_OUTPUT
+          else
+            echo "Setting release type to dry-run"
+            echo "RELEASE_TYPE=dry-run" >> $GITHUB_OUTPUT
+          fi
+  prepare_hermes_workspace:
+    runs-on: ubuntu-latest
+    env:
+      HERMES_WS_DIR: /tmp/hermes
+      HERMES_VERSION_FILE: packages/react-native/sdks/.hermesversion
+      BUILD_FROM_SOURCE: true
+    outputs:
+      react-native-version: ${{ steps.react-native-version.outputs.version }}
+      hermes-version: ${{ steps.hermes-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - name: Setup hermes version
+        id: hermes-version
+        run: |
+          mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
+
+          if [ -f "$HERMES_VERSION_FILE" ]; then
+            echo "Hermes Version file found! Using this version for the build:"
+            echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
+          else
+            echo "Hermes Version file not found!!!"
+            echo "Using the last commit from main for the build:"
+            HERMES_TAG_SHA=$(git ls-remote https://github.com/$GITHUB_REPOSITORY main | cut -f 1 | tr -d '[:space:]')
+            echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Hermes commit is $HERMES_TAG_SHA"
+      - name: Get react-native version
+        id: react-native-version
+        run: |
+          VERSION=$(cat packages/react-native/package.json | jq -r '.version')
+          # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "React Native Version is $VERSION"
+      - name: Cache hermes workspace
+        uses: actions/cache@v4.0.0
+        with:
+          path: |
+            /tmp/hermes/download/
+            /tmp/hermes/hermes/
+          key: v5-hermes-${{ github.run_number }}-${{ steps.hermes-version.outputs.version }}
+          enableCrossOsArchive: true
+      - name: Yarn- Install Dependencies
+        if: ${{ ! contains(github.event.head_commit.message, 'Bump metro@') }}
+        run: yarn install --non-interactive
+      - name: Download Hermes tarball
+        run: |
+          node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
+          cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
+          cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
+
+          echo ${{ steps.hermes-version.outputs.version }}
+  build_andriod:
+    runs-on: ubuntu-latest
+    needs: [set_release_type, prepare_hermes_workspace]
+    container:
+      image: reactnativecommunity/react-native-android:latest
+      env:
+        TERM: "dumb"
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
+        # By default we only build ARM64 to save time/resources. For release/nightlies/prealpha, we override this value to build all archs.
+        ORG_GRADLE_PROJECT_reactNativeArchitectures: "arm64-v8a"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --non-interactive
+      - name: Set React Native Version
+        run: node ./scripts/releases/set-rn-version.js --build-type ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+      - name: Setup gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.6
+      - name: Build and publish all the Android Artifacts to /tmp/maven-local
+        run: |
+          if [[ "${{ needs.set_release_type.outputs.RELEASE_TYPE }}" == "dry-run" ]]; then
+            export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a"
+          else
+            export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
+          fi
+          ./gradlew publishAllToMavenTempLocal
+        shell: bash
+      - name: Cache android build artifacts
+        uses: actions/cache/save@v4.0.0
+        with:
+          key: android-build-cache-${{ github.run_number}}
+          path: |
+            build
+            packages/rn-tester/android/app/.cxx
+            packages/rn-tester/android/app/build
+            packages/react-native/sdks/download
+            packages/react-native/sdks/hermes
+            packages/react-native/ReactAndroid/.cxx
+            packages/react-native/ReactAndroid/build
+            packages/react-native/ReactAndroid/hermes-engine/.cxx
+            packages/react-native/ReactAndroid/hermes-engine/build
+            packages/react-native/ReactAndroid/src/main/jni/prebuilt
+            packages/react-native-gradle-plugin/.gradle
+            packages/react-native-gradle-plugin/build
+            packages/react-native-codegen/lib
+          enableCrossOsArchive: true
+  test_android:
+    runs-on: ubuntu-latest
+    needs: [prepare_hermes_workspace, build_andriod]
+    container:
+      image: reactnativecommunity/react-native-android:latest
+      env:
+        TERM: "dumb"
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
+        # By default we only build ARM64 to save time/resources. For release/nightlies/prealpha, we override this value to build all archs.
+        ORG_GRADLE_PROJECT_reactNativeArchitectures: "arm64-v8a"
+        # Repeated here, as the environment key in this executor will overwrite the one in defaults
+        PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A: ${{ secrets.GITHUB_ANALYSISBOT_TOKEN_A }}
+        PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B: ${{ secrets.GITHUB_ANALYSISBOT_TOKEN_B }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --non-interactive
+      - name: Set React Native Version
+        run: node ./scripts/releases/set-rn-version.js --build-type dry-run
+      - name: Cache android build artifacts
+        uses: actions/cache@v4.0.0
+        with:
+          key: android-build-cache-${{ github.run_number}}
+          path: |
+            build
+            packages/rn-tester/android/app/.cxx
+            packages/rn-tester/android/app/build
+            packages/react-native/sdks/download
+            packages/react-native/sdks/hermes
+            packages/react-native/ReactAndroid/.cxx
+            packages/react-native/ReactAndroid/build
+            packages/react-native/ReactAndroid/hermes-engine/.cxx
+            packages/react-native/ReactAndroid/hermes-engine/build
+            packages/react-native/ReactAndroid/src/main/jni/prebuilt
+            packages/react-native-gradle-plugin/.gradle
+            packages/react-native-gradle-plugin/build
+            packages/react-native-codegen/lib
+      - name: Build & Test React Native using Gradle
+        run: ./gradlew build -PenableWarningsAsErrors=true
+      - name: Upload test results
+        uses: actions/upload-artifact@v4.3.0
+        with:
+          name: android-test-results
+          path: packages/react-native-gradle-plugin/build/test-results
+      - name: Upload android package
+        uses: actions/upload-artifact@v4.3.0
+        with:
+          name: rntester-apk
+          path: packages/rn-tester/android/app/build/outputs/apk/
+  


### PR DESCRIPTION
## Summary:

This pull request converts the CircleCI workflows to GitHub actions workflows. This change only inlcudes the android build and test jobs.  

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

[Here is the latest workflow run in my fork](https://github.com/robandpdx-org/react-native/actions/runs/8426560047).  

---
https://fburl.com/workplace/f6mz6tmw