### PR TITLE
[CodeQL] Fix comparison of narrow type with wide type in loop condition in RawPropsKeyMap.cpp

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
@@ -86,7 +86,7 @@ void RawPropsKeyMap::reindex() noexcept {
     }
   }
 
-  for (auto j = length; j < buckets_.size(); j++) {
+  for (size_t j = length; j < buckets_.size(); j++) {
     buckets_[j] = static_cast<RawPropsPropNameLength>(items_.size());
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
We ran CodeQL in react-native-windows and it found a comparison of narrow type with wide type in loop condition in ReactCommon/react/renderer/core/RawPropsKeyMap.cpp

microsoft/react-native-windows#12701

## Changelog:
[INTERNAL] [SECURITY] - Fix comparison of narrow type with wide type in loop condition in RawPropsKeyMap.cpp

## Test Plan:
Tested on windows.