### PR TITLE
Add native synchronous event support

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.java
@@ -40,6 +40,8 @@ public class EventEmitterWrapper {
   private native void dispatchEvent(
       String eventName, @Nullable NativeMap params, @EventCategoryDef int category);
 
+  private native void dispatchEventSynchronously(String eventName, @Nullable NativeMap params);
+
   private native void dispatchUniqueEvent(String eventName, @Nullable NativeMap params);
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventEmitterWrapper.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/EventEmitterWrapper.h
@@ -28,6 +28,7 @@ class EventEmitterWrapper : public jni::HybridClass<EventEmitterWrapper> {
   SharedEventEmitter eventEmitter;
 
   void dispatchEvent(std::string eventName, NativeMap* params, int category);
+  void dispatchEventSynchronously(std::string eventName, NativeMap* params);
   void dispatchUniqueEvent(std::string eventName, NativeMap* params);
 };
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Exposing the experimental API EventEmitter::experimental_flushSync to trigger synchronous events from Android. The API will be changed in the future, this is exposed only for experimentation.

Reviewed By: NickGerleman

Differential Revision: D56886402


