### PR TITLE
debug/holder

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/NoopPrinter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/NoopPrinter.java
@@ -8,8 +8,10 @@
 package com.facebook.debug.holder;
 
 import com.facebook.debug.debugoverlay.model.DebugOverlayTag;
+import com.facebook.infer.annotation.Nullsafe;
 
 /** No-op implementation of {@link Printer}. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class NoopPrinter implements Printer {
 
   public static final NoopPrinter INSTANCE = new NoopPrinter();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/PrinterHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/PrinterHolder.java
@@ -7,7 +7,10 @@
 
 package com.facebook.debug.holder;
 
+import com.facebook.infer.annotation.Nullsafe;
+
 /** Holder for debugging tool instance. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class PrinterHolder {
 
   private static Printer sPrinter = NoopPrinter.INSTANCE;


### PR DESCRIPTION
Summary:
Mark relevant classes as nullsafe prior to Kotlin conversion.

changelog: [internal] internal

Differential Revision: D55591487


