### PR TITLE
Split React-Fabric in React-Fabric and React-FabricComponents

### DIFF
--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -75,11 +75,14 @@ Pod::Spec.new do |s|
 
   add_dependency(s, "React-FabricImage")
   add_dependency(s, "React-Fabric", :additional_framework_paths => [
-    "react/renderer/textlayoutmanager/platform/ios",
-    "react/renderer/components/textinput/platform/ios",
     "react/renderer/components/view/platform/cxx",
     "react/renderer/imagemanager/platform/ios",
   ])
+  add_dependency(s, "React-FabricComponents", :additional_framework_paths => [
+    "react/renderer/textlayoutmanager/platform/ios",
+    "react/renderer/components/textinput/platform/ios",
+  ]);
+
   add_dependency(s, "React-nativeconfig")
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
   add_dependency(s, "React-ImageManager")

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -130,97 +130,12 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "components" do |ss|
-
-    ss.subspec "inputaccessory" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/inputaccessory/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/inputaccessory/tests"
-      sss.header_dir           = "react/renderer/components/inputaccessory"
-    end
-
-    ss.subspec "legacyviewmanagerinterop" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/legacyviewmanagerinterop/tests"
-      sss.header_dir           = "react/renderer/components/legacyviewmanagerinterop"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\"" }
-    end
-
-    ss.subspec "modal" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/modal/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/modal/tests"
-      sss.header_dir           = "react/renderer/components/modal"
-    end
-
-    ss.subspec "rncore" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/rncore/**/*.{m,mm,cpp,h}"
-      sss.header_dir           = "react/renderer/components/rncore"
-    end
-
     ss.subspec "root" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/root/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/root/tests"
       sss.header_dir           = "react/renderer/components/root"
-    end
-
-    ss.subspec "safeareaview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/safeareaview/tests"
-      sss.header_dir           = "react/renderer/components/safeareaview"
-
-    end
-
-    ss.subspec "scrollview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/scrollview/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/scrollview/tests"
-      sss.header_dir           = "react/renderer/components/scrollview"
-
-    end
-
-    ss.subspec "text" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/text/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/text/tests"
-      sss.header_dir           = "react/renderer/components/text"
-
-    end
-
-    ss.subspec "iostextinput" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
-      sss.header_dir           = "react/renderer/components/iostextinput"
-
-    end
-
-    ss.subspec "textinput" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}"
-      sss.header_dir           = "react/renderer/components/textinput"
-
-    end
-
-    ss.subspec "unimplementedview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/unimplementedview/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/unimplementedview/tests"
-      sss.header_dir           = "react/renderer/components/unimplementedview"
-
     end
 
     ss.subspec "view" do |sss|
@@ -232,6 +147,34 @@ Pod::Spec.new do |s|
       sss.header_dir           = "react/renderer/components/view"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/Yoga\"" }
     end
+
+    ss.subspec "legacyviewmanagerinterop" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/legacyviewmanagerinterop/tests"
+      sss.header_dir           = "react/renderer/components/legacyviewmanagerinterop"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\"" }
+    end
+  end
+
+  s.subspec "dom" do |ss|
+    ss.dependency             folly_dep_name, folly_version
+    ss.dependency             "React-graphics"
+    ss.compiler_flags       = folly_compiler_flags
+    ss.source_files         = "react/renderer/dom/**/*.{m,mm,cpp,h}"
+    ss.exclude_files        = "react/renderer/dom/tests"
+    ss.header_dir           = "react/renderer/dom"
+  end
+
+  s.subspec "scheduler" do |ss|
+    ss.dependency             folly_dep_name, folly_version
+    ss.compiler_flags       = folly_compiler_flags
+    ss.source_files         = "react/renderer/scheduler/**/*.{m,mm,cpp,h}"
+    ss.header_dir           = "react/renderer/scheduler"
+
+    ss.dependency             "React-performancetimeline"
+    ss.dependency             "React-Fabric/observers/events"
   end
 
   s.subspec "imagemanager" do |ss|
@@ -259,16 +202,6 @@ Pod::Spec.new do |s|
     end
   end
 
-  s.subspec "scheduler" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/scheduler/**/*.{m,mm,cpp,h}"
-    ss.header_dir           = "react/renderer/scheduler"
-
-    ss.dependency             "React-performancetimeline"
-    ss.dependency             "React-Fabric/observers/events"
-  end
-
   s.subspec "templateprocessor" do |ss|
     ss.dependency             folly_dep_name, folly_version
     ss.compiler_flags       = folly_compiler_flags
@@ -277,16 +210,13 @@ Pod::Spec.new do |s|
     ss.header_dir           = "react/renderer/templateprocessor"
   end
 
-  s.subspec "textlayoutmanager" do |ss|
+  s.subspec "telemetry" do |ss|
     ss.dependency             folly_dep_name, folly_version
-    ss.dependency             "React-Fabric/uimanager"
     ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/textlayoutmanager/platform/ios/**/*.{m,mm,cpp,h}",
-                              "react/renderer/textlayoutmanager/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/textlayoutmanager/tests",
-                              "react/renderer/textlayoutmanager/platform/android",
-                              "react/renderer/textlayoutmanager/platform/cxx"
-    ss.header_dir           = "react/renderer/textlayoutmanager"
+    ss.source_files         = "react/renderer/telemetry/**/*.{m,mm,cpp,h}"
+    ss.exclude_files        = "react/renderer/telemetry/tests"
+    ss.header_dir           = "react/renderer/telemetry"
+
   end
 
   s.subspec "uimanager" do |ss|
@@ -299,31 +229,9 @@ Pod::Spec.new do |s|
 
     ss.dependency             folly_dep_name, folly_version
     ss.dependency             "React-rendererconsistency"
-    ss.dependency             "React-Fabric/dom"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/uimanager/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/renderer/uimanager"
-  end
-
-  s.subspec "dom" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.dependency             "React-Fabric/components/root"
-    ss.dependency             "React-Fabric/components/text"
-    ss.dependency             "React-Fabric/core"
-    ss.dependency             "React-graphics"
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/dom/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/dom/tests"
-    ss.header_dir           = "react/renderer/dom"
-  end
-
-  s.subspec "telemetry" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/telemetry/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/telemetry/tests"
-    ss.header_dir           = "react/renderer/telemetry"
-
   end
 
   s.subspec "leakchecker" do |ss|

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -1,0 +1,205 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+folly_config = get_folly_config()
+folly_compiler_flags = folly_config[:compiler_flags]
+folly_version = folly_config[:version]
+
+folly_dep_name = 'RCT-Folly/Fabric'
+boost_compiler_flags = '-Wno-documentation'
+react_native_path = ".."
+
+Pod::Spec.new do |s|
+
+  header_search_path = [
+    "\"$(PODS_ROOT)/boost\"",
+    "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"",
+    "\"$(PODS_ROOT)/RCT-Folly\"",
+    "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
+    "\"$(PODS_TARGET_SRCROOT)\"",
+    "\"$(PODS_ROOT)/DoubleConversion\"",
+    "\"$(PODS_ROOT)/fmt/include\"",
+  ]
+
+  if ENV['USE_FRAMEWORKS']
+    header_search_path = header_search_path + [
+      "\"$(PODS_TARGET_SRCROOT)/react/renderer/textlayoutmanager/platform/ios\"",
+      "\"$(PODS_TARGET_SRCROOT)/react/renderer/components/textinput/platform/ios\"",
+      "\"$(PODS_TARGET_SRCROOT)/react/renderer/components/view/platform/cxx\"",
+    ]
+  end
+
+  s.name                   = "React-FabricComponents"
+  s.version                = version
+  s.summary                = "Fabric Components for React Native."
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = "dummyFile.cpp"
+  s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",
+                            "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
+                            "DEFINES_MODULE" => "YES",
+                            "HEADER_SEARCH_PATHS" => header_search_path.join(" "),
+                          }
+
+  if ENV['USE_FRAMEWORKS']
+    s.header_mappings_dir     = './'
+    s.module_name             = 'React_FabricComponents'
+  end
+
+  s.dependency folly_dep_name, folly_version
+
+  s.dependency "React-jsiexecutor"
+  s.dependency "RCTRequired"
+  s.dependency "RCTTypeSafety"
+  s.dependency "ReactCommon/turbomodule/core"
+  s.dependency "React-jsi"
+  s.dependency "React-logger"
+  s.dependency "glog"
+  s.dependency "DoubleConversion"
+  s.dependency "fmt", "9.1.0"
+  s.dependency "React-Core"
+  s.dependency "React-debug"
+  s.dependency "React-featureflags"
+  s.dependency "React-utils"
+  s.dependency "React-runtimescheduler"
+  s.dependency "React-cxxreact"
+  s.dependency "Yoga"
+
+  add_dependency(s, "React-rendererdebug")
+  add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
+  add_dependency(s, "React-Fabric", :additional_framework_paths => [
+    "react/renderer/components/view/platform/cxx",
+    "react/renderer/imagemanager/platform/ios"
+  ])
+  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsc"
+  end
+
+  s.subspec "components" do |ss|
+
+    ss.subspec "inputaccessory" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/inputaccessory/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/inputaccessory/tests"
+      sss.header_dir           = "react/renderer/components/inputaccessory"
+    end
+
+    ss.subspec "modal" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/modal/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/modal/tests"
+      sss.header_dir           = "react/renderer/components/modal"
+    end
+
+    ss.subspec "rncore" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/rncore/**/*.{m,mm,cpp,h}"
+      sss.header_dir           = "react/renderer/components/rncore"
+    end
+
+    ss.subspec "safeareaview" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/safeareaview/tests"
+      sss.header_dir           = "react/renderer/components/safeareaview"
+
+    end
+
+    ss.subspec "scrollview" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/scrollview/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/scrollview/tests"
+      sss.header_dir           = "react/renderer/components/scrollview"
+
+    end
+
+    ss.subspec "text" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/text/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/text/tests"
+      sss.header_dir           = "react/renderer/components/text"
+
+    end
+
+    ss.subspec "iostextinput" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
+      sss.header_dir           = "react/renderer/components/iostextinput"
+
+    end
+
+    ss.subspec "textinput" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}"
+      sss.header_dir           = "react/renderer/components/textinput"
+
+    end
+
+    ss.subspec "unimplementedview" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/unimplementedview/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/unimplementedview/tests"
+      sss.header_dir           = "react/renderer/components/unimplementedview"
+
+    end
+  end
+
+  s.subspec "textlayoutmanager" do |ss|
+    ss.dependency             folly_dep_name, folly_version
+    ss.dependency             "React-Fabric"
+    ss.compiler_flags       = folly_compiler_flags
+    ss.source_files         = "react/renderer/textlayoutmanager/platform/ios/**/*.{m,mm,cpp,h}",
+                              "react/renderer/textlayoutmanager/*.{m,mm,cpp,h}"
+    ss.exclude_files        = "react/renderer/textlayoutmanager/tests",
+                              "react/renderer/textlayoutmanager/platform/android",
+                              "react/renderer/textlayoutmanager/platform/cxx"
+    ss.header_dir           = "react/renderer/textlayoutmanager"
+  end
+
+  s.script_phases = [
+    {
+      :name => '[RN]Check rncore',
+      :execution_position => :before_compile,
+      :script => <<-EOS
+echo "Checking whether Codegen has run..."
+rncorePath="$REACT_NATIVE_PATH/ReactCommon/react/renderer/components/rncore"
+
+if [[ ! -d "$rncorePath" ]]; then
+  echo 'error: Codegen did not run properly in your project. Please reinstall cocoapods with `bundle exec pod install`.'
+  exit 1
+fi
+      EOS
+    }
+  ]
+end

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
@@ -45,7 +45,6 @@ Pod::Spec.new do |s|
   install_modules_dependencies(s)
 
   s.dependency "ReactCommon/turbomodule/core"
-  s.dependency "React-Fabric/uimanager"
-  s.dependency "React-Fabric/dom"
-  s.dependency "React-Fabric/components/root"
+  s.dependency "React-Fabric"
+  s.dependency "React-FabricComponents"
 end

--- a/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
@@ -34,9 +34,10 @@ class FabricTest < Test::Unit::TestCase
     end
 
     def check_installed_pods(prefix)
-        assert_equal(6, $podInvocationCount)
+        assert_equal(7, $podInvocationCount)
 
         check_pod("React-Fabric", :path => "#{prefix}/ReactCommon")
+        check_pod("React-FabricComponents", :path => "#{prefix}/ReactCommon")
         check_pod("React-FabricImage", :path => "#{prefix}/ReactCommon")
         check_pod("React-graphics", :path => "#{prefix}/ReactCommon/react/renderer/graphics")
         check_pod("React-RCTFabric", :path => "#{prefix}/React", :modular_headers => true)

--- a/packages/react-native/scripts/cocoapods/fabric.rb
+++ b/packages/react-native/scripts/cocoapods/fabric.rb
@@ -9,6 +9,7 @@
 # @parameter react_native_path: relative path to react-native
 def setup_fabric!(react_native_path: "../node_modules/react-native")
     pod 'React-Fabric', :path => "#{react_native_path}/ReactCommon"
+    pod 'React-FabricComponents', :path => "#{react_native_path}/ReactCommon"
     pod 'React-graphics', :path => "#{react_native_path}/ReactCommon/react/renderer/graphics"
     pod 'React-RCTFabric', :path => "#{react_native_path}/React", :modular_headers => true
     pod 'React-ImageManager', :path => "#{react_native_path}/ReactCommon/react/renderer/imagemanager/platform/ios"


### PR DESCRIPTION
Summary:
This change splits the React-Fabric podspec in two podspecs: React-Fabric and React-FabricComponents.

The reson is that we are codegenerating some of the core components and we want for the FabricComponents to depend on ReactCodegen.
Before this change, we had a circular dependency if we make ReactFabric depends on Codegen because ReactCodegen has to depend on ReactFabric.

Now, the dependency graph would be:
`React-FabricComponents --> ReactCodegen --> React-Fabric`
and no cycle is created

## Changelog
[internal] Split React-Fabric in React-Fabric and React-FabricComponents

Differential Revision: D56306355
