### PR TITLE
Fix getDevSupportManager() in ReactDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -98,7 +98,7 @@ public class ReactDelegate {
         && mReactHost.getDevSupportManager() != null) {
       return mReactHost.getDevSupportManager();
     } else if (getReactNativeHost().hasInstance()
-        && getReactNativeHost().getUseDeveloperSupport()) {
+        && getReactNativeHost().getReactInstanceManager() != null) {
       return getReactNativeHost().getReactInstanceManager().getDevSupportManager();
     } else {
       return null;


### PR DESCRIPTION
Summary:
In https://github.com/facebook/react-native/pull/43520, this was moved to supply with the relevant DevSupportManager, however this check for `useDeveloperSupport` is already part of https://github.com/facebook/react-native/blob/0.74-stable/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L263

https://github.com/facebook/react-native/blob/0.74-stable/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.java#L68-L70

Having this check here was causing early exit for Bridge RELEASE mode instead of returning the ReleaseDevSupportManager.

Changelog:
[ANDROID][FIXED] - Fixed `getDevSupportManager()` in ReactDelegate

Reviewed By: javache

Differential Revision: D56739764
