### PR TITLE
Introduce fragment-based navigation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -69,6 +69,10 @@ public abstract class ReactActivity extends AppCompatActivity
     mDelegate.getReactDelegate();
   }
 
+  public ReactActivityDelegate getReactActivityDelegate() {
+    return mDelegate;
+  }
+
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -32,6 +32,8 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
 
   protected ReactDelegate mReactDelegate;
 
+  protected boolean shouldCallDelegateLifecycleEvents = true;
+
   @Nullable private PermissionListener mPermissionListener;
 
   public ReactFragment() {
@@ -99,19 +101,25 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
   @Override
   public void onResume() {
     super.onResume();
-    mReactDelegate.onHostResume();
+    if (shouldCallDelegateLifecycleEvents) {
+      mReactDelegate.onHostResume();
+    }
   }
 
   @Override
   public void onPause() {
     super.onPause();
-    mReactDelegate.onHostPause();
+    if (shouldCallDelegateLifecycleEvents) {
+      mReactDelegate.onHostPause();
+    }
   }
 
   @Override
   public void onDestroy() {
     super.onDestroy();
-    mReactDelegate.onHostDestroy();
+    if (shouldCallDelegateLifecycleEvents) {
+      mReactDelegate.onHostDestroy();
+    }
   }
 
   // endregion


### PR DESCRIPTION
Summary:
Currently, on Twilight Android every time a new screen is opened a new XOCMainActivity is created. This is not ideal as this activity has a lot of one-time logic that's core to app startup (e.g. setting up touch event listeners, notifications, Bloks, asking for permissions) that is not needed after app startup and definitely not necessary when simply opening a new screen on the app.

This introduced fragment-based navigation which, instead of creating a new activity, creates a new fragment - making use of the current XOCMainActivity. This brings about several benefits:
- Performance: We no longer waste time/resources re-creating things that have already been initialized on app start.
- User experience:
    - We can now persist a bottom tab bar at the bottom of the app (in parity with iOS) which makes it a lot easier for a user to navigate in the app. Previously, it was easy to get lost within screens and the only way to navigate back to the tabs were to go all the way back in the stack. (cc alikherbane)
    - Previously, because we were re-creating the activity, permissions would be checked and requested on every screen open. This is super disruptive as in the worst case if the user declined every time, they would be asked again as soon as they open another screen like PDP.

## Changelog:
[Internal] [Changed] - Add option to skip calling delegate on ReactFragment lifecycle events

Differential Revision: D55533768


