### PR TITLE
Fix crash of RNTester on back navigation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
@@ -34,7 +34,7 @@ public class HermesExecutor extends JavaScriptExecutor {
     super(
         config == null
             ? initHybridDefaultConfig(enableDebugger, debuggerName)
-            : initHybrid(enableDebugger, debuggerName, config.heapSizeMB));
+            : initHybrid(enableDebugger, debuggerName, config.getHeapSizeMB()));
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DoubleTapReloadRecognizer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DoubleTapReloadRecognizer.kt
@@ -20,7 +20,7 @@ import android.widget.EditText
 public class DoubleTapReloadRecognizer {
   private var doRefresh = false
 
-  public fun didDoubleTapR(keyCode: Int, view: View): Boolean {
+  public fun didDoubleTapR(keyCode: Int, view: View?): Boolean {
     if (keyCode == KeyEvent.KEYCODE_R && view !is EditText) {
       if (doRefresh) {
         doRefresh = false


### PR DESCRIPTION
Summary:
RN Tester is crashing on back navigation with this stacktrace:

```
04-05 17:14:22.906 25051 25051 E AndroidRuntime: FATAL EXCEPTION: main
04-05 17:14:22.906 25051 25051 E AndroidRuntime: Process: com.facebook.react.uiapp, PID: 25051
04-05 17:14:22.906 25051 25051 E AndroidRuntime: java.lang.NullPointerException: Parameter specified as non-null is null: method com.facebook.react.devsupport.DoubleTapReloadRecognizer.didDoubleTapR, parameter view
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at com.facebook.react.devsupport.DoubleTapReloadRecognizer.didDoubleTapR(Unknown Source:2)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at com.facebook.react.ReactDelegate.shouldShowDevMenuOrReload(ReactDelegate.java:302)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at com.facebook.react.ReactActivityDelegate.onKeyUp(ReactActivityDelegate.java:158)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at com.facebook.react.ReactActivity.onKeyUp(ReactActivity.java:89)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.KeyEvent.dispatch(KeyEvent.java:2878)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.app.Activity.dispatchKeyEvent(Activity.java:4164)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at androidx.core.app.ComponentActivity.superDispatchKeyEvent(ComponentActivity.java:126)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at androidx.core.view.KeyEventDispatcher.dispatchKeyEvent(KeyEventDispatcher.java:86)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at androidx.core.app.ComponentActivity.dispatchKeyEvent(ComponentActivity.java:144)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at androidx.appcompat.app.AppCompatActivity.dispatchKeyEvent(AppCompatActivity.java:604)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at androidx.appcompat.view.WindowCallbackWrapper.dispatchKeyEvent(WindowCallbackWrapper.java:60)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.dispatchKeyEvent(AppCompatDelegateImpl.java:3413)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at com.android.internal.policy.DecorView.dispatchKeyEvent(DecorView.java:404)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:6377)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:6243)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5725)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5782)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5748)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:5913)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5756)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:5970)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5729)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5782)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5748)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5756)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5729)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5782)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5748)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:5946)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(ViewRootImpl.java:6104)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager$PendingEvent.run(InputMethodManager.java:3159)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(InputMethodManager.java:2723)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager.finishedInputEvent(InputMethodManager.java:2714)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(InputMethodManager.java:3136)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.view.InputEventSender.dispatchInputEventFinished(InputEventSender.java:154)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.os.MessageQueue.nativePollOnce(Native Method)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.os.MessageQueue.next(MessageQueue.java:335)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:161)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:288)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7842)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
04-05 17:14:22.906 25051 25051 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

This is happening because the `view: View` parameter is actually null at that point. I'm fixing it.


Changelog:
[Internal] [Changed] - Fix crash of RNTester on back navigation

Differential Revision: D55805574


