### PR TITLE
only trigger RCTContentDidAppearNotification when content appears

### DIFF
--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -125,9 +125,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   [super surface:surface didChangeStage:stage];
   if (RCTSurfaceStageIsRunning(stage)) {
     [_bridge.performanceLogger markStopForTag:RCTPLTTI];
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [[NSNotificationCenter defaultCenter] postNotificationName:RCTContentDidAppearNotification object:self];
-    });
   }
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.mm
@@ -7,24 +7,45 @@
 
 #import "RCTRootComponentView.h"
 
+#import <React/RCTRootView.h>
 #import <react/renderer/components/root/RootComponentDescriptor.h>
 #import <react/renderer/components/root/RootProps.h>
 #import "RCTConversions.h"
 
 using namespace facebook::react;
 
-@implementation RCTRootComponentView
+@implementation RCTRootComponentView {
+  BOOL _contentHasAppeared;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
     _props = RootShadowNode::defaultSharedProps();
+    _contentHasAppeared = NO;
   }
 
   return self;
 }
 
 #pragma mark - RCTComponentViewProtocol
+
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+  _contentHasAppeared = NO;
+}
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [super mountChildComponentView:childComponentView index:index];
+  if (!self->_contentHasAppeared) {
+    self->_contentHasAppeared = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [[NSNotificationCenter defaultCenter] postNotificationName:RCTContentDidAppearNotification object:self];
+    });
+  }
+}
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {


### PR DESCRIPTION
Summary:
changelog: [internal]

Notification RCTContentDidAppearNotification was posted too early in RCTSurfaceHostingProxyRootView, which does not know when views are mounted.
It was also posted if no views were mounted, leading to inconsistent behaviour between Paper and Fabric.

The implementation is aligned with Paper: https://github.com/facebook/react-native/blob/main/packages/react-native/React/Base/RCTRootContentView.m#L45-L55

Differential Revision: D55640654


