### PR TITLE
ReactEventEmitter null fix

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.java
@@ -8,7 +8,6 @@
 package com.facebook.react.fabric.events;
 
 import android.annotation.SuppressLint;
-import androidx.annotation.NonNull;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
@@ -34,7 +33,7 @@ public final class EventBeatManager implements BatchEventDispatchedListener {
   private native void tick();
 
   @Deprecated(forRemoval = true, since = "Deprecated on v0.72.0 Use EventBeatManager() instead")
-  public EventBeatManager(@NonNull ReactApplicationContext reactApplicationContext) {
+  public EventBeatManager(ReactApplicationContext reactApplicationContext) {
     this();
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.java
@@ -8,8 +8,8 @@
 package com.facebook.react.fabric.events;
 
 import android.annotation.SuppressLint;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.NativeMap;
@@ -21,6 +21,7 @@ import com.facebook.react.uimanager.events.EventCategoryDef;
  * This class holds reference to the C++ EventEmitter object. Instances of this class are created in
  * FabricMountingManager.cpp, where the pointer to the C++ event emitter is set.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStrip
 @SuppressLint("MissingNativeLoadLibrary")
 public class EventEmitterWrapper {
@@ -37,9 +38,9 @@ public class EventEmitterWrapper {
   }
 
   private native void dispatchEvent(
-      @NonNull String eventName, @NonNull NativeMap params, @EventCategoryDef int category);
+      String eventName, @Nullable NativeMap params, @EventCategoryDef int category);
 
-  private native void dispatchUniqueEvent(@NonNull String eventName, @NonNull NativeMap params);
+  private native void dispatchUniqueEvent(String eventName, @Nullable NativeMap params);
 
   /**
    * Invokes the execution of the C++ EventEmitter.
@@ -48,9 +49,7 @@ public class EventEmitterWrapper {
    * @param params {@link WritableMap} payload of the event
    */
   public synchronized void dispatch(
-      @NonNull String eventName,
-      @Nullable WritableMap params,
-      @EventCategoryDef int eventCategory) {
+      String eventName, @Nullable WritableMap params, @EventCategoryDef int eventCategory) {
     if (!isValid()) {
       return;
     }
@@ -64,7 +63,7 @@ public class EventEmitterWrapper {
    * @param eventName {@link String} name of the event to execute.
    * @param params {@link WritableMap} payload of the event
    */
-  public synchronized void dispatchUnique(@NonNull String eventName, @Nullable WritableMap params) {
+  public synchronized void dispatchUnique(String eventName, @Nullable WritableMap params) {
     if (!isValid()) {
       return;
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.fabric.events;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.WritableArray;
@@ -22,14 +21,14 @@ import com.facebook.systrace.Systrace;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class FabricEventEmitter implements RCTModernEventEmitter {
 
-  @NonNull private final FabricUIManager mUIManager;
+  private final FabricUIManager mUIManager;
 
-  public FabricEventEmitter(@NonNull FabricUIManager uiManager) {
+  public FabricEventEmitter(FabricUIManager uiManager) {
     mUIManager = uiManager;
   }
 
   @Override
-  public void receiveEvent(int reactTag, @NonNull String eventName, @Nullable WritableMap params) {
+  public void receiveEvent(int reactTag, String eventName, @Nullable WritableMap params) {
     receiveEvent(ViewUtil.NO_SURFACE_ID, reactTag, eventName, params);
   }
 
@@ -61,9 +60,7 @@ public class FabricEventEmitter implements RCTModernEventEmitter {
   /** Touches are dispatched by {@link #receiveTouches(TouchEvent)} */
   @Override
   public void receiveTouches(
-      @NonNull String eventName,
-      @NonNull WritableArray touches,
-      @NonNull WritableArray changedIndices) {
+      String eventName, WritableArray touches, WritableArray changedIndices) {
     throw new UnsupportedOperationException(
         "EventEmitter#receiveTouches is not supported by Fabric");
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.java
@@ -142,8 +142,11 @@ class ReactEventEmitter implements RCTModernEventEmitter {
           customCoalesceKey,
           event,
           category);
-    } else if (uiManagerType == UIManagerType.DEFAULT && getDefaultEventEmitter() != null) {
-      mDefaultEventEmitter.receiveEvent(targetReactTag, eventName, event);
+    } else if (uiManagerType == UIManagerType.DEFAULT) {
+      RCTEventEmitter defaultEmitter = getDefaultEventEmitter();
+      if (defaultEmitter != null) {
+        defaultEmitter.receiveEvent(targetReactTag, eventName, event);
+      }
     } else {
       ReactSoftExceptionLogger.logSoftException(
           TAG,


### PR DESCRIPTION
Summary:
Lint fix - flip to a guaranteed non-null value instead of the nullable field

Changelog: [Internal]

Differential Revision: D56898951
