### PR TITLE
Remove `getSurfacePresenter` and `getModuleRegistry` from RCTHost

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -77,12 +77,6 @@ typedef std::shared_ptr<facebook::react::JSRuntimeFactory> (^RCTHostJSEngineProv
 
 - (RCTFabricSurface *)createSurfaceWithModuleName:(NSString *)moduleName initialProperties:(NSDictionary *)properties;
 
-- (RCTSurfacePresenter *)getSurfacePresenter __attribute__((deprecated("Use `surfacePresenter` property instead.")));
-
-// Native module API
-
-- (RCTModuleRegistry *)getModuleRegistry __attribute__((deprecated("Use `moduleRegistry` property instead.")));
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -289,21 +289,9 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   return _moduleRegistry;
 }
 
-// Deprecated
-- (RCTModuleRegistry *)getModuleRegistry
-{
-  return self.moduleRegistry;
-}
-
 - (RCTSurfacePresenter *)surfacePresenter
 {
   return [_instance surfacePresenter];
-}
-
-// Deprecated
-- (RCTSurfacePresenter *)getSurfacePresenter
-{
-  return self.surfacePresenter;
 }
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args


### PR DESCRIPTION
Summary:
This change removes a couple of method from RCTHost which were not following the iOS convention for names.

We deprecated them in 0.74 and now that the branch is cut, we can remove them.

## Changelog:
[iOS][Breaking] - Remove `getSurfacePresenter` and `getModuleRegistry` from RCTHost

Differential Revision: D56633554
