### PR TITLE
[iOS][Fixed] Wrap UIMenuAutoFill in compilation pragmas for iOS 17 checks

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -269,11 +269,14 @@ static UIColor *defaultPlaceholderColor(void)
 
 - (void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder
 {
-  if (_contextMenuHidden) {
-    if (@available(iOS 17.0, *)) {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000
+  if (@available(iOS 17.0, *)) {
+    if (_contextMenuHidden) {
       [builder removeMenuForIdentifier:UIMenuAutoFill];
     }
   }
+#endif
+
   [super buildMenuWithBuilder:builder];
 }
 

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -144,11 +144,14 @@
 
 - (void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder
 {
-  if (_contextMenuHidden) {
-    if (@available(iOS 17.0, *)) {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000
+  if (@available(iOS 17.0, *)) {
+    if (_contextMenuHidden) {
       [builder removeMenuForIdentifier:UIMenuAutoFill];
     }
   }
+#endif
+
   [super buildMenuWithBuilder:builder];
 }
 


### PR DESCRIPTION
## Summary:

PR #43468 landed in main which uses UIMenuAutoFill that is available only in iOS 17. 
Despite having the `@available` checks, these are only runtime checks. The symbol is not stripped on older versions of Xcode and therefore our jobs which uses older Xcode versions started failing.

This change wraps the offending code in a compilation pragma that strips away the symbol when building with Xcode versions that does not know iOS 17.

## Changelog:
[iOS][Fixed] - wrap UIMenuAutoFill in compilation checks for iOS 17

## Test Plan:
CircleCI is green
