### PR TITLE
delete unused trait: AndroidMapBufferPropsSupported

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -79,8 +79,6 @@ void ViewShadowNode::initialize() noexcept {
   } else {
     traits_.unset(ShadowNodeTraits::Trait::FormsStackingContext);
   }
-
-  traits_.set(HostPlatformViewTraitsInitializer::extraTraits());
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -24,8 +24,4 @@ inline bool formsView(const ViewProps& viewProps) {
       viewProps.renderToHardwareTextureAndroid;
 }
 
-inline ShadowNodeTraits::Trait extraTraits() {
-  return ShadowNodeTraits::Trait::AndroidMapBufferPropsSupported;
-}
-
 } // namespace facebook::react::HostPlatformViewTraitsInitializer

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -20,8 +20,4 @@ inline bool formsView(const ViewProps& props) {
   return false;
 }
 
-inline ShadowNodeTraits::Trait extraTraits() {
-  return ShadowNodeTraits::Trait::None;
-}
-
 } // namespace facebook::react::HostPlatformViewTraitsInitializer

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -70,8 +70,6 @@ class ShadowNodeTraits {
     // to be cloned before the first mutation.
     ChildrenAreShared = 1 << 8,
 
-    // Temporary (?) to indicate MapBuffer support on Android
-    AndroidMapBufferPropsSupported = 1 << 9,
   };
 
   /*


### PR DESCRIPTION
Summary:
changelog: [internal]

This is not used. Let's delete it.

Reviewed By: fabriziocucci

Differential Revision: D55485422


