### PR TITLE
Add BindingsInstaller for TurboModules on iOS

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -48,6 +48,8 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
  public:
   TurboModule(std::string name, std::shared_ptr<CallInvoker> jsInvoker);
 
+  using BindingsInstaller = std::function<void(jsi::Runtime& runtime)>;
+
   // Note: keep this method declared inline to avoid conflicts
   // between RTTI and non-RTTI compilation units
   facebook::jsi::Value get(

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -166,7 +166,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 /**
  * Implements this function if a TurboModule needs to install its own JSI bindings.
  */
-- (RCTTurboModuleBindingsInstaller *)createBindingsInstaller;
+- (nonnull RCTTurboModuleBindingsInstaller *)createBindingsInstaller;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -154,9 +154,20 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 
 } // namespace facebook::react
 
+@class RCTTurboModuleBindingsInstaller;
+
 @protocol RCTTurboModule <NSObject>
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params;
+
+@optional
+
+/**
+ * Implements this function if a TurboModule needs to install its own JSI bindings.
+ */
+- (RCTTurboModuleBindingsInstaller *)createBindingsInstaller;
+
 @end
 
 /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleBindingsInstaller.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleBindingsInstaller.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+#import <ReactCommon/TurboModule.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This class is a holder for a RCTTurboModule to get the facebook::react::TurboModule::BindingsInstaller.
+ */
+@interface RCTTurboModuleBindingsInstaller : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+#ifdef __cplusplus
+- (instancetype)initWithBindingsInstaller:(facebook::react::TurboModule::BindingsInstaller)bindingsInstaller
+    NS_DESIGNATED_INITIALIZER;
+
+- (facebook::react::TurboModule::BindingsInstaller)get;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleBindingsInstaller.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleBindingsInstaller.mm
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTTurboModuleBindingsInstaller.h"
+
+@implementation RCTTurboModuleBindingsInstaller {
+  facebook::react::TurboModule::BindingsInstaller _bindingsInstaller;
+}
+
+- (instancetype)initWithBindingsInstaller:(facebook::react::TurboModule::BindingsInstaller)bindingsInstaller
+{
+  if (self = [super init]) {
+    _bindingsInstaller = bindingsInstaller;
+  }
+
+  return self;
+}
+
+- (facebook::react::TurboModule::BindingsInstaller)get
+{
+  return _bindingsInstaller;
+}
+
+@end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -306,8 +306,7 @@ typedef struct {
  * (for now).
  */
 
-- (std::shared_ptr<TurboModule>)provideTurboModule:(const char *)moduleName
-                                       withRuntime:(facebook::jsi::Runtime *)runtime
+- (std::shared_ptr<TurboModule>)provideTurboModule:(const char *)moduleName runtime:(facebook::jsi::Runtime *)runtime
 {
   auto turboModuleLookup = _turboModuleCache.find(moduleName);
   if (turboModuleLookup != _turboModuleCache.end()) {
@@ -415,9 +414,7 @@ typedef struct {
     if ([module respondsToSelector:@selector(createBindingsInstaller)]) {
       RCTTurboModuleBindingsInstaller *installer =
           (RCTTurboModuleBindingsInstaller *)[module performSelector:@selector(createBindingsInstaller)];
-      if (installer != nil) {
-        installer.get(*runtime);
-      }
+      [installer get](*runtime);
     }
     return turboModule;
   }
@@ -781,7 +778,7 @@ typedef struct {
    * Attach method queue to id<RCTBridgeModule> object.
    * This is necessary because the id<RCTBridgeModule> object can be eagerly created/initialized before the method
    * queue is required. The method queue is required for an id<RCTBridgeModule> for JS -> Native calls. So, we need it
-   * before we create the id<RCTBridgeModule>'s TurboModule jsi::HostObject in provideTurboModule:.
+   * before we create the id<RCTBridgeModule>'s TurboModule jsi::HostObject in provideTurboModule:runtime:.
    */
   objc_setAssociatedObject(module, &kAssociatedMethodQueueKey, methodQueue, OBJC_ASSOCIATION_RETAIN);
 
@@ -946,7 +943,7 @@ typedef struct {
      * Additionally, if a TurboModule with the name `name` isn't found, then we
      * trigger an assertion failure.
      */
-    auto turboModule = [self provideTurboModule:moduleName withRuntime:runtime];
+    auto turboModule = [self provideTurboModule:moduleName runtime:runtime];
 
     if (moduleWasNotInitialized && [self moduleIsInitialized:moduleName]) {
       [self->_bridge.performanceLogger markStopForTag:RCTPLTurboModuleSetup];

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.h
@@ -16,6 +16,6 @@
  */
 @interface RCTSampleTurboModule : NSObject <NativeSampleTurboModuleSpec>
 
-- (RCTTurboModuleBindingsInstaller *)createBindingsInstaller;
+- (nonnull RCTTurboModuleBindingsInstaller *)createBindingsInstaller;
 
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.h
@@ -6,6 +6,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <ReactCommon/RCTTurboModuleBindingsInstaller.h>
 
 #import "RCTNativeSampleTurboModuleSpec.h"
 
@@ -14,5 +15,7 @@
  * This class is also 100% compatible with the NativeModule system.
  */
 @interface RCTSampleTurboModule : NSObject <NativeSampleTurboModuleSpec>
+
+- (RCTTurboModuleBindingsInstaller *)createBindingsInstaller;
 
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -35,6 +35,13 @@ RCT_EXPORT_MODULE()
   return std::make_shared<NativeSampleTurboModuleSpecJSI>(params);
 }
 
+- (RCTTurboModuleBindingsInstaller *)createBindingsInstaller;
+{
+  return [[RCTTurboModuleBindingsInstaller alloc] initWithBindingsInstaller:[](facebook::jsi::Runtime &runtime) {
+    runtime.global().setProperty(runtime, "__SampleTurboModuleJSIBindings", "Hello JSI!");
+  }];
+}
+
 // Backward compatible invalidation
 - (void)invalidate
 {

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -128,6 +128,9 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
           this._setResult('promiseAssert', e.message);
         });
     },
+    installJSIBindings: () => {
+      return global.__SampleTurboModuleJSIBindings;
+    },
   };
 
   _setResult(
@@ -192,6 +195,11 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
     if (global.__turboModuleProxy == null) {
       throw new Error(
         'Cannot load this example because TurboModule is not configured.',
+      );
+    }
+    if (global.__SampleTurboModuleJSIBindings == null) {
+      throw new Error(
+        'The JSI bindings for SampleTurboModule are not installed.',
       );
     }
   }


### PR DESCRIPTION
## Summary:

Add synchronous JS bindings installation for TurboModules. That would help some 3rd party JSI based modules to install JS bindings easier.
Re-create from #43110 but for iOS
 
## Changelog:

[IOS] [ADDED] - Add BindingsInstaller for TurboModules

## Test Plan:

Added test in RN-Tester TurboModule test case