### PR TITLE
remove force_static from componentregistry module

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -16,7 +16,6 @@
 
 #include <react/renderer/animations/conversions.h>
 #include <react/renderer/animations/utils.h>
-#include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/components/image/ImageProps.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/components/view/ViewPropsInterpolation.h>


### PR DESCRIPTION
Summary:
changelog: [interna]

force_static doesn't need to be in here, let's remove it.

I change one module per diff. It makes it easier to land it and pinpoint where build failures are coming from.

Reviewed By: javache

Differential Revision: D56632286
