### PR TITLE
Remove BUILD_EXCLUDE_BABEL_REGISTER

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -38,16 +38,6 @@ const {only: _, ...nodeBabelOptions} = metroBabelRegister.config([]);
 require('../scripts/build/babel-register').registerForMonorepo();
 const transformer = require('@react-native/metro-babel-transformer');
 
-// Set BUILD_EXCLUDE_BABEL_REGISTER (see ../scripts/build/babel-register.js) to
-// prevent inline Babel registration in code under test, normally required when
-// running from source, but not in combination with the Jest transformer.
-const babelPluginPreventBabelRegister = [
-  require.resolve('babel-plugin-transform-define'),
-  {
-    'process.env.BUILD_EXCLUDE_BABEL_REGISTER': true,
-  },
-];
-
 module.exports = {
   process(src /*: string */, file /*: string */) /*: {code: string, ...} */ {
     if (nodeFiles.test(file)) {
@@ -56,10 +46,7 @@ module.exports = {
         filename: file,
         sourceType: 'script',
         ...nodeBabelOptions,
-        plugins: [
-          ...(nodeBabelOptions.plugins ?? []),
-          babelPluginPreventBabelRegister,
-        ],
+        plugins: [...(nodeBabelOptions.plugins ?? [])],
         ast: false,
       });
     }
@@ -92,7 +79,6 @@ module.exports = {
       plugins: [
         // TODO(moti): Replace with require('metro-transform-plugins').inlineRequiresPlugin when available in OSS
         require('babel-preset-fbjs/plugins/inline-requires'),
-        babelPluginPreventBabelRegister,
       ],
       sourceType: 'module',
     });

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@typescript-eslint/parser": "^7.1.1",
     "ansi-styles": "^4.2.1",
     "babel-plugin-minify-dead-code-elimination": "^0.5.2",
-    "babel-plugin-transform-define": "^2.1.2",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "babel-preset-fbjs": "^3.4.0",
     "chalk": "^4.0.0",

--- a/packages/community-cli-plugin/src/index.js
+++ b/packages/community-cli-plugin/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');

--- a/packages/core-cli-utils/index.js.flow
+++ b/packages/core-cli-utils/index.js.flow
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+export * from './src';

--- a/packages/core-cli-utils/package.json
+++ b/packages/core-cli-utils/package.json
@@ -3,7 +3,6 @@
   "version": "0.75.0-main",
   "description": "React Native CLI library for Frameworks to build on",
   "license": "MIT",
-  "main": "./src/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/react-native.git",

--- a/packages/core-cli-utils/src/index.js
+++ b/packages/core-cli-utils/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');

--- a/packages/core-cli-utils/src/public/version.js
+++ b/packages/core-cli-utils/src/public/version.js
@@ -13,8 +13,6 @@
 export type * from './version.flow';
 */
 
-if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
-  require('../../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./version.flow');

--- a/packages/dev-middleware/src/index.js
+++ b/packages/dev-middleware/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
-export * from './index.flow';
+module.exports = require('./index.flow');

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');

--- a/scripts/build/babel-register.js
+++ b/scripts/build/babel-register.js
@@ -20,15 +20,18 @@ let isRegisteredForMonorepo = false;
  * developing in the React Native repo.
  *
  * A call should located in each entry point file in a package (i.e. for all
- * paths in "exports"), inside a special `if` condition that will be compiled
- * away on build.
+ * paths in "exports"):
  *
- *   if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
- *     require('../../../scripts/build/babel-register').registerForMonorepo();
- *   }
+ *   require('../../../scripts/build/babel-register').registerForMonorepo();
  */
 function registerForMonorepo() {
   if (isRegisteredForMonorepo) {
+    return;
+  }
+
+  if (process.env.JEST_WORKER_ID != null) {
+    // Code under test doesn't need inline transformation, already handled by the
+    // Jest transformer.
     return;
   }
 

--- a/scripts/build/babel/node.config.js
+++ b/scripts/build/babel/node.config.js
@@ -29,12 +29,6 @@ const config /*: BabelCoreOptions */ = {
   ],
   plugins: [
     [
-      require.resolve('babel-plugin-transform-define'),
-      {
-        'process.env.BUILD_EXCLUDE_BABEL_REGISTER': true,
-      },
-    ],
-    [
       require.resolve('babel-plugin-minify-dead-code-elimination'),
       {keepFnName: true, keepFnArgs: true, keepClassName: true},
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,14 +3596,6 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
-babel-plugin-transform-define@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-define/-/babel-plugin-transform-define-2.1.2.tgz#d23e692cf14c68af90ca81500cd953f84678ca28"
-  integrity sha512-kiIiwIRiOVvSChdXg0efxsP+I7e7kLQUoZDHY+gbDIq7r4FcvXlYClWbbDzoeTGxDkiuivQvbQ4uOEaTIGHoKw==
-  dependencies:
-    lodash "^4.17.11"
-    traverse "0.6.6"
-
 babel-plugin-transform-flow-enums@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz#d1d0cc9bdc799c850ca110d0ddc9f21b9ec3ef25"
@@ -9384,11 +9376,6 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
-traverse@0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
-  integrity sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==
 
 ts-api-utils@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
Summary: Cleaning up this env, which became redundant after D56762162.  We do, however still check if running under Jest to skip inline transpilation if [process.env.JEST_WORKER_ID](https://jestjs.io/docs/environment-variables#jest_worker_id) exists.

Differential Revision: D56879413
