### PR TITLE
chore: update Gemfile in template

### DIFF
--- a/packages/react-native/template/Gemfile
+++ b/packages/react-native/template/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '>= 1.13'
+gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'

--- a/packages/react-native/template/Gemfile
+++ b/packages/react-native/template/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
+# Exclude problematic versions of CocoaPods that causes build failures.
+gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'

--- a/packages/react-native/template/Gemfile
+++ b/packages/react-native/template/Gemfile
@@ -3,7 +3,4 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-# Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
-# bound in the template on Cocoapods with next React Native release.
-gem 'cocoapods', '>= 1.13', '< 1.15'
-gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+gem 'cocoapods', '>= 1.13'

--- a/packages/react-native/template/Gemfile
+++ b/packages/react-native/template/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-# Exclude problematic versions of CocoaPods that causes build failures.
+# Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
+gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'


### PR DESCRIPTION
## Summary:

Cocoapods regression is now fixed (been fixed for a while) but we forgot to remove the upper bound and explicit `activesupport` in Gemfile.

https://github.com/CocoaPods/CocoaPods/releases/tag/1.15.2

## Changelog:

[IOS] [CHANGED] - Update Gemfile in template

## Test Plan:

Run `bundle install/update` should update cocoapods to the latest version and active support should work properly without any issues.