### PR TITLE
Fix `react` peer dependency to support `react` v18.3

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -99,7 +99,7 @@
   },
   "peerDependencies": {
     "@types/react": "^18.2.6",
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR updates the peer dependency for React to support version 18.3. The motivation for this change stems from an issue where installing React 18.3 alongside React Native results in npm errors due to strict peer dependency enforcement. This was causing npm to throw errors because the existing configuration did not support React 18.3.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [CHANGED] - Update `react` peer dependency to include support for `react` v18.3 to resolve npm strict peer dependency errors.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
