### PR TITLE
remove force_static from textinput module

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ImageComponentDescriptor.h"
+#include <react/renderer/imagemanager/ImageManager.h>
+
+namespace facebook::react {
+
+ImageComponentDescriptor::ImageComponentDescriptor(
+    const ComponentDescriptorParameters& parameters)
+    : ConcreteComponentDescriptor(parameters),
+      imageManager_(std::make_shared<ImageManager>(contextContainer_)){};
+
+void ImageComponentDescriptor::adopt(ShadowNode& shadowNode) const {
+  ConcreteComponentDescriptor::adopt(shadowNode);
+
+  auto& imageShadowNode = static_cast<ImageShadowNode&>(shadowNode);
+
+  // `ImageShadowNode` uses `ImageManager` to initiate image loading and
+  // communicate the loading state and results to mounting layer.
+  imageShadowNode.setImageManager(imageManager_);
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
@@ -9,10 +9,10 @@
 
 #include <react/renderer/components/image/ImageShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
-#include <react/renderer/imagemanager/ImageManager.h>
-#include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
+
+class ImageManager;
 
 /*
  * Descriptor for <Image> component.
@@ -20,22 +20,13 @@ namespace facebook::react {
 class ImageComponentDescriptor final
     : public ConcreteComponentDescriptor<ImageShadowNode> {
  public:
-  ImageComponentDescriptor(const ComponentDescriptorParameters& parameters)
-      : ConcreteComponentDescriptor(parameters),
-        imageManager_(std::make_shared<ImageManager>(contextContainer_)){};
+  explicit ImageComponentDescriptor(
+      const ComponentDescriptorParameters& parameters);
 
-  void adopt(ShadowNode& shadowNode) const override {
-    ConcreteComponentDescriptor::adopt(shadowNode);
-
-    auto& imageShadowNode = static_cast<ImageShadowNode&>(shadowNode);
-
-    // `ImageShadowNode` uses `ImageManager` to initiate image loading and
-    // communicate the loading state and results to mounting layer.
-    imageShadowNode.setImageManager(imageManager_);
-  }
+  void adopt(ShadowNode& shadowNode) const override;
 
  private:
-  const SharedImageManager imageManager_;
+  const std::shared_ptr<ImageManager> imageManager_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

force_static doesn't need to be in here, let's remove it.

I change one module per diff. It makes it easier to land it and pinpoint where build failures are coming from.

Reviewed By: christophpurrer

Differential Revision: D56678530
