### PR TITLE
Fixing exposing ReactDelegate through ReactActivity for reload()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -65,8 +65,8 @@ public abstract class ReactActivity extends AppCompatActivity
     mDelegate.onDestroy();
   }
 
-  public void getReactDelegate() {
-    mDelegate.getReactDelegate();
+  public ReactDelegate getReactDelegate() {
+    return mDelegate.getReactDelegate();
   }
 
   public ReactActivityDelegate getReactActivityDelegate() {


### PR DESCRIPTION
Summary: In https://github.com/facebook/react-native/pull/44223/ @Kudo identified the incorrect return type.

Differential Revision: D56497700


