### PR TITLE
Use different device IDs for modern and legacy backend

### DIFF
--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -83,7 +83,13 @@ static NSString *getInspectorDeviceId()
   // An alphanumeric string that uniquely identifies a device to the app's vendor. [Source: Apple docs]
   NSString *identifierForVendor = [[UIDevice currentDevice] identifierForVendor].UUIDString;
 
-  NSString *rawDeviceId = [NSString stringWithFormat:@"apple-%@-%@", identifierForVendor, bundleId];
+  auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
+
+  NSString *rawDeviceId =
+      [NSString stringWithFormat:@"apple-%@-%@-%s",
+                                 identifierForVendor,
+                                 bundleId,
+                                 inspectorFlags.getEnableModernCDPRegistry() ? "fusebox" : "legacy"];
 
   return getSHA256(rawDeviceId);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -303,7 +303,13 @@ public class DevServerHelper {
     // [Source: Android docs]
     String androidId = Settings.Secure.ANDROID_ID;
 
-    String rawDeviceId = String.format(Locale.US, "android-%s-%s", packageName, androidId);
+    String rawDeviceId =
+        String.format(
+            Locale.US,
+            "android-%s-%s-%s",
+            packageName,
+            androidId,
+            InspectorFlags.getEnableModernCDPRegistry() ? "fusebox" : "legacy");
 
     return getSHA256(rawDeviceId);
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

When going from a Fusebox build to a non-Fusebox build of the same app, users can accidentally connect a previously opened Fusebox frontend to a non-Fusebox backend (or vice versa).

To prevent this, here we assign a distinct "device ID" to the Fusebox backend on both Android and iOS. This will prevent a mismatched CDT frontend from reconnecting to the app after a backend change, forcing the user to close and reopen the debugger.

Reviewed By: hoxyq

Differential Revision: D55870800


