### PR TITLE
fix: version checker not considering nightlies

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -56,6 +56,11 @@ async function getLatestVersion(registryHost = DEFAULT_REGISTRY_HOST) {
   });
 }
 
+function parseVersion(version) {
+  const [major, minor = 0, patch = 0] = version.split('-')[0].split('.');
+  return major * 1000000 + minor * 1000 + patch;
+}
+
 /**
  * Warn when users are using `npx react-native init`, to raise awareness of the changes from RFC 0759.
  *
@@ -129,7 +134,7 @@ async function main() {
   if (isNpxRuntime && !process.env.SKIP && currentVersion !== HEAD) {
     try {
       const latest = await getLatestVersion();
-      if (latest !== currentVersion) {
+      if (parseVersion(latest) > parseVersion(currentVersion)) {
         const msg = `
   ${chalk.bold.yellow('WARNING:')} You should run ${chalk.white.bold(
     'npx react-native@latest',


### PR DESCRIPTION
## Summary:

Fix version checker not considering nightlies:

```
  WARNING: You should run npx react-native@latest to ensure you're always using the most current version of the CLI. NPX
 has cached version (0.74.0-nightly-20240214-b8ad91732) != current release (0.73.6)
```

## Changelog:

[GENERAL] [FIXED] - Fix version checker not considering nightlies

## Test Plan:

On a recent nightly version, run any cli command.