### PR TITLE
Unbreak build_android in OSS

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSCInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSCInstance.kt
@@ -10,9 +10,7 @@ package com.facebook.react.runtime
 import com.facebook.jni.HybridData
 import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.soloader.SoLoader
-import com.facebook.soloader.annotation.SoLoaderLibrary
 
-@SoLoaderLibrary("jscinstance")
 public class JSCInstance constructor() : JSRuntimeFactory(initHybrid()) {
   public companion object {
     init {


### PR DESCRIPTION
Summary:
The dependency resolution of java/com/facebook/soloader/annotation:annotation is missing in OSS and needs to be included in [build.gradle.kts](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/build.gradle.kts) instead

Changelog: [Internal]

Differential Revision: D55664486


