### PR TITLE
Expose ScrollView's persistentScrollIndicator and horizontal to the C++ side props

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
@@ -29,6 +29,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     overScrollMode: true,
     pagingEnabled: true,
     persistentScrollbar: true,
+    horizontal: true,
     scrollEnabled: true,
     scrollPerfTag: true,
     sendMomentumEvents: true,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -72,6 +72,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
             process: require('../../StyleSheet/processColor').default,
           },
           persistentScrollbar: true,
+          horizontal: true,
           endFillColor: {
             process: require('../../StyleSheet/processColor').default,
           },

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -225,6 +225,23 @@ ScrollViewProps::ScrollViewProps(
                     "showsVerticalScrollIndicator",
                     sourceProps.showsVerticalScrollIndicator,
                     true)),
+      persistentScrollbar(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.persistentScrollbar
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "persistentScrollbar",
+                    sourceProps.persistentScrollbar,
+                    true)),
+      horizontal(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.horizontal
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "horizontal",
+                                                       sourceProps.horizontal,
+                                                       true)),
       scrollEventThrottle(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.scrollEventThrottle
@@ -383,7 +400,8 @@ void ScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(pinchGestureEnabled);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollsToTop);
     RAW_SET_PROP_SWITCH_CASE_BASIC(showsHorizontalScrollIndicator);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(showsVerticalScrollIndicator);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(persistentScrollbar);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(horizontal);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollEventThrottle);
     RAW_SET_PROP_SWITCH_CASE_BASIC(zoomScale);
     RAW_SET_PROP_SWITCH_CASE_BASIC(contentInset);
@@ -489,6 +507,12 @@ SharedDebugStringConvertibleList ScrollViewProps::getDebugProps() const {
               "showsVerticalScrollIndicator",
               showsVerticalScrollIndicator,
               defaultScrollViewProps.showsVerticalScrollIndicator),
+          debugStringConvertibleItem(
+              "persistentScrollbar",
+              persistentScrollbar,
+              defaultScrollViewProps.persistentScrollbar),
+          debugStringConvertibleItem(
+              "horizontal", horizontal, defaultScrollViewProps.horizontal),
           debugStringConvertibleItem(
               "scrollEventThrottle",
               scrollEventThrottle,

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -56,6 +56,8 @@ class ScrollViewProps final : public ViewProps {
   bool scrollsToTop{true};
   bool showsHorizontalScrollIndicator{true};
   bool showsVerticalScrollIndicator{true};
+  bool persistentScrollbar{false};
+  bool horizontal{false};
   Float scrollEventThrottle{};
   Float zoomScale{1.0f};
   EdgeInsets contentInset{};


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

The corresponding prop `ScrollBar.persistentScrollIndicator` was only passed to the Android platform code an `ScrollBar.horizontal` wasn't passed to native at all.

On other platforms we need those props to be available on the C++ side, so this exposes them to the corresponding C++ ScrollViewProps.

Differential Revision: D55367445


