### PR TITLE
[RN][Codegen] add missing struct member initialization in Props.h

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -86,7 +86,7 @@ static inline std::string toString(const ArrayPropsNativeComponentViewSizesMaskW
     return result;
 }
 struct ArrayPropsNativeComponentViewObjectStruct {
-  std::string prop;
+  std::string prop{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewObjectStruct &result) {
@@ -113,8 +113,8 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 
 struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
-  Float prop1;
-  int prop2;
+  Float prop1{0.0};
+  int prop2{0};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewArrayOfObjectsStruct &result) {
@@ -760,12 +760,12 @@ static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &
   }
 }
 struct ObjectPropsNativeComponentObjectPropStruct {
-  std::string stringProp;
-  bool booleanProp;
-  Float floatProp;
-  int intProp;
-  ObjectPropsNativeComponentStringEnumProp stringEnumProp;
-  ObjectPropsNativeComponentIntEnumProp intEnumProp;
+  std::string stringProp{\\"\\"};
+  bool booleanProp{false};
+  Float floatProp{0.0};
+  int intProp{0};
+  ObjectPropsNativeComponentStringEnumProp stringEnumProp{ObjectPropsNativeComponentStringEnumProp::Small};
+  ObjectPropsNativeComponentIntEnumProp intEnumProp{ObjectPropsNativeComponentIntEnumProp::IntEnumProp0};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPropStruct &result) {
@@ -802,7 +802,7 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectPropStr
 }
 
 struct ObjectPropsNativeComponentObjectArrayPropStruct {
-  std::vector<std::string> array;
+  std::vector<std::string> array{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectArrayPropStruct &result) {
@@ -819,9 +819,9 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectArrayPr
 }
 
 struct ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct {
-  ImageSource image;
-  SharedColor color;
-  Point point;
+  ImageSource image{};
+  SharedColor color{};
+  Point point{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &result) {

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -166,6 +166,14 @@ function getEnumMaskName(enumName: string): string {
   return `${enumName}Mask`;
 }
 
+function getDefaultInitializerString(
+  componentName: string,
+  prop: NamedShape<PropTypeAnnotation>,
+): string {
+  const defaultValue = convertDefaultTypeToString(componentName, prop);
+  return `{${defaultValue}}`;
+}
+
 function convertDefaultTypeToString(
   componentName: string,
   prop: NamedShape<PropTypeAnnotation>,
@@ -305,6 +313,7 @@ const IncludeTemplate = ({
 };
 
 module.exports = {
+  getDefaultInitializerString,
   convertDefaultTypeToString,
   getCppArrayTypeForAnnotation,
   getCppTypeForAnnotation,

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -23,8 +23,8 @@ const {
   getNativeTypeFromAnnotation,
 } = require('./ComponentsGeneratorUtils.js');
 const {
-  convertDefaultTypeToString,
   generateStructName,
+  getDefaultInitializerString,
   getEnumMaskName,
   toIntEnumValueName,
 } = require('./CppHelpers.js');
@@ -460,13 +460,21 @@ function generateEnumString(
 function generatePropsString(
   componentName: string,
   props: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
+  nameParts: $ReadOnlyArray<string> = [],
 ) {
   return props
     .map(prop => {
-      const nativeType = getNativeTypeFromAnnotation(componentName, prop, []);
-      const defaultValue = convertDefaultTypeToString(componentName, prop);
+      const nativeType = getNativeTypeFromAnnotation(
+        componentName,
+        prop,
+        nameParts,
+      );
+      const defaultInitializer = getDefaultInitializerString(
+        componentName,
+        prop,
+      );
 
-      return `${nativeType} ${prop.name}{${defaultValue}};`;
+      return `${nativeType} ${prop.name}${defaultInitializer};`;
     })
     .join('\n' + '  ');
 }
@@ -633,16 +641,7 @@ function generateStruct(
 ): void {
   const structNameParts = nameParts;
   const structName = generateStructName(componentName, structNameParts);
-
-  const fields = properties
-    .map(property => {
-      return `${getNativeTypeFromAnnotation(
-        componentName,
-        property,
-        structNameParts,
-      )} ${property.name};`;
-    })
-    .join('\n' + '  ');
+  const fields = generatePropsString(componentName, properties, nameParts);
 
   properties.forEach((property: NamedShape<PropTypeAnnotation>) => {
     const name = property.name;

--- a/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
@@ -872,6 +872,38 @@ const OBJECT_PROPS: SchemaType = {
                     },
                   },
                   {
+                    name: 'stringUserDefaultProp',
+                    optional: true,
+                    typeAnnotation: {
+                      type: 'StringTypeAnnotation',
+                      default: 'user_default',
+                    },
+                  },
+                  {
+                    name: 'booleanUserDefaultProp',
+                    optional: true,
+                    typeAnnotation: {
+                      type: 'BooleanTypeAnnotation',
+                      default: true,
+                    },
+                  },
+                  {
+                    name: 'floatUserDefaultProp',
+                    optional: true,
+                    typeAnnotation: {
+                      type: 'FloatTypeAnnotation',
+                      default: 3.14,
+                    },
+                  },
+                  {
+                    name: 'intUserDefaultProp',
+                    optional: true,
+                    typeAnnotation: {
+                      type: 'Int32TypeAnnotation',
+                      default: 9999,
+                    },
+                  },
+                  {
                     name: 'stringEnumProp',
                     optional: true,
                     typeAnnotation: {

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -85,7 +85,7 @@ static inline std::string toString(const ArrayPropsNativeComponentSizesMaskWrapp
     return result;
 }
 struct ArrayPropsNativeComponentObjectStruct {
-  std::string stringProp;
+  std::string stringProp{\\"\\"};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentObjectStruct &result) {
@@ -112,7 +112,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 
 struct ArrayPropsNativeComponentArrayObjectStruct {
-  std::string stringProp;
+  std::string stringProp{\\"\\"};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayObjectStruct &result) {
@@ -139,7 +139,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 
 struct ArrayPropsNativeComponentArrayStruct {
-  std::vector<ArrayPropsNativeComponentArrayObjectStruct> object;
+  std::vector<ArrayPropsNativeComponentArrayObjectStruct> object{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayStruct &result) {
@@ -166,7 +166,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 
 struct ArrayPropsNativeComponentArrayOfArrayOfObjectStruct {
-  std::string stringProp;
+  std::string stringProp{\\"\\"};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayOfArrayOfObjectStruct &result) {
@@ -246,9 +246,9 @@ Map {
 namespace facebook::react {
 
 struct ArrayPropsNativeComponentNativePrimitivesStruct {
-  std::vector<SharedColor> colors;
-  std::vector<ImageSource> srcs;
-  std::vector<Point> points;
+  std::vector<SharedColor> colors{};
+  std::vector<ImageSource> srcs{};
+  std::vector<Point> points{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentNativePrimitivesStruct &result) {
@@ -1104,7 +1104,7 @@ static inline std::string toString(const ObjectPropsIntEnumProp &value) {
   }
 }
 struct ObjectPropsObjectPropObjectArrayPropStruct {
-  std::vector<std::string> array;
+  std::vector<std::string> array{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropObjectArrayPropStruct &result) {
@@ -1121,9 +1121,9 @@ static inline std::string toString(const ObjectPropsObjectPropObjectArrayPropStr
 }
 
 struct ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct {
-  ImageSource image;
-  SharedColor color;
-  Point point;
+  ImageSource image{};
+  SharedColor color{};
+  Point point{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct &result) {
@@ -1148,7 +1148,7 @@ static inline std::string toString(const ObjectPropsObjectPropObjectPrimitiveReq
 }
 
 struct ObjectPropsObjectPropNestedPropANestedPropBStruct {
-  std::string nestedPropC;
+  std::string nestedPropC{\\"\\"};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedPropANestedPropBStruct &result) {
@@ -1165,7 +1165,7 @@ static inline std::string toString(const ObjectPropsObjectPropNestedPropANestedP
 }
 
 struct ObjectPropsObjectPropNestedPropAStruct {
-  ObjectPropsObjectPropNestedPropANestedPropBStruct nestedPropB;
+  ObjectPropsObjectPropNestedPropANestedPropBStruct nestedPropB{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedPropAStruct &result) {
@@ -1182,7 +1182,7 @@ static inline std::string toString(const ObjectPropsObjectPropNestedPropAStruct 
 }
 
 struct ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct {
-  std::string stringProp;
+  std::string stringProp{\\"\\"};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct &result) {
@@ -1209,7 +1209,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 
 struct ObjectPropsObjectPropNestedArrayAsPropertyStruct {
-  std::vector<ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct> arrayProp;
+  std::vector<ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct> arrayProp{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedArrayAsPropertyStruct &result) {
@@ -1226,16 +1226,20 @@ static inline std::string toString(const ObjectPropsObjectPropNestedArrayAsPrope
 }
 
 struct ObjectPropsObjectPropStruct {
-  std::string stringProp;
-  bool booleanProp;
-  Float floatProp;
-  int intProp;
-  ObjectPropsStringEnumProp stringEnumProp;
-  ObjectPropsIntEnumProp intEnumProp;
-  ObjectPropsObjectPropObjectArrayPropStruct objectArrayProp;
-  ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp;
-  ObjectPropsObjectPropNestedPropAStruct nestedPropA;
-  ObjectPropsObjectPropNestedArrayAsPropertyStruct nestedArrayAsProperty;
+  std::string stringProp{\\"\\"};
+  bool booleanProp{false};
+  Float floatProp{0.0};
+  int intProp{0};
+  std::string stringUserDefaultProp{\\"user_default\\"};
+  bool booleanUserDefaultProp{true};
+  Float floatUserDefaultProp{3.14};
+  int intUserDefaultProp{9999};
+  ObjectPropsStringEnumProp stringEnumProp{ObjectPropsStringEnumProp::Option1};
+  ObjectPropsIntEnumProp intEnumProp{ObjectPropsIntEnumProp::IntEnumProp0};
+  ObjectPropsObjectPropObjectArrayPropStruct objectArrayProp{};
+  ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp{};
+  ObjectPropsObjectPropNestedPropAStruct nestedPropA{};
+  ObjectPropsObjectPropNestedArrayAsPropertyStruct nestedArrayAsProperty{};
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropStruct &result) {
@@ -1256,6 +1260,22 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
   auto tmp_intProp = map.find(\\"intProp\\");
   if (tmp_intProp != map.end()) {
     fromRawValue(context, tmp_intProp->second, result.intProp);
+  }
+  auto tmp_stringUserDefaultProp = map.find(\\"stringUserDefaultProp\\");
+  if (tmp_stringUserDefaultProp != map.end()) {
+    fromRawValue(context, tmp_stringUserDefaultProp->second, result.stringUserDefaultProp);
+  }
+  auto tmp_booleanUserDefaultProp = map.find(\\"booleanUserDefaultProp\\");
+  if (tmp_booleanUserDefaultProp != map.end()) {
+    fromRawValue(context, tmp_booleanUserDefaultProp->second, result.booleanUserDefaultProp);
+  }
+  auto tmp_floatUserDefaultProp = map.find(\\"floatUserDefaultProp\\");
+  if (tmp_floatUserDefaultProp != map.end()) {
+    fromRawValue(context, tmp_floatUserDefaultProp->second, result.floatUserDefaultProp);
+  }
+  auto tmp_intUserDefaultProp = map.find(\\"intUserDefaultProp\\");
+  if (tmp_intUserDefaultProp != map.end()) {
+    fromRawValue(context, tmp_intUserDefaultProp->second, result.intUserDefaultProp);
   }
   auto tmp_stringEnumProp = map.find(\\"stringEnumProp\\");
   if (tmp_stringEnumProp != map.end()) {

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaPojo-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaPojo-test.js.snap
@@ -1024,6 +1024,10 @@ public class ObjectPropsPropsObjectProp {
   private boolean mBooleanProp;
   private float mFloatProp;
   private int mIntProp;
+  private @Nullable String mStringUserDefaultProp;
+  private boolean mBooleanUserDefaultProp;
+  private float mFloatUserDefaultProp;
+  private int mIntUserDefaultProp;
   private @Nullable String mStringEnumProp;
   private @Nullable Integer mIntEnumProp;
   private ObjectPropsPropsObjectPropObjectArrayProp mObjectArrayProp;
@@ -1045,6 +1049,22 @@ public class ObjectPropsPropsObjectProp {
   @DoNotStrip
   public int getIntProp() {
     return mIntProp;
+  }
+  @DoNotStrip
+  public @Nullable String getStringUserDefaultProp() {
+    return mStringUserDefaultProp;
+  }
+  @DoNotStrip
+  public boolean getBooleanUserDefaultProp() {
+    return mBooleanUserDefaultProp;
+  }
+  @DoNotStrip
+  public float getFloatUserDefaultProp() {
+    return mFloatUserDefaultProp;
+  }
+  @DoNotStrip
+  public int getIntUserDefaultProp() {
+    return mIntUserDefaultProp;
   }
   @DoNotStrip
   public @Nullable String getStringEnumProp() {


### PR DESCRIPTION
Summary:
**Problem:**

It was discovered while testing 3 party library, generated member variables in a C++ `struct` in `Props.h` is not initialized.
For the problematic case it was a `boolean` but would also apply to other primitive types.
If there is no default initialization and the component prop is optional and the user of the native component does not set the prop then the variable is never initialized and this is problematic for primitive types in C++ where no initialization results in an undefined behavior.

**Proposed solution:**

(Following C++Core Guideline of [always initialize](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-always).)
Reusing `generatePropsString()` used by `ClassTemplate` to generate props for `StructTemplate` as well.
updated relevant test snapshots.
This change is only concerning the `Props.h` file.

Differential Revision: D56659457
