### PR TITLE
chore: Increase iOS script portability

### DIFF
--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -50,7 +50,7 @@ else
   export CC="$CC:-$(which gcc)"
   export CXX="$CXX:-$(which g++ || true)"
 fi
-export CXX="$CCX:-$CC"
+export CXX="$CXX:-$CC"
 
 # Remove automake symlink if it exists
 if [ -h "test-driver" ]; then

--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -42,6 +42,10 @@ EOF
     patch -p1 config.sub fix_glog_0.3.5_apple_silicon.patch
 fi
 
+XCRUN="$(which xcrun)"
+if [ -z "$XCRUN" ]; then
+  export CC="$(which gcc)"
+fi
 export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
 export CXX="$CC"
 

--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -43,11 +43,13 @@ EOF
 fi
 
 XCRUN="$(which xcrun)"
-if [ -z "$XCRUN" ]; then
-  export CC="$(which gcc)"
+if [ -n "$XCRUN" ]; then
+  export CC="$CC:-$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
+else
+  export CC="$CC:-$(which gcc)"
+  export CXX="$CXX:-$(which g++)"
 fi
-export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
-export CXX="$CC"
+export CXX="$CCX:-$CC"
 
 # Remove automake symlink if it exists
 if [ -h "test-driver" ]; then

--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -44,10 +44,11 @@ fi
 
 XCRUN="$(which xcrun)"
 if [ -n "$XCRUN" ]; then
-  export CC="$CC:-$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
+  export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
+  export CXX="$CC"
 else
   export CC="$CC:-$(which gcc)"
-  export CXX="$CXX:-$(which g++)"
+  export CXX="$CXX:-$(which g++ || true)"
 fi
 export CXX="$CCX:-$CC"
 

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -288,7 +288,9 @@ def react_native_post_install(
   ReactNativePodsUtils.set_use_hermes_build_setting(installer, hermes_enabled)
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
   ReactNativePodsUtils.set_ccache_compiler_and_linker_build_settings(installer, react_native_path, ccache_enabled)
-  ReactNativePodsUtils.apply_xcode_15_patch(installer)
+  if Environment.new().ruby_platform().include?('darwin')
+    ReactNativePodsUtils.apply_xcode_15_patch(installer)
+  end
   ReactNativePodsUtils.updateOSDeploymentTarget(installer)
   ReactNativePodsUtils.set_dynamic_frameworks_flags(installer)
   ReactNativePodsUtils.add_ndebug_flag_to_pods_in_release(installer)


### PR DESCRIPTION
## Summary:

`pod install` and CocoaPods are actually not macOS specific.
Still, the pod lifecycle scripts of `react-native` depend on macOS-only utilities and will fail on Linux.

This is an attempt to make the scripts portable and make the pod install cleanly on Linux as well as macOS.

## Changelog:

    [INTERNAL] [FIXED] - Skip XCode patching when not run on macOS
    [INTERNAL] [FIXED] - Fall back to `which gcc`/`which g++` to identify C/C++ compiler when `xcrun` not available
    [INTERNAL] [FEAT] - Recognize CC and CXX env vars supplied to the script and prefer them over autodetection


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
