### PR TITLE
Extend Property Processor to support long properties

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -128,6 +128,7 @@ public class com/facebook/react/ReactActivityDelegate {
 	public fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	protected fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 	protected fun isFabricEnabled ()Z
+	protected fun isWideColorGamutEnabled ()Z
 	protected fun loadApp (Ljava/lang/String;)V
 	public fun onActivityResult (IILandroid/content/Intent;)V
 	public fun onBackPressed ()Z

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5413,6 +5413,7 @@ public abstract interface annotation class com/facebook/react/uimanager/annotati
 	public abstract fun defaultDouble ()D
 	public abstract fun defaultFloat ()F
 	public abstract fun defaultInt ()I
+	public abstract fun defaultLong ()J
 	public abstract fun name ()Ljava/lang/String;
 }
 
@@ -5422,6 +5423,7 @@ public abstract interface annotation class com/facebook/react/uimanager/annotati
 	public abstract fun defaultDouble ()D
 	public abstract fun defaultFloat ()F
 	public abstract fun defaultInt ()I
+	public abstract fun defaultLong ()J
 	public abstract fun names ()[Ljava/lang/String;
 }
 

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -647,6 +647,7 @@ public class com/facebook/react/bridge/ColorPropConverter {
 	public fun <init> ()V
 	public static fun getColor (Ljava/lang/Object;Landroid/content/Context;)Ljava/lang/Integer;
 	public static fun getColor (Ljava/lang/Object;Landroid/content/Context;I)Ljava/lang/Integer;
+	public static fun getColorInstance (Ljava/lang/Object;Landroid/content/Context;)Landroid/graphics/Color;
 	public static fun resolveResourcePath (Landroid/content/Context;Ljava/lang/String;)Ljava/lang/Integer;
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -10,7 +10,9 @@ package com.facebook.react;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.annotation.Nullable;
@@ -102,6 +104,9 @@ public class ReactActivityDelegate {
   public void onCreate(Bundle savedInstanceState) {
     String mainComponentName = getMainComponentName();
     final Bundle launchOptions = composeLaunchOptions();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isWideColorGamutEnabled()) {
+      mActivity.getWindow().setColorMode(ActivityInfo.COLOR_MODE_WIDE_COLOR_GAMUT);
+    }
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
       mReactDelegate =
           new ReactDelegate(getPlainActivity(), getReactHost(), mainComponentName, launchOptions);
@@ -216,5 +221,14 @@ public class ReactActivityDelegate {
    */
   protected boolean isFabricEnabled() {
     return ReactFeatureFlags.enableFabricRenderer;
+  }
+
+  /**
+   * Override this method if you wish to selectively toggle wide color gamut for a specific surface.
+   *
+   * @return true if wide gamut is enabled for this Activity, false otherwise.
+   */
+  protected boolean isWideColorGamutEnabled() {
+    return false;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java
@@ -9,7 +9,11 @@ package com.facebook.react.bridge;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.graphics.Color;
+import android.graphics.ColorSpace;
+import android.os.Build;
 import android.util.TypedValue;
+import androidx.annotation.ColorLong;
 import androidx.annotation.Nullable;
 import androidx.core.content.res.ResourcesCompat;
 import com.facebook.common.logging.FLog;
@@ -24,13 +28,17 @@ public class ColorPropConverter {
   private static final String ATTR = "attr";
   private static final String ATTR_SEGMENT = "attr/";
 
-  public static Integer getColor(Object value, Context context) {
+  private static Boolean apiSupportWideGamut() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
+  }
+
+  public static Color getColorInstance(Object value, Context context) {
     if (value == null) {
       return null;
     }
 
-    if (value instanceof Double) {
-      return ((Double) value).intValue();
+    if (apiSupportWideGamut() && value instanceof Double) {
+      return Color.valueOf(((Double) value).intValue());
     }
 
     if (context == null) {
@@ -39,6 +47,22 @@ public class ColorPropConverter {
 
     if (value instanceof ReadableMap) {
       ReadableMap map = (ReadableMap) value;
+
+      // handle color(space r g b a) value
+      if (apiSupportWideGamut() && map.hasKey("space")) {
+        String rawColorSpace = map.getString("space");
+        boolean isDisplayP3 = rawColorSpace.equals("display-p3");
+        ColorSpace space =
+            ColorSpace.get(isDisplayP3 ? ColorSpace.Named.DISPLAY_P3 : ColorSpace.Named.SRGB);
+        float r = (float) map.getDouble("r");
+        float g = (float) map.getDouble("g");
+        float b = (float) map.getDouble("b");
+        float a = (float) map.getDouble("a");
+
+        @ColorLong long color = Color.pack(r, g, b, a, space);
+        return Color.valueOf(color);
+      }
+
       ReadableArray resourcePaths = map.getArray(JSON_KEY);
 
       if (resourcePaths == null) {
@@ -48,8 +72,8 @@ public class ColorPropConverter {
 
       for (int i = 0; i < resourcePaths.size(); i++) {
         Integer result = resolveResourcePath(context, resourcePaths.getString(i));
-        if (result != null) {
-          return result;
+        if (apiSupportWideGamut() && result != null) {
+          return Color.valueOf(result);
         }
       }
 
@@ -61,6 +85,17 @@ public class ColorPropConverter {
 
     throw new JSApplicationCausedNativeException(
         "ColorValue: the value must be a number or Object.");
+  }
+
+  public static Integer getColor(Object value, Context context) {
+    Color color = getColorInstance(value, context);
+    if (color == null) {
+      return null;
+    }
+    if (apiSupportWideGamut()) {
+      return color.toArgb();
+    }
+    return null;
   }
 
   public static Integer getColor(Object value, Context context, int defaultInt) {
@@ -89,8 +124,9 @@ public class ColorPropConverter {
         return resolveThemeAttribute(context, resourcePath);
       }
     } catch (Resources.NotFoundException exception) {
-      // The resource could not be found so do nothing to allow the for loop to continue and
-      // try the next fallback resource in the array.  If none of the fallbacks are
+      // The resource could not be found so do nothing to allow the for loop to
+      // continue and
+      // try the next fallback resource in the array. If none of the fallbacks are
       // found then the exception immediately after the for loop will be thrown.
     }
     return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
@@ -108,10 +108,12 @@ public class ReactPropertyProcessor extends ProcessorBase {
     DEFAULT_TYPES.put(TypeName.DOUBLE, "number");
     DEFAULT_TYPES.put(TypeName.FLOAT, "number");
     DEFAULT_TYPES.put(TypeName.INT, "number");
+    DEFAULT_TYPES.put(TypeName.LONG, "number");
 
     // Boxed primitives
     DEFAULT_TYPES.put(TypeName.BOOLEAN.box(), "boolean");
     DEFAULT_TYPES.put(TypeName.INT.box(), "number");
+    DEFAULT_TYPES.put(TypeName.LONG.box(), "number");
 
     // Class types
     DEFAULT_TYPES.put(STRING_TYPE, "String");
@@ -124,6 +126,7 @@ public class ReactPropertyProcessor extends ProcessorBase {
     BOXED_PRIMITIVES.add(TypeName.BOOLEAN.box());
     BOXED_PRIMITIVES.add(TypeName.FLOAT.box());
     BOXED_PRIMITIVES.add(TypeName.INT.box());
+    BOXED_PRIMITIVES.add(TypeName.LONG.box());
   }
 
   public ReactPropertyProcessor() {
@@ -409,6 +412,11 @@ public class ReactPropertyProcessor extends ProcessorBase {
         return;
       }
     }
+    if (propertyType.equals(TypeName.LONG)) {
+      long defaultLong = info.mProperty.defaultLong();
+      builder.add("!(value instanceof Long) ? $L : (long)value", defaultLong);
+      return;
+    }
     if ("Color".equals(info.mProperty.customType())) {
       switch (classInfo.getType()) {
         case VIEW_MANAGER:
@@ -502,6 +510,8 @@ public class ReactPropertyProcessor extends ProcessorBase {
 
     int defaultInt();
 
+    long defaultLong();
+
     boolean defaultBoolean();
   }
 
@@ -535,6 +545,11 @@ public class ReactPropertyProcessor extends ProcessorBase {
     @Override
     public int defaultInt() {
       return mProp.defaultInt();
+    }
+
+    @Override
+    public long defaultLong() {
+      return mProp.defaultLong();
     }
 
     @Override
@@ -575,6 +590,11 @@ public class ReactPropertyProcessor extends ProcessorBase {
     @Override
     public int defaultInt() {
       return mProp.defaultInt();
+    }
+
+    @Override
+    public long defaultLong() {
+      return mProp.defaultLong();
     }
 
     @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactProp.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactProp.java
@@ -96,6 +96,13 @@ public @interface ReactProp {
   int defaultInt() default 0;
 
   /**
+   * Default value for property of type {@code long}. This value will be provided to property setter
+   * method annotated with {@link ReactProp} if property with a given name gets removed from the
+   * component description in JS
+   */
+  long defaultLong() default 0L;
+
+  /**
    * Default value for property of type {@code boolean}. This value will be provided to property
    * setter method annotated with {@link ReactProp} if property with a given name gets removed from
    * the component description in JS

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropGroup.java
@@ -89,4 +89,11 @@ public @interface ReactPropGroup {
    * the component description in JS
    */
   int defaultInt() default 0;
+
+  /**
+   * Default value for property of type {@code long}. This value will be provided to property setter
+   * method annotated with {@link ReactProp} if property with a given name gets removed from the
+   * component description in JS
+   */
+  long defaultLong() default 0L;
 }


### PR DESCRIPTION
Summary:
This change is a preliminary change to add support to `Long` and `long` React props that are required for supporting WideGamut color space.

## Changelog
[Android][Added] - Extend Property Processor to support long props

Differential Revision: D56461183
