### PR TITLE
feat: Added PixelRatio API example

### DIFF
--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import React, {useState} from 'react';
+import {
+  Button,
+  StyleSheet,
+  Text,
+  TextInput,
+  PixelRatio,
+  View,
+} from 'react-native';
+
+import type {Element} from 'react';
+
+function LayoutSizeToPixel() {
+  const [layoutDPSize, setLayoutDPSize] = useState(null);
+  const pixelSize = PixelRatio.getPixelSizeForLayoutSize(
+    layoutDPSize ? layoutDPSize : 0,
+  );
+
+  const handleDPInputChange = changedText => {
+    const layoutSize = parseInt(changedText, 10);
+    setLayoutDPSize(layoutSize);
+  };
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.card}>
+        <View style={styles.row}>
+          <Text style={styles.inputLabel}>Layout Size(dp): </Text>
+          <TextInput
+            style={styles.input}
+            value={layoutDPSize ? layoutDPSize.toString() : ''}
+            keyboardType={'numeric'}
+            onChangeText={handleDPInputChange}
+          />
+        </View>
+        <View style={[styles.row, styles.outputContainer]}>
+          <Text style={styles.inputLabel}>Pixel Size: </Text>
+          <Text>{pixelSize}px</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function RoundToNearestPixel() {
+  const [layoutDPSizeText, setLayoutDPSizeText] = useState('');
+  const layoutDPSize = parseFloat(layoutDPSizeText);
+
+  const pixelSize = PixelRatio.roundToNearestPixel(
+    layoutDPSize ? layoutDPSize : 0,
+  );
+
+  const handleDPInputChange = changedText => {
+    setLayoutDPSizeText(changedText);
+  };
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.card}>
+        <View style={styles.row}>
+          <Text style={styles.inputLabel}>Layout Size(dp): </Text>
+          <TextInput
+            style={styles.input}
+            value={layoutDPSizeText ? layoutDPSizeText.toString() : ''}
+            keyboardType={'numeric'}
+            onChangeText={handleDPInputChange}
+          />
+        </View>
+        <View style={[styles.row, styles.outputContainer]}>
+          <Text style={styles.inputLabel}>Nearest Layout Size: </Text>
+          <Text>{pixelSize}dp</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function GetPixelRatio() {
+  const [pixelDensity, setPixelDensity] = useState(null);
+
+  const getPixelDensityCallback = () => {
+    setPixelDensity(PixelRatio.get());
+  };
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.card}>
+        <Button onPress={getPixelDensityCallback} title={'Get Pixel Density'} />
+        {pixelDensity ? (
+          <View style={[styles.row, styles.outputContainer]}>
+            <Text style={styles.inputLabel}>Pixel Density: </Text>
+            <Text>{pixelDensity}</Text>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function GetFontScale() {
+  const [fontScale, setFontScale] = useState(null);
+
+  const getPixelDensityCallback = () => {
+    setFontScale(PixelRatio.getFontScale());
+  };
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.card}>
+        <Button onPress={getPixelDensityCallback} title={'Get Font Scale'} />
+        {fontScale ? (
+          <View style={[styles.row, styles.outputContainer]}>
+            <Text style={styles.inputLabel}>Font scale: </Text>
+            <Text>{fontScale}</Text>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cardContainer: {
+    marginVertical: 40,
+    flex: 1,
+    alignSelf: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  outputContainer: {
+    marginTop: 16,
+  },
+  inputLabel: {
+    fontWeight: 'bold',
+  },
+  input: {
+    borderRadius: 6,
+    borderWidth: 1,
+    paddingVertical: 0,
+    height: 30,
+    width: 200,
+    alignSelf: 'center',
+    marginLeft: 14,
+    paddingHorizontal: 8,
+  },
+  card: {
+    width: 200,
+    height: 200,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backfaceVisibility: 'hidden',
+  },
+});
+
+exports.title = 'PixelRatio';
+exports.category = 'UI';
+exports.documentationURL = 'https://reactnative.dev/docs/pixelratio';
+exports.description = "Gives access to device's pixel density and font scale";
+exports.examples = [
+  {
+    title: 'Get pixel density',
+    description: 'Get pixel density of the device.',
+    render(): Element<any> {
+      return <GetPixelRatio />;
+    },
+  },
+  {
+    title: 'Get font scale',
+    description: 'Get  the scaling factor for font sizes.',
+    render(): Element<any> {
+      return <GetFontScale />;
+    },
+  },
+  {
+    title: 'Get pixel size from layout size',
+    description: 'layout size (dp) -> pixel size (px)',
+    render(): Element<any> {
+      return <LayoutSizeToPixel />;
+    },
+  },
+  {
+    title: 'Rounds a layout size to the nearest pixel',
+    description:
+      'Rounds a layout size (dp) to the nearest layout size that corresponds to an integer number of pixels',
+    render(): Element<any> {
+      return <RoundToNearestPixel />;
+    },
+  },
+];

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -174,21 +174,21 @@ exports.examples = [
   {
     title: 'Get pixel density',
     description: 'Get pixel density of the device.',
-    render(): Element<any> {
+    render(): React$Node {
       return <GetPixelRatio />;
     },
   },
   {
     title: 'Get font scale',
     description: 'Get  the scaling factor for font sizes.',
-    render(): Element<any> {
+    render(): React$Node {
       return <GetFontScale />;
     },
   },
   {
     title: 'Get pixel size from layout size',
     description: 'layout size (dp) -> pixel size (px)',
-    render(): Element<any> {
+    render(): React$Node {
       return <LayoutSizeToPixel />;
     },
   },
@@ -196,7 +196,7 @@ exports.examples = [
     title: 'Rounds a layout size to the nearest pixel',
     description:
       'Rounds a layout size (dp) to the nearest layout size that corresponds to an integer number of pixels',
-    render(): Element<any> {
+    render(): React$Node {
       return <RoundToNearestPixel />;
     },
   },

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -28,7 +28,7 @@ function LayoutSizeToPixel() {
     layoutDPSize ? layoutDPSize : 0,
   );
 
-  const handleDPInputChange = changedText => {
+  const handleDPInputChange = (changedText: string) => {
     const layoutSize = parseInt(changedText, 10);
     setLayoutDPSize(layoutSize);
   };

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -23,7 +23,7 @@ import {
 import type {Element} from 'react';
 
 function LayoutSizeToPixel() {
-  const [layoutDPSize, setLayoutDPSize] = useState(null);
+  const [layoutDPSize, setLayoutDPSize] = useState<number>(0);
   const pixelSize = PixelRatio.getPixelSizeForLayoutSize(
     layoutDPSize ? layoutDPSize : 0,
   );
@@ -63,8 +63,7 @@ function RoundToNearestPixel() {
   );
 
   const handleDPInputChange = (changedText: string) => {
-    const layoutSize = parseInt(changedText, 10);
-    setLayoutDPSizeText(layoutSize);
+    setLayoutDPSizeText(changedText);
   };
 
   return (

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -20,8 +20,6 @@ import {
   View,
 } from 'react-native';
 
-import type {Element} from 'react';
-
 function LayoutSizeToPixel() {
   const [layoutDPSize, setLayoutDPSize] = useState<number>(0);
   const pixelSize = PixelRatio.getPixelSizeForLayoutSize(

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -62,8 +62,9 @@ function RoundToNearestPixel() {
     layoutDPSize ? layoutDPSize : 0,
   );
 
-  const handleDPInputChange = changedText => {
-    setLayoutDPSizeText(changedText);
+  const handleDPInputChange = (changedText: string) => {
+    const layoutSize = parseInt(changedText, 10);
+    setLayoutDPSizeText(layoutSize);
   };
 
   return (
@@ -88,7 +89,7 @@ function RoundToNearestPixel() {
 }
 
 function GetPixelRatio() {
-  const [pixelDensity, setPixelDensity] = useState(null);
+  const [pixelDensity, setPixelDensity] = useState(0);
 
   const getPixelDensityCallback = () => {
     setPixelDensity(PixelRatio.get());
@@ -110,7 +111,7 @@ function GetPixelRatio() {
 }
 
 function GetFontScale() {
-  const [fontScale, setFontScale] = useState(null);
+  const [fontScale, setFontScale] = useState(0);
 
   const getPixelDensityCallback = () => {
     setFontScale(PixelRatio.getFontScale());

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -258,6 +258,11 @@ const APIs: Array<RNTesterModuleInfo> = ([
     module: require('../examples/PanResponder/PanResponderExample'),
   },
   {
+    key: 'PixelRatio',
+    category: 'UI',
+    module: require('../examples/PixelRatio/PixelRatioExample'),
+  },
+  {
     key: 'PermissionsExampleAndroid',
     category: 'Android',
     module: require('../examples/PermissionsAndroid/PermissionsExample'),

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -259,6 +259,10 @@ const APIs: Array<RNTesterModuleInfo> = ([
     module: require('../examples/PlatformColor/PlatformColorExample'),
   },
   {
+    key: 'PixelRatio',
+    module: require('../examples/PixelRatio/PixelRatioExample'),
+  },
+  {
     key: 'PointerEventsExample',
     module: require('../examples/PointerEvents/PointerEventsExample'),
   },


### PR DESCRIPTION
## Summary:
Added the [PixelRatio](https://reactnative.dev/docs/pixelratio) API to the RN tester app on the API list examples.

## Changelog:

[General] [Added] - Add examples for the Pixel Ratio API, with all the available methods.


## Test Plan:


**iOS** 

https://github.com/facebook/react-native/assets/72331432/dd481916-a8df-4a62-8f63-61936d886d33



**android**

https://github.com/facebook/react-native/assets/72331432/4d8d67dc-ddeb-4ca7-b61c-07522951f9ee


