### PR TITLE
chore: upgrade `ws` package to `^7.5.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "signedsource": "^1.0.0",
     "supports-color": "^7.1.0",
     "typescript": "5.0.4",
-    "ws": "^6.2.2"
+    "ws": "^7.5.1"
   }
 }

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -34,7 +34,7 @@
     "selfsigned": "^2.4.1",
     "serve-static": "^1.13.1",
     "temp-dir": "^2.0.0",
-    "ws": "^6.2.2"
+    "ws": "^7.5.1"
   },
   "engines": {
     "node": ">=18"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -142,7 +142,7 @@
     "scheduler": "0.24.0-canary-efb381bbf-20230505",
     "stacktrace-parser": "^0.1.10",
     "whatwg-fetch": "^3.0.0",
-    "ws": "^6.2.2",
+    "ws": "^7.5.1",
     "yargs": "^17.6.2"
   },
   "codegenConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3343,11 +3343,6 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async-limiter@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
-
 async-retry@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
@@ -9520,14 +9515,7 @@ ws@>=7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
-ws@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
-  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
-  dependencies:
-    async-limiter "~1.0.0"
-
-ws@^7, ws@^7.5.1:
+ws@^7, ws@^7.5.1, ws@^7.5.9:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While linking CLI to React Native project using Yarn v3 (which is default for new project initialised starting from 0.74) I hit this problem: 

```
➤ YN0000: ┌ Link step
➤ YN0001: │ Error: Assertion failed: Writing attempt prevented to /Users/szymonrybczak/development/cli/packages/cli/node_modules/ws which is outside project root: /Users/szymonrybczak/development/tmp/RC4
```

I checked with `NM_DEBUG_LEVEL=2 yarn` what is the source of this problem, and it turns out that `ws` package has different version across [`cli-server-api`](https://github.com/react-native-community/cli/blob/61b6be6b86152fa9b6036968a15d7189de04ace8/packages/cli-server-api/package.json#L18) and `react-native` package. In this PR I've updated version of `ws` package to align with `cli-server-api`.

## Changelog:

[INTERNAL] [CHANGED] - Upgrade `ws` package to `^7.5.1`


## Test Plan:

1. Create app with `npx react-native@next init RN0740RC5 --version 0.74.0-rc.5` (ensure that you have Yarn v3 inside your project)
2. Follow [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md) guide inside React Native Community CLI
3. `yarn link ~/path/to/cli --all` should pass without any issues.