### PR TITLE
Add boilerplate for handling Overlay.setPausedInDebuggerMessage

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -199,6 +199,11 @@ class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::
     [bridge_ reload];
   }
 
+  void onSetPausedInDebuggerMessage(const OverlaySetPausedInDebuggerMessageRequest &) override
+  {
+    // TODO(moti): Implement this
+  }
+
  private:
   __weak RCTBridge *bridge_;
 };

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1175,6 +1175,7 @@ public class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget : jav
 
 public abstract interface class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate {
 	public abstract fun onReload ()V
+	public abstract fun onSetPausedInDebuggerMessage (Ljava/lang/String;)V
 }
 
 public class com/facebook/react/bridge/ReactMarker {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1494,6 +1494,11 @@ public class ReactInstanceManager {
                 public void onReload() {
                   UiThreadUtil.runOnUiThread(() -> mDevSupportManager.handleReloadJS());
                 }
+
+                @Override
+                public void onSetPausedInDebuggerMessage(@Nullable String message) {
+                  // TODO(moti): Implement this
+                }
               });
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -10,11 +10,14 @@ package com.facebook.react.bridge;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
 import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
 
 @DoNotStripAny
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   public interface TargetDelegate {
     public void onReload();
+
+    public void onSetPausedInDebuggerMessage(@Nullable String message);
   }
 
   private final HybridData mHybridData;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -26,6 +26,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.infer.annotation.ThreadSafe;
+import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.JSEngineResolutionAlgorithm;
 import com.facebook.react.MemoryPressureRouter;
 import com.facebook.react.ReactHost;
@@ -464,6 +465,11 @@ public class ReactHostImpl implements ReactHost {
             },
             mBGExecutor)
         .continueWithTask(Task::getResult);
+  }
+
+  @DoNotStrip
+  private void setPausedInDebuggerMessage(@Nullable String message) {
+    // TODO(moti): Implement this
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -20,6 +20,14 @@ void ReactInstanceManagerInspectorTarget::TargetDelegate::onReload() const {
   method(self());
 }
 
+void ReactInstanceManagerInspectorTarget::TargetDelegate::
+    onSetPausedInDebuggerMessage(
+        const OverlaySetPausedInDebuggerMessageRequest& request) const {
+  auto method = javaClassStatic()->getMethod<void(local_ref<JString>)>(
+      "onSetPausedInDebuggerMessage");
+  method(self(), request.message ? make_jstring(*request.message) : nullptr);
+}
+
 ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
     jni::alias_ref<ReactInstanceManagerInspectorTarget::jhybridobject> jobj,
     jni::alias_ref<JExecutor::javaobject> executor,
@@ -80,6 +88,11 @@ void ReactInstanceManagerInspectorTarget::registerNatives() {
 void ReactInstanceManagerInspectorTarget::onReload(
     const PageReloadRequest& /*request*/) {
   delegate_->onReload();
+}
+
+void ReactInstanceManagerInspectorTarget::onSetPausedInDebuggerMessage(
+    const OverlaySetPausedInDebuggerMessageRequest& request) {
+  delegate_->onSetPausedInDebuggerMessage(request);
 }
 
 HostTarget* ReactInstanceManagerInspectorTarget::getInspectorTarget() {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -22,6 +22,8 @@ class ReactInstanceManagerInspectorTarget
         "Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;";
 
     void onReload() const;
+    void onSetPausedInDebuggerMessage(
+        const OverlaySetPausedInDebuggerMessageRequest& request) const;
   };
 
  public:
@@ -44,8 +46,12 @@ class ReactInstanceManagerInspectorTarget
 
   static void registerNatives();
 
-  void onReload(const PageReloadRequest& request) override;
   jsinspector_modern::HostTarget* getInspectorTarget();
+
+  // HostTargetDelegate methods
+  void onReload(const PageReloadRequest& request) override;
+  void onSetPausedInDebuggerMessage(
+      const OverlaySetPausedInDebuggerMessageRequest&) override;
 
  private:
   friend HybridBase;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -73,6 +73,11 @@ void JReactHostInspectorTarget::onReload(const PageReloadRequest& request) {
   javaReactHostImpl_->reload("CDP Page.reload");
 }
 
+void JReactHostInspectorTarget::onSetPausedInDebuggerMessage(
+    const OverlaySetPausedInDebuggerMessageRequest& request) {
+  javaReactHostImpl_->setPausedInDebuggerMessage(request.message);
+}
+
 HostTarget* JReactHostInspectorTarget::getInspectorTarget() {
   return inspectorTarget_ ? inspectorTarget_.get() : nullptr;
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -29,6 +29,13 @@ struct JReactHostImpl : public jni::JavaClass<JReactHostImpl> {
             "reload");
     return method(self(), reason);
   }
+
+  void setPausedInDebuggerMessage(std::optional<std::string> message) {
+    static auto method =
+        javaClassStatic()->getMethod<void(jni::local_ref<jni::JString>)>(
+            "setPausedInDebuggerMessage");
+    method(self(), message ? jni::make_jstring(*message) : nullptr);
+  }
 };
 
 class JReactHostInspectorTarget
@@ -48,6 +55,8 @@ class JReactHostInspectorTarget
   static void registerNatives();
 
   void onReload(const PageReloadRequest& request) override;
+  void onSetPausedInDebuggerMessage(
+      const OverlaySetPausedInDebuggerMessageRequest&) override;
 
   jsinspector_modern::HostTarget* getInspectorTarget();
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -46,6 +46,13 @@ class HostAgent final {
       HostTarget::SessionMetadata sessionMetadata,
       SessionState& sessionState);
 
+  HostAgent(const HostAgent&) = delete;
+  HostAgent(HostAgent&&) = delete;
+  HostAgent& operator=(const HostAgent&) = delete;
+  HostAgent& operator=(HostAgent&&) = delete;
+
+  ~HostAgent();
+
   /**
    * Handle a CDP request. The response will be sent over the provided
    * \c FrontendChannel synchronously or asynchronously.
@@ -90,6 +97,7 @@ class HostAgent final {
   const HostTarget::SessionMetadata sessionMetadata_;
   std::shared_ptr<InstanceAgent> instanceAgent_;
   FuseboxClientType fuseboxClientType_{FuseboxClientType::Unknown};
+  bool isPausedInDebuggerOverlayVisible_{false};
 
   /**
    * A shared reference to the session's state. This is only safe to access

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -67,6 +67,21 @@ class HostTargetDelegate {
     }
   };
 
+  struct OverlaySetPausedInDebuggerMessageRequest {
+    /**
+     * The message to display in the overlay. If nullopt, hide the overlay.
+     */
+    std::optional<std::string> message;
+
+    /**
+     * Equality operator, useful for unit tests
+     */
+    inline bool operator==(
+        const OverlaySetPausedInDebuggerMessageRequest& rhs) const {
+      return message == rhs.message;
+    }
+  };
+
   virtual ~HostTargetDelegate();
 
   /**
@@ -75,6 +90,19 @@ class HostTargetDelegate {
    * ILocalConnection::sendMessage was called).
    */
   virtual void onReload(const PageReloadRequest& request) = 0;
+
+  /**
+   * Called when the debugger requests that the "paused in debugger" overlay be
+   * shown or hidden. If the message is nullopt, hide the overlay, otherwise
+   * show it with the given message. This is called on the inspector thread.
+   *
+   * If this method is called with a non-null message, it's guaranteed to
+   * eventually be called again with a null message. In all other respects,
+   * the timing and payload of these messages are fully controlled by the
+   * client.
+   */
+  virtual void onSetPausedInDebuggerMessage(
+      const OverlaySetPausedInDebuggerMessageRequest& request) = 0;
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
@@ -206,6 +206,53 @@ TEST_F(HostTargetProtocolTest, PageReloadMethod) {
                          })");
 }
 
+TEST_F(HostTargetProtocolTest, OverlaySetPausedInDebuggerMessageMethod) {
+  InSequence s;
+
+  EXPECT_CALL(
+      hostTargetDelegate_,
+      onSetPausedInDebuggerMessage(
+          Eq(HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest{
+              .message = std::nullopt})))
+      .RetiresOnSaturation();
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "id": 1,
+                                               "result": {}
+                                             })")))
+      .RetiresOnSaturation();
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": "Overlay.setPausedInDebuggerMessage"
+                         })");
+
+  EXPECT_CALL(
+      hostTargetDelegate_,
+      onSetPausedInDebuggerMessage(
+          Eq(HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest{
+              .message = "Paused in debugger"})))
+      .RetiresOnSaturation();
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                               "id": 2,
+                                               "result": {}
+                                             })")))
+      .RetiresOnSaturation();
+  toPage_->sendMessage(R"({
+                           "id": 2,
+                           "method": "Overlay.setPausedInDebuggerMessage",
+                           "params": {
+                             "message": "Paused in debugger"
+                           }
+                         })");
+
+  // A cleanup message is sent automatically when we destroy the session.
+  EXPECT_CALL(
+      hostTargetDelegate_,
+      onSetPausedInDebuggerMessage(
+          Eq(HostTargetDelegate::OverlaySetPausedInDebuggerMessageRequest{
+              .message = std::nullopt})))
+      .RetiresOnSaturation();
+}
+
 TEST_F(HostTargetProtocolTest, RegisterUnregisterInstanceWithoutEvents) {
   auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -119,6 +119,11 @@ class MockHostTargetDelegate : public HostTargetDelegate {
  public:
   // HostTargetDelegate methods
   MOCK_METHOD(void, onReload, (const PageReloadRequest& request), (override));
+  MOCK_METHOD(
+      void,
+      onSetPausedInDebuggerMessage,
+      (const OverlaySetPausedInDebuggerMessageRequest& request),
+      (override));
 };
 
 class MockInstanceTargetDelegate : public InstanceTargetDelegate {};

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
@@ -183,6 +183,9 @@ class JsiIntegrationPortableTest : public ::testing::Test,
     (void)request;
     reload();
   }
+
+  void onSetPausedInDebuggerMessage(
+      const OverlaySetPausedInDebuggerMessageRequest&) override {}
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -38,6 +38,11 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     [static_cast<id<RCTReloadListener>>(host_) didReceiveReloadCommand];
   }
 
+  void onSetPausedInDebuggerMessage(const OverlaySetPausedInDebuggerMessageRequest &) override
+  {
+    // TODO(moti): Implement this
+  }
+
  private:
   __weak RCTHost *host_;
 };


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds stub support for the [`Overlay.setPausedInDebuggerMessage`](https://cdpstatus.reactnative.dev/devtools-protocol/tot/Overlay#method-setPausedInDebuggerMessage) CDP method to `HostAgent` in the Fusebox backend, and propagates it into the Android and iOS integrations through `HostTargetDelegate`.

Differential Revision: D56068444


