### PR TITLE
Add experiment to configure internal debugger branding

### DIFF
--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -129,5 +129,6 @@ function getExperiments(config: ExperimentsConfig): Experiments {
     enableNewDebugger: config.enableNewDebugger ?? false,
     enableOpenDebuggerRedirect: config.enableOpenDebuggerRedirect ?? false,
     enableNetworkInspector: config.enableNetworkInspector ?? false,
+    useFuseboxInternalBranding: config.useFuseboxInternalBranding ?? false,
   };
 }

--- a/packages/dev-middleware/src/types/Experiments.js
+++ b/packages/dev-middleware/src/types/Experiments.js
@@ -28,6 +28,12 @@ export type Experiments = $ReadOnly<{
    * Enables the Network panel when launching the custom debugger frontend.
    */
   enableNetworkInspector: boolean,
+
+  /**
+   * [Meta-internal] Controls visibility of the internal "Fusebox" codename
+   * across the UI when using the modern `rn_fusebox` entry point.
+   */
+  useFuseboxInternalBranding: boolean,
 }>;
 
 export type ExperimentsConfig = Partial<Experiments>;

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -44,6 +44,12 @@ export default function getDevToolsFrontendUrl(
   if (experiments.enableNetworkInspector) {
     searchParams.append('unstable_enableNetworkPanel', 'true');
   }
+  if (
+    options?.useFuseboxEntryPoint === true &&
+    experiments.useFuseboxInternalBranding
+  ) {
+    searchParams.append('unstable_useInternalBranding', 'true');
+  }
   if (options?.launchId != null && options.launchId !== '') {
     searchParams.append('launchId', options.launchId);
   }


### PR DESCRIPTION
Summary:
Towards the open source rollout of the `rn_fusebox.ts` entry point.

NOTE: Requires https://github.com/facebookexperimental/rn-chrome-devtools-frontend/pull/59, but can (and should) be landed safely beforehand.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D56883040
