### PR TITLE
ReactFeatureFlags.mFabricEnabled should default to ReactFeatureFlags.enableFabricRenderer

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -42,7 +42,7 @@ public class ReactDelegate {
 
   @Nullable private ReactSurface mReactSurface;
 
-  private boolean mFabricEnabled = false;
+  private boolean mFabricEnabled = ReactFeatureFlags.enableFabricRenderer;
 
   /**
    * Do not use this constructor as it's not accounting for New Architecture at all. You should


### PR DESCRIPTION
Summary:
The `mFabricEnabled` field is initialized to false. This is a misalignment with how other classes are behaving like
ReactActivityDelegate.

Changelog:
[Internal] [Changed] - ReactFeatureFlags.mFabricEnabled should default to ReactFeatureFlags.enableFabricRenderer

Reviewed By: arushikesarwani94

Differential Revision: D56013057


