### PR TITLE
Fix ReactImagePropertyTest

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
@@ -41,9 +41,9 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class ReactImagePropertyTest {
 
-  private var context: BridgeReactContext? = null
-  private var catalystInstanceMock: CatalystInstance? = null
-  private var themeContext: ThemedReactContext? = null
+  private lateinit var context: BridgeReactContext
+  private lateinit var catalystInstanceMock: CatalystInstance
+  private lateinit var themeContext: ThemedReactContext
   private lateinit var arguments: MockedStatic<Arguments>
   private lateinit var rnLog: MockedStatic<RNLog>
 
@@ -59,7 +59,7 @@ class ReactImagePropertyTest {
     SoLoader.setInTestMode()
     context = BridgeReactContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
-    context!!.initializeWithInstance(catalystInstanceMock)
+    context.initializeWithInstance(catalystInstanceMock)
     themeContext = ThemedReactContext(context, context, null, -1)
     Fresco.initialize(context)
     DisplayMetricsHolder.setWindowDisplayMetrics(DisplayMetrics())


### PR DESCRIPTION
Summary:
Changelog: [Internal]

While testing something completely unrelated (i.e. D55964787) I've notied that [test_android](https://github.com/facebook/react-native/actions/runs/8635097933/job/23673157303?pr=44026) actually fails on Github with this error:

```
> Task :packages:react-native:ReactAndroid:compileDebugUnitTestKotlin
e: file:///__w/react-native/react-native/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt:62:38 Smart cast to 'CatalystInstance' is impossible, because 'catalystInstanceMock' is a mutable property that could have been changed by this time

> Task :packages:react-native:ReactAndroid:compileReleaseUnitTestKotlin FAILED
e: file:///__w/react-native/react-native/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt:62:38 Smart cast to 'CatalystInstance' is impossible, because 'catalystInstanceMock' is a mutable property that could have been changed by this time
```

Differential Revision: D55982797


