### PR TITLE
fix ReactActivity.getReactDelegate().reload()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -14,6 +14,7 @@ import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
 import com.facebook.react.devsupport.ReleaseDevSupportManager;
@@ -98,7 +99,7 @@ public class ReactDelegate {
         && mReactHost.getDevSupportManager() != null) {
       return mReactHost.getDevSupportManager();
     } else if (getReactNativeHost().hasInstance()
-        && getReactNativeHost().getUseDeveloperSupport()) {
+        && getReactNativeHost().getReactInstanceManager() != null) {
       return getReactNativeHost().getReactInstanceManager().getDevSupportManager();
     } else {
       return null;
@@ -237,17 +238,29 @@ public class ReactDelegate {
 
   public void reload() {
     DevSupportManager devSupportManager = getDevSupportManager();
-    if (devSupportManager != null) {
-      // With Bridgeless enabled, reload in RELEASE mode
-      if (devSupportManager instanceof ReleaseDevSupportManager
-          && ReactFeatureFlags.enableBridgelessArchitecture
-          && mReactHost != null) {
-        // Do not reload the bundle from JS as there is no bundler running in release mode.
-        mReactHost.reload("ReactDelegate.reload()");
-      } else {
-        devSupportManager.handleReloadJS();
-      }
+    if (devSupportManager == null) {
+      return;
     }
+
+    // Reload in RELEASE mode
+    if (devSupportManager instanceof ReleaseDevSupportManager) {
+      // Do not reload the bundle from JS as there is no bundler running in release mode.
+      if (ReactFeatureFlags.enableBridgelessArchitecture) {
+        if (mReactHost != null) {
+          mReactHost.reload("ReactDelegate.reload()");
+        }
+      } else {
+        UiThreadUtil.runOnUiThread(() -> {
+          if (mReactNativeHost.hasInstance() && mReactNativeHost.getReactInstanceManager() != null) {
+            mReactNativeHost.getReactInstanceManager().recreateReactContextInBackground();
+          }
+        });
+      }
+      return;
+    }
+
+    // Reload in DEBUG mode
+    devSupportManager.handleReloadJS();
   }
 
   public void loadApp() {


### PR DESCRIPTION
## Summary:

fixing some problem for `ReactActivity.getReactDelegate().reload()` from #43521:
- the `reload()` does not work for bridge mode on release build

## Changelog:

[ANDROID] [FIXED] - Fixed app reloading for `ReactActivity.getReactDelegate().reload()`.

## Test Plan:

tried to temporary change toast.show as reload and test from rn-tester
```diff
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
@@ -10,6 +10,7 @@ package com.facebook.react.modules.toast
 import android.view.Gravity
 import android.widget.Toast
 import com.facebook.fbreact.specs.NativeToastAndroidSpec
+import com.facebook.react.ReactActivity
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
@@ -30,9 +31,11 @@ public class ToastModule(reactContext: ReactApplicationContext) :
       )

   override public fun show(message: String?, durationDouble: Double) {
-    val duration = durationDouble.toInt()
-    UiThreadUtil.runOnUiThread(
-        Runnable { Toast.makeText(getReactApplicationContext(), message, duration).show() })
+//    val duration = durationDouble.toInt()
+//    UiThreadUtil.runOnUiThread(
+//        Runnable { Toast.makeText(getReactApplicationContext(), message, duration).show() })
+    val activity = reactApplicationContext.currentActivity as? ReactActivity
+    activity?.reactDelegate?.reload()
   }

   override public fun showWithGravity(
```

tried for different mode
- [x] bridge mode + debug build
- [x] bridgeless mode + debug build
- [x] bridge mode + release build
- [x] bridgeless mode + release build
