### PR TITLE
Fix measure not using the last reported mark with a given name

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformanceObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformanceObserver.h
@@ -21,14 +21,15 @@ class PerformanceEntryReporter;
 using RawPerformanceEntryType = int32_t;
 
 using RawPerformanceEntry = NativePerformanceObserverCxxRawPerformanceEntry<
-    std::string,
-    RawPerformanceEntryType,
-    double,
-    double,
+    /* name */ std::string,
+    /* type */ RawPerformanceEntryType,
+    /* startTime */ double,
+    /* duration */ double,
+
     // For "event" entries only:
-    std::optional<double>,
-    std::optional<double>,
-    std::optional<uint32_t>>;
+    /* processingStart */ std::optional<double>,
+    /* processingEnd */ std::optional<double>,
+    /* interactionId */ std::optional<uint32_t>>;
 
 template <>
 struct Bridging<RawPerformanceEntry>

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/tests/PerformanceEntryReporterTest.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/tests/PerformanceEntryReporterTest.cpp
@@ -94,12 +94,14 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMarks) {
   reporter.mark("mark0", 0.0);
   reporter.mark("mark1", 1.0);
   reporter.mark("mark2", 2.0);
+  // Report mark0 again
+  reporter.mark("mark0", 3.0);
 
   auto res = reporter.popPendingEntries();
   const auto& entries = res.entries;
 
   ASSERT_EQ(0, res.droppedEntriesCount);
-  ASSERT_EQ(3, entries.size());
+  ASSERT_EQ(4, entries.size());
 
   const std::vector<RawPerformanceEntry> expected = {
       {"mark0",
@@ -122,7 +124,15 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMarks) {
        0.0,
        std::nullopt,
        std::nullopt,
-       std::nullopt}};
+       std::nullopt},
+      {"mark0",
+       static_cast<int>(PerformanceEntryType::MARK),
+       3.0,
+       0.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt},
+  };
 
   ASSERT_EQ(expected, entries);
 }
@@ -152,6 +162,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
   reporter.mark("mark3", 2.0);
   reporter.measure("measure6", 2.0, 2.0);
   reporter.mark("mark4", 2.0);
+  reporter.mark("mark4", 3.0);
+  // Uses the last reported time for mark4
+  reporter.measure("measure7", 0.0, 0.0, std::nullopt, "mark1", "mark4");
 
   auto res = reporter.popPendingEntries();
   const auto& entries = res.entries;
@@ -191,6 +204,13 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
        static_cast<int>(PerformanceEntryType::MEASURE),
        1.0,
        1.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt},
+      {"measure7",
+       static_cast<int>(PerformanceEntryType::MEASURE),
+       1.0,
+       2.0,
        std::nullopt,
        std::nullopt,
        std::nullopt},
@@ -243,7 +263,13 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
        std::nullopt,
        std::nullopt,
        std::nullopt},
-  };
+      {"mark4",
+       static_cast<int>(PerformanceEntryType::MARK),
+       3.0,
+       0.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt}};
 
   ASSERT_EQ(expected, entries);
 }

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -22,6 +22,8 @@ import NativePerformanceObserver from './specs/NativePerformanceObserver';
 
 export type PerformanceEntryList = $ReadOnlyArray<PerformanceEntry>;
 
+export {PerformanceEntry} from './PerformanceEntry';
+
 export class PerformanceObserverEntryList {
   _entries: PerformanceEntryList;
 

--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -14,7 +14,9 @@ import type MemoryInfo from 'react-native/src/private/webapis/performance/Memory
 import type ReactNativeStartupTiming from 'react-native/src/private/webapis/performance/ReactNativeStartupTiming';
 
 import RNTesterPage from '../../components/RNTesterPage';
+import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 import * as React from 'react';
+import {useContext} from 'react';
 import {Button, StyleSheet, Text, View} from 'react-native';
 import Performance from 'react-native/src/private/webapis/performance/Performance';
 
@@ -22,6 +24,8 @@ const {useState, useCallback} = React;
 const performance = new Performance();
 
 function MemoryExample(): React.Node {
+  const theme = useContext(RNTesterThemeContext);
+
   // Memory API testing
   const [memoryInfo, setMemoryInfo] = useState<?MemoryInfo>(null);
   const onGetMemoryInfo = useCallback(() => {
@@ -34,13 +38,13 @@ function MemoryExample(): React.Node {
       <View style={styles.container}>
         <Button onPress={onGetMemoryInfo} title="Click to update memory info" />
         <View>
-          <Text>
+          <Text style={{color: theme.LabelColor}}>
             {`jsHeapSizeLimit: ${String(memoryInfo?.jsHeapSizeLimit)} bytes`}
           </Text>
-          <Text>
+          <Text style={{color: theme.LabelColor}}>
             {`totalJSHeapSize: ${String(memoryInfo?.totalJSHeapSize)} bytes`}
           </Text>
-          <Text>
+          <Text style={{color: theme.LabelColor}}>
             {`usedJSHeapSize: ${String(memoryInfo?.usedJSHeapSize)} bytes`}
           </Text>
         </View>
@@ -50,6 +54,8 @@ function MemoryExample(): React.Node {
 }
 
 function StartupTimingExample(): React.Node {
+  const theme = useContext(RNTesterThemeContext);
+
   // React Startup Timing API testing
   const [startUpTiming, setStartUpTiming] =
     useState<?ReactNativeStartupTiming>(null);
@@ -66,22 +72,35 @@ function StartupTimingExample(): React.Node {
           title="Click to update React startup timing"
         />
         <View>
-          <Text>{`startTime: ${String(startUpTiming?.startTime)} ms`}</Text>
-          <Text>{`initializeRuntimeStart: ${String(
+          <Text
+            style={{
+              color: theme.LabelColor,
+            }}>{`startTime: ${String(startUpTiming?.startTime)} ms`}</Text>
+          <Text
+            style={{
+              color: theme.LabelColor,
+            }}>{`initializeRuntimeStart: ${String(
             startUpTiming?.initializeRuntimeStart,
           )} ms`}</Text>
-          <Text>
+          <Text style={{color: theme.LabelColor}}>
             {`executeJavaScriptBundleEntryPointStart: ${String(
               startUpTiming?.executeJavaScriptBundleEntryPointStart,
             )} ms`}
           </Text>
-          <Text>{`executeJavaScriptBundleEntryPointEnd: ${String(
+          <Text
+            style={{
+              color: theme.LabelColor,
+            }}>{`executeJavaScriptBundleEntryPointEnd: ${String(
             startUpTiming?.executeJavaScriptBundleEntryPointEnd,
           )} ms`}</Text>
-          <Text>{`initializeRuntimeEnd: ${String(
+          <Text
+            style={{color: theme.LabelColor}}>{`initializeRuntimeEnd: ${String(
             startUpTiming?.initializeRuntimeEnd,
           )} ms`}</Text>
-          <Text>{`endTime: ${String(startUpTiming?.endTime)} ms`}</Text>
+          <Text
+            style={{
+              color: theme.LabelColor,
+            }}>{`endTime: ${String(startUpTiming?.endTime)} ms`}</Text>
         </View>
       </View>
     </RNTesterPage>


### PR DESCRIPTION
Summary:
Changelog: [internal]

(internal because this API isn't available in OSS yet)

I found a bug in the current implementation of `performance.measure` where the API would use the first `mark` reported under a specific name instead of the last one (found it in the new example in RNTester in D55477746 that re-logs the marks every time we click on a button).

The root cause for this problem is that we were using `insert` from `std::unordered_set` to update the value, but `insert` doesn't modify the value if it's already present.

This fixes the issue by doing a lookup and removing the value prior to inserting it.

Differential Revision: D55477743


