### PR TITLE
Decouple DevInternalSettings from DevSupportManagerBase

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2085,8 +2085,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	protected fun getCurrentContext ()Lcom/facebook/react/bridge/ReactContext;
 	public fun getDevLoadingViewManager ()Lcom/facebook/react/devsupport/interfaces/DevLoadingViewManager;
 	public fun getDevServerHelper ()Lcom/facebook/react/devsupport/DevServerHelper;
-	public fun getDevSettings ()Lcom/facebook/react/devsupport/DevInternalSettings;
-	public synthetic fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
+	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
 	public fun getDevSupportEnabled ()Z
 	public fun getDownloadedJSBundleFile ()Ljava/lang/String;
 	public fun getJSAppBundleName ()Ljava/lang/String;
@@ -2220,8 +2219,7 @@ public class com/facebook/react/devsupport/PackagerStatusCheck {
 
 public final class com/facebook/react/devsupport/PerftestDevSupportManager : com/facebook/react/devsupport/ReleaseDevSupportManager {
 	public fun <init> (Landroid/content/Context;)V
-	public fun getDevSettings ()Lcom/facebook/react/devsupport/DevInternalSettings;
-	public synthetic fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
+	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
 	public fun startInspector ()V
 	public fun stopInspector ()V
 }
@@ -3227,15 +3225,25 @@ public class com/facebook/react/modules/debug/SourceCodeModule : com/facebook/fb
 
 public abstract interface class com/facebook/react/modules/debug/interfaces/DeveloperSettings {
 	public abstract fun addMenuItem (Ljava/lang/String;)V
+	public abstract fun getPackagerConnectionSettings ()Lcom/facebook/react/packagerconnection/PackagerConnectionSettings;
 	public abstract fun isAnimationFpsDebugEnabled ()Z
 	public abstract fun isDeviceDebugEnabled ()Z
 	public abstract fun isElementInspectorEnabled ()Z
 	public abstract fun isFpsDebugEnabled ()Z
+	public abstract fun isHotModuleReplacementEnabled ()Z
 	public abstract fun isJSDevModeEnabled ()Z
 	public abstract fun isJSMinifyEnabled ()Z
 	public abstract fun isRemoteJSDebugEnabled ()Z
 	public abstract fun isStartSamplingProfilerOnInit ()Z
+	public abstract fun setAnimationFpsDebugEnabled (Z)V
+	public abstract fun setDeviceDebugEnabled (Z)V
+	public abstract fun setElementInspectorEnabled (Z)V
+	public abstract fun setFpsDebugEnabled (Z)V
+	public abstract fun setHotModuleReplacementEnabled (Z)V
+	public abstract fun setJSDevModeEnabled (Z)V
+	public abstract fun setJSMinifyEnabled (Z)V
 	public abstract fun setRemoteJSDebugEnabled (Z)V
+	public abstract fun setStartSamplingProfilerOnInit (Z)V
 }
 
 public class com/facebook/react/modules/deviceinfo/DeviceInfoModule : com/facebook/fbreact/specs/NativeDeviceInfoSpec, com/facebook/react/bridge/LifecycleEventListener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
@@ -26,23 +26,36 @@ internal class DevInternalSettings(applicationContext: Context, private val list
     DeveloperSettings, OnSharedPreferenceChangeListener {
   private val preferences: SharedPreferences =
       PreferenceManager.getDefaultSharedPreferences(applicationContext)
-  val packagerConnectionSettings: PackagerConnectionSettings
+  override val packagerConnectionSettings: PackagerConnectionSettings =
+    PackagerConnectionSettings(applicationContext)
 
   init {
     preferences.registerOnSharedPreferenceChangeListener(this)
-    packagerConnectionSettings = PackagerConnectionSettings(applicationContext)
   }
 
-  override fun isFpsDebugEnabled(): Boolean = preferences.getBoolean(PREFS_FPS_DEBUG_KEY, false)
+  override var isFpsDebugEnabled: Boolean
+    get() = preferences.getBoolean(PREFS_FPS_DEBUG_KEY, false)
+    set(value) {
+      preferences.edit().putBoolean(PREFS_FPS_DEBUG_KEY, value).apply()
+    }
 
-  override fun isAnimationFpsDebugEnabled(): Boolean =
-      preferences.getBoolean(PREFS_ANIMATIONS_DEBUG_KEY, false)
+  override var isAnimationFpsDebugEnabled: Boolean
+    get() = preferences.getBoolean(PREFS_ANIMATIONS_DEBUG_KEY, false)
+    set(_) {
+      // not used
+    }
 
-  override fun isJSDevModeEnabled(): Boolean =
-      preferences.getBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, true)
+  override var isJSDevModeEnabled: Boolean
+    get() = preferences.getBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, true)
+    set(value) {
+      preferences.edit().putBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, value).apply()
+    }
 
-  override fun isJSMinifyEnabled(): Boolean =
-      preferences.getBoolean(PREFS_JS_MINIFY_DEBUG_KEY, false)
+  override var isJSMinifyEnabled: Boolean
+    get() = preferences.getBoolean(PREFS_JS_MINIFY_DEBUG_KEY, false)
+    set(_) {
+      // not used
+    }
 
   override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
     if (listener != null) {
@@ -55,41 +68,34 @@ internal class DevInternalSettings(applicationContext: Context, private val list
     }
   }
 
-  override fun isElementInspectorEnabled(): Boolean =
-      preferences.getBoolean(PREFS_INSPECTOR_DEBUG_KEY, false)
+  override var isElementInspectorEnabled: Boolean
+    get() = preferences.getBoolean(PREFS_INSPECTOR_DEBUG_KEY, false)
+    set(value) {
+      preferences.edit().putBoolean(PREFS_INSPECTOR_DEBUG_KEY, value).apply()
+    }
 
-  override fun isDeviceDebugEnabled(): Boolean = ReactBuildConfig.DEBUG
+  override var isDeviceDebugEnabled: Boolean = ReactBuildConfig.DEBUG
 
-  override fun isRemoteJSDebugEnabled(): Boolean =
-      preferences.getBoolean(PREFS_REMOTE_JS_DEBUG_KEY, false)
+  override var isRemoteJSDebugEnabled: Boolean
+    get() = preferences.getBoolean(PREFS_REMOTE_JS_DEBUG_KEY, false)
+    set(value) {
+      preferences.edit().putBoolean(PREFS_REMOTE_JS_DEBUG_KEY, value).apply()
+    }
 
-  override fun setRemoteJSDebugEnabled(remoteJSDebugEnabled: Boolean) {
-    preferences.edit().putBoolean(PREFS_REMOTE_JS_DEBUG_KEY, remoteJSDebugEnabled).apply()
-  }
-
-  override fun isStartSamplingProfilerOnInit(): Boolean =
-      preferences.getBoolean(PREFS_START_SAMPLING_PROFILER_ON_INIT, false)
+  override var isStartSamplingProfilerOnInit: Boolean
+    get() = preferences.getBoolean(PREFS_START_SAMPLING_PROFILER_ON_INIT, false)
+    set(_) {
+      // not used
+    }
 
   // Not supported.
   override fun addMenuItem(title: String) = Unit
 
-  fun setElementInspectorEnabled(enabled: Boolean) {
-    preferences.edit().putBoolean(PREFS_INSPECTOR_DEBUG_KEY, enabled).apply()
-  }
-
-  var isHotModuleReplacementEnabled: Boolean
+  override var isHotModuleReplacementEnabled: Boolean
     get() = preferences.getBoolean(PREFS_HOT_MODULE_REPLACEMENT_KEY, true)
     set(enabled) {
       preferences.edit().putBoolean(PREFS_HOT_MODULE_REPLACEMENT_KEY, enabled).apply()
     }
-
-  fun setJSDevModeEnabled(value: Boolean) {
-    preferences.edit().putBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, value).apply()
-  }
-
-  fun setFpsDebugEnabled(enabled: Boolean) {
-    preferences.edit().putBoolean(PREFS_FPS_DEBUG_KEY, enabled).apply()
-  }
 
   interface Listener {
     fun onInternalSettingsChanged()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -61,6 +61,7 @@ import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.devsupport.interfaces.StackFrame;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
+import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.packagerconnection.Responder;
 import java.io.File;
@@ -107,7 +108,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   private boolean mDevLoadingViewVisible = false;
   private int mPendingJSSplitBundleRequests = 0;
   private @Nullable ReactContext mCurrentContext;
-  private final DevInternalSettings mDevSettings;
+  private final DeveloperSettings mDevSettings;
   private boolean mIsReceiverRegistered = false;
   private boolean mIsShakeDetectorStarted = false;
   private boolean mIsDevSupportEnabled = false;
@@ -593,7 +594,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   @Override
-  public DevInternalSettings getDevSettings() {
+  public DeveloperSettings getDevSettings() {
     return mDevSettings;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
@@ -9,6 +9,7 @@ package com.facebook.react.devsupport;
 
 import android.content.Context;
 import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
 
 /**
  * Interface for accessing and interacting with development features related to performance testing.
@@ -17,7 +18,7 @@ import com.facebook.infer.annotation.Nullsafe;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public final class PerftestDevSupportManager extends ReleaseDevSupportManager {
   private final DevServerHelper mDevServerHelper;
-  private final DevInternalSettings mDevSettings;
+  private final DeveloperSettings mDevSettings;
 
   public PerftestDevSupportManager(Context applicationContext) {
     mDevSettings =
@@ -35,7 +36,7 @@ public final class PerftestDevSupportManager extends ReleaseDevSupportManager {
   }
 
   @Override
-  public DevInternalSettings getDevSettings() {
+  public DeveloperSettings getDevSettings() {
     return mDevSettings;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.kt
@@ -7,35 +7,39 @@
 
 package com.facebook.react.modules.debug.interfaces
 
+import com.facebook.react.packagerconnection.PackagerConnectionSettings
+
 /** Provides access to React Native developers settings. */
 public interface DeveloperSettings {
+  /** Return the underlying [PackagerConnectionSettings] instance. */
+  public val packagerConnectionSettings: PackagerConnectionSettings
 
-  /** whether an overlay showing current FPS should be shown. */
-  public fun isFpsDebugEnabled(): Boolean
+  /** Whether an overlay showing current FPS should be shown. */
+  public var isFpsDebugEnabled: Boolean
 
   /** Whether debug information about transitions should be displayed. */
-  public fun isAnimationFpsDebugEnabled(): Boolean
+  public var isAnimationFpsDebugEnabled: Boolean
 
   /** Whether dev mode should be enabled in JS bundles. */
-  public fun isJSDevModeEnabled(): Boolean
+  public var isJSDevModeEnabled: Boolean
 
   /** Whether JS bundle should be minified. */
-  public fun isJSMinifyEnabled(): Boolean
+  public var isJSMinifyEnabled: Boolean
 
   /** Whether element inspector is enabled. */
-  public fun isElementInspectorEnabled(): Boolean
+  public var isElementInspectorEnabled: Boolean
 
   /** Whether Nuclide JS debugging is enabled. */
-  public fun isDeviceDebugEnabled(): Boolean
+  public var isDeviceDebugEnabled: Boolean
 
   /** Whether remote JS debugging is enabled. */
-  public fun isRemoteJSDebugEnabled(): Boolean
-
-  /** Enable/Disable remote JS debugging. */
-  public fun setRemoteJSDebugEnabled(remoteJSDebugEnabled: Boolean)
+  public var isRemoteJSDebugEnabled: Boolean
 
   /** Whether Start Sampling Profiler on App Start is enabled. */
-  public fun isStartSamplingProfilerOnInit(): Boolean
+  public var isStartSamplingProfilerOnInit: Boolean
+
+  /** Whether HMR is enabled. */
+  public var isHotModuleReplacementEnabled: Boolean
 
   /** Add an item to the dev menu. */
   public fun addMenuItem(title: String)


### PR DESCRIPTION
## Summary:

I was tried to fix breaking changes for Expo's React Native nightlies CI testing. Recently React Native core has some effort to migrate Java code to Kotlin. Since https://github.com/facebook/react-native/commit/a977b2e69, we cannot reuse the `DevSupportManagerBase` and replace `DevInternalSettings` inside [expo-dev-client](https://github.com/expo/expo/blob/26c9f49042f53db7d37f832c133d4da0f6d64f02/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt#L117-L126) because we cannot access to the `DevInternalSettings` anymore because Kotlin "internal" visibility.
This PR tries to decouple `DevInternalSettings` from `DevSupportManagerBase` then we could still use reflection to change the mDevSettings.

## Changelog:

[ANDROID] [CHANGED] - Decouple `DevInternalSettings` from `DevSupportManagerBase`

## Test Plan:

CI passed
