### PR TITLE
fix: prevent error when react extension was already created

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -38,7 +38,8 @@ import org.gradle.internal.jvm.Jvm
 class ReactPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     checkJvmVersion(project)
-    val extension = project.extensions.create("react", ReactExtension::class.java, project)
+    val extension = project.extensions.findByType(ReactExtension::class.java)
+           ?: project.extensions.create("react", ReactExtension::class.java, project)
     checkIfNewArchFlagIsSet(project, extension)
 
     // We register a private extension on the rootProject so that project wide configs


### PR DESCRIPTION
## Summary:

Currently the react-native-gradle-plugin does not allow the "react" plugin extension to already exist when running its apply block. I had a use-case where I wanted to create a new gradle plugin which would take care of applying the react plugin including setting some of its options. Without the change in this PR, this would currently turn into a build failure.

## Changelog:

[ANDROID] [FIXED] - prevent error when the "react" extension was already created by another gradle plugin

## Test Plan:
