### PR TITLE
Avoid Snapshotting Modal too often

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.h
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <React/RCTMountingTransactionObserving.h>
 #import <React/RCTViewComponentView.h>
 
 /**
  * UIView class for root <ModalHostView> component.
  */
-@interface RCTModalHostViewComponentView : RCTViewComponentView <RCTMountingTransactionObserving>
+@interface RCTModalHostViewComponentView : RCTViewComponentView
 
 /**
  * Subclasses may override this method and present the modal on different view controller.

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -141,6 +141,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
                      animated:(BOOL)animated
                    completion:(void (^)(void))completion
 {
+  _modalContentsSnapshot = [self.viewController.view snapshotViewAfterScreenUpdates:NO];
   [modalViewController dismissViewControllerAnimated:animated completion:completion];
 }
 
@@ -190,14 +191,6 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
 
   assert(std::dynamic_pointer_cast<const ModalHostViewEventEmitter>(_eventEmitter));
   return std::static_pointer_cast<const ModalHostViewEventEmitter>(_eventEmitter);
-}
-
-#pragma mark - RCTMountingTransactionObserving
-
-- (void)mountingTransactionWillMount:(const MountingTransaction &)transaction
-                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
-{
-  _modalContentsSnapshot = [self.viewController.view snapshotViewAfterScreenUpdates:YES];
 }
 
 #pragma mark - UIView methods


### PR DESCRIPTION
Summary:
With a previous change, we started taking snapshots of the Modal every time a Fabric mounting event was happening. this might cause perf regression when a modal is presented, and there is no need to take a snapshot that often.

This change moves the snapshotting code right before the dismissal of the Modal.

## Changelog
[iOS][Changed] - Move the snapshotting code before the dismissal.

## Facebook
This should fix T179288585, T184520225

Differential Revision: D55914776


