### PR TITLE
Fix HermesExecutorFactory build error

### DIFF
--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -13,6 +13,7 @@
 #include <jsi/decorator.h>
 #include <jsinspector-modern/InspectorFlags.h>
 
+#include <hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h>
 #include <hermes/inspector-modern/chrome/Registration.h>
 #include <hermes/inspector/RuntimeAdapter.h>
 
@@ -258,7 +259,9 @@ HermesExecutor::HermesExecutor(
 jsinspector_modern::RuntimeTargetDelegate&
 HermesExecutor::getRuntimeTargetDelegate() {
   if (!targetDelegate_) {
-    targetDelegate_.emplace(hermesRuntime_);
+    targetDelegate_ =
+        std::make_unique<jsinspector_modern::HermesRuntimeTargetDelegate>(
+            hermesRuntime_);
   }
   return *targetDelegate_;
 }

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <hermes/hermes.h>
-#include <hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h>
 #include <jsireact/JSIExecutor.h>
 #include <utility>
 
@@ -62,8 +61,7 @@ class HermesExecutor : public JSIExecutor {
   JSIScopedTimeoutInvoker timeoutInvoker_;
   std::shared_ptr<jsi::Runtime> runtime_;
   std::shared_ptr<hermes::HermesRuntime> hermesRuntime_;
-  std::optional<jsinspector_modern::HermesRuntimeTargetDelegate>
-      targetDelegate_;
+  std::unique_ptr<jsinspector_modern::RuntimeTargetDelegate> targetDelegate_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/commit/7af288e5 introduced a breaking change for whoever importing HermesExecutorFactory.h, because the `hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h` is not a public header. Also the nested import is not ideal for CocoaPods or use_frameworks.
I think HermesRuntimeTargetDelegate could be an implementation detail that hide from header. This PR tries to turn the ownership declaration from std::optional to std::unique_ptr, so that we could hide the concrete type.

## Changelog:

[IOS] [FIXED] - Fixed `HermesExecutorFactory.h` build error when importing its private header

## Test Plan:

should introduce no breaking change and ci passed
