### PR TITLE
Fix accidentally broken build_android job

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GeneratePackageListTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GeneratePackageListTask.kt
@@ -132,20 +132,20 @@ abstract class GeneratePackageListTask : DefaultTask() {
               private ReactNativeHost reactNativeHost;
               private MainPackageConfig mConfig;
             
-              public PackageList(ReactNativeHost reactNativeHost) {
+              public PackageList2(ReactNativeHost reactNativeHost) {
                 this(reactNativeHost, null);
               }
             
-              public PackageList(Application application) {
+              public PackageList2(Application application) {
                 this(application, null);
               }
             
-              public PackageList(ReactNativeHost reactNativeHost, MainPackageConfig config) {
+              public PackageList2(ReactNativeHost reactNativeHost, MainPackageConfig config) {
                 this.reactNativeHost = reactNativeHost;
                 mConfig = config;
               }
             
-              public PackageList(Application application, MainPackageConfig config) {
+              public PackageList2(Application application, MainPackageConfig config) {
                 this.reactNativeHost = null;
                 this.application = application;
                 mConfig = config;

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GeneratePackageListTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GeneratePackageListTaskTest.kt
@@ -147,20 +147,20 @@ class GeneratePackageListTaskTest {
       private ReactNativeHost reactNativeHost;
       private MainPackageConfig mConfig;
 
-      public PackageList(ReactNativeHost reactNativeHost) {
+      public PackageList2(ReactNativeHost reactNativeHost) {
         this(reactNativeHost, null);
       }
 
-      public PackageList(Application application) {
+      public PackageList2(Application application) {
         this(application, null);
       }
 
-      public PackageList(ReactNativeHost reactNativeHost, MainPackageConfig config) {
+      public PackageList2(ReactNativeHost reactNativeHost, MainPackageConfig config) {
         this.reactNativeHost = reactNativeHost;
         mConfig = config;
       }
 
-      public PackageList(Application application, MainPackageConfig config) {
+      public PackageList2(Application application, MainPackageConfig config) {
         this.reactNativeHost = null;
         this.application = application;
         mConfig = config;
@@ -226,20 +226,20 @@ class GeneratePackageListTaskTest {
       private ReactNativeHost reactNativeHost;
       private MainPackageConfig mConfig;
 
-      public PackageList(ReactNativeHost reactNativeHost) {
+      public PackageList2(ReactNativeHost reactNativeHost) {
         this(reactNativeHost, null);
       }
 
-      public PackageList(Application application) {
+      public PackageList2(Application application) {
         this(application, null);
       }
 
-      public PackageList(ReactNativeHost reactNativeHost, MainPackageConfig config) {
+      public PackageList2(ReactNativeHost reactNativeHost, MainPackageConfig config) {
         this.reactNativeHost = reactNativeHost;
         mConfig = config;
       }
 
-      public PackageList(Application application, MainPackageConfig config) {
+      public PackageList2(Application application, MainPackageConfig config) {
         this.reactNativeHost = null;
         this.application = application;
         mConfig = config;

--- a/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/NativeSampleModule.kt
+++ b/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/NativeSampleModule.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.reactnative.osslibraryexample
+package com.facebook.react.osslibraryexample
 
 import com.facebook.fbreact.specs.NativeSampleModuleSpec
 import com.facebook.react.bridge.ReactApplicationContext

--- a/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/OSSLibraryExamplePackage.kt
+++ b/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/OSSLibraryExamplePackage.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.reactnative.osslibraryexample
+package com.facebook.react.osslibraryexample
 
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule

--- a/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/SampleNativeComponentViewManager.kt
+++ b/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/SampleNativeComponentViewManager.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.reactnative.osslibraryexample
+package com.facebook.react.osslibraryexample
 
 import android.annotation.SuppressLint
 import android.graphics.Color

--- a/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/SampleNativeView.kt
+++ b/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/SampleNativeView.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.reactnative.osslibraryexample
+package com.facebook.react.osslibraryexample
 
 import android.graphics.drawable.GradientDrawable
 import android.view.View

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -25,6 +25,7 @@ import com.facebook.react.defaults.DefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
+import com.facebook.react.osslibraryexample.OSSLibraryExamplePackage
 import com.facebook.react.popupmenu.PopupMenuPackage
 import com.facebook.react.shell.MainReactPackage
 import com.facebook.react.uiapp.component.MyLegacyViewManager
@@ -32,7 +33,6 @@ import com.facebook.react.uiapp.component.MyNativeViewManager
 import com.facebook.react.uimanager.ReactShadowNode
 import com.facebook.react.uimanager.ViewManager
 import com.facebook.soloader.SoLoader
-import com.reactnative.osslibraryexample.OSSLibraryExamplePackage
 
 class RNTesterApplication : Application(), ReactApplication {
   override val reactNativeHost: ReactNativeHost by lazy {


### PR DESCRIPTION
Summary:
I accidentally broke build_android.
Here the two fixes:
1. Make sure the constructor of PackageList2 are actually called `PackageList2`
2. Make sure the package of `OSSLibraryExamplePackage` is `com.facebook.react.osslibraryexample`

Changelog:
[Internal] [Changed] - Fix accidentally broken build_android job

Differential Revision: D56756601
