### PR TITLE
Fix minor formatting issue in AppRegistry logging in non-dev builds

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppRegistry.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.js
@@ -196,10 +196,8 @@ const AppRegistry = {
     displayMode?: number,
   ): void {
     if (appKey !== 'LogBox') {
-      const logParams = __DEV__
-        ? '" with ' + JSON.stringify(appParameters)
-        : '';
-      const msg = 'Running "' + appKey + logParams;
+      const logParams = __DEV__ ? ` with ${JSON.stringify(appParameters)}` : '';
+      const msg = `Running "${appKey}"${logParams}`;
       infoLog(msg);
       BugReporting.addSource(
         'AppRegistry.runApplication' + runCount++,


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

I was looking at the logs, troubleshooting a non-dev build issue, and noticed a line:
```
I0429 15:56:42.107558 1874554880: Running "MyApplication
```
In `__DEV__` mode this usually continues with `" with ...`, but in release mode the closing quote was missing, which made me think there may be something going on garbling the log messages.

Which ultimately was a red herring, and it's just a bad formatting in the message in release mode, which this change fixes.

Differential Revision: D56704170
