### PR TITLE
Upgrade androidx.core:core to 1.13.0

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -14,7 +14,6 @@ import android.graphics.Point
 import android.view.View
 import android.view.ViewGroup
 import android.widget.OverScroller
-import androidx.core.view.ViewCompat
 import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
@@ -416,10 +415,7 @@ public object ReactScrollViewHelper {
     scroller.setFriction(1.0f - scrollState.decelerationRate)
 
     // predict where a fling would end up so we can scroll to the nearest snap offset
-    val width =
-        (scrollView.width -
-            ViewCompat.getPaddingStart(scrollView) -
-            ViewCompat.getPaddingEnd(scrollView))
+    val width = (scrollView.width - scrollView.paddingStart - scrollView.paddingEnd)
     val height = scrollView.height - scrollView.paddingBottom - scrollView.paddingTop
     val finalAnimatedPositionScroll = scrollState.finalAnimatedPositionScroll
     scroller.fling(


### PR DESCRIPTION
Summary:
This diff is generated by Artificer tool, which upgrades managed third party libraries to their stable version. This automated diff was created to accelerate the process of upgrading androidx.core:core to 1.13.0.
 Note the dependency chain listed below before accepting:
```
androidx.core:core:1.13.0 ⏫
├╼ androidx.annotation:annotation:1.6.0:compile ✅
├╼ androidx.annotation:annotation-experimental:1.4.0:compile ✅
├╼ androidx.collection:collection:1.0.0:runtime ✅
├╼ androidx.concurrent:concurrent-futures:1.0.0:runtime ✅
├╼ androidx.interpolator:interpolator:1.0.0:runtime ✅
├╼ androidx.lifecycle:lifecycle-runtime:2.6.2:compile ✅
├╼ androidx.versionedparcelable:versionedparcelable:1.1.1:compile ✅
└╼ org.jetbrains.kotlin:kotlin-stdlib:1.8.22:compile ✅

```

Differential Revision: D56474755
