### PR TITLE
mark all of react-native as client boundary for React Server Components

### DIFF
--- a/packages/polyfills/console.js
+++ b/packages/polyfills/console.js
@@ -9,6 +9,8 @@
  * @format
  */
 
+'use client';
+
 /* eslint-disable no-shadow, eqeqeq, curly, no-unused-vars, no-void, no-control-regex  */
 
 /**

--- a/packages/react-native/Libraries/Core/InitializeCore.js
+++ b/packages/react-native/Libraries/Core/InitializeCore.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 /**
  * Sets up global variables typical in most JavaScript environments.
  *

--- a/packages/react-native/Libraries/Core/setUpGlobals.js
+++ b/packages/react-native/Libraries/Core/setUpGlobals.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+'use client';
 'use strict';
 
 /**

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 // APIs
 import typeof ActionSheetIOS from './Libraries/ActionSheetIOS/ActionSheetIOS';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While developing React Server Component support for React Native, I've been adding this patch to the `react-native` package. It opts the entire `react-native` package out of being server rendered.

In the future, we'll want to circle back and refactor the `react-native` package to be more isomorphic so we can allow for utilities like `processColor` to be used in server bundles that target native platforms.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [ADDED] - Added support for importing `react-native` in a `react-server` environment for React Server Components support.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Using react-native with this patch in a framework that supports React Server Components for native platforms, such as my unreleased branch of Expo Router, will allow for server rendering views from `react-native` to RSC Flight code with client references to the `react-native` package, e.g.

```js
import { View } from 'react-native';

export default function App() {
  return <View testID="basic-view" style={{ "backgroundColor":"#191A20" }}/>
}
```

Can be server rendered to ↓

```
2:I["/node_modules/react-native/index.bundle?platform=ios&dev=true#798513620",["..."],"View"]
1:["$","$L2",null,{"testID":"basic-view","style":{"backgroundColor":"#191A20"}}]
```

> The client boundaries (URL paths) are specific to the current Expo CLI implementation (based on Metro) and may look different in other implementations.
