### PR TITLE
[iOS][CI] Remove tests using Xcode 14

### DIFF
--- a/.circleci/configurations/executors.yml
+++ b/.circleci/configurations/executors.yml
@@ -36,10 +36,3 @@ executors:
     resource_class: macos.x86.medium.gen2
     environment:
       - RCT_BUILD_HERMES_FROM_SOURCE: true
-  reactnativeios-lts:
-    <<: *defaults
-    macos:
-      xcode: '14.3.1'
-    resource_class: macos.x86.medium.gen2
-    environment:
-      - RCT_BUILD_HERMES_FROM_SOURCE: true

--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -61,11 +61,12 @@
           ruby_version: "3.2.0"
           architecture: "NewArch"
           flavor: "Debug"
-          executor: reactnativeios-lts
+          jsengine: "Hermes"
+          use_frameworks: "StaticLibraries"
       - test_ios_template:
-          architecture: "OldArch"
           requires:
             - build_npm_package
+          architecture: "NewArch"
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
@@ -76,36 +77,23 @@
               - flavor: "Debug"
                 jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
+                architecture: "NewArch"
       - test_ios_rntester:
           requires:
             - build_hermes_macos
-          name: "Test RNTester with Ruby 3.2.0"
+          use_frameworks: "DynamicFrameworks"
           ruby_version: "3.2.0"
-          executor: reactnativeios-lts
-      - test_ios_rntester:
-          requires:
-            - build_hermes_macos
+          architecture: "NewArch"
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
-              use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
-            exclude:
-              # Tested by test_ios-Hermes
-              - jsengine: "Hermes"
-                use_frameworks: "StaticLibraries"
-              # Tested by test_ios-JSC
-              - jsengine: "JSC"
-                use_frameworks: "StaticLibraries"
-              # Tested with Ruby 3.2.0, do not test this twice.
-              - jsengine: "Hermes"
-                use_frameworks: "StaticLibraries"
       - test_ios_rntester:
           run_unit_tests: true
           use_frameworks: "StaticLibraries"
           ruby_version: "2.6.10"
+          architecture: "NewArch"
           requires:
             - build_hermes_macos
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
-              architecture: ["NewArch", "OldArch"]

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -43,8 +43,6 @@
             - build_hermesc_linux
             - build_hermes_macos
             - build_hermesc_windows
-      # - test_e2e_ios:
-      #     ruby_version: "2.7.7"
       - test_ios_template:
           requires:
             - build_npm_package
@@ -52,43 +50,39 @@
           ruby_version: "3.2.0"
           architecture: "NewArch"
           flavor: "Debug"
-          executor: reactnativeios-lts
+          jsengine: "Hermes"
+          use_frameworks: "StaticLibraries"
       - test_ios_template:
-          architecture: "OldArch"
           requires:
             - build_npm_package
+          architecture: "NewArch"
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
             exclude:
-             # Tested with Ruby 3.2.0, let's not double test this
+              # This config is tested with Ruby 3.2.0. Let's not double test it.
               - flavor: "Debug"
                 jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
+                architecture: "NewArch"
       - test_ios_rntester:
           requires:
             - build_hermes_macos
-          name: "RNTester on Ruby 3.2.0"
-          ruby_version: "3.2.0"
-          executor: reactnativeios-lts
-      - test_ios_rntester:
-          name: "RNTester with Dynamic Frameworks"
           use_frameworks: "DynamicFrameworks"
-          requires:
-            - build_hermes_macos
+          ruby_version: "3.2.0"
+          architecture: "NewArch"
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
       - test_ios_rntester:
-          name: "RNTester Integration Tests"
           run_unit_tests: true
           use_frameworks: "StaticLibraries"
           ruby_version: "2.6.10"
+          architecture: "NewArch"
           requires:
             - build_hermes_macos
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
-              architecture: ["NewArch", "OldArch"]

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -59,7 +59,7 @@ references:
   #        Dependency Anchors
   # -------------------------
   dependency_versions:
-    xcode_version: &xcode_version "15.0.1"
+    xcode_version: &xcode_version "15.2"
     nodelts_image: &nodelts_image "cimg/node:20.2.0"
     nodeprevlts_image: &nodeprevlts_image "cimg/node:18.12.1"
     nodelts_browser_image: &nodelts_browser_image "cimg/node:20.2.0-browsers"


### PR DESCRIPTION
## Summary:

Apple is enforcing that new apps submission to the store mst use XCode 15. There is no reason to keep testing on Xcode 14.3 anymore, hence we are removing those jobs.
While doing that, we are also aligning the tests between Test_All and test_iOS workflows. 

## Changelog:
[Internal] - Remove CircleCI tests for Xcode 14.3

## Test Plan:
CircleCI must stay Green
