### PR TITLE
Add missing `remove` method to `addEventListener` Jest mocks

### DIFF
--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -137,7 +137,9 @@ jest
   .mock('../Libraries/Components/AccessibilityInfo/AccessibilityInfo', () => ({
     __esModule: true,
     default: {
-      addEventListener: jest.fn(),
+      addEventListener: jest.fn(() => ({
+        remove: jest.fn(),
+      })),
       announceForAccessibility: jest.fn(),
       isAccessibilityServiceEnabled: jest.fn(),
       isBoldTextEnabled: jest.fn(),
@@ -200,7 +202,9 @@ jest
     openURL: jest.fn(),
     canOpenURL: jest.fn(() => Promise.resolve(true)),
     openSettings: jest.fn(),
-    addEventListener: jest.fn(),
+    addEventListener: jest.fn(() => ({
+      remove: jest.fn(),
+    })),
     getInitialURL: jest.fn(() => Promise.resolve()),
     sendIntent: jest.fn(),
   }))


### PR DESCRIPTION
## Summary:

While writing some Jest tests, I noticed some instances of the following error:

```
Cannot read properties of undefined (reading 'remove')
```

Looks like there were two cases where the `{remove: () => {}}` return result was missing in the provided Jest mocks:

 - `AccessibilityInfo.addEventListener`
 - `Linking.addEventListener`

## Changelog:

[GENERAL] [FIXED] - Added missing `remove` methods for `Linking.addEventListener` and `AccessibilityInfo.addEventListener` Jest mocks

## Test Plan

N/A