### PR TITLE
Use macro for CSSTokenizerTest assertions

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSAngleUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSAngleUnit.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+#include <react/utils/fnv1a.h>
+
+namespace facebook::react {
+
+/**
+ * Unit for the CSS <angle> type.
+ * https://www.w3.org/TR/css-values-4/#angles
+ */
+enum class CSSAngleUnit : uint8_t {
+  Deg,
+  Grad,
+  Rad,
+  Turn,
+};
+
+/**
+ * Parses a unit from a dimension token into a CSS angle unit.
+ */
+constexpr std::optional<CSSAngleUnit> parseCSSAngleUnit(std::string_view unit) {
+  switch (fnv1a(unit)) {
+    case fnv1a("deg"):
+      return CSSAngleUnit::Deg;
+    case fnv1a("grad"):
+      return CSSAngleUnit::Grad;
+    case fnv1a("rad"):
+      return CSSAngleUnit::Rad;
+    case fnv1a("turn"):
+      return CSSAngleUnit::Turn;
+    default:
+      return std::nullopt;
+  }
+}
+
+/**
+ * Converts a specified CSS angle to its cannonical unit (degrees)
+ */
+constexpr float canonicalize(float value, CSSAngleUnit unit) {
+  switch (unit) {
+    case CSSAngleUnit::Deg:
+      return value;
+    case CSSAngleUnit::Grad:
+      return value * 0.9f;
+    case CSSAngleUnit::Rad:
+      return value * 57.295779513f;
+    case CSSAngleUnit::Turn:
+      return value * 360.0f;
+    default:
+      return std::numeric_limits<float>::quiet_NaN();
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSDeclaredStyle.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSDeclaredStyle.h
@@ -93,7 +93,8 @@ class CSSDeclaredStyle {
                CSSLength,
                CSSNumber,
                CSSPercentage,
-               CSSRatio>)>
+               CSSRatio,
+               CSSAngle>)>
         value;
 
     constexpr bool operator<(const PropMapping& rhs) const {

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSParser.h
@@ -9,6 +9,7 @@
 
 #include <optional>
 
+#include <react/renderer/css/CSSAngleUnit.h>
 #include <react/renderer/css/CSSKeywords.h>
 #include <react/renderer/css/CSSLengthUnit.h>
 #include <react/renderer/css/CSSProperties.h>
@@ -105,6 +106,12 @@ class CSSParser {
     if constexpr (traits::containsType<CSSLength, AllowedTypesT...>()) {
       if (auto unit = parseCSSLengthUnit(peek().unit())) {
         return CSSValueT::length(consumeToken().numericValue(), *unit);
+      }
+    }
+    if constexpr (traits::containsType<CSSAngle, AllowedTypesT...>()) {
+      if (auto unit = parseCSSAngleUnit(peek().unit())) {
+        return CSSValueT::angle(
+            canonicalize(consumeToken().numericValue(), *unit));
       }
     }
     return {};

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValue.h
@@ -28,6 +28,7 @@ enum class CSSValueType : uint8_t {
   Number,
   Percentage,
   Ratio,
+  Angle,
 };
 
 /**
@@ -72,6 +73,14 @@ struct CSSNumber {
 struct CSSRatio {
   float numerator{};
   float denominator{};
+};
+
+/**
+ * Representation of CSS <angle> data type
+ * https://www.w3.org/TR/css-values-4/#angles
+ */
+struct CSSAngle {
+  float degrees{};
 };
 
 /**
@@ -161,6 +170,12 @@ class CSSValueVariant {
         CSSValueType::Ratio, CSSRatio{numerator, denominator});
   }
 
+  static constexpr CSSValueVariant angle(float degrees)
+    requires(canRepresent<CSSAngle>())
+  {
+    return CSSValueVariant(CSSValueType::Angle, CSSAngle{degrees});
+  }
+
   constexpr CSSValueType type() const {
     return type_;
   }
@@ -201,6 +216,12 @@ class CSSValueVariant {
     return getIf<CSSValueType::Ratio, CSSRatio>();
   }
 
+  constexpr CSSAngle getAngle() const
+    requires(canRepresent<CSSAngle>())
+  {
+    return getIf<CSSValueType::Angle, CSSAngle>();
+  }
+
   constexpr operator bool() const
     requires(canRepresent<CSSWideKeyword>())
   {
@@ -225,6 +246,8 @@ class CSSValueVariant {
         return getPercentage() == other.getPercentage();
       case CSSValueType::Ratio:
         return getRatio() == other.getRatio();
+      case CSSValueType::Angle:
+        return getAngle() == other.getAngle();
     }
 
     return false;

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSParserTest.cpp
@@ -267,6 +267,34 @@ TEST(CSSParser, number_ratio_values) {
   EXPECT_EQ(degenerateRatio.getNumber().value, 0.0f);
 }
 
+TEST(CSSParser, angle_values) {
+  auto emptyValue = parseCSSComponentValue<CSSWideKeyword, CSSAngle>("");
+  EXPECT_EQ(emptyValue.type(), CSSValueType::CSSWideKeyword);
+  EXPECT_EQ(emptyValue.getCSSWideKeyword(), CSSWideKeyword::Unset);
+
+  auto degreeValue = parseCSSComponentValue<CSSWideKeyword, CSSAngle>("10deg");
+  EXPECT_EQ(degreeValue.type(), CSSValueType::Angle);
+  EXPECT_EQ(degreeValue.getAngle().degrees, 10.0f);
+
+  auto radianValue = parseCSSComponentValue<CSSWideKeyword, CSSAngle>("10rad");
+  EXPECT_EQ(radianValue.type(), CSSValueType::Angle);
+  EXPECT_NEAR(radianValue.getAngle().degrees, 572.958f, 0.001f);
+
+  auto negativeRadianValue =
+      parseCSSComponentValue<CSSWideKeyword, CSSAngle>("-10rad");
+  EXPECT_EQ(negativeRadianValue.type(), CSSValueType::Angle);
+  EXPECT_NEAR(negativeRadianValue.getAngle().degrees, -572.958f, 0.001f);
+
+  auto gradianValue =
+      parseCSSComponentValue<CSSWideKeyword, CSSAngle>("10grad");
+  EXPECT_EQ(gradianValue.type(), CSSValueType::Angle);
+  ASSERT_NEAR(gradianValue.getAngle().degrees, 9.0f, 0.001f);
+
+  auto turnValue = parseCSSComponentValue<CSSWideKeyword, CSSAngle>("1turn");
+  EXPECT_EQ(turnValue.type(), CSSValueType::Angle);
+  EXPECT_EQ(turnValue.getAngle().degrees, 360.0f);
+}
+
 TEST(CSSParser, parse_prop) {
   auto emptyValue = parseCSSProp<CSSProp::Width>("");
   EXPECT_EQ(emptyValue.type(), CSSValueType::CSSWideKeyword);

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
@@ -10,145 +10,149 @@
 
 namespace facebook::react {
 
-static void expectTokens(
-    std::string_view characters,
-    std::initializer_list<CSSToken> expectedTokens) {
-  CSSTokenizer tokenizer{characters};
-
-  for (const auto& expectedToken : expectedTokens) {
-    auto nextToken = tokenizer.next();
-    EXPECT_EQ(nextToken.type(), expectedToken.type());
-    EXPECT_EQ(nextToken.stringValue(), expectedToken.stringValue());
-    EXPECT_EQ(nextToken.numericValue(), expectedToken.numericValue());
-    EXPECT_EQ(nextToken.unit(), expectedToken.unit());
-    EXPECT_EQ(nextToken, expectedToken);
+#define EXPECT_TOKENS(characters, ...)                                   \
+  {                                                                      \
+    CSSTokenizer tokenizer{characters};                                  \
+                                                                         \
+    for (const auto& expectedToken :                                     \
+         std::initializer_list<CSSToken>{__VA_ARGS__}) {                 \
+      auto nextToken = tokenizer.next();                                 \
+      EXPECT_EQ(nextToken.type(), expectedToken.type());                 \
+      EXPECT_EQ(nextToken.stringValue(), expectedToken.stringValue());   \
+      EXPECT_EQ(nextToken.numericValue(), expectedToken.numericValue()); \
+      EXPECT_EQ(nextToken.unit(), expectedToken.unit());                 \
+      EXPECT_EQ(nextToken, expectedToken);                               \
+    }                                                                    \
   }
-}
 
 TEST(CSSTokenizer, eof_values) {
-  expectTokens("", {CSSToken{CSSTokenType::EndOfFile}});
+  EXPECT_TOKENS("", CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, whitespace_values) {
-  expectTokens(
+  EXPECT_TOKENS(
       " ",
-      {CSSToken{CSSTokenType::WhiteSpace}, CSSToken{CSSTokenType::EndOfFile}});
-  expectTokens(
+      CSSToken{CSSTokenType::WhiteSpace},
+      CSSToken{CSSTokenType::EndOfFile});
+  EXPECT_TOKENS(
       " \t",
-      {CSSToken{CSSTokenType::WhiteSpace}, CSSToken{CSSTokenType::EndOfFile}});
-  expectTokens(
+      CSSToken{CSSTokenType::WhiteSpace},
+      CSSToken{CSSTokenType::EndOfFile});
+  EXPECT_TOKENS(
       "\n   \t",
-      {CSSToken{CSSTokenType::WhiteSpace}, CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::WhiteSpace},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, ident_values) {
-  expectTokens(
+  EXPECT_TOKENS(
       "auto",
-      {CSSToken{CSSTokenType::Ident, "auto"},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Ident, "auto"},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "inset auto left",
-      {CSSToken{CSSTokenType::Ident, "inset"},
-       CSSToken{CSSTokenType::WhiteSpace},
-       CSSToken{CSSTokenType::Ident, "auto"},
-       CSSToken{CSSTokenType::WhiteSpace},
-       CSSToken{CSSTokenType::Ident, "left"},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Ident, "inset"},
+      CSSToken{CSSTokenType::WhiteSpace},
+      CSSToken{CSSTokenType::Ident, "auto"},
+      CSSToken{CSSTokenType::WhiteSpace},
+      CSSToken{CSSTokenType::Ident, "left"},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, number_values) {
-  expectTokens(
+  EXPECT_TOKENS(
       "12",
-      {CSSToken{CSSTokenType::Number, 12.0f},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Number, 12.0f},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "-5",
-      {CSSToken{CSSTokenType::Number, -5.0f},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Number, -5.0f},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "123.0",
-      {CSSToken{CSSTokenType::Number, 123.0f},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Number, 123.0f},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "4.2E-1",
-      {CSSToken{CSSTokenType::Number, 4.2e-1},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Number, 4.2e-1},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "6e-10",
-      {CSSToken{CSSTokenType::Number, 6e-10f},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Number, 6e-10f},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "+81.07e+0",
-      {CSSToken{CSSTokenType::Number, +81.07e+0},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Number, +81.07e+0},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, dimension_values) {
-  expectTokens(
+  EXPECT_TOKENS(
       "12px",
-      {CSSToken{CSSTokenType::Dimension, 12.0f, "px"},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Dimension, 12.0f, "px"},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "463.2abc",
-      {CSSToken{CSSTokenType::Dimension, 463.2, "abc"},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Dimension, 463.2, "abc"},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, percent_values) {
-  expectTokens(
+  EXPECT_TOKENS(
       "12%",
-      {CSSToken{CSSTokenType::Percentage, 12.0f},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Percentage, 12.0f},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "-28.5%",
-      {CSSToken{CSSTokenType::Percentage, -28.5f},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Percentage, -28.5f},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, mixed_values) {
-  expectTokens(
+  EXPECT_TOKENS(
       "12px   -100vh",
-      {CSSToken{CSSTokenType::Dimension, 12.0f, "px"},
-       CSSToken{CSSTokenType::WhiteSpace},
-       CSSToken{CSSTokenType::Dimension, -100.0f, "vh"},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Dimension, 12.0f, "px"},
+      CSSToken{CSSTokenType::WhiteSpace},
+      CSSToken{CSSTokenType::Dimension, -100.0f, "vh"},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, ratio_values) {
-  expectTokens(
+  EXPECT_TOKENS(
       "16 / 9",
-      {CSSToken{CSSTokenType::Number, 16.0f},
-       CSSToken{CSSTokenType::WhiteSpace},
-       CSSToken{CSSTokenType::Delim, "/"},
-       CSSToken{CSSTokenType::WhiteSpace},
-       CSSToken{CSSTokenType::Number, 9.0f},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Number, 16.0f},
+      CSSToken{CSSTokenType::WhiteSpace},
+      CSSToken{CSSTokenType::Delim, "/"},
+      CSSToken{CSSTokenType::WhiteSpace},
+      CSSToken{CSSTokenType::Number, 9.0f},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, invalid_values) {
-  expectTokens(
+  EXPECT_TOKENS(
       "100*",
-      {CSSToken{CSSTokenType::Number, 100.0f},
-       CSSToken{CSSTokenType::Delim, "*"},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Number, 100.0f},
+      CSSToken{CSSTokenType::Delim, "*"},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "+",
-      {CSSToken{CSSTokenType::Delim, "+"}, CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Delim, "+"},
+      CSSToken{CSSTokenType::EndOfFile});
 
-  expectTokens(
+  EXPECT_TOKENS(
       "(%",
-      {CSSToken{CSSTokenType::Delim, "("},
-       CSSToken{CSSTokenType::Delim, "%"},
-       CSSToken{CSSTokenType::EndOfFile}});
+      CSSToken{CSSTokenType::Delim, "("},
+      CSSToken{CSSTokenType::Delim, "%"},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Turn `expectTokens()` function into a macro so that GTest assertion macros point to the right line numbers.

Changelog: [Internal]

Differential Revision: D57034303


