### PR TITLE
Deprecate RedBox from RCTBridge to RCTModuleRegistry

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -370,6 +370,9 @@ RCT_EXTERN_C_END
 - (id)moduleForName:(const char *)moduleName;
 - (id)moduleForName:(const char *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad;
 - (BOOL)moduleIsInitialized:(Class)moduleClass;
+
+// Note: This method lazily load the module as necessary.
+- (id)moduleForClass:(Class)moduleClass;
 @end
 
 typedef UIView * (^RCTBridgelessComponentViewProvider)(NSNumber *);

--- a/packages/react-native/React/Base/RCTModuleRegistry.m
+++ b/packages/react-native/React/Base/RCTModuleRegistry.m
@@ -64,4 +64,9 @@
   return NO;
 }
 
+- (id)moduleForClass:(Class)moduleClass
+{
+  return [self moduleForName:RCTBridgeModuleNameForClass(moduleClass).UTF8String];
+}
+
 @end

--- a/packages/react-native/React/CoreModules/RCTRedBox.h
+++ b/packages/react-native/React/CoreModules/RCTRedBox.h
@@ -7,9 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
-#import <React/RCTBridgeProxy.h>
 #import <React/RCTErrorCustomizer.h>
 
 @class RCTJSStackFrame;
@@ -46,21 +44,5 @@ typedef void (^RCTRedBoxButtonPressHandler)(void);
 
 /** Overrides the default behavior of calling [bridge reload] on reload. You shouldn't need to use this. */
 @property (nonatomic, strong) dispatch_block_t overrideReloadAction;
-
-@end
-
-/**
- * This category makes the red box instance available via the RCTBridge, which
- * is useful for any class that needs to access the red box or error log.
- */
-@interface RCTBridge (RCTRedBox)
-
-@property (nonatomic, readonly) RCTRedBox *redBox;
-
-@end
-
-@interface RCTBridgeProxy (RCTRedBox)
-
-@property (nonatomic, readonly) RCTRedBox *redBox;
 
 @end

--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -8,14 +8,12 @@
 #import "RCTRedBox.h"
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
-#import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
 #import <React/RCTDefines.h>
 #import <React/RCTErrorInfo.h>
 #import <React/RCTEventDispatcherProtocol.h>
 #import <React/RCTJSStackFrame.h>
 #import <React/RCTRedBoxExtraDataViewController.h>
-#import <React/RCTRedBoxSetEnabled.h>
 #import <React/RCTReloadCommand.h>
 #import <React/RCTUtils.h>
 
@@ -712,24 +710,6 @@ RCT_EXPORT_METHOD(dismiss)
 
 @end
 
-@implementation RCTBridge (RCTRedBox)
-
-- (RCTRedBox *)redBox
-{
-  return RCTRedBoxGetEnabled() ? [self moduleForClass:[RCTRedBox class]] : nil;
-}
-
-@end
-
-@implementation RCTBridgeProxy (RCTRedBox)
-
-- (RCTRedBox *)redBox
-{
-  return RCTRedBoxGetEnabled() ? [self moduleForClass:[RCTRedBox class]] : nil;
-}
-
-@end
-
 #else // Disabled
 
 @interface RCTRedBox () <NativeRedBoxSpec>
@@ -802,24 +782,6 @@ RCT_EXPORT_METHOD(dismiss)
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
   return std::make_shared<facebook::react::NativeRedBoxSpecJSI>(params);
-}
-
-@end
-
-@implementation RCTBridge (RCTRedBox)
-
-- (RCTRedBox *)redBox
-{
-  return nil;
-}
-
-@end
-
-@implementation RCTBridgeProxy (RCTRedBox)
-
-- (RCTRedBox *)redBox
-{
-  return nil;
 }
 
 @end

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -29,6 +29,7 @@
 #import <React/RCTPerformanceLogger.h>
 #import <React/RCTProfile.h>
 #import <React/RCTRedBox.h>
+#import <React/RCTRedBoxSetEnabled.h>
 #import <React/RCTReloadCommand.h>
 #import <React/RCTTurboModuleRegistry.h>
 #import <React/RCTUtils.h>
@@ -1085,7 +1086,8 @@ struct RCTInstanceCallback : public InstanceCallback {
 
   if (self->_valid && !self->_loading) {
     if ([error userInfo][RCTJSRawStackTraceKey]) {
-      [self.redBox showErrorMessage:[error localizedDescription] withRawStack:[error userInfo][RCTJSRawStackTraceKey]];
+      RCTRedBox *redBox = RCTRedBoxGetEnabled() ? [self.moduleRegistry moduleForName:"RedBox"] : nil;
+      [redBox showErrorMessage:[error localizedDescription] withRawStack:[error userInfo][RCTJSRawStackTraceKey]];
     }
 
     RCTFatal(error);
@@ -1100,7 +1102,7 @@ struct RCTInstanceCallback : public InstanceCallback {
 
   // Hack: once the bridge is invalidated below, it won't initialize any new native
   // modules. Initialize the redbox module now so we can still report this error.
-  RCTRedBox *redBox = [self redBox];
+  RCTRedBox *redBox = RCTRedBoxGetEnabled() ? [self.moduleRegistry moduleForName:"RedBox"] : nil;
 
   _loading = NO;
   _valid = NO;


### PR DESCRIPTION
Summary:
As we are going to bridgeless in new architecture, we want to clean up the usage of RCTBridge to use RCTModuleRegistry to access NativeModule.

Changelog:
[iOS][Breaking] Remove `RCTRedBox` access through `RCTBridge`

Differential Revision: D55532209


