### PR TITLE
[iOS] Change bridgeless check in dev menu

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -396,7 +396,7 @@ RCT_EXPORT_METHOD(show)
       ? UIAlertControllerStyleActionSheet
       : UIAlertControllerStyleAlert;
 
-  NSString *devMenuType = self.bridge ? @"Bridge" : @"Bridgeless";
+  NSString *devMenuType = [self.bridge isKindOfClass:RCTBridge.class] ? @"Bridge" : @"Bridgeless";
   NSString *devMenuTitle = [NSString stringWithFormat:@"React Native Dev Menu (%@)", devMenuType];
 
   _actionSheet = [UIAlertController alertControllerWithTitle:devMenuTitle message:description preferredStyle:style];


### PR DESCRIPTION
## Summary:

We would set the value of  _bridge ivar to bridgeProxy for turbo module in bridgeless mode in #43757 , so we need to change the way of bridgeless/bridge check.

## Changelog:

[IOS] [FIXED] - Change bridgeless check in dev menu


## Test Plan:

Dev menu shows bridgeless/bridge mode correctly.
