### PR TITLE
Stub support for Tracing start/end methods and events

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -116,6 +116,26 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = true;
+  } else if (req.method == "Tracing.start") {
+    // @cdp Tracing.start is implemented as a stub only.
+    frontendChannel_(cdp::jsonNotification(
+        // @cdp Tracing.bufferUsage is implemented as a stub only.
+        "Tracing.bufferUsage",
+        folly::dynamic::object("percentFull", 0)("eventCount", 0)("value", 0)));
+    shouldSendOKResponse = true;
+    isFinishedHandlingRequest = true;
+  } else if (req.method == "Tracing.end") {
+    // @cdp Tracing.end is implemented as a stub only.
+    frontendChannel_(cdp::jsonNotification(
+        // @cdp Tracing.dataCollected is implemented as a stub only.
+        "Tracing.dataCollected",
+        folly::dynamic::object("value", folly::dynamic::array())));
+    frontendChannel_(cdp::jsonNotification(
+        // @cdp Tracing.tracingComplete is implemented as a stub only.
+        "Tracing.tracingComplete",
+        folly::dynamic::object("dataLossOccurred", false)));
+    shouldSendOKResponse = true;
+    isFinishedHandlingRequest = true;
   }
 
   if (!isFinishedHandlingRequest && instanceAgent_ &&


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds the minimal boilerplate needed to support taking an (empty) recording using Chrome DevTools's Performance panel.

Differential Revision: D55925170


