### PR TITLE
[iOS] Fix RCTRCTComposedViewRegistry for Old Arch by adding count and keyEnumerator

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -1680,6 +1680,16 @@ static UIView *_jsResponder;
   return self;
 }
 
+- (NSUInteger)count
+{
+  return self->_registry.count;
+}
+
+- (NSEnumerator *)keyEnumerator
+{
+  return self->_registry.keyEnumerator;
+}
+
 - (id)objectForKey:(id)key
 {
   if (![key isKindOfClass:[NSNumber class]]) {


### PR DESCRIPTION
## Summary:

In the Old Architecture and for Swift Libraries, these two methods are used to initialize a new disctionary but their implementation was missing so some libraries like lottie were failig to build.

## Changelog:
[Internal] - Implement missing `count` and `keyEnumerator` methods for RCTComposedViewRegistry

## Test Plan:
Tested locally with the repro provided by SWM
