### PR TITLE
Delete unused RCT_ENABLE_LOADING_FROM_PACKAGER

### DIFF
--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -91,15 +91,6 @@
 #define RCT_DEV_MENU RCT_DEV
 #endif
 
-/**
- * Controls for the core packgaer loading functionality
- * By default, this inherits from RCT_DEV_MENU but it also gives the capability to
- * enable the packager functionality without the rest of the dev tools from RCT_DEV_MENU
- */
-#ifndef RCT_ENABLE_LOADING_FROM_PACKAGER
-#define RCT_ENABLE_LOADING_FROM_PACKAGER RCT_DEV_MENU
-#endif
-
 #ifndef RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
 #if RCT_DEV && (__has_include("RCTPackagerConnection.h") || __has_include(<React/RCTPackagerConnection.h>))
 #define RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION 1


### PR DESCRIPTION
Summary:
Remove `RCT_ENABLE_LOADING_FROM_PACKAGER` from `RCTDefines`, as it is not referenced anywhere and does nothing.

Changelog: [Internal]

Differential Revision: D55421282


