### PR TITLE
RN changes to enable fragment-based navigation [1/3]

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -69,6 +69,10 @@ public abstract class ReactActivity extends AppCompatActivity
     mDelegate.getReactDelegate();
   }
 
+  public ReactActivityDelegate getReactActivityDelegate() {
+    return mDelegate;
+  }
+
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -32,6 +32,8 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
 
   protected ReactDelegate mReactDelegate;
 
+  protected boolean shouldCallDelegateLifecycleEvents = true;
+
   @Nullable private PermissionListener mPermissionListener;
 
   public ReactFragment() {
@@ -99,19 +101,25 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
   @Override
   public void onResume() {
     super.onResume();
-    mReactDelegate.onHostResume();
+    if (shouldCallDelegateLifecycleEvents) {
+      mReactDelegate.onHostResume();
+    }
   }
 
   @Override
   public void onPause() {
     super.onPause();
-    mReactDelegate.onHostPause();
+    if (shouldCallDelegateLifecycleEvents) {
+      mReactDelegate.onHostPause();
+    }
   }
 
   @Override
   public void onDestroy() {
     super.onDestroy();
-    mReactDelegate.onHostDestroy();
+    if (shouldCallDelegateLifecycleEvents) {
+      mReactDelegate.onHostDestroy();
+    }
   }
 
   // endregion


### PR DESCRIPTION
Summary:
This diff introduces some changes to React Native needed to enable fragment-based navigation (see next diff for usage).

Fragment-based navigation will enable us to, instead of re-creating the entire main activity on navigation, create a fragment instead - allowing us to bypass a lot of unnecessary onCreate() logic in our main activity to improve user experience and performance.

Changelog:
[Internal] [Changed] - Add option to skip calling delegate on ReactFragment lifecycle events

Differential Revision: D55646221


