### PR TITLE
introduce PriorityRuntimeExecutor

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.h
@@ -29,9 +29,11 @@ class BufferedRuntimeExecutor {
     }
   };
 
-  BufferedRuntimeExecutor(RuntimeExecutor runtimeExecutor);
+  explicit BufferedRuntimeExecutor(PriorityRuntimeExecutor runtimeExecutor);
 
-  void execute(Work&& callback);
+  void execute(
+      Work&& callback,
+      std::optional<SchedulerPriority> priority = std::nullopt);
 
   // Flush buffered JS calls and then diable JS buffering
   void flush();
@@ -40,7 +42,7 @@ class BufferedRuntimeExecutor {
   // Perform flushing without locking mechanism
   void unsafeFlush();
 
-  RuntimeExecutor runtimeExecutor_;
+  PriorityRuntimeExecutor runtimeExecutor_;
   bool isBufferingEnabled_;
   std::mutex lock_;
   std::atomic<uint64_t> lastIndex_;

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -41,6 +41,8 @@ class ReactInstance final : private jsinspector_modern::InstanceTargetDelegate {
 
   RuntimeExecutor getBufferedRuntimeExecutor() noexcept;
 
+  PriorityRuntimeExecutor getPriorityRuntimeExecutor() noexcept;
+
   std::shared_ptr<RuntimeScheduler> getRuntimeScheduler() noexcept;
 
   struct JSRuntimeFlags {

--- a/packages/react-native/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
@@ -8,9 +8,12 @@
 #pragma once
 
 #include <mutex>
+#include <optional>
 #include <thread>
 
 #include <jsi/jsi.h>
+
+#include <ReactCommon/SchedulerPriority.h>
 
 namespace facebook::react {
 
@@ -24,6 +27,10 @@ namespace facebook::react {
  */
 using RuntimeExecutor =
     std::function<void(std::function<void(jsi::Runtime& runtime)>&& callback)>;
+
+using PriorityRuntimeExecutor = std::function<void(
+    std::function<void(jsi::Runtime& runtime)>&& callback,
+    std::optional<SchedulerPriority> priority)>;
 
 /*
  * Executes a `callback` in a *synchronous* manner on the same thread using


### PR DESCRIPTION
Summary:
Changelog: [Internal]

the goal is to allow userland to pass down scheduler priorities to the CallInvoker. 

in bridge, we currently have RuntimeSchedulerCallInvoker. though this supports priorities, we cannot reuse this as is because it is unbuffered. currently JS invocations in bridgeless are (mostly) buffered.

in bridgeless, we currently have BridgelessJSCallInvoker

in this change, i introduce a new function type, `PriorityRuntimeExecutor`, that in addition to the runtime callback, has a priority argument. i hook this up to the cxx infra where we will instead call `scheduleTask` with a priority rather than `scheduleWork` if we receive a priority from userland.

i also introduced a new API from the cxx ReactInstance, called `getPriorityRuntimeExecutor`, which will allow us to keep the current `getBufferedRuntimeExecutor` intact which will allow for a iterative migration, but also make sure that both of these APIs share the same buffer.

Differential Revision: D56455633


