### PR TITLE
Disable view preallocation when batchRenderingUpdatesInEventLoop is enabled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -11,6 +11,7 @@
 #include "MountItem.h"
 #include "StateWrapperImpl.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/jni/ReadableNativeMap.h>
 #include <react/renderer/components/scrollview/ScrollViewProps.h>
 #include <react/renderer/core/conversions.h>
@@ -777,6 +778,12 @@ void FabricMountingManager::executeMount(
 void FabricMountingManager::preallocateShadowView(
     SurfaceId surfaceId,
     const ShadowView& shadowView) {
+  if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
+    // FIXME T186151779: View preallocation is not compatible with batched
+    // rendering in the new event loop
+    return;
+  }
+
   {
     std::lock_guard lock(allocatedViewsMutex_);
     auto allocatedViewsIterator = allocatedViewRegistry_.find(surfaceId);


### PR DESCRIPTION
Summary:
When using `batchRenderingUpdatesInEventLoop` the Fabric Differentiator may more a newly created ShadowNode and subsequent update (eg coming from a layout effect) into a single MountingTransaction. This enables us to correctly implement layoutEffect in the new architecture and prevent flickering of intermediate states.

On Android, we also have a view preallocation mechanism, which will create native views for ShadowNodes as they're created by React. This mechanism is incompatible with `batchRenderingUpdatesInEventLoop` as we will ignore the `create` instruction in the MountingTransaction since we already have a preallocated view. However the props we used for preallocation will be outdated/different compared with the ones in the `MountingTransaction`, which represents a severe regression to the issue described in https://github.com/facebook/react-native/issues/44111.

Changelog: [Android][Fixed] Mutations to newly created views from useLayoutEffect were not always applied.

Differential Revision: D56301318


