### PR TITLE
Add VS Code workspace config

### DIFF
--- a/react-native.code-workspace
+++ b/react-native.code-workspace
@@ -1,0 +1,21 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"extensions": {
+		"recommendations": [
+			"dbaeumer.vscode-eslint",
+			"editorconfig.editorconfig",
+			"esbenp.prettier-vscode",
+			"flowtype.flow-for-vscode",
+			"mathiasfrohlich.Kotlin"
+		],
+	},
+	"settings": {
+		"editor.formatOnSave": true,
+		"flow.pathToFlow": "${workspaceFolder}/node_modules/.bin/flow",
+		"javascript.validate.enable": false
+	}
+}


### PR DESCRIPTION
Summary:
## Summary

Adds a `react-native.code-workspace` workspace file when using VS Code. This disables the built-in TypeScript Language Service for `.js` files, recommends extensions, enables `formatOnSave`, and configures Flow language support.

We will recommend this workspace config in our contributing guide: https://github.com/facebook/react-native-website/pull/4075.

**Motivation**

This is a DevX benefit for **React Native contributors** using open source VS Code — in particular to help with recent/trivial papercuts in PRs such as inserting a final newline in files (configured by EditorConfig).

**Recommended extensions**

NOTE: The recommended extensions list is currently minimal — happy to extend this now or in future, but let's aim to keep these conservative.

- Flow — language support
- EditorConfig — formatting based on `.editorconfig`, all file types
- Prettier — formatting for JS* files
- ESLint — linter for JS* files

**Why `react-native.code-workspace`?**

`.code-workspace` files have slight extra behaviours over a `.vscode/` directory:
- Allows user to opt-in or skip.
- Allows double-click launching from file managers.
- Allows base folder (and any subfolders in future) to be opened with local file tree scope (useful in fbsource!)
- (Minor point) Single config file over multiple files.

https://code.visualstudio.com/docs/editor/workspaces

Changelog: [Internal]

## Test plan

Aganst a new unconfigured copy of Visual Studio Code Insiders.

**Without workspace config**

❌ `.js` files raise errors by default (built-in TypeScript language service)

![image](https://github.com/facebook/react-native/assets/2547783/54ee9cc9-7c2c-4020-93f8-872a8784e458)

❌ When using the Flow VS Code extension, the wrong version (global) of Flow is used.

**With workspace config**

✅ Workspace config is suggested when folder is opened in VS Code

![image](https://github.com/facebook/react-native/assets/2547783/53471c3d-df93-4107-b46f-50c8b6b8f341)

✅ Dialog is shown on workspace launch with recommended VS Code extensions

![image](https://github.com/facebook/react-native/assets/2547783/758e9ae8-4d28-4c4a-bbcc-d4b421398a6a)

✅ Built-in TypeScript Language Service is disabled for `.js` files
✅ Flow language support is configured correctly against `flow` version in `package.json`

![image](https://github.com/facebook/react-native/assets/2547783/327fa2e8-64c5-4099-94d2-832f896b0e2b)
![image](https://github.com/facebook/react-native/assets/2547783/8085984b-98b9-40d2-93cf-ba357af8e831)

Differential Revision: D55698495


