### PR TITLE
Add legacy layout methods from Fabric to DOM native module

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -532,10 +532,6 @@ public abstract class com/facebook/react/bridge/BaseJavaModule : com/facebook/re
 	public fun invalidate ()V
 }
 
-public final class com/facebook/react/bridge/BridgeReactContext : com/facebook/react/bridge/ReactApplicationContext {
-	public fun <init> (Landroid/content/Context;)V
-}
-
 public abstract interface class com/facebook/react/bridge/Callback {
 	public abstract fun invoke ([Ljava/lang/Object;)V
 }
@@ -3988,11 +3984,6 @@ public abstract interface class com/facebook/react/uimanager/ComponentNameResolv
 	public abstract fun getComponentNames ()[Ljava/lang/String;
 }
 
-public final class com/facebook/react/uimanager/ComponentNameResolverBinding {
-	public static final field INSTANCE Lcom/facebook/react/uimanager/ComponentNameResolverBinding;
-	public static final fun install (Lcom/facebook/react/bridge/RuntimeExecutor;Ljava/lang/Object;)V
-}
-
 public class com/facebook/react/uimanager/DisplayMetricsHolder {
 	public fun <init> ()V
 	public static fun getDisplayMetricsWritableMap (D)Lcom/facebook/react/bridge/WritableMap;
@@ -4853,23 +4844,6 @@ public class com/facebook/react/uimanager/TransformHelper {
 
 public abstract interface class com/facebook/react/uimanager/UIBlock {
 	public abstract fun execute (Lcom/facebook/react/uimanager/NativeViewHierarchyManager;)V
-}
-
-public final class com/facebook/react/uimanager/UIConstantsProviderBinding {
-	public static final field INSTANCE Lcom/facebook/react/uimanager/UIConstantsProviderBinding;
-	public static final fun install (Lcom/facebook/react/bridge/RuntimeExecutor;Lcom/facebook/react/uimanager/UIConstantsProviderBinding$DefaultEventTypesProvider;Lcom/facebook/react/uimanager/UIConstantsProviderBinding$ConstantsForViewManagerProvider;Lcom/facebook/react/uimanager/UIConstantsProviderBinding$ConstantsProvider;)V
-}
-
-public abstract interface class com/facebook/react/uimanager/UIConstantsProviderBinding$ConstantsForViewManagerProvider {
-	public abstract fun getConstantsForViewManager (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeMap;
-}
-
-public abstract interface class com/facebook/react/uimanager/UIConstantsProviderBinding$ConstantsProvider {
-	public abstract fun getConstants ()Lcom/facebook/react/bridge/NativeMap;
-}
-
-public abstract interface class com/facebook/react/uimanager/UIConstantsProviderBinding$DefaultEventTypesProvider {
-	public abstract fun getDefaultEventTypes ()Lcom/facebook/react/bridge/NativeMap;
 }
 
 public class com/facebook/react/uimanager/UIImplementation {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.kt
@@ -17,4 +17,4 @@ import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
  * BridgeReactContext.
  */
 @DeprecatedInNewArchitecture
-class BridgeReactContext(base: Context) : ReactApplicationContext(base) {}
+internal class BridgeReactContext(base: Context) : ReactApplicationContext(base) {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolverBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolverBinding.kt
@@ -13,11 +13,11 @@ import com.facebook.soloader.SoLoader
 import kotlin.jvm.JvmStatic
 
 @DoNotStripAny
-public object ComponentNameResolverBinding {
+internal object ComponentNameResolverBinding {
   init {
     SoLoader.loadLibrary("uimanagerjni")
   }
 
   @JvmStatic
-  public external fun install(runtimeExecutor: RuntimeExecutor, componentNameResolver: Object)
+  public external fun install(runtimeExecutor: RuntimeExecutor, componentNameResolver: Any)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIConstantsProviderBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIConstantsProviderBinding.kt
@@ -14,7 +14,7 @@ import com.facebook.soloader.SoLoader
 import kotlin.jvm.JvmStatic
 
 @DoNotStripAny
-public object UIConstantsProviderBinding {
+internal object UIConstantsProviderBinding {
   init {
     SoLoader.loadLibrary("uimanagerjni")
   }
@@ -30,18 +30,18 @@ public object UIConstantsProviderBinding {
   @DoNotStripAny
   public interface DefaultEventTypesProvider {
     /* Returns UIManager's constants. */
-    fun getDefaultEventTypes(): NativeMap
+    public fun getDefaultEventTypes(): NativeMap
   }
 
   @DoNotStripAny
   public interface ConstantsForViewManagerProvider {
     /* Returns UIManager's constants. */
-    fun getConstantsForViewManager(viewManagerName: String): NativeMap?
+    public fun getConstantsForViewManager(viewManagerName: String): NativeMap?
   }
 
   @DoNotStripAny
   public interface ConstantsProvider {
     /* Returns UIManager's constants. */
-    fun getConstants(): NativeMap
+    public fun getConstants(): NativeMap
   }
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
@@ -88,6 +88,23 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
       jsi::Runtime& rt,
       jsi::Value shadowNodeValue,
       double pointerId);
+
+  // Legacy layout APIs
+
+  void
+  measure(jsi::Runtime& rt, jsi::Value shadowNodeValue, jsi::Function callback);
+
+  void measureInWindow(
+      jsi::Runtime& rt,
+      jsi::Value shadowNodeValue,
+      jsi::Function callback);
+
+  void measureLayout(
+      jsi::Runtime& rt,
+      jsi::Value shadowNodeValue,
+      jsi::Value relativeToShadowNodeValue,
+      jsi::Function onFail,
+      jsi::Function onSuccess);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/src/private/webapis/dom/nodes/specs/NativeDOM.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/specs/NativeDOM.js
@@ -17,6 +17,29 @@ import type {TurboModule} from '../../../../../../Libraries/TurboModule/RCTExpor
 import * as TurboModuleRegistry from '../../../../../../Libraries/TurboModule/TurboModuleRegistry';
 import nullthrows from 'nullthrows';
 
+export type MeasureInWindowOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) => void;
+
+export type MeasureOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  pageX: number,
+  pageY: number,
+) => void;
+
+export type MeasureLayoutOnSuccessCallback = (
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+) => void;
+
 export interface Spec extends TurboModule {
   +getParentNode: (
     shadowNode: mixed /* ShadowNode */,
@@ -75,6 +98,24 @@ export interface Spec extends TurboModule {
   +releasePointerCapture: (
     shadowNode: mixed /* ShadowNode */,
     pointerId: number,
+  ) => void;
+
+  /**
+   * Legacy layout APIs
+   */
+
+  +measure: (shadowNode: mixed, callback: MeasureOnSuccessCallback) => void;
+
+  +measureInWindow: (
+    shadowNode: mixed,
+    callback: MeasureInWindowOnSuccessCallback,
+  ) => void;
+
+  +measureLayout: (
+    shadowNode: mixed,
+    relativeNode: mixed,
+    onFail: () => void,
+    onSuccess: MeasureLayoutOnSuccessCallback,
   ) => void;
 }
 
@@ -271,6 +312,27 @@ export interface RefinedSpec {
   +setPointerCapture: (shadowNode: ShadowNode, pointerId: number) => void;
 
   +releasePointerCapture: (shadowNode: ShadowNode, pointerId: number) => void;
+
+  /**
+   * Legacy layout APIs
+   */
+
+  +measure: (
+    shadowNode: ShadowNode,
+    callback: MeasureOnSuccessCallback,
+  ) => void;
+
+  +measureInWindow: (
+    shadowNode: ShadowNode,
+    callback: MeasureInWindowOnSuccessCallback,
+  ) => void;
+
+  +measureLayout: (
+    shadowNode: ShadowNode,
+    relativeNode: ShadowNode,
+    onFail: () => void,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+  ) => void;
 }
 
 const NativeDOM: RefinedSpec = {
@@ -378,6 +440,27 @@ const NativeDOM: RefinedSpec = {
     return nullthrows(RawNativeDOM).releasePointerCapture(
       shadowNode,
       pointerId,
+    );
+  },
+
+  /**
+   * Legacy layout APIs
+   */
+
+  measure(shadowNode, callback) {
+    return nullthrows(RawNativeDOM).measure(shadowNode, callback);
+  },
+
+  measureInWindow(shadowNode, callback) {
+    return nullthrows(RawNativeDOM).measureInWindow(shadowNode, callback);
+  },
+
+  measureLayout(shadowNode, relativeNode, onFail, onSuccess) {
+    return nullthrows(RawNativeDOM).measureLayout(
+      shadowNode,
+      relativeNode,
+      onFail,
+      onSuccess,
     );
   },
 };

--- a/packages/react-native/src/private/webapis/dom/nodes/specs/__mocks__/NativeDOMMock.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/specs/__mocks__/NativeDOMMock.js
@@ -13,6 +13,11 @@ import type {
   InternalInstanceHandle,
   Node,
 } from '../../../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+} from '../NativeDOM';
 import typeof NativeDOM from '../NativeDOM';
 
 import {
@@ -371,6 +376,38 @@ const NativeDOMMock: NativeDOM = {
     ensureHostNode(node);
     return 'RN:' + fromNode(node).viewName;
   }),
+
+  /**
+   * Legacy layout APIs
+   */
+
+  measure: jest.fn((node: Node, callback: MeasureOnSuccessCallback): void => {
+    ensureHostNode(node);
+
+    callback(10, 10, 100, 100, 0, 0);
+  }),
+
+  measureInWindow: jest.fn(
+    (node: Node, callback: MeasureInWindowOnSuccessCallback): void => {
+      ensureHostNode(node);
+
+      callback(10, 10, 100, 100);
+    },
+  ),
+
+  measureLayout: jest.fn(
+    (
+      node: Node,
+      relativeNode: Node,
+      onFail: () => void,
+      onSuccess: MeasureLayoutOnSuccessCallback,
+    ): void => {
+      ensureHostNode(node);
+      ensureHostNode(relativeNode);
+
+      onSuccess(1, 1, 100, 100);
+    },
+  ),
 };
 
 export default NativeDOMMock;


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds an implementation for the legacy layout measurement methods in React Native (`measure`, `measureInWindow` and `measureLayout`) in the DOM native module, so we can clean up the API from the `nativeFabricUIManager` binding.

Differential Revision: D55368141


