### PR TITLE
add option to set traits when cloning up to the root

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -304,7 +304,8 @@ const ShadowNodeFamily& ShadowNode::getFamily() const {
 ShadowNode::Unshared ShadowNode::cloneTree(
     const ShadowNodeFamily& shadowNodeFamily,
     const std::function<ShadowNode::Unshared(ShadowNode const& oldShadowNode)>&
-        callback) const {
+        callback,
+    ShadowNodeTraits traits) const {
   auto ancestors = shadowNodeFamily.getAncestors(*this);
 
   if (ancestors.empty()) {
@@ -332,7 +333,8 @@ ShadowNode::Unshared ShadowNode::cloneTree(
     children[childIndex] = childNode;
 
     childNode = parentNode.clone(
-        {.children = std::make_shared<ShadowNode::ListOfShared>(children)});
+        {.children = std::make_shared<ShadowNode::ListOfShared>(children),
+         .traits = traits});
   }
 
   return std::const_pointer_cast<ShadowNode>(childNode);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -77,6 +77,7 @@ ShadowNode::ShadowNode(
   react_native_assert(children_);
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
+  traits_.set(fragment.traits.get());
 
   for (const auto& child : *children_) {
     child->family_->setParent(family_);
@@ -107,6 +108,7 @@ ShadowNode::ShadowNode(
   react_native_assert(children_);
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
+  traits_.set(fragment.traits.get());
 
   if (fragment.children) {
     for (const auto& child : *children_) {
@@ -128,11 +130,10 @@ ShadowNode::Unshared ShadowNode::clone(
           propsParserContext, props_, RawProps(*family.nativeProps_DEPRECATED));
       auto clonedNode = componentDescriptor.cloneShadowNode(
           *this,
-          {
-              props,
-              fragment.children,
-              fragment.state,
-          });
+          {.props = props,
+           .children = fragment.children,
+           .state = fragment.state,
+           .traits = fragment.traits});
       return clonedNode;
     } else {
       // TODO: We might need to merge fragment.priops with
@@ -330,10 +331,8 @@ ShadowNode::Unshared ShadowNode::cloneTree(
         ShadowNode::sameFamily(*children.at(childIndex), *childNode));
     children[childIndex] = childNode;
 
-    childNode = parentNode.clone({
-        ShadowNodeFragment::propsPlaceholder(),
-        std::make_shared<ShadowNode::ListOfShared>(children),
-    });
+    childNode = parentNode.clone(
+        {.children = std::make_shared<ShadowNode::ListOfShared>(children)});
   }
 
   return std::const_pointer_cast<ShadowNode>(childNode);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -100,8 +100,8 @@ class ShadowNode : public Sealable,
    */
   Unshared cloneTree(
       const ShadowNodeFamily& shadowNodeFamily,
-      const std::function<Unshared(ShadowNode const& oldShadowNode)>& callback)
-      const;
+      const std::function<Unshared(ShadowNode const& oldShadowNode)>& callback,
+      ShadowNodeTraits traits = {}) const;
 
 #pragma mark - Getters
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
@@ -26,6 +26,7 @@ struct ShadowNodeFragment {
   const Props::Shared& props = propsPlaceholder();
   const ShadowNode::SharedListOfShared& children = childrenPlaceholder();
   const State::Shared& state = statePlaceholder();
+  const ShadowNodeTraits traits = {};
 
   /*
    * Placeholders.

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -70,6 +70,7 @@ class ShadowNodeTraits {
     // to be cloned before the first mutation.
     ChildrenAreShared = 1 << 8,
 
+    Reserved = 1 << 31,
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -281,3 +281,33 @@ TEST_F(ShadowNodeTest, handleState) {
       { secondNode->setStateData(TestState()); },
       "Attempt to mutate a sealed object.");
 }
+
+TEST_F(ShadowNodeTest, testCloneTree) {
+  auto& family = nodeABA_->getFamily();
+  auto newTraits = ShadowNodeTraits();
+  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+  auto rootNode = nodeA_->cloneTree(
+      family,
+      [newTraits](ShadowNode const& oldShadowNode) {
+        return oldShadowNode.clone({.traits = newTraits});
+      },
+      newTraits);
+
+  EXPECT_TRUE(rootNode->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+
+  EXPECT_FALSE(rootNode->getChildren()[0]->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto const& firstLevelChild = *rootNode->getChildren()[1];
+
+  EXPECT_TRUE(
+      firstLevelChild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+
+  EXPECT_FALSE(firstLevelChild.getChildren()[1]->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto const& secondLevelchild = *firstLevelChild.getChildren()[0];
+
+  EXPECT_TRUE(
+      secondLevelchild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+}

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -212,6 +212,21 @@ TEST_F(ShadowNodeTest, handleCloneFunction) {
   EXPECT_EQ(nodeAB_->getProps(), nodeABClone->getProps());
 }
 
+TEST_F(ShadowNodeTest, handleCloningWithTraits) {
+  auto clonedWithoutTraits = nodeAB_->clone({});
+
+  EXPECT_FALSE(clonedWithoutTraits->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto newTraits = ShadowNodeTraits();
+  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+
+  auto clonedWithTraits = clonedWithoutTraits->clone({.traits = newTraits});
+
+  EXPECT_TRUE(
+      clonedWithTraits->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+}
+
 TEST_F(ShadowNodeTest, handleState) {
   auto family = componentDescriptor_.createFamily(ShadowNodeFamilyFragment{
       /* .tag = */ 9,


### PR DESCRIPTION
Summary:
changelog: [internal]

Add an option to mark all nodes clone indirectly by `ShadowNode::cloneTree`.

This is a pre-requisite for new state reconciliation algorithm. It will be used to mark part of shadow tree that was affected by native state update.

Reviewed By: rubennorte

Differential Revision: D55745323


