### PR TITLE
Move default module/component registries to com.facebook.react

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -43,6 +43,37 @@ public class com/facebook/react/DebugCorePackage$$ReactModuleInfoProvider : com/
 	public fun getReactModuleInfos ()Ljava/util/Map;
 }
 
+public final class com/facebook/react/DefaultComponentsRegistry {
+	public static final field Companion Lcom/facebook/react/DefaultComponentsRegistry$Companion;
+	public synthetic fun <init> (Lcom/facebook/react/fabric/ComponentFactory;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun register (Lcom/facebook/react/fabric/ComponentFactory;)Lcom/facebook/react/DefaultComponentsRegistry;
+}
+
+public final class com/facebook/react/DefaultComponentsRegistry$Companion {
+	public final fun register (Lcom/facebook/react/fabric/ComponentFactory;)Lcom/facebook/react/DefaultComponentsRegistry;
+}
+
+public final class com/facebook/react/DefaultSoLoader {
+	public static final field Companion Lcom/facebook/react/DefaultSoLoader$Companion;
+	public fun <init> ()V
+	public static final fun maybeLoadSoLibrary ()V
+}
+
+public final class com/facebook/react/DefaultSoLoader$Companion {
+	public final fun maybeLoadSoLibrary ()V
+}
+
+public final class com/facebook/react/DefaultTurboModuleManagerDelegate : com/facebook/react/ReactPackageTurboModuleManagerDelegate {
+	public synthetic fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/facebook/react/DefaultTurboModuleManagerDelegate$Builder : com/facebook/react/ReactPackageTurboModuleManagerDelegate$Builder {
+	public fun <init> ()V
+	public final fun addCxxReactPackage (Lkotlin/jvm/functions/Function0;)Lcom/facebook/react/DefaultTurboModuleManagerDelegate$Builder;
+	public final fun addCxxReactPackage (Lkotlin/jvm/functions/Function1;)Lcom/facebook/react/DefaultTurboModuleManagerDelegate$Builder;
+	public synthetic fun build (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/util/List;)Lcom/facebook/react/ReactPackageTurboModuleManagerDelegate;
+}
+
 public abstract class com/facebook/react/HeadlessJsTaskService : android/app/Service, com/facebook/react/jstasks/HeadlessJsTaskEventListener {
 	public fun <init> ()V
 	public static fun acquireWakeLockNow (Landroid/content/Context;)V
@@ -1967,16 +1998,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public fun <init> ()V
 }
 
-public final class com/facebook/react/defaults/DefaultComponentsRegistry {
-	public static final field Companion Lcom/facebook/react/defaults/DefaultComponentsRegistry$Companion;
-	public synthetic fun <init> (Lcom/facebook/react/fabric/ComponentFactory;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun register (Lcom/facebook/react/fabric/ComponentFactory;)Lcom/facebook/react/defaults/DefaultComponentsRegistry;
-}
-
-public final class com/facebook/react/defaults/DefaultComponentsRegistry$Companion {
-	public final fun register (Lcom/facebook/react/fabric/ComponentFactory;)Lcom/facebook/react/defaults/DefaultComponentsRegistry;
-}
-
 public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint {
 	public static final field INSTANCE Lcom/facebook/react/defaults/DefaultNewArchitectureEntryPoint;
 	public static final fun getBridgelessEnabled ()Z
@@ -2012,18 +2033,6 @@ public abstract class com/facebook/react/defaults/DefaultReactNativeHost : com/f
 	protected fun isHermesEnabled ()Ljava/lang/Boolean;
 	protected fun isNewArchEnabled ()Z
 	public final fun toReactHost (Landroid/content/Context;)Lcom/facebook/react/ReactHost;
-}
-
-public final class com/facebook/react/defaults/DefaultTurboModuleManagerDelegate : com/facebook/react/ReactPackageTurboModuleManagerDelegate {
-	public synthetic fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun initHybrid (Ljava/util/List;)Lcom/facebook/jni/HybridData;
-}
-
-public final class com/facebook/react/defaults/DefaultTurboModuleManagerDelegate$Builder : com/facebook/react/ReactPackageTurboModuleManagerDelegate$Builder {
-	public fun <init> ()V
-	public final fun addCxxReactPackage (Lkotlin/jvm/functions/Function0;)Lcom/facebook/react/defaults/DefaultTurboModuleManagerDelegate$Builder;
-	public final fun addCxxReactPackage (Lkotlin/jvm/functions/Function1;)Lcom/facebook/react/defaults/DefaultTurboModuleManagerDelegate$Builder;
-	public synthetic fun build (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/util/List;)Lcom/facebook/react/ReactPackageTurboModuleManagerDelegate;
 }
 
 public final class com/facebook/react/devsupport/BridgeDevSupportManager : com/facebook/react/devsupport/DevSupportManagerBase {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DefaultComponentsRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DefaultComponentsRegistry.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.defaults
+package com.facebook.react
 
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DefaultSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DefaultSoLoader.kt
@@ -5,15 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.defaults
+package com.facebook.react
 
 import com.facebook.soloader.SoLoader
 
-internal class DefaultSoLoader {
-  companion object {
+public class DefaultSoLoader {
+  public companion object {
     @Synchronized
     @JvmStatic
-    fun maybeLoadSoLibrary() {
+    public fun maybeLoadSoLibrary() {
       SoLoader.loadLibrary("react_newarchdefaults")
       try {
         SoLoader.loadLibrary("appmodules")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DefaultTurboModuleManagerDelegate.kt
@@ -5,12 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.defaults
+package com.facebook.react
 
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
-import com.facebook.react.ReactPackage
-import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
@@ -72,6 +70,6 @@ private constructor(
 
     @DoNotStrip
     @JvmStatic
-    external fun initHybrid(cxxReactPackages: List<CxxReactPackage>): HybridData
+    private external fun initHybrid(cxxReactPackages: List<CxxReactPackage>): HybridData
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -9,6 +9,7 @@
 
 package com.facebook.react.defaults
 
+import com.facebook.react.DefaultSoLoader
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -8,6 +8,8 @@
 package com.facebook.react.defaults
 
 import android.content.Context
+import com.facebook.react.DefaultComponentsRegistry
+import com.facebook.react.DefaultTurboModuleManagerDelegate
 import com.facebook.react.JSEngineResolutionAlgorithm
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -9,6 +9,8 @@ package com.facebook.react.defaults
 
 import android.app.Application
 import android.content.Context
+import com.facebook.react.DefaultComponentsRegistry
+import com.facebook.react.DefaultTurboModuleManagerDelegate
 import com.facebook.react.JSEngineResolutionAlgorithm
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.h
@@ -19,7 +19,7 @@ class DefaultComponentsRegistry
     : public facebook::jni::HybridClass<DefaultComponentsRegistry> {
  public:
   constexpr static auto kJavaDescriptor =
-      "Lcom/facebook/react/defaults/DefaultComponentsRegistry;";
+      "Lcom/facebook/react/DefaultComponentsRegistry;";
 
   static void registerNatives();
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.h
@@ -22,7 +22,7 @@ class DefaultTurboModuleManagerDelegate : public jni::HybridClass<
                                               TurboModuleManagerDelegate> {
  public:
   static constexpr auto kJavaDescriptor =
-      "Lcom/facebook/react/defaults/DefaultTurboModuleManagerDelegate;";
+      "Lcom/facebook/react/DefaultTurboModuleManagerDelegate;";
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jclass>,


### PR DESCRIPTION
Summary:
This makes default tmmdelegate (+ componentregistry) super accessible.

This way, eventually, we can create the default tmmdelegate (+ componentregistry) inside ReactInstanceManager, and migrate all bridge apps to the default tmmdelegate.

Changelog: [Android][Changed] - Migrate DefaultTurboModuleManagerDelegate from com.facebook.react.default -> com.facebook.react

Reviewed By: javache

Differential Revision: D55598113
