### PR TITLE
Add Step Over and Resume buttons to pause overlay

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1174,6 +1174,8 @@ public class com/facebook/react/bridge/ReactIgnorableMountingException : java/la
 public class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget : java/lang/AutoCloseable {
 	public fun <init> (Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;)V
 	public fun close ()V
+	public fun sendDebuggerResumeCommand ()V
+	public fun sendDebuggerStepOverCommand ()V
 }
 
 public abstract interface class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate {
@@ -2150,7 +2152,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun showDevOptionsDialog ()V
 	public fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
+	public fun showPausedInDebuggerOverlay (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSupportManager$PausedInDebuggerOverlayCommandListener;)V
 	public fun startInspector ()V
 	public fun stopInspector ()V
 	public fun toggleElementInspector ()V
@@ -2316,7 +2318,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun showDevOptionsDialog ()V
 	public fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
+	public fun showPausedInDebuggerOverlay (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSupportManager$PausedInDebuggerOverlayCommandListener;)V
 	public fun startInspector ()V
 	public fun stopInspector ()V
 	public fun toggleElementInspector ()V
@@ -2428,7 +2430,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun showDevOptionsDialog ()V
 	public abstract fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public abstract fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public abstract fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
+	public abstract fun showPausedInDebuggerOverlay (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSupportManager$PausedInDebuggerOverlayCommandListener;)V
 	public abstract fun startInspector ()V
 	public abstract fun stopInspector ()V
 	public abstract fun toggleElementInspector ()V
@@ -2437,6 +2439,11 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 
 public abstract interface class com/facebook/react/devsupport/interfaces/DevSupportManager$PackagerLocationCustomizer {
 	public abstract fun run (Ljava/lang/Runnable;)V
+}
+
+public abstract interface class com/facebook/react/devsupport/interfaces/DevSupportManager$PausedInDebuggerOverlayCommandListener {
+	public abstract fun onResume ()V
+	public abstract fun onStepOver ()V
 }
 
 public abstract interface class com/facebook/react/devsupport/interfaces/ErrorCustomizer {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2130,6 +2130,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun handleException (Ljava/lang/Exception;)V
 	public fun hasUpToDateJSBundleInCache ()Z
 	protected fun hideDevLoadingView ()V
+	public fun hidePausedInDebuggerOverlay ()V
 	public fun hideRedboxDialog ()V
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
@@ -2149,6 +2150,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun showDevOptionsDialog ()V
 	public fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
 	public fun startInspector ()V
 	public fun stopInspector ()V
 	public fun toggleElementInspector ()V
@@ -2294,6 +2296,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun handleException (Ljava/lang/Exception;)V
 	public fun handleReloadJS ()V
 	public fun hasUpToDateJSBundleInCache ()Z
+	public fun hidePausedInDebuggerOverlay ()V
 	public fun hideRedboxDialog ()V
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public fun loadSplitBundleFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSplitBundleCallback;)V
@@ -2313,6 +2316,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun showDevOptionsDialog ()V
 	public fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
 	public fun startInspector ()V
 	public fun stopInspector ()V
 	public fun toggleElementInspector ()V
@@ -2404,6 +2408,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun getSourceUrl ()Ljava/lang/String;
 	public abstract fun handleReloadJS ()V
 	public abstract fun hasUpToDateJSBundleInCache ()Z
+	public abstract fun hidePausedInDebuggerOverlay ()V
 	public abstract fun hideRedboxDialog ()V
 	public abstract fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public abstract fun loadSplitBundleFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSplitBundleCallback;)V
@@ -2423,6 +2428,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun showDevOptionsDialog ()V
 	public abstract fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
 	public abstract fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun showPausedInDebuggerOverlay (Ljava/lang/String;)V
 	public abstract fun startInspector ()V
 	public abstract fun stopInspector ()V
 	public abstract fun toggleElementInspector ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1502,7 +1502,11 @@ public class ReactInstanceManager {
 
                 @Override
                 public void onSetPausedInDebuggerMessage(@Nullable String message) {
-                  // TODO(moti): Implement this
+                  if (message == null) {
+                    mDevSupportManager.hidePausedInDebuggerOverlay();
+                  } else {
+                    mDevSupportManager.showPausedInDebuggerOverlay(message);
+                  }
                 }
               });
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -87,6 +87,7 @@ import com.facebook.react.devsupport.ReactInstanceDevHelper;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.devsupport.interfaces.DevSupportManager.PausedInDebuggerOverlayCommandListener;
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.internal.AndroidChoreographerProvider;
@@ -1505,7 +1506,25 @@ public class ReactInstanceManager {
                   if (message == null) {
                     mDevSupportManager.hidePausedInDebuggerOverlay();
                   } else {
-                    mDevSupportManager.showPausedInDebuggerOverlay(message);
+                    mDevSupportManager.showPausedInDebuggerOverlay(
+                        message,
+                        new PausedInDebuggerOverlayCommandListener() {
+                          @Override
+                          public void onResume() {
+                            UiThreadUtil.assertOnUiThread();
+                            if (mInspectorTarget != null) {
+                              mInspectorTarget.sendDebuggerResumeCommand();
+                            }
+                          }
+
+                          @Override
+                          public void onStepOver() {
+                            UiThreadUtil.assertOnUiThread();
+                            if (mInspectorTarget != null) {
+                              mInspectorTarget.sendDebuggerStepOverCommand();
+                            }
+                          }
+                        });
                   }
                 }
               });

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -40,6 +40,10 @@ public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
 
   private native HybridData initHybrid(Executor executor, TargetDelegate delegate);
 
+  public native void sendDebuggerResumeCommand();
+
+  public native void sendDebuggerStepOverCommand();
+
   public void close() {
     mHybridData.resetNative();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -1164,4 +1164,34 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     mDevServerHelper.openDebugger(
         mCurrentContext, mApplicationContext.getString(R.string.catalyst_open_debugger_error));
   }
+
+  private @Nullable AlertDialog mPausedInDebuggerDialog;
+
+  @Override
+  public void showPausedInDebuggerOverlay(String message) {
+    UiThreadUtil.runOnUiThread(
+        () -> {
+          if (mPausedInDebuggerDialog != null) {
+            mPausedInDebuggerDialog.dismiss();
+          }
+          Activity context = mReactInstanceDevHelper.getCurrentActivity();
+          if (context == null || context.isFinishing()) {
+            return;
+          }
+          mPausedInDebuggerDialog =
+              new AlertDialog.Builder(context).setMessage(message).setCancelable(false).create();
+          mPausedInDebuggerDialog.show();
+        });
+  }
+
+  @Override
+  public void hidePausedInDebuggerOverlay() {
+    UiThreadUtil.runOnUiThread(
+        () -> {
+          if (mPausedInDebuggerDialog != null) {
+            mPausedInDebuggerDialog.dismiss();
+            mPausedInDebuggerDialog = null;
+          }
+        });
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -1168,7 +1168,8 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   private @Nullable AlertDialog mPausedInDebuggerDialog;
 
   @Override
-  public void showPausedInDebuggerOverlay(String message) {
+  public void showPausedInDebuggerOverlay(
+      String message, PausedInDebuggerOverlayCommandListener listener) {
     UiThreadUtil.runOnUiThread(
         () -> {
           if (mPausedInDebuggerDialog != null) {
@@ -1179,7 +1180,14 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
             return;
           }
           mPausedInDebuggerDialog =
-              new AlertDialog.Builder(context).setMessage(message).setCancelable(false).create();
+              new AlertDialog.Builder(context)
+                  .setMessage(message)
+                  .setCancelable(false)
+                  .setNeutralButton(
+                      "Step Over", (DialogInterface dialog, int id) -> listener.onStepOver())
+                  .setPositiveButton(
+                      "Resume", (DialogInterface dialog, int id) -> listener.onResume())
+                  .create();
           mPausedInDebuggerDialog.show();
         });
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java
@@ -207,4 +207,10 @@ public class ReleaseDevSupportManager implements DevSupportManager {
 
   @Override
   public void openDebugger() {}
+
+  @Override
+  public void showPausedInDebuggerOverlay(String message) {}
+
+  @Override
+  public void hidePausedInDebuggerOverlay() {}
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java
@@ -209,7 +209,8 @@ public class ReleaseDevSupportManager implements DevSupportManager {
   public void openDebugger() {}
 
   @Override
-  public void showPausedInDebuggerOverlay(String message) {}
+  public void showPausedInDebuggerOverlay(
+      String message, PausedInDebuggerOverlayCommandListener listener) {}
 
   @Override
   public void hidePausedInDebuggerOverlay() {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -105,6 +105,12 @@ public interface DevSupportManager : JSExceptionHandler {
   /** Attempt to open the JS debugger on the host machine. */
   public fun openDebugger()
 
+  /** Shows the "paused in debugger" overlay with the given message. */
+  public fun showPausedInDebuggerOverlay(message: String)
+
+  /** Hides the "paused in debugger" overlay, if currently shown. */
+  public fun hidePausedInDebuggerOverlay()
+
   /**
    * The PackagerLocationCustomizer allows you to have a dynamic packager location that is
    * determined right before loading the packager. Your customizer must call |callback|, as loading

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -106,7 +106,10 @@ public interface DevSupportManager : JSExceptionHandler {
   public fun openDebugger()
 
   /** Shows the "paused in debugger" overlay with the given message. */
-  public fun showPausedInDebuggerOverlay(message: String)
+  public fun showPausedInDebuggerOverlay(
+      message: String,
+      listener: PausedInDebuggerOverlayCommandListener
+  )
 
   /** Hides the "paused in debugger" overlay, if currently shown. */
   public fun hidePausedInDebuggerOverlay()
@@ -118,5 +121,11 @@ public interface DevSupportManager : JSExceptionHandler {
    */
   public fun interface PackagerLocationCustomizer {
     public fun run(callback: Runnable?)
+  }
+
+  public interface PausedInDebuggerOverlayCommandListener {
+    public fun onResume()
+
+    public fun onStepOver()
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -469,7 +469,11 @@ public class ReactHostImpl implements ReactHost {
 
   @DoNotStrip
   private void setPausedInDebuggerMessage(@Nullable String message) {
-    // TODO(moti): Implement this
+    if (message == null) {
+      mDevSupportManager.hidePausedInDebuggerOverlay();
+    } else {
+      mDevSupportManager.showPausedInDebuggerOverlay(message);
+    }
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -53,6 +53,7 @@ import com.facebook.react.devsupport.DevSupportManagerBase;
 import com.facebook.react.devsupport.InspectorFlags;
 import com.facebook.react.devsupport.ReleaseDevSupportManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.devsupport.interfaces.DevSupportManager.PausedInDebuggerOverlayCommandListener;
 import com.facebook.react.fabric.ComponentFactory;
 import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.interfaces.TaskInterface;
@@ -472,7 +473,25 @@ public class ReactHostImpl implements ReactHost {
     if (message == null) {
       mDevSupportManager.hidePausedInDebuggerOverlay();
     } else {
-      mDevSupportManager.showPausedInDebuggerOverlay(message);
+      mDevSupportManager.showPausedInDebuggerOverlay(
+          message,
+          new PausedInDebuggerOverlayCommandListener() {
+            @Override
+            public void onResume() {
+              UiThreadUtil.assertOnUiThread();
+              if (mReactHostInspectorTarget != null) {
+                mReactHostInspectorTarget.sendDebuggerResumeCommand();
+              }
+            }
+
+            @Override
+            public void onStepOver() {
+              UiThreadUtil.assertOnUiThread();
+              if (mReactHostInspectorTarget != null) {
+                mReactHostInspectorTarget.sendDebuggerStepOverCommand();
+              }
+            }
+          });
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -24,6 +24,10 @@ internal class ReactHostInspectorTarget(private val reactHostImpl: ReactHostImpl
 
   private external fun initHybrid(reactHostImpl: ReactHostImpl, executor: Executor): HybridData
 
+  public external fun sendDebuggerResumeCommand()
+
+  public external fun sendDebuggerStepOverCommand()
+
   override fun close() {
     mHybridData.resetNative()
   }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -78,10 +78,36 @@ ReactInstanceManagerInspectorTarget::initHybrid(
   return makeCxxInstance(jobj, executor, delegate);
 }
 
+void ReactInstanceManagerInspectorTarget::sendDebuggerResumeCommand() {
+  if (inspectorTarget_) {
+    inspectorTarget_->sendCommand(HostCommand::DebuggerResume);
+  } else {
+    jni::throwNewJavaException(
+        "java/lang/IllegalStateException",
+        "Cannot send command while the Fusebox backend is not enabled");
+  }
+}
+
+void ReactInstanceManagerInspectorTarget::sendDebuggerStepOverCommand() {
+  if (inspectorTarget_) {
+    inspectorTarget_->sendCommand(HostCommand::DebuggerStepOver);
+  } else {
+    jni::throwNewJavaException(
+        "java/lang/IllegalStateException",
+        "Cannot send command while the Fusebox backend is not enabled");
+  }
+}
+
 void ReactInstanceManagerInspectorTarget::registerNatives() {
   registerHybrid({
       makeNativeMethod(
           "initHybrid", ReactInstanceManagerInspectorTarget::initHybrid),
+      makeNativeMethod(
+          "sendDebuggerResumeCommand",
+          ReactInstanceManagerInspectorTarget::sendDebuggerResumeCommand),
+      makeNativeMethod(
+          "sendDebuggerStepOverCommand",
+          ReactInstanceManagerInspectorTarget::sendDebuggerStepOverCommand),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -44,6 +44,9 @@ class ReactInstanceManagerInspectorTarget
           ReactInstanceManagerInspectorTarget::TargetDelegate::javaobject>
           delegate);
 
+  void sendDebuggerResumeCommand();
+  void sendDebuggerStepOverCommand();
+
   static void registerNatives();
 
   jsinspector_modern::HostTarget* getInspectorTarget();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -63,9 +63,35 @@ JReactHostInspectorTarget::initHybrid(
   return makeCxxInstance(reactHostImpl, executor);
 }
 
+void JReactHostInspectorTarget::sendDebuggerResumeCommand() {
+  if (inspectorTarget_) {
+    inspectorTarget_->sendCommand(HostCommand::DebuggerResume);
+  } else {
+    jni::throwNewJavaException(
+        "java/lang/IllegalStateException",
+        "Cannot send command while the Fusebox backend is not enabled");
+  }
+}
+
+void JReactHostInspectorTarget::sendDebuggerStepOverCommand() {
+  if (inspectorTarget_) {
+    inspectorTarget_->sendCommand(HostCommand::DebuggerStepOver);
+  } else {
+    jni::throwNewJavaException(
+        "java/lang/IllegalStateException",
+        "Cannot send command while the Fusebox backend is not enabled");
+  }
+}
+
 void JReactHostInspectorTarget::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", JReactHostInspectorTarget::initHybrid),
+      makeNativeMethod(
+          "sendDebuggerResumeCommand",
+          JReactHostInspectorTarget::sendDebuggerResumeCommand),
+      makeNativeMethod(
+          "sendDebuggerStepOverCommand",
+          JReactHostInspectorTarget::sendDebuggerStepOverCommand),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -53,12 +53,15 @@ class JReactHostInspectorTarget
       jni::alias_ref<JExecutor::javaobject>);
 
   static void registerNatives();
+  void sendDebuggerResumeCommand();
+  void sendDebuggerStepOverCommand();
 
+  jsinspector_modern::HostTarget* getInspectorTarget();
+
+  // HostTargetDelegate methods
   void onReload(const PageReloadRequest& request) override;
   void onSetPausedInDebuggerMessage(
       const OverlaySetPausedInDebuggerMessageRequest&) override;
-
-  jsinspector_modern::HostTarget* getInspectorTarget();
 
  private:
   JReactHostInspectorTarget(


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds the ability to interactively resume/step from the Fusebox "paused in debugger" overlay on Android. This uses HostCommands (D56098083) and extends the AlertDialog-based overlay (D56068445). In an upcoming diff on this stack, we'll update the design of the overlay to match Chrome's.

Differential Revision: D56098084
