### PR TITLE
Suppress soft exceptions in ReactHostImpl when they aren't needed

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -641,6 +641,7 @@ public class ReactHostImpl implements ReactHost {
     ReactContext currentContext = getCurrentReactContext();
     if (currentContext != null) {
       currentContext.onActivityResult(activity, requestCode, resultCode, data);
+      return;
     }
     ReactSoftExceptionLogger.logSoftException(
         TAG,
@@ -658,6 +659,7 @@ public class ReactHostImpl implements ReactHost {
     ReactContext currentContext = getCurrentReactContext();
     if (currentContext != null) {
       currentContext.onWindowFocusChange(hasFocus);
+      return;
     }
     ReactSoftExceptionLogger.logSoftException(
         TAG,
@@ -689,6 +691,7 @@ public class ReactHostImpl implements ReactHost {
         }
       }
       currentContext.onNewIntent(getCurrentActivity(), intent);
+      return;
     }
     ReactSoftExceptionLogger.logSoftException(
         TAG,


### PR DESCRIPTION
Summary:
D54574139, D54703159 and D54670119 added `onNewIntent`, `onActivityResult` and `onWindowFocusChange`

These methods, like others in this class, check for a context to be ready before passing on a method. However, these two methods don't return anything in the `if` statement, so they still fall through to the soft exception.

This diff simply adds returns to match the (what I believe to be) specific expecatation

Changelog: [Android][Fixed] - Suppress unneeded soft exceptions in ReactHostImpl when Context has initiated correctly.

Differential Revision: D55635376


