### PR TITLE
[Fabric] img events fixes for ios and android

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -136,7 +136,7 @@ using namespace facebook::react;
     return;
   }
 
-  static_cast<const ImageEventEmitter &>(*_eventEmitter).onLoad();
+  static_cast<const ImageEventEmitter &>(*_eventEmitter).onLoad(_state->getData().getImageSource());
   static_cast<const ImageEventEmitter &>(*_eventEmitter).onLoadEnd();
 
   const auto &imageProps = static_cast<const ImageProps &>(*_props);
@@ -168,16 +168,16 @@ using namespace facebook::react;
   }
 }
 
-- (void)didReceiveProgress:(float)progress fromObserver:(const void *)observer
+- (void)didReceiveProgress:(float)progress loaded:(int64_t)loaded total:(int64_t)total  fromObserver:(const void *)observer
 {
   if (!_eventEmitter) {
     return;
   }
 
-  static_cast<const ImageEventEmitter &>(*_eventEmitter).onProgress(progress);
+  static_cast<const ImageEventEmitter &>(*_eventEmitter).onProgress(progress, loaded, total);
 }
 
-- (void)didReceiveFailureFromObserver:(const void *)observer
+- (void)didReceiveFailure:(NSError *)error fromObserver:(const void *)observer
 {
   _imageView.image = nil;
 
@@ -185,7 +185,24 @@ using namespace facebook::react;
     return;
   }
 
-  static_cast<const ImageEventEmitter &>(*_eventEmitter).onError();
+  ImageErrorInfo info;
+
+  if (error) {
+    info.error = std::string([error.localizedDescription UTF8String]);
+    id code = error.userInfo[@"httpStatusCode"];
+    if (code){
+      info.responseCode = [code intValue];
+    }
+    id rspHeaders = error.userInfo[@"httpResponseHeaders"];
+    if (rspHeaders) {
+      for (NSString* key in rspHeaders) {
+        id value = rspHeaders[key];
+        info.httpResponseHeaders.push_back(std::pair<std::string,std::string>(
+                        std::string([key UTF8String]),std::string([value UTF8String])));
+      }
+    }
+  }
+  static_cast<const ImageEventEmitter &>(*_eventEmitter).onError(ImageErrorInfo(info));
   static_cast<const ImageEventEmitter &>(*_eventEmitter).onLoadEnd();
 }
 

--- a/packages/react-native/React/Fabric/RCTImageResponseDelegate.h
+++ b/packages/react-native/React/Fabric/RCTImageResponseDelegate.h
@@ -12,8 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol RCTImageResponseDelegate <NSObject>
 
 - (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(const void *)observer;
-- (void)didReceiveProgress:(float)progress fromObserver:(const void *)observer;
-- (void)didReceiveFailureFromObserver:(const void *)observer;
+- (void)didReceiveProgress:(float)progress loaded:(int64_t)loaded total:(int64_t)total fromObserver:(const void *)observer;
+- (void)didReceiveFailure:(NSError *)error fromObserver:(const void *)observer;
 
 @end
 

--- a/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.h
+++ b/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.h
@@ -20,8 +20,8 @@ class RCTImageResponseObserverProxy final : public ImageResponseObserver {
   RCTImageResponseObserverProxy(id<RCTImageResponseDelegate> delegate = nil);
 
   void didReceiveImage(const ImageResponse &imageResponse) const override;
-  void didReceiveProgress(float progress) const override;
-  void didReceiveFailure() const override;
+  void didReceiveProgress(float progress, int64_t loaded, int64_t total) const override;
+  void didReceiveFailure(const ImageLoadError& error) const override;
 
  private:
   __weak id<RCTImageResponseDelegate> delegate_;

--- a/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.mm
+++ b/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.mm
@@ -30,21 +30,22 @@ void RCTImageResponseObserverProxy::didReceiveImage(const ImageResponse &imageRe
   });
 }
 
-void RCTImageResponseObserverProxy::didReceiveProgress(float progress) const
+void RCTImageResponseObserverProxy::didReceiveProgress(float progress, int64_t loaded, int64_t total) const
 {
   auto this_ = this;
   id<RCTImageResponseDelegate> delegate = delegate_;
   RCTExecuteOnMainQueue(^{
-    [delegate didReceiveProgress:progress fromObserver:this_];
+    [delegate didReceiveProgress:progress loaded:loaded total:total fromObserver:this_];
   });
 }
 
-void RCTImageResponseObserverProxy::didReceiveFailure() const
+void RCTImageResponseObserverProxy::didReceiveFailure(const ImageLoadError &errorResponse) const
 {
   auto this_ = this;
+  NSError *error = (NSError *)unwrapManagedObject(errorResponse.getError());
   id<RCTImageResponseDelegate> delegate = delegate_;
   RCTExecuteOnMainQueue(^{
-    [delegate didReceiveFailureFromObserver:this_];
+    [delegate didReceiveFailure:error fromObserver:this_];
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.kt
@@ -41,6 +41,7 @@ private constructor(
           ON_PROGRESS -> {
             putInt("loaded", loaded)
             putInt("total", total)
+            putDouble("progress", loaded/total.toDouble())
           }
           ON_LOAD -> putMap("source", createEventDataSource())
           ON_ERROR -> putString("error", errorMessage)

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.cpp
@@ -13,24 +13,51 @@ void ImageEventEmitter::onLoadStart() const {
   dispatchEvent("loadStart");
 }
 
-void ImageEventEmitter::onLoad() const {
-  dispatchEvent("load");
+void ImageEventEmitter::onLoad(const ImageSource &source) const {
+  dispatchEvent("load", [source](jsi::Runtime& runtime) {
+    auto src = jsi::Object(runtime);
+    src.setProperty(runtime, "uri", source.uri);
+    src.setProperty(runtime, "width", source.size.width);
+    src.setProperty(runtime, "height", source.size.height);
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "source", src);
+    return payload;
+  });
 }
 
 void ImageEventEmitter::onLoadEnd() const {
   dispatchEvent("loadEnd");
 }
 
-void ImageEventEmitter::onProgress(double progress) const {
-  dispatchEvent("progress", [=](jsi::Runtime& runtime) {
+void ImageEventEmitter::onProgress(double progress, int64_t loaded, int64_t total) const {
+  dispatchEvent("progress", [progress, loaded, total](jsi::Runtime& runtime) {
     auto payload = jsi::Object(runtime);
     payload.setProperty(runtime, "progress", progress);
+    payload.setProperty(runtime, "loaded", (double)loaded);
+    payload.setProperty(runtime, "total", (double)total);
     return payload;
   });
 }
 
-void ImageEventEmitter::onError() const {
-  dispatchEvent("error");
+void ImageEventEmitter::onError(const ImageErrorInfo &error) const {
+  dispatchEvent("error", [error](jsi::Runtime& runtime) {
+    auto payload = jsi::Object(runtime);
+    if (!error.error.empty()) {
+      payload.setProperty(runtime, "error", error.error);
+    }
+    if (error.responseCode) {
+      payload.setProperty(runtime, "responseCode", error.responseCode);
+    }
+    if (!error.httpResponseHeaders.empty()) {
+      auto headers = jsi::Object(runtime);
+      for (auto const& x : error.httpResponseHeaders)
+      {
+        headers.setProperty(runtime, x.first.c_str(),x.second);
+      }
+      payload.setProperty(runtime, "httpResponseHeaders", headers);
+    }
+    return payload;
+  });
 }
 
 void ImageEventEmitter::onPartialLoad() const {

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
+#include <react/renderer/imagemanager/primitives.h>
 
 namespace facebook::react {
 
@@ -16,10 +17,10 @@ class ImageEventEmitter : public ViewEventEmitter {
   using ViewEventEmitter::ViewEventEmitter;
 
   void onLoadStart() const;
-  void onLoad() const;
+  void onLoad(const ImageSource &source) const;
   void onLoadEnd() const;
-  void onProgress(double) const;
-  void onError() const;
+  void onProgress(double, int64_t, int64_t) const;
+  void onError(const ImageErrorInfo &error) const;
   void onPartialLoad() const;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.cpp
@@ -24,4 +24,12 @@ std::shared_ptr<void> ImageResponse::getMetadata() const {
   return metadata_;
 }
 
+ImageLoadError::ImageLoadError(
+    std::shared_ptr<void> error)
+    : error_(std::move(error)) {}
+
+std::shared_ptr<void> ImageLoadError::getError() const {
+  return error_;
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
@@ -34,4 +34,13 @@ class ImageResponse final {
   std::shared_ptr<void> metadata_{};
 };
 
+class ImageLoadError {
+public:
+  ImageLoadError(std::shared_ptr<void> error);
+  std::shared_ptr<void> getError() const;
+
+private:
+  std::shared_ptr<void> error_{};
+};
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
@@ -19,9 +19,9 @@ class ImageResponseObserver {
  public:
   virtual ~ImageResponseObserver() noexcept = default;
 
-  virtual void didReceiveProgress(float progress) const = 0;
-  virtual void didReceiveImage(const ImageResponse& imageResponse) const = 0;
-  virtual void didReceiveFailure() const = 0;
+  virtual void didReceiveProgress(float progress, int64_t loaded, int64_t total) const = 0;
+  virtual void didReceiveImage(const ImageResponse &imageResponse) const = 0;
+  virtual void didReceiveFailure(const ImageLoadError &error) const = 0;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.cpp
@@ -30,8 +30,9 @@ void ImageResponseObserverCoordinator::addObserver(
       break;
     }
     case ImageResponse::Status::Failed: {
+      auto imageErrorData = imageErrorData_;
       mutex_.unlock();
-      observer.didReceiveFailure();
+      observer.didReceiveFailure(imageErrorData);
       break;
     }
   }
@@ -49,14 +50,14 @@ void ImageResponseObserverCoordinator::removeObserver(
 }
 
 void ImageResponseObserverCoordinator::nativeImageResponseProgress(
-    float progress) const {
+    float progress, int64_t loaded, int64_t total) const {
   mutex_.lock();
   auto observers = observers_;
   react_native_assert(status_ == ImageResponse::Status::Loading);
   mutex_.unlock();
 
   for (auto observer : observers) {
-    observer->didReceiveProgress(progress);
+    observer->didReceiveProgress(progress, loaded, total);
   }
 }
 
@@ -75,15 +76,16 @@ void ImageResponseObserverCoordinator::nativeImageResponseComplete(
   }
 }
 
-void ImageResponseObserverCoordinator::nativeImageResponseFailed() const {
+void ImageResponseObserverCoordinator::nativeImageResponseFailed(const ImageLoadError &loadError) const {
   mutex_.lock();
   react_native_assert(status_ == ImageResponse::Status::Loading);
   status_ = ImageResponse::Status::Failed;
+  imageErrorData_ = loadError.getError();
   auto observers = observers_;
   mutex_.unlock();
 
   for (auto observer : observers) {
-    observer->didReceiveFailure();
+    observer->didReceiveFailure(loadError);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
@@ -38,19 +38,19 @@ class ImageResponseObserverCoordinator {
   /*
    * Platform-specific image loader will call this method with progress updates.
    */
-  void nativeImageResponseProgress(float progress) const;
+  void nativeImageResponseProgress(float progress, int64_t loaded, int64_t total) const;
 
   /*
    * Platform-specific image loader will call this method with a completed image
    * response.
    */
-  void nativeImageResponseComplete(const ImageResponse& imageResponse) const;
+  void nativeImageResponseComplete(const ImageResponse &imageResponse) const;
 
   /*
    * Platform-specific image loader will call this method in case of any
    * failures.
    */
-  void nativeImageResponseFailed() const;
+  void nativeImageResponseFailed(const ImageLoadError &loadError) const;
 
  private:
   /*
@@ -76,6 +76,12 @@ class ImageResponseObserverCoordinator {
    * Mutable: protected by mutex_.
    */
   mutable std::shared_ptr<void> imageMetadata_;
+
+  /*
+   * Cache image error Data.
+   * Mutable: protected by mutex_.
+   */
+  mutable std::shared_ptr<void> imageErrorData_;
 
   /*
    * Observer and data mutex.

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.mm
@@ -74,7 +74,8 @@ using namespace facebook::react;
         auto wrappedMetadata = metadata ? wrapManagedObject(metadata) : nullptr;
         observerCoordinator->nativeImageResponseComplete(ImageResponse(wrapManagedObject(image), wrappedMetadata));
       } else {
-        observerCoordinator->nativeImageResponseFailed();
+        auto wrappedError = error ? wrapManagedObject(error) : nullptr;
+        observerCoordinator->nativeImageResponseFailed(ImageLoadError(wrappedError));
       }
     };
 
@@ -84,7 +85,7 @@ using namespace facebook::react;
         return;
       }
 
-      observerCoordinator->nativeImageResponseProgress((float)progress / (float)total);
+      observerCoordinator->nativeImageResponseProgress((float)progress / (float)total, progress, total);
     };
 
     RCTImageURLLoaderRequest *loaderRequest =

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
@@ -58,7 +58,8 @@ using namespace facebook::react;
       auto wrappedMetadata = metadata ? wrapManagedObject(metadata) : nullptr;
       observerCoordinator->nativeImageResponseComplete(ImageResponse(wrapManagedObject(image), wrappedMetadata));
     } else {
-      observerCoordinator->nativeImageResponseFailed();
+      auto wrappedError = error ? wrapManagedObject(error) : nullptr;
+      observerCoordinator->nativeImageResponseFailed(ImageLoadError(wrappedError));
     }
     dispatch_group_leave(imageWaitGroup);
   };
@@ -69,7 +70,7 @@ using namespace facebook::react;
       return;
     }
 
-    observerCoordinator->nativeImageResponseProgress((float)progress / (float)total);
+    observerCoordinator->nativeImageResponseProgress((float)progress / (float)total, progress, total);
   };
 
   RCTImageURLLoaderRequest *loaderRequest =

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -44,4 +44,11 @@ enum class ImageResizeMode {
   Repeat,
 };
 
+class ImageErrorInfo {
+public:
+  std::string error{};
+  int responseCode{};
+  std::vector<std::pair<std::string, std::string>> httpResponseHeaders{};
+};
+
 } // namespace facebook::react


### PR DESCRIPTION

## Summary:
fixes Image events in new architecture
#43874

## Changelog:

[iOS] [Fixed] - Missing `source` in `onLoad` native event arguments
[iOS] [Fixed] - Missing `error`, `responseCode`, and `httpResponseHeaders` in `onError` native event arguments
[iOS] [Fixed] - Missing `loaded` and `total`  in `onProgress` native event arguments
[Android] [Fixed] - Missing `progress`  in `onProgress` native event arguments

## Test Plan:

test using Image section of rn-tester app

before
![image](https://github.com/facebook/react-native/assets/1734518/8f7d714b-2ddf-4db0-a539-7be52e3fd948)
after 
![image](https://github.com/facebook/react-native/assets/1734518/50f14906-1b65-447f-ae84-634989c1bfc7)
