### PR TITLE
Add implementation of `adjustsFontSizeToFit` on the new architecture on Android

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7372,7 +7372,7 @@ public class com/facebook/react/views/text/TextLayoutManager {
 	public static fun isRTL (Lcom/facebook/react/bridge/ReadableMap;)Z
 	public static fun measureLines (Landroid/content/Context;Lcom/facebook/react/bridge/ReadableMap;Lcom/facebook/react/bridge/ReadableMap;F)Lcom/facebook/react/bridge/WritableArray;
 	public static fun measureText (Landroid/content/Context;Lcom/facebook/react/bridge/ReadableMap;Lcom/facebook/react/bridge/ReadableMap;FLcom/facebook/yoga/YogaMeasureMode;FLcom/facebook/yoga/YogaMeasureMode;Lcom/facebook/react/views/text/ReactTextViewManagerCallback;[F)J
-	public static fun setCachedSpannabledForTag (ILandroid/text/Spannable;)V
+	public static fun setCachedSpannableForTag (ILandroid/text/Spannable;)V
 }
 
 public class com/facebook/react/views/text/TextLayoutManagerMapBuffer {
@@ -7398,7 +7398,7 @@ public class com/facebook/react/views/text/TextLayoutManagerMapBuffer {
 	public static fun isRTL (Lcom/facebook/react/common/mapbuffer/MapBuffer;)Z
 	public static fun measureLines (Landroid/content/Context;Lcom/facebook/react/common/mapbuffer/MapBuffer;Lcom/facebook/react/common/mapbuffer/MapBuffer;F)Lcom/facebook/react/bridge/WritableArray;
 	public static fun measureText (Landroid/content/Context;Lcom/facebook/react/common/mapbuffer/MapBuffer;Lcom/facebook/react/common/mapbuffer/MapBuffer;FLcom/facebook/yoga/YogaMeasureMode;FLcom/facebook/yoga/YogaMeasureMode;Lcom/facebook/react/views/text/ReactTextViewManagerCallback;[F)J
-	public static fun setCachedSpannabledForTag (ILandroid/text/Spannable;)V
+	public static fun setCachedSpannableForTag (ILandroid/text/Spannable;)V
 }
 
 public final class com/facebook/react/views/text/TextTransform : java/lang/Enum {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -513,7 +513,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener, UIBlo
             mReactApplicationContext,
             attributedString,
             paragraphAttributes,
-            PixelUtil.toPixelFromDIP(width));
+            PixelUtil.toPixelFromDIP(width),
+            PixelUtil.toPixelFromDIP(height));
   }
 
   @SuppressWarnings("unused")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -64,6 +64,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private TextUtils.TruncateAt mEllipsizeLocation;
   private boolean mAdjustsFontSizeToFit;
   private float mFontSize;
+  private float mMinimumFontSize;
+  private float mMaximumFontSize;
   private float mLetterSpacing;
   private int mLinkifyMaskType;
   private boolean mNotifyOnInlineViewLayout;
@@ -97,6 +99,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     mTextIsSelectable = false;
     mEllipsizeLocation = TextUtils.TruncateAt.END;
     mFontSize = Float.NaN;
+    mMinimumFontSize = Float.NaN;
+    mMaximumFontSize = Float.NaN;
     mLetterSpacing = 0.f;
 
     mSpanned = null;
@@ -359,17 +363,18 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   }
 
   @Override
-  protected void onDraw(Canvas canvas) {
+  public void layout(int l, int t, int r, int b) {
+    super.layout(l, t, r, b);
+
     if (this.mAdjustsFontSizeToFit && this.getSpanned() != null) {
-      // TODO: don't do this every frame
       TextLayoutManagerMapBuffer.adjustSpannableFontToFit(
         this.getSpanned(),
         this.getWidth(),
         YogaMeasureMode.EXACTLY,
         this.getHeight(),
         YogaMeasureMode.EXACTLY,
-        Double.NaN, // TODO
-        Double.NaN, // TODO
+        mMinimumFontSize,
+        mMaximumFontSize,
         this.mNumberOfLines,
         this.getIncludeFontPadding(),
         this.getBreakStrategy(),
@@ -377,8 +382,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
       );
       this.setText(this.getSpanned());
     }
-
-    super.onDraw(canvas);
   }
 
   public void setText(ReactTextUpdate update) {
@@ -614,6 +617,14 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
             : (float) Math.ceil(PixelUtil.toPixelFromDIP(fontSize));
 
     applyTextAttributes();
+  }
+
+  public void setMinimumFontSize(float minimumFontSize) {
+    mMinimumFontSize = minimumFontSize;
+  }
+
+  public void setMaximumFontSize(float maximumFontSize) {
+    mMaximumFontSize = maximumFontSize;
   }
 
   public void setLetterSpacing(float letterSpacing) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.text;
 
 import android.content.Context;
+import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.text.Layout;
@@ -44,6 +45,8 @@ import com.facebook.react.views.text.internal.span.ReactTagSpan;
 import com.facebook.react.views.text.internal.span.TextInlineImageSpan;
 import com.facebook.react.views.text.internal.span.TextInlineViewPlaceholderSpan;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
+import com.facebook.yoga.YogaMeasureMode;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -353,6 +356,29 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
         uiManager.receiveEvent(reactTag, "topInlineViewLayout", event);
       }
     }
+  }
+
+  @Override
+  protected void onDraw(Canvas canvas) {
+    if (this.mAdjustsFontSizeToFit && this.getSpanned() != null) {
+      // TODO: don't do this every frame
+      TextLayoutManagerMapBuffer.adjustSpannableFontToFit(
+        this.getSpanned(),
+        this.getWidth(),
+        YogaMeasureMode.EXACTLY,
+        this.getHeight(),
+        YogaMeasureMode.EXACTLY,
+        Double.NaN, // TODO
+        Double.NaN, // TODO
+        this.mNumberOfLines,
+        this.getIncludeFontPadding(),
+        this.getBreakStrategy(),
+        this.getHyphenationFrequency()
+      );
+      this.setText(this.getSpanned());
+    }
+
+    super.onDraw(canvas);
   }
 
   public void setText(ReactTextUpdate update) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -65,7 +65,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private boolean mAdjustsFontSizeToFit;
   private float mFontSize;
   private float mMinimumFontSize;
-  private float mMaximumFontSize;
   private float mLetterSpacing;
   private int mLinkifyMaskType;
   private boolean mNotifyOnInlineViewLayout;
@@ -102,7 +101,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     mEllipsizeLocation = TextUtils.TruncateAt.END;
     mFontSize = Float.NaN;
     mMinimumFontSize = Float.NaN;
-    mMaximumFontSize = Float.NaN;
     mLetterSpacing = 0.f;
 
     mSpanned = null;
@@ -375,7 +373,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
         this.getHeight(),
         YogaMeasureMode.EXACTLY,
         mMinimumFontSize,
-        mMaximumFontSize,
         this.mNumberOfLines,
         this.getIncludeFontPadding(),
         this.getBreakStrategy(),
@@ -624,10 +621,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   public void setMinimumFontSize(float minimumFontSize) {
     mMinimumFontSize = minimumFontSize;
-  }
-
-  public void setMaximumFontSize(float maximumFontSize) {
-    mMaximumFontSize = maximumFontSize;
   }
 
   public void setLetterSpacing(float letterSpacing) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -70,6 +70,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private int mLinkifyMaskType;
   private boolean mNotifyOnInlineViewLayout;
   private boolean mTextIsSelectable;
+  private boolean mShouldAdjustSpannableFontSize;
 
   private ReactViewBackgroundManager mReactBackgroundManager;
   private Spannable mSpanned;
@@ -97,6 +98,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     mLinkifyMaskType = 0;
     mNotifyOnInlineViewLayout = false;
     mTextIsSelectable = false;
+    mShouldAdjustSpannableFontSize = false;
     mEllipsizeLocation = TextUtils.TruncateAt.END;
     mFontSize = Float.NaN;
     mMinimumFontSize = Float.NaN;
@@ -363,10 +365,9 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   }
 
   @Override
-  public void layout(int l, int t, int r, int b) {
-    super.layout(l, t, r, b);
-
-    if (this.mAdjustsFontSizeToFit && this.getSpanned() != null) {
+  protected void onDraw(Canvas canvas) {
+    if (this.mAdjustsFontSizeToFit && this.getSpanned() != null && mShouldAdjustSpannableFontSize) {
+      mShouldAdjustSpannableFontSize = false;
       TextLayoutManagerMapBuffer.adjustSpannableFontToFit(
         this.getSpanned(),
         this.getWidth(),
@@ -382,6 +383,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
       );
       this.setText(this.getSpanned());
     }
+
+    super.onDraw(canvas);
   }
 
   public void setText(ReactTextUpdate update) {
@@ -685,6 +688,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   public void setSpanned(Spannable spanned) {
     mSpanned = spanned;
+    mShouldAdjustSpannableFontSize = true;
   }
 
   public Spannable getSpanned() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -604,6 +604,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   public void setNumberOfLines(int numberOfLines) {
     mNumberOfLines = numberOfLines == 0 ? ViewDefaults.NUMBER_OF_LINES : numberOfLines;
     setMaxLines(mNumberOfLines);
+    mShouldAdjustSpannableFontSize = true;
   }
 
   public void setAdjustFontSizeToFit(boolean adjustsFontSizeToFit) {
@@ -621,6 +622,25 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   public void setMinimumFontSize(float minimumFontSize) {
     mMinimumFontSize = minimumFontSize;
+    mShouldAdjustSpannableFontSize = true;
+  }
+
+  @Override
+  public void setIncludeFontPadding(boolean includepad) {
+    super.setIncludeFontPadding(includepad);
+    mShouldAdjustSpannableFontSize = true;
+  }
+
+  @Override
+  public void setBreakStrategy(int breakStrategy) {
+    super.setBreakStrategy(breakStrategy);
+    mShouldAdjustSpannableFontSize = true;
+  }
+
+  @Override
+  public void setHyphenationFrequency(int hyphenationFrequency) {
+    super.setHyphenationFrequency(hyphenationFrequency);
+    mShouldAdjustSpannableFontSize = true;
   }
 
   public void setLetterSpacing(float letterSpacing) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -177,9 +177,7 @@ public class ReactTextViewManager
     view.setSpanned(spanned);
 
     float minimumFontSize = (float) paragraphAttributes.getDouble(TextLayoutManagerMapBuffer.PA_KEY_MINIMUM_FONT_SIZE);
-    float maximumFontSize = (float) paragraphAttributes.getDouble(TextLayoutManagerMapBuffer.PA_KEY_MAXIMUM_FONT_SIZE);
     view.setMinimumFontSize(minimumFontSize);
-    view.setMaximumFontSize(maximumFontSize);
 
     int textBreakStrategy =
         TextAttributeProps.getTextBreakStrategy(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -176,6 +176,11 @@ public class ReactTextViewManager
             view.getContext(), attributedString, mReactTextViewManagerCallback);
     view.setSpanned(spanned);
 
+    float minimumFontSize = (float) paragraphAttributes.getDouble(TextLayoutManagerMapBuffer.PA_KEY_MINIMUM_FONT_SIZE);
+    float maximumFontSize = (float) paragraphAttributes.getDouble(TextLayoutManagerMapBuffer.PA_KEY_MAXIMUM_FONT_SIZE);
+    view.setMinimumFontSize(minimumFontSize);
+    view.setMaximumFontSize(maximumFontSize);
+
     int textBreakStrategy =
         TextAttributeProps.getTextBreakStrategy(
             paragraphAttributes.getString(TextLayoutManagerMapBuffer.PA_KEY_TEXT_BREAK_STRATEGY));

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -99,7 +99,7 @@ public class TextLayoutManager {
     return false;
   }
 
-  public static void setCachedSpannabledForTag(int reactTag, @NonNull Spannable sp) {
+  public static void setCachedSpannableForTag(int reactTag, @NonNull Spannable sp) {
     if (ENABLE_MEASURE_LOGGING) {
       FLog.e(TAG, "Set cached spannable for tag[" + reactTag + "]: " + sp.toString());
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -650,7 +650,8 @@ public class TextLayoutManagerMapBuffer {
       @NonNull Context context,
       MapBuffer attributedString,
       MapBuffer paragraphAttributes,
-      float width) {
+      float width,
+      float height) {
 
     Spannable text = getOrCreateSpannableForText(context, attributedString, null);
     BoringLayout.Metrics boring = BoringLayout.isBoring(text, sTextPaintInstance);
@@ -665,8 +666,34 @@ public class TextLayoutManagerMapBuffer {
     int hyphenationFrequency =
         TextAttributeProps.getTextBreakStrategy(
             paragraphAttributes.getString(PA_KEY_HYPHENATION_FREQUENCY));
+    boolean adjustFontSizeToFit =
+        paragraphAttributes.contains(PA_KEY_ADJUST_FONT_SIZE_TO_FIT)
+            ? paragraphAttributes.getBoolean(PA_KEY_ADJUST_FONT_SIZE_TO_FIT)
+            : DEFAULT_ADJUST_FONT_SIZE_TO_FIT;
+    int maximumNumberOfLines =
+        paragraphAttributes.contains(PA_KEY_MAX_NUMBER_OF_LINES)
+            ? paragraphAttributes.getInt(PA_KEY_MAX_NUMBER_OF_LINES)
+            : ReactConstants.UNSET;
 
-    // TODO: adjustFontSizeToFit
+
+    if (adjustFontSizeToFit) {
+        double minimumFontSize = paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE)
+            ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE)
+            : Double.NaN;
+
+      adjustSpannableFontToFit(
+          text,
+          width,
+          YogaMeasureMode.EXACTLY,
+          height,
+          YogaMeasureMode.UNDEFINED,
+          minimumFontSize,
+          maximumNumberOfLines,
+          includeFontPadding,
+          textBreakStrategy,
+          hyphenationFrequency
+      );
+    }
 
     Layout layout =
         createLayout(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -462,31 +462,30 @@ public class TextLayoutManagerMapBuffer {
         TextAttributeProps.getHyphenationFrequency(
             paragraphAttributes.getString(PA_KEY_HYPHENATION_FREQUENCY));
     boolean adjustFontSizeToFit =
-      paragraphAttributes.contains(PA_KEY_ADJUST_FONT_SIZE_TO_FIT)
-        ? paragraphAttributes.getBoolean(PA_KEY_ADJUST_FONT_SIZE_TO_FIT)
-        : DEFAULT_ADJUST_FONT_SIZE_TO_FIT;
+        paragraphAttributes.contains(PA_KEY_ADJUST_FONT_SIZE_TO_FIT)
+            ? paragraphAttributes.getBoolean(PA_KEY_ADJUST_FONT_SIZE_TO_FIT)
+            : DEFAULT_ADJUST_FONT_SIZE_TO_FIT;
     int maximumNumberOfLines =
-      paragraphAttributes.contains(PA_KEY_MAX_NUMBER_OF_LINES)
-        ? paragraphAttributes.getInt(PA_KEY_MAX_NUMBER_OF_LINES)
-        : ReactConstants.UNSET;
+        paragraphAttributes.contains(PA_KEY_MAX_NUMBER_OF_LINES)
+            ? paragraphAttributes.getInt(PA_KEY_MAX_NUMBER_OF_LINES)
+            : ReactConstants.UNSET;
 
     if (adjustFontSizeToFit) {
-      double minimumFontSize = paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE)
-        ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE)
-        : Double.NaN;
+        double minimumFontSize = paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE)
+            ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE)
+            : Double.NaN;
 
       adjustSpannableFontToFit(
-        text,
-        width,
-        widthYogaMeasureMode,
-        height,
-        heightYogaMeasureMode,
-        minimumFontSize,
-        maximumNumberOfLines,
-        includeFontPadding,
-        textBreakStrategy,
-        hyphenationFrequency
-      );
+          text,
+          width,
+          widthYogaMeasureMode,
+          height,
+          heightYogaMeasureMode,
+          minimumFontSize,
+          maximumNumberOfLines,
+          includeFontPadding,
+          textBreakStrategy,
+          hyphenationFrequency);
     }
 
     BoringLayout.Metrics boring = BoringLayout.isBoring(text, sTextPaintInstance);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -389,7 +389,6 @@ public class TextLayoutManagerMapBuffer {
     float height,
     YogaMeasureMode heightYogaMeasureMode,
     double minimumFontSizeAttr,
-    double maximumFontSizeAttr,
     int maximumNumberOfLines,
     boolean includeFontPadding,
     int textBreakStrategy,
@@ -475,9 +474,6 @@ public class TextLayoutManagerMapBuffer {
       double minimumFontSize = paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE)
         ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE)
         : Double.NaN;
-      double maximumFontSize = paragraphAttributes.contains(PA_KEY_MAXIMUM_FONT_SIZE)
-        ? paragraphAttributes.getDouble(PA_KEY_MAXIMUM_FONT_SIZE)
-        : Double.NaN;
 
       adjustSpannableFontToFit(
         text,
@@ -486,7 +482,6 @@ public class TextLayoutManagerMapBuffer {
         height,
         heightYogaMeasureMode,
         minimumFontSize,
-        maximumFontSize,
         maximumNumberOfLines,
         includeFontPadding,
         textBreakStrategy,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -110,7 +110,7 @@ public class TextLayoutManagerMapBuffer {
   private static final LruCache<ReadableMapBuffer, Spannable> sSpannableCache =
       new LruCache<>(spannableCacheSize);
 
-  public static void setCachedSpannabledForTag(int reactTag, @NonNull Spannable sp) {
+  public static void setCachedSpannableForTag(int reactTag, @NonNull Spannable sp) {
     if (ENABLE_MEASURE_LOGGING) {
       FLog.e(TAG, "Set cached spannable for tag[" + reactTag + "]: " + sp.toString());
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -397,16 +397,17 @@ public class TextLayoutManagerMapBuffer {
     BoringLayout.Metrics boring = BoringLayout.isBoring(text, sTextPaintInstance);
     Layout layout = createLayout(text, boring, width, widthYogaMeasureMode, includeFontPadding, textBreakStrategy, hyphenationFrequency);
 
-    // Find the largest font size used in the spannable to use as a starting point.
     // Minimum font size is 4pts to match the iOS implementation.
-    int currentFontSize = (int) (Double.isNaN(minimumFontSizeAttr) ? PixelUtil.toPixelFromDIP(4) : minimumFontSizeAttr);
+    int minimumFontSize = (int) (Double.isNaN(minimumFontSizeAttr) ? PixelUtil.toPixelFromDIP(4) : minimumFontSizeAttr);
+
+    // Find the largest font size used in the spannable to use as a starting point.
+    int currentFontSize = minimumFontSize;
     ReactAbsoluteSizeSpan[] spans = text.getSpans(0, text.length(), ReactAbsoluteSizeSpan.class);
     for (ReactAbsoluteSizeSpan span : spans) {
       currentFontSize = Math.max(currentFontSize, span.getSize());
     }
 
     int initialFontSize = currentFontSize;
-    int minimumFontSize = (int) (Double.isNaN(minimumFontSizeAttr) ? PixelUtil.toPixelFromDIP(4) : minimumFontSizeAttr);
     while (currentFontSize > minimumFontSize
       && (maximumNumberOfLines != ReactConstants.UNSET && layout.getLineCount() > maximumNumberOfLines
       || heightYogaMeasureMode != YogaMeasureMode.UNDEFINED && layout.getHeight() > height)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -475,8 +475,8 @@ public class TextLayoutManagerMapBuffer {
       double minimumFontSize = paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE)
         ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE)
         : Double.NaN;
-      double maximumFontSize = paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE)
-        ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE)
+      double maximumFontSize = paragraphAttributes.contains(PA_KEY_MAXIMUM_FONT_SIZE)
+        ? paragraphAttributes.getDouble(PA_KEY_MAXIMUM_FONT_SIZE)
         : Double.NaN;
 
       adjustSpannableFontToFit(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -408,9 +408,11 @@ public class TextLayoutManagerMapBuffer {
     }
 
     int initialFontSize = currentFontSize;
-    while (currentFontSize > minimumFontSize
-      && (maximumNumberOfLines != ReactConstants.UNSET && layout.getLineCount() > maximumNumberOfLines
-      || heightYogaMeasureMode != YogaMeasureMode.UNDEFINED && layout.getHeight() > height)) {
+        while (currentFontSize > minimumFontSize
+        && ((maximumNumberOfLines != ReactConstants.UNSET
+                && layout.getLineCount() > maximumNumberOfLines)
+            || (heightYogaMeasureMode != YogaMeasureMode.UNDEFINED
+                && layout.getHeight() > height))) {
       // TODO: We could probably use a smarter algorithm here. This will require 0(n)
       // measurements based on the number of points the font size needs to be reduced by.
       currentFontSize -= Math.max(1, (int) PixelUtil.toPixelFromDIP(1));

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -397,23 +397,21 @@ public class TextLayoutManagerMapBuffer {
     BoringLayout.Metrics boring = BoringLayout.isBoring(text, sTextPaintInstance);
     Layout layout = createLayout(text, boring, width, widthYogaMeasureMode, includeFontPadding, textBreakStrategy, hyphenationFrequency);
 
-    Object[] spans =
-      text.getSpans(0, text.length(), Object.class);
-    for (Object span : spans) {
-      Log.w("RCT", span.toString());
+    // Find the largest font size used in the spannable to use as a starting point.
+    // Minimum font size is 4pts to match the iOS implementation.
+    int currentFontSize = (int) (Double.isNaN(minimumFontSizeAttr) ? PixelUtil.toPixelFromDIP(4) : minimumFontSizeAttr);
+    ReactAbsoluteSizeSpan[] spans = text.getSpans(0, text.length(), ReactAbsoluteSizeSpan.class);
+    for (ReactAbsoluteSizeSpan span : spans) {
+      currentFontSize = Math.max(currentFontSize, span.getSize());
     }
 
-    // TODO: also grow size?
-    int initialFontSize = (int) (Double.isNaN(maximumFontSizeAttr) ? PixelUtil.toPixelFromDIP(96) : maximumFontSizeAttr);
-    int currentFontSize = (int) (Double.isNaN(maximumFontSizeAttr) ? PixelUtil.toPixelFromDIP(96) : maximumFontSizeAttr);
-    // Minimum font size is 4pts to match the iOS implementation.
-    int minimumFontSize = (int) (Double.isNaN(maximumFontSizeAttr) ? PixelUtil.toPixelFromDIP(4) : maximumFontSizeAttr);
+    int initialFontSize = currentFontSize;
+    int minimumFontSize = (int) (Double.isNaN(minimumFontSizeAttr) ? PixelUtil.toPixelFromDIP(4) : minimumFontSizeAttr);
     while (currentFontSize > minimumFontSize
       && (maximumNumberOfLines != ReactConstants.UNSET && layout.getLineCount() > maximumNumberOfLines
       || heightYogaMeasureMode != YogaMeasureMode.UNDEFINED && layout.getHeight() > height)) {
       // TODO: We could probably use a smarter algorithm here. This will require 0(n)
-      // measurements
-      // based on the number of points the font size needs to be reduced by.
+      // measurements based on the number of points the font size needs to be reduced by.
       currentFontSize -= Math.max(1, (int) PixelUtil.toPixelFromDIP(1));
 
       float ratio = (float) currentFontSize / (float) initialFontSize;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -1219,7 +1219,7 @@ public class ReactEditText extends AppCompatEditText {
     }
 
     addSpansFromStyleAttributes(sb);
-    TextLayoutManager.setCachedSpannabledForTag(getId(), sb);
+    TextLayoutManager.setCachedSpannableForTag(getId(), sb);
   }
 
   void setEventDispatcher(@Nullable EventDispatcher eventDispatcher) {

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -983,6 +983,8 @@ constexpr static MapBuffer::Key PA_KEY_TEXT_BREAK_STRATEGY = 2;
 constexpr static MapBuffer::Key PA_KEY_ADJUST_FONT_SIZE_TO_FIT = 3;
 constexpr static MapBuffer::Key PA_KEY_INCLUDE_FONT_PADDING = 4;
 constexpr static MapBuffer::Key PA_KEY_HYPHENATION_FREQUENCY = 5;
+constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SIZE = 6;
+constexpr static MapBuffer::Key PA_KEY_MAXIMUM_FONT_SIZE = 7;
 
 inline MapBuffer toMapBuffer(const ParagraphAttributes& paragraphAttributes) {
   auto builder = MapBufferBuilder();
@@ -1000,6 +1002,10 @@ inline MapBuffer toMapBuffer(const ParagraphAttributes& paragraphAttributes) {
   builder.putString(
       PA_KEY_HYPHENATION_FREQUENCY,
       toString(paragraphAttributes.android_hyphenationFrequency));
+  builder.putDouble(
+      PA_KEY_MINIMUM_FONT_SIZE, paragraphAttributes.minimumFontSize);
+  builder.putDouble(
+      PA_KEY_MAXIMUM_FONT_SIZE, paragraphAttributes.maximumFontSize);
 
   return builder.build();
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

`adjustsFontSizeToFit` prop is exposed on both platforms but is missing implementation on the new arch on Android. This Pr adds it.

Fixes https://github.com/facebook/react-native/issues/43104

## Changelog:

[ANDROID] [FIXED] - Fixed `adjustsFontSizeToFit`  not working on Android when using the new architecture

## Test Plan:

Tested on the RN Tester app using the `AdjustingFontSize` test:

| Old architecture | New architecture |
|------------------|------------------|
| <video src="https://github.com/facebook/react-native/assets/21055725/9243317c-1917-4ddb-9b8a-e9e99638409d">           | <video src="https://github.com/facebook/react-native/assets/21055725/39a7a9f2-21e4-4ba7-9ceb-dfec4ca6f643">         |






