### PR TITLE
RNGP - Add autolinking fields to ReactExtensions

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -147,4 +147,23 @@ abstract class ReactExtension @Inject constructor(project: Project) {
    */
   val codegenJavaPackageName: Property<String> =
       objects.property(String::class.java).convention("com.facebook.fbreact.specs")
+
+  /** Auto-linking Config */
+
+  /**
+   * Location of the JSON file used to configure autolinking. This file is the output of the
+   * `@react-native-community/cli` config command.
+   *
+   * If not specified, RNGP will just invoke whatever you pass as [autolinkConfigCommand].
+   */
+  val autolinkConfigFile: RegularFileProperty = objects.fileProperty()
+
+  /**
+   * The command to invoke as source of truth for the autolinking configuration. Default is
+   * `["@react-native-community/cli", "config"]`.
+   */
+  val autolinkConfigCommand: ListProperty<String> =
+      objects
+          .listProperty(String::class.java)
+          .convention(listOf("@react-native-community/cli", "config"))
 }


### PR DESCRIPTION
Summary:
This diff is part of RFC0759
https://github.com/react-native-community/discussions-and-proposals/pull/759

Here we're looking into splitting the autolinking into a component that will live inside core (specifically inside the React Native Gradle Plugin - RNGP) and another component that will live inside the Community CLI.

Here I start by adding 2 fields to RNGP extension, that frameworks and templates can use to provide their autolinking config.

Changelog:
[Internal] [Changed] - RNGP - Add autolinking fields to ReactExtensions

Differential Revision: D55475597


