### PR TITLE
chore: Remove deprecated onTextInput callback

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -385,15 +385,6 @@ export type NativeProps = $ReadOnly<{|
     |}>,
   >,
 
-  onTextInput?: ?BubblingEventHandler<
-    $ReadOnly<{|
-      target: Int32,
-      text: string,
-      previousText: string,
-      range: $ReadOnly<{|start: Double, end: Double|}>,
-    |}>,
-  >,
-
   /**
    * Callback that is called when text input ends.
    */
@@ -660,12 +651,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
       phasedRegistrationNames: {
         bubbled: 'onSubmitEditing',
         captured: 'onSubmitEditingCapture',
-      },
-    },
-    topTextInput: {
-      phasedRegistrationNames: {
-        bubbled: 'onTextInput',
-        captured: 'onTextInputCapture',
       },
     },
   },

--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -76,9 +76,6 @@ const RCTTextInputViewConfig = {
     },
   },
   directEventTypes: {
-    topTextInput: {
-      registrationName: 'onTextInput',
-    },
     topScroll: {
       registrationName: 'onScroll',
     },
@@ -153,7 +150,6 @@ const RCTTextInputViewConfig = {
       onSelectionChange: true,
       onContentSizeChange: true,
       onScroll: true,
-      onTextInput: true,
     }),
   },
 };

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -486,15 +486,6 @@ export interface TextInputSubmitEditingEventData {
 }
 
 /**
- * @see TextInputProps.onTextInput
- */
-export interface TextInputTextInputEventData {
-  text: string;
-  previousText: string;
-  range: {start: number; end: number};
-}
-
-/**
  * @see https://reactnative.dev/docs/textinput#props
  */
 export interface TextInputProps
@@ -785,16 +776,6 @@ export interface TextInputProps
    */
   onSubmitEditing?:
     | ((e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => void)
-    | undefined;
-
-  /**
-   * Callback that is called on new text input with the argument
-   *  `{ nativeEvent: { text, previousText, range: { start, end } } }`.
-   *
-   * This prop requires multiline={true} to be set.
-   */
-  onTextInput?:
-    | ((e: NativeSyntheticEvent<TextInputTextInputEventData>) => void)
     | undefined;
 
   /**

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -36,7 +36,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onSelectionChange;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onChange;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onChangeSync;
-@property (nonatomic, copy, nullable) RCTDirectEventBlock onTextInput;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onScroll;
 
 @property (nonatomic, assign) NSInteger mostRecentEventCount;

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -502,17 +502,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
                                                                                         withString:text];
   }
 
-  if (_onTextInput) {
-    _onTextInput(@{
-      // We copy the string here because if it's a mutable string it may get released before we stop using it on a
-      // different thread, causing a crash.
-      @"text" : [text copy],
-      @"previousText" : previousText,
-      @"range" : @{@"start" : @(range.location), @"end" : @(range.location + range.length)},
-      @"eventCount" : @(_nativeEventCount),
-    });
-  }
-
   return text; // Accepting the change.
 }
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
@@ -64,7 +64,6 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onKeyPressSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChangeSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onTextInput, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2281,14 +2281,6 @@ export type NativeProps = $ReadOnly<{|
       contentSize: $ReadOnly<{| width: Double, height: Double |}>,
     |}>,
   >,
-  onTextInput?: ?BubblingEventHandler<
-    $ReadOnly<{|
-      target: Int32,
-      text: string,
-      previousText: string,
-      range: $ReadOnly<{| start: Double, end: Double |}>,
-    |}>,
-  >,
   onEndEditing?: ?BubblingEventHandler<
     $ReadOnly<{| target: Int32, text: string |}>,
   >,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -234,11 +234,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                     "phasedRegistrationNames",
                     MapBuilder.of("bubbled", "onEndEditing", "captured", "onEndEditingCapture")))
             .put(
-                "topTextInput",
-                MapBuilder.of(
-                    "phasedRegistrationNames",
-                    MapBuilder.of("bubbled", "onTextInput", "captured", "onTextInputCapture")))
-            .put(
                 "topFocus",
                 MapBuilder.of(
                     "phasedRegistrationNames",


### PR DESCRIPTION
## Summary:

TextInputs' `onTextInput` callback was removed way back in React Native 0.62 with https://github.com/facebook/react-native/commit/3f7e0a2c9601fc186f25bfd794cd0008ac3983ab , but remnants of the implementation exists. Let's just remove it altogether?

## Changelog:

[IOS] [REMOVED] - Remove deprecated onTextInput callback

## Test Plan:

CI should pass
