### PR TITLE
Improve heuristic that triggers onStartReached

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1219,7 +1219,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     zoomScale: 1,
   };
   _scrollRef: ?React.ElementRef<any> = null;
-  _sentStartForContentLength = 0;
+  _sentStartForFirstVisibleItemKey: ?string = null;
   _sentEndForContentLength = 0;
   _updateCellsToRenderBatcher: Batchinator;
   _viewabilityTuples: Array<ViewabilityHelperCallbackTuple> = [];
@@ -1552,16 +1552,16 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       onStartReached != null &&
       this.state.cellsAroundViewport.first === 0 &&
       isWithinStartThreshold &&
-      this._listMetrics.getContentLength() !== this._sentStartForContentLength
+      this.state.firstVisibleItemKey !== this._sentStartForFirstVisibleItemKey
     ) {
-      this._sentStartForContentLength = this._listMetrics.getContentLength();
+      this._sentStartForFirstVisibleItemKey = this.state.firstVisibleItemKey;
       onStartReached({distanceFromStart});
     }
 
     // If the user scrolls away from the start or end and back again,
     // cause onStartReached or onEndReached to be triggered again
     if (!isWithinStartThreshold) {
-      this._sentStartForContentLength = 0;
+      this._sentStartForFirstVisibleItemKey = null;
     }
     if (!isWithinEndThreshold) {
       this._sentEndForContentLength = 0;

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1546,8 +1546,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     }
 
     // Next check if the user just scrolled within the start threshold
-    // and call onStartReached only once for a given content length,
-    // and only if onEndReached is not being executed
+    // and call onStartReached only once for a given first visible item
     if (
       onStartReached != null &&
       this.state.cellsAroundViewport.first === 0 &&


### PR DESCRIPTION
## Summary:

`onStartReached` is called more than it should be since our heuristic to not re-trigger it is based on the list content size. This has worked fine for `onEndReached`, but for `onStartReached` it causes some issues.

On initial mount we receive different content size updates. I assume this is normal because of virtualization and the need to measure content. However for `onStartReached` since we usually start at scroll position 0 we are already in the threshold so any change to content size causes us to trigger a `onStartReached` event.

For example using [this code](https://gist.github.com/janicduplessis/bf507742b3ea082cf8c818d0b7b84590) we get 2 `onStartReached` calls on mount. On top of this every time we add items at the end of the list `onStartReached` is called another time.

To improve this I suggest using `firstVisibleItemKey` that we use for `maintainVisibleContentPosition` to track if we should re-trigger `onStartReached`. This means that it will be only re-triggered if new items are added at the start of the list or if we leave the threshold.

## Changelog:

[GENERAL] [FIXED] - Improve heuristic that triggers onStartReached

## Test Plan:

Tested using [this code](https://gist.github.com/janicduplessis/bf507742b3ea082cf8c818d0b7b84590). See that `onStartReached` is only called once on mount and then again only if leaving the threshold or adding new items at the start of the list. Adding items at the end of the list should also not trigger `onStartReached`.
