### PR TITLE
Mark ReactModalHostView as @NullSafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
@@ -7,9 +7,9 @@
 
 package com.facebook.react.views.modal;
 
-import android.content.DialogInterface;
 import android.graphics.Point;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** View manager for {@link ReactModalHostView} components. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModule(name = ReactModalHostManager.REACT_CLASS)
 public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView>
     implements ModalHostViewManagerInterface<ReactModalHostView> {
@@ -121,21 +122,13 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView>
         UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
     if (dispatcher != null) {
       view.setOnRequestCloseListener(
-          new ReactModalHostView.OnRequestCloseListener() {
-            @Override
-            public void onRequestClose(DialogInterface dialog) {
+          dialog ->
               dispatcher.dispatchEvent(
-                  new RequestCloseEvent(UIManagerHelper.getSurfaceId(reactContext), view.getId()));
-            }
-          });
+                  new RequestCloseEvent(UIManagerHelper.getSurfaceId(reactContext), view.getId())));
       view.setOnShowListener(
-          new DialogInterface.OnShowListener() {
-            @Override
-            public void onShow(DialogInterface dialog) {
+          dialog ->
               dispatcher.dispatchEvent(
-                  new ShowEvent(UIManagerHelper.getSurfaceId(reactContext), view.getId()));
-            }
-          });
+                  new ShowEvent(UIManagerHelper.getSurfaceId(reactContext), view.getId())));
       view.setEventDispatcher(dispatcher);
     }
   }
@@ -165,6 +158,7 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView>
   }
 
   @Override
+  @Nullable
   public Object updateState(
       ReactModalHostView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
     view.setStateWrapper(stateWrapper);


### PR DESCRIPTION
Summary:
This class was really old and had a lot of potential NPEs as it was accessing fields that could have been not initialized properly. I'm fixing it here ahead of a Kotlin migration.

Changelog:
[Internal] [Changed] -  Mark ReactModalHostView as NullSafe

Differential Revision: D55690285


