### PR TITLE
Fix broken HermesExecutor compilation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
@@ -34,7 +34,7 @@ public class HermesExecutor extends JavaScriptExecutor {
     super(
         config == null
             ? initHybridDefaultConfig(enableDebugger, debuggerName)
-            : initHybrid(enableDebugger, debuggerName, config.heapSizeMB));
+            : initHybrid(enableDebugger, debuggerName, config.getHeapSizeMB()));
   }
 
   @Override


### PR DESCRIPTION
Summary:
Converting to Kotlin the `RuntimeConfig` class caused the project to stop compiling.

Changelog:
[Internal] [Changed] - Fix broken HermesExecutor compilation

Differential Revision: D55805572


