### PR TITLE
fix: remove loadSourceForBridge in RCTRootViewFactory

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -285,23 +285,7 @@
       return [weakSelf bridge:bridge didNotFindModule:moduleName];
     };
   }
-
-  if ([self respondsToSelector:@selector(loadSourceForBridge:withBlock:)]) {
-    configuration.loadSourceForBridgeBlock =
-        ^void(RCTBridge *_Nonnull bridge, RCTSourceLoadBlock _Nonnull loadCallback) {
-          [weakSelf loadSourceForBridge:bridge withBlock:loadCallback];
-        };
-  }
-
-  if ([self respondsToSelector:@selector(loadSourceForBridge:onProgress:onComplete:)]) {
-    configuration.loadSourceForBridgeProgressBlock =
-        ^(RCTBridge *_Nonnull bridge,
-          RCTSourceLoadProgressBlock _Nonnull onProgress,
-          RCTSourceLoadBlock _Nonnull loadCallback) {
-          [weakSelf loadSourceForBridge:bridge onProgress:onProgress onComplete:loadCallback];
-        };
-  }
-
+  
   return [[RCTRootViewFactory alloc] initWithConfiguration:configuration andTurboModuleManagerDelegate:self];
 }
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -27,11 +27,6 @@ typedef NSURL *_Nullable (^RCTSourceURLForBridgeBlock)(RCTBridge *bridge);
 typedef NSArray<id<RCTBridgeModule>> *_Nonnull (^RCTExtraModulesForBridgeBlock)(RCTBridge *bridge);
 typedef NSDictionary<NSString *, Class> *_Nonnull (^RCTExtraLazyModuleClassesForBridge)(RCTBridge *bridge);
 typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *moduleName);
-typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBlock loadCallback);
-typedef void (^RCTLoadSourceForBridgeProgressBlock)(
-    RCTBridge *bridge,
-    RCTSourceLoadProgressBlock onProgress,
-    RCTSourceLoadBlock loadCallback);
 
 #pragma mark - RCTRootViewFactory Configuration
 @interface RCTRootViewFactoryConfiguration : NSObject
@@ -89,6 +84,9 @@ typedef void (^RCTLoadSourceForBridgeProgressBlock)(
  * @returns: a newly created instance of RCTBridge.
  */
 @property (nonatomic, nullable) RCTCreateBridgeWithDelegateBlock createBridgeWithDelegate;
+
+#pragma mark - RCTBridgeDelegate blocks
+
 /**
  * Block that returns the location of the JavaScript source file. When running from the packager
  * this should be an absolute URL, e.g. `http://localhost:8081/index.ios.bundle`.
@@ -126,19 +124,6 @@ typedef void (^RCTLoadSourceForBridgeProgressBlock)(
  * If the module was not registered, return NO to prevent further searches.
  */
 @property (nonatomic, nullable) RCTBridgeDidNotFindModuleBlock bridgeDidNotFindModule;
-
-/**
- * The bridge will automatically attempt to load the JS source code from the
- * location specified by the `sourceURLForBridge:` method, however, if you want
- * to handle loading the JS yourself, you can do so by implementing this method.
- */
-@property (nonatomic, nullable) RCTLoadSourceForBridgeProgressBlock loadSourceForBridgeProgressBlock;
-
-/**
- * Similar to loadSourceForBridge:onProgress:onComplete: but without progress
- * reporting.
- */
-@property (nonatomic, nullable) RCTLoadSourceForBridgeBlock loadSourceForBridgeBlock;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -273,22 +273,6 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
   return NO;
 }
 
-- (void)loadSourceForBridge:(RCTBridge *)bridge withBlock:(RCTSourceLoadBlock)loadCallback
-{
-  if (_configuration.loadSourceForBridgeBlock != nil) {
-    _configuration.loadSourceForBridgeBlock(bridge, loadCallback);
-  }
-}
-
-- (void)loadSourceForBridge:(RCTBridge *)bridge
-                 onProgress:(RCTSourceLoadProgressBlock)onProgress
-                 onComplete:(RCTSourceLoadBlock)loadCallback
-{
-  if (_configuration.loadSourceForBridgeProgressBlock != nil) {
-    _configuration.loadSourceForBridgeProgressBlock(bridge, onProgress, loadCallback);
-  }
-}
-
 - (NSURL *)bundleURL
 {
   return self->_configuration.bundleURL;


### PR DESCRIPTION
## Summary:

This PR removes forward declaration of `loadSourceForBridge` methods from the RCTRootViewFactory as it was causing an issue on old architecture, where the RedBox wouldn't popup when metro wasn't running.

As stated by @Kudo [here](https://github.com/reactwg/react-native-releases/issues/177):

> the problem was coming from the implementation
> https://github.com/facebook/react-native/blob/00725fadff28bb3c7fed65f208e647f0dab69e75/packages/react-native/React/CxxBridge/RCTCxxBridge.mm#L519-L540
> 
> we should dynamically override loadSourceForBridge:onProgress:onComplete: and loadSourceForBridge:withBlock: in RCTRootViewFactory only when AppDelegate override it. one way to achieve this might be tricky that we may need to override respondsToSelector:.
> 
> otherwise, we could just skip the loadSourceForBridge:onProgress:onComplete: and loadSourceForBridge:withBlock: support.

There is no straight forward solution to implement this without some _hacks_ so I'm removing this forward block for now.

## Changelog:

[IOS] [FIXED] - remove loadSourceForBridge in RCTRootViewFactory

## Test Plan:

CI Green
