### PR TITLE
Don't support float enums

### DIFF
--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeEnumTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeEnumTurboModule.js
@@ -34,30 +34,21 @@ export enum StatusNumEnum {
   Off = 0,
 }
 
-export enum StatusFractionEnum {
-  Active = 0.2,
-  Paused = 0.1,
-  Off = 0.0,
-}
-
 export type StateTypeWithEnums = {|
   state: string,
   regular: StatusRegularEnum,
   str: StatusStrEnum,
   num: StatusNumEnum,
-  fraction: StatusFractionEnum,
 |};
 
 export interface Spec extends TurboModule {
   +getStatusRegular: (statusProp: StateType) => StatusRegularEnum;
   +getStatusStr: (statusProp: StateType) => StatusStrEnum;
   +getStatusNum: (statusProp: StateType) => StatusNumEnum;
-  +getStatusFraction: (statusProp: StateType) => StatusFractionEnum;
   +getStateType: (
     a: StatusRegularEnum,
     b: StatusStrEnum,
     c: StatusNumEnum,
-    d: StatusFractionEnum,
   ) => StateType;
   +getStateTypeWithEnums: (
     paramOfTypeWithEnums: StateTypeWithEnums,

--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleCpp-test.js.snap
@@ -96,19 +96,12 @@ static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusNum(js
     count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asObject(rt)
   );
 }
-static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusFraction(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusFraction(
-    rt,
-    count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asObject(rt)
-  );
-}
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateType(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
   return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateType(
     rt,
     count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asString(rt),
     count <= 1 ? throw jsi::JSError(rt, \\"Expected argument in position 1 to be passed\\") : args[1].asString(rt),
-    count <= 2 ? throw jsi::JSError(rt, \\"Expected argument in position 2 to be passed\\") : args[2].asNumber(),
-    count <= 3 ? throw jsi::JSError(rt, \\"Expected argument in position 3 to be passed\\") : args[3].asNumber()
+    count <= 2 ? throw jsi::JSError(rt, \\"Expected argument in position 2 to be passed\\") : args[2].asNumber()
   );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateTypeWithEnums(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
@@ -123,8 +116,7 @@ NativeEnumTurboModuleCxxSpecJSI::NativeEnumTurboModuleCxxSpecJSI(std::shared_ptr
   methodMap_[\\"getStatusRegular\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusRegular};
   methodMap_[\\"getStatusStr\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusStr};
   methodMap_[\\"getStatusNum\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusNum};
-  methodMap_[\\"getStatusFraction\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusFraction};
-  methodMap_[\\"getStateType\\"] = MethodMetadata {4, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateType};
+  methodMap_[\\"getStateType\\"] = MethodMetadata {3, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateType};
   methodMap_[\\"getStateTypeWithEnums\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateTypeWithEnums};
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
@@ -917,19 +909,12 @@ static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusNum(js
     count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asObject(rt)
   );
 }
-static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusFraction(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusFraction(
-    rt,
-    count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asObject(rt)
-  );
-}
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateType(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
   return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateType(
     rt,
     count <= 0 ? throw jsi::JSError(rt, \\"Expected argument in position 0 to be passed\\") : args[0].asString(rt),
     count <= 1 ? throw jsi::JSError(rt, \\"Expected argument in position 1 to be passed\\") : args[1].asString(rt),
-    count <= 2 ? throw jsi::JSError(rt, \\"Expected argument in position 2 to be passed\\") : args[2].asNumber(),
-    count <= 3 ? throw jsi::JSError(rt, \\"Expected argument in position 3 to be passed\\") : args[3].asNumber()
+    count <= 2 ? throw jsi::JSError(rt, \\"Expected argument in position 2 to be passed\\") : args[2].asNumber()
   );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateTypeWithEnums(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
@@ -944,8 +929,7 @@ NativeEnumTurboModuleCxxSpecJSI::NativeEnumTurboModuleCxxSpecJSI(std::shared_ptr
   methodMap_[\\"getStatusRegular\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusRegular};
   methodMap_[\\"getStatusStr\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusStr};
   methodMap_[\\"getStatusNum\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusNum};
-  methodMap_[\\"getStatusFraction\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusFraction};
-  methodMap_[\\"getStateType\\"] = MethodMetadata {4, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateType};
+  methodMap_[\\"getStateType\\"] = MethodMetadata {3, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateType};
   methodMap_[\\"getStateTypeWithEnums\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateTypeWithEnums};
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {

--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -287,38 +287,6 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
     }
   }
 };
-
-#pragma mark - NativeEnumTurboModuleStatusFractionEnum
-
-enum class NativeEnumTurboModuleStatusFractionEnum { Active, Paused, Off };
-
-template <>
-struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
-  static NativeEnumTurboModuleStatusFractionEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue) {
-    double value = (double)rawValue.asNumber();
-    if (value == 0.2f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Active;
-    } else if (value == 0.1f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Paused;
-    } else if (value == 0f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Off;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value) {
-    if (value == NativeEnumTurboModuleStatusFractionEnum::Active) {
-      return bridging::toJs(rt, 0.2f);
-    } else if (value == NativeEnumTurboModuleStatusFractionEnum::Paused) {
-      return bridging::toJs(rt, 0.1f);
-    } else if (value == NativeEnumTurboModuleStatusFractionEnum::Off) {
-      return bridging::toJs(rt, 0f);
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
-    }
-  }
-};
   
 #pragma mark - NativeEnumTurboModuleStateType
 
@@ -363,15 +331,14 @@ struct NativeEnumTurboModuleStateTypeBridging {
 
 #pragma mark - NativeEnumTurboModuleStateTypeWithEnums
 
-template <typename P0, typename P1, typename P2, typename P3, typename P4>
+template <typename P0, typename P1, typename P2, typename P3>
 struct NativeEnumTurboModuleStateTypeWithEnums {
   P0 state;
   P1 regular;
   P2 str;
   P3 num;
-  P4 fraction;
   bool operator==(const NativeEnumTurboModuleStateTypeWithEnums &other) const {
-    return state == other.state && regular == other.regular && str == other.str && num == other.num && fraction == other.fraction;
+    return state == other.state && regular == other.regular && str == other.str && num == other.num;
   }
 };
 
@@ -387,8 +354,7 @@ struct NativeEnumTurboModuleStateTypeWithEnumsBridging {
       bridging::fromJs<decltype(types.state)>(rt, value.getProperty(rt, \\"state\\"), jsInvoker),
       bridging::fromJs<decltype(types.regular)>(rt, value.getProperty(rt, \\"regular\\"), jsInvoker),
       bridging::fromJs<decltype(types.str)>(rt, value.getProperty(rt, \\"str\\"), jsInvoker),
-      bridging::fromJs<decltype(types.num)>(rt, value.getProperty(rt, \\"num\\"), jsInvoker),
-      bridging::fromJs<decltype(types.fraction)>(rt, value.getProperty(rt, \\"fraction\\"), jsInvoker)};
+      bridging::fromJs<decltype(types.num)>(rt, value.getProperty(rt, \\"num\\"), jsInvoker)};
     return result;
   }
 
@@ -408,10 +374,6 @@ struct NativeEnumTurboModuleStateTypeWithEnumsBridging {
   static jsi::Value numToJs(jsi::Runtime &rt, decltype(types.num) value) {
     return bridging::toJs(rt, value);
   }
-
-  static jsi::Value fractionToJs(jsi::Runtime &rt, decltype(types.fraction) value) {
-    return bridging::toJs(rt, value);
-  }
 #endif
 
   static jsi::Object toJs(
@@ -423,7 +385,6 @@ struct NativeEnumTurboModuleStateTypeWithEnumsBridging {
     result.setProperty(rt, \\"regular\\", bridging::toJs(rt, value.regular, jsInvoker));
     result.setProperty(rt, \\"str\\", bridging::toJs(rt, value.str, jsInvoker));
     result.setProperty(rt, \\"num\\", bridging::toJs(rt, value.num, jsInvoker));
-    result.setProperty(rt, \\"fraction\\", bridging::toJs(rt, value.fraction, jsInvoker));
     return result;
   }
 };
@@ -436,8 +397,7 @@ public:
   virtual jsi::String getStatusRegular(jsi::Runtime &rt, jsi::Object statusProp) = 0;
   virtual jsi::String getStatusStr(jsi::Runtime &rt, jsi::Object statusProp) = 0;
   virtual jsi::Value getStatusNum(jsi::Runtime &rt, jsi::Object statusProp) = 0;
-  virtual jsi::Value getStatusFraction(jsi::Runtime &rt, jsi::Object statusProp) = 0;
-  virtual jsi::Object getStateType(jsi::Runtime &rt, jsi::String a, jsi::String b, jsi::Value c, jsi::Value d) = 0;
+  virtual jsi::Object getStateType(jsi::Runtime &rt, jsi::String a, jsi::String b, jsi::Value c) = 0;
   virtual jsi::Object getStateTypeWithEnums(jsi::Runtime &rt, jsi::Object paramOfTypeWithEnums) = 0;
 
 };
@@ -486,21 +446,13 @@ private:
       return bridging::callFromJs<jsi::Value>(
           rt, &T::getStatusNum, jsInvoker_, instance_, std::move(statusProp));
     }
-    jsi::Value getStatusFraction(jsi::Runtime &rt, jsi::Object statusProp) override {
+    jsi::Object getStateType(jsi::Runtime &rt, jsi::String a, jsi::String b, jsi::Value c) override {
       static_assert(
-          bridging::getParameterCount(&T::getStatusFraction) == 2,
-          \\"Expected getStatusFraction(...) to have 2 parameters\\");
-
-      return bridging::callFromJs<jsi::Value>(
-          rt, &T::getStatusFraction, jsInvoker_, instance_, std::move(statusProp));
-    }
-    jsi::Object getStateType(jsi::Runtime &rt, jsi::String a, jsi::String b, jsi::Value c, jsi::Value d) override {
-      static_assert(
-          bridging::getParameterCount(&T::getStateType) == 5,
-          \\"Expected getStateType(...) to have 5 parameters\\");
+          bridging::getParameterCount(&T::getStateType) == 4,
+          \\"Expected getStateType(...) to have 4 parameters\\");
 
       return bridging::callFromJs<jsi::Object>(
-          rt, &T::getStateType, jsInvoker_, instance_, std::move(a), std::move(b), std::move(c), std::move(d));
+          rt, &T::getStateType, jsInvoker_, instance_, std::move(a), std::move(b), std::move(c));
     }
     jsi::Object getStateTypeWithEnums(jsi::Runtime &rt, jsi::Object paramOfTypeWithEnums) override {
       static_assert(
@@ -2289,38 +2241,6 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
     }
   }
 };
-
-#pragma mark - NativeEnumTurboModuleStatusFractionEnum
-
-enum class NativeEnumTurboModuleStatusFractionEnum { Active, Paused, Off };
-
-template <>
-struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
-  static NativeEnumTurboModuleStatusFractionEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue) {
-    double value = (double)rawValue.asNumber();
-    if (value == 0.2f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Active;
-    } else if (value == 0.1f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Paused;
-    } else if (value == 0f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Off;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value) {
-    if (value == NativeEnumTurboModuleStatusFractionEnum::Active) {
-      return bridging::toJs(rt, 0.2f);
-    } else if (value == NativeEnumTurboModuleStatusFractionEnum::Paused) {
-      return bridging::toJs(rt, 0.1f);
-    } else if (value == NativeEnumTurboModuleStatusFractionEnum::Off) {
-      return bridging::toJs(rt, 0f);
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
-    }
-  }
-};
   
 #pragma mark - NativeEnumTurboModuleStateType
 
@@ -2365,15 +2285,14 @@ struct NativeEnumTurboModuleStateTypeBridging {
 
 #pragma mark - NativeEnumTurboModuleStateTypeWithEnums
 
-template <typename P0, typename P1, typename P2, typename P3, typename P4>
+template <typename P0, typename P1, typename P2, typename P3>
 struct NativeEnumTurboModuleStateTypeWithEnums {
   P0 state;
   P1 regular;
   P2 str;
   P3 num;
-  P4 fraction;
   bool operator==(const NativeEnumTurboModuleStateTypeWithEnums &other) const {
-    return state == other.state && regular == other.regular && str == other.str && num == other.num && fraction == other.fraction;
+    return state == other.state && regular == other.regular && str == other.str && num == other.num;
   }
 };
 
@@ -2389,8 +2308,7 @@ struct NativeEnumTurboModuleStateTypeWithEnumsBridging {
       bridging::fromJs<decltype(types.state)>(rt, value.getProperty(rt, \\"state\\"), jsInvoker),
       bridging::fromJs<decltype(types.regular)>(rt, value.getProperty(rt, \\"regular\\"), jsInvoker),
       bridging::fromJs<decltype(types.str)>(rt, value.getProperty(rt, \\"str\\"), jsInvoker),
-      bridging::fromJs<decltype(types.num)>(rt, value.getProperty(rt, \\"num\\"), jsInvoker),
-      bridging::fromJs<decltype(types.fraction)>(rt, value.getProperty(rt, \\"fraction\\"), jsInvoker)};
+      bridging::fromJs<decltype(types.num)>(rt, value.getProperty(rt, \\"num\\"), jsInvoker)};
     return result;
   }
 
@@ -2410,10 +2328,6 @@ struct NativeEnumTurboModuleStateTypeWithEnumsBridging {
   static jsi::Value numToJs(jsi::Runtime &rt, decltype(types.num) value) {
     return bridging::toJs(rt, value);
   }
-
-  static jsi::Value fractionToJs(jsi::Runtime &rt, decltype(types.fraction) value) {
-    return bridging::toJs(rt, value);
-  }
 #endif
 
   static jsi::Object toJs(
@@ -2425,7 +2339,6 @@ struct NativeEnumTurboModuleStateTypeWithEnumsBridging {
     result.setProperty(rt, \\"regular\\", bridging::toJs(rt, value.regular, jsInvoker));
     result.setProperty(rt, \\"str\\", bridging::toJs(rt, value.str, jsInvoker));
     result.setProperty(rt, \\"num\\", bridging::toJs(rt, value.num, jsInvoker));
-    result.setProperty(rt, \\"fraction\\", bridging::toJs(rt, value.fraction, jsInvoker));
     return result;
   }
 };
@@ -2438,8 +2351,7 @@ public:
   virtual jsi::String getStatusRegular(jsi::Runtime &rt, jsi::Object statusProp) = 0;
   virtual jsi::String getStatusStr(jsi::Runtime &rt, jsi::Object statusProp) = 0;
   virtual jsi::Value getStatusNum(jsi::Runtime &rt, jsi::Object statusProp) = 0;
-  virtual jsi::Value getStatusFraction(jsi::Runtime &rt, jsi::Object statusProp) = 0;
-  virtual jsi::Object getStateType(jsi::Runtime &rt, jsi::String a, jsi::String b, jsi::Value c, jsi::Value d) = 0;
+  virtual jsi::Object getStateType(jsi::Runtime &rt, jsi::String a, jsi::String b, jsi::Value c) = 0;
   virtual jsi::Object getStateTypeWithEnums(jsi::Runtime &rt, jsi::Object paramOfTypeWithEnums) = 0;
 
 };
@@ -2488,21 +2400,13 @@ private:
       return bridging::callFromJs<jsi::Value>(
           rt, &T::getStatusNum, jsInvoker_, instance_, std::move(statusProp));
     }
-    jsi::Value getStatusFraction(jsi::Runtime &rt, jsi::Object statusProp) override {
+    jsi::Object getStateType(jsi::Runtime &rt, jsi::String a, jsi::String b, jsi::Value c) override {
       static_assert(
-          bridging::getParameterCount(&T::getStatusFraction) == 2,
-          \\"Expected getStatusFraction(...) to have 2 parameters\\");
-
-      return bridging::callFromJs<jsi::Value>(
-          rt, &T::getStatusFraction, jsInvoker_, instance_, std::move(statusProp));
-    }
-    jsi::Object getStateType(jsi::Runtime &rt, jsi::String a, jsi::String b, jsi::Value c, jsi::Value d) override {
-      static_assert(
-          bridging::getParameterCount(&T::getStateType) == 5,
-          \\"Expected getStateType(...) to have 5 parameters\\");
+          bridging::getParameterCount(&T::getStateType) == 4,
+          \\"Expected getStateType(...) to have 4 parameters\\");
 
       return bridging::callFromJs<jsi::Object>(
-          rt, &T::getStateType, jsInvoker_, instance_, std::move(a), std::move(b), std::move(c), std::move(d));
+          rt, &T::getStateType, jsInvoker_, instance_, std::move(a), std::move(b), std::move(c));
     }
     jsi::Object getStateTypeWithEnums(jsi::Runtime &rt, jsi::Object paramOfTypeWithEnums) override {
       static_assert(

--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
@@ -105,7 +105,6 @@ namespace JS {
       NSString *regular() const;
       NSString *str() const;
       double num() const;
-      double fraction() const;
 
       StateTypeWithEnums(NSDictionary *const v) : _v(v) {}
     private:
@@ -122,11 +121,9 @@ namespace JS {
 - (NSString *)getStatusRegular:(JS::NativeEnumTurboModule::StateType &)statusProp;
 - (NSString *)getStatusStr:(JS::NativeEnumTurboModule::StateType &)statusProp;
 - (NSNumber *)getStatusNum:(JS::NativeEnumTurboModule::StateType &)statusProp;
-- (NSNumber *)getStatusFraction:(JS::NativeEnumTurboModule::StateType &)statusProp;
 - (NSDictionary *)getStateType:(NSString *)a
                              b:(NSString *)b
-                             c:(double)c
-                             d:(double)d;
+                             c:(double)c;
 - (NSDictionary *)getStateTypeWithEnums:(JS::NativeEnumTurboModule::StateTypeWithEnums &)paramOfTypeWithEnums;
 
 @end
@@ -1053,11 +1050,6 @@ inline NSString *JS::NativeEnumTurboModule::StateTypeWithEnums::str() const
 inline double JS::NativeEnumTurboModule::StateTypeWithEnums::num() const
 {
   id const p = _v[@\\"num\\"];
-  return RCTBridgingToDouble(p);
-}
-inline double JS::NativeEnumTurboModule::StateTypeWithEnums::fraction() const
-{
-  id const p = _v[@\\"fraction\\"];
   return RCTBridgingToDouble(p);
 }
 
@@ -1457,7 +1449,6 @@ namespace JS {
       NSString *regular() const;
       NSString *str() const;
       double num() const;
-      double fraction() const;
 
       StateTypeWithEnums(NSDictionary *const v) : _v(v) {}
     private:
@@ -1474,11 +1465,9 @@ namespace JS {
 - (NSString *)getStatusRegular:(JS::NativeEnumTurboModule::StateType &)statusProp;
 - (NSString *)getStatusStr:(JS::NativeEnumTurboModule::StateType &)statusProp;
 - (NSNumber *)getStatusNum:(JS::NativeEnumTurboModule::StateType &)statusProp;
-- (NSNumber *)getStatusFraction:(JS::NativeEnumTurboModule::StateType &)statusProp;
 - (NSDictionary *)getStateType:(NSString *)a
                              b:(NSString *)b
-                             c:(double)c
-                             d:(double)d;
+                             c:(double)c;
 - (NSDictionary *)getStateTypeWithEnums:(JS::NativeEnumTurboModule::StateTypeWithEnums &)paramOfTypeWithEnums;
 
 @end
@@ -2405,11 +2394,6 @@ inline NSString *JS::NativeEnumTurboModule::StateTypeWithEnums::str() const
 inline double JS::NativeEnumTurboModule::StateTypeWithEnums::num() const
 {
   id const p = _v[@\\"num\\"];
-  return RCTBridgingToDouble(p);
-}
-inline double JS::NativeEnumTurboModule::StateTypeWithEnums::fraction() const
-{
-  id const p = _v[@\\"fraction\\"];
   return RCTBridgingToDouble(p);
 }
 
@@ -2815,12 +2799,8 @@ namespace facebook::react {
       return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, NumberKind, \\"getStatusNum\\", @selector(getStatusNum:), args, count);
     }
 
-    static facebook::jsi::Value __hostFunction_NativeEnumTurboModuleSpecJSI_getStatusFraction(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, NumberKind, \\"getStatusFraction\\", @selector(getStatusFraction:), args, count);
-    }
-
     static facebook::jsi::Value __hostFunction_NativeEnumTurboModuleSpecJSI_getStateType(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, ObjectKind, \\"getStateType\\", @selector(getStateType:b:c:d:), args, count);
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, ObjectKind, \\"getStateType\\", @selector(getStateType:b:c:), args, count);
     }
 
     static facebook::jsi::Value __hostFunction_NativeEnumTurboModuleSpecJSI_getStateTypeWithEnums(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -2839,10 +2819,7 @@ namespace facebook::react {
         methodMap_[\\"getStatusNum\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleSpecJSI_getStatusNum};
         setMethodArgConversionSelector(@\\"getStatusNum\\", 0, @\\"JS_NativeEnumTurboModule_StateType:\\");
         
-        methodMap_[\\"getStatusFraction\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleSpecJSI_getStatusFraction};
-        setMethodArgConversionSelector(@\\"getStatusFraction\\", 0, @\\"JS_NativeEnumTurboModule_StateType:\\");
-        
-        methodMap_[\\"getStateType\\"] = MethodMetadata {4, __hostFunction_NativeEnumTurboModuleSpecJSI_getStateType};
+        methodMap_[\\"getStateType\\"] = MethodMetadata {3, __hostFunction_NativeEnumTurboModuleSpecJSI_getStateType};
         
         
         methodMap_[\\"getStateTypeWithEnums\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleSpecJSI_getStateTypeWithEnums};

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -32,7 +32,6 @@ const {getEnumName, toSafeCppString} = require('../Utils');
 const {indent} = require('../Utils');
 const {
   createAliasResolver,
-  getAreEnumMembersInteger,
   getModules,
   isArrayRecursiveMember,
   isDirectRecursiveMember,
@@ -344,7 +343,7 @@ ${value.properties
     .join('\n');
 }
 
-type NativeEnumMemberValueType = 'std::string' | 'int32_t' | 'float';
+type NativeEnumMemberValueType = 'std::string' | 'int32_t';
 
 const EnumTemplate = ({
   enumName,
@@ -399,16 +398,10 @@ function generateEnum(
   const enumName = getEnumName(moduleName, origEnumName);
 
   const nativeEnumMemberType: NativeEnumMemberValueType =
-    memberType === 'StringTypeAnnotation'
-      ? 'std::string'
-      : getAreEnumMembersInteger(members)
-      ? 'int32_t'
-      : 'float';
+    memberType === 'StringTypeAnnotation' ? 'std::string' : 'int32_t';
 
   const getMemberValueAppearance = (value: string) =>
-    memberType === 'StringTypeAnnotation'
-      ? `"${value}"`
-      : `${value}${nativeEnumMemberType === 'float' ? 'f' : ''}`;
+    memberType === 'StringTypeAnnotation' ? `"${value}"` : `${value}`;
 
   const fromCases =
     members

--- a/packages/react-native-codegen/src/generators/modules/Utils.js
+++ b/packages/react-native-codegen/src/generators/modules/Utils.js
@@ -12,7 +12,6 @@
 
 import type {
   NativeModuleAliasMap,
-  NativeModuleEnumMembers,
   NativeModuleObjectTypeAnnotation,
   NativeModuleSchema,
   NativeModuleTypeAnnotation,
@@ -78,14 +77,9 @@ function isArrayRecursiveMember(
   );
 }
 
-function getAreEnumMembersInteger(members: NativeModuleEnumMembers): boolean {
-  return !members.some(m => `${m.value}`.includes('.'));
-}
-
 module.exports = {
   createAliasResolver,
   getModules,
-  getAreEnumMembersInteger,
   isDirectRecursiveMember,
   isArrayRecursiveMember,
 };

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -240,9 +240,9 @@ template <>
 struct Bridging<SampleTurboModuleCxxEnumFloat> {
   static SampleTurboModuleCxxEnumFloat fromJs(jsi::Runtime &rt, const jsi::Value &rawValue) {
     double value = (double)rawValue.asNumber();
-    if (value == 1.23f) {
+    if (value == 1.23) {
       return SampleTurboModuleCxxEnumFloat::FA;
-    } else if (value == 4.56f) {
+    } else if (value == 4.56) {
       return SampleTurboModuleCxxEnumFloat::FB;
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
@@ -251,9 +251,9 @@ struct Bridging<SampleTurboModuleCxxEnumFloat> {
 
   static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxEnumFloat value) {
     if (value == SampleTurboModuleCxxEnumFloat::FA) {
-      return bridging::toJs(rt, 1.23f);
+      return bridging::toJs(rt, 1.23);
     } else if (value == SampleTurboModuleCxxEnumFloat::FB) {
-      return bridging::toJs(rt, 4.56f);
+      return bridging::toJs(rt, 4.56);
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
     }
@@ -1815,11 +1815,11 @@ template <>
 struct Bridging<SampleTurboModuleFloatEnum> {
   static SampleTurboModuleFloatEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue) {
     double value = (double)rawValue.asNumber();
-    if (value == 0.0f) {
+    if (value == 0.0) {
       return SampleTurboModuleFloatEnum::POINT_ZERO;
-    } else if (value == 0.1f) {
+    } else if (value == 0.1) {
       return SampleTurboModuleFloatEnum::POINT_ONE;
-    } else if (value == 0.2f) {
+    } else if (value == 0.2) {
       return SampleTurboModuleFloatEnum::POINT_TWO;
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
@@ -1828,11 +1828,11 @@ struct Bridging<SampleTurboModuleFloatEnum> {
 
   static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleFloatEnum value) {
     if (value == SampleTurboModuleFloatEnum::POINT_ZERO) {
-      return bridging::toJs(rt, 0.0f);
+      return bridging::toJs(rt, 0.0);
     } else if (value == SampleTurboModuleFloatEnum::POINT_ONE) {
-      return bridging::toJs(rt, 0.1f);
+      return bridging::toJs(rt, 0.1);
     } else if (value == SampleTurboModuleFloatEnum::POINT_TWO) {
-      return bridging::toJs(rt, 0.2f);
+      return bridging::toJs(rt, 0.2);
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
     }

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -670,11 +670,6 @@ export enum Resolution {
   High = 1080,
 }
 
-export enum Floppy {
-  LowDensity = 0.72,
-  HighDensity = 1.44,
-}
-
 export enum StringOptions {
   One = 'one',
   Two = 'two',
@@ -682,7 +677,7 @@ export enum StringOptions {
 }
 
 export interface Spec extends TurboModule {
-  getEnums(quality: Quality, resolution?: Resolution, floppy: Floppy, stringOptions: StringOptions): string;
+  getEnums(quality: Quality, resolution?: Resolution, stringOptions: StringOptions): string;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModuleIOS');
@@ -720,11 +715,6 @@ export enum Resolution {
   High = 1080,
 }
 
-export enum Floppy {
-  LowDensity = 0.72,
-  HighDensity = 1.44,
-}
-
 export enum StringOptions {
   One = 'one',
   Two = 'two',
@@ -751,7 +741,7 @@ export type CustomDeviceEvent = {
 export interface Spec extends TurboModule {
   +getCallback: () => () => void;
   +getMixed: (arg: mixed) => mixed;
-  +getEnums: (quality: Quality, resolution?: Resolution, floppy: Floppy, stringOptions: StringOptions) => string;
+  +getEnums: (quality: Quality, resolution?: Resolution, stringOptions: StringOptions) => string;
   +getBinaryTreeNode: (arg: BinaryTreeNode) => BinaryTreeNode;
   +getGraphNode: (arg: GraphNode) => GraphNode;
   +getMap: (arg: {[a: string]: ?number}) => {[b: string]: ?number};

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -161,21 +161,6 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
             }
           ]
         },
-        'Floppy': {
-          'name': 'Floppy',
-          'type': 'EnumDeclarationWithMembers',
-          'memberType': 'NumberTypeAnnotation',
-          'members': [
-            {
-              'name': 'LowDensity',
-              'value': 0.72
-            },
-            {
-              'name': 'HighDensity',
-              'value': 1.44
-            }
-          ]
-        },
         'StringOptions': {
           'name': 'StringOptions',
           'type': 'EnumDeclarationWithMembers',
@@ -255,15 +240,6 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
                   'optional': true,
                   'typeAnnotation': {
                     'name': 'Resolution',
-                    'type': 'EnumDeclaration',
-                    'memberType': 'NumberTypeAnnotation'
-                  }
-                },
-                {
-                  'name': 'floppy',
-                  'optional': false,
-                  'typeAnnotation': {
-                    'name': 'Floppy',
                     'type': 'EnumDeclaration',
                     'memberType': 'NumberTypeAnnotation'
                   }
@@ -488,21 +464,6 @@ exports[`RN Codegen Flow Parser can generate fixture IOS_ONLY_NATIVE_MODULE 1`] 
             }
           ]
         },
-        'Floppy': {
-          'name': 'Floppy',
-          'type': 'EnumDeclarationWithMembers',
-          'memberType': 'NumberTypeAnnotation',
-          'members': [
-            {
-              'name': 'LowDensity',
-              'value': 0.72
-            },
-            {
-              'name': 'HighDensity',
-              'value': 1.44
-            }
-          ]
-        },
         'StringOptions': {
           'name': 'StringOptions',
           'type': 'EnumDeclarationWithMembers',
@@ -548,15 +509,6 @@ exports[`RN Codegen Flow Parser can generate fixture IOS_ONLY_NATIVE_MODULE 1`] 
                   'optional': true,
                   'typeAnnotation': {
                     'name': 'Resolution',
-                    'type': 'EnumDeclaration',
-                    'memberType': 'NumberTypeAnnotation'
-                  }
-                },
-                {
-                  'name': 'floppy',
-                  'optional': false,
-                  'typeAnnotation': {
-                    'name': 'Floppy',
                     'type': 'EnumDeclaration',
                     'memberType': 'NumberTypeAnnotation'
                   }

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -22,6 +22,7 @@ import type {Parser} from '../../parser';
 import type {ParserErrorCapturer, TypeDeclarationMap} from '../../utils';
 
 const {
+  UnsupportedEnumDeclarationParserError,
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
 } = require('../../errors');
@@ -227,6 +228,19 @@ function translateTypeAnnotation(
     }
     case 'EnumStringBody':
     case 'EnumNumberBody': {
+      if (
+        typeAnnotation.type === 'EnumNumberBody' &&
+        typeAnnotation.members.some(
+          m =>
+            m.type === 'EnumNumberMember' && !Number.isInteger(m.init?.value),
+        )
+      ) {
+        throw new UnsupportedEnumDeclarationParserError(
+          hasteModuleName,
+          typeAnnotation,
+          parser.language(),
+        );
+      }
       return typeEnumResolution(
         typeAnnotation,
         typeResolutionStatus,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -766,11 +766,6 @@ export enum Resolution {
   High = 1080,
 }
 
-export enum Floppy {
-  LowDensity = 0.72,
-  HighDensity = 1.44,
-}
-
 export enum StringOptions {
   One = 'one',
   Two = 'two',
@@ -778,7 +773,7 @@ export enum StringOptions {
 }
 
 export interface Spec extends TurboModule {
-  readonly getEnums: (quality: Quality, resolution?: Resolution, floppy: Floppy, stringOptions: StringOptions) => string;
+  readonly getEnums: (quality: Quality, resolution?: Resolution, stringOptions: StringOptions) => string;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(
@@ -807,11 +802,6 @@ export enum Quality {
 export enum Resolution {
   Low = 720,
   High = 1080,
-}
-
-export enum Floppy {
-  LowDensity = 0.72,
-  HighDensity = 1.44,
 }
 
 export enum StringOptions {
@@ -845,7 +835,7 @@ export type CustomDeviceEvent = {
 export interface Spec extends TurboModule {
   readonly getCallback: () => () => void;
   readonly getMixed: (arg: unknown) => unknown;
-  readonly getEnums: (quality: Quality, resolution?: Resolution, floppy: Floppy, stringOptions: StringOptions) => string;
+  readonly getEnums: (quality: Quality, resolution?: Resolution, stringOptions: StringOptions) => string;
   readonly getBinaryTreeNode: (arg: BinaryTreeNode) => BinaryTreeNode;
   readonly getGraphNode: (arg: GraphNode) => GraphNode;
   readonly getMap: (arg: {[a: string]: number | null;}) => {[b: string]: number | null;};

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -152,21 +152,6 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
             }
           ]
         },
-        'Floppy': {
-          'name': 'Floppy',
-          'type': 'EnumDeclarationWithMembers',
-          'memberType': 'NumberTypeAnnotation',
-          'members': [
-            {
-              'name': 'LowDensity',
-              'value': 0.72
-            },
-            {
-              'name': 'HighDensity',
-              'value': 1.44
-            }
-          ]
-        },
         'StringOptions': {
           'name': 'StringOptions',
           'type': 'EnumDeclarationWithMembers',
@@ -246,15 +231,6 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
                   'optional': true,
                   'typeAnnotation': {
                     'name': 'Resolution',
-                    'type': 'EnumDeclaration',
-                    'memberType': 'NumberTypeAnnotation'
-                  }
-                },
-                {
-                  'name': 'floppy',
-                  'optional': false,
-                  'typeAnnotation': {
-                    'name': 'Floppy',
                     'type': 'EnumDeclaration',
                     'memberType': 'NumberTypeAnnotation'
                   }
@@ -479,21 +455,6 @@ exports[`RN Codegen TypeScript Parser can generate fixture IOS_ONLY_NATIVE_MODUL
             }
           ]
         },
-        'Floppy': {
-          'name': 'Floppy',
-          'type': 'EnumDeclarationWithMembers',
-          'memberType': 'NumberTypeAnnotation',
-          'members': [
-            {
-              'name': 'LowDensity',
-              'value': 0.72
-            },
-            {
-              'name': 'HighDensity',
-              'value': 1.44
-            }
-          ]
-        },
         'StringOptions': {
           'name': 'StringOptions',
           'type': 'EnumDeclarationWithMembers',
@@ -539,15 +500,6 @@ exports[`RN Codegen TypeScript Parser can generate fixture IOS_ONLY_NATIVE_MODUL
                   'optional': true,
                   'typeAnnotation': {
                     'name': 'Resolution',
-                    'type': 'EnumDeclaration',
-                    'memberType': 'NumberTypeAnnotation'
-                  }
-                },
-                {
-                  'name': 'floppy',
-                  'optional': false,
-                  'typeAnnotation': {
-                    'name': 'Floppy',
                     'type': 'EnumDeclaration',
                     'memberType': 'NumberTypeAnnotation'
                   }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -25,6 +25,8 @@ import type {
   TypeResolutionStatus,
 } from '../../utils';
 
+import {UnsupportedEnumDeclarationParserError} from '../../errors';
+
 const {
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
@@ -342,6 +344,20 @@ function translateTypeAnnotation(
       );
     }
     case 'TSEnumDeclaration': {
+      if (
+        typeAnnotation.members.some(
+          m =>
+            m.initializer &&
+            m.initializer.type === 'NumericLiteral' &&
+            !Number.isInteger(m.initializer.value),
+        )
+      ) {
+        throw new UnsupportedEnumDeclarationParserError(
+          hasteModuleName,
+          typeAnnotation,
+          parser.language(),
+        );
+      }
       return typeEnumResolution(
         typeAnnotation,
         typeResolutionStatus,

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -81,10 +81,10 @@ GraphNode NativeCxxModuleExample::getGraphNode(
   return arg;
 }
 
-NativeCxxModuleExampleCxxEnumFloat NativeCxxModuleExample::getNumEnum(
+NativeCxxModuleExampleCxxEnumInt NativeCxxModuleExample::getNumEnum(
     jsi::Runtime& rt,
     NativeCxxModuleExampleCxxEnumInt arg) {
-  return NativeCxxModuleExampleCxxEnumFloat::FB;
+  return arg;
 }
 
 NativeCxxModuleExampleCxxEnumStr NativeCxxModuleExample::getStrEnum(

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -161,7 +161,7 @@ class NativeCxxModuleExample
 
   GraphNode getGraphNode(jsi::Runtime& rt, GraphNode arg);
 
-  NativeCxxModuleExampleCxxEnumFloat getNumEnum(
+  NativeCxxModuleExampleCxxEnumInt getNumEnum(
       jsi::Runtime& rt,
       NativeCxxModuleExampleCxxEnumInt arg);
 

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -17,11 +17,6 @@ export enum EnumInt {
   IB = 42,
 }
 
-export enum EnumFloat {
-  FA = 1.23,
-  FB = 4.56,
-}
-
 export enum EnumNone {
   NA,
   NB,
@@ -89,7 +84,7 @@ export interface Spec extends TurboModule {
   +consumeCustomHostObject: (customHostObject: CustomHostObject) => string;
   +getBinaryTreeNode: (arg: BinaryTreeNode) => BinaryTreeNode;
   +getGraphNode: (arg: GraphNode) => GraphNode;
-  +getNumEnum: (arg: EnumInt) => EnumFloat;
+  +getNumEnum: (arg: EnumInt) => EnumInt;
   +getStrEnum: (arg: EnumNone) => EnumStr;
   +getMap: (arg: {[key: string]: ?number}) => {[key: string]: ?number};
   +getNumber: (arg: number) => number;


### PR DESCRIPTION
Summary:
Changelog: [General][BREAKING] Don't support 'float' enums in Turbo Modules

- The current implementation of 'float enums' in C++ does not work as invalid results are returned.
- At potential fix could still cause rounding errors when crossing language bounaries, e.g. `4.6` can become `4.5599999942..`
- C++ enum classes don't support float: https://eel.is/c++draft/dcl.enum#2.sentence-4

> The type-specifier-seq of an enum-base shall name an integral type; any cv-qualification is ignored.

Hence removing the feature of `float enums` for now

Differential Revision: D52120405
