### PR TITLE
Bump AGP to 8.4.0

### DIFF
--- a/packages/react-native-gradle-plugin/gradle/libs.versions.toml
+++ b/packages/react-native-gradle-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.1"
+agp = "8.4.0"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ compileSdk = "34"
 buildTools = "34.0.0"
 ndkVersion = "26.1.10909125"
 # Dependencies versions
-agp = "8.3.1"
+agp = "8.4.0"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.6.1"
 androidx-autofill = "1.1.0"


### PR DESCRIPTION
Summary:
Just keeping our version of AGP up to date.

Changelog:
[Internal] [Changed] - Bump AGP to 8.4.0

Differential Revision: D57104079


