### PR TITLE
remove from build script

### DIFF
--- a/flow-typed/npm/commander_v12.x.x.js
+++ b/flow-typed/npm/commander_v12.x.x.js
@@ -385,10 +385,7 @@ declare module 'commander' {
      * @param opts - configuration options
      * @returns new command
      */
-    command(
-      nameAndArgs: string,
-      opts?: CommandOptions,
-    ): Command;
+    command(nameAndArgs: string, opts?: CommandOptions): Command;
 
     /**
      * Define a command, implemented in a separate executable file.
@@ -1000,4 +997,3 @@ declare module 'commander' {
   ): Argument;
   declare export var program: Command;
 }
-

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -54,10 +54,6 @@ const buildConfig /*: BuildConfig */ = {
       emitTypeScriptDefs: true,
       target: 'node',
     },
-    helloworld: {
-      emitFlowDefs: false,
-      target: 'node',
-    },
     'metro-config': {
       emitTypeScriptDefs: true,
       target: 'node',


### PR DESCRIPTION
Summary:
The package was added to our build scripts, but shouldn't have been.  We're not exporting this package or making it public.

Changelog: [Internal]

This should unblock our OSS CI.

Differential Revision: D56513694


