### PR TITLE
Configure fragment-based nav to work with useEffect()

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -179,7 +179,6 @@ public class com/facebook/react/ReactFragment : androidx/fragment/app/Fragment, 
 	protected static final field ARG_FABRIC_ENABLED Ljava/lang/String;
 	protected static final field ARG_LAUNCH_OPTIONS Ljava/lang/String;
 	protected field mReactDelegate Lcom/facebook/react/ReactDelegate;
-	protected field shouldCallDelegateLifecycleEvents Z
 	public fun <init> ()V
 	public fun checkPermission (Ljava/lang/String;II)I
 	public fun checkSelfPermission (Ljava/lang/String;)I

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -32,8 +32,6 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
 
   protected ReactDelegate mReactDelegate;
 
-  protected boolean shouldCallDelegateLifecycleEvents = true;
-
   @Nullable private PermissionListener mPermissionListener;
 
   public ReactFragment() {
@@ -101,25 +99,19 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
   @Override
   public void onResume() {
     super.onResume();
-    if (shouldCallDelegateLifecycleEvents) {
-      mReactDelegate.onHostResume();
-    }
+    mReactDelegate.onHostResume();
   }
 
   @Override
   public void onPause() {
     super.onPause();
-    if (shouldCallDelegateLifecycleEvents) {
-      mReactDelegate.onHostPause();
-    }
+    mReactDelegate.onHostPause();
   }
 
   @Override
   public void onDestroy() {
     super.onDestroy();
-    if (shouldCallDelegateLifecycleEvents) {
-      mReactDelegate.onHostDestroy();
-    }
+    mReactDelegate.onHostDestroy();
   }
 
   // endregion

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -170,6 +170,7 @@ public class ReactInstanceManager {
   private final DevSupportManager mDevSupportManager;
   private final boolean mUseDeveloperSupport;
   private final boolean mRequireActivity;
+  private final boolean mKeepActivity;
   private final @Nullable NotThreadSafeBridgeIdleDebugListener mBridgeIdleDebugListener;
   private final Object mReactContextLock = new Object();
   private @Nullable volatile ReactContext mCurrentReactContext;
@@ -228,6 +229,7 @@ public class ReactInstanceManager {
       boolean useDeveloperSupport,
       DevSupportManagerFactory devSupportManagerFactory,
       boolean requireActivity,
+      boolean keepActivity,
       @Nullable NotThreadSafeBridgeIdleDebugListener bridgeIdleDebugListener,
       LifecycleState initialLifecycleState,
       JSExceptionHandler jSExceptionHandler,
@@ -257,6 +259,7 @@ public class ReactInstanceManager {
     mPackages = new ArrayList<>();
     mUseDeveloperSupport = useDeveloperSupport;
     mRequireActivity = requireActivity;
+    mKeepActivity = keepActivity;
     Systrace.beginSection(
         Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstanceManager.initDevSupportManager");
     mDevSupportManager =
@@ -700,7 +703,9 @@ public class ReactInstanceManager {
     }
 
     moveToBeforeCreateLifecycleState();
-    mCurrentActivity = null;
+    if (!mKeepActivity) {
+      mCurrentActivity = null;
+    }
   }
 
   /**
@@ -810,7 +815,7 @@ public class ReactInstanceManager {
         mLifecycleState = LifecycleState.BEFORE_RESUME;
       }
       if (mLifecycleState == LifecycleState.BEFORE_RESUME) {
-        currentContext.onHostDestroy();
+        currentContext.onHostDestroy(mKeepActivity);
       }
     }
     mLifecycleState = LifecycleState.BEFORE_CREATE;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -57,6 +57,7 @@ public class ReactInstanceManagerBuilder {
   private boolean mUseDeveloperSupport;
   private @Nullable DevSupportManagerFactory mDevSupportManagerFactory;
   private boolean mRequireActivity;
+  private boolean mKeepActivity;
   private @Nullable LifecycleState mInitialLifecycleState;
   private @Nullable JSExceptionHandler mJSExceptionHandler;
   private @Nullable Activity mCurrentActivity;
@@ -208,6 +209,11 @@ public class ReactInstanceManagerBuilder {
     return this;
   }
 
+  public ReactInstanceManagerBuilder setKeepActivity(boolean keepActivity) {
+    mKeepActivity = keepActivity;
+    return this;
+  }
+
   /**
    * When the {@link SurfaceDelegateFactory} is provided, it will be used for native modules to get
    * a {@link SurfaceDelegate} to interact with the platform specific surface that they that needs
@@ -345,6 +351,7 @@ public class ReactInstanceManagerBuilder {
             ? new DefaultDevSupportManagerFactory()
             : mDevSupportManagerFactory,
         mRequireActivity,
+        mKeepActivity,
         mBridgeIdleDebugListener,
         Assertions.assertNotNull(mInitialLifecycleState, "Initial lifecycle state was not set"),
         mJSExceptionHandler,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -73,6 +73,12 @@ public abstract class ReactNativeHost {
 
   protected ReactInstanceManager createReactInstanceManager() {
     ReactMarker.logMarker(ReactMarkerConstants.BUILD_REACT_INSTANCE_MANAGER_START);
+    ReactInstanceManagerBuilder builder = getBaseReactInstanceManagerBuilder();
+    ReactMarker.logMarker(ReactMarkerConstants.BUILD_REACT_INSTANCE_MANAGER_END);
+    return builder.build();
+  }
+
+  protected ReactInstanceManagerBuilder getBaseReactInstanceManagerBuilder() {
     ReactInstanceManagerBuilder builder =
         ReactInstanceManager.builder()
             .setApplication(mApplication)
@@ -102,9 +108,7 @@ public abstract class ReactNativeHost {
     } else {
       builder.setBundleAssetName(Assertions.assertNotNull(getBundleAssetName()));
     }
-    ReactInstanceManager reactInstanceManager = builder.build();
-    ReactMarker.logMarker(ReactMarkerConstants.BUILD_REACT_INSTANCE_MANAGER_END);
-    return reactInstanceManager;
+    return builder;
   }
 
   /** Get the {@link RedBoxHandler} to send RedBox-related callbacks to. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -41,6 +41,7 @@ public abstract class ReactContext extends ContextWrapper {
 
   @DoNotStrip
   public interface RCTDeviceEventEmitter extends JavaScriptModule {
+
     void emit(@NonNull String eventName, @Nullable Object data);
   }
 
@@ -375,7 +376,19 @@ public abstract class ReactContext extends ContextWrapper {
         handleException(e);
       }
     }
-    mCurrentActivity = null;
+    resetCurrentActivity(false);
+  }
+
+  @ThreadConfined(UI)
+  public void onHostDestroy(boolean keepActivity) {
+    onHostDestroy();
+    resetCurrentActivity(keepActivity);
+  }
+
+  private void resetCurrentActivity(boolean keepActivity) {
+    if (!keepActivity) {
+      mCurrentActivity = null;
+    }
   }
 
   /** Destroy this instance, making it unusable. */
@@ -503,6 +516,7 @@ public abstract class ReactContext extends ContextWrapper {
   }
 
   public class ExceptionHandlerWrapper implements JSExceptionHandler {
+
     @Override
     public void handleException(Exception e) {
       ReactContext.this.handleException(e);


### PR DESCRIPTION
Summary:
Previously, we skipped calling the ReactDelegate callback functions when the ReavtNavigationFragment was destroyed because it set the current activity to null when we need to actually keep the reference to the activity. However, skipping this entirely also skips core clean up logic, such as running the return() function for useEffect().

Instead of skipping the callback function entirely, we just need to make sure we don't set mCurrentActivity to null. I followed D30504616 to configure an option to not set mCurrentActivity to null if mKeepActivity flag is set on the ReactInstanceManager.

Changelog: [Internal]

Differential Revision: D56167533


