### PR TITLE
feat: Add `TurboModuleRegistry.getLazy<T>(..)`

### DIFF
--- a/packages/eslint-plugin-specs/react-native-modules.js
+++ b/packages/eslint-plugin-specs/react-native-modules.js
@@ -100,7 +100,8 @@ function isModuleRequire(node) {
     !(
       memberExpression.property.type === 'Identifier' &&
       (memberExpression.property.name === 'get' ||
-        memberExpression.property.name === 'getEnforcing')
+        memberExpression.property.name === 'getEnforcing' ||
+        memberExpression.property.name === 'getLazy')
     )
   ) {
     return false;

--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.d.ts
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.d.ts
@@ -11,3 +11,4 @@ import {TurboModule} from './RCTExport';
 
 export function get<T extends TurboModule>(name: string): T | null;
 export function getEnforcing<T extends TurboModule>(name: string): T;
+export function getLazy<T extends TurboModule>(name: string): T | null;

--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -87,3 +87,19 @@ export function getEnforcing<T: TurboModule>(name: string): T {
   invariant(module != null, message);
   return module;
 }
+
+interface ModuleHolder<T> {
+  module: T | null
+}
+
+export function getLazy<T: TurboModule>(name: string): ?T {
+  const proxy = new Proxy<ModuleHolder<T>>({ module: null }, {
+    get: (target, property) => {
+      if (target.module == null) {
+        target.module = get(name)
+      }
+      return target.module[property]
+    }
+  })
+  return proxy as T
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Adds `TurboModuleRegistry.getLazy` to get a module lazily.

Instead of requiring the module as soon as JS parses the file, it will only require the module once you try to access a property or function on the object (via a `Proxy`).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [ADDED] Add `TurboModuleRegistry.getLazy<T>(...)` to lazy-get Proxy TurboModules

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
