### PR TITLE
introduce PriorityCallInvoker

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.h
@@ -29,9 +29,11 @@ class BufferedRuntimeExecutor {
     }
   };
 
-  BufferedRuntimeExecutor(RuntimeExecutor runtimeExecutor);
+  explicit BufferedRuntimeExecutor(PriorityRuntimeExecutor runtimeExecutor);
 
-  void execute(Work&& callback);
+  void execute(
+      Work&& callback,
+      std::optional<SchedulerPriority> priority = std::nullopt);
 
   // Flush buffered JS calls and then diable JS buffering
   void flush();
@@ -40,7 +42,7 @@ class BufferedRuntimeExecutor {
   // Perform flushing without locking mechanism
   void unsafeFlush();
 
-  RuntimeExecutor runtimeExecutor_;
+  PriorityRuntimeExecutor runtimeExecutor_;
   bool isBufferingEnabled_;
   std::mutex lock_;
   std::atomic<uint64_t> lastIndex_;

--- a/packages/react-native/ReactCommon/react/runtime/PriorityCallInvoker.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/PriorityCallInvoker.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PriorityCallInvoker.h"
+
+#include <stdexcept>
+
+namespace facebook::react {
+
+PriorityCallInvoker::PriorityCallInvoker(
+    PriorityRuntimeExecutor priorityRuntimeExecutor)
+    : priorityRuntimeExecutor_(std::move(priorityRuntimeExecutor)) {}
+
+void PriorityCallInvoker::invokeAsync(CallFunc&& func) noexcept {
+  priorityRuntimeExecutor_(
+      [func = std::move(func)](jsi::Runtime& runtime) { func(runtime); },
+      std::nullopt);
+}
+
+void PriorityCallInvoker::invokeAsync(
+    SchedulerPriority priority,
+    CallFunc&& func) noexcept {
+  priorityRuntimeExecutor_(
+      [func = std::move(func)](jsi::Runtime& runtime) { func(runtime); },
+      priority);
+}
+
+void PriorityCallInvoker::invokeSync(CallFunc&& /*func*/) {
+  // TODO: Implement this method. The TurboModule infra doesn't call invokeSync.
+  throw std::runtime_error(
+      "Synchronous native -> JS calls are currently not supported.");
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/PriorityCallInvoker.h
+++ b/packages/react-native/ReactCommon/react/runtime/PriorityCallInvoker.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/CallInvoker.h>
+#include <ReactCommon/RuntimeExecutor.h>
+#include <ReactCommon/SchedulerPriority.h>
+
+namespace facebook::react {
+
+class PriorityCallInvoker : public CallInvoker {
+ public:
+  explicit PriorityCallInvoker(PriorityRuntimeExecutor priorityRuntimeExecutor);
+  void invokeAsync(CallFunc&& func) noexcept override;
+  void invokeAsync(SchedulerPriority priority, CallFunc&& func) noexcept
+      override;
+  void invokeSync(CallFunc&& func) override;
+
+ private:
+  PriorityRuntimeExecutor priorityRuntimeExecutor_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -41,6 +41,8 @@ class ReactInstance final : private jsinspector_modern::InstanceTargetDelegate {
 
   RuntimeExecutor getBufferedRuntimeExecutor() noexcept;
 
+  PriorityRuntimeExecutor getPriorityRuntimeExecutor() noexcept;
+
   std::shared_ptr<RuntimeScheduler> getRuntimeScheduler() noexcept;
 
   struct JSRuntimeFlags {

--- a/packages/react-native/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
@@ -8,9 +8,12 @@
 #pragma once
 
 #include <mutex>
+#include <optional>
 #include <thread>
 
 #include <jsi/jsi.h>
+
+#include <ReactCommon/SchedulerPriority.h>
 
 namespace facebook::react {
 
@@ -24,6 +27,10 @@ namespace facebook::react {
  */
 using RuntimeExecutor =
     std::function<void(std::function<void(jsi::Runtime& runtime)>&& callback)>;
+
+using PriorityRuntimeExecutor = std::function<void(
+    std::function<void(jsi::Runtime& runtime)>&& callback,
+    std::optional<SchedulerPriority> priority)>;
 
 /*
  * Executes a `callback` in a *synchronous* manner on the same thread using


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this change, we introduce a new CallInvoker that will replace BridgelessJSCallInvoker. instead of RuntimeExecutor, this CallInvoker is powered by a PriorityRuntimeExecutor, meaning that its underlying runtime execution has access to priorities passed in from userland.

we can now hook this up to the getPriorityRuntimeExecutor provided by ReactInstance in order to pass down scheduling priorities to the runtime scheduler, instead of always using the default.

note that this change is internal still - userland only needs to know about the CallInvoker type.

Differential Revision: D56455634


