### PR TITLE
Implement getRuntimeExecutor for BridgelessCatalystInstance

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -149,8 +149,8 @@ public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : 
     throw UnsupportedOperationException("Unimplemented method 'getJavaScriptContextHolder'")
   }
 
-  override fun getRuntimeExecutor(): RuntimeExecutor {
-    throw UnsupportedOperationException("Unimplemented method 'getRuntimeExecutor'")
+  override fun getRuntimeExecutor(): RuntimeExecutor? {
+    return reactHost.getRuntimeExecutor()
   }
 
   override fun getRuntimeScheduler(): RuntimeScheduler {


### PR DESCRIPTION
Summary:
Implement `getRuntimeExecutor()` for BridgelessCatalystInstance

Changelog:
[Android][Breaking] Implement getRuntimeExecutor() for Bridgeless Catalyst Instance

Differential Revision: D56046398


