### PR TITLE
Properly recycle RCTPullToRefreshViewcomponentView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -37,14 +37,18 @@ using namespace facebook::react;
     self.hidden = YES;
 
     _props = PullToRefreshViewShadowNode::defaultSharedProps();
-
-    _refreshControl = [UIRefreshControl new];
-    [_refreshControl addTarget:self
-                        action:@selector(handleUIControlEventValueChanged)
-              forControlEvents:UIControlEventValueChanged];
+    [self _initializeUIRefreshControl];
   }
 
   return self;
+}
+
+- (void)_initializeUIRefreshControl
+{
+  _refreshControl = [UIRefreshControl new];
+  [_refreshControl addTarget:self
+                      action:@selector(handleUIControlEventValueChanged)
+            forControlEvents:UIControlEventValueChanged];
 }
 
 #pragma mark - RCTComponentViewProtocol
@@ -52,6 +56,13 @@ using namespace facebook::react;
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {
   return concreteComponentDescriptorProvider<PullToRefreshViewComponentDescriptor>();
+}
+
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+  _scrollViewComponentView = nil;
+  [self _initializeUIRefreshControl];
 }
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
@@ -113,6 +124,7 @@ using namespace facebook::react;
 
 - (void)didMoveToWindow
 {
+  [super didMoveToWindow];
   if (self.window) {
     [self _attach];
   } else {


### PR DESCRIPTION
Summary:
This change properly recycles the RCTPullToRefreshViewComponentView so that it fixes some misbehaviors of the UIRefreshControl in OSS.

This should fix https://github.com/facebook/react-native/issues/37308 and https://github.com/facebook/react-native/issues/36173

## Changelog:
[iOS][Fixed] - Properly recycle the RCTPullToRefreshViewComponentView

Differential Revision: D56018924


