### PR TITLE
Add SocketRocket Security Policy Provider

### DIFF
--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.h
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef SRSecurityPolicy * _Nonnull (^SRSecurityPolicyProvider)(NSURLRequest *);
+typedef SRSecurityPolicy * __nullable (^SRSecurityPolicyProvider)(NSURLRequest * _Nonnull);
 
 RCT_EXTERN void RCTSetSRSecurityPolicyProvider(SRSecurityPolicyProvider);
 

--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.h
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.h
@@ -5,10 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <Foundation/Foundation.h>
 #import <React/RCTBridgeProxy.h>
 #import <React/RCTEventEmitter.h>
+#import <SocketRocket/SRWebSocket.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+typedef SRSecurityPolicy * _Nonnull (^SRSecurityPolicyProvider)(NSURLRequest *);
+
+RCT_EXTERN void RCTSetSRSecurityPolicyProvider(SRSecurityPolicyProvider);
 
 @protocol RCTWebSocketContentHandler <NSObject>
 

--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
@@ -100,12 +100,15 @@ RCT_EXPORT_METHOD(connect
   SRWebSocket *webSocket;
   if (securityPolicyProvider) {
     SRSecurityPolicy *securityPolicy = securityPolicyProvider(request);
-    webSocket = [[SRWebSocket alloc] initWithURLRequest:request protocols:protocols securityPolicy:securityPolicy];
+    if (securityPolicy) {
+      webSocket = [[SRWebSocket alloc] initWithURLRequest:request protocols:protocols securityPolicy:securityPolicy];
+    } else {
+      webSocket = [[SRWebSocket alloc] initWithURLRequest:request protocols:protocols];
+    }
   } else {
     webSocket = [[SRWebSocket alloc] initWithURLRequest:request protocols:protocols];
   }
   assert(webSocket != nil);
-
   [webSocket setDelegateDispatchQueue:[self methodQueue]];
   webSocket.delegate = self;
   webSocket.reactTag = @(socketID);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When you have a server that is under a Client Certificate logic, and has some connection to it using websockets, you can't provide the security policy to the instance created for the socket on `RCTWebSocketModule`.

Following what we have for `RCTNetworking` where you can inject a custom configuration for the `URLSession` created, these changes aim to implement a similar way to provide a custom handler for creating a Socket Rocket SecurityPolicy based on the request that will be sent through the socket.

```objc
SRSecurityPolicyProvider providerBlock = ^SRSecurityPolicy *(NSURLRequest *request) {
  if (request.URL == @"myclientcertificate.domain.com") {
    return ...;
  };
  return NULL;
}
  
RCTSetSRSecurityPolicyProvider(providerBlock);
```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [CHANGED] - Add SocketRocket Security Policy Provider

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [CHANGED] - Add SocketRocket Security Policy Provider

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I can't provide my own server with the client certificate here, but the important piece of code is above, this is a customization that is important to react-native developers, for Android we already have a way to customize the OkHttp instance being used by the socket, that [I proposed some time ago](https://github.com/facebook/react-native/pull/28659), so this new api will make it easier for developers to inject custom websocket security policies for iOS too, since they will not need to do any method swizzling or fork of react-native.
