### PR TITLE
Update AndroidManifest.xml for android:usesCleartextTraffic="true"

### DIFF
--- a/packages/react-native/template/android/app/src/main/AndroidManifest.xml
+++ b/packages/react-native/template/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"


### PR DESCRIPTION

## Summary:

In order to use localhost:8081 for dev server, we need this to allow non HTTPs requests

## Changelog:

[ANDROID][Fixed] Allow clear text traffic for the Android template app


## Test Plan:

Create a new app and run TD