### PR TITLE
Use size_t instead of casting to int32_t

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -212,7 +212,7 @@ void YogaLayoutableShadowNode::adoptYogaChild(size_t index) {
     auto clonedChildNode = childNode.clone({});
 
     // Replace the child node with a newly cloned one in the children list.
-    replaceChild(childNode, clonedChildNode, static_cast<int32_t>(index));
+    replaceChild(childNode, clonedChildNode, index);
   }
 
   ensureYogaChildrenLookFine();
@@ -256,7 +256,7 @@ void YogaLayoutableShadowNode::appendChild(
 void YogaLayoutableShadowNode::replaceChild(
     const ShadowNode& oldChild,
     const ShadowNode::Shared& newChild,
-    int32_t suggestedIndex) {
+    size_t suggestedIndex) {
   LayoutableShadowNode::replaceChild(oldChild, newChild, suggestedIndex);
 
   ensureUnsealed();
@@ -273,7 +273,7 @@ void YogaLayoutableShadowNode::replaceChild(
   }
 
   bool suggestedIndexAccurate = suggestedIndex >= 0 &&
-      suggestedIndex < static_cast<int32_t>(yogaLayoutableChildren_.size()) &&
+      suggestedIndex < yogaLayoutableChildren_.size() &&
       yogaLayoutableChildren_[suggestedIndex].get() == layoutableOldChild;
 
   auto oldChildIter = suggestedIndexAccurate
@@ -284,8 +284,7 @@ void YogaLayoutableShadowNode::replaceChild(
             [&](const YogaLayoutableShadowNode::Shared& layoutableChild) {
               return layoutableChild.get() == layoutableOldChild;
             });
-  auto oldChildIndex =
-      static_cast<int32_t>(oldChildIter - yogaLayoutableChildren_.begin());
+  auto oldChildIndex = oldChildIter - yogaLayoutableChildren_.begin();
 
   if (oldChildIter == yogaLayoutableChildren_.end()) {
     // oldChild does not exist as part of our node
@@ -516,8 +515,7 @@ YogaLayoutableShadowNode& YogaLayoutableShadowNode::cloneChildInPlace(
        ShadowNodeFragment::childrenPlaceholder(),
        childNode.getState()});
 
-  replaceChild(
-      childNode, clonedChildNode, static_cast<int32_t>(layoutableChildIndex));
+  replaceChild(childNode, clonedChildNode, layoutableChildIndex);
   return static_cast<YogaLayoutableShadowNode&>(*clonedChildNode);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -49,7 +49,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   void replaceChild(
       const ShadowNode& oldChild,
       const ShadowNode::Shared& newChild,
-      int32_t suggestedIndex = -1) override;
+      size_t suggestedIndex = SIZE_MAX) override;
 
   void updateYogaChildren();
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -107,6 +107,9 @@ ShadowNode::ShadowNode(
   react_native_assert(props_);
   react_native_assert(children_);
 
+  // State could have been progressed above by checking
+  // `sourceShadowNode.getMostRecentState()`.
+  traits_.unset(ShadowNodeTraits::Trait::ClonedByNativeStateUpdate);
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
   traits_.set(fragment.traits.get());
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -304,7 +304,8 @@ const ShadowNodeFamily& ShadowNode::getFamily() const {
 ShadowNode::Unshared ShadowNode::cloneTree(
     const ShadowNodeFamily& shadowNodeFamily,
     const std::function<ShadowNode::Unshared(ShadowNode const& oldShadowNode)>&
-        callback) const {
+        callback,
+    ShadowNodeTraits traits) const {
   auto ancestors = shadowNodeFamily.getAncestors(*this);
 
   if (ancestors.empty()) {
@@ -332,7 +333,8 @@ ShadowNode::Unshared ShadowNode::cloneTree(
     children[childIndex] = childNode;
 
     childNode = parentNode.clone(
-        {.children = std::make_shared<ShadowNode::ListOfShared>(children)});
+        {.children = std::make_shared<ShadowNode::ListOfShared>(children),
+         .traits = traits});
   }
 
   return std::const_pointer_cast<ShadowNode>(childNode);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -77,6 +77,7 @@ ShadowNode::ShadowNode(
   react_native_assert(children_);
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
+  traits_.set(fragment.traits.get());
 
   for (const auto& child : *children_) {
     child->family_->setParent(family_);
@@ -107,6 +108,7 @@ ShadowNode::ShadowNode(
   react_native_assert(children_);
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
+  traits_.set(fragment.traits.get());
 
   if (fragment.children) {
     for (const auto& child : *children_) {
@@ -128,11 +130,10 @@ ShadowNode::Unshared ShadowNode::clone(
           propsParserContext, props_, RawProps(*family.nativeProps_DEPRECATED));
       auto clonedNode = componentDescriptor.cloneShadowNode(
           *this,
-          {
-              props,
-              fragment.children,
-              fragment.state,
-          });
+          {.props = props,
+           .children = fragment.children,
+           .state = fragment.state,
+           .traits = fragment.traits});
       return clonedNode;
     } else {
       // TODO: We might need to merge fragment.priops with
@@ -330,10 +331,8 @@ ShadowNode::Unshared ShadowNode::cloneTree(
         ShadowNode::sameFamily(*children.at(childIndex), *childNode));
     children[childIndex] = childNode;
 
-    childNode = parentNode.clone({
-        ShadowNodeFragment::propsPlaceholder(),
-        std::make_shared<ShadowNode::ListOfShared>(children),
-    });
+    childNode = parentNode.clone(
+        {.children = std::make_shared<ShadowNode::ListOfShared>(children)});
   }
 
   return std::const_pointer_cast<ShadowNode>(childNode);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -240,7 +240,7 @@ void ShadowNode::appendChild(const ShadowNode::Shared& child) {
 void ShadowNode::replaceChild(
     const ShadowNode& oldChild,
     const ShadowNode::Shared& newChild,
-    int32_t suggestedIndex) {
+    size_t suggestedIndex) {
   ensureUnsealed();
 
   cloneChildrenIfShared();
@@ -249,7 +249,8 @@ void ShadowNode::replaceChild(
   auto& children = const_cast<ShadowNode::ListOfShared&>(*children_);
   auto size = children.size();
 
-  if (suggestedIndex != -1 && static_cast<size_t>(suggestedIndex) < size) {
+  if (suggestedIndex != std::numeric_limits<size_t>::max() &&
+      suggestedIndex < size) {
     // If provided `suggestedIndex` is accurate,
     // replacing in place using the index.
     if (children.at(suggestedIndex).get() == &oldChild) {

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -100,8 +100,8 @@ class ShadowNode : public Sealable,
    */
   Unshared cloneTree(
       const ShadowNodeFamily& shadowNodeFamily,
-      const std::function<Unshared(ShadowNode const& oldShadowNode)>& callback)
-      const;
+      const std::function<Unshared(ShadowNode const& oldShadowNode)>& callback,
+      ShadowNodeTraits traits = {}) const;
 
 #pragma mark - Getters
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -161,7 +162,7 @@ class ShadowNode : public Sealable,
   virtual void replaceChild(
       const ShadowNode& oldChild,
       const Shared& newChild,
-      int32_t suggestedIndex = -1);
+      size_t suggestedIndex = std::numeric_limits<size_t>::max());
 
   /*
    * Performs all side effects associated with mounting/unmounting in one place.

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
@@ -26,6 +26,7 @@ struct ShadowNodeFragment {
   const Props::Shared& props = propsPlaceholder();
   const ShadowNode::SharedListOfShared& children = childrenPlaceholder();
   const State::Shared& state = statePlaceholder();
+  const ShadowNodeTraits traits = {};
 
   /*
    * Placeholders.

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -70,7 +70,8 @@ class ShadowNodeTraits {
     // to be cloned before the first mutation.
     ChildrenAreShared = 1 << 8,
 
-    Reserved = 1 << 31,
+    // Indicates that the node was cloned because of native state update.
+    ClonedByNativeStateUpdate = 1 << 9,
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -70,6 +70,7 @@ class ShadowNodeTraits {
     // to be cloned before the first mutation.
     ChildrenAreShared = 1 << 8,
 
+    Reserved = 1 << 31,
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -281,3 +281,33 @@ TEST_F(ShadowNodeTest, handleState) {
       { secondNode->setStateData(TestState()); },
       "Attempt to mutate a sealed object.");
 }
+
+TEST_F(ShadowNodeTest, testCloneTree) {
+  auto& family = nodeABA_->getFamily();
+  auto newTraits = ShadowNodeTraits();
+  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+  auto rootNode = nodeA_->cloneTree(
+      family,
+      [newTraits](ShadowNode const& oldShadowNode) {
+        return oldShadowNode.clone({.traits = newTraits});
+      },
+      newTraits);
+
+  EXPECT_TRUE(rootNode->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+
+  EXPECT_FALSE(rootNode->getChildren()[0]->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto const& firstLevelChild = *rootNode->getChildren()[1];
+
+  EXPECT_TRUE(
+      firstLevelChild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+
+  EXPECT_FALSE(firstLevelChild.getChildren()[1]->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto const& secondLevelchild = *firstLevelChild.getChildren()[0];
+
+  EXPECT_TRUE(
+      secondLevelchild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+}

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -216,15 +216,20 @@ TEST_F(ShadowNodeTest, handleCloningWithTraits) {
   auto clonedWithoutTraits = nodeAB_->clone({});
 
   EXPECT_FALSE(clonedWithoutTraits->getTraits().check(
-      ShadowNodeTraits::Trait::Reserved));
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   auto newTraits = ShadowNodeTraits();
-  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+  newTraits.set(ShadowNodeTraits::Trait::ClonedByNativeStateUpdate);
 
   auto clonedWithTraits = clonedWithoutTraits->clone({.traits = newTraits});
 
-  EXPECT_TRUE(
-      clonedWithTraits->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+  EXPECT_TRUE(clonedWithTraits->getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
+
+  auto clonedAgain = clonedWithTraits->clone({});
+
+  EXPECT_FALSE(clonedAgain->getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 }
 
 TEST_F(ShadowNodeTest, handleState) {
@@ -285,7 +290,7 @@ TEST_F(ShadowNodeTest, handleState) {
 TEST_F(ShadowNodeTest, testCloneTree) {
   auto& family = nodeABA_->getFamily();
   auto newTraits = ShadowNodeTraits();
-  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+  newTraits.set(ShadowNodeTraits::Trait::ClonedByNativeStateUpdate);
   auto rootNode = nodeA_->cloneTree(
       family,
       [newTraits](ShadowNode const& oldShadowNode) {
@@ -293,21 +298,22 @@ TEST_F(ShadowNodeTest, testCloneTree) {
       },
       newTraits);
 
-  EXPECT_TRUE(rootNode->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+  EXPECT_TRUE(rootNode->getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   EXPECT_FALSE(rootNode->getChildren()[0]->getTraits().check(
-      ShadowNodeTraits::Trait::Reserved));
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   auto const& firstLevelChild = *rootNode->getChildren()[1];
 
-  EXPECT_TRUE(
-      firstLevelChild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+  EXPECT_TRUE(firstLevelChild.getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   EXPECT_FALSE(firstLevelChild.getChildren()[1]->getTraits().check(
-      ShadowNodeTraits::Trait::Reserved));
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   auto const& secondLevelchild = *firstLevelChild.getChildren()[0];
 
-  EXPECT_TRUE(
-      secondLevelchild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+  EXPECT_TRUE(secondLevelchild.getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -212,6 +212,21 @@ TEST_F(ShadowNodeTest, handleCloneFunction) {
   EXPECT_EQ(nodeAB_->getProps(), nodeABClone->getProps());
 }
 
+TEST_F(ShadowNodeTest, handleCloningWithTraits) {
+  auto clonedWithoutTraits = nodeAB_->clone({});
+
+  EXPECT_FALSE(clonedWithoutTraits->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto newTraits = ShadowNodeTraits();
+  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+
+  auto clonedWithTraits = clonedWithoutTraits->clone({.traits = newTraits});
+
+  EXPECT_TRUE(
+      clonedWithTraits->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+}
+
 TEST_F(ShadowNodeTest, handleState) {
   auto family = componentDescriptor_.createFamily(ShadowNodeFamilyFragment{
       /* .tag = */ 9,


### PR DESCRIPTION
Summary:
changelog: [internal]

use size_t instead of int32_t so that caller of `ShadowNode::replaceChild` does not need to cast.

Reviewed By: rubennorte

Differential Revision: D55923333


