### PR TITLE
Privacy manifest empty dict

### DIFF
--- a/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
+++ b/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
@@ -107,6 +107,7 @@ module PrivacyManifestUtils
                             accessed_api_types = content["NSPrivacyAccessedAPITypes"]
                             accessed_api_types.each do |accessed_api|
                                 api_type = accessed_api["NSPrivacyAccessedAPIType"]
+                                next unless api_type
                                 reasons = accessed_api["NSPrivacyAccessedAPITypeReasons"]
                                 used_apis[api_type] ||= []
                                 used_apis[api_type] += reasons

--- a/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
+++ b/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
@@ -99,21 +99,21 @@ module PrivacyManifestUtils
         installer.pod_targets.each do |pod_target|
             # puts pod_target
             pod_target.file_accessors.each do |file_accessor|
-            file_accessor.resource_bundles.each do |bundle_name, bundle_files|
-                bundle_files.each do |file_path|
-                # This needs to be named like that due to apple requirements
-                if File.basename(file_path) == 'PrivacyInfo.xcprivacy'
-                    content = Xcodeproj::Plist.read_from_path(file_path)
-                    accessed_api_types = content["NSPrivacyAccessedAPITypes"]
-                    accessed_api_types.each do |accessed_api|
-                    api_type = accessed_api["NSPrivacyAccessedAPIType"]
-                    reasons = accessed_api["NSPrivacyAccessedAPITypeReasons"]
-                    used_apis[api_type] ||= []
-                    used_apis[api_type] += reasons
+                file_accessor.resource_bundles.each do |bundle_name, bundle_files|
+                    bundle_files.each do |file_path|
+                        # This needs to be named like that due to apple requirements
+                        if File.basename(file_path) == 'PrivacyInfo.xcprivacy'
+                            content = Xcodeproj::Plist.read_from_path(file_path)
+                            accessed_api_types = content["NSPrivacyAccessedAPITypes"]
+                            accessed_api_types.each do |accessed_api|
+                                api_type = accessed_api["NSPrivacyAccessedAPIType"]
+                                reasons = accessed_api["NSPrivacyAccessedAPITypeReasons"]
+                                used_apis[api_type] ||= []
+                                used_apis[api_type] += reasons
+                            end
+                        end
                     end
                 end
-                end
-            end
             end
         end
         return used_apis


### PR DESCRIPTION
## Summary:

Fixes #44401 

0.74.1 Privacy polict aggregation can crash on strange policies

## Changelog:
[IOS] [FIXED] - pod update crash caused by empty dict in Privacy policy during aggregation

## Test Plan:
```bash
yarn add react-native-image-crop-picker
cd ios
pod update
```