### PR TITLE
[iOS] Remove invalidate observer instead of re-adding observer in DeviceInfo module

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -166,7 +166,7 @@ typedef void (^RCTLoadSourceForBridgeProgressBlock)(
  *
  * @parameter: moduleName  - the name of the app, used by Metro to resolve the module.
  * @parameter: initialProperties  -  a set of initial properties.
- * @parameter: moduleName  - a dictionary with a set of options.
+ * @parameter: launchOptions  - a dictionary with a set of options.
  */
 - (UIView *_Nonnull)viewWithModuleName:(NSString *)moduleName
                      initialProperties:(NSDictionary *__nullable)initialProperties

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -89,6 +89,9 @@ RCT_EXPORT_MODULE()
 
 - (void)invalidate
 {
+  if (_invalidated) {
+    return;
+  }
   _invalidated = YES;
   [self _cleanupObservers];
 }
@@ -109,10 +112,7 @@ RCT_EXPORT_MODULE()
 
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTWindowFrameDidChangeNotification object:nil];
 
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(invalidate)
-                                               name:RCTBridgeWillInvalidateModulesNotification
-                                             object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTBridgeWillInvalidateModulesNotification object:nil];
 }
 
 static BOOL RCTIsIPhoneNotched()


### PR DESCRIPTION
## Summary:

Previous fix brings in https://github.com/facebook/react-native/pull/42396. Seems it's a mistake to re-add observer?
So let's remove it and also not `invalidate` method not be called twice. 

## Changelog:

[IOS] [FIXED] - Remove invalidate observer instead of re-adding observer in DeviceInfo module

## Test Plan:

Fix for #42120 also works.
