### PR TITLE
add .gitignore for rn-tester build artifacts

### DIFF
--- a/packages/rn-tester/.gitignore
+++ b/packages/rn-tester/.gitignore
@@ -1,0 +1,1 @@
+rn-tester.xcodeproj.local/


### PR DESCRIPTION
Summary:
changelog: [internal]

Building rn-tester left artifacts that would be picked up by mercurial.

```
❯ hg s
? rn-tester.xcodeproj.local/Project Settings.plist
? rn-tester.xcodeproj.local/Project Settings.plist.lock
```

To mitigate this, add  `rn-tester.xcodeproj.local` introduce .gitignore for rn-tester.

Reviewed By: fabriziocucci

Differential Revision: D56006193


