### PR TITLE
Fix Android instacrashing on JSC with NoSuchMethodException

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSCInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSCInstance.kt
@@ -9,14 +9,16 @@ package com.facebook.react.runtime
 
 import com.facebook.jni.HybridData
 import com.facebook.jni.annotations.DoNotStrip
+import com.facebook.jni.annotations.DoNotStripAny
 import com.facebook.soloader.SoLoader
 
-public class JSCInstance constructor() : JSRuntimeFactory(initHybrid()) {
+@DoNotStripAny
+public class JSCInstance : JSRuntimeFactory(initHybrid()) {
   private companion object {
     init {
       SoLoader.loadLibrary("jscinstance")
     }
 
-    @DoNotStrip protected external fun initHybrid(): HybridData
+    @DoNotStrip @JvmStatic private external fun initHybrid(): HybridData
   }
 }


### PR DESCRIPTION
Summary:
JSC is currently instacrashing because we missed a JvmStatic.
Android will attempt to load JSCInstance.initHybrid which is missing unless we specify JvmStatic.


Changelog:
[Internal] [Changed] - Fix Android instacrashing on JSC with NoSuchMethodException

Differential Revision: D55795290


