### PR TITLE
Fix missing setLeftTopRightBottom method

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
@@ -50,7 +50,10 @@ public class ReactHorizontalScrollContainerView extends ReactViewGroup {
       int newLeft = 0;
       int width = right - left;
       int newRight = newLeft + width;
-      setLeftTopRightBottom(newLeft, top, newRight, bottom);
+      setLeft(newLeft);
+      setTop(top);
+      setRight(newRight);
+      setBottom(bottom);
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

We were seeing errors due to `setLeftTopRightBottom` being called without a check for the Android version despite that method [being added in Android API level 29](https://developer.android.com/reference/android/view/View#setLeftTopRightBottom(int,%20int,%20int,%20int)). I've replaced it with the older API methods to fix the issue.

This issue originates from https://github.com/facebook/react-native/pull/38526

## Changelog:

[ANDROID] [FIXED] - Resolved error "No virtual method setLeftTopRightBottom"

## Test Plan:

Change is pretty trivial, but we tested it in our production app ([Tarteel](https://www.tarteel.ai/)) for a week and confirmed that the error is resolved.
