### PR TITLE
Add percentages for border-radius props

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4178,6 +4178,25 @@ public class com/facebook/react/uimanager/LayoutShadowNode$$PropsSetter : com/fa
 	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
+public final class com/facebook/react/uimanager/LengthPercentage {
+	public fun <init> ()V
+	public fun <init> (FLcom/facebook/react/uimanager/LengthPercentageType;)V
+	public synthetic fun <init> (FLcom/facebook/react/uimanager/LengthPercentageType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getUnit ()Lcom/facebook/react/uimanager/LengthPercentageType;
+	public final fun getValue ()F
+	public final fun setFromDynamic (Lcom/facebook/react/bridge/Dynamic;)V
+	public final fun setUnit (Lcom/facebook/react/uimanager/LengthPercentageType;)V
+	public final fun setValue (F)V
+}
+
+public final class com/facebook/react/uimanager/LengthPercentageType : java/lang/Enum {
+	public static final field PERCENT Lcom/facebook/react/uimanager/LengthPercentageType;
+	public static final field POINT Lcom/facebook/react/uimanager/LengthPercentageType;
+	public static final field UNDEFINED Lcom/facebook/react/uimanager/LengthPercentageType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/uimanager/LengthPercentageType;
+	public static fun values ()[Lcom/facebook/react/uimanager/LengthPercentageType;
+}
+
 public class com/facebook/react/uimanager/MatrixMathHelper {
 	public fun <init> ()V
 	public static fun applyPerspective ([DD)V
@@ -5484,7 +5503,7 @@ public class com/facebook/react/uimanager/drawable/CSSBackgroundDrawable : andro
 	public fun paddingBoxPath ()Landroid/graphics/Path;
 	public fun setAlpha (I)V
 	public fun setBorderColor (IFF)V
-	public fun setBorderRadius (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Ljava/lang/Float;)V
+	public fun setBorderRadius (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Lcom/facebook/react/uimanager/LengthPercentage;)V
 	public fun setBorderRadius (Lcom/facebook/react/uimanager/style/BorderRadiusStyle;)V
 	public fun setBorderStyle (Ljava/lang/String;)V
 	public fun setBorderWidth (IF)V
@@ -5804,56 +5823,56 @@ public final class com/facebook/react/uimanager/style/BorderRadiusProp : java/la
 
 public final class com/facebook/react/uimanager/style/BorderRadiusStyle {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;)V
-	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public synthetic fun <init> (Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;)V
-	public final fun component1 ()Ljava/lang/Float;
-	public final fun component10 ()Ljava/lang/Float;
-	public final fun component11 ()Ljava/lang/Float;
-	public final fun component12 ()Ljava/lang/Float;
-	public final fun component13 ()Ljava/lang/Float;
-	public final fun component2 ()Ljava/lang/Float;
-	public final fun component3 ()Ljava/lang/Float;
-	public final fun component4 ()Ljava/lang/Float;
-	public final fun component5 ()Ljava/lang/Float;
-	public final fun component6 ()Ljava/lang/Float;
-	public final fun component7 ()Ljava/lang/Float;
-	public final fun component8 ()Ljava/lang/Float;
-	public final fun component9 ()Ljava/lang/Float;
-	public final fun copy (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;)Lcom/facebook/react/uimanager/style/BorderRadiusStyle;
-	public static synthetic fun copy$default (Lcom/facebook/react/uimanager/style/BorderRadiusStyle;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;ILjava/lang/Object;)Lcom/facebook/react/uimanager/style/BorderRadiusStyle;
+	public final fun component1 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component10 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component11 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component12 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component13 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component2 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component3 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component4 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component5 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component6 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component7 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component8 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun component9 ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun copy (Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;)Lcom/facebook/react/uimanager/style/BorderRadiusStyle;
+	public static synthetic fun copy$default (Lcom/facebook/react/uimanager/style/BorderRadiusStyle;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;Lcom/facebook/react/uimanager/LengthPercentage;ILjava/lang/Object;)Lcom/facebook/react/uimanager/style/BorderRadiusStyle;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun get (Lcom/facebook/react/uimanager/style/BorderRadiusProp;)Ljava/lang/Float;
-	public final fun getBottomEnd ()Ljava/lang/Float;
-	public final fun getBottomLeft ()Ljava/lang/Float;
-	public final fun getBottomRight ()Ljava/lang/Float;
-	public final fun getBottomStart ()Ljava/lang/Float;
-	public final fun getEndEnd ()Ljava/lang/Float;
-	public final fun getEndStart ()Ljava/lang/Float;
-	public final fun getStartEnd ()Ljava/lang/Float;
-	public final fun getStartStart ()Ljava/lang/Float;
-	public final fun getTopEnd ()Ljava/lang/Float;
-	public final fun getTopLeft ()Ljava/lang/Float;
-	public final fun getTopRight ()Ljava/lang/Float;
-	public final fun getTopStart ()Ljava/lang/Float;
-	public final fun getUniform ()Ljava/lang/Float;
+	public final fun get (Lcom/facebook/react/uimanager/style/BorderRadiusProp;)Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getBottomEnd ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getBottomLeft ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getBottomRight ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getBottomStart ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getEndEnd ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getEndStart ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getStartEnd ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getStartStart ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getTopEnd ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getTopLeft ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getTopRight ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getTopStart ()Lcom/facebook/react/uimanager/LengthPercentage;
+	public final fun getUniform ()Lcom/facebook/react/uimanager/LengthPercentage;
 	public final fun hasRoundedBorders ()Z
 	public fun hashCode ()I
-	public final fun resolve (ILandroid/content/Context;)Lcom/facebook/react/uimanager/style/ComputedBorderRadius;
-	public final fun set (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Ljava/lang/Float;)V
-	public final fun setBottomEnd (Ljava/lang/Float;)V
-	public final fun setBottomLeft (Ljava/lang/Float;)V
-	public final fun setBottomRight (Ljava/lang/Float;)V
-	public final fun setBottomStart (Ljava/lang/Float;)V
-	public final fun setEndEnd (Ljava/lang/Float;)V
-	public final fun setEndStart (Ljava/lang/Float;)V
-	public final fun setStartEnd (Ljava/lang/Float;)V
-	public final fun setStartStart (Ljava/lang/Float;)V
-	public final fun setTopEnd (Ljava/lang/Float;)V
-	public final fun setTopLeft (Ljava/lang/Float;)V
-	public final fun setTopRight (Ljava/lang/Float;)V
-	public final fun setTopStart (Ljava/lang/Float;)V
-	public final fun setUniform (Ljava/lang/Float;)V
+	public final fun resolve (ILandroid/content/Context;FF)Lcom/facebook/react/uimanager/style/ComputedBorderRadius;
+	public final fun set (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setBottomEnd (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setBottomLeft (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setBottomRight (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setBottomStart (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setEndEnd (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setEndStart (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setStartEnd (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setStartStart (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setTopEnd (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setTopLeft (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setTopRight (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setTopStart (Lcom/facebook/react/uimanager/LengthPercentage;)V
+	public final fun setUniform (Lcom/facebook/react/uimanager/LengthPercentage;)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -7884,7 +7903,7 @@ public class com/facebook/react/views/view/ReactViewGroup : android/view/ViewGro
 	public fun setBorderColor (IFF)V
 	public fun setBorderRadius (F)V
 	public fun setBorderRadius (FI)V
-	public fun setBorderRadius (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Ljava/lang/Float;)V
+	public fun setBorderRadius (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Lcom/facebook/react/uimanager/LengthPercentage;)V
 	public fun setBorderStyle (Ljava/lang/String;)V
 	public fun setBorderWidth (IF)V
 	public fun setHitSlopRect (Landroid/graphics/Rect;)V
@@ -7920,6 +7939,7 @@ public class com/facebook/react/views/view/ReactViewManager : com/facebook/react
 	public fun setBackfaceVisibility (Lcom/facebook/react/views/view/ReactViewGroup;Ljava/lang/String;)V
 	public fun setBorderColor (Lcom/facebook/react/views/view/ReactViewGroup;ILjava/lang/Integer;)V
 	public fun setBorderRadius (Lcom/facebook/react/views/view/ReactViewGroup;IF)V
+	public fun setBorderRadius (Lcom/facebook/react/views/view/ReactViewGroup;ILcom/facebook/react/bridge/Dynamic;)V
 	public fun setBorderStyle (Lcom/facebook/react/views/view/ReactViewGroup;Ljava/lang/String;)V
 	public fun setBorderWidth (Lcom/facebook/react/views/view/ReactViewGroup;IF)V
 	public fun setCollapsable (Lcom/facebook/react/views/view/ReactViewGroup;Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+import com.facebook.common.logging.FLog
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableType
+import com.facebook.react.common.ReactConstants
+import com.facebook.yoga.YogaConstants
+import java.lang.NumberFormatException
+
+public enum class LengthPercentageType {
+  UNDEFINED,
+  POINT,
+  PERCENT,
+}
+
+public class LengthPercentage(
+    public var value: Float = YogaConstants.UNDEFINED,
+    public var unit: LengthPercentageType = LengthPercentageType.UNDEFINED,
+) {
+  public constructor() : this(YogaConstants.UNDEFINED, LengthPercentageType.UNDEFINED)
+
+  public fun setFromDynamic(dynamic: Dynamic) {
+    when (dynamic.getType()) {
+      ReadableType.Number -> {
+        unit = LengthPercentageType.POINT
+        value = PixelUtil.toPixelFromDIP(dynamic.asDouble())
+      }
+      ReadableType.String -> {
+        val s: String = dynamic.asString()
+        if (s.endsWith("%")) {
+          unit = LengthPercentageType.PERCENT
+          try {
+            value = s.substring(0, s.length - 1).toFloat()
+          } catch (e: NumberFormatException) {
+            unit = LengthPercentageType.UNDEFINED
+            value = YogaConstants.UNDEFINED
+            FLog.w(ReactConstants.TAG, "Invalid percentage format: $s")
+          }
+        } else {
+          FLog.w(ReactConstants.TAG, "Invalid string value: $s")
+          unit = LengthPercentageType.UNDEFINED
+          value = YogaConstants.UNDEFINED
+        }
+      }
+      else -> {
+        unit = LengthPercentageType.UNDEFINED
+        value = YogaConstants.UNDEFINED
+        FLog.w(ReactConstants.TAG, "Unsupported type for radius property: ${dynamic.getType()}")
+      }
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -27,10 +27,13 @@ import androidx.core.graphics.ColorUtils;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.FloatUtil;
+import com.facebook.react.uimanager.LengthPercentage;
+import com.facebook.react.uimanager.LengthPercentageType;
 import com.facebook.react.uimanager.Spacing;
 import com.facebook.react.uimanager.style.BorderRadiusProp;
 import com.facebook.react.uimanager.style.BorderRadiusStyle;
 import com.facebook.react.uimanager.style.ComputedBorderRadius;
+import com.facebook.yoga.YogaConstants;
 import java.util.Locale;
 
 /**
@@ -235,23 +238,28 @@ public class CSSBackgroundDrawable extends Drawable {
   }
 
   /**
-   * @deprecated Use {@link #setBorderRadius(BorderRadiusProp, Float)} instead.
+   * @deprecated Use {@link #setBorderRadius(BorderRadiusProp, LengthPercentage)} instead.
    */
   public void setRadius(float radius) {
-    @Nullable Float boxedRadius = Float.isNaN(radius) ? null : Float.valueOf(radius);
-    setBorderRadius(BorderRadiusProp.BORDER_RADIUS, boxedRadius);
+    Float boxedRadius = Float.isNaN(radius) ? YogaConstants.UNDEFINED : Float.valueOf(radius);
+    setBorderRadius(
+        BorderRadiusProp.BORDER_RADIUS,
+        new LengthPercentage(boxedRadius, LengthPercentageType.POINT));
   }
 
   /**
-   * @deprecated Use {@link #setBorderRadius(BorderRadiusProp, Float)} instead.
+   * @deprecated Use {@link #setBorderRadius(BorderRadiusProp, LengthPercentage)} instead.
    */
   public void setRadius(float radius, int position) {
-    @Nullable Float boxedRadius = Float.isNaN(radius) ? null : Float.valueOf(radius);
-    setBorderRadius(BorderRadiusProp.values()[position], boxedRadius);
+    Float boxedRadius = Float.isNaN(radius) ? YogaConstants.UNDEFINED : Float.valueOf(radius);
+    setBorderRadius(
+        BorderRadiusProp.values()[position],
+        new LengthPercentage(boxedRadius, LengthPercentageType.POINT));
   }
 
-  public void setBorderRadius(BorderRadiusProp property, @Nullable Float radius) {
-    if (!FloatUtil.floatsEqual(mBorderRadius.getUniform(), radius)) {
+  public void setBorderRadius(BorderRadiusProp property, LengthPercentage radius) {
+    if (mBorderRadius.getUniform() == null
+        || !FloatUtil.floatsEqual(mBorderRadius.getUniform().getValue(), radius.getValue())) {
       mBorderRadius.set(property, radius);
       mNeedUpdatePathForBorderRadius = true;
       invalidateSelf();
@@ -568,7 +576,12 @@ public class CSSBackgroundDrawable extends Drawable {
     mTempRectForCenterDrawPath.left += borderWidth.left * 0.5f;
     mTempRectForCenterDrawPath.right -= borderWidth.right * 0.5f;
 
-    ComputedBorderRadius radius = mBorderRadius.resolve(mLayoutDirection, mContext);
+    ComputedBorderRadius radius =
+        mBorderRadius.resolve(
+            mLayoutDirection,
+            mContext,
+            mOuterClipTempRectForBorderRadius.width(),
+            mOuterClipTempRectForBorderRadius.height());
     float topLeftRadius = radius.getTopLeft();
     float topRightRadius = radius.getTopRight();
     float bottomLeftRadius = radius.getBottomLeft();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderRadiusStyle.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderRadiusStyle.kt
@@ -10,6 +10,8 @@ package com.facebook.react.uimanager.style
 import android.content.Context
 import android.util.LayoutDirection
 import com.facebook.react.modules.i18nmanager.I18nUtil
+import com.facebook.react.uimanager.LengthPercentage
+import com.facebook.react.uimanager.LengthPercentageType
 
 /** Represents the collection of possible border radius style properties. */
 public enum class BorderRadiusProp {
@@ -30,25 +32,25 @@ public enum class BorderRadiusProp {
 
 /** Represents all logical properties and shorthands for border radius. */
 public data class BorderRadiusStyle(
-    var uniform: Float? = null,
-    var topLeft: Float? = null,
-    var topRight: Float? = null,
-    var bottomLeft: Float? = null,
-    var bottomRight: Float? = null,
-    var topStart: Float? = null,
-    var topEnd: Float? = null,
-    var bottomStart: Float? = null,
-    var bottomEnd: Float? = null,
-    var startStart: Float? = null,
-    var startEnd: Float? = null,
-    var endStart: Float? = null,
-    var endEnd: Float? = null
+    var uniform: LengthPercentage? = null,
+    var topLeft: LengthPercentage? = null,
+    var topRight: LengthPercentage? = null,
+    var bottomLeft: LengthPercentage? = null,
+    var bottomRight: LengthPercentage? = null,
+    var topStart: LengthPercentage? = null,
+    var topEnd: LengthPercentage? = null,
+    var bottomStart: LengthPercentage? = null,
+    var bottomEnd: LengthPercentage? = null,
+    var startStart: LengthPercentage? = null,
+    var startEnd: LengthPercentage? = null,
+    var endStart: LengthPercentage? = null,
+    var endEnd: LengthPercentage? = null
 ) {
-  public constructor(properties: List<Pair<BorderRadiusProp, Float>>) : this() {
+  public constructor(properties: List<Pair<BorderRadiusProp, LengthPercentage>>) : this() {
     properties.forEach { (k, v) -> set(k, v) }
   }
 
-  public fun set(property: BorderRadiusProp, value: Float?) {
+  public fun set(property: BorderRadiusProp, value: LengthPercentage?) {
     when (property) {
       BorderRadiusProp.BORDER_RADIUS -> uniform = value
       BorderRadiusProp.BORDER_TOP_LEFT_RADIUS -> topLeft = value
@@ -66,7 +68,7 @@ public data class BorderRadiusStyle(
     }
   }
 
-  public fun get(property: BorderRadiusProp): Float? {
+  public fun get(property: BorderRadiusProp): LengthPercentage? {
     return when (property) {
       BorderRadiusProp.BORDER_RADIUS -> uniform
       BorderRadiusProp.BORDER_TOP_LEFT_RADIUS -> topLeft
@@ -85,45 +87,87 @@ public data class BorderRadiusStyle(
   }
 
   public fun hasRoundedBorders(): Boolean {
-    return ((uniform ?: 0f) > 0f) ||
-        ((topLeft ?: 0f) > 0f) ||
-        ((topRight ?: 0f) > 0f) ||
-        ((bottomLeft ?: 0f) > 0f) ||
-        ((bottomRight ?: 0f) > 0f) ||
-        ((topStart ?: 0f) > 0f) ||
-        ((topEnd ?: 0f) > 0f) ||
-        ((bottomStart ?: 0f) > 0f) ||
-        ((bottomEnd ?: 0f) > 0f) ||
-        ((startStart ?: 0f) > 0f) ||
-        ((startEnd ?: 0f) > 0f) ||
-        ((endStart ?: 0f) > 0f) ||
-        ((endEnd ?: 0f) > 0f)
+    return ((uniform?.value ?: 0f) > 0f) ||
+        ((topLeft?.value ?: 0f) > 0f) ||
+        ((topRight?.value ?: 0f) > 0f) ||
+        ((bottomLeft?.value ?: 0f) > 0f) ||
+        ((bottomRight?.value ?: 0f) > 0f) ||
+        ((topStart?.value ?: 0f) > 0f) ||
+        ((topEnd?.value ?: 0f) > 0f) ||
+        ((bottomStart?.value ?: 0f) > 0f) ||
+        ((bottomEnd?.value ?: 0f) > 0f) ||
+        ((startStart?.value ?: 0f) > 0f) ||
+        ((startEnd?.value ?: 0f) > 0f) ||
+        ((endStart?.value ?: 0f) > 0f) ||
+        ((endEnd?.value ?: 0f) > 0f)
+  }
+
+  private fun percentToPoint(width: Float, height: Float) {
+    val borderRadiusVariables =
+        listOf(
+            uniform,
+            topLeft,
+            topRight,
+            bottomLeft,
+            bottomRight,
+            topStart,
+            topEnd,
+            bottomStart,
+            bottomEnd,
+            startStart,
+            startEnd,
+            endStart,
+            endEnd)
+    for (variable in borderRadiusVariables) {
+      variable?.let {
+        if (it.unit == LengthPercentageType.PERCENT && width != 0f && height != 0f) {
+          it.value = (it.value / 100) * Math.max(width, height)
+          it.unit = LengthPercentageType.POINT
+        }
+      }
+    }
   }
 
   public fun resolve(
       layoutDirection: Int,
       context: Context,
+      width: Float,
+      height: Float,
   ): ComputedBorderRadius {
+    percentToPoint(width, height)
+
+    val topLeft: Float =
+        startStart?.value ?: topStart?.value ?: topLeft?.value ?: uniform?.value ?: 0f
+    val topRight: Float =
+        endStart?.value ?: topEnd?.value ?: topRight?.value ?: uniform?.value ?: 0f
+    val bottomLeft: Float =
+        startEnd?.value ?: bottomStart?.value ?: bottomLeft?.value ?: uniform?.value ?: 0f
+    val bottomRight: Float =
+        endEnd?.value ?: bottomEnd?.value ?: bottomRight?.value ?: uniform?.value ?: 0f
+
     return when (layoutDirection) {
       LayoutDirection.LTR ->
           ComputedBorderRadius(
-              topLeft = startStart ?: topStart ?: topLeft ?: uniform ?: 0f,
-              topRight = endStart ?: topEnd ?: topRight ?: uniform ?: 0f,
-              bottomLeft = startEnd ?: bottomStart ?: bottomLeft ?: uniform ?: 0f,
-              bottomRight = endEnd ?: bottomEnd ?: bottomRight ?: uniform ?: 0f)
+              topLeft = topLeft,
+              topRight = topRight,
+              bottomLeft = bottomLeft,
+              bottomRight = bottomRight,
+          )
       LayoutDirection.RTL ->
           if (I18nUtil.getInstance().doLeftAndRightSwapInRTL(context)) {
             ComputedBorderRadius(
-                topLeft = endStart ?: topEnd ?: topRight ?: uniform ?: 0f,
-                topRight = startStart ?: topStart ?: topLeft ?: uniform ?: 0f,
-                bottomLeft = endEnd ?: bottomStart ?: bottomRight ?: uniform ?: 0f,
-                bottomRight = startEnd ?: bottomEnd ?: bottomLeft ?: uniform ?: 0f)
+                topLeft = topRight,
+                topRight = topLeft,
+                bottomLeft = bottomRight,
+                bottomRight = bottomLeft,
+            )
           } else {
             ComputedBorderRadius(
-                topLeft = endStart ?: topEnd ?: topLeft ?: uniform ?: 0f,
-                topRight = startStart ?: topStart ?: topRight ?: uniform ?: 0f,
-                bottomLeft = endEnd ?: bottomStart ?: bottomLeft ?: uniform ?: 0f,
-                bottomRight = startEnd ?: bottomEnd ?: bottomRight ?: uniform ?: 0f)
+                topLeft = topRight,
+                topRight = topLeft,
+                bottomLeft = bottomRight,
+                bottomRight = bottomLeft,
+            )
           }
       else -> throw IllegalArgumentException("Expected resolved layout direction")
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -37,6 +37,7 @@ import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.uimanager.IllegalViewOperationException;
+import com.facebook.react.uimanager.LengthPercentage;
 import com.facebook.react.uimanager.MeasureSpecAssertions;
 import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.ReactClippingProhibitedView;
@@ -332,7 +333,7 @@ public class ReactViewGroup extends ViewGroup
     backgroundDrawable.setRadius(borderRadius, position);
   }
 
-  public void setBorderRadius(BorderRadiusProp property, @Nullable Float borderRadius) {
+  public void setBorderRadius(BorderRadiusProp property, LengthPercentage borderRadius) {
     CSSBackgroundDrawable backgroundDrawable = getOrCreateReactViewBackground();
     backgroundDrawable.setBorderRadius(property, borderRadius);
   }
@@ -923,7 +924,9 @@ public class ReactViewGroup extends ViewGroup
             }
 
             final ComputedBorderRadius borderRadius =
-                mReactBackgroundDrawable.getBorderRadius().resolve(mLayoutDirection, getContext());
+                mReactBackgroundDrawable
+                    .getBorderRadius()
+                    .resolve(mLayoutDirection, getContext(), getWidth(), getHeight());
 
             if (borderRadius.hasRoundedBorders()) {
               if (mPath == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -21,6 +21,8 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.LengthPercentage;
+import com.facebook.react.uimanager.LengthPercentageType;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.Spacing;
@@ -30,6 +32,7 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.style.BorderRadiusProp;
 import com.facebook.yoga.YogaConstants;
 import java.util.Map;
 
@@ -128,6 +131,26 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
         ViewProps.BORDER_START_START_RADIUS,
       },
       defaultFloat = YogaConstants.UNDEFINED)
+  public void setBorderRadius(ReactViewGroup view, int index, Dynamic rawBorderRadius) {
+
+    LengthPercentage borderRadius = new LengthPercentage();
+
+    borderRadius.setFromDynamic(rawBorderRadius);
+    if ((borderRadius.getUnit() != LengthPercentageType.UNDEFINED)
+        && (borderRadius.getValue() < 0)) {
+      borderRadius.setValue(YogaConstants.UNDEFINED);
+    }
+
+    if (index == 0) {
+      view.setBorderRadius(BorderRadiusProp.BORDER_RADIUS, borderRadius);
+    } else {
+      view.setBorderRadius(BorderRadiusProp.values()[index - 1], borderRadius);
+    }
+  }
+
+  /**
+   * @deprecated Use {@link #setBorderRadius(ReactViewGroup, int, Dynamic)} instead.
+   */
   public void setBorderRadius(ReactViewGroup view, int index, float borderRadius) {
     if (!YogaConstants.isUndefined(borderRadius) && borderRadius < 0) {
       borderRadius = YogaConstants.UNDEFINED;


### PR DESCRIPTION
Summary:
Why?
Previously we didn't support using percentages like:
```
style={{
  width=100,
  height=100,
  borderRadius='100%',
}}
```

These percentages refer to the corresponding dimension of the border box.

What?
- Added LengthPercentage class and LengthPercentageType enum. To track when we are dealing with percentage vs points
- Now radius properties start as Dynamic which then get transformed into LengthPercentage.
- Modified certain function parameters so we can consider height and width when resolving BorderRadius values

With this we conditionally calculate the corresponding point (dp) value for a given percentage (considering size). Ex:

```
result = {raw_percentage_value} / 100 * (max(height, width))
```

We know the maximum border radius for our current implementation is half the dp of the shorter side of our view, hence why we consider half our maximum view side as equivalent to 100%.


Note: We still don't support vertical/horizontal border radii

## Changelog:

[Android][Added] - Added support for using percentages when defining border radius related properties.

Differential Revision: D56943825


