### PR TITLE
iOS Remove unused RCTUIManager from RCTRootView

### DIFF
--- a/packages/react-native/React/Base/RCTRootView.m
+++ b/packages/react-native/React/Base/RCTRootView.m
@@ -30,12 +30,6 @@
 
 NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotification";
 
-@interface RCTUIManager (RCTRootView)
-
-- (NSNumber *)allocateRootTag;
-
-@end
-
 @implementation RCTRootView {
   RCTBridge *_bridge;
   NSString *_moduleName;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Seems to be un-used

Differential Revision: D55874782


