### PR TITLE
Fix bridge mode by constructing ReactDelegate correctly.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -108,7 +108,11 @@ public class ReactActivityDelegate {
     } else {
       mReactDelegate =
           new ReactDelegate(
-              getPlainActivity(), getReactNativeHost(), mainComponentName, launchOptions) {
+              getPlainActivity(),
+              getReactNativeHost(),
+              mainComponentName,
+              launchOptions,
+              isFabricEnabled()) {
             @Override
             protected ReactRootView createRootView() {
               ReactRootView rootView = ReactActivityDelegate.this.createRootView();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -44,6 +44,15 @@ public class ReactDelegate {
 
   private boolean mFabricEnabled = false;
 
+  /**
+   * Do not use this constructor as it's not accounting for New Architecture at all. You should
+   * either use {@link ReactDelegate#ReactDelegate(Activity, ReactHost, String, Bundle)} if you're
+   * on bridgeless mode or {@link ReactDelegate#ReactDelegate(Activity, ReactNativeHost, String,
+   * Bundle, boolean)} and use the last parameter to toggle paper/fabric.
+   *
+   * @deprecated Use one of the other constructors instead to account for New Architecture.
+   */
+  @Deprecated
   public ReactDelegate(
       Activity activity,
       ReactNativeHost reactNativeHost,


### PR DESCRIPTION
Summary:
Currently NewArch-BridgeMode is partially broken when creating views via `ReactDelegate`.
That's because we're using the ctor that doesn't account for `Boolean: fabricEnabled`.

That means that the `RootView` that it will be created are all having setIsFabric(FALSE).
This is causing problems like whitescreens on several reload + multiple warnings such as:
```
                         E  com.facebook.react.bridge.ReactNoCrashSoftException: Cannot get UIManager because the context doesn't contain an active CatalystInstance.
```

Fixes #43692

See for more context on this issues: https://github.com/facebook/react-native/issues/43692

Changelog:
[Android] [Fixed] - Fix bridge mode by constructing ReactDelegate correctly

Reviewed By: cipolleschi

Differential Revision: D55921078


