### PR TITLE
Use semver to compare version in cli instead of custom function

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -13,6 +13,7 @@
 const {name, version: currentVersion} = require('./package.json');
 const chalk = require('chalk');
 const {get} = require('https');
+const semver = require('semver');
 const {URL} = require('url');
 
 const deprecated = () => {
@@ -54,11 +55,6 @@ async function getLatestVersion(registryHost = DEFAULT_REGISTRY_HOST) {
       });
     }).on('error', e => rej(e));
   });
-}
-
-function parseVersion(version) {
-  const [major, minor = 0, patch = 0] = version.split('-')[0].split('.');
-  return major * 1000000 + minor * 1000 + patch;
 }
 
 /**
@@ -134,7 +130,7 @@ async function main() {
   if (isNpxRuntime && !process.env.SKIP && currentVersion !== HEAD) {
     try {
       const latest = await getLatestVersion();
-      if (parseVersion(latest) > parseVersion(currentVersion)) {
+      if (semver.lt(currentVersion, latest)) {
         const msg = `
   ${chalk.bold.yellow('WARNING:')} You should run ${chalk.white.bold(
     'npx react-native@latest',


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Changed] - Use semver to do version comparison in cli instead of custom fn `parseVersion`

~~adding test for PR change in https://github.com/facebook/react-native/pull/43712~~
