### PR TITLE
Fix bug with EdgeInsets caused by iOS 10 specific code

### DIFF
--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -215,16 +215,6 @@ static UIImage *RCTGetSolidBorderImage(
       borderInsets.bottom + MAX(cornerInsets.bottomLeft.height, cornerInsets.bottomRight.height),
       borderInsets.right + MAX(cornerInsets.bottomRight.width, cornerInsets.topRight.width)};
 
-  if (hasCornerRadii) {
-    // Asymmetrical edgeInsets cause strange artifacting on iOS 10 and earlier.
-    edgeInsets = (UIEdgeInsets){
-        MAX(edgeInsets.top, edgeInsets.bottom),
-        MAX(edgeInsets.left, edgeInsets.right),
-        MAX(edgeInsets.top, edgeInsets.bottom),
-        MAX(edgeInsets.left, edgeInsets.right),
-    };
-  }
-
   const CGSize size = makeStretchable ? (CGSize){
     // 1pt for the middle stretchable area along each axis
     edgeInsets.left + 1 + edgeInsets.right,


### PR DESCRIPTION
Summary: Non-uniform edge insets caused issues on iOS 10. The code nowadays interferes with the rendering for large borderRadii so this diff removes it.

Differential Revision: D56333637
