### PR TITLE
fix: Remove Flow from @react-native/assets-registry - registry.js

### DIFF
--- a/packages/assets/registry.js
+++ b/packages/assets/registry.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  * @format
  */
 

--- a/packages/assets/registry.js
+++ b/packages/assets/registry.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow noflow
  * @format
  */
 

--- a/packages/assets/registry.js
+++ b/packages/assets/registry.js
@@ -4,34 +4,20 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict
  * @format
  */
 
 'use strict';
 
-export type PackagerAsset = {
-  +__packager_asset: boolean,
-  +fileSystemLocation: string,
-  +httpServerLocation: string,
-  +width: ?number,
-  +height: ?number,
-  +scales: Array<number>,
-  +hash: string,
-  +name: string,
-  +type: string,
-  ...
-};
+const assets = [];
 
-const assets: Array<PackagerAsset> = [];
-
-function registerAsset(asset: PackagerAsset): number {
+function registerAsset(asset) {
   // `push` returns new array length, so the first asset will
   // get id 1 (not 0) to make the value truthy
   return assets.push(asset);
 }
 
-function getAssetByID(assetId: number): PackagerAsset {
+function getAssetByID(assetId) {
   return assets[assetId - 1];
 }
 


### PR DESCRIPTION
## Summary

### React native shipping Flow types breaks universal apps

In essence:

> Next.js does not transpile Flow, yet combining Expo with Next.js is becoming a more common combo

Related issues and Github comments:
- https://github.com/expo/expo/issues/21623#issuecomment-1492180436
- https://github.com/expo/expo/issues/21623#issuecomment-1640395262
- https://github.com/expo/expo/issues/21469#issuecomment-1879873320

It might be a better idea to rewrite the entire `@react-native/assets-registry` in Typescript instead of Flow. I'm willing to do this myself if you're open for that. But really, as long as Flow goes, it will no longer break universal app setups with Next.js

## Changelog:

[GENERAL] [REMOVED] - Fixed @react-native/assets-registry breaking in Next.js due to Flow types

## Test Plan

Reproducible by starting a new `expo` + `next.js` and adding + using e.g. `@bacons/mdx` or `@expo/vector-icons` on the web with Next.js 13+

Fix testable by applying the following `patch-package` diff:

https://github.com/expo/expo/issues/21623#issuecomment-1492180436

`@react-native+assets+1.0.0.patch`

```diff
diff --git a/node_modules/@react-native/assets/registry.js b/node_modules/@react-native/assets/registry.js
index 088187f..0a384d1 100644
--- a/node_modules/@react-native/assets/registry.js
+++ b/node_modules/@react-native/assets/registry.js
@@ -10,28 +10,16 @@
 
 'use strict';
  
-export type PackagerAsset = {
-  +__packager_asset: boolean,
-  +fileSystemLocation: string,
-  +httpServerLocation: string,
-  +width: ?number,
-  +height: ?number,
-  +scales: Array<number>,
-  +hash: string,
-  +name: string,
-  +type: string,
-  ...
-};
 
-const assets: Array<PackagerAsset> = [];
+const assets = [];
 
-function registerAsset(asset: PackagerAsset): number {
+function registerAsset(asset) {
   // `push` returns new array length, so the first asset will
   // get id 1 (not 0) to make the value truthy
   return assets.push(asset);
 }
 
-function getAssetByID(assetId: number): PackagerAsset {
+function getAssetByID(assetId) {
   return assets[assetId - 1];
 }
```

