### PR TITLE
[iOS] Support launchOptions in bridgeless mode

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -123,7 +123,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
     RCTEnableTurboModuleInterop(YES);
     RCTEnableTurboModuleInteropBridgeProxy(YES);
 
-    [self createReactHostIfNeeded];
+    [self createReactHostIfNeeded:launchOptions];
 
     RCTFabricSurface *surface = [_reactHost createSurfaceWithModuleName:moduleName initialProperties:initProps];
 
@@ -207,7 +207,7 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 #pragma mark - New Arch Utilities
 
-- (void)createReactHostIfNeeded
+- (void)createReactHostIfNeeded:(NSDictionary *)launchOptions
 {
   if (_reactHost) {
     return;
@@ -219,7 +219,8 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
                        turboModuleManagerDelegate:_turboModuleManagerDelegate
                                  jsEngineProvider:^std::shared_ptr<facebook::react::JSRuntimeFactory>() {
                                    return [weakSelf createJSRuntimeFactory];
-                                 }];
+                                 }
+                                    launchOptions:launchOptions];
   [_reactHost setBundleURLProvider:^NSURL *() {
     return [weakSelf bundleURL];
   }];

--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -8,6 +8,7 @@
 #import <React/RCTLinkingManager.h>
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
+#import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
@@ -153,12 +154,15 @@ RCT_EXPORT_METHOD(canOpenURL
 
 RCT_EXPORT_METHOD(getInitialURL : (RCTPromiseResolveBlock)resolve reject : (__unused RCTPromiseRejectBlock)reject)
 {
+  RCTBridge *bridge = self.bridge;
+  if (!bridge) {
+    bridge = [RCTBridge currentBridge];
+  }
   NSURL *initialURL = nil;
-  if (self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey]) {
-    initialURL = self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey];
+  if (bridge.launchOptions[UIApplicationLaunchOptionsURLKey]) {
+    initialURL = bridge.launchOptions[UIApplicationLaunchOptionsURLKey];
   } else {
-    NSDictionary *userActivityDictionary =
-        self.bridge.launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey];
+    NSDictionary *userActivityDictionary = bridge.launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey];
     if ([userActivityDictionary[UIApplicationLaunchOptionsUserActivityTypeKey] isEqual:NSUserActivityTypeBrowsingWeb]) {
       initialURL = ((NSUserActivity *)userActivityDictionary[@"UIApplicationLaunchOptionsUserActivityKey"]).webpageURL;
     }

--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -8,7 +8,6 @@
 #import <React/RCTLinkingManager.h>
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
-#import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
@@ -154,15 +153,12 @@ RCT_EXPORT_METHOD(canOpenURL
 
 RCT_EXPORT_METHOD(getInitialURL : (RCTPromiseResolveBlock)resolve reject : (__unused RCTPromiseRejectBlock)reject)
 {
-  RCTBridge *bridge = self.bridge;
-  if (!bridge) {
-    bridge = [RCTBridge currentBridge];
-  }
   NSURL *initialURL = nil;
-  if (bridge.launchOptions[UIApplicationLaunchOptionsURLKey]) {
-    initialURL = bridge.launchOptions[UIApplicationLaunchOptionsURLKey];
+  if (self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey]) {
+    initialURL = self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey];
   } else {
-    NSDictionary *userActivityDictionary = bridge.launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey];
+    NSDictionary *userActivityDictionary =
+        self.bridge.launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey];
     if ([userActivityDictionary[UIApplicationLaunchOptionsUserActivityTypeKey] isEqual:NSUserActivityTypeBrowsingWeb]) {
       initialURL = ((NSUserActivity *)userActivityDictionary[@"UIApplicationLaunchOptionsUserActivityKey"]).webpageURL;
     }

--- a/packages/react-native/React/Base/RCTBridgeProxy.h
+++ b/packages/react-native/React/Base/RCTBridgeProxy.h
@@ -22,7 +22,8 @@
                    callableJSModules:(RCTCallableJSModules *)callableJSModules
                   dispatchToJSThread:(void (^)(dispatch_block_t))dispatchToJSThread
                registerSegmentWithId:(void (^)(NSNumber *, NSString *))registerSegmentWithId
-                             runtime:(void *)runtime NS_DESIGNATED_INITIALIZER;
+                             runtime:(void *)runtime
+                       launchOptions:(nullable NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER;
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)sel;
 - (void)forwardInvocation:(NSInvocation *)invocation;

--- a/packages/react-native/React/Base/RCTBridgeProxy.mm
+++ b/packages/react-native/React/Base/RCTBridgeProxy.mm
@@ -35,6 +35,7 @@ using namespace facebook;
   RCTModuleRegistry *_moduleRegistry;
   RCTBundleManager *_bundleManager;
   RCTCallableJSModules *_callableJSModules;
+  NSDictionary *_launchOptions;
   void (^_dispatchToJSThread)(dispatch_block_t);
   void (^_registerSegmentWithId)(NSNumber *, NSString *);
   void *_runtime;
@@ -47,6 +48,7 @@ using namespace facebook;
                   dispatchToJSThread:(void (^)(dispatch_block_t))dispatchToJSThread
                registerSegmentWithId:(void (^)(NSNumber *, NSString *))registerSegmentWithId
                              runtime:(void *)runtime
+                       launchOptions:(nullable NSDictionary *)launchOptions
 {
   self = [super self];
   if (self) {
@@ -57,6 +59,7 @@ using namespace facebook;
     _dispatchToJSThread = dispatchToJSThread;
     _registerSegmentWithId = registerSegmentWithId;
     _runtime = runtime;
+    _launchOptions = [launchOptions copy];
   }
   return self;
 }
@@ -191,8 +194,7 @@ using namespace facebook;
 
 - (NSDictionary *)launchOptions
 {
-  [self logError:@"This method is not supported. Returning nil." cmd:_cmd];
-  return nil;
+  return _launchOptions;
 }
 
 - (BOOL)loading

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -674,7 +674,7 @@ static Class getFallbackClassFromName(const char *name)
        */
       if (_bridge) {
         [(id)module setValue:_bridge forKey:@"bridge"];
-      } else if (_bridgeProxy && [self _isLegacyModuleClass:[module class]]) {
+      } else if (_bridgeProxy) {
         [(id)module setValue:_bridgeProxy forKey:@"bridge"];
       }
     } @catch (NSException *exception) {

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -48,7 +48,8 @@ typedef std::shared_ptr<facebook::react::JSRuntimeFactory> (^RCTHostJSEngineProv
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                      hostDelegate:(id<RCTHostDelegate>)hostDelegate
        turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
-                 jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider NS_DESIGNATED_INITIALIZER;
+                 jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
+                    launchOptions:(nullable NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, weak, nullable) id<RCTHostRuntimeDelegate> runtimeDelegate;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -58,6 +58,8 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   RCTHostBundleURLProvider _bundleURLProvider;
   RCTHostJSEngineProvider _jsEngineProvider;
 
+  NSDictionary *_launchOptions;
+
   // All the surfaces that need to be started after main bundle execution
   NSMutableArray<RCTFabricSurface *> *_surfaceStartBuffer;
   std::mutex _surfaceStartBufferMutex;
@@ -85,6 +87,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                      hostDelegate:(id<RCTHostDelegate>)hostDelegate
        turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
                  jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
+                    launchOptions:(nullable NSDictionary *)launchOptions
 {
   if (self = [super init]) {
     _hostDelegate = hostDelegate;
@@ -93,6 +96,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     _bundleManager = [RCTBundleManager new];
     _moduleRegistry = [RCTModuleRegistry new];
     _jsEngineProvider = [jsEngineProvider copy];
+    _launchOptions = [launchOptions copy];
 
     __weak RCTHost *weakSelf = self;
 
@@ -204,7 +208,8 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
                                      moduleRegistry:_moduleRegistry
-                              parentInspectorTarget:_inspectorTarget.get()];
+                              parentInspectorTarget:_inspectorTarget.get()
+                                      launchOptions:_launchOptions];
   [_hostDelegate hostDidStart:self];
 }
 
@@ -284,7 +289,8 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
                                      moduleRegistry:_moduleRegistry
-                              parentInspectorTarget:_inspectorTarget.get()];
+                              parentInspectorTarget:_inspectorTarget.get()
+                                      launchOptions:_launchOptions];
   [_hostDelegate hostDidStart:self];
 
   for (RCTFabricSurface *surface in [self _getAttachedSurfaces]) {

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
@@ -62,7 +62,8 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry
-           parentInspectorTarget:(facebook::react::jsinspector_modern::HostTarget *)parentInspectorTarget;
+           parentInspectorTarget:(facebook::react::jsinspector_modern::HostTarget *)parentInspectorTarget
+                   launchOptions:(nullable NSDictionary *)launchOptions;
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -84,6 +84,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   std::mutex _invalidationMutex;
   std::atomic<bool> _valid;
   RCTJSThreadManager *_jsThreadManager;
+  NSDictionary *_launchOptions;
 
   // APIs supporting interop with native modules and view managers
   RCTBridgeModuleDecorator *_bridgeModuleDecorator;
@@ -100,6 +101,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry
            parentInspectorTarget:(jsinspector_modern::HostTarget *)parentInspectorTarget
+                   launchOptions:(nullable NSDictionary *)launchOptions
 {
   if (self = [super init]) {
     _performanceLogger = [RCTPerformanceLogger new];
@@ -125,6 +127,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
             [weakSelf callFunctionOnJSModule:moduleName method:methodName args:args];
           }];
     }
+    _launchOptions = launchOptions;
 
     NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
 
@@ -277,7 +280,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
               [strongSelf registerSegmentWithId:segmentId path:path];
             }
           }
-          runtime:_reactInstance->getJavaScriptContext()];
+          runtime:_reactInstance->getJavaScriptContext()
+          launchOptions:_launchOptions];
   bridgeProxy.jsCallInvoker = jsCallInvoker;
   [RCTBridge setCurrentBridge:(RCTBridge *)bridgeProxy];
 


### PR DESCRIPTION
## Summary:

Support launchOptions in bridgeless mode

## Changelog:

[IOS] [FIXED] - Support launchOptions in bridgeless mode

## Test Plan:

```
useEffect(() => {
    const processInitialURL = async () => {
      const url = await Linking.getInitialURL();
      if (url !== null) {
        console.log(`Initial url is: ${url}`);
      }
    };

    processInitialURL();
  }, []);
```
