### PR TITLE
Implement getJavaScriptContextHolder for BridgelessCatalystInstance

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -145,8 +145,8 @@ public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : 
   }
 
   @Deprecated(message = "This API is unsupported in the New Architecture.")
-  override fun getJavaScriptContextHolder(): JavaScriptContextHolder {
-    throw UnsupportedOperationException("Unimplemented method 'getJavaScriptContextHolder'")
+  override fun getJavaScriptContextHolder(): JavaScriptContextHolder? {
+    return reactHost.getJavaScriptContextHolder()
   }
 
   override fun getRuntimeExecutor(): RuntimeExecutor {


### PR DESCRIPTION
Summary:
Implement getJavaScriptContextHolder() for BridgelessCatalystInstance

Changelog:
[Android][Breaking] Implement getJavaScriptContextHolder() for Bridgeless Catalyst Instance

Differential Revision: D56046452


