### PR TITLE
Introduce new State Alignment Mechanism

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -212,7 +212,7 @@ void YogaLayoutableShadowNode::adoptYogaChild(size_t index) {
     auto clonedChildNode = childNode.clone({});
 
     // Replace the child node with a newly cloned one in the children list.
-    replaceChild(childNode, clonedChildNode, static_cast<int32_t>(index));
+    replaceChild(childNode, clonedChildNode, index);
   }
 
   ensureYogaChildrenLookFine();
@@ -256,7 +256,7 @@ void YogaLayoutableShadowNode::appendChild(
 void YogaLayoutableShadowNode::replaceChild(
     const ShadowNode& oldChild,
     const ShadowNode::Shared& newChild,
-    int32_t suggestedIndex) {
+    size_t suggestedIndex) {
   LayoutableShadowNode::replaceChild(oldChild, newChild, suggestedIndex);
 
   ensureUnsealed();
@@ -273,7 +273,7 @@ void YogaLayoutableShadowNode::replaceChild(
   }
 
   bool suggestedIndexAccurate = suggestedIndex >= 0 &&
-      suggestedIndex < static_cast<int32_t>(yogaLayoutableChildren_.size()) &&
+      suggestedIndex < yogaLayoutableChildren_.size() &&
       yogaLayoutableChildren_[suggestedIndex].get() == layoutableOldChild;
 
   auto oldChildIter = suggestedIndexAccurate
@@ -284,8 +284,7 @@ void YogaLayoutableShadowNode::replaceChild(
             [&](const YogaLayoutableShadowNode::Shared& layoutableChild) {
               return layoutableChild.get() == layoutableOldChild;
             });
-  auto oldChildIndex =
-      static_cast<int32_t>(oldChildIter - yogaLayoutableChildren_.begin());
+  auto oldChildIndex = oldChildIter - yogaLayoutableChildren_.begin();
 
   if (oldChildIter == yogaLayoutableChildren_.end()) {
     // oldChild does not exist as part of our node
@@ -516,8 +515,7 @@ YogaLayoutableShadowNode& YogaLayoutableShadowNode::cloneChildInPlace(
        ShadowNodeFragment::childrenPlaceholder(),
        childNode.getState()});
 
-  replaceChild(
-      childNode, clonedChildNode, static_cast<int32_t>(layoutableChildIndex));
+  replaceChild(childNode, clonedChildNode, layoutableChildIndex);
   return static_cast<YogaLayoutableShadowNode&>(*clonedChildNode);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -49,7 +49,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   void replaceChild(
       const ShadowNode& oldChild,
       const ShadowNode::Shared& newChild,
-      int32_t suggestedIndex = -1) override;
+      size_t suggestedIndex = SIZE_MAX) override;
 
   void updateYogaChildren();
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -287,7 +287,11 @@ void ShadowNode::setMounted(bool mounted) const {
   family_->eventEmitter_->setEnabled(mounted);
 }
 
-void ShadowNode::progressStateIfNecessary() {
+bool ShadowNode::getHasBeenMounted() const {
+  return hasBeenMounted_;
+}
+
+bool ShadowNode::progressStateIfNecessary() {
   if (!hasBeenMounted_ && state_) {
     ensureUnsealed();
     auto mostRecentState = family_->getMostRecentStateIfObsolete(*state_);
@@ -297,8 +301,10 @@ void ShadowNode::progressStateIfNecessary() {
       // Must call ComponentDescriptor::adopt to trigger any side effect
       // state may have. E.g. adjusting padding.
       componentDescriptor.adopt(*this);
+      return true;
     }
   }
+  return false;
 }
 
 const ShadowNodeFamily& ShadowNode::getFamily() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -107,6 +107,9 @@ ShadowNode::ShadowNode(
   react_native_assert(props_);
   react_native_assert(children_);
 
+  // State could have been progressed above by checking
+  // `sourceShadowNode.getMostRecentState()`.
+  traits_.unset(ShadowNodeTraits::Trait::ClonedByNativeStateUpdate);
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
   traits_.set(fragment.traits.get());
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -304,7 +304,8 @@ const ShadowNodeFamily& ShadowNode::getFamily() const {
 ShadowNode::Unshared ShadowNode::cloneTree(
     const ShadowNodeFamily& shadowNodeFamily,
     const std::function<ShadowNode::Unshared(ShadowNode const& oldShadowNode)>&
-        callback) const {
+        callback,
+    ShadowNodeTraits traits) const {
   auto ancestors = shadowNodeFamily.getAncestors(*this);
 
   if (ancestors.empty()) {
@@ -332,7 +333,8 @@ ShadowNode::Unshared ShadowNode::cloneTree(
     children[childIndex] = childNode;
 
     childNode = parentNode.clone(
-        {.children = std::make_shared<ShadowNode::ListOfShared>(children)});
+        {.children = std::make_shared<ShadowNode::ListOfShared>(children),
+         .traits = traits});
   }
 
   return std::const_pointer_cast<ShadowNode>(childNode);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -77,6 +77,7 @@ ShadowNode::ShadowNode(
   react_native_assert(children_);
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
+  traits_.set(fragment.traits.get());
 
   for (const auto& child : *children_) {
     child->family_->setParent(family_);
@@ -107,6 +108,7 @@ ShadowNode::ShadowNode(
   react_native_assert(children_);
 
   traits_.set(ShadowNodeTraits::Trait::ChildrenAreShared);
+  traits_.set(fragment.traits.get());
 
   if (fragment.children) {
     for (const auto& child : *children_) {
@@ -128,11 +130,10 @@ ShadowNode::Unshared ShadowNode::clone(
           propsParserContext, props_, RawProps(*family.nativeProps_DEPRECATED));
       auto clonedNode = componentDescriptor.cloneShadowNode(
           *this,
-          {
-              props,
-              fragment.children,
-              fragment.state,
-          });
+          {.props = props,
+           .children = fragment.children,
+           .state = fragment.state,
+           .traits = fragment.traits});
       return clonedNode;
     } else {
       // TODO: We might need to merge fragment.priops with
@@ -330,10 +331,8 @@ ShadowNode::Unshared ShadowNode::cloneTree(
         ShadowNode::sameFamily(*children.at(childIndex), *childNode));
     children[childIndex] = childNode;
 
-    childNode = parentNode.clone({
-        ShadowNodeFragment::propsPlaceholder(),
-        std::make_shared<ShadowNode::ListOfShared>(children),
-    });
+    childNode = parentNode.clone(
+        {.children = std::make_shared<ShadowNode::ListOfShared>(children)});
   }
 
   return std::const_pointer_cast<ShadowNode>(childNode);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -240,7 +240,7 @@ void ShadowNode::appendChild(const ShadowNode::Shared& child) {
 void ShadowNode::replaceChild(
     const ShadowNode& oldChild,
     const ShadowNode::Shared& newChild,
-    int32_t suggestedIndex) {
+    size_t suggestedIndex) {
   ensureUnsealed();
 
   cloneChildrenIfShared();
@@ -249,7 +249,8 @@ void ShadowNode::replaceChild(
   auto& children = const_cast<ShadowNode::ListOfShared&>(*children_);
   auto size = children.size();
 
-  if (suggestedIndex != -1 && static_cast<size_t>(suggestedIndex) < size) {
+  if (suggestedIndex != std::numeric_limits<size_t>::max() &&
+      suggestedIndex < size) {
     // If provided `suggestedIndex` is accurate,
     // replacing in place using the index.
     if (children.at(suggestedIndex).get() == &oldChild) {

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -100,8 +100,8 @@ class ShadowNode : public Sealable,
    */
   Unshared cloneTree(
       const ShadowNodeFamily& shadowNodeFamily,
-      const std::function<Unshared(ShadowNode const& oldShadowNode)>& callback)
-      const;
+      const std::function<Unshared(ShadowNode const& oldShadowNode)>& callback,
+      ShadowNodeTraits traits = {}) const;
 
 #pragma mark - Getters
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -172,13 +172,21 @@ class ShadowNode : public Sealable,
   void setMounted(bool mounted) const;
 
   /*
+   * Returns true if the shadow node has been marked as mounted before by
+   * calling `setMounted`.
+   */
+  bool getHasBeenMounted() const;
+
+  /*
    * Applies the most recent state to the ShadowNode if following conditions are
    * met:
    * - ShadowNode has a state.
    * - ShadowNode has not been mounted before.
    * - ShadowNode's current state is obsolete.
+   *
+   * Returns true if the state was applied, false otherwise.
    */
-  void progressStateIfNecessary();
+  bool progressStateIfNecessary();
 
 #pragma mark - DebugStringConvertible
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -161,7 +162,7 @@ class ShadowNode : public Sealable,
   virtual void replaceChild(
       const ShadowNode& oldChild,
       const Shared& newChild,
-      int32_t suggestedIndex = -1);
+      size_t suggestedIndex = std::numeric_limits<size_t>::max());
 
   /*
    * Performs all side effects associated with mounting/unmounting in one place.

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
@@ -26,6 +26,7 @@ struct ShadowNodeFragment {
   const Props::Shared& props = propsPlaceholder();
   const ShadowNode::SharedListOfShared& children = childrenPlaceholder();
   const State::Shared& state = statePlaceholder();
+  const ShadowNodeTraits traits = {};
 
   /*
    * Placeholders.

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -70,7 +70,8 @@ class ShadowNodeTraits {
     // to be cloned before the first mutation.
     ChildrenAreShared = 1 << 8,
 
-    Reserved = 1 << 31,
+    // Indicates that the node was cloned because of native state update.
+    ClonedByNativeStateUpdate = 1 << 9,
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -70,6 +70,7 @@ class ShadowNodeTraits {
     // to be cloned before the first mutation.
     ChildrenAreShared = 1 << 8,
 
+    Reserved = 1 << 31,
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -281,3 +281,33 @@ TEST_F(ShadowNodeTest, handleState) {
       { secondNode->setStateData(TestState()); },
       "Attempt to mutate a sealed object.");
 }
+
+TEST_F(ShadowNodeTest, testCloneTree) {
+  auto& family = nodeABA_->getFamily();
+  auto newTraits = ShadowNodeTraits();
+  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+  auto rootNode = nodeA_->cloneTree(
+      family,
+      [newTraits](ShadowNode const& oldShadowNode) {
+        return oldShadowNode.clone({.traits = newTraits});
+      },
+      newTraits);
+
+  EXPECT_TRUE(rootNode->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+
+  EXPECT_FALSE(rootNode->getChildren()[0]->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto const& firstLevelChild = *rootNode->getChildren()[1];
+
+  EXPECT_TRUE(
+      firstLevelChild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+
+  EXPECT_FALSE(firstLevelChild.getChildren()[1]->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto const& secondLevelchild = *firstLevelChild.getChildren()[0];
+
+  EXPECT_TRUE(
+      secondLevelchild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+}

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -216,15 +216,20 @@ TEST_F(ShadowNodeTest, handleCloningWithTraits) {
   auto clonedWithoutTraits = nodeAB_->clone({});
 
   EXPECT_FALSE(clonedWithoutTraits->getTraits().check(
-      ShadowNodeTraits::Trait::Reserved));
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   auto newTraits = ShadowNodeTraits();
-  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+  newTraits.set(ShadowNodeTraits::Trait::ClonedByNativeStateUpdate);
 
   auto clonedWithTraits = clonedWithoutTraits->clone({.traits = newTraits});
 
-  EXPECT_TRUE(
-      clonedWithTraits->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+  EXPECT_TRUE(clonedWithTraits->getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
+
+  auto clonedAgain = clonedWithTraits->clone({});
+
+  EXPECT_FALSE(clonedAgain->getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 }
 
 TEST_F(ShadowNodeTest, handleState) {
@@ -285,7 +290,7 @@ TEST_F(ShadowNodeTest, handleState) {
 TEST_F(ShadowNodeTest, testCloneTree) {
   auto& family = nodeABA_->getFamily();
   auto newTraits = ShadowNodeTraits();
-  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+  newTraits.set(ShadowNodeTraits::Trait::ClonedByNativeStateUpdate);
   auto rootNode = nodeA_->cloneTree(
       family,
       [newTraits](ShadowNode const& oldShadowNode) {
@@ -293,21 +298,22 @@ TEST_F(ShadowNodeTest, testCloneTree) {
       },
       newTraits);
 
-  EXPECT_TRUE(rootNode->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+  EXPECT_TRUE(rootNode->getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   EXPECT_FALSE(rootNode->getChildren()[0]->getTraits().check(
-      ShadowNodeTraits::Trait::Reserved));
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   auto const& firstLevelChild = *rootNode->getChildren()[1];
 
-  EXPECT_TRUE(
-      firstLevelChild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+  EXPECT_TRUE(firstLevelChild.getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   EXPECT_FALSE(firstLevelChild.getChildren()[1]->getTraits().check(
-      ShadowNodeTraits::Trait::Reserved));
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
   auto const& secondLevelchild = *firstLevelChild.getChildren()[0];
 
-  EXPECT_TRUE(
-      secondLevelchild.getTraits().check(ShadowNodeTraits::Trait::Reserved));
+  EXPECT_TRUE(secondLevelchild.getTraits().check(
+      ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -212,6 +212,21 @@ TEST_F(ShadowNodeTest, handleCloneFunction) {
   EXPECT_EQ(nodeAB_->getProps(), nodeABClone->getProps());
 }
 
+TEST_F(ShadowNodeTest, handleCloningWithTraits) {
+  auto clonedWithoutTraits = nodeAB_->clone({});
+
+  EXPECT_FALSE(clonedWithoutTraits->getTraits().check(
+      ShadowNodeTraits::Trait::Reserved));
+
+  auto newTraits = ShadowNodeTraits();
+  newTraits.set(ShadowNodeTraits::Trait::Reserved);
+
+  auto clonedWithTraits = clonedWithoutTraits->clone({.traits = newTraits});
+
+  EXPECT_TRUE(
+      clonedWithTraits->getTraits().check(ShadowNodeTraits::Trait::Reserved));
+}
+
 TEST_F(ShadowNodeTest, handleState) {
   auto family = componentDescriptor_.createFamily(ShadowNodeFamilyFragment{
       /* .tag = */ 9,

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -25,25 +25,50 @@ namespace facebook::react {
 using CommitStatus = ShadowTree::CommitStatus;
 using CommitMode = ShadowTree::CommitMode;
 
-// --- Clone-less progress state algorithm ---
+// --- State Alignment Mechanism algorithm ---
 // Note: Ideally, we don't have to const_cast but our use of constness in
 // C++ is overly restrictive. We do const_cast here but the only place where
 // we change ShadowNode is by calling `ShadowNode::progressStateIfNecessary`
 // where checks are in place to avoid manipulating a sealed ShadowNode.
 
-static void progressStateIfNecessary(ShadowNode& newShadowNode) {
-  newShadowNode.progressStateIfNecessary();
+static void progressStateIfNecessary(
+    ShadowNode& newShadowNode,
+    const ShadowNode& baseShadowNode);
 
-  for (const auto& childNode : newShadowNode.getChildren()) {
-    progressStateIfNecessary(const_cast<ShadowNode&>(*childNode));
+/*
+ * Looks at the new parent, new child and base child node to determine how to
+ * reconcile the state.
+ *
+ * Only to be called when baseChildNode has trait `ClonedByNativeStateUpdate`.
+ */
+static void progressStateIfNecessary(
+    ShadowNode& newShadowNode,
+    const ShadowNode& newChildNode,
+    const ShadowNode& baseChildNode,
+    size_t suggestedIndex) {
+  auto& shadowNode = const_cast<ShadowNode&>(newChildNode);
+  if (shadowNode.progressStateIfNecessary()) {
+    // State was progressed without the need to clone.
+    // We are done with this node, but need to keep traversing.
+    progressStateIfNecessary(shadowNode, baseChildNode);
+  } else if (newChildNode.getHasBeenMounted()) {
+    // `newShadowNode` was cloned from react and cloned from a native state
+    // update. This child node was cloned only from a native state update.
+    // This is branching and it is safe to promote the new branch from
+    // native state update.
+    auto clonedChildNode = baseChildNode.clone({});
+    newShadowNode.replaceChild(newChildNode, clonedChildNode, suggestedIndex);
+  } else {
+    // `newShadowNode` was cloned from react and cloned from a native state
+    // update. This child node was cloned also by react.
+    // we can't reason about this on this layer and need to keep traversing.
+    progressStateIfNecessary(shadowNode, baseChildNode);
   }
 }
 
 static void progressStateIfNecessary(
     ShadowNode& newShadowNode,
     const ShadowNode& baseShadowNode) {
-  newShadowNode.progressStateIfNecessary();
-
   auto& newChildren = newShadowNode.getChildren();
   auto& baseChildren = baseShadowNode.getChildren();
 
@@ -63,21 +88,51 @@ static void progressStateIfNecessary(
     }
 
     if (!ShadowNode::sameFamily(newChildNode, baseChildNode)) {
-      // The nodes are not of the same family. Tree hierarchy has changed
-      // and we have to fall back to full sub-tree traversal from this point on.
+      // React has changed the structure of the tree. We will realign the
+      // structure below.
       break;
     }
 
-    progressStateIfNecessary(
-        const_cast<ShadowNode&>(newChildNode), baseChildNode);
+    if (!baseChildNode.getTraits().check(
+            ShadowNodeTraits::Trait::ClonedByNativeStateUpdate)) {
+      // was not cloned with a new state, we can continue.
+      continue;
+    }
+
+    progressStateIfNecessary(newShadowNode, newChildNode, baseChildNode, index);
   }
 
+  // === Realigning the tree ===
+
+  auto unprocessedBaseChildren = baseChildren.begin();
+  std::advance(unprocessedBaseChildren, index);
   for (; index < newChildrenSize; ++index) {
     const auto& newChildNode = *newChildren[index];
-    progressStateIfNecessary(const_cast<ShadowNode&>(newChildNode));
+    auto baseChildNodeIterator = std::find_if(
+        unprocessedBaseChildren,
+        baseChildren.end(),
+        [&newChildNode](auto baseChildNode) {
+          return ShadowNode::sameFamily(newChildNode, *baseChildNode);
+        });
+    if (baseChildNodeIterator == baseChildren.end()) {
+      // This must never happen and there is a mismatch between the two trees.
+      // No way of recover from this, let's just continue.
+      continue;
+    }
+
+    auto const& baseChildNode = *(*baseChildNodeIterator);
+
+    if (!baseChildNode.getTraits().check(
+            ShadowNodeTraits::Trait::ClonedByNativeStateUpdate)) {
+      // was not cloned with a new state, we can continue.
+      continue;
+    }
+
+    progressStateIfNecessary(newShadowNode, newChildNode, baseChildNode, index);
   }
 }
-// --- End of Clone-less progress state algorithm ---
+
+// --- End of State Alignment Mechanism algorithm ---
 
 /*
  * Generates (possibly) a new tree where all nodes with non-obsolete `State`

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
@@ -201,13 +201,11 @@ TEST_P(StateReconciliationTest, testStateReconciliation) {
       },
       {.enableStateReconciliation = true});
 
-  if (!GetParam()) {
-    EXPECT_EQ(
-        findDescendantNode(shadowTree, scrollViewFamily)
-            ->getState()
-            ->getRevision(),
-        state3->getRevision());
-  }
+  EXPECT_EQ(
+      findDescendantNode(shadowTree, scrollViewFamily)
+          ->getState()
+          ->getRevision(),
+      state3->getRevision());
 }
 
 TEST_P(StateReconciliationTest, testCloneslessStateReconciliationDoesntClone) {
@@ -672,10 +670,7 @@ TEST_P(StateReconciliationTest, testScrollViewWithComplexChildrenReorder) {
   EXPECT_NE(findDescendantNode(shadowTree, childA->getFamily()), nullptr);
   EXPECT_NE(findDescendantNode(shadowTree, childB->getFamily()), nullptr);
 
-  if (!GetParam()) {
-    EXPECT_EQ(
-        findDescendantNode(shadowTree, childAFamily)->getState(), newState);
-  }
+  EXPECT_EQ(findDescendantNode(shadowTree, childAFamily)->getState(), newState);
 }
 
 TEST_P(StateReconciliationTest, testScrollViewWithChildrenReorder) {


### PR DESCRIPTION
Summary:
changelog: [internal]

This is an evolution of cloneless state progression, introduced in D49012353.

# Problem 

## When React clones the wrong node revision
Whenever React wants to commit a new change, it first needs to clone shadow nodes. React sometimes clones from the wrong revision. This has mostly been fine, Fabric does state reconciliation to pass newest state forward. State reconciliation is needed, as we need to keep native state in the shadow tree. 
However, when React clones a node that has never been through layout step, it will clone a node without any layout information and its yoga node is dirtied. Even though there might be a subsequent revision of the node with layout information already calculated. As a result, Yoga needs to traverse bigger parts of the tree, even though layout has been calculated before. It is just cached on a different revision that was used as a source.

There are two main sources (there is more but they don't help to paint the picture) when this can happen. Background Executor and State Progression. Let's start with the simpler one but less severe: Background Executor.

Background Executor moves layout from JavaScript thread. React can start cloning nodes right away, even though they might not have layout information calculated yet. This is a race condition and depending on when the node is cloned, we can see different results. In this case, React eventually clones node from the correct revision with the layout cache. It will be in a correct state in the end. This case is not as bad as far as I can tell but I included it here because it better illustrates what is going on. 

State Progression is where things get worse. In this scenario, React will never clone from the correct revision and will never recover from this. Anytime React clones node with a state that needs to be progressed, it will get cloned one more time during commit but React will hold the wrong revision. Depending on where this node is located in the view hierarchy, it may lead to expensive layout calculations.

Example:
Let's use notation A/r1 as node of family A revision 1.

- React calls create node. Node A/r1 is created and React holds reference to this. It will later use it to clone it.
Node A has native state that was updated. New revision A/r2 is created. Now React and RN do not observe the same node anymore (this is sometimes necessary). 
- React now clones node A to create A/r3. This revision may have the wrong yoga cache. Now this might sound like one off but let's explore what happens next.
- During commit, Fabric must do state progression to give node A/r3 state from A/r2. This requires cloning and new revision A/r4 is created. React has again a wrong node that does not have Yoga cache and can't recover from this state.

The blast radius of this varies depending on where in the tree the node is.

# Solution - State Alignment Mechanism
The main principle for new state progression is to make sure React references the correct shadow node after commit to avoid layout cache miss on subsequent commit.

Agenda for the diagrams below:
- Black colour: node was not cloned.
- Blue colour: node was cloned by React.
- Orange colour: node was cloned by host platform.
- Blue and Orange colour: node was cloned by both React and host platform.


## Simple cases
### Base case

 {F1483309510}

### React Cloned

 {F1483308354} 

### React and host platform clone the same node

 {F1483309324} 

## Medium difficulty

### React clones a different branch than host platform

 {F1483349393} 

### React deletes a branch that was cloned by host platform
 {F1483349259} 


### React changes structure of the tree, node cloned by host platform remains

 {F1483349758} 

### React reorders nodes that were cloned by host platform

 {F1483350283}

Differential Revision: D53405702


