### PR TITLE
Fix PointerEvents not dispatching post-scroll

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
@@ -116,7 +116,7 @@ public class ReactSurfaceView(context: Context?, private val surface: ReactSurfa
   override fun onChildEndedNativeGesture(childView: View, ev: MotionEvent) {
     val eventDispatcher = surface.eventDispatcher ?: return
     jsTouchDispatcher.onChildEndedNativeGesture(ev, eventDispatcher)
-    jsPointerDispatcher?.onChildStartedNativeGesture(childView, ev, eventDispatcher)
+    jsPointerDispatcher?.onChildEndedNativeGesture()
   }
 
   override fun handleException(t: Throwable) {


### PR DESCRIPTION
Summary: Changelog: [Android][Fixed] PointerEvents were not dispatching after a scroll event

Reviewed By: RSNara

Differential Revision: D56519337


