### PR TITLE
Pass the RuntimeScheduler to the TimerManager

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -8,6 +8,8 @@
 #include "TimerManager.h"
 
 #include <cxxreact/SystraceSection.h>
+#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#include <chrono>
 #include <utility>
 
 namespace facebook::react {
@@ -19,6 +21,11 @@ TimerManager::TimerManager(
 void TimerManager::setRuntimeExecutor(
     RuntimeExecutor runtimeExecutor) noexcept {
   runtimeExecutor_ = runtimeExecutor;
+}
+
+void TimerManager::setRuntimeScheduler(
+    std::weak_ptr<RuntimeScheduler> runtimeScheduler) noexcept {
+  runtimeScheduler_ = runtimeScheduler;
 }
 
 std::shared_ptr<TimerHandle> TimerManager::createReactNativeMicrotask(

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.h
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.h
@@ -16,6 +16,8 @@
 
 namespace facebook::react {
 
+class RuntimeScheduler;
+
 /*
  * A HostObject subclass representing the result of a setTimeout call.
  * Can be used as an argument to clearTimeout.
@@ -65,6 +67,9 @@ class TimerManager {
 
   void setRuntimeExecutor(RuntimeExecutor runtimeExecutor) noexcept;
 
+  void setRuntimeScheduler(
+      std::weak_ptr<RuntimeScheduler> runtimeScheduler) noexcept;
+
   void callReactNativeMicrotasks(jsi::Runtime& runtime);
 
   void callTimer(uint32_t);
@@ -97,6 +102,7 @@ class TimerManager {
       std::shared_ptr<TimerHandle> handle);
 
   RuntimeExecutor runtimeExecutor_;
+  std::weak_ptr<RuntimeScheduler> runtimeScheduler_;
   std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry_;
 
   // A map (id => callback func) of the currently active JS timers

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -305,13 +305,16 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   auto contextContainer = std::make_shared<ContextContainer>();
   [_delegate didCreateContextContainer:contextContainer];
 
+  std::weak_ptr<RuntimeScheduler> runtimeScheduler =
+      std::weak_ptr<RuntimeScheduler>(_reactInstance->getRuntimeScheduler());
+  timerManager->setRuntimeScheduler(runtimeScheduler);
   contextContainer->insert(
       "RCTImageLoader", facebook::react::wrapManagedObject([_turboModuleManager moduleForName:"RCTImageLoader"]));
   contextContainer->insert(
       "RCTEventDispatcher",
       facebook::react::wrapManagedObject([_turboModuleManager moduleForName:"RCTEventDispatcher"]));
   contextContainer->insert("RCTBridgeModuleDecorator", facebook::react::wrapManagedObject(_bridgeModuleDecorator));
-  contextContainer->insert("RuntimeScheduler", std::weak_ptr<RuntimeScheduler>(_reactInstance->getRuntimeScheduler()));
+  contextContainer->insert("RuntimeScheduler", runtimeScheduler);
   contextContainer->insert("RCTBridgeProxy", facebook::react::wrapManagedObject(bridgeProxy));
 
   _surfacePresenter = [[RCTSurfacePresenter alloc]


### PR DESCRIPTION
Summary:
To implement idleCallbacks, we need the concept of priorities, tasks and timeout.

Runtime Scheduler offers all of them, so, as a first step, we want to pass the scheduler to the TimerManager.

## Changelog
[iOS][Added] - Pass the RuntimeScheduler to the TimerManager

Differential Revision: D56471829


