### PR TITLE
Correctly parse partial objects with optional value

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
@@ -1201,7 +1201,7 @@ inline JS::NativeOptionalObjectTurboModule::Constants::Builder::Builder(Constant
 inline NSString *JS::NativePartialAnnotationTurboModule::SpecGetSomeObjFromPartialSomeObjValue::a() const
 {
   id const p = _v[@\\"a\\"];
-  return RCTBridgingToOptionalString(p);
+  return RCTBridgingToString(p);
 }
 inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetSomeObjFromPartialSomeObjValue::b() const
 {
@@ -1211,7 +1211,7 @@ inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetSomeOb
 inline NSString *JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue1::a() const
 {
   id const p = _v[@\\"a\\"];
-  return RCTBridgingToOptionalString(p);
+  return RCTBridgingToString(p);
 }
 inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue1::b() const
 {
@@ -1221,7 +1221,7 @@ inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetPartia
 inline NSString *JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue2::a() const
 {
   id const p = _v[@\\"a\\"];
-  return RCTBridgingToOptionalString(p);
+  return RCTBridgingToString(p);
 }
 inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue2::b() const
 {
@@ -2553,7 +2553,7 @@ inline JS::NativeOptionalObjectTurboModule::Constants::Builder::Builder(Constant
 inline NSString *JS::NativePartialAnnotationTurboModule::SpecGetSomeObjFromPartialSomeObjValue::a() const
 {
   id const p = _v[@\\"a\\"];
-  return RCTBridgingToOptionalString(p);
+  return RCTBridgingToString(p);
 }
 inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetSomeObjFromPartialSomeObjValue::b() const
 {
@@ -2563,7 +2563,7 @@ inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetSomeOb
 inline NSString *JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue1::a() const
 {
   id const p = _v[@\\"a\\"];
-  return RCTBridgingToOptionalString(p);
+  return RCTBridgingToString(p);
 }
 inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue1::b() const
 {
@@ -2573,7 +2573,7 @@ inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetPartia
 inline NSString *JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue2::a() const
 {
   id const p = _v[@\\"a\\"];
-  return RCTBridgingToOptionalString(p);
+  return RCTBridgingToString(p);
 }
 inline std::optional<bool> JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue2::b() const
 {

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -170,7 +170,7 @@ describe('FlowParser', () => {
       const expected = [
         {
           name: 'a',
-          optional: true,
+          optional: false,
           typeAnnotation: {type: 'StringTypeAnnotation'},
         },
         {
@@ -623,7 +623,7 @@ describe('TypeScriptParser', () => {
       const expected = [
         {
           name: 'a',
-          optional: true,
+          optional: false,
           typeAnnotation: {properties: [], type: 'ObjectTypeAnnotation'},
         },
         {

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1760,7 +1760,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
                 'properties': [
                   {
                     'name': 'a',
-                    'optional': true,
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'StringTypeAnnotation'
                     }
@@ -1795,7 +1795,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
                     'properties': [
                       {
                         'name': 'a',
-                        'optional': true,
+                        'optional': false,
                         'typeAnnotation': {
                           'type': 'StringTypeAnnotation'
                         }
@@ -1868,7 +1868,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
                     'properties': [
                       {
                         'name': 'a',
-                        'optional': true,
+                        'optional': false,
                         'typeAnnotation': {
                           'type': 'StringTypeAnnotation'
                         }
@@ -1891,7 +1891,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
                     'properties': [
                       {
                         'name': 'a',
-                        'optional': true,
+                        'optional': false,
                         'typeAnnotation': {
                           'type': 'StringTypeAnnotation'
                         }

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -304,7 +304,7 @@ class FlowParser implements Parser {
     return properties.map(prop => {
       return {
         name: prop.key.name,
-        optional: true,
+        optional: prop?.optional ?? false,
         typeAnnotation: flowTranslateTypeAnnotation(
           hasteModuleName,
           prop.value,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -2226,7 +2226,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
                 'properties': [
                   {
                     'name': 'a',
-                    'optional': true,
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'StringTypeAnnotation'
                     }
@@ -2261,7 +2261,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
                     'properties': [
                       {
                         'name': 'a',
-                        'optional': true,
+                        'optional': false,
                         'typeAnnotation': {
                           'type': 'StringTypeAnnotation'
                         }
@@ -2334,7 +2334,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
                     'properties': [
                       {
                         'name': 'a',
-                        'optional': true,
+                        'optional': false,
                         'typeAnnotation': {
                           'type': 'StringTypeAnnotation'
                         }
@@ -2357,7 +2357,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
                     'properties': [
                       {
                         'name': 'a',
-                        'optional': true,
+                        'optional': false,
                         'typeAnnotation': {
                           'type': 'StringTypeAnnotation'
                         }

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -290,7 +290,7 @@ class TypeScriptParser implements Parser {
     return properties.map(prop => {
       return {
         name: prop.key.name,
-        optional: true,
+        optional: prop?.optional ?? false,
         typeAnnotation: typeScriptTranslateTypeAnnotation(
           hasteModuleName,
           prop.typeAnnotation.typeAnnotation,


### PR DESCRIPTION
Summary:
The flow parser *always* returns if a property IS `optional` (true|false) OR not

The TypeScript one only emits `optional` if the prop is optional.

The current `partialProperty` UTs are not correct.

Changelog: [General][Fixed] -  Correctly parse partial objects with optional value

Differential Revision: D56689387
