### PR TITLE
feat: move notifying observers to event dispatcher

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -50,10 +50,6 @@ import memoize from 'memoize-one';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 
-if (Platform.OS === 'ios') {
-  require('../../Renderer/shims/ReactNative'); // Force side effects to prevent T55744311
-}
-
 const {NativeHorizontalScrollViewTuple, NativeVerticalScrollViewTuple} =
   Platform.OS === 'android'
     ? {

--- a/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
+++ b/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
@@ -235,7 +235,9 @@ RCT_EXPORT_MODULE()
 {
   NSDictionary *userInfo = notification.userInfo;
   id<RCTEvent> event = [userInfo objectForKey:@"event"];
-  [self notifyObserversOfEvent:event];
+  if (event) {
+    [self notifyObserversOfEvent:event];
+  }
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
+++ b/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
@@ -54,6 +54,12 @@ RCT_EXPORT_MODULE()
   _eventsDispatchScheduled = NO;
   _observers = [NSHashTable weakObjectsHashTable];
   _observersLock = [NSRecursiveLock new];
+
+  NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
+  [defaultCenter addObserver:self
+                    selector:@selector(_notifyEventDispatcherObserversOfEvent_DEPRECATED:)
+                        name:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
+                      object:nil];
 }
 
 - (void)sendViewEventWithName:(NSString *)name reactTag:(NSNumber *)reactTag
@@ -223,6 +229,13 @@ RCT_EXPORT_MODULE()
   for (NSNumber *eventId in eventQueue) {
     [self dispatchEvent:events[eventId]];
   }
+}
+
+- (void)_notifyEventDispatcherObserversOfEvent_DEPRECATED:(NSNotification *)notification
+{
+  NSDictionary *userInfo = notification.userInfo;
+  id<RCTEvent> event = [userInfo objectForKey:@"event"];
+  [self notifyObserversOfEvent:event];
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -68,15 +68,10 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
                                                       scrollViewZoomScale:scrollView.zoomScale
                                                                  userData:nil
                                                             coalescingKey:coalescingKey];
-  RCTBridge *bridge = [RCTBridge currentBridge];
-  if (bridge) {
-    [bridge.eventDispatcher sendEvent:scrollEvent];
-  } else {
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:scrollEvent, @"event", nil];
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
-                                                        object:nil
-                                                      userInfo:userInfo];
-  }
+  NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:scrollEvent, @"event", nil];
+  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
+                                                      object:nil
+                                                    userInfo:userInfo];
 }
 
 @interface RCTScrollViewComponentView () <

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -128,13 +128,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     }
     _launchOptions = launchOptions;
 
-    NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
-
-    [defaultCenter addObserver:self
-                      selector:@selector(_notifyEventDispatcherObserversOfEvent_DEPRECATED:)
-                          name:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
-                        object:nil];
-
     [self _start];
   }
   return self;
@@ -478,19 +471,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   if (_onInitialBundleLoad) {
     _onInitialBundleLoad();
     _onInitialBundleLoad = nil;
-  }
-}
-
-- (void)_notifyEventDispatcherObserversOfEvent_DEPRECATED:(NSNotification *)notification
-{
-  NSDictionary *userInfo = notification.userInfo;
-  id<RCTEvent> event = [userInfo objectForKey:@"event"];
-
-  RCTModuleRegistry *moduleRegistry = _bridgeModuleDecorator.moduleRegistry;
-  if (event && moduleRegistry) {
-    id<RCTEventDispatcherProtocol> legacyEventDispatcher = [moduleRegistry moduleForName:"EventDispatcher"
-                                                                   lazilyLoadIfNecessary:YES];
-    [legacyEventDispatcher notifyObserversOfEvent:event];
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Based on the discussion starting here: https://discord.com/channels/514829729862516747/1073566663825432587/1237407161991172157, I suggest moving the call to `_notifyEventDispatcherObserversOfEvent_DEPRECATED` straight to `RCTEventDispatcher.mm`. It was previously in `RCTInstance.mm` which is only relevant on bridgeless mode. We want to mimic the behavior of https://github.com/facebook/react-native/blob/06eea61c19cd730cf0c14a436f042d30791c3f4a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm#L75-L78 but without using `currentBridge` since it is considered bad practice: https://github.com/software-mansion/react-native-reanimated/issues/5497#issuecomment-2083400038.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [CHANGED] - Move `notifyObservers` straight to `RCTEventDispatcher.mm`.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

See that example with `stickyHeaders` still works correctly on both bridgeless and bridge mode.

Videos with it on https://github.com/facebook/react-native/blob/deee037c62a7d62a349d34db427b14d3560ddf83/packages/rn-tester/js/examples/FlatList/FlatList-stickyHeaders.js example with more items for visibility:

- bridgeless:

https://github.com/facebook/react-native/assets/32481228/8b78104a-226b-466a-9f32-60ba4ec14100

- bridge:


https://github.com/facebook/react-native/assets/32481228/f2ca67cb-578f-45d4-954f-3249c6fa9410

- old arch:



https://github.com/facebook/react-native/assets/32481228/7d642923-ddda-4dd3-8f14-c9982a03bc2e

