### PR TITLE
Apply padding to the text attachements

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -243,8 +243,8 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
         dynamic_cast<LayoutableShadowNode&>(*clonedShadowNode);
 
     auto attachmentFrame = measurement.attachments[i].frame;
-    attachmentFrame.origin.x += this->yogaNode_.getLayout().padding(yoga::PhysicalEdge::Left);
-    attachmentFrame.origin.y += this->yogaNode_.getLayout().padding(yoga::PhysicalEdge::Top);
+    attachmentFrame.origin.x += layoutMetrics.contentInsets.left;
+    attachmentFrame.origin.y += layoutMetrics.contentInsets.top;
 
     auto attachmentSize = roundToPixel<&ceil>(
         attachmentFrame.size, layoutMetrics.pointScaleFactor);

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -243,6 +243,9 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
         dynamic_cast<LayoutableShadowNode&>(*clonedShadowNode);
 
     auto attachmentFrame = measurement.attachments[i].frame;
+    attachmentFrame.origin.x += this->yogaNode_.getLayout().padding(yoga::PhysicalEdge::Left);
+    attachmentFrame.origin.y += this->yogaNode_.getLayout().padding(yoga::PhysicalEdge::Top);
+
     auto attachmentSize = roundToPixel<&ceil>(
         attachmentFrame.size, layoutMetrics.pointScaleFactor);
     auto attachmentOrigin = roundToPixel<&round>(


### PR DESCRIPTION
## Summary:

Paddings are not applied to inline views in text, this PR fixes that.

Closes https://github.com/facebook/react-native/issues/42099

## Changelog:

[GENERAL] [FIXED] - Fixed padding not being applied to inline views in text

## Test Plan:

<details>
<summary>A simple test case</summary>

```jsx
      <Text style={{paddingHorizontal: 40, paddingVertical: 40, backgroundColor: 'green', width: 300 }}>
        <View style={{backgroundColor: 'red', width: 50, height: 50}} />
        foobar foobar
        <View style={{backgroundColor: 'red', width: 50, height: 50}} />
      </Text>
```

|iOS before|iOS after|Android before|Android after|
|-|-|-|-|
|<img width="502" alt="Screenshot 2024-04-25 at 17 17 50" src="https://github.com/facebook/react-native/assets/21055725/e6981de0-6714-4bb0-a006-547b30374b8a">|<img width="546" alt="Screenshot 2024-04-25 at 17 15 56" src="https://github.com/facebook/react-native/assets/21055725/51e8458b-ad4e-4755-865c-664414bfee55">|<img width="457" alt="Screenshot 2024-04-26 at 11 18 17" src="https://github.com/facebook/react-native/assets/21055725/ac351eff-6d24-40a0-bf7e-0cf3782e9368">|<img width="457" alt="Screenshot 2024-04-26 at 11 17 11" src="https://github.com/facebook/react-native/assets/21055725/3284a79a-157d-43ea-b080-849520e2ee7d">|

</details>