### PR TITLE
Add QualifierAlignment to Clang Format Config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -84,6 +84,7 @@ SpacesInSquareBrackets: false
 Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
+QualifierAlignment: Left
 ---
 Language: ObjC
 ColumnLimit:     120

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -105,8 +105,8 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 {
   if (self = [super init]) {
     _configuration = configuration;
-    _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
-    _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+    _contextContainer = std::make_shared<const facebook::react::ContextContainer>();
+    _reactNativeConfig = std::make_shared<const facebook::react::EmptyReactNativeConfig>();
     _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
     _turboModuleManagerDelegate = turboModuleManagerDelegate;
   }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -74,11 +74,11 @@ using namespace facebook::react;
 {
   RCTAssert(state, @"`state` must not be null.");
   RCTAssert(
-      std::dynamic_pointer_cast<ImageShadowNode::ConcreteState const>(state),
+      std::dynamic_pointer_cast<const ImageShadowNode::ConcreteState>(state),
       @"`state` must be a pointer to `ImageShadowNode::ConcreteState`.");
 
-  auto oldImageState = std::static_pointer_cast<ImageShadowNode::ConcreteState const>(_state);
-  auto newImageState = std::static_pointer_cast<ImageShadowNode::ConcreteState const>(state);
+  auto oldImageState = std::static_pointer_cast<const ImageShadowNode::ConcreteState>(_state);
+  auto newImageState = std::static_pointer_cast<const ImageShadowNode::ConcreteState>(state);
 
   [self _setStateAndResubscribeImageResponseObserver:newImageState];
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -120,7 +120,7 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
 - (void)updateState:(const facebook::react::State::Shared &)state
            oldState:(const facebook::react::State::Shared &)oldState
 {
-  _state = std::static_pointer_cast<InputAccessoryShadowNode::ConcreteState const>(state);
+  _state = std::static_pointer_cast<const InputAccessoryShadowNode::ConcreteState>(state);
   CGSize oldScreenSize = RCTCGSizeFromSize(_state->getData().viewportSize);
   CGSize viewportSize = RCTViewportSize();
   viewportSize.height = std::nan("");

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -193,7 +193,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
 - (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
-  _state = std::static_pointer_cast<LegacyViewManagerInteropShadowNode::ConcreteState const>(state);
+  _state = std::static_pointer_cast<const LegacyViewManagerInteropShadowNode::ConcreteState>(state);
 }
 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
@@ -217,7 +217,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
       if (weakSelf) {
         __typeof(self) strongSelf = weakSelf;
         const auto &eventEmitter =
-            static_cast<LegacyViewManagerInteropViewEventEmitter const &>(*strongSelf->_eventEmitter);
+            static_cast<const LegacyViewManagerInteropViewEventEmitter &>(*strongSelf->_eventEmitter);
         eventEmitter.dispatchEvent(eventName, event);
       }
     };

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
@@ -63,7 +63,7 @@ using namespace facebook::react;
 
         auto newData = oldData;
         newData.padding = newPadding;
-        return std::make_shared<SafeAreaViewShadowNode::ConcreteState::Data const>(newData);
+        return std::make_shared<const SafeAreaViewShadowNode::ConcreteState::Data>(newData);
       });
 }
 
@@ -77,7 +77,7 @@ using namespace facebook::react;
 - (void)updateState:(const facebook::react::State::Shared &)state
            oldState:(const facebook::react::State::Shared &)oldState
 {
-  _state = std::static_pointer_cast<SafeAreaViewShadowNode::ConcreteState const>(state);
+  _state = std::static_pointer_cast<const SafeAreaViewShadowNode::ConcreteState>(state);
 }
 
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -308,8 +308,8 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 - (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
-  assert(std::dynamic_pointer_cast<ScrollViewShadowNode::ConcreteState const>(state));
-  _state = std::static_pointer_cast<ScrollViewShadowNode::ConcreteState const>(state);
+  assert(std::dynamic_pointer_cast<const ScrollViewShadowNode::ConcreteState>(state));
+  _state = std::static_pointer_cast<const ScrollViewShadowNode::ConcreteState>(state);
   auto &data = _state->getData();
 
   auto contentOffset = RCTCGPointFromPoint(data.contentOffset);
@@ -412,7 +412,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   _state->updateState([contentOffset](const ScrollViewShadowNode::ConcreteState::Data &data) {
     auto newData = data;
     newData.contentOffset = contentOffset;
-    return std::make_shared<ScrollViewShadowNode::ConcreteState::Data const>(newData);
+    return std::make_shared<const ScrollViewShadowNode::ConcreteState::Data>(newData);
   });
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -105,7 +105,7 @@ using namespace facebook::react;
 
 - (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
-  _state = std::static_pointer_cast<ParagraphShadowNode::ConcreteState const>(state);
+  _state = std::static_pointer_cast<const ParagraphShadowNode::ConcreteState>(state);
   [self setNeedsDisplay];
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -216,7 +216,7 @@ using namespace facebook::react;
 
 - (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
-  _state = std::static_pointer_cast<TextInputShadowNode::ConcreteState const>(state);
+  _state = std::static_pointer_cast<const TextInputShadowNode::ConcreteState>(state);
 
   if (!_state) {
     assert(false && "State is `null` for <TextInput> component.");

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -195,7 +195,7 @@ using namespace facebook::react;
   RCTAssert(
       propsRawPtr &&
           ([self class] == [RCTViewComponentView class] ||
-           typeid(*propsRawPtr).hash_code() != typeid(ViewProps const).hash_code()),
+           typeid(*propsRawPtr).hash_code() != typeid(const ViewProps).hash_code()),
       @"`RCTViewComponentView` subclasses (and `%@` particularly) must setup `_props`"
        " instance variable with a default value in the constructor.",
       NSStringFromClass([self class]));

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -145,7 +145,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
                 @"Legacy ViewManagers should be migrated to Fabric ComponentViews in the new architecture to reduce risk. Component using interop layer: %@",
                 componentNameString]);
 
-    auto flavor = std::make_shared<std::string const>(name);
+    auto flavor = std::make_shared<const std::string>(name);
     auto componentName = ComponentName{flavor->c_str()};
     auto componentHandle = reinterpret_cast<ComponentHandle>(componentName);
     auto constructor = [RCTLegacyViewManagerInteropComponentView componentDescriptorProvider].constructor;
@@ -159,7 +159,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   }
 
   // Fallback 4: use <UnimplementedView> if component doesn't exist.
-  auto flavor = std::make_shared<std::string const>(name);
+  auto flavor = std::make_shared<const std::string>(name);
   auto componentName = ComponentName{flavor->c_str()};
   auto componentHandle = reinterpret_cast<ComponentHandle>(componentName);
   auto constructor = [RCTUnimplementedViewComponentView componentDescriptorProvider].constructor;

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -295,7 +295,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   toolbox.asynchronousEventBeatFactory =
       [runtimeExecutor](const EventBeat::SharedOwnerBox &ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
-        std::make_unique<MainRunLoopObserver const>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
+        std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
     return std::make_unique<AsynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor);
   };
 

--- a/packages/react-native/React/Tests/Text/RCTParagraphComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Text/RCTParagraphComponentViewTests.mm
@@ -316,7 +316,7 @@ static ParagraphShadowNode::ConcreteState::Shared stateWithShadowNode(
     std::shared_ptr<ParagraphShadowNode> paragraphShadowNode)
 {
   auto sharedState =
-      std::static_pointer_cast<ParagraphShadowNode::ConcreteState const>(paragraphShadowNode->getState());
+      std::static_pointer_cast<const ParagraphShadowNode::ConcreteState>(paragraphShadowNode->getState());
   return sharedState;
 }
 

--- a/packages/react-native/ReactCommon/cxxreact/MoveWrapper.h
+++ b/packages/react-native/ReactCommon/cxxreact/MoveWrapper.h
@@ -107,7 +107,7 @@ class MoveWrapper {
 
   // If you want these you're probably doing it wrong, though they'd be
   // easy enough to implement
-  MoveWrapper& operator=(MoveWrapper const&) = delete;
+  MoveWrapper& operator=(const MoveWrapper&) = delete;
   MoveWrapper& operator=(MoveWrapper&&) = delete;
 
  private:

--- a/packages/react-native/ReactCommon/cxxreact/SystraceSection.h
+++ b/packages/react-native/ReactCommon/cxxreact/SystraceSection.h
@@ -50,7 +50,7 @@ struct DummySystraceSection {
  public:
   template <typename... ConvertsToStringPiece>
   explicit DummySystraceSection(
-      __unused const char* name,
+      const __unused char* name,
       __unused ConvertsToStringPiece&&... args) {}
 };
 using SystraceSection = DummySystraceSection;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/FollyDynamicMatchers.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/FollyDynamicMatchers.cpp
@@ -22,7 +22,7 @@ std::string as_string(folly::dynamic value) {
 }
 
 std::string explain_error(
-    folly::dynamic::json_pointer_resolution_error<folly::dynamic const> error) {
+    folly::dynamic::json_pointer_resolution_error<const folly::dynamic> error) {
   using err_code = folly::dynamic::json_pointer_resolution_error_code;
 
   switch (error.error_code) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/FollyDynamicMatchers.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/FollyDynamicMatchers.h
@@ -19,7 +19,7 @@ namespace folly_dynamic_matchers_utils {
 std::string as_string(std::string value);
 std::string as_string(folly::dynamic value);
 std::string explain_error(
-    folly::dynamic::json_pointer_resolution_error<folly::dynamic const> error);
+    folly::dynamic::json_pointer_resolution_error<const folly::dynamic> error);
 
 } // namespace folly_dynamic_matchers_utils
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
@@ -61,7 +61,7 @@ class ComponentDescriptorProviderRegistry final {
   mutable std::shared_mutex mutex_;
   mutable std::vector<std::weak_ptr<const ComponentDescriptorRegistry>>
       componentDescriptorRegistries_;
-  mutable std::unordered_map<ComponentHandle, ComponentDescriptorProvider const>
+  mutable std::unordered_map<ComponentHandle, const ComponentDescriptorProvider>
       componentDescriptorProviders_;
   mutable ComponentDescriptorProviderRequest
       componentDescriptorProviderRequest_{};

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
@@ -109,7 +109,7 @@ static const std::shared_ptr<void> constructCoordinator(
     bridgeProxy = unwrapManagedObjectWeakly(optionalBridgeProxy.value());
   }
 
-  auto componentName = *std::static_pointer_cast<std::string const>(flavor);
+  auto componentName = *std::static_pointer_cast<const std::string>(flavor);
   Class viewManagerClass = getViewManagerClass(componentName, bridge, bridgeProxy);
   assert(viewManagerClass);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
@@ -22,7 +22,7 @@ class LegacyViewManagerInteropViewProps final : public ViewProps {
 
 #pragma mark - Props
 
-  folly::dynamic const otherProps;
+  const folly::dynamic otherProps;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -97,7 +97,7 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
    */
   void updateStateIfNeeded(const Content& content);
 
-  std::shared_ptr<TextLayoutManager const> textLayoutManager_;
+  std::shared_ptr<const TextLayoutManager> textLayoutManager_;
 
   /*
    * Cached content of the subtree started from the node.

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphState.h
@@ -52,13 +52,13 @@ class ParagraphState final {
    * This is not on every platform. This is not used on Android, but is
    * used on the iOS mounting layer.
    */
-  std::weak_ptr<TextLayoutManager const> layoutManager;
+  std::weak_ptr<const TextLayoutManager> layoutManager;
 
 #ifdef ANDROID
   ParagraphState(
-      AttributedString const& attributedString,
-      ParagraphAttributes const& paragraphAttributes,
-      std::weak_ptr<const TextLayoutManager> const& layoutManager)
+      const AttributedString& attributedString,
+      const ParagraphAttributes& paragraphAttributes,
+      const std::weak_ptr<const TextLayoutManager>& layoutManager)
       : attributedString(attributedString),
         paragraphAttributes(paragraphAttributes),
         layoutManager(layoutManager) {}

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
@@ -36,7 +36,7 @@ class TextInputProps final : public BaseTextInputProps {
    */
   std::optional<Selection> selection{};
 
-  std::string const inputAccessoryViewID{};
+  const std::string inputAccessoryViewID{};
 
   bool onKeyPressSync{false};
   bool onChangeSync{false};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -398,7 +398,7 @@ BorderMetrics BaseViewProps::resolveBorderMetrics(
 }
 
 Transform BaseViewProps::resolveTransform(
-    LayoutMetrics const& layoutMetrics) const {
+    const LayoutMetrics& layoutMetrics) const {
   float viewWidth = layoutMetrics.frame.size.width;
   float viewHeight = layoutMetrics.frame.size.height;
   if (!transformOrigin.isSet() || (viewWidth == 0 && viewHeight == 0)) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/ViewTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/ViewTest.cpp
@@ -174,7 +174,7 @@ TEST_F(YogaDirtyFlagTest, removingLastChildMustDirtyYogaNode) {
 
         return oldShadowNode.clone(
             {ShadowNodeFragment::propsPlaceholder(),
-             std::make_shared<ShadowNode::ListOfShared const>(children)});
+             std::make_shared<const ShadowNode::ListOfShared>(children)});
       });
 
   EXPECT_TRUE(
@@ -193,7 +193,7 @@ TEST_F(YogaDirtyFlagTest, reversingListOfChildrenMustDirtyYogaNode) {
 
         return oldShadowNode.clone(
             {ShadowNodeFragment::propsPlaceholder(),
-             std::make_shared<ShadowNode::ListOfShared const>(children)});
+             std::make_shared<const ShadowNode::ListOfShared>(children)});
       });
 
   EXPECT_TRUE(

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
@@ -60,7 +60,7 @@ class ConcreteState : public State {
    */
   void updateState(Data&& newData) const {
     updateState([data{std::move(newData)}](const Data& oldData) -> SharedData {
-      return std::make_shared<Data const>(data);
+      return std::make_shared<const Data>(data);
     });
   }
 
@@ -85,7 +85,7 @@ class ConcreteState : public State {
     auto stateUpdate = StateUpdate{
         family, [=](const StateData::Shared& oldData) -> StateData::Shared {
           react_native_assert(oldData);
-          return callback(*static_cast<Data const*>(oldData.get()));
+          return callback(*static_cast<const Data*>(oldData.get()));
         }};
 
     family->dispatchRawState(std::move(stateUpdate));

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -20,7 +20,7 @@ template <class T>
 using LayoutableSmallVector = std::vector<T>;
 
 static LayoutableSmallVector<Rect> calculateTransformedFrames(
-    const LayoutableSmallVector<ShadowNode const*>& shadowNodeList,
+    const LayoutableSmallVector<const ShadowNode*>& shadowNodeList,
     LayoutableShadowNode::LayoutInspectingPolicy policy) {
   auto size = shadowNodeList.size();
   auto transformedFrames = LayoutableSmallVector<Rect>{size};

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
@@ -211,7 +211,7 @@ const RawValue* RawProps::at(
 
 void RawProps::iterateOverValues(
     const std::function<
-        void(RawPropsPropNameHash, const char*, RawValue const&)>& fn) const {
+        void(RawPropsPropNameHash, const char*, const RawValue&)>& fn) const {
   return parser_->iterateOverValues(*this, fn);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -101,7 +101,7 @@ class RawProps final {
    */
   void iterateOverValues(
       const std::function<
-          void(RawPropsPropNameHash, const char*, RawValue const&)>& fn) const;
+          void(RawPropsPropNameHash, const char*, const RawValue&)>& fn) const;
 
  private:
   friend class RawPropsParser;

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -174,7 +174,7 @@ void RawPropsParser::preparse(const RawProps& rawProps) const noexcept {
 void RawPropsParser::iterateOverValues(
     const RawProps& rawProps,
     const std::function<
-        void(RawPropsPropNameHash, const char*, RawValue const&)>& visit)
+        void(RawPropsPropNameHash, const char*, const RawValue&)>& visit)
     const {
   switch (rawProps.mode_) {
     case RawProps::Mode::Empty:

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -79,7 +79,7 @@ class RawPropsParser final {
   void iterateOverValues(
       const RawProps& rawProps,
       const std::function<
-          void(RawPropsPropNameHash, const char*, RawValue const&)>& visit)
+          void(RawPropsPropNameHash, const char*, const RawValue&)>& visit)
       const;
 
   mutable std::vector<RawPropsKey> keys_{};

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -313,7 +313,7 @@ const ShadowNodeFamily& ShadowNode::getFamily() const {
 
 ShadowNode::Unshared ShadowNode::cloneTree(
     const ShadowNodeFamily& shadowNodeFamily,
-    const std::function<ShadowNode::Unshared(ShadowNode const& oldShadowNode)>&
+    const std::function<ShadowNode::Unshared(const ShadowNode& oldShadowNode)>&
         callback,
     ShadowNodeTraits traits) const {
   auto ancestors = shadowNodeFamily.getAncestors(*this);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -101,7 +101,7 @@ class ShadowNode : public Sealable,
    */
   Unshared cloneTree(
       const ShadowNodeFamily& shadowNodeFamily,
-      const std::function<Unshared(ShadowNode const& oldShadowNode)>& callback,
+      const std::function<Unshared(const ShadowNode& oldShadowNode)>& callback,
       ShadowNodeTraits traits = {}) const;
 
 #pragma mark - Getters

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -91,7 +91,7 @@ class ShadowNodeFamily final {
    * Sets and gets the most recent state.
    */
   std::shared_ptr<const State> getMostRecentState() const;
-  void setMostRecentState(const std::shared_ptr<State const>& state) const;
+  void setMostRecentState(const std::shared_ptr<const State>& state) const;
 
   /*
    * Dispatches a state update with given priority.
@@ -134,7 +134,7 @@ class ShadowNodeFamily final {
   /*
    * Weak reference to the React instance handle
    */
-  InstanceHandle::Shared const instanceHandle_;
+  const InstanceHandle::Shared instanceHandle_;
 
   /*
    * `EventEmitter` associated with all nodes of the family.

--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -110,8 +110,8 @@ T convertRawProp(
     const PropsParserContext& context,
     const RawProps& rawProps,
     const char* name,
-    T const& sourceValue,
-    U const& defaultValue,
+    const T& sourceValue,
+    const U& defaultValue,
     const char* namePrefix = nullptr,
     const char* nameSuffix = nullptr) {
   const auto* rawValue = rawProps.at(name, namePrefix, nameSuffix);

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -269,7 +269,7 @@ TEST_F(ShadowNodeTest, handleState) {
       traits);
 
   TestShadowNode::ConcreteState::Shared _state =
-      std::static_pointer_cast<TestShadowNode::ConcreteState const>(
+      std::static_pointer_cast<const TestShadowNode::ConcreteState>(
           initialState);
   _state->updateState(TestState());
 
@@ -293,7 +293,7 @@ TEST_F(ShadowNodeTest, testCloneTree) {
   newTraits.set(ShadowNodeTraits::Trait::ClonedByNativeStateUpdate);
   auto rootNode = nodeA_->cloneTree(
       family,
-      [newTraits](ShadowNode const& oldShadowNode) {
+      [newTraits](const ShadowNode& oldShadowNode) {
         return oldShadowNode.clone({.traits = newTraits});
       },
       newTraits);
@@ -304,7 +304,7 @@ TEST_F(ShadowNodeTest, testCloneTree) {
   EXPECT_FALSE(rootNode->getChildren()[0]->getTraits().check(
       ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
-  auto const& firstLevelChild = *rootNode->getChildren()[1];
+  const auto& firstLevelChild = *rootNode->getChildren()[1];
 
   EXPECT_TRUE(firstLevelChild.getTraits().check(
       ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
@@ -312,7 +312,7 @@ TEST_F(ShadowNodeTest, testCloneTree) {
   EXPECT_FALSE(firstLevelChild.getChildren()[1]->getTraits().check(
       ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));
 
-  auto const& secondLevelchild = *firstLevelChild.getChildren()[0];
+  const auto& secondLevelchild = *firstLevelChild.getChildren()[0];
 
   EXPECT_TRUE(secondLevelchild.getTraits().check(
       ShadowNodeTraits::Trait::ClonedByNativeStateUpdate));

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -140,32 +140,32 @@ std::string toString(const std::optional<T>& value) {
  * types.
  */
 template <typename T>
-std::string getDebugName(T const& object) {
+std::string getDebugName(const T& object) {
   return "Node";
 }
 
 template <typename T>
-std::string getDebugValue(T const& object) {
+std::string getDebugValue(const T& object) {
   return "";
 }
 
 template <typename T>
 std::vector<T> getDebugChildren(
-    T const& object,
+    const T& object,
     DebugStringConvertibleOptions options) {
   return {};
 }
 
 template <typename T>
 std::vector<T> getDebugProps(
-    T const& object,
+    const T& object,
     DebugStringConvertibleOptions options) {
   return {};
 }
 
 template <typename T>
 std::string getDebugPropsDescription(
-    T const& object,
+    const T& object,
     DebugStringConvertibleOptions options) {
   if (options.depth >= options.maximumDepth) {
     return "";
@@ -195,7 +195,7 @@ std::string getDebugPropsDescription(
 
 template <typename T>
 std::string getDebugChildrenDescription(
-    T const& object,
+    const T& object,
     DebugStringConvertibleOptions options) {
   if (options.depth >= options.maximumDepth) {
     return "";
@@ -219,7 +219,7 @@ std::string getDebugChildrenDescription(
 
 template <typename T>
 std::string getDebugDescription(
-    T const& object,
+    const T& object,
     DebugStringConvertibleOptions options) {
   auto nameString = getDebugName(object);
   auto valueString = getDebugValue(object);
@@ -360,7 +360,7 @@ inline std::string getDebugDescription(
 // `std::unique_ptr<T>`
 template <typename T>
 inline std::string getDebugDescription(
-    const std::unique_ptr<T const>& pointer,
+    const std::unique_ptr<const T>& pointer,
     DebugStringConvertibleOptions options) {
   return getDebugDescription((void*)pointer.get(), options) + "(unique)";
 }

--- a/packages/react-native/ReactCommon/react/renderer/debug/SystraceSection.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/SystraceSection.h
@@ -50,7 +50,7 @@ struct DummySystraceSection {
  public:
   template <typename... ConvertsToStringPiece>
   explicit DummySystraceSection(
-      __unused const char* name,
+      const __unused char* name,
       __unused ConvertsToStringPiece&&... args) {}
 };
 using SystraceSection = DummySystraceSection;

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
@@ -350,7 +350,7 @@ DOMPoint getScrollPosition(
     return DOMPoint{};
   }
 
-  auto layoutableShadowNode = dynamic_cast<LayoutableShadowNode const*>(
+  auto layoutableShadowNode = dynamic_cast<const LayoutableShadowNode*>(
       shadowNodeInCurrentRevision.get());
   // This should never happen
   if (layoutableShadowNode == nullptr) {
@@ -385,7 +385,7 @@ DOMSizeRounded getScrollSize(
     return DOMSizeRounded{};
   }
 
-  auto layoutableShadowNode = dynamic_cast<YogaLayoutableShadowNode const*>(
+  auto layoutableShadowNode = dynamic_cast<const YogaLayoutableShadowNode*>(
       shadowNodeInCurrentRevision.get());
   // This should never happen
   if (layoutableShadowNode == nullptr) {

--- a/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.cpp
@@ -35,7 +35,7 @@ ShadowNode::Unshared ComponentBuilder::build(
   auto constShadowNode = componentDescriptor.createShadowNode(
       ShadowNodeFragment{
           elementFragment.props,
-          std::make_shared<ShadowNode::ListOfShared const>(children),
+          std::make_shared<const ShadowNode::ListOfShared>(children),
           initialState},
       family);
 

--- a/packages/react-native/ReactCommon/react/renderer/element/Element.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/Element.h
@@ -38,7 +38,7 @@ class Element final {
   using ConcreteUnsharedShadowNode = std::shared_ptr<ConcreteShadowNode>;
 
   using ConcreteReferenceCallback =
-      std::function<void(const std::shared_ptr<ShadowNodeT const>& shadowNode)>;
+      std::function<void(const std::shared_ptr<const ShadowNodeT>& shadowNode)>;
 
   /*
    * Constructs an `Element`.
@@ -96,7 +96,7 @@ class Element final {
         [callback = std::move(callback)](
             const State::Shared& state) -> StateData::Shared {
       auto stateData =
-          static_cast<ConcreteState const*>(state.get())->getData();
+          static_cast<const ConcreteState*>(state.get())->getData();
       callback(stateData);
       return std::make_shared<ConcreteStateData>(stateData);
     };
@@ -126,7 +126,7 @@ class Element final {
     fragment_.referenceCallback =
         [callback = std::move(callback)](const ShadowNode::Shared& shadowNode) {
           callback(std::const_pointer_cast<ConcreteShadowNode>(
-              std::static_pointer_cast<ConcreteShadowNode const>(shadowNode)));
+              std::static_pointer_cast<const ConcreteShadowNode>(shadowNode)));
         };
     return *this;
   }
@@ -138,7 +138,7 @@ class Element final {
   Element& reference(ConcreteUnsharedShadowNode& outShadowNode) {
     fragment_.referenceCallback = [&](const ShadowNode::Shared& shadowNode) {
       outShadowNode = std::const_pointer_cast<ConcreteShadowNode>(
-          std::static_pointer_cast<ConcreteShadowNode const>(shadowNode));
+          std::static_pointer_cast<const ConcreteShadowNode>(shadowNode));
     };
     return *this;
   }

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -121,7 +121,7 @@ static void progressStateIfNecessary(
       continue;
     }
 
-    auto const& baseChildNode = *(*baseChildNodeIterator);
+    const auto& baseChildNode = *(*baseChildNodeIterator);
 
     if (!baseChildNode.getTraits().check(
             ShadowNodeTraits::Trait::ClonedByNativeStateUpdate)) {
@@ -176,7 +176,7 @@ static ShadowNode::Unshared progressState(const ShadowNode& shadowNode) {
 
   return shadowNode.clone({
       ShadowNodeFragment::propsPlaceholder(),
-      areChildrenChanged ? std::make_shared<ShadowNode::ListOfShared const>(
+      areChildrenChanged ? std::make_shared<const ShadowNode::ListOfShared>(
                                std::move(newChildren))
                          : ShadowNodeFragment::childrenPlaceholder(),
       isStateChanged ? newState : ShadowNodeFragment::statePlaceholder(),
@@ -263,7 +263,7 @@ static ShadowNode::Unshared progressState(
 
   return shadowNode.clone({
       ShadowNodeFragment::propsPlaceholder(),
-      areChildrenChanged ? std::make_shared<ShadowNode::ListOfShared const>(
+      areChildrenChanged ? std::make_shared<const ShadowNode::ListOfShared>(
                                std::move(newChildren))
                          : ShadowNodeFragment::childrenPlaceholder(),
       isStateChanged ? newState : ShadowNodeFragment::statePlaceholder(),

--- a/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.cpp
@@ -182,7 +182,7 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
           STUB_VIEW_LOG({
             std::string strChildList = "";
             int i = 0;
-            for (auto const& child : parentStubView->children) {
+            for (const auto& child : parentStubView->children) {
               strChildList.append(std::to_string(i));
               strChildList.append(":");
               strChildList.append(std::to_string(child->tag));

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/OrderIndexTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/OrderIndexTest.cpp
@@ -88,7 +88,7 @@ class OrderIndexTest : public ::testing::Test {
   }
 
   void testViewTree_(
-      const std::function<void(StubViewTree const& viewTree)>& callback) {
+      const std::function<void(const StubViewTree& viewTree)>& callback) {
     rootShadowNode_->layoutIfNeeded();
 
     callback(buildStubViewTreeUsingDifferentiator(*rootShadowNode_));

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -164,7 +164,7 @@ class StackingContextTest : public ::testing::Test {
   }
 
   void testViewTree_(
-      const std::function<void(StubViewTree const& viewTree)>& callback) {
+      const std::function<void(const StubViewTree& viewTree)>& callback) {
     rootShadowNode_->layoutIfNeeded();
 
     callback(buildStubViewTreeUsingDifferentiator(*rootShadowNode_));

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -364,8 +364,8 @@ TEST_P(RuntimeSchedulerTest, continuationTask) {
         jsi::PropNameID::forUtf8(*runtime_, ""),
         1,
         [&](jsi::Runtime& /*runtime*/,
-            jsi::Value const& /*unused*/,
-            jsi::Value const* /*arguments*/,
+            const jsi::Value& /*unused*/,
+            const jsi::Value* /*arguments*/,
             size_t /*unused*/) noexcept -> jsi::Value {
           didContinuationTask = true;
           return jsi::Value::undefined();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -75,7 +75,7 @@ Scheduler::Scheduler(
                        ReactEventPriority priority,
                        const EventPayload& payload) {
     uiManager->visitBinding(
-        [&](UIManagerBinding const& uiManagerBinding) {
+        [&](const UIManagerBinding& uiManagerBinding) {
           uiManagerBinding.dispatchEvent(
               runtime, eventTarget, type, priority, payload);
         },

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -86,7 +86,7 @@ void SurfaceManager::constraintSurfaceLayout(
 
 void SurfaceManager::visit(
     SurfaceId surfaceId,
-    const std::function<void(SurfaceHandler const& surfaceHandler)>& callback)
+    const std::function<void(const SurfaceHandler& surfaceHandler)>& callback)
     const noexcept {
   std::shared_lock lock(mutex_);
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -55,7 +55,7 @@ class SurfaceManager final {
  private:
   void visit(
       SurfaceId surfaceId,
-      const std::function<void(SurfaceHandler const& surfaceHandler)>& callback)
+      const std::function<void(const SurfaceHandler& surfaceHandler)>& callback)
       const noexcept;
 
   const Scheduler& scheduler_;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutContext.h
@@ -26,14 +26,14 @@ struct TextLayoutContext {
 };
 
 inline bool operator==(
-    TextLayoutContext const& lhs,
-    TextLayoutContext const& rhs) {
+    const TextLayoutContext& lhs,
+    const TextLayoutContext& rhs) {
   return std::tie(lhs.pointScaleFactor) == std::tie(rhs.pointScaleFactor);
 }
 
 inline bool operator!=(
-    TextLayoutContext const& lhs,
-    TextLayoutContext const& rhs) {
+    const TextLayoutContext& lhs,
+    const TextLayoutContext& rhs) {
   return !(lhs == rhs);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -176,7 +176,7 @@ void UIManager::completeSurface(
 
   shadowTreeRegistry_.visit(surfaceId, [&](const ShadowTree& shadowTree) {
     auto result = shadowTree.commit(
-        [&](RootShadowNode const& oldRootShadowNode) {
+        [&](const RootShadowNode& oldRootShadowNode) {
           return std::make_shared<RootShadowNode>(
               oldRootShadowNode,
               ShadowNodeFragment{
@@ -367,11 +367,11 @@ void UIManager::updateState(const StateUpdate& stateUpdate) const {
   shadowTreeRegistry_.visit(
       family->getSurfaceId(), [&](const ShadowTree& shadowTree) {
         shadowTree.commit(
-            [&](RootShadowNode const& oldRootShadowNode) {
+            [&](const RootShadowNode& oldRootShadowNode) {
               auto isValid = true;
 
               auto rootNode = oldRootShadowNode.cloneTree(
-                  *family, [&](ShadowNode const& oldShadowNode) {
+                  *family, [&](const ShadowNode& oldShadowNode) {
                     auto newData =
                         callback(oldShadowNode.getState()->getDataPointer());
 
@@ -435,9 +435,9 @@ void UIManager::setNativeProps_DEPRECATED(
         auto ancestorShadowNode =
             shadowTree.getCurrentRevision().rootShadowNode;
         shadowTree.commit(
-            [&](RootShadowNode const& oldRootShadowNode) {
+            [&](const RootShadowNode& oldRootShadowNode) {
               auto rootNode = oldRootShadowNode.cloneTree(
-                  family, [&](ShadowNode const& oldShadowNode) {
+                  family, [&](const ShadowNode& oldShadowNode) {
                     auto& componentDescriptor =
                         componentDescriptorRegistry_->at(
                             shadowNode->getComponentHandle());
@@ -501,7 +501,7 @@ ShadowNode::Shared UIManager::findShadowNodeByTag_DEPRECATED(Tag tag) const {
   auto shadowNode = ShadowNode::Shared{};
 
   shadowTreeRegistry_.enumerate([&](const ShadowTree& shadowTree, bool& stop) {
-    RootShadowNode const* rootShadowNode;
+    const RootShadowNode* rootShadowNode;
     // The public interface of `ShadowTree` discourages accessing a stored
     // pointer to a root node because of the possible data race.
     // To work around this, we ask for a commit and immediately cancel it
@@ -510,16 +510,16 @@ ShadowNode::Shared UIManager::findShadowNodeByTag_DEPRECATED(Tag tag) const {
     // because this `findShadowNodeByTag` is deprecated. It is only added
     // to make migration to the new architecture easier.
     shadowTree.tryCommit(
-        [&](RootShadowNode const& oldRootShadowNode) {
+        [&](const RootShadowNode& oldRootShadowNode) {
           rootShadowNode = &oldRootShadowNode;
           return nullptr;
         },
         {/* default commit options */});
 
     if (rootShadowNode != nullptr) {
-      auto const& children = rootShadowNode->getChildren();
+      const auto& children = rootShadowNode->getChildren();
       if (!children.empty()) {
-        auto const& child = children.front();
+        const auto& child = children.front();
         shadowNode = findShadowNodeByTagRecursively(child, tag);
         if (shadowNode) {
           stop = true;
@@ -545,7 +545,7 @@ UIManagerDelegate* UIManager::getDelegate() {
 }
 
 void UIManager::visitBinding(
-    const std::function<void(UIManagerBinding const& uiManagerBinding)>&
+    const std::function<void(const UIManagerBinding& uiManagerBinding)>&
         callback,
     jsi::Runtime& runtime) const {
   auto uiManagerBinding = UIManagerBinding::getBinding(runtime);

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -78,7 +78,7 @@ class UIManager final : public ShadowTreeDelegate {
    * The callback is called synchronously on the same thread.
    */
   void visitBinding(
-      const std::function<void(UIManagerBinding const& uiManagerBinding)>&
+      const std::function<void(const UIManagerBinding& uiManagerBinding)>&
           callback,
       jsi::Runtime& runtime) const;
 

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -40,7 +40,7 @@ class ShadowTreeEdge final {
 
 static bool traverseShadowTree(
     const ShadowNode::Shared& parentShadowNode,
-    const std::function<void(ShadowTreeEdge const& edge, bool& stop)>&
+    const std::function<void(const ShadowTreeEdge& edge, bool& stop)>&
         callback) {
   auto index = int{0};
   for (const auto& childNode : parentShadowNode->getChildren()) {
@@ -115,7 +115,7 @@ static inline ShadowNode::Unshared messWithChildren(
   entropy.shuffle(children);
   return shadowNode.clone(
       {ShadowNodeFragment::propsPlaceholder(),
-       std::make_shared<ShadowNode::ListOfShared const>(children)});
+       std::make_shared<const ShadowNode::ListOfShared>(children)});
 }
 
 static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(

--- a/packages/react-native/ReactCommon/react/utils/ContextContainer.h
+++ b/packages/react-native/ReactCommon/react/utils/ContextContainer.h
@@ -39,7 +39,7 @@ class ContextContainer final {
    *`ReactNativeConfig`.
    */
   template <typename T>
-  void insert(const std::string& key, T const& instance) const {
+  void insert(const std::string& key, const T& instance) const {
     std::unique_lock lock(mutex_);
 
     instances_.insert({key, std::make_shared<T>(instance)});

--- a/packages/react-native/ReactCommon/react/utils/fnv1a.h
+++ b/packages/react-native/ReactCommon/react/utils/fnv1a.h
@@ -27,7 +27,7 @@ constexpr uint32_t fnv1a(std::string_view string) noexcept {
 
   uint32_t hash = offset_basis;
 
-  for (auto const& c : string) {
+  for (const auto& c : string) {
     hash ^= static_cast<int8_t>(CharTransformT{}(c));
     // Using shifts and adds instead of multiplication with a prime number.
     // This is faster when compiled with optimizations.


### PR DESCRIPTION
Summary:
This sets `QualiferAlignment` so that code is automatically formatted to west const, matching https://www.internalfb.com/intern/wiki/Cpp/CppStyle

I did a pass at this before, but now that we are on new Clang Format, we can enforce it automatically, and I think a couple more cases not previously changed now are.

Changelog: [Internal]

Differential Revision: D56143678
