### PR TITLE
introduce CallInvokerHolder stable API

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1071,6 +1071,7 @@ public abstract class com/facebook/react/bridge/ReactContext : android/content/C
 	public fun getCurrentActivity ()Landroid/app/Activity;
 	public fun getExceptionHandler ()Lcom/facebook/react/bridge/JSExceptionHandler;
 	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
+	public fun getJSCallInvokerHolder ()Lcom/facebook/react/turbomodule/core/interfaces/CallInvokerHolder;
 	public fun getJSExceptionHandler ()Lcom/facebook/react/bridge/JSExceptionHandler;
 	public fun getJSMessageQueueThread ()Lcom/facebook/react/bridge/queue/MessageQueueThread;
 	public fun getJSModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/JavaScriptModule;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
@@ -118,6 +118,7 @@ public interface CatalystInstance
    * Returns a hybrid object that contains a pointer to a JS CallInvoker, which is used to schedule
    * work on the JS Thread. Required for TurboModuleManager initialization.
    */
+  @Deprecated
   CallInvokerHolder getJSCallInvokerHolder();
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -27,6 +27,7 @@ import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
+import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -577,6 +578,17 @@ public abstract class ReactContext extends ContextWrapper {
   public @Nullable JavaScriptContextHolder getJavaScriptContextHolder() {
     if (mCatalystInstance != null) {
       return mCatalystInstance.getJavaScriptContextHolder();
+    }
+    return null;
+  }
+
+  /**
+   * Returns a hybrid object that contains a pointer to a JS CallInvoker, which is used to schedule
+   * work on the JS Thread.
+   */
+  public @Nullable CallInvokerHolder getJSCallInvokerHolder() {
+    if (mCatalystInstance != null) {
+      return mCatalystInstance.getJSCallInvokerHolder();
     }
     return null;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -26,6 +26,7 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcherProvider;
 import java.lang.reflect.InvocationHandler;
@@ -167,6 +168,11 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   @Override
   public void handleException(Exception e) {
     mReactHost.handleHostException(e);
+  }
+
+  @Override
+  public @Nullable CallInvokerHolder getJSCallInvokerHolder() {
+    return mReactHost.getJSCallInvokerHolder();
   }
 
   DefaultHardwareBackBtnHandler getDefaultHardwareBackBtnHandler() {


### PR DESCRIPTION
Summary:
Changelog: [Android][Added]

I am adding this API in favor of RCTRuntimeExecutor. CallInvoker is now preferred because after #43375, the CallInvoker has access to the jsi::Runtime. Since the community is using CallInvoker already for their async access use cases, CallInvoker is the preferred choice of RuntimeExecutor / RuntimeScheduler because of easier migration. Also, having a wrapper like CallInvoker will give us more flexibility in the future if we want to expand this API.

this will be forward compatible in the old architecture

Differential Revision: D56866817
