### PR TITLE
Fixup margin: auto and justification behavior for overflowed containers

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/Align.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/Align.h
@@ -26,4 +26,47 @@ inline Align resolveChildAlignment(
   return align;
 }
 
+/**
+ * Fallback alignment to use on overflow
+ * https://www.w3.org/TR/css-align-3/#distribution-values
+ */
+constexpr Align fallbackAlignment(Align align) {
+  switch (align) {
+      // Fallback to flex-start
+    case Align::SpaceBetween:
+    case Align::Stretch:
+      return Align::FlexStart;
+
+    // Fallback to safe center. TODO: This should be aligned to Start
+    // instead of FlexStart (for row-reverse containers)
+    case Align::SpaceAround:
+    case Align::SpaceEvenly:
+      return Align::FlexStart;
+    default:
+      return align;
+  }
+}
+
+/**
+ * Fallback alignment to use on overflow
+ * https://www.w3.org/TR/css-align-3/#distribution-values
+ */
+constexpr Justify fallbackAlignment(Justify align) {
+  switch (align) {
+      // Fallback to flex-start
+    case Justify::SpaceBetween:
+      // TODO: Support `justify-content: stretch`
+      // case Justify::Stretch:
+      return Justify::FlexStart;
+
+    // Fallback to safe center. TODO: This should be aligned to Start
+    // instead of FlexStart (for row-reverse containers)
+    case Justify::SpaceAround:
+    case Justify::SpaceEvenly:
+      return Justify::FlexStart;
+    default:
+      return align;
+  }
+}
+
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
@@ -27,6 +27,7 @@ FlexLine calculateFlexLine(
   float sizeConsumed = 0.0f;
   float totalFlexGrowFactors = 0.0f;
   float totalFlexShrinkScaledFactors = 0.0f;
+  size_t numberOfAutoMargins = 0;
   size_t endOfLineIndex = startOfLineIndex;
   size_t firstElementInLineIndex = startOfLineIndex;
 
@@ -47,6 +48,13 @@ FlexLine calculateFlexLine(
         firstElementInLineIndex++;
       }
       continue;
+    }
+
+    if (child->style().flexStartMarginIsAuto(mainAxis, ownerDirection)) {
+      numberOfAutoMargins++;
+    }
+    if (child->style().flexEndMarginIsAuto(mainAxis, ownerDirection)) {
+      numberOfAutoMargins++;
     }
 
     const bool isFirstElementInLine =
@@ -102,10 +110,11 @@ FlexLine calculateFlexLine(
   }
 
   return FlexLine{
-      std::move(itemsInFlow),
-      sizeConsumed,
-      endOfLineIndex,
-      FlexLineRunningLayout{
+      .itemsInFlow = std::move(itemsInFlow),
+      .sizeConsumed = sizeConsumed,
+      .endOfLineIndex = endOfLineIndex,
+      .numberOfAutoMargins = numberOfAutoMargins,
+      .layout = FlexLineRunningLayout{
           totalFlexGrowFactors,
           totalFlexShrinkScaledFactors,
       }};

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.h
@@ -52,6 +52,9 @@ struct FlexLine {
   // The index of the first item beyond the current line.
   const size_t endOfLineIndex{0};
 
+  // Number of edges along the line flow with an auto margin.
+  const size_t numberOfAutoMargins{0};
+
   // Layout information about the line computed in steps after line-breaking
   FlexLineRunningLayout layout{};
 };


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/yoga/issues/978

1. Don't allow auto margin spaces to become a negative length
2. Replicate fallback alignment behavior specified by box-alignment spec that we are using for align-content.

Differential Revision: D56091577


