### PR TITLE
Handle `fontWeight` normalization for TextInput component

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1401,6 +1401,12 @@ function InternalTextInput(props: Props): React.Node {
 
   const style = flattenStyle<TextStyleProp>(props.style);
 
+  if (typeof style?.fontWeight === 'number') {
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[cannot-write]
+    style.fontWeight = style?.fontWeight.toString();
+  }
+
   if (Platform.OS === 'ios') {
     const RCTTextInputView =
       props.multiline === true


### PR DESCRIPTION
Summary:
Web props work (somewhere around  D41230978 and D39268920) made it so that numeric font weights can be set instead of just strings. This is implemented by converting number to string before passing to native component within the `Text` component.

We have UBN crash with:
```
2024-04-19 09:38:21.360 16963 17190 E pages.ViewManager: Error while updating prop fontWeight
2024-04-19 09:38:21.360 16963 17190 E pages.ViewManager: java.lang.IllegalArgumentException: method com.facebook.react.views.text.ReactBaseTextShadowNode.setFontWeight argument 1 has type java.lang.String, got java.lang.Double
2024-04-19 09:38:21.360 16963 17190 E pages.ViewManager: 	at java.lang.reflect.Method.invoke(Native Method)
```

`TextStyleProps` can also be passed to `TextInput`, which passes to underlying native component, without going through this logic. And the types for Native props directly derive from JS props, so type system does not catch passing incorrect number type to underlying native component.

This does a quick and dirty replication of the exact logic in `Text.js` to `TextInput.js`. I'd love to potentially fix this up for Fabric in a different way when we rethink CSS parsing.

Changelog:
[Genera][Fixed] - Handle `fontWeight` normalization for TextInput component

Reviewed By: arushikesarwani94

Differential Revision: D56539571
