### PR TITLE
Introduce ReactContext.hasReactInstance()

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1114,6 +1114,7 @@ public abstract class com/facebook/react/bridge/ReactContext : android/content/C
 	public fun hasCatalystInstance ()Z
 	public fun hasCurrentActivity ()Z
 	public fun hasNativeModule (Ljava/lang/Class;)Z
+	public fun hasReactInstance ()Z
 	protected fun initializeInteropModules ()V
 	protected fun initializeInteropModules (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun initializeMessageQueueThreads (Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -262,7 +262,17 @@ public abstract class ReactContext extends ContextWrapper {
     return mCatalystInstance != null && !mCatalystInstance.isDestroyed();
   }
 
+  /**
+   * This API has been deprecated due to naming consideration, please use hasReactInstance() instead
+   *
+   * @return
+   */
+  @Deprecated
   public boolean hasCatalystInstance() {
+    return mCatalystInstance != null;
+  }
+
+  public boolean hasReactInstance() {
     return mCatalystInstance != null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -95,6 +95,11 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
     return mReactHost.isInstanceInitialized();
   }
 
+  @Override
+  public boolean hasReactInstance() {
+    return mReactHost.isInstanceInitialized();
+  }
+
   DevSupportManager getDevSupportManager() {
     return mReactHost.getDevSupportManager();
   }


### PR DESCRIPTION
Summary:
This is just the bridgeless analogue to .hasCatalystInstance()

Changelog: [Android][Added] - Introduced ReactContext.hasReactInstance() to replace .hasCatalystInstance()

Reviewed By: fabriziocucci

Differential Revision: D56164488


