### PR TITLE
do not force CMake version for windows

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -1035,7 +1035,7 @@ jobs:
           name: Build HermesC for Windows
           command: |
             if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
-              choco install --no-progress cmake --version 3.14.7 -y
+              choco install --no-progress cmake -y
               if (-not $?) { throw "Failed to install CMake" }
 
               cd $Env:HERMES_WS_DIR\icu


### PR DESCRIPTION
Summary:
build_hermesc_windows is starting to fail because version 3.14.7 is [not available anymore](https://app.circleci.com/pipelines/github/facebook/react-native/44621/workflows/0c7d3474-ddf4-4138-bdbc-3fec59486f6c/jobs/1452518?invite=true#step-108-735_84) on chocolatey. By removing the version, the system should try to download the latest available.

## Changelog:
[Internal] - use the latest cmake on chocolatey for windows

Differential Revision: D55799078


