### PR TITLE
Migrate references to deprecated UIActivityIndicatorViewStyles

### DIFF
--- a/packages/react-native/Libraries/Wrapper/Example/RCTWrapperReactRootViewController.m
+++ b/packages/react-native/Libraries/Wrapper/Example/RCTWrapperReactRootViewController.m
@@ -35,7 +35,7 @@
   rootView.backgroundColor = [UIColor whiteColor];
 
   UIActivityIndicatorView *progressIndicatorView =
-      [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+      [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
   [progressIndicatorView startAnimating];
   rootView.loadingView = progressIndicatorView;
 

--- a/packages/react-native/React/Views/RCTActivityIndicatorViewManager.m
+++ b/packages/react-native/React/Views/RCTActivityIndicatorViewManager.m
@@ -12,9 +12,6 @@
 
 @implementation RCTConvert (UIActivityIndicatorView)
 
-// NOTE: It's pointless to support UIActivityIndicatorViewStyleGray
-// as we can set the color to any arbitrary value that we want to
-
 RCT_ENUM_CONVERTER(
     UIActivityIndicatorViewStyle,
     (@{


### PR DESCRIPTION
Summary:
## Changelog:

[iOS][Fixed] Removed references to deprecated UIActivityIndicatorViewStyles

Differential Revision: D57006157


