### PR TITLE
return correct isAccessibilityElement from RCTViewComponentView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -763,6 +763,15 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   return RCTRecursiveAccessibilityLabel(self);
 }
 
+- (BOOL)isAccessibilityElement
+{
+  if (self.contentView != nil) {
+    return self.contentView.isAccessibilityElement;
+  }
+
+  return [super isAccessibilityElement];
+}
+
 - (NSString *)accessibilityValue
 {
   const auto &props = static_cast<const ViewProps &>(*_props);


### PR DESCRIPTION
Summary:
changelog: [internal]

RCTViewComponentView was missing isAccessibilityElement override. Here I add it and use contentView to determine if element is accessible.

Reviewed By: rubennorte

Differential Revision: D55483944


