### PR TITLE
FIx "Buffer() is deprecated" warning from inspector proxy

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -631,7 +631,7 @@ export default class Device {
             // $FlowFixMe[cannot-write]
             payload.params.sourceMapURL =
               'data:application/json;charset=utf-8;base64,' +
-              new Buffer(sourceMap).toString('base64');
+              Buffer.from(sourceMap).toString('base64');
           } catch (exception) {
             this.#sendErrorToDebugger(
               `Failed to fetch source map ${params.sourceMapURL}: ${exception.message}`,


### PR DESCRIPTION
Summary:
Under Node 20, the use of `new Buffer(string)` is deprecated and logs a warning. This replaces it with the recommended `Buffer.from(string)`.

Changelog:
[General][Fixed] FIx "Buffer() is deprecated" warning from debugger proxy.

Differential Revision: D55472025
