### PR TITLE
Add BindingsInstaller for TurboModules on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/BindingsInstallerHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/BindingsInstallerHolder.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core
+
+import com.facebook.jni.HybridData
+import com.facebook.proguard.annotations.DoNotStrip
+
+/**
+ * A Java holder for a C++ BindingsInstallerHolder.
+ */
+@DoNotStrip
+public class BindingsInstallerHolder(@field:DoNotStrip private val mHybridData: HybridData)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core.interfaces
+
+import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.turbomodule.core.BindingsInstallerHolder
+
+/**
+ * Implements this interface if a TurboModule needs to install its own JSI bindings.
+ */
+@DoNotStrip
+public interface TurboModuleWithJSIBindings {
+  /**
+   * Returns the [BindingsInstallerHolder] that the core will later invoke with
+   * an `facebook::jsi::Runtime` instance.
+   * The implementation will typically mix with JNI and C++.
+   */
+  @DoNotStrip
+  public fun getBindingsInstaller(): BindingsInstallerHolder
+}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(callinvokerholder
 add_library(
         turbomodulejsijni
         SHARED
+        ReactCommon/BindingsInstallerHolder.cpp
         ReactCommon/CompositeTurboModuleManagerDelegate.cpp
         ReactCommon/OnLoad.cpp
         ReactCommon/TurboModuleManager.cpp

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/BindingsInstallerHolder.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/BindingsInstallerHolder.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "BindingsInstallerHolder.h"
+
+namespace facebook::react {
+
+BindingsInstallerHolder::BindingsInstallerHolder(
+    TurboModule::BindingsInstaller bindingsInstaller)
+    : bindingsInstaller_(bindingsInstaller) {}
+
+TurboModule::BindingsInstaller BindingsInstallerHolder::get() {
+  return bindingsInstaller_;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/BindingsInstallerHolder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/BindingsInstallerHolder.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/TurboModule.h>
+#include <fbjni/fbjni.h>
+
+namespace facebook::react {
+
+class BindingsInstallerHolder
+    : public jni::HybridClass<BindingsInstallerHolder> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/turbomodule/core/BindingsInstallerHolder;";
+
+  TurboModule::BindingsInstaller get();
+
+ private:
+  friend HybridBase;
+  BindingsInstallerHolder(TurboModule::BindingsInstaller bindingsInstaller);
+  TurboModule::BindingsInstaller bindingsInstaller_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -12,6 +12,7 @@
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 
+#include <ReactCommon/BindingsInstallerHolder.h>
 #include <ReactCommon/CxxTurboModuleUtils.h>
 #include <ReactCommon/JavaInteropTurboModule.h>
 #include <ReactCommon/TurboCxxModule.h>
@@ -128,8 +129,10 @@ void TurboModuleManager::registerNatives() {
 
 TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
     jni::alias_ref<jhybridobject> javaPart,
+    jsi::Runtime* runtime,
     bool enableSyncVoidMethods) {
   return [turboModuleCache_ = std::weak_ptr<ModuleCache>(turboModuleCache_),
+          runtime,
           jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
           nativeMethodCallInvoker_ =
               std::weak_ptr<NativeMethodCallInvoker>(nativeMethodCallInvoker_),
@@ -208,6 +211,18 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
           .shouldVoidMethodsExecuteSync = enableSyncVoidMethods};
 
       auto turboModule = delegate->cthis()->getTurboModule(name, params);
+      if (moduleInstance->isInstanceOf(
+              JTurboModuleWithJSIBindings::javaClassStatic())) {
+        auto getBindingsInstaller =
+            moduleInstance->getClass()
+                ->getMethod<BindingsInstallerHolder::javaobject()>(
+                    "getBindingsInstaller");
+        auto installer = getBindingsInstaller(moduleInstance);
+        if (installer) {
+          installer->cthis()->get()(*runtime);
+        }
+      }
+
       turboModuleCache->insert({name, turboModule});
       TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
       return turboModule;
@@ -325,7 +340,8 @@ void TurboModuleManager::installJSIBindings(
                              enableSyncVoidMethods](jsi::Runtime& runtime) {
     TurboModuleBinding::install(
         runtime,
-        cxxPart->createTurboModuleProvider(javaPart, enableSyncVoidMethods),
+        cxxPart->createTurboModuleProvider(
+            javaPart, &runtime, enableSyncVoidMethods),
         shouldCreateLegacyModules
             ? cxxPart->createLegacyModuleProvider(javaPart)
             : nullptr);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -67,6 +67,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
 
   TurboModuleProviderFunctionType createTurboModuleProvider(
       jni::alias_ref<jhybridobject> javaPart,
+      jsi::Runtime* runtime,
       bool enableSyncVoidMethods);
   TurboModuleProviderFunctionType createLegacyModuleProvider(
       jni::alias_ref<jhybridobject> javaPart);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -48,6 +48,8 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
  public:
   TurboModule(std::string name, std::shared_ptr<CallInvoker> jsInvoker);
 
+  using BindingsInstaller = std::function<void(jsi::Runtime& runtime)>;
+
   // Note: keep this method declared inline to avoid conflicts
   // between RTTI and non-RTTI compilation units
   facebook::jsi::Value get(

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
@@ -22,6 +22,12 @@ struct JTurboModule : jni::JavaClass<JTurboModule> {
       "Lcom/facebook/react/turbomodule/core/interfaces/TurboModule;";
 };
 
+struct JTurboModuleWithJSIBindings
+    : jni::JavaClass<JTurboModuleWithJSIBindings> {
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/turbomodule/core/interfaces/TurboModuleWithJSIBindings;";
+};
+
 class JSI_EXPORT JavaTurboModule : public TurboModule {
  public:
   // TODO(T65603471): Should we unify this with a Fabric abstraction?

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
@@ -23,4 +23,5 @@ target_include_directories(sampleturbomodule PUBLIC .)
 target_link_libraries(sampleturbomodule
         fbjni
         jsi
-        react_nativemodule_core)
+        react_nativemodule_core
+        turbomodulejsijni)

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ReactCommon/SampleTurboModuleJSIBindings.h>
+
+namespace facebook::react {
+
+// static
+void SampleTurboModuleJSIBindings::registerNatives() {
+  javaClassLocal()->registerNatives({
+      makeNativeMethod(
+          "getBindingsInstallerCxx",
+          SampleTurboModuleJSIBindings::getBindingsInstallerCxx),
+  });
+}
+
+// static
+jni::local_ref<BindingsInstallerHolder::javaobject>
+SampleTurboModuleJSIBindings::getBindingsInstallerCxx(
+    jni::alias_ref<jni::JClass> clazz) {
+  return jni::make_local(
+      BindingsInstallerHolder::newObjectCxxArgs([](jsi::Runtime& runtime) {
+        runtime.global().setProperty(
+            runtime, "__SampleTurboModuleJSIBindings", "Hello JSI!");
+      }));
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleJSIBindings.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/BindingsInstallerHolder.h>
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+namespace facebook::react {
+
+class SampleTurboModuleJSIBindings
+    : public jni::JavaClass<SampleTurboModuleJSIBindings> {
+ public:
+  static constexpr const char* kJavaDescriptor =
+      "Lcom/facebook/fbreact/specs/SampleTurboModule;";
+
+  SampleTurboModuleJSIBindings() = default;
+
+  static void registerNatives();
+
+ private:
+  // Using static function as a simple demonstration
+  static jni::local_ref<BindingsInstallerHolder::javaobject>
+  getBindingsInstallerCxx(jni::alias_ref<jni::JClass> clazz);
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -23,11 +23,14 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.turbomodule.core.BindingsInstallerHolder;
+import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings;
 import java.util.HashMap;
 import java.util.Map;
 
 @ReactModule(name = SampleTurboModule.NAME)
-public class SampleTurboModule extends NativeSampleTurboModuleSpec {
+public class SampleTurboModule extends NativeSampleTurboModuleSpec
+    implements TurboModuleWithJSIBindings {
 
   public static final String NAME = "SampleTurboModule";
 
@@ -251,4 +254,12 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec {
   public String getName() {
     return NAME;
   }
+
+  @Override
+  @DoNotStrip
+  public BindingsInstallerHolder getBindingsInstaller() {
+    return getBindingsInstallerCxx();
+  }
+
+  private static native BindingsInstallerHolder getBindingsInstallerCxx();
 }

--- a/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
+++ b/packages/rn-tester/android/app/src/main/jni/OnLoad.cpp
@@ -8,6 +8,7 @@
 #include <DefaultComponentsRegistry.h>
 #include <DefaultTurboModuleManagerDelegate.h>
 #include <NativeCxxModuleExample.h>
+#include <ReactCommon/SampleTurboModuleJSIBindings.h>
 #include <ReactCommon/SampleTurboModuleSpec.h>
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
@@ -73,5 +74,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
     facebook::react::DefaultComponentsRegistry::
         registerComponentDescriptorsFromEntryPoint =
             &facebook::react::registerComponents;
+    facebook::react::SampleTurboModuleJSIBindings::registerNatives();
   });
 }

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -14,6 +14,7 @@ import styles from './TurboModuleExampleCommon';
 import * as React from 'react';
 import {
   FlatList,
+  Platform,
   RootTagContext,
   Text,
   TouchableOpacity,
@@ -128,6 +129,9 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
           this._setResult('promiseAssert', e.message);
         });
     },
+    installJSIBindings: () => {
+      return global.__SampleTurboModuleJSIBindings;
+    },
   };
 
   _setResult(
@@ -192,6 +196,14 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
     if (global.__turboModuleProxy == null) {
       throw new Error(
         'Cannot load this example because TurboModule is not configured.',
+      );
+    }
+    if (
+      global.__SampleTurboModuleJSIBindings == null &&
+      Platform.OS === 'android' // TODO: Add iOS support
+    ) {
+      throw new Error(
+        'The JSI bindings for SampleTurboModule are not installed.',
       );
     }
   }


### PR DESCRIPTION
## Summary:

Add synchronous JS bindings installation for TurboModules on Android. That would help some 3rd party JSI based modules to install JS bindings easier.
The iOS implementation will be in a separate PR.
Re-create from #43110
 
## Changelog:

[ANDROID] [ADDED] - Add BindingsInstaller for TurboModules

## Test Plan:

Added test in RN-Tester TurboModule test case