### PR TITLE
Back out "Use ClassFinder inside ViewManagerPropertyUpdater"

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
@@ -9,7 +9,6 @@ package com.facebook.react.uimanager;
 
 import android.view.View;
 import com.facebook.common.logging.FLog;
-import com.facebook.react.common.ClassFinder;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -110,13 +109,9 @@ public class ViewManagerPropertyUpdater {
   private static <T> T findGeneratedSetter(Class<?> cls) {
     String clsName = cls.getName();
     try {
-      Class<?> setterClass = ClassFinder.findClass(clsName + "$$PropsSetter");
-      if (setterClass != null) {
-        //noinspection unchecked
-        return (T) setterClass.newInstance();
-      } else {
-        return null;
-      }
+      Class<?> setterClass = Class.forName(clsName + "$$PropsSetter");
+      //noinspection unchecked
+      return (T) setterClass.newInstance();
     } catch (ClassNotFoundException e) {
       FLog.w(TAG, "Could not find generated setter for " + cls);
       return null;


### PR DESCRIPTION
Summary:
We're seeing an increase of crashes on Twilight (https://www.internalfb.com/logview/twilight_android_crashes/d25ec89876821abdd07f98d08a729f7c?trace_tab=0&ds=%7B%22start%22%3A%22-2%20weeks%22%2C%22end%22%3A%22now%22%7D) related to setting fontWeight with Double instead of String.

Original commit changeset: a67195e98377

Original Phabricator Diff: D56191175

Changelog:
[Internal] [Changed] - Revert use ClassFinder inside ViewManagerPropertyUpdater

Differential Revision: D56311183


