### PR TITLE
Annotate AndroidUnicodeUtils as NullSafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
@@ -7,6 +7,7 @@
 
 package com.facebook.hermes.unicode;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import java.text.Collator;
 import java.text.DateFormat;
@@ -16,6 +17,7 @@ import java.util.Locale;
 // TODO: use com.facebook.common.locale.Locales.getApplicationLocale() as the current locale,
 // rather than the device locale. This is challenging because getApplicationLocale() is only
 // available via DI.
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStrip
 public class AndroidUnicodeUtils {
   @DoNotStrip


### PR DESCRIPTION
Summary:
This is just an example on how to use the NullSafe annotation

Changelog:
[Internal] [Changed] - Annotate AndroidUnicodeUtils as NullSafe

Differential Revision: D55419929


