### PR TITLE
remove undefined behaviour when cancelling ongoing animation

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -205,11 +205,11 @@ class TouchableBounce extends React.Component<Props, State> {
 
   componentDidMount(): mixed {
     this.state.pressability.configure(this._createPressabilityConfig());
+    this.state.scale.resetAnimation();
   }
 
   componentWillUnmount(): void {
     this.state.pressability.reset();
-    this.state.scale.resetAnimation();
   }
 }
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -316,11 +316,11 @@ class TouchableOpacity extends React.Component<Props, State> {
 
   componentDidMount(): void {
     this.state.pressability.configure(this._createPressabilityConfig());
+    this.state.anim.resetAnimation();
   }
 
   componentWillUnmount(): void {
     this.state.pressability.reset();
-    this.state.anim.resetAnimation();
   }
 }
 


### PR DESCRIPTION
Summary:
changelog: [internal]

Restarting animation state in `componentWillUnmount` may get the animation into inconsistent state, leading to broken behaviour. It is safe to restart the animation state inside of `componentDidMount` as this prepares the component when it is mounted.

Differential Revision: D57102842


