### PR TITLE
RN: Configure `no-string-refs` as Error

### DIFF
--- a/packages/eslint-config-react-native/index.js
+++ b/packages/eslint-config-react-native/index.js
@@ -312,7 +312,7 @@ module.exports = {
     'react/no-did-mount-set-state': 1,
     'react/no-did-update-set-state': 1,
     'react/no-multi-comp': 0,
-    'react/no-string-refs': 1,
+    'react/no-string-refs': 2,
     'react/no-unknown-property': 0,
     'react/no-unstable-nested-components': 1,
     'react/prop-types': 0,


### PR DESCRIPTION
Summary:
In a future release of React Native, string refs will no longer be supported. This increases the severity of the `no-string-refs` lint rule to convey this.

Changelog:
[General][Changed] - `no-string-refs` is now a lint error

Reviewed By: kassens

Differential Revision: D56826663
