### PR TITLE
Pass StackTrace directly to Hermes ConsoleMessage

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -143,10 +143,10 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
       hermesStackTrace = std::move(**hermesStackTraceWrapper);
     }
     HermesConsoleMessage hermesConsoleMessage{
-        message.timestamp, type, std::move(message.args)};
-    // NOTE: HermesConsoleMessage should really have a constructor that takes a
-    // stack trace.
-    hermesConsoleMessage.stackTrace = std::move(hermesStackTrace);
+        message.timestamp,
+        type,
+        std::move(message.args),
+        std::move(hermesStackTrace)};
     cdpDebugAPI_->addConsoleMessage(std::move(hermesConsoleMessage));
   }
 


### PR DESCRIPTION
Summary:
Hermes' ConsoleMessage constructor now accepts StackTrace, so the construction can be done in one go.

Changelog: [Internal]

Differential Revision: D56738060
