### PR TITLE
chore(dev-middleware): add `localhost` as default host in `start` command config

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/index.js
+++ b/packages/community-cli-plugin/src/commands/start/index.js
@@ -27,7 +27,7 @@ const startCommand: Command = {
     },
     {
       name: '--host <string>',
-      default: '',
+      default: 'localhost',
     },
     {
       name: '--projectRoot <path>',

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -34,7 +34,7 @@ export type StartCommandArgs = {
   cert?: string,
   customLogReporterPath?: string,
   experimentalDebugger: boolean,
-  host?: string,
+  host: string,
   https?: boolean,
   maxWorkers?: number,
   key?: string,
@@ -63,14 +63,13 @@ async function runServer(
     projectRoot: args.projectRoot,
     sourceExts: args.sourceExts,
   });
-  const hostname = args.host?.length ? args.host : 'localhost';
   const {
     projectRoot,
     server: {port},
     watchFolders,
   } = metroConfig;
   const protocol = args.https === true ? 'https' : 'http';
-  const devServerUrl = url.format({protocol, hostname, port});
+  const devServerUrl = url.format({protocol, hostname: args.host, port});
 
   logger.info(`Welcome to React Native v${ctx.reactNativeVersion}`);
 
@@ -104,7 +103,7 @@ async function runServer(
     messageSocketEndpoint,
     eventsSocketEndpoint,
   } = createDevServerMiddleware({
-    host: hostname,
+    host: args.host,
     port,
     watchFolders,
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Inside [Re.Pack](https://github.com/callstack/repack) we consume command's options, to reduce the amount of assumptions that 3rd party tools need to make - we can move assigning default value to config command level, so default values will be aligned across tools. 

For default `start` command this change doesn't change any behaviour. 


## Changelog:


[INTERNAL] [CHANGED] - Add `localhost` as default host in `start` command config


## Test Plan:

`start` command should work the same way as before.