### PR TITLE
move launch ID gen out of dev-middleware

### DIFF
--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -18,7 +18,6 @@ import type {NextHandleFunction} from 'connect';
 import type {IncomingMessage, ServerResponse} from 'http';
 
 import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';
-import crypto from 'crypto';
 import url from 'url';
 
 const debuggerInstances = new Map<string, ?LaunchedBrowser>();
@@ -58,7 +57,11 @@ export default function openDebuggerMiddleware({
       (experiments.enableOpenDebuggerRedirect && req.method === 'GET')
     ) {
       const {query} = url.parse(req.url, true);
-      const {appId, device}: {appId?: string, device?: string, ...} = query;
+      const {
+        appId,
+        device,
+        launchId,
+      }: {appId?: string, device?: string, launchId?: string, ...} = query;
 
       const targets = inspectorProxy.getPageDescriptions().filter(
         // Only use targets with better reloading support
@@ -108,7 +111,6 @@ export default function openDebuggerMiddleware({
         return;
       }
 
-      const launchId = crypto.randomUUID();
       const useFuseboxEntryPoint =
         target.reactNative.capabilities?.prefersFuseboxFrontend;
 

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -153,6 +153,8 @@ export default function openDebuggerMiddleware({
           status: 'success',
           appId: appId ?? null,
           deviceId: device ?? null,
+          resolvedTargetDescription: target.description,
+          prefersFuseboxFrontend: useFuseboxEntryPoint ?? false,
         });
         return;
       } catch (e) {

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -36,7 +36,12 @@ export type ReportableEvent =
       type: 'launch_debugger_frontend',
       launchType: 'launch' | 'redirect',
       ...
-        | SuccessResult<{appId: string | null, deviceId: string | null}>
+        | SuccessResult<{
+            appId: string | null,
+            deviceId: string | null,
+            resolvedTargetDescription: string,
+            prefersFuseboxFrontend: boolean,
+          }>
         | ErrorResult<mixed>
         | CodedErrorResult<'NO_APPS_FOUND'>,
     }


### PR DESCRIPTION
Summary: Changelog: [General][Removed] `launchId` query param for `/debugger-frontend` is no longer generated automatically for each `/open-debugger` call. Caller of `/open-debugger` is now responsible for generating the `launchId`, which will be passed along to `/debugger-frontend`.

Reviewed By: robhogan

Differential Revision: D55164645
