### PR TITLE
Updated NewAppScreen

### DIFF
--- a/packages/react-native/Libraries/NewAppScreen/components/Header.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/Header.js
@@ -8,42 +8,67 @@
  * @format
  */
 
-import type {Node} from 'react';
+import type { Node } from "react";
 
-import ImageBackground from '../../Image/ImageBackground';
-import StyleSheet from '../../StyleSheet/StyleSheet';
-import Text from '../../Text/Text';
-import useColorScheme from '../../Utilities/useColorScheme';
-import Colors from './Colors';
-import NewArchitectureBadge from './NewArchitectureBadge';
-import React from 'react';
+import ImageBackground from "../../Image/ImageBackground";
+import StyleSheet from "../../StyleSheet/StyleSheet";
+import Text from "../../Text/Text";
+import View from "react-native/Libraries/Components/View/View";
+import useColorScheme from "../../Utilities/useColorScheme";
+import Colors from "./Colors";
+import NewArchitectureBadge from "./NewArchitectureBadge";
+import React from "react";
+
+import appData from "../../../../../app.json";
 
 const Header = (): Node => {
-  const isDarkMode = useColorScheme() === 'dark';
+  const isDarkMode = useColorScheme() === "dark";
   return (
     <ImageBackground
       accessibilityRole="image"
       testID="new-app-screen-header"
-      source={require('./logo.png')}
+      source={require("./logo.png")}
       style={[
         styles.background,
         {
           backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
         },
       ]}
-      imageStyle={styles.logo}>
+      imageStyle={styles.logo}
+    >
       <NewArchitectureBadge />
-      <Text
-        style={[
-          styles.text,
-          {
-            color: isDarkMode ? Colors.white : Colors.black,
-          },
-        ]}>
-        Welcome to
-        {'\n'}
-        React Native
-      </Text>
+      <View>
+        <Text
+          style={[
+            styles.headerText,
+            {
+              color: isDarkMode ? Colors.white : Colors.black,
+            },
+          ]}
+        >
+          Welcome to
+        </Text>
+        <Text
+          style={[
+            styles.displayName,
+            {
+              color: isDarkMode ? Colors.white : Colors.black,
+            },
+          ]}
+        >
+          {appData.displayName}
+        </Text>
+        <Text
+          style={[
+            styles.poweredByText,
+            {
+              color: isDarkMode ? Colors.white : Colors.black,
+            },
+          ]}
+        >
+          Powered By React Native
+        </Text>
+      </View>
     </ImageBackground>
   );
 };
@@ -56,8 +81,8 @@ const styles = StyleSheet.create({
   },
   logo: {
     opacity: 0.2,
-    overflow: 'visible',
-    resizeMode: 'cover',
+    overflow: "visible",
+    resizeMode: "cover",
     /*
      * These negative margins allow the image to be offset similarly across screen sizes and component sizes.
      *
@@ -67,10 +92,22 @@ const styles = StyleSheet.create({
     marginLeft: -128,
     marginBottom: -192,
   },
-  text: {
+  headerText: {
     fontSize: 40,
-    fontWeight: '700',
-    textAlign: 'center',
+    fontWeight: "700",
+    textAlign: "center",
+    color: "white",
+  },
+  displayName: {
+    textTransform: "capitalize",
+    textAlign: "center",
+    fontSize: 48,
+    fontWeight: "700",
+  },
+  poweredByText: {
+    fontSize: 28,
+    fontWeight: "normal",
+    textAlign: "center",
   },
 });
 

--- a/packages/react-native/Libraries/NewAppScreen/components/Header.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/Header.js
@@ -15,7 +15,7 @@ import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
 import useColorScheme from '../../Utilities/useColorScheme';
 import Colors from './Colors';
-import HermesBadge from './HermesBadge';
+import NewArchitectureBadge from './NewArchitectureBadge';
 import React from 'react';
 
 const Header = (): Node => {
@@ -32,7 +32,7 @@ const Header = (): Node => {
         },
       ]}
       imageStyle={styles.logo}>
-      <HermesBadge />
+      <NewArchitectureBadge />
       <Text
         style={[
           styles.text,

--- a/packages/react-native/Libraries/NewAppScreen/components/NewArchitectureBadge.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/NewArchitectureBadge.js
@@ -17,11 +17,13 @@ import useColorScheme from '../../Utilities/useColorScheme';
 import Colors from './Colors';
 import React from 'react';
 
-const HermesBadge = (): Node => {
+const NewArchitectureBadge = (): Node => {
   const isDarkMode = useColorScheme() === 'dark';
-  const version =
+  const hermesVersion =
     global.HermesInternal?.getRuntimeProperties?.()['OSS Release Version'] ??
     '';
+  const renderer = global?.nativeFabricUIManager ? 'Fabric, New Architecture' : 'Paper';
+  
   return global.HermesInternal ? (
     <View style={styles.badge}>
       <Text
@@ -31,7 +33,16 @@ const HermesBadge = (): Node => {
             color: isDarkMode ? Colors.light : Colors.dark,
           },
         ]}>
-        {`Engine: Hermes ${version}`}
+        {`Engine: Hermes ${hermesVersion}`}
+      </Text>
+      <Text
+        style={[
+          styles.badgeText,
+          {
+            color: isDarkMode ? Colors.light : Colors.dark,
+          },
+        ]}>
+        {`Renderer: ${renderer}`}
       </Text>
     </View>
   ) : null;
@@ -50,4 +61,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default HermesBadge;
+export default NewArchitectureBadge;

--- a/packages/react-native/Libraries/NewAppScreen/index.js
+++ b/packages/react-native/Libraries/NewAppScreen/index.js
@@ -11,14 +11,14 @@
 import Colors from './components/Colors';
 import DebugInstructions from './components/DebugInstructions';
 import Header from './components/Header';
-import HermesBadge from './components/HermesBadge';
+import NewArchitectureBadge from './components/NewArchitectureBadge';
 import LearnMoreLinks from './components/LearnMoreLinks';
 import ReloadInstructions from './components/ReloadInstructions';
 
 export {
   Colors,
   Header,
-  HermesBadge,
+  NewArchitectureBadge,
   LearnMoreLinks,
   DebugInstructions,
   ReloadInstructions,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6088,9 +6088,9 @@ declare export default typeof Header;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/HermesBadge.js 1`] = `
-"declare const HermesBadge: () => Node;
-declare export default typeof HermesBadge;
+exports[`public API should not change unintentionally Libraries/NewAppScreen/components/NewArchitectureBadge.js 1`] = `
+"declare const NewArchitectureBadge: () => Node;
+declare export default typeof NewArchitectureBadge;
 "
 `;
 
@@ -6110,7 +6110,7 @@ exports[`public API should not change unintentionally Libraries/NewAppScreen/ind
 "export {
   Colors,
   Header,
-  HermesBadge,
+  NewArchitectureBadge,
   LearnMoreLinks,
   DebugInstructions,
   ReloadInstructions,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
With the push for the new architecture, it felt appropriate to rename the HermesBadge on the NewAppScreen's Header to NewArchitectureBadge to show the render system being used and in the future, if React Compiler is used. and any other changes that may arrive in the future. Additionally, the NewAppScreen now shows the app's displayName, with a "Powered By React Native"

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
- [General] [Changed] - Renamed HermesBadge to NewArchitectureBadge
- [General] [Changed] - Show the current render system being used
- [General] [Changed] - NewAppScreen's Header now shows the app's displayName.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Screenshot attached. To test, simply run and see the changes reflected. 

![NewAppScreen](https://github.com/facebook/react-native/assets/8391175/a81fdc81-961d-4a45-8fe3-bd9d4dfe66c2)


