### PR TITLE
Add method to specify a custom timeout

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -53,6 +53,21 @@ std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
   return runtimeSchedulerImpl_->scheduleTask(priority, std::move(callback));
 }
 
+std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
+    SchedulerPriority priority,
+    jsi::Function&& callback,
+    std::chrono::milliseconds timeout) noexcept {
+  return runtimeSchedulerImpl_->scheduleTask(
+      priority, std::move(callback), timeout);
+}
+std::shared_ptr<Task> RuntimeScheduler::scheduleTask(
+    SchedulerPriority priority,
+    RawCallback&& callback,
+    std::chrono::milliseconds timeout) noexcept {
+  return runtimeSchedulerImpl_->scheduleTask(
+      priority, std::move(callback), timeout);
+}
+
 bool RuntimeScheduler::getShouldYield() const noexcept {
   return runtimeSchedulerImpl_->getShouldYield();
 }

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -29,6 +29,14 @@ class RuntimeSchedulerBase {
   virtual std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
       RawCallback&& callback) noexcept = 0;
+  virtual std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      jsi::Function&& callback,
+      std::chrono::milliseconds timeout) noexcept = 0;
+  virtual std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      RawCallback&& callback,
+      std::chrono::milliseconds timeout) noexcept = 0;
   virtual void cancelTask(Task& task) noexcept = 0;
   virtual bool getShouldYield() const noexcept = 0;
   virtual SchedulerPriority getCurrentPriorityLevel() const noexcept = 0;
@@ -85,6 +93,14 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
       RawCallback&& callback) noexcept override;
+  std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      jsi::Function&& callback,
+      std::chrono::milliseconds timeout) noexcept override;
+  std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      RawCallback&& callback,
+      std::chrono::milliseconds timeout) noexcept override;
 
   /*
    * Cancelled task will never be executed.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -43,6 +43,14 @@ void RuntimeScheduler_Legacy::scheduleWork(RawCallback&& callback) noexcept {
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
     jsi::Function&& callback) noexcept {
+  return scheduleTask(
+      priority, std::move(callback), timeoutForSchedulerPriority(priority));
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
+    SchedulerPriority priority,
+    jsi::Function&& callback,
+    std::chrono::milliseconds timeout) noexcept {
   SystraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
@@ -50,7 +58,7 @@ std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
       "callbackType",
       "jsi::Function");
 
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto expirationTime = now_() + timeout;
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);
   taskQueue_.push(task);
@@ -63,6 +71,13 @@ std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
     RawCallback&& callback) noexcept {
+  return scheduleTask(
+      priority, std::move(callback), timeoutForSchedulerPriority(priority));
+}
+std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
+    SchedulerPriority priority,
+    RawCallback&& callback,
+    std::chrono::milliseconds timeout) noexcept {
   SystraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
@@ -70,7 +85,7 @@ std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
       "callbackType",
       "RawCallback");
 
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto expirationTime = now_() + timeout;
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);
   taskQueue_.push(task);

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -60,6 +60,15 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
       RawCallback&& callback) noexcept override;
+  std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      jsi::Function&& callback,
+      std::chrono::milliseconds timeout) noexcept override;
+
+  std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      RawCallback&& callback,
+      std::chrono::milliseconds timeout) noexcept override;
 
   /*
    * Cancelled task will never be executed.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -32,6 +32,14 @@ void RuntimeScheduler_Modern::scheduleWork(RawCallback&& callback) noexcept {
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
     SchedulerPriority priority,
     jsi::Function&& callback) noexcept {
+  return scheduleTask(
+      priority, std::move(callback), timeoutForSchedulerPriority(priority));
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
+    SchedulerPriority priority,
+    jsi::Function&& callback,
+    std::chrono::milliseconds timeout) noexcept {
   SystraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
@@ -39,7 +47,7 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
       "callbackType",
       "jsi::Function");
 
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto expirationTime = now_() + timeout;
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);
 
@@ -51,6 +59,14 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
     SchedulerPriority priority,
     RawCallback&& callback) noexcept {
+  return scheduleTask(
+      priority, std::move(callback), timeoutForSchedulerPriority(priority));
+}
+
+std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
+    SchedulerPriority priority,
+    RawCallback&& callback,
+    std::chrono::milliseconds timeout) noexcept {
   SystraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
@@ -58,7 +74,7 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
       "callbackType",
       "RawCallback");
 
-  auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
+  auto expirationTime = now_() + timeout;
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -70,6 +70,20 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
       SchedulerPriority priority,
       RawCallback&& callback) noexcept override;
 
+  std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      jsi::Function&& callback,
+      std::chrono::milliseconds timeout) noexcept override;
+
+  /*
+   * Adds a custom callback to the priority queue with the given priority.
+   * Triggers workloop if needed.
+   */
+  std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      RawCallback&& callback,
+      std::chrono::milliseconds timeout) noexcept override;
+
   /*
    * Cancelled task will never be executed.
    *

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -8,6 +8,8 @@
 #include "TimerManager.h"
 
 #include <cxxreact/SystraceSection.h>
+#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#include <chrono>
 #include <utility>
 
 namespace facebook::react {
@@ -19,6 +21,11 @@ TimerManager::TimerManager(
 void TimerManager::setRuntimeExecutor(
     RuntimeExecutor runtimeExecutor) noexcept {
   runtimeExecutor_ = runtimeExecutor;
+}
+
+void TimerManager::setRuntimeScheduler(
+    std::weak_ptr<RuntimeScheduler> runtimeScheduler) noexcept {
+  runtimeScheduler_ = runtimeScheduler;
 }
 
 std::shared_ptr<TimerHandle> TimerManager::createReactNativeMicrotask(

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -432,6 +432,76 @@ void TimerManager::attachGlobals(jsi::Runtime& runtime) {
             deleteTimer(rt, host);
             return jsi::Value::undefined();
           }));
+
+  runtime.global().setProperty(
+      runtime,
+      "requestIdleCallback",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "requestIdleCallback"),
+          2, // callback, options
+          [this](
+              jsi::Runtime& rt,
+              const jsi::Value& /*thisVal*/,
+              const jsi::Value* args,
+              size_t count) {
+            if (count < 0) {
+              throw jsi::JSError(
+                  rt,
+                  "requestIdleCallback must be called with at least a callback)");
+            }
+
+            if (!args[0].isObject() || !args[0].asObject(rt).isFunction(rt)) {
+              throw jsi::JSError(
+                  rt,
+                  "The first argument to requestIdleCallback must be a function.");
+            }
+
+            auto callback = args[0].getObject(rt).getFunction(rt);
+
+            if (count == 2) {
+              if (!args[1].isNull() && !args[1].isObject()) {
+                throw jsi::JSError(
+                    rt,
+                    "The second argument of requestIdleCallback, if provided, must be an object");
+              }
+              auto options = args[1].asObject(rt);
+              if (!options.hasProperty(rt, "timeout")) {
+                throw jsi::JSError(
+                    rt,
+                    "The second argument of requestIdleCallback must have a timeout property");
+              }
+              auto timeout = options.getProperty(rt, "timeout").asNumber();
+              auto handle =
+                  createIdleCallbackWithTimeout(std::move(callback), timeout);
+              return jsi::Object::createFromHostObject(rt, handle);
+            }
+
+            auto handle = createIdleCallback(std::move(callback));
+            return jsi::Object::createFromHostObject(rt, handle);
+          }));
+
+  runtime.global().setProperty(
+      runtime,
+      "cancelIdleCallback",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "cancelIdleCallback"),
+          1, // idleCallbackID
+          [this](
+              jsi::Runtime& rt,
+              const jsi::Value& /*thisVal*/,
+              const jsi::Value* args,
+              size_t count) {
+            if (count > 0 && args[0].isObject() &&
+                args[0].asObject(rt).isHostObject<TimerHandle>(rt)) {
+              std::shared_ptr<TimerHandle> host =
+                  args[0].asObject(rt).asHostObject<TimerHandle>(rt);
+              clearIdleCallback(rt, host);
+            }
+
+            return jsi::Value::undefined();
+          }));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -152,6 +152,21 @@ void TimerManager::callTimer(uint32_t timerID) {
   });
 }
 
+std::shared_ptr<TimerHandle> TimerManager::createIdleCallback(
+    jsi::Function&& callback) {
+  return nullptr;
+}
+
+std::shared_ptr<TimerHandle> TimerManager::createIdleCallbackWithTimeout(
+    jsi::Function&& callback,
+    int32_t timeout) {
+  return nullptr;
+}
+
+void TimerManager::clearIdleCallback(
+    jsi::Runtime& runtime,
+    std::shared_ptr<TimerHandle> idleCallbackHandle) {}
+
 void TimerManager::attachGlobals(jsi::Runtime& runtime) {
   // Install host functions for timers.
   // TODO (T45786383): Add missing timer functions from JSTimers

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.h
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.h
@@ -101,6 +101,16 @@ class TimerManager {
       jsi::Runtime& runtime,
       std::shared_ptr<TimerHandle> handle);
 
+  std::shared_ptr<TimerHandle> createIdleCallback(jsi::Function&& callback);
+
+  std::shared_ptr<TimerHandle> createIdleCallbackWithTimeout(
+      jsi::Function&& callback,
+      int32_t timeout);
+
+  void clearIdleCallback(
+      jsi::Runtime& runtime,
+      std::shared_ptr<TimerHandle> idleCallbackHandle);
+
   RuntimeExecutor runtimeExecutor_;
   std::weak_ptr<RuntimeScheduler> runtimeScheduler_;
   std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry_;

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.h
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.h
@@ -16,6 +16,8 @@
 
 namespace facebook::react {
 
+class RuntimeScheduler;
+
 /*
  * A HostObject subclass representing the result of a setTimeout call.
  * Can be used as an argument to clearTimeout.
@@ -65,6 +67,9 @@ class TimerManager {
 
   void setRuntimeExecutor(RuntimeExecutor runtimeExecutor) noexcept;
 
+  void setRuntimeScheduler(
+      std::weak_ptr<RuntimeScheduler> runtimeScheduler) noexcept;
+
   void callReactNativeMicrotasks(jsi::Runtime& runtime);
 
   void callTimer(uint32_t);
@@ -97,6 +102,7 @@ class TimerManager {
       std::shared_ptr<TimerHandle> handle);
 
   RuntimeExecutor runtimeExecutor_;
+  std::weak_ptr<RuntimeScheduler> runtimeScheduler_;
   std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry_;
 
   // A map (id => callback func) of the currently active JS timers

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -305,13 +305,16 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   auto contextContainer = std::make_shared<ContextContainer>();
   [_delegate didCreateContextContainer:contextContainer];
 
+  std::weak_ptr<RuntimeScheduler> runtimeScheduler =
+      std::weak_ptr<RuntimeScheduler>(_reactInstance->getRuntimeScheduler());
+  timerManager->setRuntimeScheduler(runtimeScheduler);
   contextContainer->insert(
       "RCTImageLoader", facebook::react::wrapManagedObject([_turboModuleManager moduleForName:"RCTImageLoader"]));
   contextContainer->insert(
       "RCTEventDispatcher",
       facebook::react::wrapManagedObject([_turboModuleManager moduleForName:"RCTEventDispatcher"]));
   contextContainer->insert("RCTBridgeModuleDecorator", facebook::react::wrapManagedObject(_bridgeModuleDecorator));
-  contextContainer->insert("RuntimeScheduler", std::weak_ptr<RuntimeScheduler>(_reactInstance->getRuntimeScheduler()));
+  contextContainer->insert("RuntimeScheduler", runtimeScheduler);
   contextContainer->insert("RCTBridgeProxy", facebook::react::wrapManagedObject(bridgeProxy));
 
   _surfacePresenter = [[RCTSurfacePresenter alloc]


### PR DESCRIPTION
Summary:
The RuntimeScheduler now has some fixed timouts depending on the priority selected when scheduling a task.

However, some JS APIs like the `requestIdleCallback` allow the user to specify a custom timeout for the task. This change introduces this new APIs

## Changelog:
[General][Added] - Add APIs to specify a custom timeout in the Runtime Scheduler

Differential Revision: D56476044


