### PR TITLE
Set HERMES_RELEASE_VERSION correctly

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -786,8 +786,6 @@ jobs:
       - HERMES_WS_DIR: *hermes_workspace_root
       - HERMES_TARBALL_ARTIFACTS_DIR: *hermes_tarball_artifacts_dir
       - HERMES_OSXBIN_ARTIFACTS_DIR: *hermes_osxbin_artifacts_dir
-      - IOS_DEPLOYMENT_TARGET: 13.4
-      - MAC_DEPLOYMENT_TARGET: 10.13
     steps:
       - *attach_hermes_workspace
       - stop_job_if_apple_artifacts_are_there:
@@ -817,10 +815,14 @@ jobs:
 
             if [[ "$SLICE" == "macosx" ]]; then
               echo "[HERMES] Building Hermes for MacOS"
+              export MAC_DEPLOYMENT_TARGET=10.13
               BUILD_TYPE="<< parameters.flavor >>" ./utils/build-mac-framework.sh
+              unset MAC_DEPLOYMENT_TARGET
             else
               echo "[HERMES] Building Hermes for iOS: $SLICE"
+              export IOS_DEPLOYMENT_TARGET=13.4
               BUILD_TYPE="<< parameters.flavor >>" ./utils/build-ios-framework.sh "$SLICE"
+              unset IOS_DEPLOYMENT_TARGET
             fi
 
             echo "Moving from build_$SLICE to $FINAL_PATH"
@@ -860,8 +862,6 @@ jobs:
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
       - HERMES_TARBALL_ARTIFACTS_DIR: *hermes_tarball_artifacts_dir
-      - IOS_DEPLOYMENT_TARGET: 13.4
-      - MAC_DEPLOYMENT_TARGET: 10.13
     steps:
       - *attach_hermes_workspace
       # Try to store the artifacts if they are already in the workspace
@@ -902,7 +902,9 @@ jobs:
           command: |
             cd ./packages/react-native/sdks/hermes || exit 1
             echo "[HERMES] Creating the universal framework"
+            export IOS_DEPLOYMENT_TARGET=13.4
             ./utils/build-ios-framework.sh build_framework
+            unset IOS_DEPLOYMENT_TARGET
       - run:
           name: Package the Hermes Apple frameworks
           command: |

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -813,6 +813,7 @@ jobs:
               exit 0
             fi
 
+            export RELEASE_VERSION=$(cat /tmp/react-native-version)
             if [[ "$SLICE" == "macosx" ]]; then
               echo "[HERMES] Building Hermes for MacOS"
               export MAC_DEPLOYMENT_TARGET=10.13
@@ -824,6 +825,7 @@ jobs:
               BUILD_TYPE="<< parameters.flavor >>" ./utils/build-ios-framework.sh "$SLICE"
               unset IOS_DEPLOYMENT_TARGET
             fi
+            unset RELEASE_VERSION
 
             echo "Moving from build_$SLICE to $FINAL_PATH"
             mv build_"$SLICE" "$FINAL_PATH"
@@ -903,7 +905,9 @@ jobs:
             cd ./packages/react-native/sdks/hermes || exit 1
             echo "[HERMES] Creating the universal framework"
             export IOS_DEPLOYMENT_TARGET=13.4
+            export RELEASE_VERSION=$(cat /tmp/react-native-version)
             ./utils/build-ios-framework.sh build_framework
+            unset RELEASE_VERSION
             unset IOS_DEPLOYMENT_TARGET
       - run:
           name: Package the Hermes Apple frameworks

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -82,10 +82,10 @@ references:
     hermes_windows_cache_key: &hermes_windows_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-windows-{{ checksum "/Users/circleci/project/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     # Hermes iOS
     hermesc_apple_cache_key: &hermesc_apple_cache_key v3-hermesc-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    hermes_apple_slices_cache_key: &hermes_apple_slices_cache_key v6-hermes-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
+    hermes_apple_slices_cache_key: &hermes_apple_slices_cache_key v7-hermes-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v5-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v4-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
-    hermes_macosx_bin_release_cache_key: &hermes_macosx_bin_release_cache_key v3-hermes-release-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
+    hermes_macosx_bin_release_cache_key: &hermes_macosx_bin_release_cache_key v4-hermes-release-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_macosx_bin_debug_cache_key: &hermes_macosx_bin_debug_cache_key v2-hermes-debug-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_dsym_debug_cache_key: &hermes_dsym_debug_cache_key v2-hermes-debug-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_dsym_release_cache_key: &hermes_dsym_release_cache_key v2-hermes-release-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -7,6 +7,8 @@
 # Defines functions for building various Hermes frameworks.
 # See build-ios-framework.sh and build-mac-framework.sh for usage examples.
 
+set -x -e
+
 CURR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 IMPORT_HERMESC_PATH=${HERMES_OVERRIDE_HERMESC_PATH:-$PWD/build_host_hermesc/ImportHermesc.cmake}

--- a/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -x -e
+
 # Given a specific target, retrieve the right architecture for it
 # $1 the target you want to build. Allowed values: iphoneos, iphonesimulator, catalyst
 function get_architecture {

--- a/packages/react-native/sdks/hermes-engine/utils/build-mac-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-mac-framework.sh
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -x -e
+
 # shellcheck source=xplat/js/react-native-github/sdks/hermes-engine/utils/build-apple-framework.sh
 CURR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 . "${CURR_SCRIPT_DIR}/build-apple-framework.sh"


### PR DESCRIPTION
Summary:
This diff initializes `RELEASE_VERSION` with the value that is provided by the `get_react_native_version` job (it stores its output into `/tmp/react-native-version`).

Changelog: [Internal]

Differential Revision: D55484988


