### PR TITLE
Fix broken build due to a land time race

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
@@ -64,7 +64,7 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
     if (!isShowing) {
       return
     }
-    (reactRootView?.parent as ViewGroup)?.removeView(reactRootView)
+    (reactRootView?.parent as ViewGroup?)?.removeView(reactRootView)
     dialog?.dismiss()
     dialog = null
   }


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

With D55574528 and D55623682 having landed concurrently, and the latter enabling warnings-as-errors for Kotlin files vs the former having one such warning, this caused a build breakage.

This diff fixes  it.

Reviewed By: andrewdacenko, blakef

Differential Revision: D55636176


