### PR TITLE
Add metro app building support

### DIFF
--- a/packages/core-cli-utils/src/index.flow.js
+++ b/packages/core-cli-utils/src/index.flow.js
@@ -12,11 +12,13 @@
 // @babel/register doesn't like export {foo} from './bar'; statements,
 // so we have to jump through hoops here.
 import {tasks as _android} from './private/android.js';
+import {tasks as _app} from './private/app.js';
 import {tasks as _apple} from './private/apple.js';
 import {tasks as _clean} from './private/clean.js';
 import * as _version from './public/version.js';
 
 export const android = _android;
+export const app = _app;
 export const apple = _apple;
 export const clean = _clean;
 export const version = _version;

--- a/packages/core-cli-utils/src/private/app.js
+++ b/packages/core-cli-utils/src/private/app.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Task} from './types';
+import type {ExecaPromise} from 'execa';
+
+import {task} from './utils';
+import execa from 'execa';
+import path from 'path';
+
+type AppOptions = {
+  cwd: string,
+};
+
+type BundleOptions =
+  | {mode: 'bundle', ...AppOptions}
+  | {mode: 'watch', callback?: (metro: ExecaPromise) => void, ...AppOptions};
+
+const FIRST = 1,
+  SECOND = 2;
+
+function getNodePackagePath(packageName: string): string {
+  // $FlowFixMe[prop-missing] type definition is incomplete
+  return require.resolve(packageName, {cwd: [process.cwd(), ...module.paths]});
+}
+
+function metro(...args: $ReadOnlyArray<string>): ExecaPromise {
+  return execa('node', [
+    getNodePackagePath(path.join('metro', 'src', 'cli.js')),
+    ...args,
+  ]);
+}
+
+const noMetro = new Error('Metro is not available');
+
+export const tasks = {
+  bundle: (
+    options: BundleOptions,
+    ...args: $ReadOnlyArray<string>
+  ): {
+    validate: Task<void>,
+    run: Task<ExecaPromise>,
+  } => ({
+    /* eslint-disable sort-keys */
+    validate: task(FIRST, 'Check if Metro is available', () => {
+      try {
+        require('metro');
+      } catch {
+        throw noMetro;
+      }
+    }),
+
+    run:
+      options.mode === 'bundle'
+        ? task(SECOND, 'Metro generating an .jsbundle', () =>
+            metro('bundle', ...args),
+          )
+        : task(SECOND, 'Metro watching for changes', () => {
+            const proc = metro('serve', ...args);
+            return proc;
+          }),
+  }),
+};

--- a/packages/core-cli-utils/src/private/apple.js
+++ b/packages/core-cli-utils/src/private/apple.js
@@ -30,6 +30,7 @@ type AppleBuildOptions = {
 
 type AppleBootstrapOption = {
   // Enabled by default
+  hermes?: boolean | string,
   newArchitecture: boolean,
   ...AppleOptions,
 };
@@ -75,12 +76,26 @@ export const tasks = {
         cwd: options.cwd,
       }),
     ),
-    installDependencies: task(THIRD, 'Install CocoaPods dependencies', () =>
-      execa('bundle', ['exec', 'pod', 'install'], {
+    installDependencies: task(THIRD, 'Install CocoaPods dependencies', () => {
+      const env = {
+        RCT_NEW_ARCH_ENABLED: options.newArchitecture ? '1' : '0',
+        HERMES: '1',
+      };
+      if (options.hermes != null) {
+        switch (typeof options.hermes) {
+          case 'string':
+            env.HERMES = options.hermes;
+            break;
+          case 'boolean':
+            env.HERMES = options.hermes ? '1' : '0';
+            break;
+        }
+      }
+      return execa('bundle', ['exec', 'pod', 'install'], {
         cwd: options.cwd,
-        env: {RCT_NEW_ARCH_ENABLED: options.newArchitecture ? '1' : '0'},
-      }),
-    ),
+        env,
+      });
+    }),
   }),
 
   // 2. Build the iOS app using a setup environment


### PR DESCRIPTION
Summary:
Contains a *light* wrapper to help launch Metro and build bundles or wait for localhost requests against Metro's dev-server. 

Changelog: [Internal]

Differential Revision: D57067040


