### PR TITLE
chore(AndroidExecutors): clean up outdated compat function

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/AndroidExecutors.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/AndroidExecutors.java
@@ -78,7 +78,7 @@ final class AndroidExecutors {
             TimeUnit.SECONDS,
             new LinkedBlockingQueue<Runnable>());
 
-    allowCoreThreadTimeout(executor, true);
+    executor.allowCoreThreadTimeOut(true);
 
     return executor;
   }
@@ -104,25 +104,9 @@ final class AndroidExecutors {
             new LinkedBlockingQueue<Runnable>(),
             threadFactory);
 
-    allowCoreThreadTimeout(executor, true);
+    executor.allowCoreThreadTimeOut(true);
 
     return executor;
-  }
-
-  /**
-   * Compatibility helper function for {@link
-   * java.util.concurrent.ThreadPoolExecutor#allowCoreThreadTimeOut(boolean)}
-   *
-   * <p>Only available on android-9+.
-   *
-   * @param executor the {@link java.util.concurrent.ThreadPoolExecutor}
-   * @param value true if should time out, else false
-   */
-  @SuppressLint("NewApi")
-  public static void allowCoreThreadTimeout(@NonNull ThreadPoolExecutor executor, boolean value) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
-      executor.allowCoreThreadTimeOut(value);
-    }
   }
 
   /**


### PR DESCRIPTION
## Summary:

this PR cleans up an outdated compatibility function in AndroidExecutors. the function in question was checking whether the code was running on Gingerbread or later - this is no longer needed, as RN requires Marshmallow or later.

## Changelog:

[INTERNAL] [FIXED] - Clean up outdated compatibility function

## Test Plan:

this should work as normal.
