### PR TITLE
Fix `caretHidden` prop when text color set

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.BlendMode;
 import android.graphics.BlendModeColorFilter;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -34,6 +35,7 @@ import androidx.autofill.HintConstants;
 import androidx.core.content.ContextCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.R;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
@@ -589,6 +591,28 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   @ReactProp(name = "cursorColor", customType = "Color")
   public void setCursorColor(ReactEditText view, @Nullable Integer color) {
+    view.setTag(R.id.cursor_color, color);
+    updateCursorDrawable(view);
+  }
+
+  private void updateCursorDrawable(ReactEditText view) {
+    if (view.getStagedInputType() == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+        && shouldHideCursorForEmailTextInput()) {
+      return;
+    }
+
+    @Nullable Boolean caretHiddenTag = (Boolean) view.getTag(R.id.caret_hidden);
+    boolean caretHidden = caretHiddenTag != null && caretHiddenTag;
+    view.setCursorVisible(!caretHidden);
+
+    if (caretHidden) {
+      setCursorDrawableColor(view, Color.TRANSPARENT);
+    } else {
+      setCursorDrawableColor(view, (Integer) view.getTag(R.id.cursor_color));
+    }
+  }
+
+  private void setCursorDrawableColor(ReactEditText view, @Nullable Integer color) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       Drawable cursorDrawable = view.getTextCursorDrawable();
       if (cursorDrawable != null) {
@@ -650,11 +674,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   @ReactProp(name = "caretHidden", defaultBoolean = false)
   public void setCaretHidden(ReactEditText view, boolean caretHidden) {
-    if (view.getStagedInputType() == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
-        && shouldHideCursorForEmailTextInput()) {
-      return;
-    }
-    view.setCursorVisible(!caretHidden);
+    view.setTag(R.id.caret_hidden, caretHidden);
+    updateCursorDrawable(view);
   }
 
   @ReactProp(name = "contextMenuHidden", defaultBoolean = false)

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -56,4 +56,11 @@
 
   <!-- tag is used to invalidate transform style in view manager -->
   <item type="id" name="invalidate_transform"/>
+
+  <!-- tag is used to store cursor color-->
+  <item type="id" name="cursor_color"/>
+
+  <!-- tag is used to store whether caret is hidden-->
+  <item type="id" name="caret_hidden"/>
+
 </resources>


### PR DESCRIPTION
Summary:
Android `setCursorVisible` does not seem to work correctly when text is present, even if set by ForegroundColorSpan. I did some diving to see if I could root cause this within Android, but couldn't find. So this applies a hack (that we also use in FDS) to hide via transparent drawable instead of builtin API.

Changelog:
[Android][Fixed] - Fix `caretHidden` prop when text color set

Differential Revision: D55377434


