### PR TITLE
Align debugger Chrome launch flags with Meta-internal version

### DIFF
--- a/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
@@ -51,12 +51,23 @@ const DefaultBrowserLauncher: BrowserLauncher = {
       `react-native-debugger-frontend-${browserType}`,
     );
     const launchedChrome = await ChromeLauncher.launch({
-      chromePath,
       chromeFlags: [
+        ...ChromeLauncher.Launcher.defaultFlags().filter(
+          /**
+           * This flag controls whether Chrome treats a visually covered (occluded) tab
+           * as "backgrounded". We launch CDT as a single tab/window via `--app`, so we
+           * do want Chrome to treat our tab as "backgrounded" when the UI is covered.
+           * Omitting this flag allows "visibilitychange" events to fire properly.
+           */
+          flag => flag !== '--disable-backgrounding-occluded-windows',
+        ),
         `--app=${url}`,
         `--user-data-dir=${userDataDir}`,
         '--window-size=1200,600',
+        '--guest',
       ],
+      chromePath,
+      ignoreDefaultFlags: true,
     });
 
     return {


### PR DESCRIPTION
Summary:
Changelog: [General][Changed] Update Chrome launch flags for `--experimental-debugger` launch flow

Internally at Meta, we've been testing the experimental debugger launch flow with a different set of Chrome flags than are currently shipped in open source. This diff fixes those differences:

* Removes `--disable-backgrounding-occluded-windows`
* Adds `--guest`

Reviewed By: EdmondChuiHW

Differential Revision: D56418271


