### PR TITLE
Use useDevSupport instead of ReactHostImpl.DEV

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1983,8 +1983,8 @@ public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/face
 public final class com/facebook/react/defaults/DefaultReactHost {
 	public static final field INSTANCE Lcom/facebook/react/defaults/DefaultReactHost;
 	public static final fun getDefaultReactHost (Landroid/content/Context;Lcom/facebook/react/ReactNativeHost;)Lcom/facebook/react/ReactHost;
-	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Z)Lcom/facebook/react/ReactHost;
-	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/facebook/react/ReactHost;
+	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZ)Lcom/facebook/react/ReactHost;
+	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/facebook/react/ReactHost;
 }
 
 public abstract class com/facebook/react/defaults/DefaultReactNativeHost : com/facebook/react/ReactNativeHost {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -14,6 +14,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.interfaces.exceptionmanager.ReactJsExceptionHandler
 import com.facebook.react.runtime.JSCInstance
@@ -49,7 +50,8 @@ public object DefaultReactHost {
       packageList: List<ReactPackage>,
       jsMainModulePath: String = "index",
       jsBundleAssetPath: String = "index",
-      isHermesEnabled: Boolean = true
+      isHermesEnabled: Boolean = true,
+      useDevSupport: Boolean = ReactBuildConfig.DEBUG,
   ): ReactHost {
     if (reactHost == null) {
       val jsBundleLoader =
@@ -62,6 +64,7 @@ public object DefaultReactHost {
               reactPackages = packageList,
               jsRuntimeFactory = jsRuntimeFactory,
               turboModuleManagerDelegateBuilder = DefaultTurboModuleManagerDelegate.Builder())
+      // FIXME: this is not a sane default exception handler
       val reactJsExceptionHandler = ReactJsExceptionHandler { _ -> }
       val componentFactory = ComponentFactory()
       DefaultComponentsRegistry.register(componentFactory)
@@ -71,9 +74,10 @@ public object DefaultReactHost {
                   context,
                   defaultReactHostDelegate,
                   componentFactory,
-                  true,
+                  true /* allowPackagerServerAccess */,
                   reactJsExceptionHandler,
-                  true)
+                  useDevSupport,
+              )
               .apply {
                 jsEngineResolutionAlgorithm =
                     if (isHermesEnabled) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -110,5 +110,6 @@ protected constructor(
           jsMainModuleName,
           bundleAssetName ?: "index",
           isHermesEnabled ?: true,
+          useDeveloperSupport,
       )
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -93,9 +93,6 @@ import kotlin.jvm.functions.Function0;
 @ThreadSafe
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactHostImpl implements ReactHost {
-
-  // TODO T61403233 Make this configurable by product code
-  private static final boolean DEV = ReactBuildConfig.DEBUG;
   private static final String TAG = "ReactHost";
   private static final int BRIDGELESS_MARKER_INSTANCE_KEY = 1;
   private static final AtomicInteger mCounter = new AtomicInteger(0);
@@ -129,7 +126,7 @@ public class ReactHostImpl implements ReactHost {
   private final AtomicReference<WeakReference<Activity>> mLastUsedActivity =
       new AtomicReference<>(new WeakReference<>(null));
   private final BridgelessReactStateTracker mBridgelessReactStateTracker =
-      new BridgelessReactStateTracker(DEV);
+      new BridgelessReactStateTracker(ReactBuildConfig.DEBUG);
   private final ReactLifecycleStateManager mReactLifecycleStateManager =
       new ReactLifecycleStateManager(mBridgelessReactStateTracker);
   private final int mId = mCounter.getAndIncrement();
@@ -178,14 +175,15 @@ public class ReactHostImpl implements ReactHost {
     mQueueThreadExceptionHandler = ReactHostImpl.this::handleHostException;
     mMemoryPressureRouter = new MemoryPressureRouter(context);
     mAllowPackagerServerAccess = allowPackagerServerAccess;
-    if (DEV) {
+    mUseDevSupport = useDevSupport;
+
+    if (mUseDevSupport) {
       mDevSupportManager =
           new BridgelessDevSupportManager(
               ReactHostImpl.this, mContext, mReactHostDelegate.getJsMainModulePath());
     } else {
       mDevSupportManager = new DisabledDevSupportManager();
     }
-    mUseDevSupport = useDevSupport;
   }
 
   @Override
@@ -761,7 +759,7 @@ public class ReactHostImpl implements ReactHost {
     final String method = "handleHostException(message = \"" + e.getMessage() + "\")";
     log(method);
 
-    if (DEV) {
+    if (mUseDevSupport) {
       mDevSupportManager.handleException(e);
     }
     destroy(method, e);
@@ -1118,7 +1116,7 @@ public class ReactHostImpl implements ReactHost {
     final String method = "getJSBundleLoader()";
     log(method);
 
-    if (DEV && mAllowPackagerServerAccess) {
+    if (mUseDevSupport && mAllowPackagerServerAccess) {
       return isMetroRunning()
           .onSuccessTask(
               task -> {
@@ -1131,7 +1129,7 @@ public class ReactHostImpl implements ReactHost {
               },
               mBGExecutor);
     } else {
-      if (DEV) {
+      if (ReactBuildConfig.DEBUG) {
         FLog.d(TAG, "Packager server access is disabled in this environment");
       }
 


### PR DESCRIPTION
Summary: Changelog: [Android][Changed] In bridgeless, `useDevSupport` now is configurable by ReactNativeHost.

Differential Revision: D55365753


