### PR TITLE
Migration RN Alert Dialog to androidx

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -8,12 +8,12 @@
 package com.facebook.react.modules.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
 /** A fragment used to display the dialog. */

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
@@ -7,10 +7,11 @@
 
 package com.facebook.react.modules.dialog
 
-import android.app.AlertDialog
 import android.content.DialogInterface
 import android.os.Looper.getMainLooper
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
+import com.facebook.react.R
 import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
@@ -48,6 +49,9 @@ class DialogModuleTest {
   fun setUp() {
     activityController = Robolectric.buildActivity(FragmentActivity::class.java)
     activity = activityController.create().start().resume().get()
+    // We must set the theme to a descendant of AppCompat for the AlertDialog to show without
+    // raising an exception
+    activity.setTheme(APP_COMPAT_THEME)
 
     val context: ReactApplicationContext = mock(ReactApplicationContext::class.java)
     whenever(context.hasActiveReactInstance()).thenReturn(true)
@@ -60,6 +64,16 @@ class DialogModuleTest {
   @After
   fun tearDown() {
     activityController.pause().stop().destroy()
+  }
+
+  @Test
+  fun testIllegalActivityTheme() {
+    val options = JavaOnlyMap()
+    activity.setTheme(NON_APP_COMPAT_THEME)
+
+    assertThrows(NullPointerException::class.java) { dialogModule.showAlert(options, null, null) }
+
+    activity.setTheme(APP_COMPAT_THEME)
   }
 
   @Test
@@ -157,5 +171,10 @@ class DialogModuleTest {
   private fun getFragment(): AlertFragment? {
     return activity.supportFragmentManager.findFragmentByTag(DialogModule.FRAGMENT_TAG)
         as? AlertFragment
+  }
+
+  companion object {
+    private val APP_COMPAT_THEME: Int = R.style.Theme_ReactNative_AppCompat_Light
+    private val NON_APP_COMPAT_THEME: Int = android.R.style.Theme_DeviceDefault_Light
   }
 }


### PR DESCRIPTION
Summary:
Migrates the `AlertFragment` from `android.app.AlertDialog` to `androidx.appcompat.app.AlertDialog`. This backports tons of fixes that have gone into the AlertDialog component over the years, including proper line wrapping of button text, alignment of buttons, etc.

## For consideration
- Alert dialog themes may no longer need the `android` namespace, meaning themes can now be specified as `alertDialogTheme` rather than `android:alertDialogTheme`.
- This change requires all implementing activities to have a theme that inherits from `Theme.AppCompat`. Creation of any activities which do not have a descendant of this style will result in an `IllegalStateException`: https://www.internalfb.com/intern/signalinfra/exception_owners/?mid=5ee93f6ecd59f3d8ad82a78c213ea016&result_id=16044073705339118.281475102518721.1715097866

Differential Revision: D57019423


