### PR TITLE
Lift console method bodies out of installConsoleHandler

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/ForwardingConsoleMethods.def
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ForwardingConsoleMethods.def
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `console` methods that have no behaviour other than emitting a
+ * Runtime.consoleAPICalled message.
+ */
+
+// console.clear
+FORWARDING_CONSOLE_METHOD(clear, ConsoleAPIType::kClear)
+// console.debug
+FORWARDING_CONSOLE_METHOD(debug, ConsoleAPIType::kDebug)
+// console.dir
+FORWARDING_CONSOLE_METHOD(dir, ConsoleAPIType::kDir)
+// console.dirxml
+FORWARDING_CONSOLE_METHOD(dirxml, ConsoleAPIType::kDirXML)
+// console.error
+FORWARDING_CONSOLE_METHOD(error, ConsoleAPIType::kError)
+// console.group
+FORWARDING_CONSOLE_METHOD(group, ConsoleAPIType::kStartGroup)
+// console.groupCollapsed
+FORWARDING_CONSOLE_METHOD(groupCollapsed, ConsoleAPIType::kStartGroupCollapsed)
+// console.groupEnd
+FORWARDING_CONSOLE_METHOD(groupEnd, ConsoleAPIType::kEndGroup)
+// console.info
+FORWARDING_CONSOLE_METHOD(info, ConsoleAPIType::kInfo)
+// console.log
+FORWARDING_CONSOLE_METHOD(log, ConsoleAPIType::kLog)
+// console.table
+FORWARDING_CONSOLE_METHOD(table, ConsoleAPIType::kTable)
+// console.trace
+FORWARDING_CONSOLE_METHOD(trace, ConsoleAPIType::kTrace)
+// console.warn
+FORWARDING_CONSOLE_METHOD(warn, ConsoleAPIType::kWarning)

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = "*.{cpp,h,def}"
   s.header_dir             = 'jsinspector-modern'
   s.compiler_flags         = folly_compiler_flags
   s.pod_target_xcconfig    = {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The bodies of all `console` methods are currently written as lambdas within `installConsoleHandler` but actually capture nothing meaningful from that scope. This diff rewrites them as free functions instead.

To enable the "forwarding console methods" to be written as free functions, we also replace the runtime loop over `kForwardingConsoleMethods` with a compile-time equivalent using macros. (This technique is inspired by the Hermes source code, which uses it heavily for compile-time code generation.)

Differential Revision: D56679956
