### PR TITLE
Implement potential fix for mounting errors during synchronous state updates (v2)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -208,10 +208,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener, UIBlo
           // This executor can be technically accessed before the dispatcher is created,
           // but if that happens, something is terribly wrong
           if (ReactNativeFeatureFlags.forceBatchingMountItemsOnAndroid()) {
-            for (MountItem mountItem : items) {
-              mMountItemDispatcher.addMountItem(mountItem);
-            }
-            mMountItemDispatcher.tryDispatchMountItems();
+            mMountItemDispatcher.batchMountItemsIfNecessary(items);
           } else {
             mMountItemDispatcher.dispatchMountItems(items);
           }


### PR DESCRIPTION
Summary:
This is a new attempt at fixing mounting errors during synchronous state updates after what we tried in https://github.com/facebook/react-native/pull/44015.

That fix didn't work because `dispatchMountItems` actually makes a copy of the mount items that it's going to process, so when we added the mount items to the list they were actually not being picked up by the current processing.

This changes the fix to expose a new list of mount items being processed, and if that's defined then we add it to the list. Otherwise we process as usual.

Differential Revision: D57107212


