### PR TITLE
Fix @react-native/oss-library-example package.json#exports

### DIFF
--- a/packages/react-native-test-library/package.json
+++ b/packages/react-native-test-library/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./index.js",
   "exports": {
-    "./": "./index.js",
+    ".": "./index.js",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
Summary:
Fix `package.json#exports` main entry point in `react-native/oss-library-example` (which is actually at `packages/react-native-test-library`), to fix a Metro resolver warning on building RN-tester.

Changelog: [Internal]

(This package is not published)

Differential Revision: D56414480


