### PR TITLE
Fix onKeyLongPress() in RELEASE

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -221,11 +221,13 @@ public class ReactDelegate {
 
   public boolean onKeyLongPress(int keyCode) {
     if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
-      if (ReactFeatureFlags.enableBridgelessArchitecture
-          && mReactHost != null
-          && mReactHost.getDevSupportManager() != null) {
-        mReactHost.getDevSupportManager().showDevOptionsDialog();
-        return true;
+      if (ReactFeatureFlags.enableBridgelessArchitecture && mReactHost != null) {
+        DevSupportManager devSupportManager = mReactHost.getDevSupportManager();
+        // onKeyLongPress is a Dev API and not supported in RELEASE mode.
+        if (devSupportManager != null && !(devSupportManager instanceof ReleaseDevSupportManager)) {
+          devSupportManager.showDevOptionsDialog();
+          return true;
+        }
       } else {
         if (getReactNativeHost().hasInstance() && getReactNativeHost().getUseDeveloperSupport()) {
           getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();


### PR DESCRIPTION
Summary:
In RELEASE mode, the `devSupportManager` received is ReleaseDevSupportManager for which `showDevOptionsDialog()` is a no-op
https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java#L66

Which is expected since this is a capability only in Dev mode(useDeveloperSupport = true). However, ATM `onKeyLongPresss()` returns true in RELEASE as well which is a bug.

Since there is no need for `onKeyLongPress()` in RELEASE, changing it's logic to introduce that check and return false in case of RELEASE.

Changelog:
[Android][Fixed] onKeyLongPress() in RELEASE mode

Differential Revision: D56850466
