### PR TITLE
add forward compatibility for bridgeless CallInvoker API

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeModuleDecorator.m
+++ b/packages/react-native/React/Base/RCTBridgeModuleDecorator.m
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "RCTBridgeModuleDecorator.h"
+#import "RCTBridgeModuleDecorator.h"
 
 @implementation RCTBridgeModuleDecorator
 

--- a/packages/react-native/React/Base/RCTModuleData.h
+++ b/packages/react-native/React/Base/RCTModuleData.h
@@ -12,12 +12,20 @@
 @protocol RCTBridgeMethod;
 @protocol RCTBridgeModule;
 @class RCTBridge;
+@class RCTModuleData;
 @class RCTModuleRegistry;
 @class RCTViewRegistry;
 @class RCTBundleManager;
 @class RCTCallableJSModules;
+@class RCTCallInvoker;
 
 typedef id<RCTBridgeModule> (^RCTBridgeModuleProvider)(void);
+
+@protocol RCTModuleDataCallInvokerProvider <NSObject>
+
+- (RCTCallInvoker *)callInvokerForModuleData:(RCTModuleData *)moduleData;
+
+@end
 
 @interface RCTModuleData : NSObject <RCTInvalidating>
 
@@ -27,14 +35,6 @@ typedef id<RCTBridgeModule> (^RCTBridgeModuleProvider)(void);
             viewRegistry_DEPRECATED:(RCTViewRegistry *)viewRegistry_DEPRECATED
                       bundleManager:(RCTBundleManager *)bundleManager
                   callableJSModules:(RCTCallableJSModules *)callableJSModules;
-
-- (instancetype)initWithModuleClass:(Class)moduleClass
-                     moduleProvider:(RCTBridgeModuleProvider)moduleProvider
-                             bridge:(RCTBridge *)bridge
-                     moduleRegistry:(RCTModuleRegistry *)moduleRegistry
-            viewRegistry_DEPRECATED:(RCTViewRegistry *)viewRegistry_DEPRECATED
-                      bundleManager:(RCTBundleManager *)bundleManager
-                  callableJSModules:(RCTCallableJSModules *)callableJSModules NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithModuleInstance:(id<RCTBridgeModule>)instance
                                 bridge:(RCTBridge *)bridge
@@ -109,5 +109,7 @@ typedef id<RCTBridgeModule> (^RCTBridgeModuleProvider)(void);
  * -partialBatchDidFlush.
  */
 @property (nonatomic, assign, readonly) BOOL implementsPartialBatchDidFlush;
+
+@property (nonatomic, weak, readwrite) id<RCTModuleDataCallInvokerProvider> callInvokerProvider;
 
 @end

--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -16,6 +16,7 @@
 #import "RCTBridge+Private.h"
 #import "RCTBridge.h"
 #import "RCTBridgeModuleDecorator.h"
+#import "RCTCallInvokerModule.h"
 #import "RCTConstants.h"
 #import "RCTInitializing.h"
 #import "RCTLog.h"
@@ -87,24 +88,24 @@ int32_t getUniqueId()
                       bundleManager:(RCTBundleManager *)bundleManager
                   callableJSModules:(RCTCallableJSModules *)callableJSModules
 {
-  return [self initWithModuleClass:moduleClass
-                    moduleProvider:^id<RCTBridgeModule> {
-                      return [moduleClass new];
-                    }
-                            bridge:bridge
-                    moduleRegistry:moduleRegistry
-           viewRegistry_DEPRECATED:viewRegistry_DEPRECATED
-                     bundleManager:bundleManager
-                 callableJSModules:callableJSModules];
+  return [self _initWithModuleClass:moduleClass
+                     moduleProvider:^id<RCTBridgeModule> {
+                       return [moduleClass new];
+                     }
+                             bridge:bridge
+                     moduleRegistry:moduleRegistry
+            viewRegistry_DEPRECATED:viewRegistry_DEPRECATED
+                      bundleManager:bundleManager
+                  callableJSModules:callableJSModules];
 }
 
-- (instancetype)initWithModuleClass:(Class)moduleClass
-                     moduleProvider:(RCTBridgeModuleProvider)moduleProvider
-                             bridge:(RCTBridge *)bridge
-                     moduleRegistry:(RCTModuleRegistry *)moduleRegistry
-            viewRegistry_DEPRECATED:(RCTViewRegistry *)viewRegistry_DEPRECATED
-                      bundleManager:(RCTBundleManager *)bundleManager
-                  callableJSModules:(RCTCallableJSModules *)callableJSModules
+- (instancetype)_initWithModuleClass:(Class)moduleClass
+                      moduleProvider:(RCTBridgeModuleProvider)moduleProvider
+                              bridge:(RCTBridge *)bridge
+                      moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+             viewRegistry_DEPRECATED:(RCTViewRegistry *)viewRegistry_DEPRECATED
+                       bundleManager:(RCTBundleManager *)bundleManager
+                   callableJSModules:(RCTCallableJSModules *)callableJSModules
 {
   if (self = [super init]) {
     _bridge = bridge;
@@ -201,6 +202,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
                                                    bundleManager:_bundleManager
                                                callableJSModules:_callableJSModules];
       [moduleDecorator attachInteropAPIsToModule:_instance];
+
+      // This is a more performant alternative for conformsToProtocol:@protocol(RCTCallInvokerModule)
+      if ([_instance respondsToSelector:@selector(setCallInvoker:)]) {
+        [(id<RCTCallInvokerModule>)_instance setCallInvoker:[self.callInvokerProvider callInvokerForModuleData:self]];
+      }
     }
 
     [self setUpMethodQueue];

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -15,6 +15,7 @@
 #import <React/RCTBridgeMethod.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBridgeModuleDecorator.h>
+#import <React/RCTCallInvoker.h>
 #import <React/RCTConstants.h>
 #import <React/RCTConvert.h>
 #import <React/RCTCxxBridgeDelegate.h>
@@ -168,7 +169,7 @@ static void registerPerformanceLoggerHooks(RCTPerformanceLogger *performanceLogg
   };
 }
 
-@interface RCTCxxBridge ()
+@interface RCTCxxBridge () <RCTModuleDataCallInvokerProvider>
 
 @property (nonatomic, weak, readonly) RCTBridge *parentBridge;
 @property (nonatomic, assign, readonly) BOOL moduleSetupComplete;
@@ -767,6 +768,7 @@ struct RCTInstanceCallback : public InstanceCallback {
                                     viewRegistry_DEPRECATED:_viewRegistry_DEPRECATED
                                               bundleManager:_bundleManager
                                           callableJSModules:_callableJSModules];
+    moduleData.callInvokerProvider = self;
     BridgeNativeModulePerfLogger::moduleDataCreateEnd([moduleName UTF8String], moduleDataId);
 
     _moduleDataByName[moduleName] = moduleData;
@@ -1593,6 +1595,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
     (std::shared_ptr<NativeMethodCallInvoker>)nativeInvoker
 {
   return _reactInstance ? _reactInstance->getDecoratedNativeMethodCallInvoker(nativeInvoker) : nullptr;
+}
+
+#pragma mark - RCTModuleDataCallInvokerProvider
+
+- (RCTCallInvoker *)callInvokerForModuleData:(RCTModuleData *)moduleData
+{
+  return [[RCTCallInvoker alloc] initWithCallInvoker:self.jsCallInvoker];
 }
 
 @end


### PR DESCRIPTION
Summary:
Changelog: [Internal]

In order to make migration a little bit cleaner, I thought it would be nice to implement forward compatibility for RCTCallInvokerModule. This way, the consumer doesn't have to have branching logic when they try to retrieve the callInvoker in their code, and can remove a callsite to the bridge.

Differential Revision: D56807993
