### PR TITLE
Back out "fix: prevent error when react extension was already created"

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -38,10 +38,7 @@ import org.gradle.internal.jvm.Jvm
 class ReactPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     checkJvmVersion(project)
-    val extension =
-        project.rootProject.extensions.findByType(ReactExtension::class.java)
-            ?: project.rootProject.extensions.create("react", ReactExtension::class.java, project)
-
+    val extension = project.extensions.create("react", ReactExtension::class.java, project)
     checkIfNewArchFlagIsSet(project, extension)
 
     // We register a private extension on the rootProject so that project wide configs


### PR DESCRIPTION
Summary:
New build failures when this was merged seem likely related.

```
FAILURE: Build failed with an exception.

* Where:
Build file '/root/react-native/packages/react-native/ReactAndroid/build.gradle.kts' line: 784

* What went wrong:
Script compilation errors:

  Line 784: react {
            ^ Unresolved reference: react

  Line 787:   libraryName = "rncore"
              ^ Unresolved reference: libraryName

  Line 788:   jsRootDir = file("../src")
              ^ Unresolved reference: jsRootDir
```

Changelog: [Internal]

Reviewed By: arushikesarwani94

Differential Revision: D55618667


