### PR TITLE
chore: remove `@babel/plugin-transform-destructuring` plugin

### DIFF
--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -34,7 +34,6 @@
     "@babel/plugin-transform-block-scoping": "^7.0.0",
     "@babel/plugin-transform-classes": "^7.0.0",
     "@babel/plugin-transform-computed-properties": "^7.0.0",
-    "@babel/plugin-transform-destructuring": "^7.20.0",
     "@babel/plugin-transform-flow-strip-types": "^7.20.0",
     "@babel/plugin-transform-function-name": "^7.0.0",
     "@babel/plugin-transform-literals": "^7.0.0",

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -106,12 +106,7 @@ const getPreset = (src, options) => {
       require('@babel/plugin-transform-named-capturing-groups-regex'),
     ]);
   }
-  if (!isHermesCanary) {
-    extraPlugins.push([
-      require('@babel/plugin-transform-destructuring'),
-      {useBuiltIns: true},
-    ]);
-  }
+
   if (!isHermes && (isNull || hasClass || src.indexOf('...') !== -1)) {
     extraPlugins.push(
       [require('@babel/plugin-transform-spread')],

--- a/packages/react-native-codegen-typescript-test/package.json
+++ b/packages/react-native-codegen-typescript-test/package.json
@@ -29,7 +29,6 @@
     "@babel/plugin-proposal-optional-chaining": "^7.20.0",
     "@babel/plugin-syntax-dynamic-import": "^7.8.0",
     "@babel/plugin-transform-async-to-generator": "^7.20.0",
-    "@babel/plugin-transform-destructuring": "^7.20.0",
     "@babel/plugin-transform-flow-strip-types": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@types/jest": "^29.5.3",

--- a/packages/react-native-codegen/.babelrc
+++ b/packages/react-native-codegen/.babelrc
@@ -2,7 +2,6 @@
   "plugins": [
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-transform-async-to-generator",
-    "@babel/plugin-transform-destructuring",
     "@babel/plugin-transform-flow-strip-types",
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-class-properties",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -45,7 +45,6 @@
     "@babel/plugin-proposal-optional-chaining": "^7.20.0",
     "@babel/plugin-syntax-dynamic-import": "^7.8.0",
     "@babel/plugin-transform-async-to-generator": "^7.20.0",
-    "@babel/plugin-transform-destructuring": "^7.20.0",
     "@babel/plugin-transform-flow-strip-types": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "chalk": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,7 +801,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.9"
 
-"@babel/plugin-transform-destructuring@^7.0.0", "@babel/plugin-transform-destructuring@^7.20.0", "@babel/plugin-transform-destructuring@^7.20.2":
+"@babel/plugin-transform-destructuring@^7.0.0", "@babel/plugin-transform-destructuring@^7.20.2":
   version "7.21.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.21.3.tgz#73b46d0fd11cd6ef57dea8a381b1215f4959d401"
   integrity sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

- Hermes in `react-native@0.73.6` appears to support destructuring natively. The babel preset only removes the plugin if running Hermes canary, which doesn't seem to be needed anymore.
- Caniuse indicates that JSC has supported all destructuring features since iOS 11.3 (we're on ~13) https://caniuse.com/?search=destructuring
- `@babel/preset-env` with reasonably modern defaults doesn't apply this transform anymore [repl](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=JYWwDg9gTgLgBAbzgVwM4FMDKMCGN1wC-cAZlBCHAORTo4DGMVA3AFCsnIB2jwEXcAGIQIACgCUiVnDj1-qeAG1gAGjgYYASTUA6PRBgALdFFQBdOAF4UGbHnSiADOOZxpcWjGRQBXZABt_VkIgA&debug=false&forceAllTransforms=false&modules=commonjs&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2%2Ctypescript%2Cflow&prettier=false&targets=&version=7.24.3&externalPlugins=&assumptions=%7B%7D). (This is for web / Node.js support since we reuse the babel preset in Expo CLI).
- Original discussion https://discord.com/channels/514829729862516747/896089100199788604/1222231550456893563


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [BREAKING] - Remove `@babel/plugin-transform-destructuring` transform (`[a, b, ...c]`) from all platforms and engines.


<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- I removed the plugin in an Expo SDK 50 project (`code node_modules/@react-native/babel-preset/src/configs/main.js` -> delete plugin).
- I added a `const [index, setIndex, ...foo] = React.useState(0);` to the code to ensure at least one instance of destructuring (there are many throughout the default modules though). 
- Then ran with a clear metro cache (`npx expo start -c`) on iOS, Android, web, Node.js (Expo Router). 
- Also ran clean cache against JSC / Hermes (changing `jsEngine` in the `app.json`).
- I verified by pulling the source from the browser that the transform wasn't being applied anywhere, e.g. `http://localhost:8081/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&lazy=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=com.bacon.mar26&transform.routerRoot=app&transform.engine=hermes&transform.bytecode=true`
  - Source looked like: `var [index, setIndex, ...foo] = (0, _react.useState)(0);` (modifications primarily coming from `@babel/plugin-transform-modules-commonjs` and `@babel/plugin-transform-block-scoping`).
- Built a bare app on iOS just to confirm no differences in behavior.
- Then I ran a script against the Hermes bin just to be absolutely sure no errors would arise against Hermes: `./ios/Pods/hermes-engine/destroot/bin/hermes ./foo.js` where `foo.js` contained:

```js
const [a, b, ...c] = (() => [0, 1])();
```



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
