### PR TITLE
Fix name lookup in PerformanceEntryReporter (use-after-free)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/BoundedConsumableBuffer.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/BoundedConsumableBuffer.h
@@ -24,6 +24,9 @@ constexpr int DEFAULT_MAX_SIZE = 1024;
  *   the consumer effectively clears the buffer
  * - Even after the entries are consumed, all of the non-overwritten entries
  *   can still be independently retrieved an arbitrary amount of times
+ *
+ * Note that the space for maxSize elements is reserved on construction. This
+ * ensures that pointers to elements remain stable across add() operations.
  */
 template <class T>
 class BoundedConsumableBuffer {
@@ -44,7 +47,9 @@ class BoundedConsumableBuffer {
     DROP = 2,
   };
 
-  BoundedConsumableBuffer(int maxSize = DEFAULT_MAX_SIZE) : maxSize_(maxSize) {}
+  BoundedConsumableBuffer(int maxSize = DEFAULT_MAX_SIZE) : maxSize_(maxSize) {
+    entries_.reserve(maxSize_);
+  }
 
   /**
    * Adds (pushes) element into the buffer. Returns the result/status of the
@@ -122,6 +127,8 @@ class BoundedConsumableBuffer {
     std::vector<T> entries;
     int numToConsume = 0;
     int i;
+
+    entries.reserve(maxSize_);
     for (i = 0; i < numToConsume_; i++) {
       if (!predicate(entries_[pos])) {
         entries.push_back(entries_[pos]);


### PR DESCRIPTION
Summary:
PerformanceEntryReporter maintains a buffer of RawPerformanceEntry objects,
as well as a set of _pointers_ to elements within that buffer, used to find
entries by name.

However, those pointers aren't stable: BoundedConsumableBuffer internally uses
a vector, and there are a few cases where existing references get invalidated:

- When the vector's capacity changes (as new entries get inserted) [1]
- After calling clear-with-predicate, which copies elements into a new vector

This causes nameLookup to contain dangling pointers, and subsequent operations
on it can result in use-after-free.

Fix this by having BoundedConsumableBuffer reserve space for maxSize entries
up front (which ensures that existing pointers remain valid after adding new
elements) and by rebuilding nameLookup after clearing entries by name.

Note that reserve() causes the buffer's memory use to be higher than before in
case where the number of elements is small relative to the max size. Given the
(only) existing usage in PerformanceEntryReporter, as well as the property that
consumed elements remain in the buffer, that cost should be minor.

Changelog: [Internal]

[1] https://en.cppreference.com/w/cpp/container/vector/push_back

Reviewed By: rshest

Differential Revision: D55273403


