### PR TITLE
Remove core modules from the default tmmdelegate

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp
@@ -32,6 +32,7 @@
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <rncli.h>
+#include <rncore.h>
 
 #ifdef REACT_NATIVE_APP_CODEGEN_HEADER
 #include REACT_NATIVE_APP_CODEGEN_HEADER
@@ -95,8 +96,17 @@ std::shared_ptr<TurboModule> javaModuleProvider(
   }
 #endif
 
+  // We first try to look up core modules
+  if (auto module = rncore_ModuleProvider(name, params)) {
+    return module;
+  }
+
   // And we fallback to the module providers autolinked by RN CLI
-  return rncli_ModuleProvider(name, params);
+  if (auto module = rncli_ModuleProvider(name, params)) {
+    return module;
+  }
+
+  return nullptr;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp
@@ -12,7 +12,6 @@
 #include <react/nativemodule/dom/NativeDOM.h>
 #include <react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h>
 #include <react/nativemodule/microtasks/NativeMicrotasks.h>
-#include <rncore.h>
 
 namespace facebook::react {
 
@@ -100,7 +99,8 @@ std::shared_ptr<TurboModule> DefaultTurboModuleManagerDelegate::getTurboModule(
       return resolvedModule;
     }
   }
-  return rncore_ModuleProvider(name, params);
+
+  return nullptr;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -17,12 +17,20 @@
 #include <ReactCommon/TurboCxxModule.h>
 #include <ReactCommon/TurboModuleBinding.h>
 #include <ReactCommon/TurboModulePerfLogger.h>
+#include <glog/logging.h>
 
 #include "TurboModuleManager.h"
 
 namespace facebook::react {
 
 namespace {
+
+static void logFoundModule(const std::string& moduleName) {
+  static int count = 0;
+  count++;
+  LOG(INFO) << "RAMAN: found module " << std::to_string(count) << ") "
+            << moduleName << std::endl;
+}
 
 class JMethodDescriptor : public jni::JavaClass<JMethodDescriptor> {
  public:
@@ -163,6 +171,7 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
 
     auto cxxModule = delegate->cthis()->getTurboModule(name, jsCallInvoker);
     if (cxxModule) {
+      logFoundModule(name);
       turboModuleCache->insert({name, cxxModule});
       return cxxModule;
     }
@@ -172,6 +181,7 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
     if (it != cxxTurboModuleMapProvider.end()) {
       auto turboModule = it->second(jsCallInvoker);
       turboModuleCache->insert({name, turboModule});
+      logFoundModule(name);
       return turboModule;
     }
 
@@ -189,6 +199,7 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
       turboModuleCache->insert({name, turboModule});
 
       TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+      logFoundModule(name);
       return turboModule;
     }
 
@@ -210,6 +221,7 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
       auto turboModule = delegate->cthis()->getTurboModule(name, params);
       turboModuleCache->insert({name, turboModule});
       TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+      logFoundModule(name);
       return turboModule;
     }
 

--- a/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
+++ b/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
@@ -11,6 +11,7 @@
 #include <ReactCommon/SampleTurboModuleSpec.h>
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+#include <rncore.h>
 
 #ifdef REACT_NATIVE_APP_CODEGEN_HEADER
 #include REACT_NATIVE_APP_CODEGEN_HEADER
@@ -51,6 +52,12 @@ std::shared_ptr<TurboModule> javaModuleProvider(
     return module;
   }
 #endif
+
+  // We first try to look up core modules
+  if (auto module = rncore_ModuleProvider(name, params)) {
+    return module;
+  }
+
   return nullptr;
 }
 


### PR DESCRIPTION
Summary:
## Problem
If we link the default tmmdelegate with our vr apps, we get this issue:

```
ld.lld: error: duplicate symbol: facebook::react::NativeDevLoadingViewSpecJSI::NativeDevLoadingViewSpecJSI(facebook::react::JavaTurboModule::InitParams const&)
>>> defined at firsttimenux_v2AppModulesCodegen-generated.cpp:1367 (buck-out/v2/gen/fbsource/bcbe7a50bd5ff29a/arvr/libraries/react-panellib/FirstTimeNux/__firsttimenux_v2AppModulesCodegen-codegen-modules-jni_cpp__/out/firsttimenux_v2AppModulesCodegen-generated.cpp:1367)
>>>            firsttimenux_v2AppModulesCodegen-generated.cpp.pic.o:(facebook::react::NativeDevLoadingViewSpecJSI::NativeDevLoadingViewSpecJSI(facebook::react::JavaTurboModule::InitParams const&)) in archive buck-out/v2/gen/fbsource/bcbe7a50bd5ff29a/arvr/libraries/react-panellib/FirstTimeNux/__firsttimenux_v2AppModulesCodegen-jni__/libfirsttimenux_v2AppModulesCodegen-jni.pic.a
>>> defined at rncore-generated.cpp:606 (buck-out/v2/gen/fbsource/bcbe7a50bd5ff29a/xplat/js/react-native-github/__rncore-codegen-modules-jni_cpp__/out/rncore-generated.cpp:606)
>>>            rncore-generated.cpp.pic.o:(.text._ZN8facebook5react27NativeDevLoadingViewSpecJSIC2ERKNS0_15JavaTurboModule10InitParamsE+0x0) in archive buck-out/v2/gen/fbsource/bcbe7a50bd5ff29a/xplat/js/react-native-github/__rncore-jniAndroid__/librncore-jniAndroid.pic.a
```

## Cause
My best understanding of the problem:
- Default tmmdelegate links against rncore, which contains codegen for react native's standard library of modules.
- But, the default delegate also pulls in this appmodules.so library. That library also contains codegen for react native's standard library of modules + the app's modules.

So, two so libraries define the same symbols. Hence the build fails.

## Solution
Remove the codegen for react native's standard library of modules from the default tmmdelegate.

Prereq: In open source, also make appmodules.so include the codegen for react native's standard library of modules.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D55613024


