### PR TITLE
Split scheduler commit and flush delegate methods

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)schedulerDidFinishTransaction:(facebook::react::MountingCoordinator::Shared)mountingCoordinator;
 
+- (void)schedulerShouldRenderTransactions:(facebook::react::MountingCoordinator::Shared)mountingCoordinator;
+
 - (void)schedulerDidDispatchCommand:(const facebook::react::ShadowView &)shadowView
                         commandName:(const std::string &)commandName
                                args:(const folly::dynamic &)args;

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -31,6 +31,12 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     [scheduler.delegate schedulerDidFinishTransaction:mountingCoordinator];
   }
 
+  void schedulerShouldRenderTransactions(const MountingCoordinator::Shared &mountingCoordinator) override
+  {
+    RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
+    [scheduler.delegate schedulerShouldRenderTransactions:mountingCoordinator];
+  }
+
   void schedulerDidRequestPreliminaryViewAllocation(SurfaceId surfaceId, const ShadowNode &shadowNode) override
   {
     // Does nothing.

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -334,7 +334,16 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (void)schedulerDidFinishTransaction:(MountingCoordinator::Shared)mountingCoordinator
 {
-  [_mountingManager scheduleTransaction:mountingCoordinator];
+  if (!ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
+    [_mountingManager scheduleTransaction:mountingCoordinator];
+  }
+}
+
+- (void)schedulerShouldRenderTransactions:(MountingCoordinator::Shared)mountingCoordinator
+{
+  if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
+    [_mountingManager scheduleTransaction:mountingCoordinator];
+  }
 }
 
 - (void)schedulerDidDispatchCommand:(const ShadowView &)shadowView

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -101,6 +101,9 @@ class Binding : public jni::HybridClass<Binding, JBinding>,
   void schedulerDidFinishTransaction(
       const MountingCoordinator::Shared& mountingCoordinator) override;
 
+  void schedulerShouldRenderTransactions(
+      const MountingCoordinator::Shared& mountingCoordinator) override;
+
   void schedulerDidRequestPreliminaryViewAllocation(
       const SurfaceId surfaceId,
       const ShadowNode& shadowNode) override;
@@ -145,6 +148,9 @@ class Binding : public jni::HybridClass<Binding, JBinding>,
   std::unordered_map<SurfaceId, SurfaceHandler> surfaceHandlerRegistry_{};
   std::shared_mutex
       surfaceHandlerRegistryMutex_; // Protects `surfaceHandlerRegistry_`.
+
+  // Track pending transactions, one per surfaceId
+  std::vector<MountingTransaction> pendingTransactions_;
 
   float pointScaleFactor_ = 1;
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.cpp
@@ -41,4 +41,17 @@ Number MountingTransaction::getNumber() const {
   return number_;
 }
 
+void MountingTransaction::mergeWith(MountingTransaction&& transaction) {
+  react_native_assert(transaction.getSurfaceId() == surfaceId_);
+  number_ = transaction.getNumber();
+  mutations_.insert(
+      mutations_.end(),
+      std::make_move_iterator(transaction.mutations_.begin()),
+      std::make_move_iterator(transaction.mutations_.end()));
+
+  // TODO T186641819: Telemetry for merged transactions is not supported, use
+  // the latest instance
+  telemetry_ = std::move(transaction.telemetry_);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.h
@@ -76,6 +76,12 @@ class MountingTransaction final {
    */
   Number getNumber() const;
 
+  /*
+   * Merges the given transaction in the current transaction, so they
+   * can be executed atomatically as a single transaction.
+   */
+  void mergeWith(MountingTransaction&& transaction);
+
  private:
   SurfaceId surfaceId_;
   Number number_;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -291,6 +291,8 @@ void Scheduler::uiManagerDidFinishTransaction(
   SystraceSection s("Scheduler::uiManagerDidFinishTransaction");
 
   if (delegate_ != nullptr) {
+    delegate_->schedulerDidFinishTransaction(mountingCoordinator);
+
     auto weakRuntimeScheduler =
         contextContainer_->find<std::weak_ptr<RuntimeScheduler>>(
             "RuntimeScheduler");
@@ -301,13 +303,14 @@ void Scheduler::uiManagerDidFinishTransaction(
       runtimeScheduler->scheduleRenderingUpdate(
           [delegate = delegate_,
            mountingCoordinator = std::move(mountingCoordinator)]() {
-            delegate->schedulerDidFinishTransaction(mountingCoordinator);
+            delegate->schedulerShouldRenderTransactions(mountingCoordinator);
           });
     } else {
-      delegate_->schedulerDidFinishTransaction(mountingCoordinator);
+      delegate_->schedulerShouldRenderTransactions(mountingCoordinator);
     }
   }
 }
+
 void Scheduler::uiManagerDidCreateShadowNode(const ShadowNode& shadowNode) {
   SystraceSection s("Scheduler::uiManagerDidCreateShadowNode");
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -29,6 +29,13 @@ class SchedulerDelegate {
       const MountingCoordinator::Shared& mountingCoordinator) = 0;
 
   /*
+   * Called when the runtime scheduler decides that one-or-more previously
+   * finished transactions should now be flushed to the screen (atomically).
+   */
+  virtual void schedulerShouldRenderTransactions(
+      const MountingCoordinator::Shared& mountingCoordinator) = 0;
+
+  /*
    * Called right after a new ShadowNode was created.
    */
   virtual void schedulerDidRequestPreliminaryViewAllocation(


### PR DESCRIPTION
Summary:
The current approach used for `batchRenderingUpdatesInEventLoop` is not compatible with Android due to limitations in its props processing model. The raw props changeset is passed through to Android, and must be available for the Android mounting layer to correctly apply changes.

We have some logic to merge these payloads when multiple ShadowNode clones take place but were previously assuming that a ShadowTree commit was a safe state to synchronize.

In the current implementation this means that two commits driven from layout effects (triggering states A → B → C) may cause Android to observe only the B → C props change, and miss out on any props changed in A → B.

Changelog: [Android] Fixed cascading renders not mounting correctly when `batchRenderingUpdatesInEventLoop` is enabled.

Differential Revision: D56414689


