### PR TITLE
Make DefaultReactHost configurable w/ cxxreactpackages

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1976,8 +1976,8 @@ public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/face
 public final class com/facebook/react/defaults/DefaultReactHost {
 	public static final field INSTANCE Lcom/facebook/react/defaults/DefaultReactHost;
 	public static final fun getDefaultReactHost (Landroid/content/Context;Lcom/facebook/react/ReactNativeHost;)Lcom/facebook/react/ReactHost;
-	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZ)Lcom/facebook/react/ReactHost;
-	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/facebook/react/ReactHost;
+	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;)Lcom/facebook/react/ReactHost;
+	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
 }
 
 public abstract class com/facebook/react/defaults/DefaultReactNativeHost : com/facebook/react/ReactNativeHost {
@@ -1987,7 +1987,6 @@ public abstract class com/facebook/react/defaults/DefaultReactNativeHost : com/f
 	protected fun getUIManagerProvider ()Lcom/facebook/react/bridge/UIManagerProvider;
 	protected fun isHermesEnabled ()Ljava/lang/Boolean;
 	protected fun isNewArchEnabled ()Z
-	public final fun toReactHost (Landroid/content/Context;)Lcom/facebook/react/ReactHost;
 }
 
 public final class com/facebook/react/defaults/DefaultTurboModuleManagerDelegate : com/facebook/react/ReactPackageTurboModuleManagerDelegate {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultComponentsRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultComponentsRegistry.kt
@@ -17,6 +17,8 @@ import com.facebook.react.fabric.ComponentFactory
  *
  * This class works together with the [DefaultNewArchitectureEntryPoint] and it's C++ implementation
  * is hosted inside the React Native framework
+ *
+ * TODO(T186951312): Should this be @UnstableReactNativeAPI?
  */
 @DoNotStrip
 public class DefaultComponentsRegistry

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -15,6 +15,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UIManagerProvider
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.fabric.FabricUIManagerProviderImpl
 import com.facebook.react.fabric.ReactNativeConfig
@@ -103,7 +104,8 @@ protected constructor(
    *
    * @param context the Android [Context] to use for creating the [ReactHost]
    */
-  public fun toReactHost(context: Context): ReactHost =
+  @UnstableReactNativeAPI
+  internal fun toReactHost(context: Context): ReactHost =
       DefaultReactHost.getDefaultReactHost(
           context,
           packages,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
@@ -21,6 +21,8 @@ import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
  *
  * This class works together with the [DefaultNewArchitectureEntryPoint] and it's C++ implementation
  * is hosted inside the React Native framework
+ *
+ * TODO(T186951312): Should this be @UnstableReactNativeAPI?
  */
 @OptIn(UnstableReactNativeAPI::class)
 public class DefaultTurboModuleManagerDelegate


### PR DESCRIPTION
Summary:
One way we register cxx turbo modules with React Native is via cxxreactpackages.

This diff allows the application to pass in cxxreactpackages into the default react host, which allows the application to, in turn, register cxx modules with react native!

Changelog: [Android][Added] - Allow bridgeless apps to register cxx modules via cxxreactpackages

Reviewed By: cortinico

Differential Revision: D56547493
