### PR TITLE
fix Flow failure breaking yarn run build

### DIFF
--- a/packages/core-cli-utils/src/index.js
+++ b/packages/core-cli-utils/src/index.js
@@ -31,4 +31,4 @@ if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
   }
 }
 
-module.exports = require('./index.flow.js');
+export * from './index.flow.js';


### PR DESCRIPTION
Summary:
`flow-api-translator` can't handle `module.exports`. Simplest fix is to not identify
the bridging file (that we use to register with babel to transpile when run directly)
as a flow file.

Changelog: [Internal] - Fixing an internal build script broken by D56243647

Differential Revision: D56638506
