### PR TITLE
Add useNativeViewConfigsInBridgelessMode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e3cfdd93315067ed37e7cf93aa60af74>>
+ * @generated SignedSource<<074ec00cfb1585c529df9391492c21e4>>
  */
 
 /**
@@ -105,6 +105,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useModernRuntimeScheduler(): Boolean = accessor.useModernRuntimeScheduler()
+
+  /**
+   * When enabled, the native view configs are used in bridgeless mode.
+   */
+  @JvmStatic
+  public fun useNativeViewConfigsInBridgelessMode(): Boolean = accessor.useNativeViewConfigsInBridgelessMode()
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9184044883f829855c2de9db42566287>>
+ * @generated SignedSource<<c4038f6f8d4c7f9ead85e45f8d989e69>>
  */
 
 /**
@@ -33,6 +33,7 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
+  private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -147,6 +148,15 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useModernRuntimeScheduler()
       useModernRuntimeSchedulerCache = cached
+    }
+    return cached
+  }
+
+  override fun useNativeViewConfigsInBridgelessMode(): Boolean {
+    var cached = useNativeViewConfigsInBridgelessModeCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.useNativeViewConfigsInBridgelessMode()
+      useNativeViewConfigsInBridgelessModeCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4154c0f81f2e5ad7ff03e252c4aa965c>>
+ * @generated SignedSource<<490e64811f966f5e8399ed835db6b846>>
  */
 
 /**
@@ -53,6 +53,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun inspectorEnableModernCDPRegistry(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useModernRuntimeScheduler(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun useNativeViewConfigsInBridgelessMode(): Boolean
 
   @DoNotStrip @JvmStatic public external fun override(provider: Any)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c903b5aa8d70665c1104baa6670f8cb1>>
+ * @generated SignedSource<<0e0913ae19c39f88c2e2536c2b5087e1>>
  */
 
 /**
@@ -48,4 +48,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun inspectorEnableModernCDPRegistry(): Boolean = false
 
   override fun useModernRuntimeScheduler(): Boolean = false
+
+  override fun useNativeViewConfigsInBridgelessMode(): Boolean = false
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c087df804587a9a02a0547684d0e9c92>>
+ * @generated SignedSource<<4d92852851feacdbf9d4f3c4ead3124a>>
  */
 
 /**
@@ -37,6 +37,7 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
   private var inspectorEnableCxxInspectorPackagerConnectionCache: Boolean? = null
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
+  private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -164,6 +165,16 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
       cached = currentProvider.useModernRuntimeScheduler()
       accessedFeatureFlags.add("useModernRuntimeScheduler")
       useModernRuntimeSchedulerCache = cached
+    }
+    return cached
+  }
+
+  override fun useNativeViewConfigsInBridgelessMode(): Boolean {
+    var cached = useNativeViewConfigsInBridgelessModeCache
+    if (cached == null) {
+      cached = currentProvider.useNativeViewConfigsInBridgelessMode()
+      accessedFeatureFlags.add("useNativeViewConfigsInBridgelessMode")
+      useNativeViewConfigsInBridgelessModeCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c39073091ea96d16a352d00def1b5532>>
+ * @generated SignedSource<<f68e85831f9af20785ff0cbf431a4dc5>>
  */
 
 /**
@@ -48,4 +48,6 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun inspectorEnableModernCDPRegistry(): Boolean
 
   @DoNotStrip public fun useModernRuntimeScheduler(): Boolean
+
+  @DoNotStrip public fun useNativeViewConfigsInBridgelessMode(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<db9ab5f48de2fdbee406ddea10125feb>>
+ * @generated SignedSource<<a04c3da47e634d788d6edb24fac0bf02>>
  */
 
 /**
@@ -117,6 +117,12 @@ class ReactNativeFeatureFlagsProviderHolder
     return method(javaProvider_);
   }
 
+  bool useNativeViewConfigsInBridgelessMode() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useNativeViewConfigsInBridgelessMode");
+    return method(javaProvider_);
+  }
+
  private:
   jni::global_ref<jobject> javaProvider_;
 };
@@ -186,6 +192,11 @@ bool JReactNativeFeatureFlagsCxxInterop::useModernRuntimeScheduler(
   return ReactNativeFeatureFlags::useModernRuntimeScheduler();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::useNativeViewConfigsInBridgelessMode(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode();
+}
+
 void JReactNativeFeatureFlagsCxxInterop::override(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/,
     jni::alias_ref<jobject> provider) {
@@ -242,6 +253,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useModernRuntimeScheduler",
         JReactNativeFeatureFlagsCxxInterop::useModernRuntimeScheduler),
+      makeNativeMethod(
+        "useNativeViewConfigsInBridgelessMode",
+        JReactNativeFeatureFlagsCxxInterop::useNativeViewConfigsInBridgelessMode),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6b33129341a4b68cdbbdbce9f57e4d63>>
+ * @generated SignedSource<<b0b829e8b839a5f39837867e92925c61>>
  */
 
 /**
@@ -67,6 +67,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useModernRuntimeScheduler(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool useNativeViewConfigsInBridgelessMode(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static void override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<56f79a4cb62a993f9c3a8ea01eed2ab6>>
+ * @generated SignedSource<<05aace8ad7171ff940f014643e050ff0>>
  */
 
 /**
@@ -71,6 +71,10 @@ bool ReactNativeFeatureFlags::inspectorEnableModernCDPRegistry() {
 
 bool ReactNativeFeatureFlags::useModernRuntimeScheduler() {
   return getAccessor().useModernRuntimeScheduler();
+}
+
+bool ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode() {
+  return getAccessor().useNativeViewConfigsInBridgelessMode();
 }
 
 void ReactNativeFeatureFlags::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bab6aad25607059d465d6c80711a4adf>>
+ * @generated SignedSource<<730c667fb34f911b92318c26cfa32cf5>>
  */
 
 /**
@@ -101,6 +101,11 @@ class ReactNativeFeatureFlags {
    * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.
    */
   RN_EXPORT static bool useModernRuntimeScheduler();
+
+  /**
+   * When enabled, the native view configs are used in bridgeless mode.
+   */
+  RN_EXPORT static bool useNativeViewConfigsInBridgelessMode();
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5b42b33319369b7936662a2608794ba5>>
+ * @generated SignedSource<<c91ec1127cfd0ad95c861008be5711bf>>
  */
 
 /**
@@ -258,6 +258,24 @@ bool ReactNativeFeatureFlagsAccessor::useModernRuntimeScheduler() {
 
     flagValue = currentProvider_->useModernRuntimeScheduler();
     useModernRuntimeScheduler_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
+bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
+  auto flagValue = useNativeViewConfigsInBridgelessMode_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(13, "useNativeViewConfigsInBridgelessMode");
+
+    flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
+    useNativeViewConfigsInBridgelessMode_ = flagValue;
   }
 
   return flagValue.value();

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a508f23dce88a9c186d6bd84e65b3af7>>
+ * @generated SignedSource<<d0ed3514b47846bb1ceb69aa6a3c94fe>>
  */
 
 /**
@@ -44,6 +44,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool inspectorEnableCxxInspectorPackagerConnection();
   bool inspectorEnableModernCDPRegistry();
   bool useModernRuntimeScheduler();
+  bool useNativeViewConfigsInBridgelessMode();
 
   void override(std::unique_ptr<ReactNativeFeatureFlagsProvider> provider);
 
@@ -54,7 +55,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 13> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 14> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> batchRenderingUpdatesInEventLoop_;
@@ -69,6 +70,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> inspectorEnableCxxInspectorPackagerConnection_;
   std::atomic<std::optional<bool>> inspectorEnableModernCDPRegistry_;
   std::atomic<std::optional<bool>> useModernRuntimeScheduler_;
+  std::atomic<std::optional<bool>> useNativeViewConfigsInBridgelessMode_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9fd009411ce19224a3102d2713b0b042>>
+ * @generated SignedSource<<82ad92aa5bd70e278b4c2aceb2cb4859>>
  */
 
 /**
@@ -76,6 +76,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool useModernRuntimeScheduler() override {
+    return false;
+  }
+
+  bool useNativeViewConfigsInBridgelessMode() override {
     return false;
   }
 };

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7384eeb8615a45b79cdcceb731d98e9d>>
+ * @generated SignedSource<<388fefb77dab0a5229417412d4f4a21c>>
  */
 
 /**
@@ -38,6 +38,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool inspectorEnableCxxInspectorPackagerConnection() = 0;
   virtual bool inspectorEnableModernCDPRegistry() = 0;
   virtual bool useModernRuntimeScheduler() = 0;
+  virtual bool useNativeViewConfigsInBridgelessMode() = 0;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<08ed8c4c27411ba5a04acb314eb36b63>>
+ * @generated SignedSource<<2c451878b4abdfd143fdc00f3a8f1159>>
  */
 
 /**
@@ -100,6 +100,11 @@ bool NativeReactNativeFeatureFlags::inspectorEnableModernCDPRegistry(
 bool NativeReactNativeFeatureFlags::useModernRuntimeScheduler(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useModernRuntimeScheduler();
+}
+
+bool NativeReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode();
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<adcc82e9ad406a40cfaddaad816fb0f0>>
+ * @generated SignedSource<<deb1d977999fc23ef8f72630001808b2>>
  */
 
 /**
@@ -60,6 +60,8 @@ class NativeReactNativeFeatureFlags
   bool inspectorEnableModernCDPRegistry(jsi::Runtime& runtime);
 
   bool useModernRuntimeScheduler(jsi::Runtime& runtime);
+
+  bool useNativeViewConfigsInBridgelessMode(jsi::Runtime& runtime);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -92,6 +92,11 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.',
     },
+    useNativeViewConfigsInBridgelessMode: {
+      defaultValue: false,
+      description:
+        'When enabled, the native view configs are used in bridgeless mode.',
+    },
   },
 
   jsOnly: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<366b36d877532c93aa6e5a97b85edd06>>
+ * @generated SignedSource<<1d670e4e74d58e40c3e5c9dba2ceb560>>
  * @flow strict-local
  */
 
@@ -53,6 +53,7 @@ export type ReactNativeFeatureFlags = {
   inspectorEnableCxxInspectorPackagerConnection: Getter<boolean>,
   inspectorEnableModernCDPRegistry: Getter<boolean>,
   useModernRuntimeScheduler: Getter<boolean>,
+  useNativeViewConfigsInBridgelessMode: Getter<boolean>,
 }
 
 /**
@@ -147,6 +148,10 @@ export const inspectorEnableModernCDPRegistry: Getter<boolean> = createNativeFla
  * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.
  */
 export const useModernRuntimeScheduler: Getter<boolean> = createNativeFlagGetter('useModernRuntimeScheduler', false);
+/**
+ * When enabled, the native view configs are used in bridgeless mode.
+ */
+export const useNativeViewConfigsInBridgelessMode: Getter<boolean> = createNativeFlagGetter('useNativeViewConfigsInBridgelessMode', false);
 
 /**
  * Overrides the feature flags with the provided methods.

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0d744f7a8519800a42cb0c3957862775>>
+ * @generated SignedSource<<d2b677b2a67f597ba4d38625a752e180>>
  * @flow strict-local
  */
 
@@ -36,6 +36,7 @@ export interface Spec extends TurboModule {
   +inspectorEnableCxxInspectorPackagerConnection?: () => boolean;
   +inspectorEnableModernCDPRegistry?: () => boolean;
   +useModernRuntimeScheduler?: () => boolean;
+  +useNativeViewConfigsInBridgelessMode?: () => boolean;
 }
 
 const NativeReactNativeFeatureFlags: ?Spec = TurboModuleRegistry.get<Spec>(


### PR DESCRIPTION
Summary:
# Feature flag cleanup/migration
This migration is part of the new Feature Flag system built by rubennorte. The goal of this migration is to clean up our Feature Flags and consolidate them into a single place, accessible by all platforms.
# In this diff
Generate new flag useNativeViewConfigsInBridgelessMode that will be used in

https://www.internalfb.com/code/fbsource/[2b7df36a7830c2713219538f83683d6b675fc369]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java?lines=233

https://www.internalfb.com/code/fbsource/[2b7df36a7830c2713219538f83683d6b675fc369]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt?lines=46

Differential Revision: D55693703


