### PR TITLE
Add test fixture for function property types

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -742,6 +742,13 @@ export type GraphNode = {
   neighbors?: Array<GraphNode>,
 };
 
+export type MenuItem = {
+  label: string,
+  onPress: (value: string, flag: boolean) => void,
+  shortcut?: string,
+  items?: Array<MenuItem>,
+};
+
 export interface Spec extends TurboModule {
   +getCallback: () => () => void;
   +getMixed: (arg: mixed) => mixed;
@@ -751,6 +758,7 @@ export interface Spec extends TurboModule {
   +getMap: (arg: {[a: string]: ?number}) => {[b: string]: ?number};
   +getAnotherMap: (arg: {[string]: string}) => {[string]: string};
   +getUnion: (chooseInt: ChooseInt, chooseFloat: ChooseFloat, chooseObject: ChooseObject, chooseString: ChooseString) => ChooseObject;
+  +setMenu: (menuItem: MenuItem) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModuleCxx');

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -102,6 +102,62 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
               }
             }
           ]
+        },
+        'MenuItem': {
+          'type': 'ObjectTypeAnnotation',
+          'properties': [
+            {
+              'name': 'label',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              }
+            },
+            {
+              'name': 'onPress',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'FunctionTypeAnnotation',
+                'returnTypeAnnotation': {
+                  'type': 'VoidTypeAnnotation'
+                },
+                'params': [
+                  {
+                    'name': 'value',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'StringTypeAnnotation'
+                    }
+                  },
+                  {
+                    'name': 'flag',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'BooleanTypeAnnotation'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              'name': 'shortcut',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              }
+            },
+            {
+              'name': 'items',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'TypeAliasTypeAnnotation',
+                  'name': 'MenuItem'
+                }
+              }
+            }
+          ]
         }
       },
       'enumMap': {
@@ -392,6 +448,26 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
                     'memberType': 'StringTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'setMenu',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'VoidTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'menuItem',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'TypeAliasTypeAnnotation',
+                    'name': 'MenuItem'
                   }
                 }
               ]

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -836,6 +836,13 @@ export type GraphNode = {
   neighbors?: Array<GraphNode>,
 };
 
+export type MenuItem = {
+  label: string,
+  onPress: (value: string, flag: boolean) => void,
+  shortcut?: string,
+  items?: Array<MenuItem>,
+};
+
 export interface Spec extends TurboModule {
   readonly getCallback: () => () => void;
   readonly getMixed: (arg: unknown) => unknown;
@@ -845,6 +852,7 @@ export interface Spec extends TurboModule {
   readonly getMap: (arg: {[a: string]: number | null;}) => {[b: string]: number | null;};
   readonly getAnotherMap: (arg: {[key: string]: string}) => {[key: string]: string};
   readonly getUnion: (chooseInt: ChooseInt, chooseFloat: ChooseFloat, chooseObject: ChooseObject, chooseString: ChooseString) => ChooseObject;
+  readonly setMenu: (menuItem: MenuItem) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -93,6 +93,62 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
               }
             }
           ]
+        },
+        'MenuItem': {
+          'type': 'ObjectTypeAnnotation',
+          'properties': [
+            {
+              'name': 'label',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              }
+            },
+            {
+              'name': 'onPress',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'FunctionTypeAnnotation',
+                'returnTypeAnnotation': {
+                  'type': 'VoidTypeAnnotation'
+                },
+                'params': [
+                  {
+                    'name': 'value',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'StringTypeAnnotation'
+                    }
+                  },
+                  {
+                    'name': 'flag',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'BooleanTypeAnnotation'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              'name': 'shortcut',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              }
+            },
+            {
+              'name': 'items',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'TypeAliasTypeAnnotation',
+                  'name': 'MenuItem'
+                }
+              }
+            }
+          ]
         }
       },
       'enumMap': {
@@ -383,6 +439,26 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
                     'memberType': 'StringTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'setMenu',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'VoidTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'menuItem',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'TypeAliasTypeAnnotation',
+                    'name': 'MenuItem'
                   }
                 }
               ]


### PR DESCRIPTION
Summary:
This feature was added in https://github.com/facebook/react-native/pull/41810
This change adds a test fixture for it and updates the UT snapshot

Changelog: [Internal]

Differential Revision: D56739139
