### PR TITLE
Make new nodes dirty by default

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -72,10 +72,6 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
       yogaNode_(&initializeYogaConfig(yogaConfig_)) {
   yogaNode_.setContext(this);
 
-  // Newly created node must be `dirty` just because it is new.
-  // This is not a default for `yoga::Node`.
-  yogaNode_.setDirty(true);
-
   if (getTraits().check(ShadowNodeTraits::Trait::MeasurableYogaNode)) {
     react_native_assert(
         getTraits().check(ShadowNodeTraits::Trait::LeafYogaNode));

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -271,7 +271,7 @@ class YG_EXPORT Node : public ::YGNode {
 
   bool hasNewLayout_ : 1 = true;
   bool isReferenceBaseline_ : 1 = false;
-  bool isDirty_ : 1 = false;
+  bool isDirty_ : 1 = true;
   bool alwaysFormsContainingBlock_ : 1 = false;
   NodeType nodeType_ : bitCount<NodeType>() = NodeType::Default;
   void* context_ = nullptr;


### PR DESCRIPTION
Summary:
Yoga has quirk where newly constructed nodes are clean, which isn't really correct. Normally never shows in in real code because setting a style or children  will dirty. Fabric doesn't use the public APIs that do this dirtying, so it ends up getting creative instead.

We should fix so that newly constructed nodes are dirty. Copy-constructed Nodes (also only a Fabric thing, will retain original dirty flag.

Changelog: [Internal]

Differential Revision: D55855328


