### PR TITLE
delete deprecated Xcode version check

### DIFF
--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |spec|
   spec.pod_target_xcconfig = {
     "USE_HEADERMAP" => "NO",
     "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src",
-    "DEFINES_MODULE" => should_define_modules # When the workaround is removed, set this var to "YES"
+    "DEFINES_MODULE" => "YES"
   }
 
   # Pinning to the same version as React.podspec.

--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -30,18 +30,6 @@ Pod::Spec.new do |spec|
   spec.exclude_files       = "src/windows/**/*"
   spec.compiler_flags      = '-Wno-shorten-64-to-32'
 
-  # TODO: T167482718 Remove this code after April 2024, when Apple will
-  # push the lower version of Xcode required to upload apps to the Store.
-  xcode_path = `xcodebuild -version` # This return the current version of Xcode
-
-  match = xcode_path.match(/Xcode (\d+)\.(\d+)/)
-  major_version = match[1].to_i
-  minor_version = match[2].to_i
-  is_greater_than_15 = major_version >= 15
-  is_greater_than_14_3 = major_version == 14 && minor_version >= 3
-  should_define_modules = is_greater_than_15 ? "YES" : is_greater_than_14_3 ? "YES" : "NO"
-  # End TODO.
-
   spec.pod_target_xcconfig = {
     "USE_HEADERMAP" => "NO",
     "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src",


### PR DESCRIPTION
## Summary:

IOS builds started failing due to Xcode version checks falsely claiming newer versions are not installed

TODO affecting Xcode version checking reads: Remove this code after April 2024, when Apple will push the lower version of Xcode required to upload apps to the Store.

## Changelog:

remove deprecated Xcode version check

Pick one each for the category and type tags:

[IOS] [REMOVED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan
Should run as before, only the deprecated version check has been removed.