### PR TITLE
Make INTERNAL_CALLSITES_REGEX work with Windows paths

### DIFF
--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -35,7 +35,10 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
     '/node_modules/react-refresh/.+\\.js$',
     '/node_modules/scheduler/.+\\.js$',
     '^\\[native code\\]$',
-  ].join('|'),
+  ]
+    // Make patterns work with both Windows and POSIX paths.
+    .map(pathPattern => pathPattern.replaceAll('/', '[/\\\\]'))
+    .join('|'),
 );
 
 export {mergeConfig} from 'metro-config';

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -12,6 +12,8 @@
 #import "RCTDefines.h"
 #import "RCTLog.h"
 
+#import <jsinspector-modern/InspectorFlags.h>
+
 NSString *const RCTBundleURLProviderUpdatedNotification = @"RCTBundleURLProviderUpdatedNotification";
 
 const NSUInteger kRCTBundleURLProviderDefaultPort = RCT_METRO_PORT;
@@ -281,6 +283,12 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
     [[NSURLQueryItem alloc] initWithName:@"modulesOnly" value:modulesOnly ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"runModule" value:runModule ? @"true" : @"false"],
   ];
+  auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
+  if (inspectorFlags.getEnableModernCDPRegistry()) {
+    queryItems = [queryItems arrayByAddingObject:[[NSURLQueryItem alloc] initWithName:@"excludeSource" value:@"true"]];
+    queryItems = [queryItems arrayByAddingObject:[[NSURLQueryItem alloc] initWithName:@"sourcePaths"
+                                                                                value:@"url-server"]];
+  }
 
   NSString *bundleID = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey];
   if (bundleID) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -382,17 +382,20 @@ public class DevServerHelper {
       String mainModuleID, BundleType type, String host, boolean modulesOnly, boolean runModule) {
     boolean dev = getDevMode();
     return String.format(
-        Locale.US,
-        "http://%s/%s.%s?platform=android&dev=%s&lazy=%s&minify=%s&app=%s&modulesOnly=%s&runModule=%s",
-        host,
-        mainModuleID,
-        type.typeID(),
-        dev, // dev
-        dev, // lazy
-        getJSMinifyMode(),
-        mPackageName,
-        modulesOnly ? "true" : "false",
-        runModule ? "true" : "false");
+            Locale.US,
+            "http://%s/%s.%s?platform=android&dev=%s&lazy=%s&minify=%s&app=%s&modulesOnly=%s&runModule=%s",
+            host,
+            mainModuleID,
+            type.typeID(),
+            dev, // dev
+            dev, // lazy
+            getJSMinifyMode(),
+            mPackageName,
+            modulesOnly ? "true" : "false",
+            runModule ? "true" : "false")
+        + (InspectorFlags.getEnableModernCDPRegistry()
+            ? "&excludeSource=true&sourcePaths=url-server"
+            : "");
   }
 
   private String createBundleURL(String mainModuleID, BundleType type) {


### PR DESCRIPTION
Summary: Changelog: [General][Fixed] LogBox and Chrome DevTools stack frame collapsing patterns are now compatible with Windows file paths.

Differential Revision: D57091214


