### PR TITLE
[Codegen] fix array enum prop parsing for array enum types

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -34,7 +34,7 @@ ArrayPropsNativeComponentViewProps::ArrayPropsNativeComponentViewProps(
     points(convertRawProp(context, rawProps, \\"points\\", sourceProps.points, {})),
     edgeInsets(convertRawProp(context, rawProps, \\"edgeInsets\\", sourceProps.edgeInsets, {})),
     dimensions(convertRawProp(context, rawProps, \\"dimensions\\", sourceProps.dimensions, {})),
-    sizes(convertRawProp(context, rawProps, \\"sizes\\", sourceProps.sizes, {static_cast<ArrayPropsNativeComponentViewSizesMask>(ArrayPropsNativeComponentViewSizes::Small)})),
+    sizes(convertRawProp(context, rawProps, \\"sizes\\", ArrayPropsNativeComponentViewSizesMaskWrapped{ .value = sourceProps.sizes }, {static_cast<ArrayPropsNativeComponentViewSizesMask>(ArrayPropsNativeComponentViewSizes::Small)}).value),
     object(convertRawProp(context, rawProps, \\"object\\", sourceProps.object, {})),
     arrayOfObjects(convertRawProp(context, rawProps, \\"arrayOfObjects\\", sourceProps.arrayOfObjects, {}))
       {}

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -28,6 +28,10 @@ namespace facebook::react {
 
 using ArrayPropsNativeComponentViewSizesMask = uint32_t;
 
+struct ArrayPropsNativeComponentViewSizesMaskWrapped {
+  ArrayPropsNativeComponentViewSizesMask value;
+};
+
 enum class ArrayPropsNativeComponentViewSizes: ArrayPropsNativeComponentViewSizesMask {
   Small = 1 << 0,
   Large = 1 << 1
@@ -51,29 +55,29 @@ constexpr void operator|=(
   lhs = lhs | static_cast<ArrayPropsNativeComponentViewSizesMask>(rhs);
 }
 
-static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewSizesMask &result) {
+static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewSizesMaskWrapped &wrapped) {
   auto items = std::vector<std::string>{value};
   for (const auto &item : items) {
     if (item == \\"small\\") {
-      result |= ArrayPropsNativeComponentViewSizes::Small;
+      wrapped.value |= ArrayPropsNativeComponentViewSizes::Small;
       continue;
     }
     if (item == \\"large\\") {
-      result |= ArrayPropsNativeComponentViewSizes::Large;
+      wrapped.value |= ArrayPropsNativeComponentViewSizes::Large;
       continue;
     }
     abort();
   }
 }
 
-static inline std::string toString(const ArrayPropsNativeComponentViewSizesMask &value) {
+static inline std::string toString(const ArrayPropsNativeComponentViewSizesMaskWrapped &wrapped) {
     auto result = std::string{};
     auto separator = std::string{\\", \\"};
 
-    if (value & ArrayPropsNativeComponentViewSizes::Small) {
+    if (wrapped.value & ArrayPropsNativeComponentViewSizes::Small) {
       result += \\"small\\" + separator;
     }
-    if (value & ArrayPropsNativeComponentViewSizes::Large) {
+    if (wrapped.value & ArrayPropsNativeComponentViewSizes::Large) {
       result += \\"large\\" + separator;
     }
     if (!result.empty()) {

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -169,6 +169,7 @@ function getEnumMaskName(enumName: string): string {
 function convertDefaultTypeToString(
   componentName: string,
   prop: NamedShape<PropTypeAnnotation>,
+  fromBuilder = false,
 ): string {
   const typeAnnotation = prop.typeAnnotation;
   switch (typeAnnotation.type) {
@@ -231,6 +232,9 @@ function convertDefaultTypeToString(
           const defaultValue = `${enumName}::${toSafeCppString(
             elementType.default,
           )}`;
+          if ( fromBuilder ){
+            return `${enumMaskName}Wrapped{ .value = static_cast<${enumMaskName}>(${defaultValue})}`;
+          }
           return `static_cast<${enumMaskName}>(${defaultValue})`;
         default:
           return '';
@@ -256,6 +260,39 @@ function convertDefaultTypeToString(
   }
 }
 
+function getSourceProp(
+  componentName: string,
+  prop: NamedShape<PropTypeAnnotation>,
+): string {
+  const typeAnnotation = prop.typeAnnotation;
+  switch (typeAnnotation.type) {
+    case 'ArrayTypeAnnotation':
+      const elementType = typeAnnotation.elementType;
+      switch (elementType.type) {
+        case 'StringEnumTypeAnnotation':
+          const enumName = getEnumName(componentName, prop.name);
+          const enumMaskName = getEnumMaskName(enumName);
+          return `${enumMaskName}Wrapped{ .value = sourceProps.${prop.name} }`;
+      }
+  }
+  return `sourceProps.${prop.name}`;
+}
+
+function isWrappedPropType(
+  prop: NamedShape<PropTypeAnnotation>,
+): boolean {
+  const typeAnnotation = prop.typeAnnotation;
+  switch (typeAnnotation.type) {
+    case 'ArrayTypeAnnotation':
+      const elementType = typeAnnotation.elementType;
+      switch (elementType.type) {
+        case 'StringEnumTypeAnnotation':
+          return true;
+      }
+  }
+  return false;
+}
+
 const IncludeTemplate = ({
   headerPrefix,
   file,
@@ -279,4 +316,6 @@ module.exports = {
   generateStructName,
   generateEventStructName,
   IncludeTemplate,
+  getSourceProp,
+  isWrappedPropType,
 };

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -169,7 +169,7 @@ function getEnumMaskName(enumName: string): string {
 function convertDefaultTypeToString(
   componentName: string,
   prop: NamedShape<PropTypeAnnotation>,
-  fromBuilder = false,
+  fromBuilder: boolean  = false,
 ): string {
   const typeAnnotation = prop.typeAnnotation;
   switch (typeAnnotation.type) {

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -169,7 +169,7 @@ function getEnumMaskName(enumName: string): string {
 function convertDefaultTypeToString(
   componentName: string,
   prop: NamedShape<PropTypeAnnotation>,
-  fromBuilder: boolean  = false,
+  fromBuilder: boolean = false,
 ): string {
   const typeAnnotation = prop.typeAnnotation;
   switch (typeAnnotation.type) {
@@ -232,7 +232,7 @@ function convertDefaultTypeToString(
           const defaultValue = `${enumName}::${toSafeCppString(
             elementType.default,
           )}`;
-          if ( fromBuilder ){
+          if (fromBuilder) {
             return `${enumMaskName}Wrapped{ .value = static_cast<${enumMaskName}>(${defaultValue})}`;
           }
           return `static_cast<${enumMaskName}>(${defaultValue})`;
@@ -278,9 +278,7 @@ function getSourceProp(
   return `sourceProps.${prop.name}`;
 }
 
-function isWrappedPropType(
-  prop: NamedShape<PropTypeAnnotation>,
-): boolean {
+function isWrappedPropType(prop: NamedShape<PropTypeAnnotation>): boolean {
   const typeAnnotation = prop.typeAnnotation;
   switch (typeAnnotation.type) {
     case 'ArrayTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -16,6 +16,8 @@ const {
   IncludeTemplate,
   convertDefaultTypeToString,
   getImports,
+  getSourceProp,
+  isWrappedPropType,
 } = require('./CppHelpers');
 
 // File path -> contents
@@ -71,8 +73,14 @@ ${className}::${className}(
 function generatePropsString(componentName: string, component: ComponentShape) {
   return component.props
     .map(prop => {
+      const sourceProp = getSourceProp(componentName, prop);
       const defaultValue = convertDefaultTypeToString(componentName, prop);
-      return `${prop.name}(convertRawProp(context, rawProps, "${prop.name}", sourceProps.${prop.name}, {${defaultValue}}))`;
+      const isWrappedProp = isWrappedPropType(prop);
+      let convertRawProp = `convertRawProp(context, rawProps, "${prop.name}", ${sourceProp} , {${defaultValue}})`;
+      if (isWrappedProp) {
+        convertRawProp += '.value';
+      }
+      return `${prop.name}(${convertRawProp})`;
     })
     .join(',\n' + '    ');
 }

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -76,7 +76,7 @@ function generatePropsString(componentName: string, component: ComponentShape) {
       const sourceProp = getSourceProp(componentName, prop);
       const defaultValue = convertDefaultTypeToString(componentName, prop);
       const isWrappedProp = isWrappedPropType(prop);
-      let convertRawProp = `convertRawProp(context, rawProps, "${prop.name}", ${sourceProp} , {${defaultValue}})`;
+      let convertRawProp = `convertRawProp(context, rawProps, "${prop.name}", ${sourceProp}, {${defaultValue}})`;
       if (isWrappedProp) {
         convertRawProp += '.value';
       }

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -214,6 +214,10 @@ const ArrayEnumTemplate = ({
   `
 using ${enumMask} = uint32_t;
 
+struct ${enumMask}Wrapped {
+  ${enumMask} value;
+};
+
 enum class ${enumName}: ${enumMask} {
   ${values}
 };
@@ -236,7 +240,7 @@ constexpr void operator|=(
   lhs = lhs | static_cast<${enumMask}>(rhs);
 }
 
-static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ${enumMask} &result) {
+static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ${enumMask}Wrapped &wrapped) {
   auto items = std::vector<std::string>{value};
   for (const auto &item : items) {
     ${fromCases}
@@ -244,7 +248,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
   }
 }
 
-static inline std::string toString(const ${enumMask} &value) {
+static inline std::string toString(const ${enumMask}Wrapped &wrapped) {
     auto result = std::string{};
     auto separator = std::string{", "};
 
@@ -302,7 +306,7 @@ function generateArrayEnumString(
     .map(
       option =>
         `if (item == "${option}") {
-      result |= ${enumName}::${toSafeCppString(option)};
+      wrapped.value |= ${enumName}::${toSafeCppString(option)};
       continue;
     }`,
     )
@@ -311,7 +315,7 @@ function generateArrayEnumString(
   const toCases = options
     .map(
       option =>
-        `if (value & ${enumName}::${toSafeCppString(option)}) {
+        `if (wrapped.value & ${enumName}::${toSafeCppString(option)}) {
       result += "${option}" + separator;
     }`,
     )

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -33,7 +33,7 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
     srcs(convertRawProp(context, rawProps, \\"srcs\\", sourceProps.srcs, {})),
     points(convertRawProp(context, rawProps, \\"points\\", sourceProps.points, {})),
     dimensions(convertRawProp(context, rawProps, \\"dimensions\\", sourceProps.dimensions, {})),
-    sizes(convertRawProp(context, rawProps, \\"sizes\\", sourceProps.sizes, {static_cast<ArrayPropsNativeComponentSizesMask>(ArrayPropsNativeComponentSizes::Small)})),
+    sizes(convertRawProp(context, rawProps, \\"sizes\\", ArrayPropsNativeComponentSizesMaskWrapped{ .value = sourceProps.sizes }, {static_cast<ArrayPropsNativeComponentSizesMask>(ArrayPropsNativeComponentSizes::Small)}).value),
     object(convertRawProp(context, rawProps, \\"object\\", sourceProps.object, {})),
     array(convertRawProp(context, rawProps, \\"array\\", sourceProps.array, {})),
     arrayOfArrayOfObject(convertRawProp(context, rawProps, \\"arrayOfArrayOfObject\\", sourceProps.arrayOfArrayOfObject, {}))

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -27,6 +27,10 @@ namespace facebook::react {
 
 using ArrayPropsNativeComponentSizesMask = uint32_t;
 
+struct ArrayPropsNativeComponentSizesMaskWrapped {
+  ArrayPropsNativeComponentSizesMask value;
+};
+
 enum class ArrayPropsNativeComponentSizes: ArrayPropsNativeComponentSizesMask {
   Small = 1 << 0,
   Large = 1 << 1
@@ -50,29 +54,29 @@ constexpr void operator|=(
   lhs = lhs | static_cast<ArrayPropsNativeComponentSizesMask>(rhs);
 }
 
-static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentSizesMask &result) {
+static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentSizesMaskWrapped &wrapped) {
   auto items = std::vector<std::string>{value};
   for (const auto &item : items) {
     if (item == \\"small\\") {
-      result |= ArrayPropsNativeComponentSizes::Small;
+      wrapped.value |= ArrayPropsNativeComponentSizes::Small;
       continue;
     }
     if (item == \\"large\\") {
-      result |= ArrayPropsNativeComponentSizes::Large;
+      wrapped.value |= ArrayPropsNativeComponentSizes::Large;
       continue;
     }
     abort();
   }
 }
 
-static inline std::string toString(const ArrayPropsNativeComponentSizesMask &value) {
+static inline std::string toString(const ArrayPropsNativeComponentSizesMaskWrapped &wrapped) {
     auto result = std::string{};
     auto separator = std::string{\\", \\"};
 
-    if (value & ArrayPropsNativeComponentSizes::Small) {
+    if (wrapped.value & ArrayPropsNativeComponentSizes::Small) {
       result += \\"small\\" + separator;
     }
-    if (value & ArrayPropsNativeComponentSizes::Large) {
+    if (wrapped.value & ArrayPropsNativeComponentSizes::Large) {
       result += \\"large\\" + separator;
     }
     if (!result.empty()) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

codegen generates type alias for  array enum props with uint32_t which cause wrong overloaded fromRawValue to call at runtime eventually app to terminate
more detailed info at issue #43821 

## Changelog:



[Internal] [Fixed] - Codegen for array enum props

## Test Plan:

TODO
