### PR TITLE
Fix Circle CI builds due to incorrect UnsupportedEnumDeclarationParserError import

### DIFF
--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -25,9 +25,8 @@ import type {
   TypeResolutionStatus,
 } from '../../utils';
 
-import {UnsupportedEnumDeclarationParserError} from '../../errors';
-
 const {
+  UnsupportedEnumDeclarationParserError,
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
 } = require('../../errors');


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The import style used
```
npm ERR! /home/circleci/react-native/packages/react-native-codegen/lib/parsers/typescript/modules/index.js:13
npm ERR! import {UnsupportedEnumDeclarationParserError} from '../../errors';
npm ERR! ^^^^^^
npm ERR!
npm ERR! SyntaxError: Cannot use import statement outside a module
npm ERR!     at internalCompileFunction (node:internal/vm:73:18)
npm ERR!     at wrapSafe (node:internal/modules/cjs/loader:1175:20)
npm ERR!     at Module._compile (node:internal/modules/cjs/loader:1219:27)
npm ERR!     at Module._extensions..js (node:internal/modules/cjs/loader:1309:10)
npm ERR!     at Module.load (node:internal/modules/cjs/loader:1113:32)
npm ERR!     at Module._load (node:internal/modules/cjs/loader:960:12)
npm ERR!     at Module.require (node:internal/modules/cjs/loader:1137:19)
npm ERR!     at require (node:internal/modules/helpers:121:18)
npm ERR!     at Object.<anonymous> (/home/circleci/react-native/packages/react-native-codegen/lib/parsers/typescript/parser.js:60:19)
npm ERR!     at Module._compile (node:internal/modules/cjs/loader:1255:14)
```
is not supported.

Differential Revision: D56809538
