### PR TITLE
remove force_Static from safeareaview module

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <react/debug/react_native_assert.h>
 #include <react/renderer/components/safeareaview/SafeAreaViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 


### PR DESCRIPTION
Summary:
force_static doesn't need to be in here, let's remove it.

I change one module per diff. It makes it easier to land it and pinpoint where build failures are coming from.

Differential Revision: D56630625
