### PR TITLE
Remove manual flattening of pointerEvents in View

### DIFF
--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -10,7 +10,6 @@
 
 import type {ViewProps} from './ViewPropTypes';
 
-import flattenStyle from '../../StyleSheet/flattenStyle';
 import TextAncestor from '../../Text/TextAncestor';
 import ViewNativeComponent from './ViewNativeComponent';
 import * as React from 'react';
@@ -53,7 +52,6 @@ const View: React.AbstractComponent<
       id,
       importantForAccessibility,
       nativeID,
-      pointerEvents,
       tabIndex,
       ...otherProps
     }: ViewProps,
@@ -96,12 +94,6 @@ const View: React.AbstractComponent<
       };
     }
 
-    // $FlowFixMe[underconstrained-implicit-instantiation]
-    let style = flattenStyle(otherProps.style);
-
-    // $FlowFixMe[sketchy-null-mixed]
-    const newPointerEvents = style?.pointerEvents || pointerEvents;
-
     const actualView = (
       <ViewNativeComponent
         {...otherProps}
@@ -120,9 +112,6 @@ const View: React.AbstractComponent<
             : importantForAccessibility
         }
         nativeID={id ?? nativeID}
-        style={style}
-        // $FlowFixMe[incompatible-type]
-        pointerEvents={newPointerEvents}
         ref={forwardedRef}
       />
     );

--- a/packages/react-native/Libraries/Components/View/__tests__/View-test.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-test.js
@@ -178,7 +178,6 @@ describe('View compat with web', () => {
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`
       <RCTView
-        pointerEvents="none"
         style={
           Object {
             "backgroundColor": "white",


### PR DESCRIPTION
Summary:
Confirmed in https://github.com/facebook/react/commit/d779eba4b375134f373b7dfb9ea98d01c84bc48e that style properties already take priority over direct props, so we can avoid flattening style here.

Changelog: [General][Fixed] Small performance tweak to View wrapper to avoid unnecessary style flattening.

Reviewed By: sammy-SC

Differential Revision: D56740899
