### PR TITLE
Skip invalidation of FabricUIManager on instance destroy

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -294,6 +294,7 @@ public class com/facebook/react/ReactInstanceManagerBuilder {
 	public fun setJSExceptionHandler (Lcom/facebook/react/bridge/JSExceptionHandler;)Lcom/facebook/react/ReactInstanceManagerBuilder;
 	public fun setJSMainModulePath (Ljava/lang/String;)Lcom/facebook/react/ReactInstanceManagerBuilder;
 	public fun setJavaScriptExecutorFactory (Lcom/facebook/react/bridge/JavaScriptExecutorFactory;)Lcom/facebook/react/ReactInstanceManagerBuilder;
+	public fun setKeepFabricUIManagerOnDestroy (Z)Lcom/facebook/react/ReactInstanceManagerBuilder;
 	public fun setLazyViewManagersEnabled (Z)Lcom/facebook/react/ReactInstanceManagerBuilder;
 	public fun setMinNumShakes (I)Lcom/facebook/react/ReactInstanceManagerBuilder;
 	public fun setMinTimeLeftInFrameForNonBatchedOperationMs (I)Lcom/facebook/react/ReactInstanceManagerBuilder;
@@ -310,6 +311,7 @@ public abstract class com/facebook/react/ReactNativeHost {
 	public fun clear ()V
 	protected fun createReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	protected final fun getApplication ()Landroid/app/Application;
+	protected fun getBaseReactInstanceManagerBuilder ()Lcom/facebook/react/ReactInstanceManagerBuilder;
 	protected fun getBundleAssetName ()Ljava/lang/String;
 	protected fun getChoreographerProvider ()Lcom/facebook/react/internal/ChoreographerProvider;
 	protected fun getDevLoadingViewManager ()Lcom/facebook/react/devsupport/interfaces/DevLoadingViewManager;
@@ -634,6 +636,7 @@ public class com/facebook/react/bridge/CatalystInstanceImpl$Builder {
 	public fun setJSBundleLoader (Lcom/facebook/react/bridge/JSBundleLoader;)Lcom/facebook/react/bridge/CatalystInstanceImpl$Builder;
 	public fun setJSExceptionHandler (Lcom/facebook/react/bridge/JSExceptionHandler;)Lcom/facebook/react/bridge/CatalystInstanceImpl$Builder;
 	public fun setJSExecutor (Lcom/facebook/react/bridge/JavaScriptExecutor;)Lcom/facebook/react/bridge/CatalystInstanceImpl$Builder;
+	public fun setKeepFabricUIManagerOnDestroy (Z)Lcom/facebook/react/bridge/CatalystInstanceImpl$Builder;
 	public fun setReactQueueConfigurationSpec (Lcom/facebook/react/bridge/queue/ReactQueueConfigurationSpec;)Lcom/facebook/react/bridge/CatalystInstanceImpl$Builder;
 	public fun setRegistry (Lcom/facebook/react/bridge/NativeModuleRegistry;)Lcom/facebook/react/bridge/CatalystInstanceImpl$Builder;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -193,6 +193,8 @@ public class ReactInstanceManager {
   private List<ViewManager> mViewManagers;
   private boolean mUseFallbackBundle = true;
 
+  private boolean mKeepFabricUIManagerOnDestroy;
+
   private class ReactContextInitParams {
     private final JavaScriptExecutorFactory mJsExecutorFactory;
     private final JSBundleLoader mJsBundleLoader;
@@ -241,7 +243,8 @@ public class ReactInstanceManager {
       @Nullable ReactPackageTurboModuleManagerDelegate.Builder tmmDelegateBuilder,
       @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
       @Nullable DevLoadingViewManager devLoadingViewManager,
-      @Nullable ChoreographerProvider choreographerProvider) {
+      @Nullable ChoreographerProvider choreographerProvider,
+      boolean keepFabricUIManagerOnDestroy) {
     FLog.d(TAG, "ReactInstanceManager.ctor()");
     initializeSoLoaderIfNecessary(applicationContext);
 
@@ -277,6 +280,7 @@ public class ReactInstanceManager {
     mMemoryPressureRouter = new MemoryPressureRouter(applicationContext);
     mJSExceptionHandler = jSExceptionHandler;
     mTMMDelegateBuilder = tmmDelegateBuilder;
+    mKeepFabricUIManagerOnDestroy = keepFabricUIManagerOnDestroy;
     synchronized (mPackages) {
       PrinterHolder.getPrinter()
           .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: Use Split Packages");
@@ -1367,7 +1371,8 @@ public class ReactInstanceManager {
             .setRegistry(nativeModuleRegistry)
             .setJSBundleLoader(jsBundleLoader)
             .setJSExceptionHandler(exceptionHandler)
-            .setInspectorTarget(getOrCreateInspectorTarget());
+            .setInspectorTarget(getOrCreateInspectorTarget())
+            .setKeepFabricUIManagerOnDestroy(mKeepFabricUIManagerOnDestroy);
 
     ReactMarker.logMarker(CREATE_CATALYST_INSTANCE_START);
     // CREATE_CATALYST_INSTANCE_END is in JSCExecutor.cpp

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -75,6 +75,8 @@ public class ReactInstanceManagerBuilder {
   private @Nullable JSEngineResolutionAlgorithm mJSEngineResolutionAlgorithm = null;
   private @Nullable ChoreographerProvider mChoreographerProvider = null;
 
+  private boolean mKeepFabricUIManagerOnDestroy;
+
   /* package protected */ ReactInstanceManagerBuilder() {}
 
   /** Factory for desired implementation of JavaScriptExecutor. */
@@ -295,6 +297,16 @@ public class ReactInstanceManagerBuilder {
   }
 
   /**
+   * When set to true, the FabricUIManager will not be invalidated when the ReactInstanceManager is
+   * destroyed
+   */
+  public ReactInstanceManagerBuilder setKeepFabricUIManagerOnDestroy(
+      boolean keepFabricUIManagerOnDestroy) {
+    mKeepFabricUIManagerOnDestroy = keepFabricUIManagerOnDestroy;
+    return this;
+  }
+
+  /**
    * Instantiates a new {@link ReactInstanceManager}. Before calling {@code build}, the following
    * must be called:
    *
@@ -358,7 +370,8 @@ public class ReactInstanceManagerBuilder {
         mTMMDelegateBuilder,
         mSurfaceDelegateFactory,
         mDevLoadingViewManager,
-        mChoreographerProvider);
+        mChoreographerProvider,
+        mKeepFabricUIManagerOnDestroy);
   }
 
   private JavaScriptExecutorFactory getDefaultJSExecutorFactory(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -73,6 +73,13 @@ public abstract class ReactNativeHost {
 
   protected ReactInstanceManager createReactInstanceManager() {
     ReactMarker.logMarker(ReactMarkerConstants.BUILD_REACT_INSTANCE_MANAGER_START);
+    ReactInstanceManagerBuilder builder = getBaseReactInstanceManagerBuilder();
+    ReactInstanceManager reactInstanceManager = builder.build();
+    ReactMarker.logMarker(ReactMarkerConstants.BUILD_REACT_INSTANCE_MANAGER_END);
+    return reactInstanceManager;
+  }
+
+  protected ReactInstanceManagerBuilder getBaseReactInstanceManagerBuilder() {
     ReactInstanceManagerBuilder builder =
         ReactInstanceManager.builder()
             .setApplication(mApplication)
@@ -102,9 +109,7 @@ public abstract class ReactNativeHost {
     } else {
       builder.setBundleAssetName(Assertions.assertNotNull(getBundleAssetName()));
     }
-    ReactInstanceManager reactInstanceManager = builder.build();
-    ReactMarker.logMarker(ReactMarkerConstants.BUILD_REACT_INSTANCE_MANAGER_END);
-    return reactInstanceManager;
+    return builder;
   }
 
   /** Get the {@link RedBoxHandler} to send RedBox-related callbacks to. */


### PR DESCRIPTION
Summary:
On Twilight app, we destroy the ReactInstanceManager in 2 different places: on [login](https://www.internalfb.com/code/fbsource/[010a2797a2a5ec79140b616ea6e9c8296058bae2]/fbandroid/java/com/facebook/catalyst/shell/FbReactLoginActivity.java?lines=53) and on [logout](https://www.internalfb.com/code/fbsource/[010a2797a2a5ec79140b616ea6e9c8296058bae2]/fbandroid/java/com/oculus/twilight/crossapp/activity/XOCMainActivity.kt?lines=193). The reason we decided to destroy ReactInstanceManager on login and logout is because we needed to reset the module parameters for our network requests so we could make them with the correct user identity when the user logs in and revoke the ability to make these requests when user logs out (see D37537716).

However, the call to FabricUIManager.invalidate() is problematic as it fails to properly clean up the surfaces on Twilight, causing the app to crash. Instead of destroying it, because the app is 95% ReactNative is defaulted to using the FabricUIManager by statically setting ReactFeatureFlags.enableFabricRenderer = true. This way, we still perform the clean up of the modules and re-create them on auth change, but we avoid the app crashing when it tries to destroy the UI manager.

Changelog: [Internal]

Differential Revision: D56208758


