### PR TITLE
fix: always subscribe RDT listeners, even if frontend is already connected

### DIFF
--- a/packages/react-native/Libraries/Core/setUpReactDevTools.js
+++ b/packages/react-native/Libraries/Core/setUpReactDevTools.js
@@ -113,29 +113,30 @@ if (__DEV__) {
     }
   }
 
-  // 1. If React DevTools has already been opened and initialized in Fusebox:
+  // 1. If React DevTools has already been opened and initialized in Fusebox, bindings survive reloads
   if (global[reactDevToolsFuseboxGlobalBindingName] != null) {
     disconnectBackendFromReactDevToolsInFuseboxIfNeeded();
     const domain =
       fuseboxReactDevToolsDispatcher.initializeDomain('react-devtools');
     connectToReactDevToolsInFusebox(domain);
-  } else {
-    // 2. If React DevTools panel in Fusebox was opened for the first time after the runtime has been created
-    global.__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__.onDomainInitialization.addEventListener(
-      (domain: Domain) => {
-        if (domain.name === 'react-devtools') {
-          disconnectBackendFromReactDevToolsInFuseboxIfNeeded();
-          connectToReactDevToolsInFusebox(domain);
-        }
-      },
-    );
-
-    // 3. Fallback to attempting to connect WS-based RDT frontend
-    const RCTNativeAppEventEmitter = require('../EventEmitter/RCTNativeAppEventEmitter');
-    RCTNativeAppEventEmitter.addListener(
-      'RCTDevMenuShown',
-      connectToWSBasedReactDevToolsFrontend,
-    );
-    connectToWSBasedReactDevToolsFrontend(); // Try connecting once on load
   }
+
+  // 2. If React DevTools panel in Fusebox was opened for the first time after the runtime has been created
+  // 2. OR if React DevTools frontend was re-initialized: Chrome DevTools was closed and then re-opened
+  global.__FUSEBOX_REACT_DEVTOOLS_DISPATCHER__.onDomainInitialization.addEventListener(
+    (domain: Domain) => {
+      if (domain.name === 'react-devtools') {
+        disconnectBackendFromReactDevToolsInFuseboxIfNeeded();
+        connectToReactDevToolsInFusebox(domain);
+      }
+    },
+  );
+
+  // 3. Fallback to attempting to connect WS-based RDT frontend
+  const RCTNativeAppEventEmitter = require('../EventEmitter/RCTNativeAppEventEmitter');
+  RCTNativeAppEventEmitter.addListener(
+    'RCTDevMenuShown',
+    connectToWSBasedReactDevToolsFrontend,
+  );
+  connectToWSBasedReactDevToolsFrontend(); // Try connecting once on load
 }

--- a/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
@@ -62,9 +62,9 @@ class DebuggingOverlayRegistry {
   constructor() {
     if (reactDevToolsHook?.reactDevtoolsAgent != null) {
       this.#onReactDevToolsAgentAttached(reactDevToolsHook.reactDevtoolsAgent);
-      return;
     }
 
+    // There could be cases when frontend is disconnected and then connected again for the same React Native runtime.
     reactDevToolsHook?.on?.(
       'react-devtools',
       this.#onReactDevToolsAgentAttached,


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Previous implementation doesn't have support for one specific case, when RN runtime was initialized and frontend is ready to be connected, but then it gets disconnected and re-connected again for the same runtime.

The issues were:
- For Fusebox: backend and frontend are correctly re-connected if user had Chrome DevTools opened, frontend invalidated via reload, then Chrome DevTools closed and re-opened again
- For DebuggingOverlayRegistry: it didn't subscribe to events from new `react-devtools-agent`, which emits events such as `showNativeHighlight` or `drawTraceUpdates`

Differential Revision: D56239185


