### PR TITLE
React-Native-Restart in release

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -15,6 +15,7 @@ import android.view.KeyEvent;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.react.devsupport.DisabledDevSupportManager;
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.interfaces.fabric.ReactSurface;
@@ -228,7 +229,15 @@ public class ReactDelegate {
   public void reload() {
     DevSupportManager devSupportManager = getDevSupportManager();
     if (devSupportManager != null) {
-      devSupportManager.handleReloadJS();
+      // With Bridgeless enabled, reload in RELEASE mode
+      if (devSupportManager instanceof DisabledDevSupportManager
+          && ReactFeatureFlags.enableBridgelessArchitecture
+          && mReactHost != null) {
+        // Do not reload the bundle from JS as there is no bundler running in release mode.
+        mReactHost.reload("ReactDelegate.reload()");
+      } else {
+        devSupportManager.handleReloadJS();
+      }
     }
   }
 


### PR DESCRIPTION
Summary: https://github.com/facebook/react-native/pull/43521 & https://github.com/facebook/react-native/pull/43588 aimed to fix `react-native-restart`, however in release `handleReloadJS()` is a no-op in [DisabledDevSupportManager](https://github.com/facebook/react-native/blob/ac714b1c3300d3a169bdcfec05d556e18a7b83ff/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java#L139) which is why this should not work. Fixing it by relying on `ReactHostImpl.reload()` instead for Bridgeless.

Differential Revision: D55342296


