### PR TITLE
Remove RuntimeAdapter.h from HermesRuntimeAgentDelegate

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.cpp
@@ -12,7 +12,6 @@
 #include <hermes/AsyncDebuggerAPI.h>
 #include <hermes/cdp/CDPAgent.h>
 #include <hermes/hermes.h>
-#include <hermes/inspector/RuntimeAdapter.h>
 #include <jsinspector-modern/ReactCdp.h>
 
 using namespace facebook::hermes;


### PR DESCRIPTION
Summary:
RuntimeAdapter.h is only needed when using CDPHandler, which the new code path doesn't need.

Changelog: [Internal]

Differential Revision: D56738299
