### PR TITLE
introduce CallInvoker API for bridgeless modules

### DIFF
--- a/packages/react-native/React/Base/RCTCallInvoker.h
+++ b/packages/react-native/React/Base/RCTCallInvoker.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+#import <ReactCommon/CallInvoker.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTCallInvoker : NSObject
+
+#ifdef __cplusplus
+- (instancetype)initWithCallInvoker:(std::shared_ptr<facebook::react::CallInvoker>)callInvoker
+    NS_DESIGNATED_INITIALIZER;
+
+- (std::shared_ptr<facebook::react::CallInvoker>)callInvoker;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/RCTCallInvoker.mm
+++ b/packages/react-native/React/Base/RCTCallInvoker.mm
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTCallInvoker.h"
+
+@implementation RCTCallInvoker {
+  std::shared_ptr<facebook::react::CallInvoker> _callInvoker;
+}
+
+- (instancetype)initWithCallInvoker:(std::shared_ptr<facebook::react::CallInvoker>)callInvoker
+{
+  if (self = [super init]) {
+    _callInvoker = callInvoker;
+  }
+
+  return self;
+}
+
+- (std::shared_ptr<facebook::react::CallInvoker>)callInvoker
+{
+  return _callInvoker;
+}
+
+@end

--- a/packages/react-native/React/Base/RCTCallInvokerModule.h
+++ b/packages/react-native/React/Base/RCTCallInvokerModule.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@class RCTCallInvoker;
+
+/**
+ * Have your module conform to this protocol to access the CallInvoker.
+ */
+@protocol RCTCallInvokerModule <NSObject>
+
+@property (nonatomic, nullable, readwrite) RCTCallInvoker *callInvoker;
+
+@end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -19,6 +19,8 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBridgeProxy.h>
+#import <React/RCTCallInvoker.h>
+#import <React/RCTCallInvokerModule.h>
 #import <React/RCTConstants.h>
 #import <React/RCTCxxModule.h>
 #import <React/RCTInitializing.h>
@@ -695,6 +697,12 @@ typedef struct {
     RCTRuntimeExecutor *runtimeExecutor = [[RCTRuntimeExecutor alloc]
         initWithRuntimeExecutor:[_runtimeHandler runtimeExecutorForTurboModuleManager:self]];
     [(id<RCTRuntimeExecutorModule>)module setRuntimeExecutor:runtimeExecutor];
+  }
+
+  // This is a more performant alternative for conformsToProtocol:@protocol(RCTCallInvokerModule)
+  if ([module respondsToSelector:@selector(setCallInvoker:)]) {
+    RCTCallInvoker *callInvoker = [[RCTCallInvoker alloc] initWithCallInvoker:_jsInvoker];
+    [(id<RCTCallInvokerModule>)module setCallInvoker:callInvoker];
   }
 
   /**


### PR DESCRIPTION
Summary:
Changelog: [iOS][Added] introduce CallInvoker support in bridgeless native modules

I am adding this API in favor of RCTRuntimeExecutor. CallInvoker is now preferred because after #43375, the CallInvoker has access to the jsi::Runtime. Since the community is using CallInvoker already for their async access use cases, CallInvoker is the preferred choice of RuntimeExecutor / RuntimeScheduler because of easier migration. Also, having a wrapper like CallInvoker will give us more flexibility in the future if we want to expand this API.

Differential Revision: D56807994
