### PR TITLE
Use hook syntax for builtin React hooks in xplat (1/2)

### DIFF
--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestEventRecorder.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestEventRecorder.js
@@ -107,8 +107,9 @@ class RNTesterPlatformTestEventRecorder {
   ): $ReadOnly<{[targetName: string]: ViewProps}> {
     // Yes this method exists as a class's prototype method but it will still only be used
     // in functional components
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useMemo(() => {
+    // prettier-ignore
+    // $FlowFixMe[react-rule-hook]
+    return useMemo(() => { // eslint-disable-line react-hooks/rules-of-hooks
       const result: {[targetName: string]: ViewProps} = {};
       for (const targetName of targetNames) {
         const recordedEventHandler =


### PR DESCRIPTION
Summary:
Migrate React builtin hooks to use the new React "hook" type. This diff converts all builtin hooks except for `useContext` which will be updated after the next flow release. 

Details:
- Announcement: https://fb.workplace.com/groups/react.fyi/posts/7642294409114198
- Docs: https://www.internalfb.com/intern/wiki/Component_Syntax_Documentation/Hook_syntax_0/
- Support group: https://fb.workplace.com/groups/749069370011855

Changelog: [flow] Suppress react builtin hook errors

Reviewed By: SamChou19815

Differential Revision: D55500989


