### PR TITLE
Fix Animate.sequence restart issues

### DIFF
--- a/packages/react-native/Libraries/Animated/AnimatedImplementation.js
+++ b/packages/react-native/Libraries/Animated/AnimatedImplementation.js
@@ -315,6 +315,8 @@ const sequence = function (
         current++;
 
         if (current === animations.length) {
+          // if the start is called, even without a reset, it should start from the beginning
+          current = 0;
           callback && callback(result);
           return;
         }


### PR DESCRIPTION
## Summary:

Currently, if the `Animated.sequence` animation is finished, and then the `start()` method is called without a `reset()` method being invoked beforehand, the failure happens: ```undefined is not an object (evaluating 'animations[current].start')```.
Use cases: 
- sequence animation started, finished, and then started again
- sequence animation is used in `Animation.loop` with `resetBeforeIteration` set to `false`, which essentially does the same as the previous case

Related issues:
- https://github.com/facebook/react-native/issues/43120
- https://github.com/facebook/react-native/issues/37611

## Changelog:

[General] [Fixed] - Fix sequence restart failure

## Test Plan:

Test cases are included: 1 for regression and 2 for mentioned use cases in the summary