### PR TITLE
remove "main" package.json entries and build step

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -57,6 +57,7 @@ munge_underscores=true
 module.name_mapper='^react-native$' -> '<PROJECT_ROOT>/packages/react-native/index.js'
 module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/packages/react-native/\1'
 module.name_mapper='^@react-native/dev-middleware$' -> '<PROJECT_ROOT>/packages/dev-middleware'
+module.name_mapper='^@react-native/core-cli-utils\(.*\)$' -> '<PROJECT_ROOT>/packages/core-cli-utils/\1'
 module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> '<PROJECT_ROOT>/packages/react-native/Libraries/Image/RelativeImageStub'
 
 suppress_type=$FlowIssue

--- a/packages/community-cli-plugin/src/index.js
+++ b/packages/community-cli-plugin/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');

--- a/packages/core-cli-utils/index.js.flow
+++ b/packages/core-cli-utils/index.js.flow
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+export * from './src';

--- a/packages/core-cli-utils/package.json
+++ b/packages/core-cli-utils/package.json
@@ -3,7 +3,6 @@
   "version": "0.75.0-main",
   "description": "React Native CLI library for Frameworks to build on",
   "license": "MIT",
-  "main": "./src/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/react-native.git",

--- a/packages/core-cli-utils/src/index.js
+++ b/packages/core-cli-utils/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');

--- a/packages/core-cli-utils/src/public/version.js
+++ b/packages/core-cli-utils/src/public/version.js
@@ -13,8 +13,6 @@
 export type * from './version.flow';
 */
 
-if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
-  require('../../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./version.flow');

--- a/packages/dev-middleware/src/index.js
+++ b/packages/dev-middleware/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
-export * from './index.flow';
+module.exports = require('./index.flow');

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -13,8 +13,6 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
-}
+require('../../../scripts/build/babel-register').registerForMonorepo();
 
 module.exports = require('./index.flow');

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -278,10 +278,6 @@ async function rewritePackageExports(packageName /*: string */) {
   }
   pkg.exports = rewriteExportsField(pkg.exports);
 
-  if (pkg.main != null) {
-    pkg.main = rewriteExportsTarget(pkg.main);
-  }
-
   await fs.writeFile(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
 }
 


### PR DESCRIPTION
Summary:
Conform to the style of other packages that are built using the monorepo build script, which don't use the `"main"` field.  Instead these utilise:

- root level `index.flow.js` → `src/`
- .flowconfig (both github and other) to resolve the module.

Changelog: [Internal]

Differential Revision: D56879279


