### PR TITLE
Adding BridgelessReleaseDevSupportManager

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3706,6 +3706,55 @@ public final class com/facebook/react/runtime/BridgelessCatalystInstance : com/f
 	public fun setTurboModuleRegistry (Lcom/facebook/react/internal/turbomodule/core/interfaces/TurboModuleRegistry;)V
 }
 
+public class com/facebook/react/runtime/BridgelessReleaseDevSupportManager : com/facebook/react/devsupport/interfaces/DevSupportManager {
+	public fun <init> (Lcom/facebook/react/runtime/ReactHostImpl;)V
+	public fun addCustomDevOption (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevOptionHandler;)V
+	public fun createRootView (Ljava/lang/String;)Landroid/view/View;
+	public fun createSurfaceDelegate (Ljava/lang/String;)Lcom/facebook/react/common/SurfaceDelegate;
+	public fun destroyRootView (Landroid/view/View;)V
+	public fun downloadBundleResourceFromUrlSync (Ljava/lang/String;Ljava/io/File;)Ljava/io/File;
+	public fun getCurrentActivity ()Landroid/app/Activity;
+	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
+	public fun getDevSupportEnabled ()Z
+	public fun getDownloadedJSBundleFile ()Ljava/lang/String;
+	public fun getJSBundleURLForRemoteDebugging ()Ljava/lang/String;
+	public fun getLastErrorCookie ()I
+	public fun getLastErrorStack ()[Lcom/facebook/react/devsupport/interfaces/StackFrame;
+	public fun getLastErrorTitle ()Ljava/lang/String;
+	public fun getLastErrorType ()Lcom/facebook/react/devsupport/interfaces/ErrorType;
+	public fun getRedBoxHandler ()Lcom/facebook/react/devsupport/interfaces/RedBoxHandler;
+	public fun getSourceMapUrl ()Ljava/lang/String;
+	public fun getSourceUrl ()Ljava/lang/String;
+	public fun handleException (Ljava/lang/Exception;)V
+	public fun handleReloadJS ()V
+	public fun hasUpToDateJSBundleInCache ()Z
+	public fun hidePausedInDebuggerOverlay ()V
+	public fun hideRedboxDialog ()V
+	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
+	public fun loadSplitBundleFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSplitBundleCallback;)V
+	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
+	public fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
+	public fun openDebugger ()V
+	public fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
+	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
+	public fun reloadJSFromServer (Ljava/lang/String;)V
+	public fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V
+	public fun reloadSettings ()V
+	public fun setDevSupportEnabled (Z)V
+	public fun setFpsDebugEnabled (Z)V
+	public fun setHotModuleReplacementEnabled (Z)V
+	public fun setPackagerLocationCustomizer (Lcom/facebook/react/devsupport/interfaces/DevSupportManager$PackagerLocationCustomizer;)V
+	public fun setRemoteJSDebugEnabled (Z)V
+	public fun showDevOptionsDialog ()V
+	public fun showNewJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
+	public fun showNewJavaError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun showPausedInDebuggerOverlay (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevSupportManager$PausedInDebuggerOverlayCommandListener;)V
+	public fun startInspector ()V
+	public fun stopInspector ()V
+	public fun toggleElementInspector ()V
+	public fun updateJSError (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;I)V
+}
+
 public class com/facebook/react/runtime/CoreReactPackage$$ReactModuleInfoProvider : com/facebook/react/module/model/ReactModuleInfoProvider {
 	public fun <init> ()V
 	public fun getReactModuleInfos ()Ljava/util/Map;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -98,7 +98,7 @@ public class ReactDelegate {
         && mReactHost.getDevSupportManager() != null) {
       return mReactHost.getDevSupportManager();
     } else if (getReactNativeHost().hasInstance()
-        && getReactNativeHost().getUseDeveloperSupport()) {
+        && getReactNativeHost().getReactInstanceManager() != null) {
       return getReactNativeHost().getReactInstanceManager().getDevSupportManager();
     } else {
       return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReleaseDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReleaseDevSupportManager.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.runtime;
+
+import android.app.Activity;
+import android.util.Pair;
+import android.view.View;
+import androidx.annotation.Nullable;
+import com.facebook.react.bridge.DefaultJSExceptionHandler;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.SurfaceDelegate;
+import com.facebook.react.devsupport.interfaces.BundleLoadCallback;
+import com.facebook.react.devsupport.interfaces.DevOptionHandler;
+import com.facebook.react.devsupport.interfaces.DevSplitBundleCallback;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.devsupport.interfaces.ErrorCustomizer;
+import com.facebook.react.devsupport.interfaces.ErrorType;
+import com.facebook.react.devsupport.interfaces.PackagerStatusCallback;
+import com.facebook.react.devsupport.interfaces.RedBoxHandler;
+import com.facebook.react.devsupport.interfaces.StackFrame;
+import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
+import java.io.File;
+
+/**
+ * A dummy implementation of {@link DevSupportManager} to be used in production mode where
+ * development features aren't needed.
+ */
+public class BridgelessReleaseDevSupportManager implements DevSupportManager {
+
+  private final DefaultJSExceptionHandler mDefaultJSExceptionHandler;
+  private final ReactHostImpl mReactHost;
+
+  public BridgelessReleaseDevSupportManager(ReactHostImpl host) {
+    mDefaultJSExceptionHandler = new DefaultJSExceptionHandler();
+    mReactHost = host;
+  }
+
+  @Override
+  public void showNewJavaError(String message, Throwable e) {}
+
+  @Override
+  public void addCustomDevOption(String optionName, DevOptionHandler optionHandler) {}
+
+  @Override
+  public void showNewJSError(String message, ReadableArray details, int errorCookie) {}
+
+  @Override
+  public @Nullable View createRootView(String appKey) {
+    return null;
+  }
+
+  @Override
+  public void destroyRootView(View rootView) {}
+
+  @Override
+  public void updateJSError(String message, ReadableArray details, int errorCookie) {}
+
+  @Override
+  public void hideRedboxDialog() {}
+
+  @Override
+  public void showDevOptionsDialog() {}
+
+  @Override
+  public void setDevSupportEnabled(boolean isDevSupportEnabled) {}
+
+  @Override
+  public void startInspector() {}
+
+  @Override
+  public void stopInspector() {}
+
+  @Override
+  public void setHotModuleReplacementEnabled(boolean isHotModuleReplacementEnabled) {}
+
+  @Override
+  public void setRemoteJSDebugEnabled(boolean isRemoteJSDebugEnabled) {}
+
+  @Override
+  public void setFpsDebugEnabled(boolean isFpsDebugEnabled) {}
+
+  @Override
+  public void toggleElementInspector() {}
+
+  @Override
+  public boolean getDevSupportEnabled() {
+    return false;
+  }
+
+  @Override
+  public DeveloperSettings getDevSettings() {
+    return null;
+  }
+
+  @Override
+  public RedBoxHandler getRedBoxHandler() {
+    return null;
+  }
+
+  @Override
+  public void onNewReactContextCreated(ReactContext reactContext) {}
+
+  @Override
+  public void onReactInstanceDestroyed(ReactContext reactContext) {}
+
+  @Override
+  public String getSourceMapUrl() {
+    return null;
+  }
+
+  @Override
+  public String getSourceUrl() {
+    return null;
+  }
+
+  @Override
+  public String getJSBundleURLForRemoteDebugging() {
+    return null;
+  }
+
+  @Override
+  public String getDownloadedJSBundleFile() {
+    return null;
+  }
+
+  @Override
+  public boolean hasUpToDateJSBundleInCache() {
+    return false;
+  }
+
+  @Override
+  public void reloadSettings() {}
+
+  @Override
+  public void handleReloadJS() {
+    mReactHost.reload("BridgelessReleaseDevSupportManager.handleReloadJS()");
+  }
+
+  @Override
+  public void reloadJSFromServer(String bundleURL) {}
+
+  @Override
+  public void reloadJSFromServer(final String bundleURL, final BundleLoadCallback callback) {}
+
+  @Override
+  public void loadSplitBundleFromServer(String bundlePath, DevSplitBundleCallback callback) {}
+
+  @Override
+  public void isPackagerRunning(final PackagerStatusCallback callback) {
+    callback.onPackagerStatusFetched(false);
+  }
+
+  @Override
+  public @Nullable File downloadBundleResourceFromUrlSync(
+      final String resourceURL, final File outputFile) {
+    return null;
+  }
+
+  @Override
+  public @Nullable String getLastErrorTitle() {
+    return null;
+  }
+
+  @Override
+  public @Nullable StackFrame[] getLastErrorStack() {
+    return null;
+  }
+
+  @Override
+  public @Nullable ErrorType getLastErrorType() {
+    return null;
+  }
+
+  @Override
+  public int getLastErrorCookie() {
+    return 0;
+  }
+
+  @Override
+  public void registerErrorCustomizer(ErrorCustomizer errorCustomizer) {}
+
+  @Override
+  public Pair<String, StackFrame[]> processErrorCustomizers(Pair<String, StackFrame[]> errorInfo) {
+    return errorInfo;
+  }
+
+  @Override
+  public void setPackagerLocationCustomizer(
+      DevSupportManager.PackagerLocationCustomizer packagerLocationCustomizer) {}
+
+  @Override
+  public void handleException(Exception e) {
+    mDefaultJSExceptionHandler.handleException(e);
+  }
+
+  @Override
+  public @Nullable Activity getCurrentActivity() {
+    return null;
+  }
+
+  @Override
+  public @Nullable SurfaceDelegate createSurfaceDelegate(String moduleName) {
+    return null;
+  }
+
+  @Override
+  public void openDebugger() {}
+
+  @Override
+  public void showPausedInDebuggerOverlay(
+      String message, PausedInDebuggerOverlayCommandListener listener) {}
+
+  @Override
+  public void hidePausedInDebuggerOverlay() {}
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -51,7 +51,6 @@ import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.devsupport.DevSupportManagerBase;
 import com.facebook.react.devsupport.InspectorFlags;
-import com.facebook.react.devsupport.ReleaseDevSupportManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager.PausedInDebuggerOverlayCommandListener;
 import com.facebook.react.fabric.ComponentFactory;
@@ -184,7 +183,7 @@ public class ReactHostImpl implements ReactHost {
           new BridgelessDevSupportManager(
               ReactHostImpl.this, mContext, mReactHostDelegate.getJsMainModulePath());
     } else {
-      mDevSupportManager = new ReleaseDevSupportManager();
+      mDevSupportManager = new BridgelessReleaseDevSupportManager(ReactHostImpl.this);
     }
   }
 


### PR DESCRIPTION
Summary:
`handleReloadJS()` was a no-op for [ReleaseDevSupportManager](https://www.internalfb.com/code/fbsource/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java?lines=139)

which is why in order to fix reload() for Bridgeless in Android went through this path D55342296.

However, this is the same case for [shouldShowDevMenuOrReload](https://www.internalfb.com/code/fbsource/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java?lines=299) since  `showDevOptionsDialog()` & `handleReloadJS()` were no-op for ReleaseDevSupportManager.

Changelog:
[ANDROID][ADDED] Add BridgelessReleaseDevSupportManager in order to handle APIs pertaining to Bridgeless in RELEASE(useDeveloperSupport = false)mode.

Differential Revision: D56734242
