### PR TITLE
reset animation state in TouchableOpacity and TouchableBounce

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -209,6 +209,7 @@ class TouchableBounce extends React.Component<Props, State> {
 
   componentWillUnmount(): void {
     this.state.pressability.reset();
+    this.state.scale.resetAnimation();
   }
 }
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -320,6 +320,7 @@ class TouchableOpacity extends React.Component<Props, State> {
 
   componentWillUnmount(): void {
     this.state.pressability.reset();
+    this.state.anim.resetAnimation();
   }
 }
 


### PR DESCRIPTION
Summary:
## Changelog:

[iOS] [Fixed] - Fixed stale state on TouchableOpacity and TouchableBounce

When TouchableOpacity and TouchableBounce are unmounted, we need to reset their state. This includes animation state. If we don't do that, view is unmounted on the mounting layer and animation will not be applied. This leaves view in undefined state. In TouchableOpacity, it is view with reduced opacity. TouchableBounce that is view with applied transform.

This was reported in https://github.com/facebook/react-native/issues/44044

Reviewed By: rubennorte, cipolleschi

Differential Revision: D56416571


