### PR TITLE
exclude react-native/sdks from consideration

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 ; Ignore templates for 'react-native init'
 <PROJECT_ROOT>/packages/react-native/template/.*
+<PROJECT_ROOT>/packages/react-native/sdks/.*
 
 ; Ignore the Dangerfile
 <PROJECT_ROOT>/packages/react-native-bots/dangerfile.js


### PR DESCRIPTION
Summary:
Flow shouldn't consider definitions inside this folder.  This speeds up working in the OSS checkout if you happen to have Hermes built.

Changelog: [Internal]

Differential Revision: D56575537
