### PR TITLE
remove force_static from view module

### DIFF
--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -16,6 +16,7 @@
 
 #include <react/config/ReactNativeConfig.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/graphics/Color.h>
 #include <react/renderer/mounting/Differentiator.h>
 #include <react/renderer/mounting/stubs/stubs.h>
 


### PR DESCRIPTION
Summary:
changelog: [internal]

force_static doesn't need to be in here, let's remove it.

I change one module per diff. It makes it easier to land it and pinpoint where build failures are coming from.

Reviewed By: christophpurrer

Differential Revision: D56678747
