### PR TITLE
Use ClassFinder inside ViewManagerPropertyUpdater

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
@@ -9,6 +9,7 @@ package com.facebook.react.uimanager;
 
 import android.view.View;
 import com.facebook.common.logging.FLog;
+import com.facebook.react.common.ClassFinder;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -109,7 +110,7 @@ public class ViewManagerPropertyUpdater {
   private static <T> T findGeneratedSetter(Class<?> cls) {
     String clsName = cls.getName();
     try {
-      Class<?> setterClass = Class.forName(clsName + "$$PropsSetter");
+      Class<?> setterClass = ClassFinder.findClass(clsName + "$$PropsSetter");
       //noinspection unchecked
       return (T) setterClass.newInstance();
     } catch (ClassNotFoundException e) {


### PR DESCRIPTION
Summary:
In OSS, we should use the ClassFinder wrapper as the `Class.byName` calls will never succeed (we don't run the annotation processor in OSS).

Changelog:
[Internal] [Changed] - Use ClassFinder inside ViewManagerPropertyUpdater

Differential Revision: D56191175


