### PR TITLE
RN: Optimize `StyleSheet.compose`

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -23,6 +23,8 @@ import type {
   ____ViewStyleProp_Internal,
 } from './StyleSheetTypes';
 
+import composeStyles from '../../src/private/core/composeStyles';
+
 const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
 const PixelRatio = require('../Utilities/PixelRatio').default;
 const flatten = require('./flattenStyle');
@@ -268,16 +270,7 @@ module.exports = {
    * array, saving allocations and maintaining reference equality for
    * PureComponent checks.
    */
-  compose<T: DangerouslyImpreciseStyleProp>(
-    style1: ?T,
-    style2: ?T,
-  ): ?T | $ReadOnlyArray<T> {
-    if (style1 != null && style2 != null) {
-      return ([style1, style2]: $ReadOnlyArray<T>);
-    } else {
-      return style1 != null ? style1 : style2;
-    }
-  },
+  compose: composeStyles,
 
   /**
    * Flattens an array of style objects, into one aggregated style object.

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7502,10 +7502,7 @@ declare module.exports: {
   hairlineWidth: hairlineWidth,
   absoluteFill: any,
   absoluteFillObject: absoluteFill,
-  compose<T: DangerouslyImpreciseStyleProp>(
-    style1: ?T,
-    style2: ?T
-  ): ?T | $ReadOnlyArray<T>,
+  compose: composeStyles,
   flatten: flatten,
   setStyleAttributePreprocessor(
     property: string,

--- a/packages/react-native/src/private/core/composeStyles.js
+++ b/packages/react-native/src/private/core/composeStyles.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+/**
+ * Combines two styles such that `style2` will override any styles in `style1`.
+ * If either style is null or undefined, the other one is returned without
+ * allocating an array, saving allocations and enabling memoization.
+ */
+export default function composeStyles<T1, T2>(
+  style1: ?T1,
+  style2: ?T2,
+): ?(T1 | T2 | $ReadOnlyArray<T1 | T2>) {
+  if (style1 == null) {
+    return style2;
+  }
+  if (style2 == null) {
+    return style1;
+  }
+  return [style1, style2];
+}


### PR DESCRIPTION
Summary:
Changes two important aspects of `StyleSheet.compose`:

- Extract it from `StyleSheet` so that it can be imported from other internal modules without incurring circular dependencies. (Surprisingly, `StyleSheet` has a lot of dependencies.)
- Avoid a redundant `style1 != null` check.

Changelog:
[General][Changed] - Optimized performance of `StyleSheet.compose`

Reviewed By: sammy-SC

Differential Revision: D56621407
