### PR TITLE
[Android] Fixes Android tests build error

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -14,7 +14,9 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_mounting_SRC CONFIGURE_DEPENDS *.cpp)
+file(GLOB react_render_mounting_SRC CONFIGURE_DEPENDS 
+        *.cpp
+        stubs/*.cpp)
 add_library(react_render_mounting STATIC ${react_render_mounting_SRC})
 
 target_include_directories(react_render_mounting PRIVATE .)

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -20,7 +20,7 @@
 #include "ShadowTreeRevision.h"
 
 #ifdef RN_SHADOW_TREE_INTROSPECTION
-#include <react/renderer/mounting/stubs.h>
+#include <react/renderer/mounting/stubs/stubs.h>
 #endif
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
@@ -11,7 +11,7 @@
 #include <unordered_map>
 
 #include <react/renderer/mounting/ShadowViewMutation.h>
-#include <react/renderer/mounting/StubView.h>
+#include <react/renderer/mounting/stubs/StubView.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/MountingTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/MountingTest.cpp
@@ -11,7 +11,7 @@
 #include <react/renderer/components/view/ViewComponentDescriptor.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/mounting/Differentiator.h>
-#include <react/renderer/mounting/stubs.h>
+#include <react/renderer/mounting/stubs/stubs.h>
 
 #include <react/test_utils/shadowTreeGeneration.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/OrderIndexTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/OrderIndexTest.cpp
@@ -19,7 +19,7 @@
 #include <react/renderer/element/testUtils.h>
 #include <react/renderer/mounting/Differentiator.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
-#include <react/renderer/mounting/stubs.h>
+#include <react/renderer/mounting/stubs/stubs.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -19,7 +19,7 @@
 #include <react/renderer/element/testUtils.h>
 #include <react/renderer/mounting/Differentiator.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
-#include <react/renderer/mounting/stubs.h>
+#include <react/renderer/mounting/stubs/stubs.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -17,7 +17,7 @@
 #include <react/config/ReactNativeConfig.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/mounting/Differentiator.h>
-#include <react/renderer/mounting/stubs.h>
+#include <react/renderer/mounting/stubs/stubs.h>
 
 #include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/components/view/ViewComponentDescriptor.h>


### PR DESCRIPTION
## Summary:

Fixes build_android failure. Brings in https://github.com/facebook/react-native/pull/44131. cc @NickGerleman 

```
' file not found
  #include <react/renderer/mounting/stubs.h>
```

## Changelog:

[INTERNAL] [FIXED] - Fixes Android tests build error

## Test Plan:

ci green.
