### PR TITLE
fix a crash in <Modal /> component

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -75,19 +75,19 @@ public class ReactModalHostView(context: ThemedReactContext) :
   public var statusBarTranslucent: Boolean = false
     set(value) {
       field = value
-      propertyRequiresNewDialog = true
+      createNewDialog = true
     }
 
   public var animationType: String? = null
     set(value) {
       field = value
-      propertyRequiresNewDialog = true
+      createNewDialog = true
     }
 
   public var hardwareAccelerated: Boolean = false
     set(value) {
       field = value
-      propertyRequiresNewDialog = true
+      createNewDialog = true
     }
 
   public var stateWrapper: StateWrapper?
@@ -105,9 +105,10 @@ public class ReactModalHostView(context: ThemedReactContext) :
   private var hostView: DialogRootViewGroup
 
   // Set this flag to true if changing a particular property on the view requires a new Dialog to
-  // be created.  For instance, animation does since it affects Dialog creation through the theme
+  // be created or Dialog was destroyed. For instance, animation does since it affects Dialog
+  // creation through the theme
   // but transparency does not since we can access the window to update the property.
-  private var propertyRequiresNewDialog = false
+  private var createNewDialog = false
 
   init {
     context.addLifecycleEventListener(this)
@@ -176,6 +177,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
         }
       }
       dialog = null
+      createNewDialog = true
 
       // We need to remove the mHostView from the parent
       // It is possible we are dismissing this dialog and reattaching the hostView to another
@@ -210,7 +212,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
 
     // If the existing Dialog is currently up, we may need to redraw it or we may be able to update
     // the property without having to recreate the dialog
-    if (propertyRequiresNewDialog) {
+    if (createNewDialog) {
       dismiss()
     } else {
       updateProperties()
@@ -218,7 +220,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
     }
 
     // Reset the flag since we are going to create a new dialog
-    propertyRequiresNewDialog = false
+    createNewDialog = false
     val theme: Int =
         when (animationType) {
           "fade" -> R.style.Theme_FullScreenDialogAnimatedFade


### PR DESCRIPTION
Summary:
changelog: [Android][Fixed] - fix a crash in Modal component

Instance variable `propertyRequiresNewDialog` in `ReactModalHostView` controls if new dialog will be created on next `showOrUpdate` or not. It must be kept in sync with `dialog` ivar.

if `dismiss` is ever called from anywhere but `showOrUpdate`, the class gets into a state where the next `showOrUpdate` call will throw an error because dialog is set to null but `propertyRequiresNewDialog` stays false.

`dismiss` is called from three places: `showOrUpdate` (this is ok), `onDropInstance()` and `onDetachedFromWindow`.

The fix in this diff is to make sure propertyRequiresNewDialog is set to true when dialog is dismissed.

Differential Revision: D56627522
