### PR TITLE
fix (iOS): call `selectTextOnFocus` after `becomeFirstResponder`

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -377,10 +377,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
     self.backedTextInputView.attributedText = [NSAttributedString new];
   }
 
-  if (_selectTextOnFocus) {
-    [self.backedTextInputView selectAll:nil];
-  }
-
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
                                  reactTag:self.reactTag
                                      text:[self.backedTextInputView.attributedText.string copy]
@@ -611,6 +607,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 - (void)reactFocus
 {
   [self.backedTextInputView reactFocus];
+  
+  if (_selectTextOnFocus) {
+    [self.backedTextInputView selectAll:nil];
+  }
 }
 
 - (void)reactBlur

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -281,11 +281,6 @@ using namespace facebook::react;
     [self textInputDidChange];
   }
 
-  if (props.traits.selectTextOnFocus) {
-    [_backedTextInputView selectAll:nil];
-    [self textInputDidChangeSelection];
-  }
-
   if (_eventEmitter) {
     static_cast<const TextInputEventEmitter &>(*_eventEmitter).onFocus([self _textInputMetrics]);
   }
@@ -425,6 +420,13 @@ using namespace facebook::react;
 - (void)focus
 {
   [_backedTextInputView becomeFirstResponder];
+  
+  const auto &props = static_cast<const TextInputProps &>(*_props);
+
+  if (props.traits.selectTextOnFocus) {
+    [_backedTextInputView selectAll:nil];
+    [self textInputDidChangeSelection];
+  }
 }
 
 - (void)blur


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes https://github.com/facebook/react-native/issues/41988

Hopefully even if this isn't the right way to go about solving this, it at least points in the right direction for a different fix!

Currently - both on Paper and Fabric - the `selectTextOnFocus` prop does not work as expected on a single line text input. It seems that if the `UITextField` has not yet become the first responder, the text will be briefly selected but then deselected immediately afterward.

This can be seen in the tester when running for either Fabric or Paper (video using Fabric)

https://github.com/facebook/react-native/assets/153161762/aa9c609e-6eb8-4177-a41f-32aae53c06ac

Instead, we can move the `selectAll` call to `reactFocus` in `RCTBaseTextInputView` or `focus` `RCTTextInputComponentView` - both of which first call `becomeFirstResponder` - to get the expected result.

## Changelog:

[IOS] [FIXED] - `selectTextOnFocus` prop should be called after the `UITextField` has become the first responder

## Test Plan:

See the rn-tester above prior to these changes. Then test the same against this PR.


https://github.com/facebook/react-native/assets/153161762/8378157c-06e7-424c-a83c-fa71d737dc61
