### PR TITLE
Fix race condition in native module invalidation

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -178,6 +178,11 @@ static Class getFallbackClassFromName(const char *name)
   return moduleClass;
 }
 
+typedef struct {
+  id<RCTBridgeModule> module;
+  dispatch_queue_t methodQueue;
+} ModuleQueuePair;
+
 @implementation RCTTurboModuleManager {
   std::shared_ptr<CallInvoker> _jsInvoker;
   __weak id<RCTTurboModuleManagerDelegate> _delegate;
@@ -1033,7 +1038,7 @@ static Class getFallbackClassFromName(const char *name)
 {
   // Backward-compatibility: RCTInvalidating handling.
   dispatch_group_t moduleInvalidationGroup = dispatch_group_create();
-
+  std::vector<ModuleQueuePair> modulesToInvalidate;
   for (auto &pair : _moduleHolders) {
     std::string moduleName = pair.first;
     ModuleHolder *moduleHolder = &pair.second;
@@ -1056,22 +1061,31 @@ static Class getFallbackClassFromName(const char *name)
             [module class]);
         continue;
       }
+      modulesToInvalidate.push_back({module, methodQueue});
+    }
+  }
 
-      dispatch_group_enter(moduleInvalidationGroup);
-      dispatch_block_t invalidateModule = ^{
-        [((id<RCTInvalidating>)module) invalidate];
-        dispatch_group_leave(moduleInvalidationGroup);
-      };
+  for (auto unused : modulesToInvalidate) {
+    dispatch_group_enter(moduleInvalidationGroup);
+  }
 
-      if (_bridge) {
-        [_bridge dispatchBlock:invalidateModule queue:methodQueue];
+  for (auto &moduleQueuePair : modulesToInvalidate) {
+    id<RCTBridgeModule> module = moduleQueuePair.module;
+    dispatch_queue_t methodQueue = moduleQueuePair.methodQueue;
+
+    dispatch_block_t invalidateModule = ^{
+      [((id<RCTInvalidating>)module) invalidate];
+      dispatch_group_leave(moduleInvalidationGroup);
+    };
+
+    if (_bridge) {
+      [_bridge dispatchBlock:invalidateModule queue:methodQueue];
+    } else {
+      // Bridgeless mode
+      if (methodQueue == RCTJSThread) {
+        invalidateModule();
       } else {
-        // Bridgeless mode
-        if (methodQueue == RCTJSThread) {
-          invalidateModule();
-        } else {
-          dispatch_async(methodQueue, invalidateModule);
-        }
+        dispatch_async(methodQueue, invalidateModule);
       }
     }
   }


### PR DESCRIPTION
Summary:
This is an attempt to fix a couple of similar memory corruption crashes that happen during the deallocation of RCTHost.

**Hypotheis:** there is a race condition between [this](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm#L1038-L1058) and [this](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm#L1062) chunks of work.
I.e. let's say we are invalidating 10 modules. Because of the race condition it is possible that we call `dispatch_group_enter`/`dispatch_group_enter` for the first five before we call `dispatch_group_enter` for the sixth one. In that case we would resume at [dispatch_group_wait](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm#L1079), not waiting for the remaining modules to invalidate. That would lead to `RCTInstance` potentially being invalidated prematurely, deallocating all its ivars including `_turboModuleManager` and `_jsThreadManager`. That in turn would lead to memory access error during the invalidation of remaining modules.

This diff is trying to solve this problem by calling `dispatch_group_enter` for all modules before any other work is performed.

Changelog: [iOS][Fixed] - Fixed race condition in native module invalidation.

Differential Revision: D55965290


