### PR TITLE
[Fabric] Fixes bundle url reset logic

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -107,7 +107,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     };
 
     auto bundleURLSetter = ^(NSURL *bundleURL_) {
-      [weakSelf _setBundleURL:bundleURL];
+      [weakSelf _setBundleURL:bundleURL_];
     };
 
     auto defaultBundleURLGetter = ^NSURL *()


### PR DESCRIPTION
## Summary:

Fixes bundle url reset logic

## Changelog:

[IOS] [FIXED] - [Fabric] Fixes bundle url reset logic

## Test Plan:

bundle url set works.
