### PR TITLE
Document HostFunction dtor threading requirement

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -1000,6 +1000,11 @@ class JSI_EXPORT Function : public Object {
   /// \param name the name property for the function.
   /// \param paramCount the length property for the function, which
   /// may not be the number of arguments the function is passed.
+  /// \note The std::function's dtor will be called when the GC finalizes this
+  /// function. As with HostObject, this may be as late as when the Runtime is
+  /// shut down, and may occur on an arbitrary thread. If the function contains
+  /// any captured values, you are responsible for ensuring that their
+  /// destructors are safe to call on any thread.
   static Function createFromHostFunction(
       Runtime& runtime,
       const jsi::PropNameID& name,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Updates the doc comment on `Function::createFromHostFunction` to mention that (a copy of) the provided `std::function` may be destroyed on an arbitrary thread, much like `HostObject` (where this is already documented).

Differential Revision: D56628194
