### PR TITLE
clean up interfaces for view preallocation

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -31,7 +31,7 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     [scheduler.delegate schedulerDidFinishTransaction:mountingCoordinator];
   }
 
-  void schedulerDidRequestPreliminaryViewAllocation(SurfaceId surfaceId, const ShadowNode &shadowNode) override
+  void schedulerDidRequestPreliminaryViewAllocation(const ShadowNode &shadowNode) override
   {
     // Does nothing.
     // This delegate method is not currently used on iOS.

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -14,11 +14,7 @@
 #include "FabricMountingManager.h"
 #include "JBackgroundExecutor.h"
 #include "ReactNativeConfigHolder.h"
-#include "StateWrapperImpl.h"
 #include "SurfaceHandlerBinding.h"
-
-#include <cfenv>
-#include <cmath>
 
 #include <fbjni/fbjni.h>
 #include <glog/logging.h>
@@ -475,7 +471,6 @@ void Binding::schedulerDidFinishTransaction(
 }
 
 void Binding::schedulerDidRequestPreliminaryViewAllocation(
-    const SurfaceId surfaceId,
     const ShadowNode& shadowNode) {
   if (!shadowNode.getTraits().check(ShadowNodeTraits::Trait::FormsView)) {
     return;
@@ -485,7 +480,7 @@ void Binding::schedulerDidRequestPreliminaryViewAllocation(
   if (!mountingManager) {
     return;
   }
-  mountingManager->preallocateShadowView(surfaceId, ShadowView(shadowNode));
+  mountingManager->preallocateShadowView(shadowNode);
 }
 
 void Binding::schedulerDidDispatchCommand(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -102,7 +102,6 @@ class Binding : public jni::HybridClass<Binding, JBinding>,
       const MountingCoordinator::Shared& mountingCoordinator) override;
 
   void schedulerDidRequestPreliminaryViewAllocation(
-      const SurfaceId surfaceId,
       const ShadowNode& shadowNode) override;
 
   void schedulerDidDispatchCommand(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -775,20 +775,22 @@ void FabricMountingManager::executeMount(
 }
 
 void FabricMountingManager::preallocateShadowView(
-    SurfaceId surfaceId,
-    const ShadowView& shadowView) {
+    const ShadowNode& shadowNode) {
   {
     std::lock_guard lock(allocatedViewsMutex_);
-    auto allocatedViewsIterator = allocatedViewRegistry_.find(surfaceId);
+    auto allocatedViewsIterator =
+        allocatedViewRegistry_.find(shadowNode.getSurfaceId());
     if (allocatedViewsIterator == allocatedViewRegistry_.end()) {
       return;
     }
     auto& allocatedViews = allocatedViewsIterator->second;
-    if (allocatedViews.find(shadowView.tag) != allocatedViews.end()) {
+    if (allocatedViews.find(shadowNode.getTag()) != allocatedViews.end()) {
       return;
     }
-    allocatedViews.insert(shadowView.tag);
+    allocatedViews.insert(shadowNode.getTag());
   }
+
+  auto shadowView = ShadowView(shadowNode);
 
   bool isLayoutableShadowNode = shadowView.layoutMetrics != EmptyLayoutMetrics;
 
@@ -817,7 +819,7 @@ void FabricMountingManager::preallocateShadowView(
 
   preallocateView(
       javaUIManager_,
-      surfaceId,
+      shadowNode.getSurfaceId(),
       shadowView.tag,
       component.get(),
       props.get(),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -32,7 +32,7 @@ class FabricMountingManager final {
 
   void onSurfaceStop(SurfaceId surfaceId);
 
-  void preallocateShadowView(SurfaceId surfaceId, const ShadowView& shadowView);
+  void preallocateShadowView(const ShadowNode& shadowNode);
 
   void executeMount(const MountingTransaction& transaction);
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -312,8 +312,7 @@ void Scheduler::uiManagerDidCreateShadowNode(const ShadowNode& shadowNode) {
   SystraceSection s("Scheduler::uiManagerDidCreateShadowNode");
 
   if (delegate_ != nullptr) {
-    delegate_->schedulerDidRequestPreliminaryViewAllocation(
-        shadowNode.getSurfaceId(), shadowNode);
+    delegate_->schedulerDidRequestPreliminaryViewAllocation(shadowNode);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -32,8 +32,7 @@ class SchedulerDelegate {
    * Called right after a new ShadowNode was created.
    */
   virtual void schedulerDidRequestPreliminaryViewAllocation(
-      SurfaceId surfaceId,
-      const ShadowNode& shadowView) = 0;
+      const ShadowNode& shadowNode) = 0;
 
   virtual void schedulerDidDispatchCommand(
       const ShadowView& shadowView,

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -89,8 +89,7 @@ std::shared_ptr<ShadowNode> UIManager::createNode(
 
   auto shadowNode = componentDescriptor.createShadowNode(
       ShadowNodeFragment{
-          /* .props = */
-          fallbackDescriptor != nullptr &&
+          .props = fallbackDescriptor != nullptr &&
                   fallbackDescriptor->getComponentHandle() ==
                       componentDescriptor.getComponentHandle()
               ? componentDescriptor.cloneProps(
@@ -98,8 +97,8 @@ std::shared_ptr<ShadowNode> UIManager::createNode(
                     props,
                     RawProps(folly::dynamic::object("name", name)))
               : props,
-          /* .children = */ ShadowNodeFragment::childrenPlaceholder(),
-          /* .state = */ state,
+          .children = ShadowNodeFragment::childrenPlaceholder(),
+          .state = state,
       },
       family);
 
@@ -152,8 +151,8 @@ std::shared_ptr<ShadowNode> UIManager::cloneNode(
   auto clonedShadowNode = componentDescriptor.cloneShadowNode(
       shadowNode,
       {
-          /* .props = */ props,
-          /* .children = */ children,
+          .props = props,
+          .children = children,
       });
 
   return clonedShadowNode;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -527,9 +527,9 @@ jsi::Value UIManagerBinding::get(
                     strongUIManager->completeSurface(
                         surfaceId,
                         shadowNodeList,
-                        {/* .enableStateReconciliation = */ true,
-                         /* .mountSynchronously = */ false,
-                         /* .shouldYield = */ shouldYield});
+                        {.enableStateReconciliation = true,
+                         .mountSynchronously = false,
+                         .shouldYield = shouldYield});
                   }
                 });
           } else {


### PR DESCRIPTION
Summary:
changelog: [internal]

surfaceId parameter is not needed `schedulerDidRequestPreliminaryViewAllocation` as it can be derived from shadow node.
Additionally, conversion to ShadowView can happen on the lower layers.

Reviewed By: NickGerleman

Differential Revision: D56350599


