### PR TITLE
Expose BaseJavaModule constructors through ViewManager

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3940,6 +3940,7 @@ public abstract interface class com/facebook/react/turbomodule/core/interfaces/T
 
 public abstract class com/facebook/react/uimanager/BaseViewManager : com/facebook/react/uimanager/ViewManager, android/view/View$OnLayoutChangeListener, com/facebook/react/uimanager/BaseViewManagerInterface {
 	public fun <init> ()V
+	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
 	public fun getExportedCustomBubblingEventTypeConstants ()Ljava/util/Map;
 	public fun getExportedCustomDirectEventTypeConstants ()Ljava/util/Map;
 	protected fun onAfterUpdateTransaction (Landroid/view/View;)V
@@ -5160,6 +5161,7 @@ public class com/facebook/react/uimanager/ViewGroupDrawingOrderHelper {
 
 public abstract class com/facebook/react/uimanager/ViewGroupManager : com/facebook/react/uimanager/BaseViewManager, com/facebook/react/uimanager/IViewGroupManager {
 	public fun <init> ()V
+	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
 	public synthetic fun addView (Landroid/view/View;Landroid/view/View;I)V
 	public fun addView (Landroid/view/ViewGroup;Landroid/view/View;I)V
 	public fun addViews (Landroid/view/ViewGroup;Ljava/util/List;)V
@@ -5182,6 +5184,7 @@ public abstract class com/facebook/react/uimanager/ViewGroupManager : com/facebo
 
 public abstract class com/facebook/react/uimanager/ViewManager : com/facebook/react/bridge/BaseJavaModule {
 	public fun <init> ()V
+	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
 	protected fun addEventEmitters (Lcom/facebook/react/uimanager/ThemedReactContext;Landroid/view/View;)V
 	public fun createShadowNodeInstance ()Lcom/facebook/react/uimanager/ReactShadowNode;
 	public fun createShadowNodeInstance (Lcom/facebook/react/bridge/ReactApplicationContext;)Lcom/facebook/react/uimanager/ReactShadowNode;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -19,6 +19,7 @@ import androidx.core.view.ViewCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
 import com.facebook.react.bridge.Dynamic;
+import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
@@ -53,6 +54,14 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final String STATE_BUSY = "busy";
   private static final String STATE_EXPANDED = "expanded";
   private static final String STATE_MIXED = "mixed";
+
+  public BaseViewManager() {
+    super(null);
+  }
+
+  public BaseViewManager(@Nullable ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
 
   @Override
   protected T prepareToRecycleView(@NonNull ThemedReactContext reactContext, T view) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
 import java.util.List;
 import java.util.WeakHashMap;
@@ -21,6 +22,14 @@ public abstract class ViewGroupManager<T extends ViewGroup>
     extends BaseViewManager<T, LayoutShadowNode> implements IViewGroupManager<T> {
 
   private static WeakHashMap<View, Integer> mZIndexHash = new WeakHashMap<>();
+
+  public ViewGroupManager() {
+    super(null);
+  }
+
+  public ViewGroupManager(@Nullable ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
 
   @Override
   public LayoutShadowNode createShadowNodeInstance() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -46,6 +46,14 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    */
   @Nullable private HashMap<Integer, Stack<T>> mRecyclableViews = null;
 
+  public ViewManager() {
+    super(null);
+  }
+
+  public ViewManager(@Nullable ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
+
   /** Call in constructor of concrete ViewManager class to enable. */
   protected void setupViewRecycling() {
     if (ReactFeatureFlags.enableViewRecycling) {


### PR DESCRIPTION
Summary:
ViewManagers are all BaseJavaModule, and thus have access to methods like `getReactApplicationContext`. We don't expose the appropriate constructors though to pass this context down from the base class.

Not a breaking change, as the no-arg constructor is still used implicitly.

Changelog: [Android][Fixed] ViewManagers can pass context to their base class.

Differential Revision: D56804318
