### PR TITLE
add option to set traits with ShadowNodeFragment

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -77,6 +77,7 @@ ShadowNode::ShadowNode(
   react_native_assert(children_);
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
+  traits_.set(fragment.traits.get());
 
   for (const auto& child : *children_) {
     child->family_->setParent(family_);
@@ -107,6 +108,7 @@ ShadowNode::ShadowNode(
   react_native_assert(children_);
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
+  traits_.set(fragment.traits.get());
 
   if (fragment.children) {
     for (const auto& child : *children_) {
@@ -128,11 +130,10 @@ ShadowNode::Unshared ShadowNode::clone(
           propsParserContext, props_, RawProps(*family.nativeProps_DEPRECATED));
       auto clonedNode = componentDescriptor.cloneShadowNode(
           *this,
-          {
-              props,
-              fragment.children,
-              fragment.state,
-          });
+          {.props = props,
+           .children = fragment.children,
+           .state = fragment.state,
+           .traits = fragment.traits});
       return clonedNode;
     } else {
       // TODO: We might need to merge fragment.priops with
@@ -330,10 +331,8 @@ ShadowNode::Unshared ShadowNode::cloneTree(
         ShadowNode::sameFamily(*children.at(childIndex), *childNode));
     children[childIndex] = childNode;
 
-    childNode = parentNode.clone({
-        ShadowNodeFragment::propsPlaceholder(),
-        std::make_shared<ShadowNode::ListOfShared>(children),
-    });
+    childNode = parentNode.clone(
+        {.children = std::make_shared<ShadowNode::ListOfShared>(children)});
   }
 
   return std::const_pointer_cast<ShadowNode>(childNode);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
@@ -26,6 +26,7 @@ struct ShadowNodeFragment {
   const Props::Shared& props = propsPlaceholder();
   const ShadowNode::SharedListOfShared& children = childrenPlaceholder();
   const State::Shared& state = statePlaceholder();
+  const ShadowNodeTraits traits = {};
 
   /*
    * Placeholders.

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -70,6 +70,7 @@ class ShadowNodeTraits {
     // to be cloned before the first mutation.
     ChildrenAreShared = 1 << 8,
 
+    Reserved = 1 << 31,
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -212,6 +212,21 @@ TEST_F(ShadowNodeTest, handleCloneFunction) {
   EXPECT_EQ(nodeAB_->getProps(), nodeABClone->getProps());
 }
 
+TEST_F(ShadowNodeTest, handleCloningWithTraits) {
+  auto clonedWithoutTraits = nodeAB_->clone({});
+
+  EXPECT_FALSE(clonedWithoutTraits->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto newTraits = ShadowNodeTraits();
+  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+
+  auto clonedWithTraits = clonedWithoutTraits->clone({.traits = newTraits});
+
+  EXPECT_TRUE(
+      clonedWithTraits->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+}
+
 TEST_F(ShadowNodeTest, handleState) {
   auto family = componentDescriptor_.createFamily(ShadowNodeFamilyFragment{
       /* .tag = */ 9,


### PR DESCRIPTION
Summary:
changelog: [internal]

Add option to set traits when node is created or cloned via ShadowNodeFragment.

This is a pre-requisite for new state reconciliation algorithm.

Reviewed By: rubennorte

Differential Revision: D55691094


