### PR TITLE
Fix Symbol not found: (_JSGlobalContextSetInspectable)

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -377,9 +377,11 @@ JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
 {
 #ifndef NDEBUG
 #ifdef _JSC_HAS_INSPECTABLE
+#if (__OSX_AVAILABLE_STARTING(MAC_NA, IPHONE_16_4))
   if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
     JSGlobalContextSetInspectable(ctx_, true);
   }
+#endif
 #endif
 #endif
 }


### PR DESCRIPTION
Summary:
This change will fix a symbol not found for JSC Runtime.

The `if` check was not a compile time check, therefore the symbol ended up in the binary even if it is not available.

Following this post on [Apple forum](https://forums.developer.apple.com/forums/thread/749534), this changes should do the trick.

## Changelog
[iOS][Fixed] - Fix Symbol not found: (_JSGlobalContextSetInspectable)

Differential Revision: D56425834


