### PR TITLE
Fix kotlinification of RuntimeConfig

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -17,12 +17,20 @@
 #include <ReactCommon/TurboCxxModule.h>
 #include <ReactCommon/TurboModuleBinding.h>
 #include <ReactCommon/TurboModulePerfLogger.h>
+#include <glog/logging.h>
 
 #include "TurboModuleManager.h"
 
 namespace facebook::react {
 
 namespace {
+
+static void logFoundModule(const std::string& moduleName) {
+  static int count = 0;
+  count++;
+  LOG(INFO) << "RAMAN: found module " << std::to_string(count) << ") "
+            << moduleName << std::endl;
+}
 
 class JMethodDescriptor : public jni::JavaClass<JMethodDescriptor> {
  public:
@@ -163,6 +171,7 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
 
     auto cxxModule = delegate->cthis()->getTurboModule(name, jsCallInvoker);
     if (cxxModule) {
+      logFoundModule(name);
       turboModuleCache->insert({name, cxxModule});
       return cxxModule;
     }
@@ -172,6 +181,7 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
     if (it != cxxTurboModuleMapProvider.end()) {
       auto turboModule = it->second(jsCallInvoker);
       turboModuleCache->insert({name, turboModule});
+      logFoundModule(name);
       return turboModule;
     }
 
@@ -189,6 +199,7 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
       turboModuleCache->insert({name, turboModule});
 
       TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+      logFoundModule(name);
       return turboModule;
     }
 
@@ -210,6 +221,7 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
       auto turboModule = delegate->cthis()->getTurboModule(name, params);
       turboModuleCache->insert({name, turboModule});
       TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+      logFoundModule(name);
       return turboModule;
     }
 


### PR DESCRIPTION
Summary:
In D55788661, we kotlinified RuntimeConfig:

Which meant converting this:

```
public final class RuntimeConfig {
  public long heapSizeMB;
}
```

To
```
public class RuntimeConfig {
  public var heapSizeMB: Long = 0L
}

```

## Problem

HermesExecutor uses RuntimeConfig like this:

```
HermesExecutor(Nullable RuntimeConfig config, boolean enableDebugger, String debuggerName) {
    super(
        config == null
            ? initHybridDefaultConfig(enableDebugger, debuggerName)
            : initHybrid(enableDebugger, debuggerName, config.heapSizeMB));
  }
```

But, heapSizeMB is no longer a "java property" on RuntimeConfig. I think a property exists for heapSizeMB, but it's private on RuntimeConfig. Instead, java is expected to use the getter and setters, which are public. So, compiling HermesExecutor fails, because HermesExecutor is trying to access a private thing on RuntimeConfig.

This diff just migrates HermesExecutor (java) to use the getter for heapSizeMB, which fixes the error.

Changelog: [Internal]

Reviewed By: fabriziocucci, zeyap

Differential Revision: D55821869
