### PR TITLE
Rename reactnative.a -> react_cxxreact.a

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -204,6 +204,7 @@ add_executable(reactnative_unittest
   hermes-engine::libhermes
   hermes_inspector_modern
   jsi
+  react_cxxreact
   react_codegen_rncore
   react_debug
   react_render_animations
@@ -217,7 +218,6 @@ add_executable(reactnative_unittest
   react_render_textlayoutmanager
   react_render_uimanager
   react_utils
-  reactnative
   rrc_modal
   rrc_scrollview
   rrc_text

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -35,8 +35,8 @@ target_link_libraries(reactnativejni
         folly_runtime
         glog_init
         logger
+        react_cxxreact
         react_render_runtimescheduler
-        reactnative
         runtimeexecutor
         yoga
         )

--- a/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
@@ -13,12 +13,12 @@ add_compile_options(
         -Wno-unused-lambda-capture
         -DLOG_TAG=\"ReactNative\")
 
-file(GLOB reactnative_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(reactnative STATIC ${reactnative_SRC})
+file(GLOB react_cxxreact_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_cxxreact STATIC ${react_cxxreact_SRC})
 
-target_include_directories(reactnative PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_cxxreact PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(reactnative
+target_link_libraries(react_cxxreact
         boost
         callinvoker
         folly_runtime

--- a/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(jsireact
 target_include_directories(jsireact PUBLIC .)
 
 target_link_libraries(jsireact
-        reactnative
+        react_cxxreact
         reactperflogger
         folly_runtime
         glog

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/CMakeLists.txt
@@ -21,7 +21,8 @@ target_include_directories(react_nativemodule_dom PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_nativemodule_dom
         rrc_root
+        react_codegen_rncore
+        react_cxxreact
         react_render_dom
         react_render_uimanager
-        react_codegen_rncore
-        reactnative)
+)

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(react_nativemodule_featureflags SHARED ${react_nativemodule_featuref
 target_include_directories(react_nativemodule_featureflags PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_nativemodule_featureflags
-        react_featureflags
         react_codegen_rncore
-        reactnative)
+        react_cxxreact
+        react_featureflags
+)

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/CMakeLists.txt
@@ -21,4 +21,5 @@ target_include_directories(react_nativemodule_microtasks PUBLIC ${REACT_COMMON_D
 
 target_link_libraries(react_nativemodule_microtasks
         react_codegen_rncore
-        reactnative)
+        react_cxxreact
+)

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -24,6 +24,8 @@ target_link_libraries(react_render_uimanager
         glog
         folly_runtime
         jsi
+        react_config
+        react_cxxreact
         react_debug
         react_featureflags
         react_render_componentregistry
@@ -36,8 +38,6 @@ target_link_libraries(react_render_uimanager
         react_render_leakchecker
         react_render_runtimescheduler
         react_render_mounting
-        react_config
-        reactnative
         rrc_root
         rrc_view
         runtimeexecutor


### PR DESCRIPTION
Summary:
This frees up the `reactnative` CMake target so we could use it as single .so
for the CMake build.

Changelog:
[Internal] [Changed] - Rename reactnative.a -> react_cxxreact.a

Differential Revision: D55745640


