### PR TITLE
Remove deprecated measureLayoutRelativeToParent of UIManagerModule

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -1385,24 +1385,6 @@ RCT_EXPORT_METHOD(measureLayout
 }
 
 /**
- * Returns the computed recursive offset layout in a dictionary form. The
- * returned values are relative to the `ancestor` shadow view. Returns `nil`, if
- * the `ancestor` shadow view is not actually an `ancestor`. Does not touch
- * anything on the main UI thread. Invokes supplied callback with (x, y, width,
- * height).
- */
-RCT_EXPORT_METHOD(measureLayoutRelativeToParent
-                  : (nonnull NSNumber *)reactTag errorCallback
-                  : (__unused RCTResponseSenderBlock)errorCallback callback
-                  : (RCTResponseSenderBlock)callback)
-{
-  RCTLogWarn(
-      @"RCTUIManager.measureLayoutRelativeToParent method is deprecated and it will not be implemented in newer versions of RN (Fabric) - T47686450");
-  RCTShadowView *shadowView = _shadowViewRegistry[reactTag];
-  RCTMeasureLayout(shadowView, shadowView.reactSuperview, callback);
-}
-
-/**
  * JS sets what *it* considers to be the responder. Later, scroll views can use
  * this in order to determine if scrolling is appropriate.
  */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -526,22 +526,6 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   }
 
   /**
-   * Like {@link #measure} and {@link #measureLayout} but measures relative to the immediate parent.
-   *
-   * <p>NB: Unlike {@link #measure}, this will measure relative to the view layout, not the visible
-   * window which can cause unexpected results when measuring relative to things like ScrollViews
-   * that can have offset content on the screen.
-   *
-   * @deprecated this method will not be available in FabricUIManager class.
-   */
-  @ReactMethod
-  @Deprecated
-  public void measureLayoutRelativeToParent(
-      int tag, Callback errorCallback, Callback successCallback) {
-    mUIImplementation.measureLayoutRelativeToParent(tag, errorCallback, successCallback);
-  }
-
-  /**
    * Find the touch target child native view in the supplied root view hierarchy, given a react
    * target location.
    *


### PR DESCRIPTION
Summary:
`measureLayoutRelativeToParent` was deprecated 5 years ago in D16471845 and doesn't have [JS usages](https://fburl.com/code/tgwon7nb)

Hence deleting this for 0.75 Release. This will simplify the backwards compatibility of UIManagerModule

Changelog:
[Android][Removed] Remove deprecated UIManagerModule.measureLayoutRelativeToParent()

Differential Revision: D57069921


