### PR TITLE
Pull react instance method impls out of ReactContext

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -543,6 +543,22 @@ public abstract class com/facebook/react/bridge/BaseJavaModule : com/facebook/re
 
 public final class com/facebook/react/bridge/BridgeReactContext : com/facebook/react/bridge/ReactApplicationContext {
 	public fun <init> (Landroid/content/Context;)V
+	public fun destroy ()V
+	public fun getCatalystInstance ()Lcom/facebook/react/bridge/CatalystInstance;
+	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
+	public fun getJSModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/JavaScriptModule;
+	public fun getJavaScriptContextHolder ()Lcom/facebook/react/bridge/JavaScriptContextHolder;
+	public fun getNativeModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/NativeModule;
+	public fun getNativeModules ()Ljava/util/Collection;
+	public fun getSourceURL ()Ljava/lang/String;
+	public fun handleException (Ljava/lang/Exception;)V
+	public fun hasActiveCatalystInstance ()Z
+	public fun hasActiveReactInstance ()Z
+	public fun hasCatalystInstance ()Z
+	public fun hasNativeModule (Ljava/lang/Class;)Z
+	public final fun initializeWithInstance (Lcom/facebook/react/bridge/CatalystInstance;)V
+	public fun isBridgeless ()Z
+	public fun registerSegment (ILjava/lang/String;Lcom/facebook/react/bridge/Callback;)V
 }
 
 public abstract interface class com/facebook/react/bridge/Callback {
@@ -1088,36 +1104,35 @@ public abstract class com/facebook/react/bridge/ReactContext : android/content/C
 	public fun assertOnNativeModulesQueueThread ()V
 	public fun assertOnNativeModulesQueueThread (Ljava/lang/String;)V
 	public fun assertOnUiQueueThread ()V
-	public fun destroy ()V
+	public abstract fun destroy ()V
 	public fun emitDeviceEvent (Ljava/lang/String;)V
 	public fun emitDeviceEvent (Ljava/lang/String;Ljava/lang/Object;)V
-	public fun getCatalystInstance ()Lcom/facebook/react/bridge/CatalystInstance;
+	public abstract fun getCatalystInstance ()Lcom/facebook/react/bridge/CatalystInstance;
 	public fun getCurrentActivity ()Landroid/app/Activity;
 	public fun getExceptionHandler ()Lcom/facebook/react/bridge/JSExceptionHandler;
-	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
+	public abstract fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
 	public fun getJSExceptionHandler ()Lcom/facebook/react/bridge/JSExceptionHandler;
 	public fun getJSMessageQueueThread ()Lcom/facebook/react/bridge/queue/MessageQueueThread;
-	public fun getJSModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/JavaScriptModule;
-	public fun getJavaScriptContextHolder ()Lcom/facebook/react/bridge/JavaScriptContextHolder;
+	public abstract fun getJSModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/JavaScriptModule;
+	public abstract fun getJavaScriptContextHolder ()Lcom/facebook/react/bridge/JavaScriptContextHolder;
 	public fun getLifecycleState ()Lcom/facebook/react/common/LifecycleState;
-	public fun getNativeModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/NativeModule;
-	public fun getNativeModules ()Ljava/util/Collection;
+	public abstract fun getNativeModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/NativeModule;
+	public abstract fun getNativeModules ()Ljava/util/Collection;
 	public fun getNativeModulesMessageQueueThread ()Lcom/facebook/react/bridge/queue/MessageQueueThread;
-	public fun getSourceURL ()Ljava/lang/String;
+	public abstract fun getSourceURL ()Ljava/lang/String;
 	public fun getSystemService (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getUiMessageQueueThread ()Lcom/facebook/react/bridge/queue/MessageQueueThread;
-	public fun handleException (Ljava/lang/Exception;)V
-	public fun hasActiveCatalystInstance ()Z
-	public fun hasActiveReactInstance ()Z
-	public fun hasCatalystInstance ()Z
+	public abstract fun handleException (Ljava/lang/Exception;)V
+	public abstract fun hasActiveCatalystInstance ()Z
+	public abstract fun hasActiveReactInstance ()Z
+	public abstract fun hasCatalystInstance ()Z
 	public fun hasCurrentActivity ()Z
-	public fun hasNativeModule (Ljava/lang/Class;)Z
+	public abstract fun hasNativeModule (Ljava/lang/Class;)Z
+	protected fun initializeFromOther (Lcom/facebook/react/bridge/ReactContext;)V
 	protected fun initializeInteropModules ()V
-	protected fun initializeInteropModules (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun initializeMessageQueueThreads (Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;)V
-	public fun initializeWithInstance (Lcom/facebook/react/bridge/CatalystInstance;)V
 	public fun internal_registerInteropModule (Ljava/lang/Class;Ljava/lang/Object;)V
-	public fun isBridgeless ()Z
+	public abstract fun isBridgeless ()Z
 	public fun isOnJSQueueThread ()Z
 	public fun isOnNativeModulesQueueThread ()Z
 	public fun isOnUiQueueThread ()Z
@@ -1127,7 +1142,7 @@ public abstract class com/facebook/react/bridge/ReactContext : android/content/C
 	public fun onHostResume (Landroid/app/Activity;)V
 	public fun onNewIntent (Landroid/app/Activity;Landroid/content/Intent;)V
 	public fun onWindowFocusChange (Z)V
-	public fun registerSegment (ILjava/lang/String;Lcom/facebook/react/bridge/Callback;)V
+	public abstract fun registerSegment (ILjava/lang/String;Lcom/facebook/react/bridge/Callback;)V
 	public fun removeActivityEventListener (Lcom/facebook/react/bridge/ActivityEventListener;)V
 	public fun removeLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
 	public fun removeWindowFocusChangeListener (Lcom/facebook/react/bridge/WindowFocusChangeListener;)V
@@ -4822,16 +4837,25 @@ public class com/facebook/react/uimanager/ThemedReactContext : com/facebook/reac
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;)V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;Ljava/lang/String;)V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Landroid/content/Context;Ljava/lang/String;I)V
-	public fun addLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
-	public fun getCurrentActivity ()Landroid/app/Activity;
+	public fun destroy ()V
+	public fun getCatalystInstance ()Lcom/facebook/react/bridge/CatalystInstance;
 	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
+	public fun getJSModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/JavaScriptModule;
+	public fun getJavaScriptContextHolder ()Lcom/facebook/react/bridge/JavaScriptContextHolder;
 	public fun getModuleName ()Ljava/lang/String;
+	public fun getNativeModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/NativeModule;
+	public fun getNativeModules ()Ljava/util/Collection;
 	public fun getReactApplicationContext ()Lcom/facebook/react/bridge/ReactApplicationContext;
+	public fun getSourceURL ()Ljava/lang/String;
 	public fun getSurfaceID ()Ljava/lang/String;
 	public fun getSurfaceId ()I
-	public fun hasCurrentActivity ()Z
+	public fun handleException (Ljava/lang/Exception;)V
+	public fun hasActiveCatalystInstance ()Z
+	public fun hasActiveReactInstance ()Z
+	public fun hasCatalystInstance ()Z
+	public fun hasNativeModule (Ljava/lang/Class;)Z
 	public fun isBridgeless ()Z
-	public fun removeLifecycleEventListener (Lcom/facebook/react/bridge/LifecycleEventListener;)V
+	public fun registerSegment (ILjava/lang/String;Lcom/facebook/react/bridge/Callback;)V
 }
 
 public class com/facebook/react/uimanager/TouchTargetHelper {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -90,10 +90,24 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
     return new BridgelessCatalystInstance(mReactHost);
   }
 
+  @Deprecated
+  @Override
+  public boolean hasActiveCatalystInstance() {
+    return hasActiveReactInstance();
+  }
+
   @Override
   public boolean hasActiveReactInstance() {
     return mReactHost.isInstanceInitialized();
   }
+
+  @Override
+  public boolean hasCatalystInstance() {
+    return false;
+  }
+
+  @Override
+  public void destroy() {}
 
   DevSupportManager getDevSupportManager() {
     return mReactHost.getDevSupportManager();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -7,13 +7,20 @@
 
 package com.facebook.react.uimanager;
 
-import android.app.Activity;
 import android.content.Context;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.JavaScriptContextHolder;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.bridge.UIManager;
+import com.facebook.react.common.annotations.FrameworkAPI;
+import com.facebook.react.common.annotations.UnstableReactNativeAPI;
+import java.util.Collection;
 
 /**
  * Wraps {@link ReactContext} with the base {@link Context} passed into the constructor. It provides
@@ -46,33 +53,67 @@ public class ThemedReactContext extends ReactContext {
       @Nullable String moduleName,
       int surfaceId) {
     super(base);
-    if (reactApplicationContext.hasCatalystInstance()) {
-      initializeWithInstance(reactApplicationContext.getCatalystInstance());
+    if (reactApplicationContext.hasActiveReactInstance()) {
+      initializeFromOther(reactApplicationContext);
     }
-    initializeInteropModules(reactApplicationContext);
     mReactApplicationContext = reactApplicationContext;
     mModuleName = moduleName;
     mSurfaceId = surfaceId;
   }
 
   @Override
-  public void addLifecycleEventListener(LifecycleEventListener listener) {
-    mReactApplicationContext.addLifecycleEventListener(listener);
+  public <T extends JavaScriptModule> T getJSModule(Class<T> jsInterface) {
+    return mReactApplicationContext.getJSModule(jsInterface);
   }
 
   @Override
-  public void removeLifecycleEventListener(LifecycleEventListener listener) {
-    mReactApplicationContext.removeLifecycleEventListener(listener);
+  public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
+    return mReactApplicationContext.hasNativeModule(nativeModuleInterface);
   }
 
   @Override
-  public boolean hasCurrentActivity() {
-    return mReactApplicationContext.hasCurrentActivity();
+  public Collection<NativeModule> getNativeModules() {
+    return mReactApplicationContext.getNativeModules();
+  }
+
+  @Nullable
+  @Override
+  public <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
+    return mReactApplicationContext.getNativeModule(nativeModuleInterface);
+  }
+
+  @Nullable
+  @Override
+  @FrameworkAPI
+  @UnstableReactNativeAPI
+  public RuntimeExecutor getRuntimeExecutor() {
+    return mReactApplicationContext.getRuntimeExecutor();
   }
 
   @Override
-  public @Nullable Activity getCurrentActivity() {
-    return mReactApplicationContext.getCurrentActivity();
+  public CatalystInstance getCatalystInstance() {
+    return mReactApplicationContext.getCatalystInstance();
+  }
+
+  @Deprecated
+  @Override
+  public boolean hasActiveCatalystInstance() {
+    return mReactApplicationContext.hasActiveCatalystInstance();
+  }
+
+  @Override
+  public boolean hasActiveReactInstance() {
+    return mReactApplicationContext.hasActiveCatalystInstance();
+  }
+
+  @Override
+  public boolean hasCatalystInstance() {
+    return mReactApplicationContext.hasCatalystInstance();
+  }
+
+  @Override
+  public void destroy() {
+    mReactApplicationContext.destroy();
   }
 
   /**
@@ -104,15 +145,35 @@ public class ThemedReactContext extends ReactContext {
   }
 
   @Override
+  public void handleException(Exception e) {
+    mReactApplicationContext.handleException(e);
+  }
+
+  @Deprecated
+  @Override
   public boolean isBridgeless() {
     return mReactApplicationContext.isBridgeless();
   }
 
+  @Nullable
+  @Override
+  public JavaScriptContextHolder getJavaScriptContextHolder() {
+    return mReactApplicationContext.getJavaScriptContextHolder();
+  }
+
   @Override
   public UIManager getFabricUIManager() {
-    if (isBridgeless()) {
-      return mReactApplicationContext.getFabricUIManager();
-    }
-    return super.getFabricUIManager();
+    return mReactApplicationContext.getFabricUIManager();
+  }
+
+  @Nullable
+  @Override
+  public String getSourceURL() {
+    return mReactApplicationContext.getSourceURL();
+  }
+
+  @Override
+  public void registerSegment(int segmentId, String path, Callback callback) {
+    mReactApplicationContext.registerSegment(segmentId, path, callback);
   }
 }


### PR DESCRIPTION
Summary:
## Context
Prior, ReactContext used to implement bridge logic.

For bridgeless mode, we created BridgelessReactContext < ReactContext

## Problem

This could lead to failures: we could call bridge methods in bridgeless mode.

## Changes
Primary change:
- Make all the react instance methods inside ReactContext abstract.

Secondary changes: Implement react instance methods in concrete subclasses:
- **New:** BridgeReactContext: By delegating to CatalystInstance
- **New:** ThemedReactContext: By delegating to inner ReactContext
- **Unchanged:** BridgelessReactContext: By delegating to ReactHost

## Auxiliary changes
This fixes ThemedReactContext in bridgeless mode.

**Problem:** Prior, ThemedReactContext's react instance methods did not work in bridgeless mode: ThemedReactContext wasn't initialized in bridgeless mode, so all those methods had undefined behaviour.

**Solution:** ThemedReactContext now implements all react instance methods, by just forwarding to the initialized ReactContext it decorates (which has an instance).

Changelog: [Android][Removed] Delete ReactContext.initializeWithInstance(). ReactContext now no longer contains legacy react instance methods. Please use BridgeReactInstance instead.

---

Reviewed By: fkgozali

Differential Revision: D55505416


