### PR TITLE
Remove leftover fields from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,7 @@
   "name": "@react-native/monorepo",
   "private": true,
   "version": "1000.0.0",
-  "description": "A framework for building native apps using React",
   "license": "MIT",
-  "repository": "github:facebook/react-native",
-  "types": "types",
-  "jest-junit": {
-    "outputDirectory": "reports/junit",
-    "outputName": "js-test-results.xml"
-  },
   "scripts": {
     "android": "cd packages/rn-tester && npm run android",
     "build-android": "./gradlew :packages:react-native:ReactAndroid:build",
@@ -45,9 +38,6 @@
     "packages/*",
     "tools/*"
   ],
-  "peerDependencies": {
-    "react": "18.2.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/eslint-parser": "^7.20.0",


### PR DESCRIPTION
Summary:
Removes fields in the root `package.json` manifest left over from the monorepo migration. `@react-native/monorepo` is not a package published to npm, but is a root project configuration for the monorepo. Therefore it **doesn't need**:

- npm metadata fields (or even a `name` or `version` — I'm leaving these included due to 1/ references in fbsource, 2/ some non-Yarn tooling may complain).
- Fields used by tooling that are present in packages/react-native: `jest-junit`, `types`.
- A `peerDependency` on `react` (again, present in packages/react-native/package.json).

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D56134668


