### PR TITLE
Vendoring Boost to reduce footprint

### DIFF
--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -5,19 +5,21 @@
 
 Pod::Spec.new do |spec|
   spec.name = 'boost'
-  spec.version = '1.83.0'
+  spec.version = '1.84.0'
   spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
-  spec.source = { :http => 'https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.bz2',
-                  :sha256 => '6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e' }
+  spec.source = { :git => "https://github.com/react-native-community/boost-for-react-native",
+                  :tag => "v1.84.0" }
 
   # Pinning to the same version as React.podspec.
   spec.platforms = min_supported_versions
   spec.requires_arc = false
+  spec.source_files = 'boost/**/*.{hpp,cpp}'
 
   spec.module_name = 'boost'
   spec.header_dir = 'boost'
   spec.preserve_path = 'boost'
+  spec.header_mappings_dir = 'boost/boost'
 end

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - boost (1.83.0)
+  - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (1000.0.0)
   - fmt (9.1.0)
@@ -1655,7 +1655,7 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: d3f49c53809116a5d38da093a8aa78bf551aed09
+  boost: b6c2ab552684b545148f00ac9e0bb243cc0a43f5
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: f4492a543c5a8fa1502d3a5867e3f7252497cfe8
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120


### PR DESCRIPTION
Summary:
This change tries to vendor boost. It has several sustainable benefits:
- Reduce the download time to download boost
- Reduce the time to install pods
- Reduce the time to build the project
- Protects us from SEVs due to boost download link being down (happened twice already)
- Fixes how we build boost: currently it is a pseudo-target in iOS with no code, this makes all the symbols weak and this does not plays nicely with the new Apple linker.

## Changelog:
[Internal] - Vendor boost from React Native

Differential Revision: D55742345
