### PR TITLE
conditional Babel registration no longer necessary

### DIFF
--- a/packages/community-cli-plugin/src/index.js
+++ b/packages/community-cli-plugin/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');

--- a/packages/core-cli-utils/src/index.js
+++ b/packages/core-cli-utils/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');

--- a/packages/core-cli-utils/src/public/version.js
+++ b/packages/core-cli-utils/src/public/version.js
@@ -13,8 +13,6 @@
 export type * from './version.flow';
 */
 
-if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
-  require('../../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./version.flow');

--- a/packages/dev-middleware/src/index.js
+++ b/packages/dev-middleware/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
-export * from './index.flow';
+module.exports = require('./index.flow');

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');


### PR DESCRIPTION
Summary:
Packages that are built and directly run in the monorepo no longer need to worry about
conditionally registering themselves to transpile Flow -> JS at runtime. Our build step
strips this file now.

Differential Revision: D56839521
