### PR TITLE
Add ReactRootViewTagGenerator

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManagerUtils.m
+++ b/packages/react-native/React/Modules/RCTUIManagerUtils.m
@@ -97,7 +97,8 @@ void RCTUnsafeExecuteOnUIManagerQueueSync(dispatch_block_t block)
 
 NSNumber *RCTAllocateRootViewTag(void)
 {
-  // Numbering of these tags goes from 1, 11, 21, 31, ..., 100501, ...
+  // Keep in sync with ReactRootViewTagGenerator.h - see that file for an explanation on why the
+  // increment here is 10.
   static _Atomic int64_t rootViewTagCounter = 0;
   return @(atomic_fetch_add_explicit(&rootViewTagCounter, 1, memory_order_relaxed) * 10 + 1);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactRootViewTagGenerator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactRootViewTagGenerator.kt
@@ -10,7 +10,7 @@ package com.facebook.react.uimanager
 /** Incremental counter for React Root View tag. */
 public object ReactRootViewTagGenerator {
 
-  // Keep in sync with ReactIOSTagHandles JS module - see that file for an explanation on why the
+  // Keep in sync with ReactRootViewTagGenerator.h - see that file for an explanation on why the
   // increment here is 10.
   private const val ROOT_VIEW_TAG_INCREMENT = 10
   private var nextRootViewTag = 1

--- a/packages/react-native/ReactCommon/react/renderer/core/ReactRootViewTagGenerator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ReactRootViewTagGenerator.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ReactRootViewTagGenerator.h"
+
+#include <atomic>
+
+namespace facebook::react {
+
+constexpr SurfaceId ROOT_VIEW_TAG_INCREMENT = 10;
+
+SurfaceId getNextRootViewTag() noexcept {
+  // Numbering of these tags goes from 11, 21, 31, ..., 100501, ...
+  static std::atomic<SurfaceId> nextRootViewTag = 1;
+  return nextRootViewTag += ROOT_VIEW_TAG_INCREMENT;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ReactRootViewTagGenerator.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ReactRootViewTagGenerator.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/core/ReactPrimitives.h>
+
+namespace facebook::react {
+
+SurfaceId getNextRootViewTag() noexcept;
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [Added] Add ReactRootViewTagGenerator

This copies over a modified version of the [react-native-windows](https://github.com/microsoft/react-native-windows/blob/main/vnext/Microsoft.ReactNative/Modules/ReactRootViewTagGenerator.h) implementation so it can be shared with other C based platforms

This also updates the outdated comment about the non existing ReactIOSTagHandles JS module.

Differential Revision: D55772580
