### PR TITLE
add PopupMenuDismissEvent

### DIFF
--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/PopupMenuDismissEvent.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/PopupMenuDismissEvent.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Deprecated usage inc imports of RCTEventEmitter
+@file:Suppress("DEPRECATION")
+
+package com.facebook.react.popupmenu
+
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.facebook.react.uimanager.events.RCTEventEmitter
+
+public class PopupMenuDismissEvent(surfaceId: Int, viewId: Int) :
+    Event<PopupMenuDismissEvent>(surfaceId, viewId) {
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap? = null
+
+  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+    rctEventEmitter.receiveEvent(viewTag, eventName, eventData)
+  }
+
+  public companion object {
+    public const val EVENT_NAME: String = "topPopupDismiss"
+  }
+}

--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
@@ -43,6 +43,14 @@ public class ReactPopupMenuContainer(context: Context) : FrameLayout(context) {
         }
         true
       }
+      popupMenu.setOnDismissListener {
+        val reactContext = context as ReactContext
+        val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+        if (eventDispatcher != null) {
+          val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
+          eventDispatcher.dispatchEvent(PopupMenuDismissEvent(surfaceId, id))
+        }
+      }
       popupMenu.show()
     }
   }

--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuManager.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuManager.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.popupmenu
 
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
@@ -48,7 +49,23 @@ public class ReactPopupMenuManager :
     popupMenu.showPopupMenu()
   }
 
+  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> {
+    val baseEventTypeConstants = super.getExportedCustomDirectEventTypeConstants()
+    val eventTypeConstants: MutableMap<String, Any> = baseEventTypeConstants ?: HashMap()
+    eventTypeConstants.putAll(DIRECT_EVENT_TYPE_CONSTANT)
+    return eventTypeConstants
+  }
+
   public companion object {
     public const val REACT_CLASS: String = "AndroidPopupMenu"
+    private val DIRECT_EVENT_TYPE_CONSTANT =
+        MapBuilder.builder<String, Any>()
+            .put(
+                PopupMenuSelectionEvent.EVENT_NAME,
+                mapOf("topPopupMenuSelectionChange" to "onPopupMenuSelectionChange"))
+            .put(
+                PopupMenuDismissEvent.EVENT_NAME,
+                mapOf("topPopupMenuDismiss" to "onPopupMenuDismiss"))
+            .build()
   }
 }

--- a/packages/react-native-popup-menu-android/js/PopupMenuAndroid.android.js
+++ b/packages/react-native-popup-menu-android/js/PopupMenuAndroid.android.js
@@ -25,6 +25,8 @@ type PopupMenuSelectionEvent = SyntheticEvent<
   }>,
 >;
 
+type PopupMenuDismissEvent = SyntheticEvent<$ReadOnly<{}>>;
+
 export type PopupMenuAndroidInstance = {
   +show: () => void,
 };
@@ -32,6 +34,7 @@ export type PopupMenuAndroidInstance = {
 type Props = {
   menuItems: $ReadOnlyArray<string>,
   onSelectionChange: number => void,
+  onPopupDismiss?: () => void,
   children: React.Node,
   instanceRef: RefObject<?PopupMenuAndroidInstance>,
 };
@@ -39,6 +42,7 @@ type Props = {
 export default function PopupMenuAndroid({
   menuItems,
   onSelectionChange,
+  onPopupDismiss,
   children,
   instanceRef,
 }: Props): React.Node {
@@ -48,6 +52,12 @@ export default function PopupMenuAndroid({
       onSelectionChange(event.nativeEvent.item);
     },
     [onSelectionChange],
+  );
+  const _onPopupDismiss = useCallback(
+    (event: PopupMenuDismissEvent) => {
+      onPopupDismiss?.();
+    },
+    [onPopupDismiss],
   );
 
   useImperativeHandle(instanceRef, ItemViewabilityInstance => {
@@ -62,6 +72,7 @@ export default function PopupMenuAndroid({
     <PopupMenuAndroidNativeComponent
       ref={nativeRef}
       onSelectionChange={_onSelectionChange}
+      onPopupDismiss={_onPopupDismiss}
       menuItems={menuItems}>
       {children}
     </PopupMenuAndroidNativeComponent>

--- a/packages/react-native-popup-menu-android/js/PopupMenuAndroid.js
+++ b/packages/react-native-popup-menu-android/js/PopupMenuAndroid.js
@@ -43,6 +43,7 @@ export type PopupMenuAndroidInstance = {
 type Props = {
   menuItems: $ReadOnlyArray<string>,
   onSelectionChange: number => void,
+  onPopupDismiss?: () => void,
   children: Node,
   instanceRef: RefObject<?PopupMenuAndroidInstance>,
 };

--- a/packages/react-native-popup-menu-android/js/PopupMenuAndroidNativeComponent.android.js
+++ b/packages/react-native-popup-menu-android/js/PopupMenuAndroidNativeComponent.android.js
@@ -23,6 +23,8 @@ type PopupMenuSelectionEvent = $ReadOnly<{
   item: Int32,
 }>;
 
+type PopupMenuDismissEvent = $ReadOnly<{}>;
+
 type NativeProps = $ReadOnly<{
   ...ViewProps,
 
@@ -30,6 +32,7 @@ type NativeProps = $ReadOnly<{
   menuItems?: ?$ReadOnlyArray<string>,
 
   onSelectionChange?: DirectEventHandler<PopupMenuSelectionEvent>,
+  onPopupDismiss?: DirectEventHandler<PopupMenuDismissEvent>,
 }>;
 
 type ComponentType = HostComponent<NativeProps>;


### PR DESCRIPTION
Summary:
Deprecated `UIManager.showPopupMenu()` had success callback that would be triggered on 1) item selection or 2) dismiss.
New `PopupMenuAndroid` only has item selection callback so adding in missing dismiss callback.

Changelog:
[Android][Added] - Add (optional) onPopupDismiss() callback for PopupMenuAndroid

Reviewed By: cortinico

Differential Revision: D55531870


