### PR TITLE
Fix broken CircleCI build

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/network/OkHttpCallUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/network/OkHttpCallUtil.kt
@@ -16,13 +16,13 @@ public object OkHttpCallUtil {
 
   @JvmStatic
   public fun cancelTag(client: OkHttpClient, tag: Any) {
-    for (call in client.dispatcher().queuedCalls()) {
+    for (call in client.dispatcher.queuedCalls()) {
       if (tag == call.request().tag()) {
         call.cancel()
         return
       }
     }
-    for (call in client.dispatcher().runningCalls()) {
+    for (call in client.dispatcher.runningCalls()) {
       if (tag == call.request().tag()) {
         call.cancel()
         return


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Apparently D55707704 broke the CircleCI build (even though there was no error on the diff).

> Using 'dispatcher(): Dispatcher' is an error. moved to val

Reviewed By: javache, cortinico

Differential Revision: D55744165


