### PR TITLE
Fix Open Debugger dev menu item missing from iOS Bridgeless

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -158,6 +158,11 @@ RCT_EXPORT_MODULE()
   return NO;
 }
 
+- (BOOL)_isBridgeMode
+{
+  return [self.bridge isKindOfClass:[RCTBridge class]];
+}
+
 - (instancetype)initWithDataSource:(id<RCTDevSettingsDataSource>)dataSource
 {
   if (self = [super init]) {
@@ -178,7 +183,7 @@ RCT_EXPORT_MODULE()
 - (void)initialize
 {
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
-  if (self.bridge) {
+  if ([self _isBridgeMode]) {
     RCTBridge *__weak weakBridge = self.bridge;
     _bridgeExecutorOverrideToken = [[RCTPackagerConnection sharedPackagerConnection]
         addNotificationHandler:^(id params) {
@@ -209,7 +214,7 @@ RCT_EXPORT_MODULE()
 #endif
 
 #if RCT_ENABLE_INSPECTOR
-  if (self.bridge) {
+  if ([self _isBridgeMode]) {
     // We need this dispatch to the main thread because the bridge is not yet
     // finished with its initialisation. By the time it relinquishes control of
     // the main thread, this operation can be performed.
@@ -250,7 +255,7 @@ RCT_EXPORT_MODULE()
 {
   [super invalidate];
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
-  if (self.bridge) {
+  if ([self _isBridgeMode]) {
     [[RCTPackagerConnection sharedPackagerConnection] removeHandler:_bridgeExecutorOverrideToken];
   }
 
@@ -281,7 +286,7 @@ RCT_EXPORT_MODULE()
 - (BOOL)isDeviceDebuggingAvailable
 {
 #if RCT_ENABLE_INSPECTOR
-  if (self.bridge) {
+  if ([self _isBridgeMode]) {
     return self.bridge.isInspectable;
   } else {
     return self.isInspectable;


### PR DESCRIPTION
Summary:
After a [recent change](https://github.com/facebook/react-native/commit/90296be1d4fab09a52e02dd09f34f819136d0a07) we break part of the integration with the debug menu, which is was using the presence/absence of the bridge to decide whether we were in bridge or bridgeless.

For backward compatibility reasosn, the bridge ivar is now populated with the bridgeProxy, so just checking whether is nil or not is not enough to verify whether we are in bridge or in bridgeless mode anymore.

## Changelog:
[iOS][Fixed] - Make sure that the Open Debugger appears in bridgeless mode

Reviewed By: fkgozali

Differential Revision: D56067897


