### PR TITLE
Annotate as @Nullsafe everything in package com.facebook.react.views.text.internal.span

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLetterSpacingSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLetterSpacingSpan.java
@@ -9,6 +9,7 @@ package com.facebook.react.views.text.internal.span;
 
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * A {@link MetricAffectingSpan} that allows to set the letter spacing on the selected text span.
@@ -16,6 +17,7 @@ import android.text.style.MetricAffectingSpan;
  * <p>The letter spacing is specified in pixels, which are converted to ems at paint time; this span
  * must therefore be applied after any spans affecting font size.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class CustomLetterSpacingSpan extends MetricAffectingSpan implements ReactSpan {
 
   private final float mLetterSpacing;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLineHeightSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLineHeightSpan.java
@@ -9,11 +9,13 @@ package com.facebook.react.views.text.internal.span;
 
 import android.graphics.Paint;
 import android.text.style.LineHeightSpan;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * We use a custom {@link LineHeightSpan}, because `lineSpacingExtra` is broken. Details here:
  * https://github.com/facebook/react-native/issues/7546
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class CustomLineHeightSpan implements LineHeightSpan, ReactSpan {
   private final int mHeight;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactAbsoluteSizeSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactAbsoluteSizeSpan.java
@@ -8,10 +8,12 @@
 package com.facebook.react.views.text.internal.span;
 
 import android.text.style.AbsoluteSizeSpan;
+import com.facebook.infer.annotation.Nullsafe;
 
 /*
  * Wraps {@link AbsoluteSizeSpan} as a {@link ReactSpan}.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactAbsoluteSizeSpan extends AbsoluteSizeSpan implements ReactSpan {
   public ReactAbsoluteSizeSpan(int size) {
     super(size);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundColorSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundColorSpan.java
@@ -8,10 +8,12 @@
 package com.facebook.react.views.text.internal.span;
 
 import android.text.style.BackgroundColorSpan;
+import com.facebook.infer.annotation.Nullsafe;
 
 /*
  * Wraps {@link BackgroundColorSpan} as a {@link ReactSpan}.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactBackgroundColorSpan extends BackgroundColorSpan implements ReactSpan {
   public ReactBackgroundColorSpan(int color) {
     super(color);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactClickableSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactClickableSpan.java
@@ -11,6 +11,7 @@ import android.text.TextPaint;
 import android.text.style.ClickableSpan;
 import android.view.View;
 import androidx.annotation.NonNull;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.EventDispatcher;
@@ -38,6 +39,7 @@ import com.facebook.react.views.view.ViewGroupClickEvent;
  * accessible (TalkBack announces that the text has links available, and the links are exposed in
  * the context menu).
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactClickableSpan extends ClickableSpan implements ReactSpan {
 
   private final int mReactTag;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactForegroundColorSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactForegroundColorSpan.java
@@ -8,10 +8,12 @@
 package com.facebook.react.views.text.internal.span;
 
 import android.text.style.ForegroundColorSpan;
+import com.facebook.infer.annotation.Nullsafe;
 
 /*
  * Wraps {@link ForegroundColorSpan} as a {@link ReactSpan}.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactForegroundColorSpan extends ForegroundColorSpan implements ReactSpan {
   public ReactForegroundColorSpan(int color) {
     super(color);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactSpan.java
@@ -7,8 +7,11 @@
 
 package com.facebook.react.views.text.internal.span;
 
+import com.facebook.infer.annotation.Nullsafe;
+
 /*
  * Enables us to distinguish between spans that were added by React Native and spans that were
  * added by something else. All spans that React Native adds should implement this interface.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public interface ReactSpan {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactStrikethroughSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactStrikethroughSpan.java
@@ -8,8 +8,10 @@
 package com.facebook.react.views.text.internal.span;
 
 import android.text.style.StrikethroughSpan;
+import com.facebook.infer.annotation.Nullsafe;
 
 /*
  * Wraps {@link StrikethroughSpan} as a {@link ReactSpan}.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactStrikethroughSpan extends StrikethroughSpan implements ReactSpan {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTagSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTagSpan.java
@@ -7,10 +7,13 @@
 
 package com.facebook.react.views.text.internal.span;
 
+import com.facebook.infer.annotation.Nullsafe;
+
 /**
  * Instances of this class are used to place reactTag information of nested text react nodes into
  * spannable text rendered by single {@link TextView}
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactTagSpan implements ReactSpan {
 
   private final int mReactTag;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactUnderlineSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactUnderlineSpan.java
@@ -8,8 +8,10 @@
 package com.facebook.react.views.text.internal.span;
 
 import android.text.style.UnderlineSpan;
+import com.facebook.infer.annotation.Nullsafe;
 
 /*
  * Wraps {@link UnderlineSpan} as a {@link ReactSpan}.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactUnderlineSpan extends UnderlineSpan implements ReactSpan {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/SetSpanOperation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/SetSpanOperation.java
@@ -11,7 +11,9 @@ import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class SetSpanOperation {
   private static final String TAG = "SetSpanOperation";
   static final int SPAN_MAX_PRIORITY = Spanned.SPAN_PRIORITY >> Spanned.SPAN_PRIORITY_SHIFT;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ShadowStyleSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ShadowStyleSpan.java
@@ -9,7 +9,9 @@ package com.facebook.react.views.text.internal.span;
 
 import android.text.TextPaint;
 import android.text.style.CharacterStyle;
+import com.facebook.infer.annotation.Nullsafe;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ShadowStyleSpan extends CharacterStyle implements ReactSpan {
   private final float mDx, mDy, mRadius;
   private final int mColor;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextInlineImageSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextInlineImageSpan.java
@@ -13,8 +13,10 @@ import android.text.style.ReplacementSpan;
 import android.view.View;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 
 /** Base class for inline image spans. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class TextInlineImageSpan extends ReplacementSpan implements ReactSpan {
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextInlineViewPlaceholderSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextInlineViewPlaceholderSpan.java
@@ -10,11 +10,13 @@ package com.facebook.react.views.text.internal.span;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.text.style.ReplacementSpan;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * TextInlineViewPlaceholderSpan is a span for inlined views that are inside <Text/>. It computes
  * its size based on the input size. It contains no draw logic, just positioning logic.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class TextInlineViewPlaceholderSpan extends ReplacementSpan implements ReactSpan {
   private int mReactTag;
   private int mWidth;


### PR DESCRIPTION
Summary:
This just annotates more classes as nullsafe.

Changelog:
[Internal] [Changed] - Annotate as Nullsafe everything in package com.facebook.react.views.text.internal.span

Differential Revision: D55739092


