### PR TITLE
Register globals for idleCallback

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -125,6 +125,9 @@ ReactInstance::ReactInstance(
           std::function<void(jsi::Runtime & runtime)>&& callback) {
         runtimeScheduler->scheduleWork(std::move(callback));
       });
+  
+
+  bufferedRuntimeScheduler_ = std::make_shared<RuntimeScheduler>(this->getBufferedRuntimeExecutor());
 }
 
 void ReactInstance::unregisterFromInspector() {
@@ -161,11 +164,14 @@ RuntimeExecutor ReactInstance::getBufferedRuntimeExecutor() noexcept {
   };
 }
 
-// TODO(T184010230): Should the RuntimeScheduler returned from this method be
-// buffered?
 std::shared_ptr<RuntimeScheduler>
 ReactInstance::getRuntimeScheduler() noexcept {
   return runtimeScheduler_;
+}
+
+std::shared_ptr<RuntimeScheduler>
+ReactInstance::getBufferedRuntimeScheduler() noexcept {
+  return bufferedRuntimeScheduler_;
 }
 
 namespace {

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -42,6 +42,8 @@ class ReactInstance final : private jsinspector_modern::InstanceTargetDelegate {
   RuntimeExecutor getBufferedRuntimeExecutor() noexcept;
 
   std::shared_ptr<RuntimeScheduler> getRuntimeScheduler() noexcept;
+  
+  std::shared_ptr<RuntimeScheduler> getBufferedRuntimeScheduler() noexcept;
 
   struct JSRuntimeFlags {
     bool isProfiling = false;
@@ -80,6 +82,7 @@ class ReactInstance final : private jsinspector_modern::InstanceTargetDelegate {
   std::shared_ptr<TimerManager> timerManager_;
   std::unordered_map<std::string, std::shared_ptr<CallableModule>> modules_;
   std::shared_ptr<RuntimeScheduler> runtimeScheduler_;
+  std::shared_ptr<RuntimeScheduler> bufferedRuntimeScheduler_;
   std::shared_ptr<JsErrorHandler> jsErrorHandler_;
 
   jsinspector_modern::InstanceTarget* inspectorTarget_{nullptr};

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -8,6 +8,8 @@
 #include "TimerManager.h"
 
 #include <cxxreact/SystraceSection.h>
+#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#include <chrono>
 #include <utility>
 
 namespace facebook::react {
@@ -19,6 +21,11 @@ TimerManager::TimerManager(
 void TimerManager::setRuntimeExecutor(
     RuntimeExecutor runtimeExecutor) noexcept {
   runtimeExecutor_ = runtimeExecutor;
+}
+
+void TimerManager::setRuntimeScheduler(
+    std::weak_ptr<RuntimeScheduler> runtimeScheduler) noexcept {
+  runtimeScheduler_ = runtimeScheduler;
 }
 
 std::shared_ptr<TimerHandle> TimerManager::createReactNativeMicrotask(

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -152,6 +152,21 @@ void TimerManager::callTimer(uint32_t timerID) {
   });
 }
 
+std::shared_ptr<TimerHandle> TimerManager::createIdleCallback(
+    jsi::Function&& callback) {
+  return nullptr;
+}
+
+std::shared_ptr<TimerHandle> TimerManager::createIdleCallbackWithTimeout(
+    jsi::Function&& callback,
+    int32_t timeout) {
+  return nullptr;
+}
+
+void TimerManager::clearIdleCallback(
+    jsi::Runtime& runtime,
+    std::shared_ptr<TimerHandle> idleCallbackHandle) {}
+
 void TimerManager::attachGlobals(jsi::Runtime& runtime) {
   // Install host functions for timers.
   // TODO (T45786383): Add missing timer functions from JSTimers

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.h
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.h
@@ -101,6 +101,16 @@ class TimerManager {
       jsi::Runtime& runtime,
       std::shared_ptr<TimerHandle> handle);
 
+  std::shared_ptr<TimerHandle> createIdleCallback(jsi::Function&& callback);
+
+  std::shared_ptr<TimerHandle> createIdleCallbackWithTimeout(
+      jsi::Function&& callback,
+      int32_t timeout);
+
+  void clearIdleCallback(
+      jsi::Runtime& runtime,
+      std::shared_ptr<TimerHandle> idleCallbackHandle);
+
   RuntimeExecutor runtimeExecutor_;
   std::weak_ptr<RuntimeScheduler> runtimeScheduler_;
   std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry_;

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.h
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.h
@@ -16,6 +16,8 @@
 
 namespace facebook::react {
 
+class RuntimeScheduler;
+
 /*
  * A HostObject subclass representing the result of a setTimeout call.
  * Can be used as an argument to clearTimeout.
@@ -65,6 +67,9 @@ class TimerManager {
 
   void setRuntimeExecutor(RuntimeExecutor runtimeExecutor) noexcept;
 
+  void setRuntimeScheduler(
+      std::weak_ptr<RuntimeScheduler> runtimeScheduler) noexcept;
+
   void callReactNativeMicrotasks(jsi::Runtime& runtime);
 
   void callTimer(uint32_t);
@@ -97,6 +102,7 @@ class TimerManager {
       std::shared_ptr<TimerHandle> handle);
 
   RuntimeExecutor runtimeExecutor_;
+  std::weak_ptr<RuntimeScheduler> runtimeScheduler_;
   std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry_;
 
   // A map (id => callback func) of the currently active JS timers

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -144,7 +144,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 {
   if (_valid) {
     _reactInstance->callFunctionOnModule(
-        [moduleName UTF8String], [method UTF8String], convertIdToFollyDynamic(args ?: @[]));
+        [moduleName UTF8String], [method UTF8String], convertIdToFollyDynamic(args ? args : @[]));
   }
 }
 
@@ -255,6 +255,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
   RuntimeExecutor bufferedRuntimeExecutor = _reactInstance->getBufferedRuntimeExecutor();
   timerManager->setRuntimeExecutor(bufferedRuntimeExecutor);
+
+  timerManager->setRuntimeScheduler(std::weak_ptr<RuntimeScheduler>(_reactInstance->getBufferedRuntimeScheduler()));
 
   auto jsCallInvoker = make_shared<BridgelessJSCallInvoker>(bufferedRuntimeExecutor);
   RCTBridgeProxy *bridgeProxy =


### PR DESCRIPTION
Summary:
Register Globals to call `requestIdleCallback` and `cancelIdleCallback`

## Changelog
[General][Added] - Register globals for IdleCallbacks

Differential Revision: D56472923


