### PR TITLE
Noop: ReactInstance: Add todo above getRuntimeScheduler()

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -163,6 +163,8 @@ RuntimeExecutor ReactInstance::getBufferedRuntimeExecutor() noexcept {
   };
 }
 
+// TODO(T184010230): Should the RuntimeScheduler returned from this method be
+// buffered?
 std::shared_ptr<RuntimeScheduler>
 ReactInstance::getRuntimeScheduler() noexcept {
   return runtimeScheduler_;


### PR DESCRIPTION
Summary:
getRuntimeScheduler() allows things to schedule work on the js thread by bypassing main bundle buffering.

This is unsafe: almost everything should be using the buffered runtime executor, unless it sets up bindings used in the main bundle.

I filed a task for the investigation to see if there's any problems. And added it to the code in this diff.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D55547899


