### PR TITLE
Introduce DevSupportManager.openDebugger() method

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2114,6 +2114,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
+	public fun openDebugger ()V
 	public fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public fun reloadJSFromServer (Ljava/lang/String;)V
@@ -2170,6 +2171,7 @@ public class com/facebook/react/devsupport/DisabledDevSupportManager : com/faceb
 	public fun loadSplitBundleFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSplitBundleCallback;)V
 	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
+	public fun openDebugger ()V
 	public fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public fun reloadJSFromServer (Ljava/lang/String;)V
@@ -2382,6 +2384,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun loadSplitBundleFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSplitBundleCallback;)V
 	public abstract fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public abstract fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
+	public abstract fun openDebugger ()V
 	public abstract fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public abstract fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public abstract fun reloadJSFromServer (Ljava/lang/String;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -384,12 +384,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       if (!isConnected) {
         disabledItemKeys.add(debuggerItemString);
       }
-      options.put(
-          debuggerItemString,
-          () ->
-              mDevServerHelper.openDebugger(
-                  mCurrentContext,
-                  mApplicationContext.getString(R.string.catalyst_open_debugger_error)));
+      options.put(debuggerItemString, () -> openDebugger());
     }
 
     options.put(
@@ -1162,5 +1157,11 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     } else {
       context.registerReceiver(receiver, filter);
     }
+  }
+
+  @Override
+  public void openDebugger() {
+    mDevServerHelper.openDebugger(
+        mCurrentContext, mApplicationContext.getString(R.string.catalyst_open_debugger_error));
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -204,4 +204,7 @@ public class DisabledDevSupportManager implements DevSupportManager {
   public @Nullable SurfaceDelegate createSurfaceDelegate(String moduleName) {
     return null;
   }
+
+  @Override
+  public void openDebugger() {}
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -128,4 +128,7 @@ public interface DevSupportManager extends JSExceptionHandler {
    */
   @Nullable
   SurfaceDelegate createSurfaceDelegate(String moduleName);
+
+  /** Attempt to open the JS debugger on the host machine. */
+  void openDebugger();
 }


### PR DESCRIPTION
Summary:
Changelog: [Changed][Android] Expose `openDebugger()` method on `DevSupportManager`

Exposes the `openDebugger()` method on `DevSupportManager` for ease of integration by RN Android frameworks.

Differential Revision: D55408820


