### PR TITLE
fix: [iOS] RCTReloadCommand should pass its bundleURL when reloading

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -302,6 +302,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (void)didReceiveReloadCommand
 {
+  [self didReceiveReloadCommand:nil];
+}
+
+- (void)didReceiveReloadCommand:(NSURL *)bundleURL
+{
+  if (bundleURL) {
+    _bundleURL = bundleURL;
+  }
 #if RCT_ENABLE_INSPECTOR
   auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
   if (!inspectorFlags.getEnableModernCDPRegistry()) {

--- a/packages/react-native/React/Base/RCTReloadCommand.h
+++ b/packages/react-native/React/Base/RCTReloadCommand.h
@@ -16,6 +16,7 @@
  */
 @protocol RCTReloadListener
 - (void)didReceiveReloadCommand;
+- (void)didReceiveReloadCommand:(NSURL  * _Nullable)bundleURL;
 @end
 
 /**

--- a/packages/react-native/React/Base/RCTReloadCommand.m
+++ b/packages/react-native/React/Base/RCTReloadCommand.m
@@ -54,7 +54,7 @@ void RCTTriggerReloadCommandListeners(NSString *reason)
                                                     }];
 
   for (id<RCTReloadListener> l in [listeners allObjects]) {
-    [l didReceiveReloadCommand];
+    [l didReceiveReloadCommand:bundleURL];
   }
   [listenersLock unlock];
 }

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -291,9 +291,17 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 
 - (void)didReceiveReloadCommand
 {
+  [self didReceiveReloadCommand:nil];
+}
+
+- (void)didReceiveReloadCommand:(NSURL * _Nullable)bundleURL
+{
   [_instance invalidate];
   _instance = nil;
-  if (_bundleURLProvider) {
+  if (bundleURL) {
+    [self _setBundleURL:bundleURL];
+  }
+  else if (_bundleURLProvider) {
     [self _setBundleURL:_bundleURLProvider()];
   }
 


### PR DESCRIPTION
## Summary:

An Expo feature that makes use of the `RCTReloadCommand` class `RCTTriggerReloadCommandListeners()` to reload with a specific bundle URL is not working, because setting the bundle URL via `RCTReloadCommandSetBundleURL()` has no effect.

The fix is to add a new method to the `RCTReloadListener` protocol that allows the new URL to be passed into the listener (`RCTBridge` or `RCTHost`) to set the bundle URL correctly before reload.

## Changelog:

[iOS][Fixed] RCTReloadCommand should pass its bundle URL when reloading

## Test Plan:

Working on a non-Expo test app to demonstrate the fix.