### PR TITLE
Hoist TextInput.autoCapitalize to BaseTextInputProps on C++ side

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -96,7 +96,13 @@ BaseTextInputProps::BaseTextInputProps(
           rawProps,
           "autoFocus",
           sourceProps.autoFocus,
-          {})){};
+          {})),
+      autoCapitalize(convertRawProp(
+          context,
+          rawProps,
+          "autoCapitalize",
+          sourceProps.autoCapitalize,
+          {})) {}
 
 void BaseTextInputProps::setProp(
     const PropsParserContext& context,
@@ -173,6 +179,7 @@ void BaseTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(cursorColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(text);
     RAW_SET_PROP_SWITCH_CASE_BASIC(mostRecentEventCount);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(autoCapitalize);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -61,6 +61,8 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
   int mostRecentEventCount{0};
 
   bool autoFocus{false};
+
+  std::string autoCapitalize{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -75,10 +75,6 @@ AndroidTextInputProps::AndroidTextInputProps(
           "showSoftInputOnFocus",
           sourceProps.showSoftInputOnFocus,
           {false})),
-      autoCapitalize(CoreFeatures::enablePropIteratorSetter? sourceProps.autoCapitalize : convertRawProp(context, rawProps,
-          "autoCapitalize",
-          sourceProps.autoCapitalize,
-          {})),
       autoCorrect(CoreFeatures::enablePropIteratorSetter? sourceProps.autoCorrect : convertRawProp(context, rawProps,
           "autoCorrect",
           sourceProps.autoCorrect,
@@ -228,7 +224,6 @@ void AndroidTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(inlineImagePadding);
     RAW_SET_PROP_SWITCH_CASE_BASIC(importantForAutofill);
     RAW_SET_PROP_SWITCH_CASE_BASIC(showSoftInputOnFocus);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(autoCapitalize);
     RAW_SET_PROP_SWITCH_CASE_BASIC(autoCorrect);
     RAW_SET_PROP_SWITCH_CASE_BASIC(allowFontScaling);
     RAW_SET_PROP_SWITCH_CASE_BASIC(maxFontSizeMultiplier);

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -84,7 +84,6 @@ class AndroidTextInputProps final : public BaseTextInputProps {
   int inlineImagePadding{0};
   std::string importantForAutofill{};
   bool showSoftInputOnFocus{false};
-  std::string autoCapitalize{};
   bool autoCorrect{false};
   bool allowFontScaling{false};
   Float maxFontSizeMultiplier{0.0};


### PR DESCRIPTION
Summary:
## Changelog:
[Internal]-

Even though `TextInput.autoCapitalize` is supposed to be cross-platform, on the C++ side of the props data structures it was only exposed as an Android-specific one.

This would have it still work on the iOS side (as the corresponding prop is passed to Objective C around the C++ structs anyway), however it may also cause subtle scenarios, whereas the prop changes dynamically on the iOS side, but this doesn't get reflected on the native side.

This change fixes this problem by simply hoisting the prop into the `BaseTextInputProps`, which makes it available across all platforms, as it should be.

Differential Revision: D56726940
