### PR TITLE
Enable Kotlin warnings as errors in rn_android_library

### DIFF
--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/PopupMenuSelectionEvent.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/PopupMenuSelectionEvent.kt
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Deprecated usage inc imports of RCTEventEmitter
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.popupmenu
 
 import com.facebook.react.bridge.Arguments

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.uimanager
 
 import android.util.TypedValue
+import kotlin.math.min
 
 /** Android dp to pixel manipulation */
 public object PixelUtil {
@@ -29,12 +30,13 @@ public object PixelUtil {
   @JvmStatic
   public fun toPixelFromSP(value: Float, maxFontScale: Float = Float.NaN): Float {
     val displayMetrics = DisplayMetricsHolder.getWindowDisplayMetrics()
-    var scaledDensity = displayMetrics.scaledDensity
-    val currentFontScale = scaledDensity / displayMetrics.density
-    if (maxFontScale >= 1 && maxFontScale < currentFontScale) {
-      scaledDensity = displayMetrics.density * maxFontScale
+    val scaledValue = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, value, displayMetrics)
+
+    if (maxFontScale >= 1) {
+      return min(scaledValue, value * displayMetrics.density * maxFontScale)
     }
-    return value * scaledDensity
+
+    return scaledValue
   }
 
   /** Convert from SP to PX */


### PR DESCRIPTION
Summary:
This is another place where the OSS build went ahead of the internal source of truth, which has caused build breaks more than once.

This enables warnings as errors in `rn_android_library` for consistency. This is used for a couple libraries outside of ReactAndroid that might need fixup/suppression.

Changelog: [Internal]

Differential Revision: D55623682


