### PR TITLE
Use private fields in performance APIs

### DIFF
--- a/packages/react-native/src/private/webapis/performance/MemoryInfo.js
+++ b/packages/react-native/src/private/webapis/performance/MemoryInfo.js
@@ -19,15 +19,15 @@ type MemoryInfoLike = {
 
 // Read-only object with JS memory information. This is returned by the performance.memory API.
 export default class MemoryInfo {
-  _jsHeapSizeLimit: ?number;
-  _totalJSHeapSize: ?number;
-  _usedJSHeapSize: ?number;
+  #jsHeapSizeLimit: ?number;
+  #totalJSHeapSize: ?number;
+  #usedJSHeapSize: ?number;
 
   constructor(memoryInfo: ?MemoryInfoLike) {
     if (memoryInfo != null) {
-      this._jsHeapSizeLimit = memoryInfo.jsHeapSizeLimit;
-      this._totalJSHeapSize = memoryInfo.totalJSHeapSize;
-      this._usedJSHeapSize = memoryInfo.usedJSHeapSize;
+      this.#jsHeapSizeLimit = memoryInfo.jsHeapSizeLimit;
+      this.#totalJSHeapSize = memoryInfo.totalJSHeapSize;
+      this.#usedJSHeapSize = memoryInfo.usedJSHeapSize;
     }
   }
 
@@ -35,20 +35,20 @@ export default class MemoryInfo {
    * The maximum size of the heap, in bytes, that is available to the context
    */
   get jsHeapSizeLimit(): ?number {
-    return this._jsHeapSizeLimit;
+    return this.#jsHeapSizeLimit;
   }
 
   /**
    * The total allocated heap size, in bytes
    */
   get totalJSHeapSize(): ?number {
-    return this._totalJSHeapSize;
+    return this.#totalJSHeapSize;
   }
 
   /**
    * The currently active segment of JS heap, in bytes.
    */
   get usedJSHeapSize(): ?number {
-    return this._usedJSHeapSize;
+    return this.#usedJSHeapSize;
   }
 }

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -25,18 +25,18 @@ export type PerformanceEntryList = $ReadOnlyArray<PerformanceEntry>;
 export {PerformanceEntry} from './PerformanceEntry';
 
 export class PerformanceObserverEntryList {
-  _entries: PerformanceEntryList;
+  #entries: PerformanceEntryList;
 
   constructor(entries: PerformanceEntryList) {
-    this._entries = entries;
+    this.#entries = entries;
   }
 
   getEntries(): PerformanceEntryList {
-    return this._entries;
+    return this.#entries;
   }
 
   getEntriesByType(type: PerformanceEntryType): PerformanceEntryList {
-    return this._entries.filter(entry => entry.entryType === type);
+    return this.#entries.filter(entry => entry.entryType === type);
   }
 
   getEntriesByName(
@@ -44,9 +44,9 @@ export class PerformanceObserverEntryList {
     type?: PerformanceEntryType,
   ): PerformanceEntryList {
     if (type === undefined) {
-      return this._entries.filter(entry => entry.name === name);
+      return this.#entries.filter(entry => entry.name === name);
     } else {
-      return this._entries.filter(
+      return this.#entries.filter(
         entry => entry.name === name && entry.entryType === type,
       );
     }
@@ -175,11 +175,11 @@ function getSupportedPerformanceEntryTypes(): $ReadOnlyArray<PerformanceEntryTyp
  * observer.observe({ type: "event" });
  */
 export default class PerformanceObserver {
-  _callback: PerformanceObserverCallback;
-  _type: 'single' | 'multiple' | void;
+  #callback: PerformanceObserverCallback;
+  #type: 'single' | 'multiple' | void;
 
   constructor(callback: PerformanceObserverCallback) {
-    this._callback = callback;
+    this.#callback = callback;
   }
 
   observe(options: PerformanceObserverInit): void {
@@ -188,17 +188,17 @@ export default class PerformanceObserver {
       return;
     }
 
-    this._validateObserveOptions(options);
+    this.#validateObserveOptions(options);
 
     let requestedEntryTypes;
 
     if (options.entryTypes) {
-      this._type = 'multiple';
+      this.#type = 'multiple';
       requestedEntryTypes = new Map(
         options.entryTypes.map(t => [t, undefined]),
       );
     } else {
-      this._type = 'single';
+      this.#type = 'single';
       requestedEntryTypes = new Map([
         [options.type, options.durationThreshold],
       ]);
@@ -217,7 +217,7 @@ export default class PerformanceObserver {
     }
 
     registeredObservers.set(this, {
-      callback: this._callback,
+      callback: this.#callback,
       entryTypes: nextEntryTypes,
     });
 
@@ -284,7 +284,7 @@ export default class PerformanceObserver {
     applyDurationThresholds();
   }
 
-  _validateObserveOptions(options: PerformanceObserverInit): void {
+  #validateObserveOptions(options: PerformanceObserverInit): void {
     const {type, entryTypes, durationThreshold} = options;
 
     if (!type && !entryTypes) {
@@ -299,13 +299,13 @@ export default class PerformanceObserver {
       );
     }
 
-    if (this._type === 'multiple' && type) {
+    if (this.#type === 'multiple' && type) {
       throw new Error(
         "Failed to execute 'observe' on 'PerformanceObserver': This observer has performed observe({entryTypes:...}, therefore it cannot perform observe({type:...})",
       );
     }
 
-    if (this._type === 'single' && entryTypes) {
+    if (this.#type === 'single' && entryTypes) {
       throw new Error(
         "Failed to execute 'observe' on 'PerformanceObserver': This PerformanceObserver has performed observe({type:...}, therefore it cannot perform observe({entryTypes:...})",
       );

--- a/packages/react-native/src/private/webapis/performance/ReactNativeStartupTiming.js
+++ b/packages/react-native/src/private/webapis/performance/ReactNativeStartupTiming.js
@@ -27,22 +27,22 @@ export default class ReactNativeStartupTiming {
   // We do NOT match web spect here for two reasons:
   // 1. The `ReactNativeStartupTiming` is non-standard API
   // 2. The timing information is relative to the time origin, which means `0` has valid meaning
-  _startTime: ?number;
-  _endTime: ?number;
-  _initializeRuntimeStart: ?number;
-  _initializeRuntimeEnd: ?number;
-  _executeJavaScriptBundleEntryPointStart: ?number;
-  _executeJavaScriptBundleEntryPointEnd: ?number;
+  #startTime: ?number;
+  #endTime: ?number;
+  #initializeRuntimeStart: ?number;
+  #initializeRuntimeEnd: ?number;
+  #executeJavaScriptBundleEntryPointStart: ?number;
+  #executeJavaScriptBundleEntryPointEnd: ?number;
 
   constructor(startUpTiming: ?ReactNativeStartupTimingLike) {
     if (startUpTiming != null) {
-      this._startTime = startUpTiming.startTime;
-      this._endTime = startUpTiming.endTime;
-      this._initializeRuntimeStart = startUpTiming.initializeRuntimeStart;
-      this._initializeRuntimeEnd = startUpTiming.initializeRuntimeEnd;
-      this._executeJavaScriptBundleEntryPointStart =
+      this.#startTime = startUpTiming.startTime;
+      this.#endTime = startUpTiming.endTime;
+      this.#initializeRuntimeStart = startUpTiming.initializeRuntimeStart;
+      this.#initializeRuntimeEnd = startUpTiming.initializeRuntimeEnd;
+      this.#executeJavaScriptBundleEntryPointStart =
         startUpTiming.executeJavaScriptBundleEntryPointStart;
-      this._executeJavaScriptBundleEntryPointEnd =
+      this.#executeJavaScriptBundleEntryPointEnd =
         startUpTiming.executeJavaScriptBundleEntryPointEnd;
     }
   }
@@ -51,41 +51,41 @@ export default class ReactNativeStartupTiming {
    * Start time of the RN app startup process. This is provided by the platform by implementing the `ReactMarker.setAppStartTime` API in the native platform code.
    */
   get startTime(): ?number {
-    return this._startTime;
+    return this.#startTime;
   }
 
   /**
    * End time of the RN app startup process. This is equal to `executeJavaScriptBundleEntryPointEnd`.
    */
   get endTime(): ?number {
-    return this._endTime;
+    return this.#endTime;
   }
 
   /**
    * Start time when RN runtime get initialized. This is when RN infra first kicks in app startup process.
    */
   get initializeRuntimeStart(): ?number {
-    return this._initializeRuntimeStart;
+    return this.#initializeRuntimeStart;
   }
 
   /**
    * End time when RN runtime get initialized. This is the last marker before ends of the app startup process.
    */
   get initializeRuntimeEnd(): ?number {
-    return this._initializeRuntimeEnd;
+    return this.#initializeRuntimeEnd;
   }
 
   /**
    * Start time of JS bundle being executed. This indicates the RN JS bundle is loaded and start to be evaluated.
    */
   get executeJavaScriptBundleEntryPointStart(): ?number {
-    return this._executeJavaScriptBundleEntryPointStart;
+    return this.#executeJavaScriptBundleEntryPointStart;
   }
 
   /**
    * End time of JS bundle being executed. This indicates all the synchronous entry point jobs are finished.
    */
   get executeJavaScriptBundleEntryPointEnd(): ?number {
-    return this._executeJavaScriptBundleEntryPointEnd;
+    return this.#executeJavaScriptBundleEntryPointEnd;
   }
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

This migrates all the classes related to performance in `react-native/src/private` to use private fields instead of regular fields prefixed with `_`.

Differential Revision: D55931659
