### PR TITLE
Add HostCommands for resuming and stepping debugger

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -199,6 +199,11 @@ class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::
     [bridge_ reload];
   }
 
+  void onSetPausedInDebuggerMessage(const OverlaySetPausedInDebuggerMessageRequest &) override
+  {
+    // TODO(moti): Implement this
+  }
+
  private:
   __weak RCTBridge *bridge_;
 };

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1175,6 +1175,7 @@ public class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget : jav
 
 public abstract interface class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate {
 	public abstract fun onReload ()V
+	public abstract fun onSetPausedInDebuggerMessage (Ljava/lang/String;)V
 }
 
 public class com/facebook/react/bridge/ReactMarker {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2127,6 +2127,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun handleException (Ljava/lang/Exception;)V
 	public fun hasUpToDateJSBundleInCache ()Z
 	protected fun hideDevLoadingView ()V
+	public fun hidePausedInDebuggerOverlay ()V
 	public fun hideRedboxDialog ()V
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
@@ -2146,6 +2147,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun showDevOptionsDialog ()V
 	public fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
 	public fun startInspector ()V
 	public fun stopInspector ()V
 	public fun toggleElementInspector ()V
@@ -2291,6 +2293,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun handleException (Ljava/lang/Exception;)V
 	public fun handleReloadJS ()V
 	public fun hasUpToDateJSBundleInCache ()Z
+	public fun hidePausedInDebuggerOverlay ()V
 	public fun hideRedboxDialog ()V
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public fun loadSplitBundleFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSplitBundleCallback;)V
@@ -2310,6 +2313,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun showDevOptionsDialog ()V
 	public fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
 	public fun startInspector ()V
 	public fun stopInspector ()V
 	public fun toggleElementInspector ()V
@@ -2401,6 +2405,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun getSourceUrl ()Ljava/lang/String;
 	public abstract fun handleReloadJS ()V
 	public abstract fun hasUpToDateJSBundleInCache ()Z
+	public abstract fun hidePausedInDebuggerOverlay ()V
 	public abstract fun hideRedboxDialog ()V
 	public abstract fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public abstract fun loadSplitBundleFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSplitBundleCallback;)V
@@ -2420,6 +2425,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun showDevOptionsDialog ()V
 	public abstract fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public abstract fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
 	public abstract fun startInspector ()V
 	public abstract fun stopInspector ()V
 	public abstract fun toggleElementInspector ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1494,6 +1494,11 @@ public class ReactInstanceManager {
                 public void onReload() {
                   UiThreadUtil.runOnUiThread(() -> mDevSupportManager.handleReloadJS());
                 }
+
+                @Override
+                public void onSetPausedInDebuggerMessage(@Nullable String message) {
+                  // TODO(moti): Implement this
+                }
               });
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1497,7 +1497,11 @@ public class ReactInstanceManager {
 
                 @Override
                 public void onSetPausedInDebuggerMessage(@Nullable String message) {
-                  // TODO(moti): Implement this
+                  if (message == null) {
+                    mDevSupportManager.hidePausedInDebuggerOverlay();
+                  } else {
+                    mDevSupportManager.showPausedInDebuggerOverlay(message);
+                  }
                 }
               });
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -10,11 +10,14 @@ package com.facebook.react.bridge;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
 import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
 
 @DoNotStripAny
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   public interface TargetDelegate {
     public void onReload();
+
+    public void onSetPausedInDebuggerMessage(@Nullable String message);
   }
 
   private final HybridData mHybridData;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -1164,4 +1164,34 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     mDevServerHelper.openDebugger(
         mCurrentContext, mApplicationContext.getString(R.string.catalyst_open_debugger_error));
   }
+
+  private @Nullable AlertDialog mPausedInDebuggerDialog;
+
+  @Override
+  public void showPausedInDebuggerOverlay(String message) {
+    UiThreadUtil.runOnUiThread(
+        () -> {
+          if (mPausedInDebuggerDialog != null) {
+            mPausedInDebuggerDialog.dismiss();
+          }
+          Activity context = mReactInstanceDevHelper.getCurrentActivity();
+          if (context == null || context.isFinishing()) {
+            return;
+          }
+          mPausedInDebuggerDialog =
+              new AlertDialog.Builder(context).setMessage(message).setCancelable(false).create();
+          mPausedInDebuggerDialog.show();
+        });
+  }
+
+  @Override
+  public void hidePausedInDebuggerOverlay() {
+    UiThreadUtil.runOnUiThread(
+        () -> {
+          if (mPausedInDebuggerDialog != null) {
+            mPausedInDebuggerDialog.dismiss();
+            mPausedInDebuggerDialog = null;
+          }
+        });
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java
@@ -207,4 +207,10 @@ public class ReleaseDevSupportManager implements DevSupportManager {
 
   @Override
   public void openDebugger() {}
+
+  @Override
+  public void showPausedInDebuggerOverlay(String message) {}
+
+  @Override
+  public void hidePausedInDebuggerOverlay() {}
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -105,6 +105,12 @@ public interface DevSupportManager : JSExceptionHandler {
   /** Attempt to open the JS debugger on the host machine. */
   public fun openDebugger()
 
+  /** Shows the "paused in debugger" overlay with the given message. */
+  public fun showPausedInDebuggerOverlay(message: String)
+
+  /** Hides the "paused in debugger" overlay, if currently shown. */
+  public fun hidePausedInDebuggerOverlay()
+
   /**
    * The PackagerLocationCustomizer allows you to have a dynamic packager location that is
    * determined right before loading the packager. Your customizer must call |callback|, as loading

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -469,7 +469,11 @@ public class ReactHostImpl implements ReactHost {
 
   @DoNotStrip
   private void setPausedInDebuggerMessage(@Nullable String message) {
-    // TODO(moti): Implement this
+    if (message == null) {
+      mDevSupportManager.hidePausedInDebuggerOverlay();
+    } else {
+      mDevSupportManager.showPausedInDebuggerOverlay(message);
+    }
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -26,6 +26,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.infer.annotation.ThreadSafe;
+import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.JSEngineResolutionAlgorithm;
 import com.facebook.react.MemoryPressureRouter;
 import com.facebook.react.ReactHost;
@@ -464,6 +465,11 @@ public class ReactHostImpl implements ReactHost {
             },
             mBGExecutor)
         .continueWithTask(Task::getResult);
+  }
+
+  @DoNotStrip
+  private void setPausedInDebuggerMessage(@Nullable String message) {
+    // TODO(moti): Implement this
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -20,6 +20,14 @@ void ReactInstanceManagerInspectorTarget::TargetDelegate::onReload() const {
   method(self());
 }
 
+void ReactInstanceManagerInspectorTarget::TargetDelegate::
+    onSetPausedInDebuggerMessage(
+        const OverlaySetPausedInDebuggerMessageRequest& request) const {
+  auto method = javaClassStatic()->getMethod<void(local_ref<JString>)>(
+      "onSetPausedInDebuggerMessage");
+  method(self(), request.message ? make_jstring(*request.message) : nullptr);
+}
+
 ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
     jni::alias_ref<ReactInstanceManagerInspectorTarget::jhybridobject> jobj,
     jni::alias_ref<JExecutor::javaobject> executor,
@@ -80,6 +88,11 @@ void ReactInstanceManagerInspectorTarget::registerNatives() {
 void ReactInstanceManagerInspectorTarget::onReload(
     const PageReloadRequest& /*request*/) {
   delegate_->onReload();
+}
+
+void ReactInstanceManagerInspectorTarget::onSetPausedInDebuggerMessage(
+    const OverlaySetPausedInDebuggerMessageRequest& request) {
+  delegate_->onSetPausedInDebuggerMessage(request);
 }
 
 HostTarget* ReactInstanceManagerInspectorTarget::getInspectorTarget() {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -22,6 +22,8 @@ class ReactInstanceManagerInspectorTarget
         "Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;";
 
     void onReload() const;
+    void onSetPausedInDebuggerMessage(
+        const OverlaySetPausedInDebuggerMessageRequest& request) const;
   };
 
  public:
@@ -44,8 +46,12 @@ class ReactInstanceManagerInspectorTarget
 
   static void registerNatives();
 
-  void onReload(const PageReloadRequest& request) override;
   jsinspector_modern::HostTarget* getInspectorTarget();
+
+  // HostTargetDelegate methods
+  void onReload(const PageReloadRequest& request) override;
+  void onSetPausedInDebuggerMessage(
+      const OverlaySetPausedInDebuggerMessageRequest&) override;
 
  private:
   friend HybridBase;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -73,6 +73,11 @@ void JReactHostInspectorTarget::onReload(const PageReloadRequest& request) {
   javaReactHostImpl_->reload("CDP Page.reload");
 }
 
+void JReactHostInspectorTarget::onSetPausedInDebuggerMessage(
+    const OverlaySetPausedInDebuggerMessageRequest& request) {
+  javaReactHostImpl_->setPausedInDebuggerMessage(request.message);
+}
+
 HostTarget* JReactHostInspectorTarget::getInspectorTarget() {
   return inspectorTarget_ ? inspectorTarget_.get() : nullptr;
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -29,6 +29,13 @@ struct JReactHostImpl : public jni::JavaClass<JReactHostImpl> {
             "reload");
     return method(self(), reason);
   }
+
+  void setPausedInDebuggerMessage(std::optional<std::string> message) {
+    static auto method =
+        javaClassStatic()->getMethod<void(jni::local_ref<jni::JString>)>(
+            "setPausedInDebuggerMessage");
+    method(self(), message ? jni::make_jstring(*message) : nullptr);
+  }
 };
 
 class JReactHostInspectorTarget
@@ -48,6 +55,8 @@ class JReactHostInspectorTarget
   static void registerNatives();
 
   void onReload(const PageReloadRequest& request) override;
+  void onSetPausedInDebuggerMessage(
+      const OverlaySetPausedInDebuggerMessageRequest&) override;
 
   jsinspector_modern::HostTarget* getInspectorTarget();
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/CdpJson.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CdpJson.cpp
@@ -58,4 +58,15 @@ std::string jsonNotification(
   return folly::toJson(std::move(dynamicNotification));
 }
 
+std::string jsonRequest(
+    RequestId id,
+    std::string_view method,
+    std::optional<folly::dynamic> params) {
+  auto dynamicRequest = folly::dynamic::object("id", id)("method", method);
+  if (params) {
+    dynamicRequest("params", *params);
+  }
+  return folly::toJson(std::move(dynamicRequest));
+}
+
 } // namespace facebook::react::jsinspector_modern::cdp

--- a/packages/react-native/ReactCommon/jsinspector-modern/CdpJson.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CdpJson.h
@@ -110,14 +110,28 @@ std::string jsonResult(
     const folly::dynamic& result = folly::dynamic::object());
 
 /**
- * Returns a JSON-formatted string representing a unilateral notifcation.
+ * Returns a JSON-formatted string representing a unilateral notification.
  *
  * {"method": <method>, "params": <params>}
  *
  * \param method Notification (aka "event") method.
- * \param params Optional payload pbject.
+ * \param params Optional payload object.
  */
 std::string jsonNotification(
+    std::string_view method,
+    std::optional<folly::dynamic> params = std::nullopt);
+
+/**
+ * Returns a JSON-formatted string representing a request.
+ *
+ * {"id": <id>, "method": <method>, "params": <params>}
+ *
+ * \param id Request ID.
+ * \param method Requested method.
+ * \param params Optional payload object.
+ */
+std::string jsonRequest(
+    RequestId id,
     std::string_view method,
     std::optional<folly::dynamic> params = std::nullopt);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -107,6 +107,22 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = true;
+  } else if (req.method == "Overlay.setPausedInDebuggerMessage") {
+    auto message = req.params.isObject() && req.params.count("message")
+        ? std::optional(req.params.at("message").asString())
+        : std::nullopt;
+    if (!isPausedInDebuggerOverlayVisible_ && message.has_value()) {
+      targetController_.incrementPauseOverlayCounter();
+    } else if (isPausedInDebuggerOverlayVisible_ && !message.has_value()) {
+      targetController_.decrementPauseOverlayCounter();
+    }
+    isPausedInDebuggerOverlayVisible_ = message.has_value();
+    targetController_.getDelegate().onSetPausedInDebuggerMessage({
+        .message = message,
+    });
+
+    shouldSendOKResponse = true;
+    isFinishedHandlingRequest = true;
   } else if (req.method == "FuseboxClient.setClientMetadata") {
     fuseboxClientType_ = FuseboxClientType::Fusebox;
 
@@ -152,6 +168,20 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
       req.id,
       cdp::ErrorCode::MethodNotFound,
       req.method + " not implemented yet"));
+}
+
+HostAgent::~HostAgent() {
+  if (isPausedInDebuggerOverlayVisible_) {
+    // In case of a non-graceful shutdown of the session, ensure we clean up
+    // the "paused on debugger" overlay if we've previously asked the
+    // integrator to display it.
+    isPausedInDebuggerOverlayVisible_ = false;
+    if (!targetController_.decrementPauseOverlayCounter()) {
+      targetController_.getDelegate().onSetPausedInDebuggerMessage({
+          .message = std::nullopt,
+      });
+    }
+  }
 }
 
 void HostAgent::sendFuseboxNotice() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -46,6 +46,13 @@ class HostAgent final {
       HostTarget::SessionMetadata sessionMetadata,
       SessionState& sessionState);
 
+  HostAgent(const HostAgent&) = delete;
+  HostAgent(HostAgent&&) = delete;
+  HostAgent& operator=(const HostAgent&) = delete;
+  HostAgent& operator=(HostAgent&&) = delete;
+
+  ~HostAgent();
+
   /**
    * Handle a CDP request. The response will be sent over the provided
    * \c FrontendChannel synchronously or asynchronously.
@@ -90,6 +97,7 @@ class HostAgent final {
   const HostTarget::SessionMetadata sessionMetadata_;
   std::shared_ptr<InstanceAgent> instanceAgent_;
   FuseboxClientType fuseboxClientType_{FuseboxClientType::Unknown};
+  bool isPausedInDebuggerOverlayVisible_{false};
 
   /**
    * A shared reference to the session's state. This is only safe to access

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostCommand.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostCommand.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react::jsinspector_modern {
+
+enum class HostCommand {
+  /** Resumes JavaScript execution. */
+  DebuggerResume,
+  /** Steps over the statement. */
+  DebuggerStepOver
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -162,4 +162,16 @@ bool HostTargetController::hasInstance() const {
   return target_.hasInstance();
 }
 
+void HostTargetController::incrementPauseOverlayCounter() {
+  ++pauseOverlayCounter_;
+}
+
+bool HostTargetController::decrementPauseOverlayCounter() {
+  assert(pauseOverlayCounter_ > 0 && "Pause overlay counter underflow");
+  if (--pauseOverlayCounter_ == 0) {
+    return false;
+  }
+  return true;
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -67,6 +67,21 @@ class HostTargetDelegate {
     }
   };
 
+  struct OverlaySetPausedInDebuggerMessageRequest {
+    /**
+     * The message to display in the overlay. If nullopt, hide the overlay.
+     */
+    std::optional<std::string> message;
+
+    /**
+     * Equality operator, useful for unit tests
+     */
+    inline bool operator==(
+        const OverlaySetPausedInDebuggerMessageRequest& rhs) const {
+      return message == rhs.message;
+    }
+  };
+
   virtual ~HostTargetDelegate();
 
   /**
@@ -75,6 +90,19 @@ class HostTargetDelegate {
    * ILocalConnection::sendMessage was called).
    */
   virtual void onReload(const PageReloadRequest& request) = 0;
+
+  /**
+   * Called when the debugger requests that the "paused in debugger" overlay be
+   * shown or hidden. If the message is nullopt, hide the overlay, otherwise
+   * show it with the given message. This is called on the inspector thread.
+   *
+   * If this method is called with a non-null message, it's guaranteed to
+   * eventually be called again with a null message. In all other respects,
+   * the timing and payload of these messages are fully controlled by the
+   * client.
+   */
+  virtual void onSetPausedInDebuggerMessage(
+      const OverlaySetPausedInDebuggerMessageRequest& request) = 0;
 };
 
 /**
@@ -89,8 +117,28 @@ class HostTargetController final {
 
   bool hasInstance() const;
 
+  /**
+   * Increments the target's pause overlay counter. The counter represents the
+   * exact number of Agents that have (concurrently) requested the pause
+   * overlay to be shown. It's the caller's responsibility to only call this
+   * when the pause overlay's requested state transitions from hidden to
+   * visible.
+   */
+  void incrementPauseOverlayCounter();
+
+  /**
+   * Decrements the target's pause overlay counter. The counter represents the
+   * exact number of Agents that have (concurrently) requested the pause
+   * overlay to be shown. It's the caller's responsibility to only call this
+   * when the pause overlay's requested state transitions from hidden to
+   * visible.
+   * \returns false if the counter has reached 0, otherwise true.
+   */
+  bool decrementPauseOverlayCounter();
+
  private:
   HostTarget& target_;
+  size_t pauseOverlayCounter_{0};
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -8,11 +8,11 @@
 #pragma once
 
 #include "ExecutionContextManager.h"
+#include "HostCommand.h"
+#include "InspectorInterfaces.h"
+#include "InstanceTarget.h"
 #include "ScopedExecutor.h"
 #include "WeakList.h"
-
-#include <jsinspector-modern/InspectorInterfaces.h>
-#include <jsinspector-modern/InstanceTarget.h>
 
 #include <optional>
 #include <string>
@@ -33,6 +33,7 @@ namespace facebook::react::jsinspector_modern {
 
 class HostTargetSession;
 class HostAgent;
+class HostCommandSender;
 class HostTarget;
 
 /**
@@ -202,6 +203,12 @@ class JSINSPECTOR_EXPORT HostTarget
    */
   void unregisterInstance(InstanceTarget& instance);
 
+  /**
+   * Sends an imperative command to the HostTarget. May be called from any
+   * thread.
+   */
+  void sendCommand(HostCommand command);
+
  private:
   /**
    * Constructs a new HostTarget.
@@ -220,6 +227,7 @@ class JSINSPECTOR_EXPORT HostTarget
   // briefly outliving the HostTarget, which it generally shouldn't).
   std::shared_ptr<ExecutionContextManager> executionContextManager_;
   std::shared_ptr<InstanceTarget> currentInstance_{nullptr};
+  std::unique_ptr<HostCommandSender> commandSender_;
 
   inline HostTargetDelegate& getDelegate() {
     return delegate_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorUtilities.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorUtilities.h
@@ -49,4 +49,12 @@ class RAIIRemoteConnection {
   std::unique_ptr<IRemoteConnection> remote_;
 };
 
+/**
+ * An \c IRemoteConnection that does nothing.
+ */
+class NullRemoteConnection : public IRemoteConnection {
+  inline void onMessage(std::string /*message*/) override {}
+  inline void onDisconnect() override {}
+};
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -119,6 +119,11 @@ class MockHostTargetDelegate : public HostTargetDelegate {
  public:
   // HostTargetDelegate methods
   MOCK_METHOD(void, onReload, (const PageReloadRequest& request), (override));
+  MOCK_METHOD(
+      void,
+      onSetPausedInDebuggerMessage,
+      (const OverlaySetPausedInDebuggerMessageRequest& request),
+      (override));
 };
 
 class MockInstanceTargetDelegate : public InstanceTargetDelegate {};

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
@@ -183,6 +183,9 @@ class JsiIntegrationPortableTest : public ::testing::Test,
     (void)request;
     reload();
   }
+
+  void onSetPausedInDebuggerMessage(
+      const OverlaySetPausedInDebuggerMessageRequest&) override {}
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -38,6 +38,11 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     [static_cast<id<RCTReloadListener>>(host_) didReceiveReloadCommand];
   }
 
+  void onSetPausedInDebuggerMessage(const OverlaySetPausedInDebuggerMessageRequest &) override
+  {
+    // TODO(moti): Implement this
+  }
+
  private:
   __weak RCTHost *host_;
 };


### PR DESCRIPTION
Summary:
## Design

Adds a new public `HostTarget::sendCommand` method, enabling integrators to send simple imperative commands to the target.

As an implementation detail, the commands are translated internally to CDP and sent over a dedicated `HostTargetSession` (encapsulated in `HostCommandSender`). Any response from the underlying Agent is ignored.

From the caller's perspective, these commands don't occur in the context of a session at all, and from the frontend's perspective, only the *effects* of the commands (if any) are seen.

## Use case

HostCommands are specifically useful when we want to resume/step execution in response to a UI action. The commands map directly to the `Debugger.resume` and `Debugger.stepOver` CDP methods.

NOTE: This is inspired by Chrome/V8's existing support for multiple concurrent CDP sessions. Any CDP client can successfully send `Debugger.resume` and `Debugger.stepOver` (without even subscribing to debugger events using `Debugger.enable`) and affect the state of other ongoing debugging sessions.

Changelog: [Internal]

Differential Revision: D56098083


