### PR TITLE
Avoid calling abstract methods in RCTComposedViewRegistry

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -1693,7 +1693,7 @@ static UIView *_jsResponder;
 - (id)objectForKey:(id)key
 {
   if (![key isKindOfClass:[NSNumber class]]) {
-    return [super objectForKey:key];
+    return NULL;
   }
 
   NSNumber *index = (NSNumber *)key;
@@ -1705,14 +1705,15 @@ static UIView *_jsResponder;
   if (view) {
     return [RCTUIManager paperViewOrCurrentView:view];
   }
-  return [super objectForKey:key];
+  return NULL;
 }
 
 - (void)removeObjectForKey:(id)key
 {
   if (![key isKindOfClass:[NSNumber class]]) {
-    return [super removeObjectForKey:key];
+    return;
   }
+
   NSNumber *tag = (NSNumber *)key;
 
   if (_registry[key]) {
@@ -1720,8 +1721,6 @@ static UIView *_jsResponder;
     [mutableRegistry removeObjectForKey:tag];
   } else if ([_uiManager viewForReactTag:tag]) {
     [_uiManager removeViewFromRegistry:tag];
-  } else {
-    [super removeObjectForKey:key];
   }
 }
 


### PR DESCRIPTION
Summary:
`RCTComposedViewRegistry` extends `NSMutableDictionary` which is a clustered class in iOS.
NSMutableDictionary is techncially an abstract class, but when instantiated by `[NSMutableDictionary new];` the system will return one of concrete classes that inherit from `NSMutableDictionary`, opaquely from the perspective of the caller.

By calling `super`, we are actually calling the not implemented method for the abstract class. If this happen, this can crash the app.

Given that the `RCTComposedViewRegistry` is extending the dictionary only for its interface but is using other mechanisms as storage, is it fair to return `NULL`if the storages don't have the requested view.

## Changelog
[iOS][Fixed] -  Avoid calling abstract methods in RCTComposedViewRegistry

Differential Revision: D56755427
