### PR TITLE
Use Cocoapods 1.15.2 which fixes #42698

### DIFF
--- a/packages/react-native/template/Gemfile
+++ b/packages/react-native/template/Gemfile
@@ -3,7 +3,5 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-# Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
-# bound in the template on Cocoapods with next React Native release.
-gem 'cocoapods', '>= 1.13', '< 1.15'
+gem 'cocoapods', '~> 1.13'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-# Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
-# bound in the template on Cocoapods with next React Native release.
-gem 'cocoapods', '>= 1.13', '< 1.15'
+gem 'cocoapods', '~> 1.13'
 gem 'rexml'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'


### PR DESCRIPTION
Summary:
Previously we had to limit (#42702) Cocoapods to avoid a broken version, this is no longer the case.

Changelog: [iOS][Changed] - Remove limit on Cocoapods to allow 1.15.2

Differential Revision: D56299927


