### PR TITLE
RNGP - Autolinking - Add model classes for parsing the `config` output

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -11,6 +11,7 @@ import com.facebook.react.utils.projectPathToLibraryName
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -147,4 +148,35 @@ abstract class ReactExtension @Inject constructor(project: Project) {
    */
   val codegenJavaPackageName: Property<String> =
       objects.property(String::class.java).convention("com.facebook.fbreact.specs")
+
+  /** Auto-linking Config */
+
+  /**
+   * Location of the JSON file used to configure autolinking. This file is the output of the
+   * `@react-native-community/cli` config command.
+   *
+   * If not specified, RNGP will just invoke whatever you pass as [autolinkConfigCommand].
+   */
+  val autolinkConfigFile: RegularFileProperty = objects.fileProperty()
+
+  /**
+   * The command to invoke as source of truth for the autolinking configuration. Default is `["npx",
+   * "@react-native-community/cli", "config"]`.
+   */
+  val autolinkConfigCommand: ListProperty<String> =
+      objects
+          .listProperty(String::class.java)
+          .convention(listOf("npx", "@react-native-community/cli", "config"))
+
+  /**
+   * Location of the lock files used to consider wether autolinking [autolinkConfigCommand] should
+   * re-execute or not. If file collection is unchanged, the autolinking command will not be
+   * re-executed.
+   *
+   * If not specified, RNGP will just look for both yarn.lock and package.lock in the [root] folder.
+   */
+  val autolinkLockFiles: Property<FileCollection> =
+      objects
+          .property(FileCollection::class.java)
+          .convention(root.files("../yarn.lock", "../package-lock.json"))
 }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -169,7 +169,7 @@ abstract class ReactExtension @Inject constructor(project: Project) {
           .convention(listOf("npx", "@react-native-community/cli", "config"))
 
   /**
-   * Location of the lock files used to consider wether autolinking [autolinkConfigCommand] should
+   * Location of the lock files used to consider whether autolinking [autolinkConfigCommand] should
    * re-execute or not. If file collection is unchanged, the autolinking command will not be
    * re-executed.
    *

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -12,6 +12,7 @@ import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.facebook.react.internal.PrivateReactExtension
 import com.facebook.react.tasks.GenerateCodegenArtifactsTask
 import com.facebook.react.tasks.GenerateCodegenSchemaTask
+import com.facebook.react.tasks.RunAutolinkingConfigTask
 import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForApp
 import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForLibraries
 import com.facebook.react.utils.AgpConfiguratorUtils.configureDevPorts
@@ -78,6 +79,7 @@ class ReactPlugin : Plugin<Project> {
           project.configureReactTasks(variant = variant, config = extension)
         }
       }
+      configureAutolinking(project, extension)
       configureCodegen(project, extension, rootExtension, isLibrary = false)
     }
 
@@ -208,5 +210,22 @@ class ReactPlugin : Plugin<Project> {
     // `preBuild` is one of the base tasks automatically registered by AGP.
     // This will invoke the codegen before compiling the entire project.
     project.tasks.named("preBuild", Task::class.java).dependsOn(generateCodegenArtifactsTask)
+  }
+
+  /** This function sets up Autolinking for App users */
+  private fun configureAutolinking(
+      project: Project,
+      extension: ReactExtension,
+  ) {
+    val generatedAutolinkingDir: Provider<Directory> =
+        project.layout.buildDirectory.dir("generated/autolinking")
+    val configOutputFile = generatedAutolinkingDir.get().file("config-output.json")
+
+    project.tasks.register("runAutolinkingConfig", RunAutolinkingConfigTask::class.java) { task ->
+      task.autolinkConfigCommand.set(extension.autolinkConfigCommand)
+      task.autolinkConfigFile.set(extension.autolinkConfigFile)
+      task.autolinkOutputFile.set(configOutputFile)
+      task.autolinkLockFiles.set(extension.autolinkLockFiles)
+    }
   }
 }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingAndroidProjectJson.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingAndroidProjectJson.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.model
+
+data class ModelAutolinkingAndroidProjectJson(
+    val sourceDir: String,
+    val appName: String,
+    val packageName: String,
+    val applicationId: String,
+    val mainActivity: String,
+    val watchModeCommandParams: List<String>?,
+    val dependencyConfiguration: String?
+)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingConfigJson.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingConfigJson.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.model
+
+data class ModelAutolinkingConfigJson(
+    val reactNativeVersion: String,
+    val dependencies: Map<String, ModelAutolinkingDependenciesJson>?,
+    val project: ModelAutolinkingProjectJson?,
+)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesJson.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesJson.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.model
+
+data class ModelAutolinkingDependenciesJson(
+    val root: String,
+    val name: String,
+    val platforms: ModelAutolinkingDependenciesPlatformJson?
+) {
+
+  val nameCleansed: String
+    get() = name.replace(Regex("[~*!'()]+"), "_").replace(Regex("^@([\\w-.]+)/"), "$1_")
+}

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesPlatformAndroidJson.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesPlatformAndroidJson.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.model
+
+data class ModelAutolinkingDependenciesPlatformAndroidJson(
+    val sourceDir: String,
+    val packageImportPath: String,
+    val packageInstance: String,
+    val buildTypes: List<String>,
+    val libraryName: String,
+    val componentDescriptors: List<String>,
+    val cmakeListsPath: String,
+    val cxxModuleCMakeListsModuleName: String?,
+    val cxxModuleCMakeListsPath: String?,
+    val cxxModuleHeaderName: String?,
+    val dependencyConfiguration: String?
+)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesPlatformJson.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesPlatformJson.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.model
+
+data class ModelAutolinkingDependenciesPlatformJson(
+    val android: ModelAutolinkingDependenciesPlatformAndroidJson?
+)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingProjectJson.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/model/ModelAutolinkingProjectJson.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.model
+
+data class ModelAutolinkingProjectJson(val android: ModelAutolinkingAndroidProjectJson?)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/RunAutolinkingConfigTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/RunAutolinkingConfigTask.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks
+
+import com.facebook.react.utils.windowsAwareCommandLine
+import java.io.FileOutputStream
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
+
+/**
+ * A task that will run @react-native-community/cli config if necessary to generate the autolinking
+ * configuration file.
+ */
+abstract class RunAutolinkingConfigTask : Exec() {
+
+  init {
+    group = "react"
+  }
+
+  @get:Input abstract val autolinkConfigCommand: ListProperty<String>
+
+  /*
+   * We don't want to re-run config if the lockfiles haven't changed.
+   * So we have the lockfiles as @InputFiles for this task.
+   */
+  @get:InputFiles abstract val autolinkLockFiles: Property<FileCollection>
+
+  @get:InputFile @get:Optional abstract val autolinkConfigFile: RegularFileProperty
+
+  @get:OutputFile abstract val autolinkOutputFile: RegularFileProperty
+
+  override fun exec() {
+    wipeOutputDir()
+    setupCommandLine()
+    super.exec()
+  }
+
+  internal fun setupCommandLine() {
+    if (!autolinkConfigFile.isPresent || !autolinkConfigFile.get().asFile.exists()) {
+      setupConfigCommandLine()
+    } else {
+      setupConfigCopyCommandLine()
+    }
+  }
+
+  internal fun wipeOutputDir() {
+    autolinkOutputFile.asFile.get().apply {
+      deleteRecursively()
+      parentFile.mkdirs()
+    }
+  }
+
+  internal fun setupConfigCommandLine() {
+    workingDir(project.projectDir)
+    standardOutput = FileOutputStream(autolinkOutputFile.get().asFile)
+    commandLine(
+        windowsAwareCommandLine(
+            *autolinkConfigCommand.get().toTypedArray(),
+        ))
+  }
+
+  internal fun setupConfigCopyCommandLine() {
+    workingDir(project.projectDir)
+    commandLine(
+        windowsAwareCommandLine(
+            "cp",
+            autolinkConfigFile.get().asFile.absolutePath,
+            autolinkOutputFile.get().asFile.absolutePath))
+  }
+}

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JsonUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JsonUtils.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.utils
 
+import com.facebook.react.model.ModelAutolinkingConfigJson
 import com.facebook.react.model.ModelPackageJson
 import com.google.gson.Gson
 import java.io.File
@@ -17,5 +18,11 @@ object JsonUtils {
   fun fromPackageJson(input: File): ModelPackageJson? =
       input.bufferedReader().use {
         runCatching { gsonConverter.fromJson(it, ModelPackageJson::class.java) }.getOrNull()
+      }
+
+  fun fromAutolinkingConfigJson(input: File): ModelAutolinkingConfigJson? =
+      input.bufferedReader().use {
+        runCatching { gsonConverter.fromJson(it, ModelAutolinkingConfigJson::class.java) }
+            .getOrNull()
       }
 }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesJsonTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesJsonTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ModelAutolinkingDependenciesJsonTest {
+
+  @Test
+  fun nameCleansed_withoutScope() {
+    assertEquals("name", ModelAutolinkingDependenciesJson("", "name", null).nameCleansed)
+    assertEquals(
+        "react_native", ModelAutolinkingDependenciesJson("", "react~native", null).nameCleansed)
+    assertEquals(
+        "react_native", ModelAutolinkingDependenciesJson("", "react*native", null).nameCleansed)
+    assertEquals(
+        "react_native", ModelAutolinkingDependenciesJson("", "react!native", null).nameCleansed)
+    assertEquals(
+        "react_native", ModelAutolinkingDependenciesJson("", "react'native", null).nameCleansed)
+    assertEquals(
+        "react_native", ModelAutolinkingDependenciesJson("", "react(native", null).nameCleansed)
+    assertEquals(
+        "react_native", ModelAutolinkingDependenciesJson("", "react)native", null).nameCleansed)
+    assertEquals(
+        "react_native",
+        ModelAutolinkingDependenciesJson("", "react~*!'()native", null).nameCleansed)
+  }
+
+  @Test
+  fun nameCleansed_withScope() {
+    assertEquals(
+        "react-native_package",
+        ModelAutolinkingDependenciesJson("", "@react-native/package", null).nameCleansed)
+    assertEquals(
+        "this_is_a_more_complicated_example_of_weird_packages",
+        ModelAutolinkingDependenciesJson(
+                "", "@this*is~a(more)complicated/example!of~weird)packages", null)
+            .nameCleansed)
+  }
+}

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/RunAutolinkingConfigTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/RunAutolinkingConfigTaskTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks
+
+import com.facebook.react.tests.createProject
+import com.facebook.react.tests.createTestTask
+import java.io.File
+import java.io.FileOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class RunAutolinkingConfigTaskTest {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test
+  fun runAutolinkingConfigTask_groupIsSetCorrectly() {
+    val task = createTestTask<BundleHermesCTask> {}
+    assertEquals("react", task.group)
+  }
+
+  @Test
+  fun runAutolinkingConfigTask_staticInputs_areSetCorrectly() {
+    val project = createProject()
+
+    val task =
+        createTestTask<RunAutolinkingConfigTask> {
+          it.autolinkConfigCommand.set(listOf("rm", "-rf", "/"))
+          it.autolinkLockFiles.set(project.files("packager.lock", "another-packager.lock"))
+          it.autolinkConfigFile.set(tempFolder.newFile("dependencies.json"))
+          it.autolinkOutputFile.set(tempFolder.newFile("output.json"))
+        }
+
+    assertEquals(3, task.inputs.files.files.size)
+    task.autolinkLockFiles.get().files.forEach {
+      assertTrue(
+          it.name == "depedencies.json" ||
+              it.name == "packager.lock" ||
+              it.name == "another-packager.lock")
+    }
+
+    assertTrue(task.inputs.properties.containsKey("autolinkConfigCommand"))
+    assertEquals(1, task.outputs.files.files.size)
+    assertEquals(File(tempFolder.root, "output.json"), task.outputs.files.singleFile)
+    assertEquals(listOf("rm", "-rf", "/"), task.autolinkConfigCommand.get())
+
+    assertEquals(2, task.autolinkLockFiles.get().files.size)
+    task.autolinkLockFiles.get().files.forEach {
+      assertTrue(it.name == "packager.lock" || it.name == "another-packager.lock")
+    }
+
+    assertEquals(File(tempFolder.root, "dependencies.json"), task.autolinkConfigFile.get().asFile)
+    assertEquals(File(tempFolder.root, "output.json"), task.autolinkOutputFile.get().asFile)
+  }
+
+  @Test
+  fun wipeOutputDir_worksCorrectly() {
+    val outputDir =
+        tempFolder.newFolder("output").apply {
+          File(this, "output.json").createNewFile()
+          File(this, "NothingToSeeHere.java").createNewFile()
+        }
+
+    val task = createTestTask<RunAutolinkingConfigTask> { it.autolinkOutputFile.set(outputDir) }
+    task.wipeOutputDir()
+
+    assertFalse(outputDir.exists())
+  }
+
+  @Test
+  fun setupConfigCommandLine_worksCorrectly() {
+    val project = createProject()
+
+    val task =
+        createTestTask<RunAutolinkingConfigTask>(project) {
+          it.autolinkConfigCommand.set(listOf("rm", "-rf", "/"))
+          it.autolinkOutputFile.set(tempFolder.newFile("output.json"))
+        }
+    task.setupConfigCommandLine()
+
+    assertEquals(project.projectDir, task.workingDir)
+    assertTrue(task.standardOutput is FileOutputStream)
+    assertEquals(listOf("rm", "-rf", "/"), task.commandLine)
+  }
+
+  @Test
+  fun setupConfigCopyCommandLine_worksCorrectly() {
+    val project = createProject()
+
+    val task =
+        createTestTask<RunAutolinkingConfigTask>(project) {
+          it.autolinkConfigFile.set(tempFolder.newFile("dependencies.json"))
+          it.autolinkOutputFile.set(tempFolder.newFile("output.json"))
+        }
+    task.setupConfigCopyCommandLine()
+
+    assertEquals(project.projectDir, task.workingDir)
+    assertTrue(task.standardOutput !is FileOutputStream)
+    assertEquals("cp", task.commandLine[0])
+    assertEquals(File(tempFolder.root, "dependencies.json").absolutePath, task.commandLine[1])
+    assertEquals(File(tempFolder.root, "output.json").absolutePath, task.commandLine[2])
+  }
+
+  @Test
+  fun setupCommandLine_withoutAutolinkConfigFileConfigured_invokesCommand() {
+    val project = createProject()
+
+    val task =
+        createTestTask<RunAutolinkingConfigTask>(project) {
+          it.autolinkConfigCommand.set(listOf("rm", "-rf", "/"))
+          it.autolinkOutputFile.set(tempFolder.newFile("output.json"))
+        }
+    task.setupCommandLine()
+
+    assertEquals(listOf("rm", "-rf", "/"), task.commandLine)
+  }
+
+  @Test
+  fun setupCommandLine_withoutMissingConfigFile_invokesCommand() {
+    val project = createProject()
+
+    val task =
+        createTestTask<RunAutolinkingConfigTask>(project) {
+          it.autolinkConfigCommand.set(listOf("rm", "-rf", "/"))
+          it.autolinkConfigFile.set(File(tempFolder.root, "dependencies.json"))
+          it.autolinkOutputFile.set(tempFolder.newFile("output.json"))
+        }
+    task.setupCommandLine()
+
+    assertEquals(listOf("rm", "-rf", "/"), task.commandLine)
+  }
+
+  @Test
+  fun setupCommandLine_withoutExistingConfigFile_invokesCp() {
+    val project = createProject()
+    val configFile = tempFolder.newFile("dependencies.json").apply { writeText("¯\\_(ツ)_/¯") }
+
+    val task =
+        createTestTask<RunAutolinkingConfigTask>(project) {
+          it.autolinkConfigCommand.set(listOf("rm", "-rf", "/"))
+          it.autolinkConfigFile.set(configFile)
+          it.autolinkOutputFile.set(tempFolder.newFile("output.json"))
+        }
+    task.setupCommandLine()
+
+    assertEquals(
+        listOf("cp", configFile.absolutePath, File(tempFolder.root, "output.json").absolutePath),
+        task.commandLine)
+  }
+}

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/JsonUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/JsonUtilsTest.kt
@@ -18,14 +18,14 @@ class JsonUtilsTest {
   @get:Rule val tempFolder = TemporaryFolder()
 
   @Test
-  fun withInvalidJson_returnsNull() {
+  fun fromPackageJson_withInvalidJson_returnsNull() {
     val invalidJson = createJsonFile("""¯\_(ツ)_/¯""")
 
     assertNull(JsonUtils.fromPackageJson(invalidJson))
   }
 
   @Test
-  fun withEmptyJson_returnsEmptyObject() {
+  fun fromPackageJson_withEmptyJson_returnsEmptyObject() {
     val invalidJson = createJsonFile("""{}""")
 
     val parsed = JsonUtils.fromPackageJson(invalidJson)
@@ -35,7 +35,7 @@ class JsonUtilsTest {
   }
 
   @Test
-  fun withOldJsonConfig_returnsAnEmptyLibrary() {
+  fun fromPackageJson_withOldJsonConfig_returnsAnEmptyLibrary() {
     val oldJsonConfig =
         createJsonFile(
             """
@@ -62,7 +62,7 @@ class JsonUtilsTest {
   }
 
   @Test
-  fun withValidJson_parsesCorrectly() {
+  fun fromPackageJson_withValidJson_parsesCorrectly() {
     val validJson =
         createJsonFile(
             """
@@ -119,6 +119,185 @@ class JsonUtilsTest {
     val parsed = JsonUtils.fromPackageJson(validJson)!!
 
     assertEquals("1000.0.0", parsed.version)
+  }
+
+  @Test
+  fun fromAutolinkingConfigJson_withInvalidJson_returnsNull() {
+    val invalidJson = createJsonFile("""¯\_(ツ)_/¯""")
+
+    assertNull(JsonUtils.fromAutolinkingConfigJson(invalidJson))
+  }
+
+  @Test
+  fun fromAutolinkingConfigJson_withSimpleJson_returnsIt() {
+    val validJson =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0"
+      }
+      """
+                .trimIndent())
+    val parsed = JsonUtils.fromAutolinkingConfigJson(validJson)!!
+
+    assertEquals("1000.0.0", parsed.reactNativeVersion)
+  }
+
+  @Test
+  fun fromAutolinkingConfigJson_withProjectSpecified_canParseIt() {
+    val validJson =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0",
+        "project": {
+          "ios": {
+            "sourceDir": "./packages/rn-tester",
+            "xcodeProject": {
+              "name": "RNTesterPods.xcworkspace",
+              "isWorkspace": true
+            },
+            "automaticPodsInstallation": false
+          },
+          "android": {
+            "sourceDir": "./packages/rn-tester",
+            "appName": "RN-Tester",
+            "packageName": "com.facebook.react.uiapp",
+            "applicationId": "com.facebook.react.uiapp",
+            "mainActivity": ".RNTesterActivity",
+            "watchModeCommandParams": [
+              "--mode HermesDebug"
+            ],
+            "dependencyConfiguration": "implementation"
+          }
+        }
+      }
+      """
+                .trimIndent())
+    val parsed = JsonUtils.fromAutolinkingConfigJson(validJson)!!
+
+    assertEquals("./packages/rn-tester", parsed.project!!.android!!.sourceDir)
+    assertEquals("RN-Tester", parsed.project!!.android!!.appName)
+    assertEquals("com.facebook.react.uiapp", parsed.project!!.android!!.packageName)
+    assertEquals("com.facebook.react.uiapp", parsed.project!!.android!!.applicationId)
+    assertEquals(".RNTesterActivity", parsed.project!!.android!!.mainActivity)
+    assertEquals("--mode HermesDebug", parsed.project!!.android!!.watchModeCommandParams!![0])
+    assertEquals("implementation", parsed.project!!.android!!.dependencyConfiguration)
+  }
+
+  @Test
+  fun fromAutolinkingConfigJson_withDependenciesSpecified_canParseIt() {
+    val validJson =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0",
+        "dependencies": {
+          "@react-native/oss-library-example": {
+            "root": "./node_modules/@react-native/oss-library-example",
+            "name": "@react-native/oss-library-example",
+            "platforms": {
+              "ios": {
+                "podspecPath": "./node_modules/@react-native/oss-library-example/OSSLibraryExample.podspec",
+                "version": "0.0.1",
+                "configurations": [],
+                "scriptPhases": []
+              },
+              "android": {
+                "sourceDir": "./node_modules/@react-native/oss-library-example/android",
+                "packageImportPath": "import com.facebook.react.osslibraryexample.OSSLibraryExamplePackage;",
+                "packageInstance": "new OSSLibraryExamplePackage()",
+                "buildTypes": ["staging", "debug", "release"],
+                "libraryName": "OSSLibraryExampleSpec",
+                "componentDescriptors": [
+                  "SampleNativeComponentComponentDescriptor"
+                ],
+                "cmakeListsPath": "./node_modules/@react-native/oss-library-example/android/build/generated/source/codegen/jni/CMakeLists.txt",
+                "cxxModuleCMakeListsModuleName": null,
+                "cxxModuleCMakeListsPath": null,
+                "cxxModuleHeaderName": null,
+                "dependencyConfiguration": "implementation"
+              }
+            }
+          }
+        }
+      }
+      """
+                .trimIndent())
+    val parsed = JsonUtils.fromAutolinkingConfigJson(validJson)!!
+
+    assertEquals(
+        "./node_modules/@react-native/oss-library-example",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!.root)
+    assertEquals(
+        "@react-native/oss-library-example",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!.name)
+    assertEquals(
+        "react-native_oss-library-example",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!.nameCleansed)
+    assertEquals(
+        "./node_modules/@react-native/oss-library-example/android",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .sourceDir)
+    assertEquals(
+        "import com.facebook.react.osslibraryexample.OSSLibraryExamplePackage;",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .packageImportPath)
+    assertEquals(
+        "new OSSLibraryExamplePackage()",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .packageInstance)
+    assertEquals(
+        listOf("staging", "debug", "release"),
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .buildTypes)
+    assertEquals(
+        "OSSLibraryExampleSpec",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .libraryName)
+    assertEquals(
+        listOf("SampleNativeComponentComponentDescriptor"),
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .componentDescriptors)
+    assertEquals(
+        "./node_modules/@react-native/oss-library-example/android/build/generated/source/codegen/jni/CMakeLists.txt",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .cmakeListsPath)
+    assertNull(
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .cxxModuleHeaderName)
+    assertNull(
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .cxxModuleCMakeListsPath)
+    assertNull(
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .cxxModuleCMakeListsModuleName)
+    assertEquals(
+        "implementation",
+        parsed.dependencies!!["@react-native/oss-library-example"]!!
+            .platforms!!
+            .android!!
+            .dependencyConfiguration)
   }
 
   private fun createJsonFile(@Language("JSON") input: String) =

--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -61,6 +61,10 @@ react {
   //   The hermes compiler command to run. By default it is 'hermesc'
   hermesCommand = "$reactNativeDirPath/ReactAndroid/hermes-engine/build/hermes/bin/hermesc"
   enableHermesOnlyInVariants = listOf("hermesDebug", "hermesRelease")
+
+  /* Autolinking */
+  //   The location of the monorepo lockfiles to `config` is cached correctly.
+  autolinkLockFiles = files("$rootDir/yarn.lock")
 }
 
 /** Run Proguard to shrink the Java bytecode in release builds. */


### PR DESCRIPTION
Summary:
This diff is part of RFC0759
https://github.com/react-native-community/discussions-and-proposals/pull/759

Here I'm creating data classes that will allow us to parse the `config` JSON output.
Code is pretty straightforward and follows the structure as the `config` command output.

Changelog:
[Internal] [Changed] - RNGP - Autolinking - Add model classes for parsing the `config` output

Differential Revision: D55475595
