### PR TITLE
use forward declaration in ComponentDescriptor.h

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ComponentDescriptor.h"
+#include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
 
@@ -15,8 +16,8 @@ ComponentDescriptor::ComponentDescriptor(
       contextContainer_(parameters.contextContainer),
       flavor_(parameters.flavor) {}
 
-const ContextContainer::Shared& ComponentDescriptor::getContextContainer()
-    const {
+const std::shared_ptr<const ContextContainer>&
+ComponentDescriptor::getContextContainer() const {
   return contextContainer_;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -15,12 +15,12 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/State.h>
 #include <react/renderer/core/StateData.h>
-#include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
 
 class ComponentDescriptorParameters;
 class ComponentDescriptor;
+class ContextContainer;
 
 using SharedComponentDescriptor = std::shared_ptr<const ComponentDescriptor>;
 
@@ -53,7 +53,7 @@ class ComponentDescriptor {
   /*
    * Returns stored instance of `ContextContainer`.
    */
-  const ContextContainer::Shared& getContextContainer() const;
+  const std::shared_ptr<const ContextContainer>& getContextContainer() const;
 
   /*
    * Returns `componentHandle` associated with particular kind of components.
@@ -132,7 +132,7 @@ class ComponentDescriptor {
   friend ShadowNode;
 
   EventDispatcher::Weak eventDispatcher_;
-  ContextContainer::Shared contextContainer_;
+  std::shared_ptr<const ContextContainer> contextContainer_;
   RawPropsParser rawPropsParser_{};
   Flavor flavor_;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

Employ forward declaration in ComponentDescriptor.h to avoid importing header unnecessarly.

Differential Revision: D56631399
