### PR TITLE
Fix: OSS builds can accidentally using coreutils cp

### DIFF
--- a/packages/react-native-codegen/scripts/oss/build.sh
+++ b/packages/react-native-codegen/scripts/oss/build.sh
@@ -29,9 +29,10 @@ EDEN_SAFE_MV="mv"
 if [ -x "$(command -v eden)" ]; then
   pushd "$THIS_DIR"
 
-  # Detect if we are in an EdenFS checkout
+  # Detect if we are in an EdenFS checkout, but be sure to use /bin/cp
+  # incase users have GNU coreutils installed which is incompatible with -X
   if [[ "$OSTYPE" == "darwin"* ]] && eden info; then
-    EDEN_SAFE_MV="cp -R -X"
+    EDEN_SAFE_MV="/bin/cp -R -X"
   fi
 
   popd >/dev/null
@@ -60,7 +61,7 @@ else
   if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
     tar cf - --exclude='*.lock' "$CODEGEN_DIR" | (cd "$TMP_DIR" && tar xvf - );
   else
-    cp -R "$CODEGEN_DIR/." "$TMP_DIR";
+    /bin/cp -R "$CODEGEN_DIR/." "$TMP_DIR";
   fi
 
   pushd "$TMP_DIR" >/dev/null

--- a/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
+++ b/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
@@ -104,7 +104,7 @@ moveOutputs () {
     mkdir -p "$RCT_SCRIPT_OUTPUT_DIR"
 
     # Copy all output to output_dir
-    cp -R -X "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
+    /bin/cp -R -X "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
     echo "$LIBRARY_NAME output has been written to $RCT_SCRIPT_OUTPUT_DIR:" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
     ls -1 "$RCT_SCRIPT_OUTPUT_DIR" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
 }


### PR DESCRIPTION
Summary:
There are two places where we use a feature specific to the system version of 'cp', the:

  -X    Do not copy Extended Attributes (EAs) or resource forks.

This feature isn't available in GNU's cp, which is commonly installed on macOS using:

  brew install coreutils && brew link coreutils

We can avoid the problem alltogether by being specific about the path of the system cp.

Changelog: [General][Fixed] don't break script phase and codegen when coreutils installed on macOS

Differential Revision: D56143216


