### PR TITLE
Fix BackHandle undefined cause crash issue

### DIFF
--- a/packages/react-native/Libraries/Utilities/BackHandler.android.js
+++ b/packages/react-native/Libraries/Utilities/BackHandler.android.js
@@ -19,7 +19,7 @@ const _backPressSubscriptions = [];
 
 RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function () {
   for (let i = _backPressSubscriptions.length - 1; i >= 0; i--) {
-    if (_backPressSubscriptions[i]()) {
+    if (_backPressSubscriptions[i] && _backPressSubscriptions[i]()) {
       return;
     }
   }


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
we got an error of `t[n] is not a function. (In 't[n]()', 't[n]' is undefined) \n <unknown> (index.bundle:317:168:317)`, it related the `BackHandle` execute handle function
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
Add undefined check before execute backhandle function
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
