### PR TITLE
Fix problems in PerformanceObserver notifications

### DIFF
--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -100,11 +100,17 @@ const onPerformanceEntry = () => {
       const durationThreshold = observerConfig.entryTypes.get(entry.entryType);
       return entry.duration >= (durationThreshold ?? 0);
     });
-    observerConfig.callback(
-      new PerformanceObserverEntryList(entriesForObserver),
-      observer,
-      droppedEntriesCount,
-    );
+    if (entriesForObserver.length !== 0) {
+      try {
+        observerConfig.callback(
+          new PerformanceObserverEntryList(entriesForObserver),
+          observer,
+          droppedEntriesCount,
+        );
+      } catch (error) {
+        console.error(error);
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

(This is an internal change because the API hasn't been released in OSS yet)

This fixes 2 problems in how we dispatch `PerformanceObserver` notifications:
1. If an observer callback throws an error, the remaining observers don't receive notifications.
2. We're notifying observers with an empty list of events when they don't match the filters.

Differential Revision: D55646390


