### PR TITLE
convert circleci mac and ios workflows to github actions

### DIFF
--- a/.github/actions/cache_setup/action.yml
+++ b/.github/actions/cache_setup/action.yml
@@ -1,0 +1,88 @@
+name: cache_setup
+description: "Cache setup"
+inputs:
+  hermes-version:
+    description: "Hermes version"
+    required: true
+  react-native-version:
+    description: "React Native version"
+    required: true
+outputs:
+  cache-hit-hermes-tarball-release:
+    description: "Whether the hermes tarball release cache was hit"
+    value: ${{ steps.cache_hermes_tarball_release.outputs.cache-hit }}
+  cache-hit-hermes-tarball-debug:
+    description: "Whether the hermes tarball debug cache was hit"
+    value: ${{ steps.cache_hermes_tarball_debug.outputs.cache-hit }}
+  cache-hit-macos-bin-release:
+    description: "Whether the macos bin release cache was hit"
+    value: ${{ steps.cache_macos_bin_release.outputs.cache-hit }}
+  cache-hit-macos-bin-debug:
+    description: "Whether the macos bin debug cache was hit"
+    value: ${{ steps.cache_macos_bin_debug.outputs.cache-hit }}
+  cache-hit-dsym-release:
+    description: "Whether the dsym release cache was hit"
+    value: ${{ steps.cache_dsym_release.outputs.cache-hit }}
+  cache-hit-dsym-debug:
+    description: "Whether the dsym debug cache was hit"
+    value: ${{ steps.cache_dsym_debug.outputs.cache-hit }}
+runs:
+  using: composite
+  steps:
+    - name: Cache hermes tarball release
+      id: cache_hermes_tarball_release
+      uses: actions/cache@v4.0.0
+      with:
+        path: /tmp/hermes/hermes-runtime-darwin/hermes-ios-Release.tar.gz
+        key: v4-hermes-tarball-release-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}
+        enableCrossOsArchive: true
+    - name: Cache hermes tarball debug
+      id: cache_hermes_tarball_debug
+      uses: actions/cache@v4.0.0
+      with:
+        path: /tmp/hermes/hermes-runtime-darwin/hermes-ios-Debug.tar.gz
+        key: v4-hermes-tarball-debug-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}
+        enableCrossOsArchive: true
+    - name: Cache macos bin release
+      id: cache_macos_bin_release
+      uses: actions/cache@v4.0.0
+      with:
+        path: /tmp/hermes/osx-bin/Release
+        key: v2-hermes-release-macosx-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        enableCrossOsArchive: true
+    - name: Cache macos bin debug
+      id: cache_macos_bin_debug
+      uses: actions/cache@v4.0.0
+      with:
+        path: /tmp/hermes/osx-bin/Debug
+        key: v2-hermes-debug-macosx-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        enableCrossOsArchive: true
+    - name: Cache dsym release
+      id: cache_dsym_release
+      uses: actions/cache@v4.0.0
+      with:
+        path: /tmp/hermes/dSYM/Release
+        key: v2-hermes-release-dsym-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        enableCrossOsArchive: true
+    - name: Cache dsym debug
+      id: cache_dsym_debug
+      uses: actions/cache@v4.0.0
+      with:
+        path: /tmp/hermes/dSYM/Debug
+        key: v2-hermes-debug-dsym-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        enableCrossOsArchive: true
+    - name: HermesC Apple
+      id: hermesc_apple
+      uses: actions/cache@v4.0.0
+      with:
+        path: /tmp/hermes/hermesc-apple
+        key: v2-hermesc-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        enableCrossOsArchive: true
+    - name: Cache hermes workspace
+      uses: actions/cache@v4.0.0
+      with:
+        path: |
+          /tmp/hermes/download/
+          /tmp/hermes/hermes/
+        key: v1-hermes-${{ inputs.hermes-version }}-${{ github.run_number }}
+        enableCrossOsArchive: true

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -9,6 +9,6 @@ runs:
   using: "composite"
   steps:
     - name: Setup xcode
-      uses: maxim-lobanov/setup-xcode@v1.6.0
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
       with:
         xcode-version: ${{ inputs.xcode-version }}

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -4,7 +4,7 @@ inputs:
   xcode-version:
     description: 'The xcode version to use'
     required: false
-    default: '14.3.1'
+    default: '15.2'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -1,0 +1,14 @@
+name: Setup xcode
+description: 'Set up your GitHub Actions workflow with a specific version of xcode'
+inputs:
+  xcode-version:
+    description: 'The xcode version to use'
+    required: false
+    default: '14.3.1'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup xcode
+      uses: maxim-lobanov/setup-xcode@v1.6.0
+      with:
+        xcode-version: ${{ inputs.xcode-version }}

--- a/.github/actions/setup_hermes_workspace/action.yml
+++ b/.github/actions/setup_hermes_workspace/action.yml
@@ -1,0 +1,11 @@
+name: setup_hermes_workspace
+description: "Setup hermes workspace"
+runs:
+  using: composite
+  steps:
+    - name: Set up workspace
+      shell: bash
+      run: |
+        mkdir -p $HERMES_OSXBIN_ARTIFACTS_DIR ./packages/react-native/sdks/hermes
+        cp -r $HERMES_WS_DIR/hermes/* ./packages/react-native/sdks/hermes/.
+        cp -r ./packages/react-native/sdks/hermes-engine/utils ./packages/react-native/sdks/hermes/.

--- a/.github/actions/setup_xcode_build_cache/action.yml
+++ b/.github/actions/setup_xcode_build_cache/action.yml
@@ -1,0 +1,28 @@
+name: setup_xcode_build_cache
+description: Add caching to iOS jobs to speed up builds
+inputs:
+  hermes-version:
+    description: The version of hermes
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: See commands.yml with_xcodebuild_cache
+      shell: bash
+      run: echo "See commands.yml with_xcodebuild_cache"
+    - name: Prepare Xcodebuild cache
+      shell: bash
+      run: |
+        WEEK=$(date +"%U")
+        YEAR=$(date +"%Y")
+        echo "$WEEK-$YEAR" > /tmp/week_year
+    - name: Cache podfile lock
+      uses: actions/cache@v4.0.0
+      with:
+        path: packages/rn-tester/Podfile.lock
+        key: v9-podfilelock-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile') }}-{{ hashfiles('/tmp/week_year') }}-${{ inputs.hermes-version}}
+    - name: Cache cocoapods
+      uses: actions/cache@v4.0.0
+      with:
+        path: packages/rn-tester/Pods
+        key: v11-cocoapods-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-{{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}

--- a/.github/actions/test_ios_rntester/action.yml
+++ b/.github/actions/test_ios_rntester/action.yml
@@ -44,9 +44,6 @@ runs:
       with:
         hermes-version: ${{ inputs.hermes-version }}
         react-native-version: ${{ inputs.react-native-version }}
-    - name: Delete iOS Simulators
-      shell: bash
-      run: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/ &
     - name: Setup ruby
       uses: ruby/setup-ruby@v1.170.0
       with:

--- a/.github/actions/test_ios_rntester/action.yml
+++ b/.github/actions/test_ios_rntester/action.yml
@@ -1,0 +1,158 @@
+name: test_ios_rntester
+description: Test iOS RNTester
+inputs:
+  jsengine:
+    description: Which JavaScript engine to use. Must be one of "Hermes", "JSC".
+    default: Hermes
+  use-frameworks:
+      description: The dependency building and linking strategy to use. Must be one of "StaticLibraries", "DynamicFrameworks"
+      default: StaticLibraries
+  architecture:
+    description: The React Native architecture to Test. RNTester has always Fabric enabled, but we want to run integration test with the old arch setup
+    default: NewArch
+  ruby-version:
+    description: The version of ruby that must be used
+    default: 2.6.10
+  run-unit-tests:
+    description: whether unit tests should run or not.
+    default: false
+  hermes-tarball-artifacts-dir:
+    description: The directory where the hermes tarball artifacts are stored
+    default: /tmp/hermes/hermes-runtime-darwin
+  flavor:
+    description: The flavor of the build. Must be one of "Debug", "Release".
+    default: Debug
+  hermes-version:
+    description: The version of hermes
+    required: true
+  react-native-version:
+    description: The version of react-native
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup xcode
+      uses: ./.github/actions/setup-xcode
+    - name: Setup node.js
+      uses: ./.github/actions/setup-node
+    - name: Run yarn
+      shell: bash
+      run: yarn install --non-interactive
+    - name: Cache setup
+      id: cache_setup
+      uses: ./.github/actions/cache_setup
+      with:
+        hermes-version: ${{ inputs.hermes-version }}
+        react-native-version: ${{ inputs.react-native-version }}
+    - name: Delete iOS Simulators
+      shell: bash
+      run: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/ &
+    - name: Setup ruby
+      uses: ruby/setup-ruby@v1.170.0
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+    - name: Prepare IOS Tests
+      if: ${{ inputs.run-unit-tests == true }}
+      uses: ./.github/actions/prepare_ios_tests
+    - name: Set HERMES_ENGINE_TARBALL_PATH envvar if Hermes tarball is present
+      shell: bash
+      run: |
+        HERMES_TARBALL_ARTIFACTS_DIR=${{ inputs.hermes-tarball-artifacts-dir }}
+        if [ ! -d $HERMES_TARBALL_ARTIFACTS_DIR ]; then
+          echo "Hermes tarball artifacts dir not present ($HERMES_TARBALL_ARTIFACTS_DIR). Build Hermes from source."
+          exit 0
+        fi
+
+        if [ ! -d ~/react-native ]; then
+          echo "No React Native checkout found. Run `checkout` first."
+          exit 0
+        fi
+
+        TARBALL_FILENAME=$(node ./packages/react-native/scripts/hermes/get-tarball-name.js --buildType "${{ inputs.flavor }}")
+        TARBALL_PATH=$HERMES_TARBALL_ARTIFACTS_DIR/$TARBALL_FILENAME
+
+        echo "Looking for $TARBALL_FILENAME in $HERMES_TARBALL_ARTIFACTS_DIR"
+        echo "$TARBALL_PATH"
+
+        if [ ! -f $TARBALL_PATH ]; then
+          echo "Hermes tarball not present ($TARBALL_PATH). Build Hermes from source."
+          exit 0
+        fi
+
+        echo "Found Hermes tarball at $TARBALL_PATH"
+        echo "HERMES_ENGINE_TARBALL_PATH=$TARBALL_PATH" >> $GITHUB_ENV
+    - name: Print Hermes version
+      shell: bash
+      run: |
+        HERMES_TARBALL_ARTIFACTS_DIR=${{ inputs.hermes-tarball-artifacts-dir }}
+        TARBALL_FILENAME=$(node ./packages/react-native/scripts/hermes/get-tarball-name.js --buildType "${{ inputs.flavor }}")
+        TARBALL_PATH=$HERMES_TARBALL_ARTIFACTS_DIR/$TARBALL_FILENAME
+        if [[ -e $TARBALL_PATH ]]; then
+          tar -xf $TARBALL_PATH
+          echo 'print(HermesInternal?.getRuntimeProperties?.()["OSS Release Version"])' > test.js
+          ./destroot/bin/hermes test.js
+          rm test.js
+          rm -rf destroot
+        else
+          echo 'No Hermes tarball found.'
+        fi
+    - name: Setup xcode build cache
+      uses: ./.github/actions/setup_xcode_build_cache
+      with:
+        hermes-version: ${{ inputs.hermes-version }}
+    - name: Install CocoaPods dependencies
+      shell: bash
+      run: |
+        if [[ ${{ inputs.jsengine }} == "JSC" ]]; then
+          export USE_HERMES=0
+        fi
+
+        if [[ ${{ inputs.use-frameworks }} == "DynamicFrameworks" ]]; then
+          export USE_FRAMEWORKS=dynamic
+        fi
+
+        if [[ ${{ inputs.architecture }} == "NewArch" ]]; then
+          export RCT_NEW_ARCH_ENABLED=1
+        fi
+        
+        cd packages/rn-tester
+
+        bundle install
+        bundle exec pod install
+    - name: Build RNTester
+      if: ${{ inputs.run-unit-tests != true }}
+      shell: bash
+      run: |
+        xcodebuild build \
+          -workspace packages/rn-tester/RNTesterPods.xcworkspace \
+          -scheme RNTester \
+          -sdk iphonesimulator
+    - name: "Run Tests: iOS Unit and Integration Tests"
+      if: ${{ inputs.run-unit-tests == true }}
+      shell: bash
+      run: node ./scripts/circleci/run_with_retry.js 3 yarn test-ios
+    - name: Zip Derived data folder
+      if: ${{ inputs.run-unit-tests == true }}
+      shell: bash
+      run: |
+        echo "zipping tests results"
+        cd /Users/distiller/Library/Developer/Xcode
+        XCRESULT_PATH=$(find . -name '*.xcresult')
+        tar -zcvf xcresults.tar.gz $XCRESULT_PATH
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2.2.4
+      if: ${{ inputs.run-unit-tests == true }}
+      with:
+        name: xcresults
+        path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
+    - name: Report bundle size
+      if: ${{ inputs.run-unit-tests == true }}
+      uses: ./.github/actions/report_bundle_size
+      with:
+        platform: ios
+    - name: Store test results
+      if: ${{ inputs.run-unit-tests == true }}
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: test-results
+        path: ./reports/junit

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -84,6 +84,336 @@ jobs:
           cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
 
           echo ${{ steps.hermes-version.outputs.version }}
+  build_hermesc_apple:
+    runs-on: macos-13
+    needs: prepare_hermes_workspace
+    env:
+      HERMES_WS_DIR: /tmp/hermes
+      HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Cache hermes workspace
+        uses: actions/cache@v4.0.0
+        with:
+          path: |
+            /tmp/hermes/download/
+            /tmp/hermes/hermes/
+          key: v1-hermes-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ github.run_number }}
+          enableCrossOsArchive: true
+      - name: Setup Hermes workspace
+        uses: ./.github/actions/setup_hermes_workspace
+      - name: Hermes apple cache
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
+          key: v2-hermesc-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+      - name: Build HermesC Apple
+        run: |
+          cd ./packages/react-native/sdks/hermes || exit 1
+          . ./utils/build-apple-framework.sh
+          build_host_hermesc_if_needed
+  build_apple_slices_hermes:
+    runs-on: macos-13
+    needs: [build_hermesc_apple, prepare_hermes_workspace]
+    env:
+      HERMES_WS_DIR: /tmp/hermes
+      HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
+      HERMES_OSXBIN_ARTIFACTS_DIR: /tmp/hermes/osx-bin
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+        slice: [macosx, iphoneos, iphonesimulator, catalyst]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Cache setup
+        id: cache_setup
+        uses: ./.github/actions/cache_setup
+        with:
+          hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
+          react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+      - name: Setup Hermes workspace
+        uses: ./.github/actions/setup_hermes_workspace
+      - name: Check if the required artifacts already exist
+        id: check_if_apple_artifacts_are_there
+        run: |
+          if ${{ matrix.flavor == 'Debug' }} && \\
+            ${{ steps.cache_setup.outputs.cache-hit-hermes-tarball-debug == true }} && \
+            ${{ steps.cache_setup.outputs.cache-hit-macos-bin-debug == true }} && \
+            ${{ steps.cache_setup.outputs.cache-hit-dsym-debug == true }} ; then
+            echo "ARTIFACTS_EXIST=true" >> $GITHUB_ENV
+          fi
+
+          if ${{ matrix.flavor == 'Release' }} && \\
+            ${{ steps.cache_setup.outputs.cache-hit-hermes-tarball-release == true }} && \
+            ${{ steps.cache_setup.outputs.cache-hit-macos-bin-release == true }} && \
+            ${{ steps.cache_setup.outputs.cache-hit-dsym-release == true }} ; then
+            echo "ARTIFACTS_EXIST=true" >> $GITHUB_ENV
+          fi
+      - name: Build the Hermes ${{ matrix.slice }} frameworks
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        run: |
+          cd ./packages/react-native/sdks/hermes || exit 1
+          SLICE=${{ matrix.slice }}
+          FLAVOR=${{ matrix.flavor }}
+          FINAL_PATH=build_"$SLICE"_"$FLAVOR"
+          echo "Final path for this slice is: $FINAL_PATH"
+
+          if [[ -d "$FINAL_PATH" ]]; then
+            echo "[HERMES] Skipping! Found the requested slice at $FINAL_PATH".
+            exit 0
+          fi
+
+          if [[ "$SLICE" == "macosx" ]]; then
+            echo "[HERMES] Building Hermes for MacOS"
+            BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-mac-framework.sh
+          else
+            echo "[HERMES] Building Hermes for iOS: $SLICE"
+            BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-ios-framework.sh "$SLICE"
+          fi
+
+          echo "Moving from build_$SLICE to $FINAL_PATH"
+          mv build_"$SLICE" "$FINAL_PATH"
+
+          # check whether everything is there
+          if [[ -d "$FINAL_PATH/API/hermes/hermes.framework" ]]; then
+            echo "Successfully built hermes.framework for $SLICE in $FLAVOR"
+          else
+            echo "Failed to built hermes.framework for $SLICE in $FLAVOR"
+            exit 1
+          fi
+
+          if [[ -d "$FINAL_PATH/API/hermes/hermes.framework.dSYM" ]]; then
+            echo "Successfully built hermes.framework.dSYM for $SLICE in $FLAVOR"
+          else
+            echo "Failed to built hermes.framework.dSYM for $SLICE in $FLAVOR"
+            echo "Please try again"
+            exit 1
+          fi
+      - name: Save slice cache
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_${{ matrix.slice }}_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ matrix.slice }}-${{ matrix.flavor }}
+  build_hermes_macos:
+    runs-on: macos-13
+    needs: [build_apple_slices_hermes, prepare_hermes_workspace]
+    env:
+      HERMES_WS_DIR: /tmp/hermes
+      HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Cache setup
+        id: cache_setup
+        uses: ./.github/actions/cache_setup
+        with:
+          hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
+          react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+      - name: Setup Hermes workspace
+        uses: ./.github/actions/setup_hermes_workspace
+      - name: Check if the required artifacts already exist
+        id: check_if_apple_artifacts_are_there
+        run: |
+          if ${{ matrix.flavor == 'Debug' }} &&
+            ${{ steps.cache_setup.outputs.cache-hit-hermes-tarball-debug == true }} && \
+            ${{ steps.cache_setup.outputs.cache-hit-macos-bin-debug == true }} && \
+            ${{ steps.cache_setup.outputs.cache-hit-dsym-debug == true }} ; then
+            echo "ARTIFACTS_EXIST=true" >> $GITHUB_ENV
+          fi
+
+          if ${{ matrix.flavor == 'Release' }} && \\
+            ${{ steps.cache_setup.outputs.cache-hit-hermes-tarball-release == true }} && \
+            ${{ steps.cache_setup.outputs.cache-hit-macos-bin-release == true }} && \
+            ${{ steps.cache_setup.outputs.cache-hit-dsym-release == true }} ; then
+            echo "ARTIFACTS_EXIST=true" >> $GITHUB_ENV
+          fi
+      
+      - name: Yarn- Install Dependencies
+        if: ${{ ! contains(github.event.head_commit.message, 'Bump metro@') && steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        run: yarn install --non-interactive
+      - name: Slice cache macosx
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_macosx_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-macosx-${{ matrix.flavor }}
+      - name: Slice cache iphoneos
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_iphoneos_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-iphoneos-${{ matrix.flavor }}
+      - name: Slice cache iphonesimulator
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_iphonesimulator_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-iphonesimulator-${{ matrix.flavor }}
+      - name: Slice cache catalyst
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_catalyst_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-catalyst-${{ matrix.flavor }}
+      - name: Move back build folders
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        run: |
+          ls -l ./packages/react-native/sdks/hermes
+          cd ./packages/react-native/sdks/hermes || exit 1
+          mv build_macosx_${{ matrix.flavor }} build_macosx
+          mv build_iphoneos_${{ matrix.flavor }} build_iphoneos
+          mv build_iphonesimulator_${{ matrix.flavor }} build_iphonesimulator
+          mv build_catalyst_${{ matrix.flavor }} build_catalyst
+      - name: Prepare destroot folder
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        run: |
+          cd ./packages/react-native/sdks/hermes || exit 1
+          . ./utils/build-apple-framework.sh
+          prepare_dest_root_for_ci
+      - name: Create fat framework for iOS
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        run: |
+          cd ./packages/react-native/sdks/hermes || exit 1
+          echo "[HERMES] Creating the universal framework"
+          ./utils/build-ios-framework.sh build_framework
+      - name: Package the Hermes Apple frameworks
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        run: |
+          BUILD_TYPE="${{ matrix.flavor }}"
+          echo "Packaging Hermes Apple frameworks for $BUILD_TYPE build type"
+
+          TARBALL_OUTPUT_DIR=$(mktemp -d /tmp/hermes-tarball-output-XXXXXXXX)
+
+          TARBALL_FILENAME=$(node ./packages/react-native/scripts/hermes/get-tarball-name.js --buildType "$BUILD_TYPE")
+
+          echo "Packaging Hermes Apple frameworks for $BUILD_TYPE build type"
+
+          TARBALL_OUTPUT_PATH=$(node ./packages/react-native/scripts/hermes/create-tarball.js \
+            --inputDir ./packages/react-native/sdks/hermes \
+            --buildType "$BUILD_TYPE" \
+            --outputDir $TARBALL_OUTPUT_DIR)
+
+          echo "Hermes tarball saved to $TARBALL_OUTPUT_PATH"
+
+          mkdir -p $HERMES_TARBALL_ARTIFACTS_DIR
+          cp $TARBALL_OUTPUT_PATH $HERMES_TARBALL_ARTIFACTS_DIR/.
+
+          mkdir -p /tmp/hermes/osx-bin/${{ matrix.flavor }}
+          cp ./packages/react-native/sdks/hermes/build_macosx/bin/* /tmp/hermes/osx-bin/${{ matrix.flavor }}
+          ls -lR /tmp/hermes/osx-bin/
+      - name: Upload darwin artifacts
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: hermes-darwin-bin-${{ matrix.flavor }}
+          path: /tmp/hermes/hermes-runtime-darwin
+      - name: Upload osx-bin
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: hermes-osx-bin-${{ matrix.flavor }}
+          path: /tmp/hermes/osx-bin
+      - name: Create dSYM archive
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        run: |
+          FLAVOR=${{ matrix.flavor }}
+          WORKING_DIR="/tmp/hermes_tmp/dSYM/$FLAVOR"
+
+          mkdir -p "$WORKING_DIR/macosx"
+          mkdir -p "$WORKING_DIR/catalyst"
+          mkdir -p "$WORKING_DIR/iphoneos"
+          mkdir -p "$WORKING_DIR/iphonesimulator"
+
+          cd ./packages/react-native/sdks/hermes || exit 1
+
+          DSYM_FILE_PATH=API/hermes/hermes.framework.dSYM
+          cp -r build_macosx/$DSYM_FILE_PATH "$WORKING_DIR/macosx/"
+          cp -r build_catalyst/$DSYM_FILE_PATH "$WORKING_DIR/catalyst/"
+          cp -r build_iphoneos/$DSYM_FILE_PATH "$WORKING_DIR/iphoneos/"
+          cp -r build_iphonesimulator/$DSYM_FILE_PATH "$WORKING_DIR/iphonesimulator/"
+
+          DEST_DIR="/tmp/hermes/dSYM/$FLAVOR"
+          tar -C "$WORKING_DIR" -czvf "hermes.framework.dSYM" .
+
+          mkdir -p "$DEST_DIR"
+          mv "hermes.framework.dSYM" "$DEST_DIR"
+      - name: Upload hermes dSYM acrifacts
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: hermes-dSYM-${{ matrix.flavor }}
+          path: /tmp/hermes/dSYM/${{ matrix.flavor }}
+  test_ios_rntester_ruby_3_2_0:
+    runs-on: macos-13
+    needs: [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
+    env:
+      HERMES_WS_DIR: /tmp/hermes
+      HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Run it
+        uses: ./.github/actions/test_ios_rntester
+        with:
+          ruby-version: "3.2.0"
+          hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
+          react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+  test_ios_rntester1:
+    runs-on: macos-13
+    needs: [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
+    env:
+      HERMES_WS_DIR: /tmp/hermes
+      HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        jsengine: [Hermes, JSC]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Run it
+        uses: ./.github/actions/test_ios_rntester
+        with:
+          jsengine: ${{ matrix.jsengine }}
+          use-frameworks: DynamicFrameworks
+          hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
+          react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+  test_ios_rntester2:
+    runs-on: macos-13
+    needs: [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
+    env:
+      HERMES_WS_DIR: /tmp/hermes
+      HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        jsengine: [Hermes, JSC]
+        architecture: [NewArch, OldArch]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Run it
+        uses: ./.github/actions/test_ios_rntester
+        with:
+          jsengine: ${{ matrix.jsengine }}
+          architecture: ${{ matrix.architecture }}
+          run-unit-tests: true
+          use-frameworks: StaticLibraries
+          hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
+          react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
   build_android:
     runs-on: ubuntu-latest
     needs: [set_release_type, prepare_hermes_workspace]

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -349,7 +349,7 @@ jobs:
 
           mkdir -p "$DEST_DIR"
           mv "hermes.framework.dSYM" "$DEST_DIR"
-      - name: Upload hermes dSYM acrifacts
+      - name: Upload hermes dSYM artifacts
         uses: actions/upload-artifact@v4.3.1
         with:
           name: hermes-dSYM-${{ matrix.flavor }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -369,7 +369,7 @@ jobs:
           ruby-version: "3.2.0"
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-  test_ios_rntester1:
+  test_ios_rntester_dynamic_frameworks:
     runs-on: macos-13
     needs: [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
     env:
@@ -390,7 +390,7 @@ jobs:
           use-frameworks: DynamicFrameworks
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-  test_ios_rntester2:
+  test_ios_rntester:
     runs-on: macos-13
     needs: [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
     env:


### PR DESCRIPTION
## Summary:

This pull request converts the CircleCI workflows to GitHub actions workflows. This change only inlcudes the mac and ios build and test jobs.  

## Changelog:
[Internal] - Migrate iOS to github actions

## Test Plan:

[Here is the latest workflow run in my fork](https://github.com/robandpdx-org/react-native/actions/runs/8637660560).  

---
https://fburl.com/workplace/f6mz6tmw
