### PR TITLE
Allow custom override for setColorScheme and utilize UIScreen.mainScreen for default fallback

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAppearance.h
+++ b/packages/react-native/React/CoreModules/RCTAppearance.h
@@ -11,8 +11,12 @@
 #import <React/RCTConvert.h>
 #import <React/RCTEventEmitter.h>
 
+typedef void (^rct_color_scheme_change_callback_t)(NSString *);
+
 RCT_EXTERN void RCTEnableAppearancePreference(BOOL enabled);
 RCT_EXTERN void RCTOverrideAppearancePreference(NSString *const);
+RCT_EXTERN void RCTAddColorSchemeChangeCallback(rct_color_scheme_change_callback_t callback);
+RCT_EXTERN void RCTUseUIMainScreenForSystemStyle(BOOL useMainScreen);
 RCT_EXTERN NSString *RCTCurrentOverrideAppearancePreference();
 RCT_EXTERN NSString *RCTColorSchemePreference(UITraitCollection *traitCollection);
 


### PR DESCRIPTION
Summary:
This diff introduces two configurable APIs for the RCTAppearance module.

1. It allows a custom handler when setColorScheme() is called
2. It allows the default fallback style to be grabbed from UIScreen.mainScreen. Previously with the TraitCollections being passed in from overridden views it was not getting the accurate system fallback.

We need this for Twilight, which is adopting a Light/Dark mode toggle. Previously when setColorScheme was getting called it would modify overrideUserInterfaceStyle and that would serve as the "default fallback" for future setColorScheme calls. setColorScheme shouldn't be setting the defaults, it should be setting the user-session theme preference.

Changelog:
[Internal] [Changed] - Added option for custom Appearance setColorScheme() handler and treating the UIScreen.mainScreen's userInterfaceStyle as the source of truth for the system's dark/light mode.

Differential Revision: D56868862
