### PR TITLE
Hotfix privacy manifest aggregation script

### DIFF
--- a/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
+++ b/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
@@ -77,6 +77,10 @@ module PrivacyManifestUtils
     end
 
     def self.get_privacyinfo_file_path(user_project)
+        existing_file = user_project.files.find { |file_ref| file_ref.path.end_with? "PrivacyInfo.xcprivacy" }
+        if existing_file
+            return existing_file.real_path
+        end
         # We try to find a file we know exists in the project to get the path to the main group directory
         info_plist_path = user_project.files.find { |file_ref| file_ref.name == "Info.plist" }
         if info_plist_path.nil?

--- a/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
+++ b/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
@@ -70,7 +70,7 @@ module PrivacyManifestUtils
         reference_exists = target.resources_build_phase.files_references.any? { |file_ref| file_ref.path.end_with? "PrivacyInfo.xcprivacy" }
         unless reference_exists
             # We try to find the main group, but if it doesn't exist, we default to adding the file to the project root – both work
-            file_root = user_project.root_object.main_group.children.find { |group| group.class == Xcodeproj::Project::Object::PBXGroup && group.name == target.name } || user_project
+            file_root = user_project.root_object.main_group.children.find { |group| group.class == Xcodeproj::Project::Object::PBXGroup && (group.name == target.name || group.path == target.name) } || user_project
             file_ref = file_root.new_file(file_path)
             build_file = target.resources_build_phase.add_file_reference(file_ref, true)
         end

--- a/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
+++ b/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
@@ -70,7 +70,7 @@ module PrivacyManifestUtils
         reference_exists = target.resources_build_phase.files_references.any? { |file_ref| file_ref.path.end_with? "PrivacyInfo.xcprivacy" }
         unless reference_exists
             # We try to find the main group, but if it doesn't exist, we default to adding the file to the project root – both work
-            file_root = user_project.root_object.main_group.children.first { |group| group.name == target.name } || user_project
+            file_root = user_project.root_object.main_group.children.find { |group| group.class == Xcodeproj::Project::Object::PBXGroup && group.name == target.name } || user_project
             file_ref = file_root.new_file(file_path)
             build_file = target.resources_build_phase.add_file_reference(file_ref, true)
         end


### PR DESCRIPTION
## Summary:

As pointed out by @liamjones here:
https://github.com/facebook/react-native/pull/44214#discussion_r1587755403

The original PR did introduce a bug in the `find/first` check, but in my testing, we do need to look at `group.name`, so let's make sure we check both.

This also makes it play nice with an existing file even if it is added to a different directory, by appending to it instead of forcing it to exist in the main group.

## Changelog:

(probably no entry?)

## Test Plan:

Tested on rn-tester
