### PR TITLE
Update build.gradle.kts to include soloader.annotation for SoLoaderLi…

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -761,6 +761,7 @@ dependencies {
   api(libs.fresco.ui.common)
   api(libs.infer.annotation)
   api(libs.soloader)
+  api(libs.soloader.annotation)
   api(libs.yoga.proguard.annotations)
 
   api(libs.jsr305)


### PR DESCRIPTION
## Summary:

Update build.gradle.kts to include soloader.annotation for SoLoaderLibrary

## Changelog:

[INTERNAL][ADDED} - Updating gradle file with soloader.annotation for SoLoaderLibrary import to work

## Test Plan:

Circle CI Build Android is unblocked
