### PR TITLE
JS plumbing to get filters into native

### DIFF
--- a/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -12,6 +12,7 @@ import type {AnyAttributeType} from '../../Renderer/shims/ReactNativeTypes';
 
 import processAspectRatio from '../../StyleSheet/processAspectRatio';
 import processColor from '../../StyleSheet/processColor';
+import processFilter from '../../StyleSheet/processFilter';
 import processFontVariant from '../../StyleSheet/processFontVariant';
 import processTransform from '../../StyleSheet/processTransform';
 import processTransformOrigin from '../../StyleSheet/processTransformOrigin';
@@ -113,6 +114,11 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
    */
   transform: {process: processTransform},
   transformOrigin: {process: processTransformOrigin},
+
+  /**
+   * Filter
+   */
+  experimental_filter: {process: processFilter},
 
   /**
    * View

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -166,6 +166,9 @@ const validAttributesForNonEventProps = {
   backgroundColor: {process: require('../StyleSheet/processColor').default},
   transform: true,
   transformOrigin: true,
+  experimental_filter: {
+    process: require('../StyleSheet/processFilter').default,
+  },
   opacity: true,
   elevation: true,
   shadowColor: {process: require('../StyleSheet/processColor').default},

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -220,6 +220,9 @@ const validAttributesForNonEventProps = {
   hitSlop: {diff: require('../Utilities/differ/insetsDiffer')},
   collapsable: true,
   collapsableChildren: true,
+  experimental_filter: {
+    process: require('../StyleSheet/processFilter').default,
+  },
 
   borderTopWidth: true,
   borderTopColor: {process: require('../StyleSheet/processColor').default},

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type AnimatedNode from '../Animated/nodes/AnimatedNode';
+import type {FilterPrimitive} from '../StyleSheet/processFilter';
 import type {
   ____DangerouslyImpreciseStyle_InternalOverrides,
   ____ImageStyle_InternalOverrides,
@@ -690,10 +691,15 @@ export type ____ShadowStyle_Internal = $ReadOnly<{
   ...____ShadowStyle_InternalOverrides,
 }>;
 
+type ____FilterStyle_Internal = $ReadOnly<{
+  experimental_filter?: $ReadOnlyArray<FilterPrimitive>,
+}>;
+
 export type ____ViewStyle_InternalCore = $ReadOnly<{
   ...$Exact<____LayoutStyle_Internal>,
   ...$Exact<____ShadowStyle_Internal>,
   ...$Exact<____TransformStyle_Internal>,
+  ...____FilterStyle_Internal,
   backfaceVisibility?: 'visible' | 'hidden',
   backgroundColor?: ____ColorValue_Internal,
   borderColor?: ____ColorValue_Internal,

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processFilter-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processFilter-test.js
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ * @flow strict-local
+ */
+
+'use strict';
+
+import type {FilterPrimitive} from '../processFilter';
+
+const processFilter = require('../processFilter').default;
+
+// js1 test processFilter
+describe('processFilter', () => {
+  testStandardFilter('brightness');
+  testStandardFilter('opacity');
+  testStandardFilter('contrast');
+  testStandardFilter('saturate');
+  testStandardFilter('grayscale');
+  testStandardFilter('sepia');
+  testStandardFilter('invert');
+
+  testNumericFilter('blur', 5, [
+    {
+      blur: 5,
+    },
+  ]);
+  testNumericFilter('blur', -5, []);
+  testUnitFilter('blur', 5, '%', []);
+  testUnitFilter('blur', 5, 'px', [
+    {
+      blur: 5,
+    },
+  ]);
+
+  testNumericFilter('hueRotate', 0, [{hueRotate: 0}]);
+  testUnitFilter('hueRotate', 90, 'deg', [{hueRotate: 90}]);
+  testUnitFilter('hueRotate', 1.5708, 'rad', [
+    {hueRotate: (180 * 1.5708) / Math.PI},
+  ]);
+  testUnitFilter('hueRotate', -90, 'deg', [{hueRotate: -90}]);
+  testUnitFilter('hueRotate', 1.5, 'grad', []);
+  testNumericFilter('hueRotate', 90, []);
+  testUnitFilter('hueRotate', 50, '%', []);
+
+  it('multiple filters', () => {
+    expect(
+      processFilter([
+        {brightness: 0.5},
+        {opacity: 0.5},
+        {blur: 5},
+        {hueRotate: '90deg'},
+      ]),
+    ).toEqual([{brightness: 0.5}, {opacity: 0.5}, {blur: 5}, {hueRotate: 90}]);
+  });
+  it('multiple filters one invalid', () => {
+    expect(
+      processFilter([
+        {brightness: 0.5},
+        {opacity: 0.5},
+        {blur: 5},
+        {hueRotate: '90foo'},
+      ]),
+    ).toEqual([]);
+  });
+  it('multiple same filters', () => {
+    expect(
+      processFilter([
+        {brightness: 0.5},
+        {brightness: 0.5},
+        {brightness: 0.5},
+        {brightness: 0.5},
+      ]),
+    ).toEqual([
+      {brightness: 0.5},
+      {brightness: 0.5},
+      {brightness: 0.5},
+      {brightness: 0.5},
+    ]);
+  });
+  it('empty', () => {
+    expect(processFilter([])).toEqual([]);
+  });
+  it('Non filter', () => {
+    // $FlowExpectedError[incompatible-call]
+    expect(processFilter([{foo: 5}])).toEqual([]);
+  });
+  it('Invalid amount type', () => {
+    // $FlowExpectedError[incompatible-call]
+    expect(processFilter([{brightness: {}}])).toEqual([]);
+  });
+  it('string multiple filters', () => {
+    expect(
+      processFilter('brightness(0.5) opacity(0.5) blur(5) hueRotate(90deg)'),
+    ).toEqual([{brightness: 0.5}, {opacity: 0.5}, {blur: 5}, {hueRotate: 90}]);
+  });
+  it('string multiple filters one invalid', () => {
+    expect(
+      processFilter('brightness(0.5) opacity(0.5) blur(5) hueRotate(90foo)'),
+    ).toEqual([]);
+  });
+  it('string multiple same filters', () => {
+    expect(
+      processFilter(
+        'brightness(0.5) brightness(0.5) brightness(0.5) brightness(0.5)',
+      ),
+    ).toEqual([
+      {brightness: 0.5},
+      {brightness: 0.5},
+      {brightness: 0.5},
+      {brightness: 0.5},
+    ]);
+  });
+  it('string empty', () => {
+    expect(processFilter('')).toEqual([]);
+  });
+  it('string non filter', () => {
+    // $FlowExpectedError[incompatible-call]
+    expect(processFilter('foo: 5')).toEqual([]);
+  });
+  it('string invalid amount type', () => {
+    // $FlowExpectedError[incompatible-call]
+    expect(processFilter('brightness: {}')).toEqual([]);
+  });
+  it('string brightness(.5)', () => {
+    // $FlowExpectedError[incompatible-call]
+    expect(processFilter('brightness(.5)')).toEqual([{brightness: 0.5}]);
+  });
+});
+
+function testStandardFilter(filter: string): void {
+  const value = 0.5;
+  const expected = createFilterPrimitive(filter, value);
+  const percentExpected = createFilterPrimitive(filter, value / 100);
+
+  testNumericFilter(filter, value, [expected]);
+  testNumericFilter(filter, -value, []);
+  testUnitFilter(filter, value, 'px', [expected]);
+  testUnitFilter(filter, value, '%', [percentExpected]);
+}
+
+function testNumericFilter(
+  filter: string,
+  value: number,
+  expected: Array<FilterPrimitive>,
+): void {
+  const filterObject = createFilterPrimitive(filter, value);
+  const filterString = filter + '(' + value.toString() + ')';
+
+  it(filterString, () => {
+    expect(processFilter([filterObject])).toEqual(expected);
+  });
+  it('string ' + filterString, () => {
+    expect(processFilter(filterString)).toEqual(expected);
+  });
+}
+
+function testUnitFilter(
+  filter: string,
+  value: number,
+  unit: string,
+  expected: Array<FilterPrimitive>,
+): void {
+  const unitAmount = value + unit;
+  const filterObject = createFilterPrimitive(filter, unitAmount);
+  const filterString = filter + '(' + unitAmount + ')';
+
+  it(filterString, () => {
+    expect(processFilter([filterObject])).toEqual(expected);
+  });
+  it('string ' + filterString, () => {
+    expect(processFilter(filterString)).toEqual(expected);
+  });
+}
+
+function createFilterPrimitive(
+  filter: string,
+  value: number | string,
+): FilterPrimitive {
+  switch (filter) {
+    case 'brightness':
+      return {brightness: value};
+    case 'blur':
+      return {blur: value};
+    case 'contrast':
+      return {contrast: value};
+    case 'grayscale':
+      return {grayscale: value};
+    case 'hueRotate':
+      return {hueRotate: value};
+    case 'invert':
+      return {invert: value};
+    case 'opacity':
+      return {opacity: value};
+    case 'saturate':
+      return {saturate: value};
+    case 'sepia':
+      return {sepia: value};
+    default:
+      throw new Error('Invalid filter: ' + filter);
+  }
+}

--- a/packages/react-native/Libraries/StyleSheet/processFilter.js
+++ b/packages/react-native/Libraries/StyleSheet/processFilter.js
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+export type FilterPrimitive =
+  | {brightness: number | string}
+  | {blur: number | string}
+  | {contrast: number | string}
+  | {grayscale: number | string}
+  | {hueRotate: number | string}
+  | {invert: number | string}
+  | {opacity: number | string}
+  | {saturate: number | string}
+  | {sepia: number | string};
+
+export default function processFilter(
+  filter: $ReadOnlyArray<FilterPrimitive> | string,
+): $ReadOnlyArray<FilterPrimitive> {
+  let result: Array<FilterPrimitive> = [];
+  if (typeof filter === 'string') {
+    // matches on functions with args like "brightness(1.5)"
+    const regex = new RegExp(/(\w+)\(([^)]+)\)/g);
+    let matches;
+
+    while ((matches = regex.exec(filter))) {
+      const amount = _getFilterAmount(matches[1], matches[2]);
+
+      if (amount != null) {
+        const filterPrimitive = {};
+        // $FlowFixMe The key will be the correct one but flow can't see that.
+        filterPrimitive[matches[1]] = amount;
+        // $FlowFixMe The key will be the correct one but flow can't see that.
+        result.push(filterPrimitive);
+      } else {
+        // If any primitive is invalid then apply none of the filters. This is how
+        // web works and makes it clear that something is wrong becuase no
+        // graphical effects are happening.
+        return [];
+      }
+    }
+  } else {
+    for (const filterPrimitive of filter) {
+      const [filterName, filterValue] = Object.entries(filterPrimitive)[0];
+      const amount = _getFilterAmount(filterName, filterValue);
+
+      if (amount != null) {
+        const resultObject = {};
+        // $FlowFixMe
+        resultObject[filterName] = amount;
+        // $FlowFixMe
+        result.push(resultObject);
+      } else {
+        // If any primitive is invalid then apply none of the filters. This is how
+        // web works and makes it clear that something is wrong becuase no
+        // graphical effects are happening.
+        return [];
+      }
+    }
+  }
+
+  return result;
+}
+
+function _getFilterAmount(filterName: string, filterArgs: mixed): ?number {
+  let filterArgAsNumber: number;
+  let unit: string;
+  if (typeof filterArgs === 'string') {
+    // matches on args with units like "1.5 5% -80deg"
+    const argsWithUnitsRegex = new RegExp(/([+-]?\d*(\.\d+)?)([a-zA-Z%]+)?/g);
+    const match = argsWithUnitsRegex.exec(filterArgs);
+
+    if (!match || isNaN(Number(match[1]))) {
+      return undefined;
+    }
+
+    filterArgAsNumber = Number(match[1]);
+    unit = match[3];
+  } else if (typeof filterArgs === 'number') {
+    filterArgAsNumber = filterArgs;
+  } else {
+    return undefined;
+  }
+
+  switch (filterName) {
+    // Hue rotate takes some angle that can have a unit and can be
+    // negative. Additionally, 0 with no unit is allowed.
+    case 'hueRotate':
+      if (filterArgAsNumber === 0) {
+        return 0;
+      }
+      if (unit !== 'deg' && unit !== 'rad') {
+        return undefined;
+      }
+      return unit === 'rad'
+        ? (180 * filterArgAsNumber) / Math.PI
+        : filterArgAsNumber;
+    // blur takes any positive CSS length that is not a percent. In RN
+    // we currently only have DIPs, so we are not parsing units here.
+    case 'blur':
+      if ((unit && unit !== 'px') || filterArgAsNumber < 0) {
+        return undefined;
+      }
+      return filterArgAsNumber;
+    // All other filters except take a non negative number or percentage. There
+    // are no units associated with this value and percentage numbers map 1-to-1
+    // to a non-percentage number (e.g. 50% == 0.5).
+    case 'brightness':
+    case 'contrast':
+    case 'grayscale':
+    case 'invert':
+    case 'opacity':
+    case 'saturate':
+    case 'sepia':
+      if ((unit && unit !== '%' && unit !== 'px') || filterArgAsNumber < 0) {
+        return undefined;
+      }
+      if (unit === '%') {
+        filterArgAsNumber /= 100;
+      }
+      return filterArgAsNumber;
+    default:
+      return undefined;
+  }
+}

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7631,10 +7631,14 @@ export type ____ShadowStyle_Internal = $ReadOnly<{
   ...____ShadowStyle_InternalCore,
   ...____ShadowStyle_InternalOverrides,
 }>;
+type ____FilterStyle_Internal = $ReadOnly<{
+  experimental_filter?: $ReadOnlyArray<FilterPrimitive>,
+}>;
 export type ____ViewStyle_InternalCore = $ReadOnly<{
   ...$Exact<____LayoutStyle_Internal>,
   ...$Exact<____ShadowStyle_Internal>,
   ...$Exact<____TransformStyle_Internal>,
+  ...____FilterStyle_Internal,
   backfaceVisibility?: \\"visible\\" | \\"hidden\\",
   backgroundColor?: ____ColorValue_Internal,
   borderColor?: ____ColorValue_Internal,
@@ -7928,6 +7932,23 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/proce
   colors: ?$ReadOnlyArray<ColorValue>
 ): ?$ReadOnlyArray<ProcessedColorValue>;
 declare module.exports: processColorArray;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/processFilter.js 1`] = `
+"export type FilterPrimitive =
+  | { brightness: number | string }
+  | { blur: number | string }
+  | { contrast: number | string }
+  | { grayscale: number | string }
+  | { hueRotate: number | string }
+  | { invert: number | string }
+  | { opacity: number | string }
+  | { saturate: number | string }
+  | { sepia: number | string };
+declare export default function processFilter(
+  filter: $ReadOnlyArray<FilterPrimitive> | string
+): $ReadOnlyArray<FilterPrimitive>;
 "
 `;
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -29,6 +29,7 @@ using namespace facebook::react;
 @implementation RCTViewComponentView {
   UIColor *_backgroundColor;
   __weak CALayer *_borderLayer;
+  CALayer *_filterLayer;
   BOOL _needsInvalidateLayer;
   BOOL _isJSResponder;
   BOOL _removeClippedSubviews;
@@ -388,6 +389,11 @@ using namespace facebook::react;
     self.accessibilityIdentifier = RCTNSStringFromString(newViewProps.testId);
   }
 
+  // `filter`
+  if (oldViewProps.filter != newViewProps.filter) {
+    _needsInvalidateLayer = YES;
+  }
+
   _needsInvalidateLayer = _needsInvalidateLayer || needsInvalidateLayer;
 
   _props = std::static_pointer_cast<const ViewProps>(props);
@@ -725,6 +731,33 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 
     layer.cornerRadius = cornerRadius;
     layer.mask = maskLayer;
+  }
+
+  [_filterLayer removeFromSuperlayer];
+  _filterLayer = nil;
+  self.layer.opacity = (float)_props->opacity;
+  if (!_props->filter.empty()) {
+    float multiplicativeBrightness = 1;
+    for (const auto &primitive : _props->filter) {
+      if (primitive.type == FilterType::Brightness) {
+        multiplicativeBrightness *= primitive.amount;
+      } else if (primitive.type == FilterType::Opacity) {
+        self.layer.opacity *= primitive.amount;
+      }
+    }
+
+    _filterLayer = [CALayer layer];
+    _filterLayer.frame = CGRectMake(0, 0, layer.frame.size.width, layer.frame.size.height);
+    _filterLayer.compositingFilter = @"multiplyBlendMode";
+    _filterLayer.backgroundColor = [UIColor colorWithRed:multiplicativeBrightness
+                                                   green:multiplicativeBrightness
+                                                    blue:multiplicativeBrightness
+                                                   alpha:self.layer.opacity]
+                                       .CGColor;
+    // So that this layer is always above any potential sublayers this view may
+    // add
+    _filterLayer.zPosition = CGFLOAT_MAX;
+    [self.layer addSublayer:_filterLayer];
   }
 }
 

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3970,6 +3970,7 @@ public abstract class com/facebook/react/uimanager/BaseViewManager : com/faceboo
 	public fun setClick (Landroid/view/View;Z)V
 	public fun setClickCapture (Landroid/view/View;Z)V
 	public fun setElevation (Landroid/view/View;F)V
+	public fun setFilter (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setImportantForAccessibility (Landroid/view/View;Ljava/lang/String;)V
 	public fun setMoveShouldSetResponder (Landroid/view/View;Z)V
 	public fun setMoveShouldSetResponderCapture (Landroid/view/View;Z)V
@@ -4039,6 +4040,7 @@ public abstract interface class com/facebook/react/uimanager/BaseViewManagerInte
 	public abstract fun setBorderTopLeftRadius (Landroid/view/View;F)V
 	public abstract fun setBorderTopRightRadius (Landroid/view/View;F)V
 	public abstract fun setElevation (Landroid/view/View;F)V
+	public abstract fun setFilter (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
 	public abstract fun setImportantForAccessibility (Landroid/view/View;Ljava/lang/String;)V
 	public abstract fun setNativeId (Landroid/view/View;Ljava/lang/String;)V
 	public abstract fun setOpacity (Landroid/view/View;F)V
@@ -5334,6 +5336,7 @@ public final class com/facebook/react/uimanager/ViewProps {
 	public static final field ELLIPSIZE_MODE Ljava/lang/String;
 	public static final field ENABLED Ljava/lang/String;
 	public static final field END Ljava/lang/String;
+	public static final field FILTER Ljava/lang/String;
 	public static final field FLEX Ljava/lang/String;
 	public static final field FLEX_BASIS Ljava/lang/String;
 	public static final field FLEX_DIRECTION Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerInterface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerInterface.java
@@ -48,6 +48,8 @@ public interface BaseViewManagerInterface<T extends View> {
 
   void setElevation(T view, float elevation);
 
+  void setFilter(T view, ReadableArray filter);
+
   void setShadowColor(T view, int shadowColor);
 
   void setImportantForAccessibility(T view, @Nullable String importantForAccessibility);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
@@ -35,9 +35,10 @@ internal object FilterHelper {
             "grayscale" -> createGrayscaleEffect(amount, chainedEffects)
             "sepia" -> createSepiaEffect(amount, chainedEffects)
             "saturate" -> createSaturateEffect(amount, chainedEffects)
-            "hue-rotate" -> createHueRotateEffect(amount, chainedEffects)
+            "hueRotate" -> createHueRotateEffect(amount, chainedEffects)
             "invert" -> createInvertEffect(amount, chainedEffects)
             "blur" -> createBlurEffect(amount, chainedEffects)
+            "opacity" -> createOpacityEffect(amount, chainedEffects)
             else -> throw IllegalArgumentException("Invalid filter name: $filterName")
           }
     }
@@ -63,6 +64,7 @@ internal object FilterHelper {
             "saturate" -> createSaturateColorMatrix(amount)
             "hueRotate" -> createHueRotateColorMatrix(amount)
             "invert" -> createInvertColorMatrix(amount)
+            "opacity" -> createOpacityColorMatrix(amount)
             else -> throw IllegalArgumentException("Invalid color matrix filter: $filterName")
           }
 
@@ -114,6 +116,20 @@ internal object FilterHelper {
   private fun createBrightnessColorMatrix(amount: Float): ColorMatrix {
     val matrix = ColorMatrix()
     matrix.setScale(amount, amount, amount, 1f)
+    return matrix
+  }
+
+  // https://www.w3.org/TR/filter-effects-1/#opacityEquivalent
+  public fun createOpacityEffect(
+      amount: Float,
+      chainedEffects: RenderEffect? = null
+  ): RenderEffect {
+    return createColorMatrixEffect(createOpacityColorMatrix(amount), chainedEffects)
+  }
+
+  public fun createOpacityColorMatrix(amount: Float): ColorMatrix {
+    val matrix = ColorMatrix()
+    matrix.setScale(1f, 1f, 1f, amount)
     return matrix
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
@@ -12,8 +12,9 @@ import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.graphics.RenderEffect
 import android.graphics.Shader
-import android.graphics.Shader.TileMode
 import com.facebook.react.bridge.ReadableArray
+import kotlin.math.cos
+import kotlin.math.sin
 
 @TargetApi(31)
 internal object FilterHelper {
@@ -23,9 +24,9 @@ internal object FilterHelper {
     filters ?: return null
     var chainedEffects: RenderEffect? = null
     for (i in 0 until filters.size()) {
-      val filter = filters.getMap(i)
-      val filterName = filter.getString("name") ?: continue
-      val amount = filter.getDouble("amount").toFloat()
+      val filter = filters.getMap(i).getEntryIterator().next()
+      val filterName = filter.key
+      val amount = (filter.value as Double).toFloat()
 
       chainedEffects =
           when (filterName) {
@@ -41,6 +42,47 @@ internal object FilterHelper {
           }
     }
     return chainedEffects
+  }
+
+  @JvmStatic
+  public fun parseColorMatrixFilters(filters: ReadableArray?): ColorMatrixColorFilter? {
+    filters ?: return null
+    // New ColorMatrix objects represent the identity matrix
+    val resultColorMatrix = ColorMatrix()
+    for (i in 0 until filters.size()) {
+      val filter = filters.getMap(i).getEntryIterator().next()
+      val filterName = filter.key
+      val amount = (filter.value as Double).toFloat()
+
+      val tempColorMatrix =
+          when (filterName) {
+            "brightness" -> createBrightnessColorMatrix(amount)
+            "contrast" -> createContrastColorMatrix(amount)
+            "grayscale" -> createGrayscaleColorMatrix(amount)
+            "sepia" -> createSepiaColorMatrix(amount)
+            "saturate" -> createSaturateColorMatrix(amount)
+            "hueRotate" -> createHueRotateColorMatrix(amount)
+            "invert" -> createInvertColorMatrix(amount)
+            else -> throw IllegalArgumentException("Invalid color matrix filter: $filterName")
+          }
+
+      resultColorMatrix.preConcat(tempColorMatrix)
+    }
+
+    return ColorMatrixColorFilter(resultColorMatrix)
+  }
+
+  @JvmStatic
+  public fun isOnlyColorMatrixFilters(filters: ReadableArray?): Boolean {
+    filters ?: return false
+    for (i in 0 until filters.size()) {
+      val filter = filters.getMap(i).getEntryIterator().next()
+      val filterName = filter.key
+      if (filterName == "blur") {
+        return false
+      }
+    }
+    return true
   }
 
   // https://www.w3.org/TR/filter-effects-1/#blurEquivalent
@@ -66,9 +108,13 @@ internal object FilterHelper {
       amount: Float,
       chainedEffects: RenderEffect? = null
   ): RenderEffect {
+    return createColorMatrixEffect(createBrightnessColorMatrix(amount), chainedEffects)
+  }
+
+  private fun createBrightnessColorMatrix(amount: Float): ColorMatrix {
     val matrix = ColorMatrix()
     matrix.setScale(amount, amount, amount, 1f)
-    return createColorMatrixEffect(matrix, chainedEffects)
+    return matrix
   }
 
   // https://www.w3.org/TR/filter-effects-1/#contrastEquivalent
@@ -76,33 +122,35 @@ internal object FilterHelper {
       amount: Float,
       chainedEffects: RenderEffect? = null
   ): RenderEffect {
+    return createColorMatrixEffect(createContrastColorMatrix(amount), chainedEffects)
+  }
+
+  private fun createContrastColorMatrix(amount: Float): ColorMatrix {
     // Multiply by 255 as Android operates in [0, 255] while the spec operates in [0, 1].
     // This really only matters if there is an intercept that needs to be added
     val intercept = 255 * (-(amount / 2.0f) + 0.5f)
-    val matrix =
-        ColorMatrix(
-            floatArrayOf(
-                amount,
-                0f,
-                0f,
-                0f,
-                intercept,
-                0f,
-                amount,
-                0f,
-                0f,
-                intercept,
-                0f,
-                0f,
-                amount,
-                0f,
-                intercept,
-                0f,
-                0f,
-                0f,
-                1f,
-                0f))
-    return createColorMatrixEffect(matrix, chainedEffects)
+    return ColorMatrix(
+        floatArrayOf(
+            amount,
+            0f,
+            0f,
+            0f,
+            intercept,
+            0f,
+            amount,
+            0f,
+            0f,
+            intercept,
+            0f,
+            0f,
+            amount,
+            0f,
+            intercept,
+            0f,
+            0f,
+            0f,
+            1f,
+            0f))
   }
 
   // https://www.w3.org/TR/filter-effects-1/#grayscaleEquivalent
@@ -110,60 +158,64 @@ internal object FilterHelper {
       amount: Float,
       chainedEffects: RenderEffect? = null
   ): RenderEffect {
+    return createColorMatrixEffect(createGrayscaleColorMatrix(amount), chainedEffects)
+  }
+
+  private fun createGrayscaleColorMatrix(amount: Float): ColorMatrix {
     val inverseAmount = 1 - amount
-    val matrix =
-        ColorMatrix(
-            floatArrayOf(
-                0.2_126f + 0.7_874f * inverseAmount,
-                0.7_152f - 0.7_152f * inverseAmount,
-                0.0_722f - 0.0_722f * inverseAmount,
-                0f,
-                0f,
-                0.2_126f - 0.2_126f * inverseAmount,
-                0.7_152f + 0.2_848f * inverseAmount,
-                0.0_722f - 0.0_722f * inverseAmount,
-                0f,
-                0f,
-                0.2_126f - 0.2_126f * inverseAmount,
-                0.7_152f - 0.7_152f * inverseAmount,
-                0.0_722f + 0.9_278f * inverseAmount,
-                0f,
-                0f,
-                0f,
-                0f,
-                0f,
-                1f,
-                0f))
-    return createColorMatrixEffect(matrix, chainedEffects)
+    return ColorMatrix(
+        floatArrayOf(
+            0.2_126f + 0.7_874f * inverseAmount,
+            0.7_152f - 0.7_152f * inverseAmount,
+            0.0_722f - 0.0_722f * inverseAmount,
+            0f,
+            0f,
+            0.2_126f - 0.2_126f * inverseAmount,
+            0.7_152f + 0.2_848f * inverseAmount,
+            0.0_722f - 0.0_722f * inverseAmount,
+            0f,
+            0f,
+            0.2_126f - 0.2_126f * inverseAmount,
+            0.7_152f - 0.7_152f * inverseAmount,
+            0.0_722f + 0.9_278f * inverseAmount,
+            0f,
+            0f,
+            0f,
+            0f,
+            0f,
+            1f,
+            0f))
   }
 
   // https://www.w3.org/TR/filter-effects-1/#sepiaEquivalent
   public fun createSepiaEffect(amount: Float, chainedEffects: RenderEffect? = null): RenderEffect {
+    return createColorMatrixEffect(createSepiaColorMatrix(amount), chainedEffects)
+  }
+
+  private fun createSepiaColorMatrix(amount: Float): ColorMatrix {
     val inverseAmount = 1 - amount
-    val matrix =
-        ColorMatrix(
-            floatArrayOf(
-                0.393f + 0.607f * inverseAmount,
-                0.769f - 0.769f * inverseAmount,
-                0.189f - 0.189f * inverseAmount,
-                0f,
-                0f,
-                0.349f - 0.349f * inverseAmount,
-                0.686f + 0.314f * inverseAmount,
-                0.168f - 0.168f * inverseAmount,
-                0f,
-                0f,
-                0.272f - 0.272f * inverseAmount,
-                0.534f - 0.534f * inverseAmount,
-                0.131f + 0.869f * inverseAmount,
-                0f,
-                0f,
-                0f,
-                0f,
-                0f,
-                1f,
-                0f))
-    return createColorMatrixEffect(matrix, chainedEffects)
+    return ColorMatrix(
+        floatArrayOf(
+            0.393f + 0.607f * inverseAmount,
+            0.769f - 0.769f * inverseAmount,
+            0.189f - 0.189f * inverseAmount,
+            0f,
+            0f,
+            0.349f - 0.349f * inverseAmount,
+            0.686f + 0.314f * inverseAmount,
+            0.168f - 0.168f * inverseAmount,
+            0f,
+            0f,
+            0.272f - 0.272f * inverseAmount,
+            0.534f - 0.534f * inverseAmount,
+            0.131f + 0.869f * inverseAmount,
+            0f,
+            0f,
+            0f,
+            0f,
+            0f,
+            1f,
+            0f))
   }
 
   // https://www.w3.org/TR/filter-effects-1/#saturateEquivalent
@@ -171,9 +223,13 @@ internal object FilterHelper {
       amount: Float,
       chainedEffects: RenderEffect? = null
   ): RenderEffect {
+    return createColorMatrixEffect(createSaturateColorMatrix(amount), chainedEffects)
+  }
+
+  private fun createSaturateColorMatrix(amount: Float): ColorMatrix {
     val matrix = ColorMatrix()
     matrix.setSaturation(amount)
-    return createColorMatrixEffect(matrix, chainedEffects)
+    return matrix
   }
 
   // https://www.w3.org/TR/filter-effects-1/#huerotateEquivalent
@@ -181,63 +237,67 @@ internal object FilterHelper {
       amount: Float,
       chainedEffects: RenderEffect? = null
   ): RenderEffect {
+    return createColorMatrixEffect(createHueRotateColorMatrix(amount), chainedEffects)
+  }
+
+  private fun createHueRotateColorMatrix(amount: Float): ColorMatrix {
     val amountRads = Math.toRadians(amount.toDouble())
-    val cos = Math.cos(amountRads).toFloat()
-    val sin = Math.sin(amountRads).toFloat()
-    val matrix =
-        ColorMatrix(
-            floatArrayOf(
-                0.213f + 0.787f * cos - 0.213f * sin,
-                0.715f - 0.715f * cos - 0.715f * sin,
-                0.072f - 0.072f * cos + 0.928f * sin,
-                0f,
-                0f,
-                0.213f - 0.213f * cos + 0.143f * sin,
-                0.715f + 0.285f * cos + 0.140f * sin,
-                0.072f - 0.072f * cos - 0.283f * sin,
-                0f,
-                0f,
-                0.213f - 0.213f * cos - 0.787f * sin,
-                0.715f - 0.715f * cos + 0.715f * sin,
-                0.072f + 0.928f * cos + 0.072f * sin,
-                0f,
-                0f,
-                0f,
-                0f,
-                0f,
-                1f,
-                0f))
-    return createColorMatrixEffect(matrix, chainedEffects)
+    val cos = cos(amountRads).toFloat()
+    val sin = sin(amountRads).toFloat()
+    return ColorMatrix(
+        floatArrayOf(
+            0.213f + 0.787f * cos - 0.213f * sin,
+            0.715f - 0.715f * cos - 0.715f * sin,
+            0.072f - 0.072f * cos + 0.928f * sin,
+            0f,
+            0f,
+            0.213f - 0.213f * cos + 0.143f * sin,
+            0.715f + 0.285f * cos + 0.140f * sin,
+            0.072f - 0.072f * cos - 0.283f * sin,
+            0f,
+            0f,
+            0.213f - 0.213f * cos - 0.787f * sin,
+            0.715f - 0.715f * cos + 0.715f * sin,
+            0.072f + 0.928f * cos + 0.072f * sin,
+            0f,
+            0f,
+            0f,
+            0f,
+            0f,
+            1f,
+            0f))
   }
 
   // https://www.w3.org/TR/filter-effects-1/#invertEquivalent
   public fun createInvertEffect(amount: Float, chainedEffects: RenderEffect? = null): RenderEffect {
+    return createColorMatrixEffect(createInvertColorMatrix(amount), chainedEffects)
+  }
+
+  private fun createInvertColorMatrix(amount: Float): ColorMatrix {
     val slope = 1 - 2 * amount
     val intercept = amount * 255
-    val matrix =
-        ColorMatrix(
-            floatArrayOf(
-                slope,
-                0f,
-                0f,
-                0f,
-                intercept,
-                0f,
-                slope,
-                0f,
-                0f,
-                intercept,
-                0f,
-                0f,
-                slope,
-                0f,
-                intercept,
-                0f,
-                0f,
-                0f,
-                1f,
-                0f))
-    return createColorMatrixEffect(matrix, chainedEffects)
+    return ColorMatrix(
+        floatArrayOf(
+            slope,
+            0f,
+            0f,
+            0f,
+            intercept,
+            0f,
+            slope,
+            0f,
+            0f,
+            intercept,
+            0f,
+            0f,
+            slope,
+            0f,
+            intercept,
+            0f,
+            0f,
+            0f,
+            1f,
+            0f))
   }
 
   private fun createColorMatrixEffect(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
@@ -135,6 +135,7 @@ public object ViewProps {
   public const val BORDER_START_COLOR: String = "borderStartColor"
   public const val BORDER_END_COLOR: String = "borderEndColor"
   public const val ON_LAYOUT: String = "onLayout"
+  public const val FILTER: String = "experimental_filter"
   public const val TRANSFORM: String = "transform"
   public const val TRANSFORM_ORIGIN: String = "transformOrigin"
   public const val ELEVATION: String = "elevation"

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -56,4 +56,10 @@
 
   <!-- tag is used to invalidate transform style in view manager -->
   <item type="id" name="invalidate_transform"/>
+
+  <!-- tag is used to store if we should render the view to a hardware texture -->
+  <item type="id" name="use_hardware_layer"/>
+
+  <!-- tag is used to store graphical filter effects to apply to the view -->
+  <item type="id" name="filter"/>
 </resources>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -150,6 +150,14 @@ BaseViewProps::BaseViewProps(
                                                        "cursor",
                                                        sourceProps.cursor,
                                                        {})),
+      filter(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.filter
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "experimental_filter",
+                                                       sourceProps.filter,
+                                                       {})),
       transform(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.transform
                                                  : convertRawProp(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -14,6 +14,7 @@
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
+#include <react/renderer/graphics/Filter.h>
 #include <react/renderer/graphics/Transform.h>
 
 #include <optional>
@@ -53,6 +54,9 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
   Float shadowRadius{3};
 
   Cursor cursor{};
+
+  // Filter
+  std::vector<FilterPrimitive> filter{};
 
   // Transform
   Transform transform{};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -61,6 +61,7 @@ void ViewShadowNode::initialize() noexcept {
       viewProps.accessibilityViewIsModal ||
       viewProps.importantForAccessibility != ImportantForAccessibility::Auto ||
       viewProps.removeClippedSubviews || viewProps.cursor != Cursor::Auto ||
+      !viewProps.filter.empty() ||
       HostPlatformViewTraitsInitializer::formsStackingContext(viewProps);
 
   bool formsView = formsStackingContext ||

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -376,8 +376,11 @@ void YogaLayoutableShadowNode::updateYogaProps() {
   yogaNode_.setStyle(styleResult);
   if (getTraits().check(ShadowNodeTraits::ViewKind)) {
     auto& viewProps = static_cast<const ViewProps&>(*props_);
-    YGNodeSetAlwaysFormsContainingBlock(
-        &yogaNode_, viewProps.transform != Transform::Identity());
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
+    bool alwaysFormsContainingBlock =
+        viewProps.transform != Transform::Identity() ||
+        !viewProps.filter.empty();
+    YGNodeSetAlwaysFormsContainingBlock(&yogaNode_, alwaysFormsContainingBlock);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/graphics/Float.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace facebook::react {
+
+enum class FilterType {
+  Blur,
+  Brightness,
+  Contrast,
+  Grayscale,
+  HueRotate,
+  Invert,
+  Opacity,
+  Saturate,
+  Sepia
+};
+
+struct FilterPrimitive {
+  bool operator==(const FilterPrimitive& other) const = default;
+
+  FilterType type;
+  Float amount;
+};
+
+inline FilterType filterTypeFromString(std::string_view filterName) {
+  if (filterName == "blur") {
+    return FilterType::Blur;
+  } else if (filterName == "brightness") {
+    return FilterType::Brightness;
+  } else if (filterName == "contrast") {
+    return FilterType::Contrast;
+  } else if (filterName == "grayscale") {
+    return FilterType::Grayscale;
+  } else if (filterName == "hueRotate") {
+    return FilterType::HueRotate;
+  } else if (filterName == "invert") {
+    return FilterType::Invert;
+  } else if (filterName == "opacity") {
+    return FilterType::Opacity;
+  } else if (filterName == "saturate") {
+    return FilterType::Saturate;
+  } else if (filterName == "sepia") {
+    return FilterType::Sepia;
+  } else {
+    throw std::invalid_argument(std::string(filterName));
+  }
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
This is the JS plumbing to get it so that views can now use filters. The typing looks like

`filter: [{brightness: 1.5}, {hueRotate: '90deg'}]`

which is different than web which would look like `filter: brightness(1.5) hue-rotate(90deg)`. I feel like the web version is overly complicated and not very *react native-y*. Transform uses the array based approach (albeit they also accept a string). Open to changing this but really feel like the web format is silly and bad since it would just involve parsing some arbitrary string.

The diff includes:

* Style sheet changes so typing is valid
* Process function to turn filter format into {name: string, amount: string}
* Test for process function
* View config changes on Android, iOS and ReactNativeStyleAttributes

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D56845572


