### PR TITLE
Fix font scaling when `numberOfLines` is not set on Android on the new arch

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -419,6 +419,7 @@ public class TextLayoutManagerMapBuffer {
     int initialFontSize = currentFontSize;
     while (currentFontSize > minimumFontSize
         && ((maximumNumberOfLines != ReactConstants.UNSET
+               && maximumNumberOfLines != 0
                 && layout.getLineCount() > maximumNumberOfLines)
             || (heightYogaMeasureMode != YogaMeasureMode.UNDEFINED
                 && layout.getHeight() > height))) {


### PR DESCRIPTION
## Summary:

This is a follow-up to https://github.com/facebook/react-native/pull/44075. I've missed the fact that `ReactConstants.UNSET` is `-1` and the default value of `numberOfLines` prop is `0`. This resulted in font size being set to the minimal value when `adjustFontSizeToFit` was used without setting `numberOfLines` to a positive value.

## Changelog:

[ANDROID] [FIXED] - Fixed `adjustFontSizeToFit` when used without `numberOfLines`

## Test Plan:

<details>
<summary>Tested on the following code</summary>

```jsx
import { Text, SafeAreaView, View, StyleSheet } from 'react-native';

export default function Test() {
  return (
    <SafeAreaView style={styles.container}>
      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }}>
          Some text that fits (no adjust, unlimited height)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} adjustsFontSizeToFit>
          Some text that fits (adjust, unlimited height)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} numberOfLines={1}>
          Some text that fits (no adjust, 1 line)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} adjustsFontSizeToFit numberOfLines={1}>
          Some text that fits (adjust, 1 line)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }}>
          Some longer text that doesn't fit if displayed in one line (no adjust, unlimited height)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} adjustsFontSizeToFit>
          Some longer text that doesn't fit if displayed in one line (adjust, unlimited height)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} numberOfLines={1}>
          Some longer text that doesn't fit if displayed in one line (no adjust, 1 line)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} adjustsFontSizeToFit numberOfLines={1}>
        Some longer text that doesn't fit if displayed in one line (adjust, 1 line)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }}>
          Even longer text that doesn't even fit if it has as much as two entire lines for itself, what a darn shame (no adjust, unlimited height)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} adjustsFontSizeToFit>
          Even longer text that doesn't even fit if it has as much as two entire lines for itself, what a darn shame (adjust, unlimited height)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} numberOfLines={2}>
          Even longer text that doesn't even fit if it has as much as two entire lines for itself, what a darn shame (no adjust, 2 lines)
        </Text>
      </View>

      <View style={{margin: 4, borderWidth: 1, borderColor: 'black'}}>
        <Text style={{ fontSize: 16 }} numberOfLines={2} adjustsFontSizeToFit>
          Even longer text that doesn't even fit if it has as much as two entire lines for itself, what a darn shame (adjust, 2 lines)
        </Text>
      </View>
    </SafeAreaView>
  );
}
```

</details>

|Old arch|New arch (without this PR)|New arch (with this PR)|
|-|-|-|
|<img width="447" alt="a_old" src="https://github.com/facebook/react-native/assets/21055725/4822f7f1-a19c-4225-9318-0eb2fec6f925">|<img width="447" alt="a_new_no_change" src="https://github.com/facebook/react-native/assets/21055725/ff594673-b362-4a81-8837-624cb1061d28">|<img width="447" alt="a_new_changed" src="https://github.com/facebook/react-native/assets/21055725/1f29c01c-1c91-4c9f-9edd-0950338b5d39">|



