### PR TITLE
Fix app crash on device hardware button pressed

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DoubleTapReloadRecognizer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DoubleTapReloadRecognizer.kt
@@ -20,7 +20,10 @@ import android.widget.EditText
 public class DoubleTapReloadRecognizer {
   private var doRefresh = false
 
-  public fun didDoubleTapR(keyCode: Int, view: View): Boolean {
+  public fun didDoubleTapR(keyCode: Int, view: View?): Boolean {
+    if (view == null) {
+      return false
+    }
     if (keyCode == KeyEvent.KEYCODE_R && view !is EditText) {
       if (doRefresh) {
         doRefresh = false


### PR DESCRIPTION
Summary:
Twilight Android is crashing on device hardware button pressed with the following error: P1206398153

This file was recently Kotlinified in D55747942 but View was cast to nonnull

This allows the view passed to be null to avoid app crashing

Differential Revision: D55808402


