### PR TITLE
Fix memoization for Animated components when no style is passed in

### DIFF
--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -12,6 +12,7 @@ import View from '../Components/View/View';
 import useMergeRefs from '../Utilities/useMergeRefs';
 import useAnimatedProps from './useAnimatedProps';
 import * as React from 'react';
+import {useMemo} from 'react';
 
 // $FlowFixMe[deprecated-type]
 export type AnimatedProps<Props: {...}> = $ObjMap<
@@ -46,7 +47,10 @@ export default function createAnimatedComponent<TProps: {...}, TInstance>(
       const {passthroughAnimatedPropExplicitValues, style} = reducedProps;
       const {style: passthroughStyle, ...passthroughProps} =
         passthroughAnimatedPropExplicitValues ?? {};
-      const mergedStyle = {...style, ...passthroughStyle};
+      const mergedStyle = useMemo(
+        () => ({...style, ...passthroughStyle}),
+        [style, passthroughStyle],
+      );
 
       return (
         <Component


### PR DESCRIPTION
Summary:
Any component wrapped via `createAnimatedComponent()` will always re-render, because it creates a new `style` object. It's impossible to memoize.

Adding `useMemo()` here ensures that the `style` object passed to the underlying object is stable: if no `style` is passed to the wrapped component, then memoization can work.

Allowing memoization to function when the `style` object is passed in will require a deeper fix. See https://fb.workplace.com/groups/rn.support/permalink/26084643474490921/

Before:
{F1496803038}

After:
{F1496805410}

Differential Revision: D56618868
