### PR TITLE
Fix double metro banner in Bridgeless

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -31,7 +31,6 @@
 #import <React/RCTModuleData.h>
 #import <React/RCTPerformanceLogger.h>
 #import <React/RCTRedBox.h>
-#import <React/RCTReloadCommand.h>
 #import <React/RCTSurfacePresenter.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <ReactCommon/RuntimeExecutor.h>
@@ -134,11 +133,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     [defaultCenter addObserver:self
                       selector:@selector(_notifyEventDispatcherObserversOfEvent_DEPRECATED:)
                           name:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
-                        object:nil];
-
-    [defaultCenter addObserver:self
-                      selector:@selector(didReceiveReloadCommand)
-                          name:RCTTriggerReloadCommandNotification
                         object:nil];
 
     [self _start];
@@ -517,11 +511,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                      message:message
                  exceptionId:error.exceptionId
                      isFatal:error.isFatal];
-}
-
-- (void)didReceiveReloadCommand
-{
-  [self _loadJSBundle:[_bridgeModuleDecorator.bundleManager bundleURL]];
 }
 
 @end


### PR DESCRIPTION
Summary:
Following up https://github.com/facebook/react-native/issues/43943, the metro loading banner is presented twice in Bridgeless mode.

This happens because both the RCTInstance and the RCTHost are listening to the Reload Command and issuing the instructions to refetch the JSBundle and to present the banner.

The RCTInstance should not concern itself with lifecycle events, owned by the RCTHost.

## Changelog:
[iOS][Fixed] - Avoid to show Metro Loading banner twice.

Reviewed By: cortinico

Differential Revision: D55870640


