### PR TITLE
Deprecate react_native_image_logging GK (#43997)

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -26,18 +26,6 @@
 
 using namespace facebook::react;
 
-static BOOL imagePerfInstrumentationEnabled = NO;
-
-BOOL RCTImageLoadingPerfInstrumentationEnabled(void)
-{
-  return imagePerfInstrumentationEnabled;
-}
-
-void RCTEnableImageLoadingPerfInstrumentation(BOOL enabled)
-{
-  imagePerfInstrumentationEnabled = enabled;
-}
-
 static NSInteger RCTImageBytesForImage(UIImage *image)
 {
   NSInteger singleImageBytes = (NSInteger)(image.size.width * image.size.height * image.scale * image.scale * 4);

--- a/packages/react-native/Libraries/Image/RCTImageLoaderWithAttributionProtocol.h
+++ b/packages/react-native/Libraries/Image/RCTImageLoaderWithAttributionProtocol.h
@@ -10,9 +10,6 @@
 #import <React/RCTImageLoaderProtocol.h>
 #import <React/RCTImageURLLoaderWithAttribution.h>
 
-RCT_EXTERN BOOL RCTImageLoadingPerfInstrumentationEnabled(void);
-RCT_EXTERN void RCTEnableImageLoadingPerfInstrumentation(BOOL enabled);
-
 @protocol RCTImageLoaderWithAttributionProtocol <RCTImageLoaderProtocol, RCTImageLoaderLoggableProtocol>
 
 // TODO (T61325135): Remove C++ checks


### PR DESCRIPTION
Summary:


Clean up RCTImageLoadingPerfInstrumentationEnabled as GK is 100%

Changelog:
[iOS][Breaking] Remove unused RCTImageLoadingPerfInstrumentationEnabled

Reviewed By: philIip

Differential Revision: D55769009


