### PR TITLE
Migration RN Alert Dialog to androidx

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -8,12 +8,12 @@
 package com.facebook.react.modules.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
 /** A fragment used to display the dialog. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -11,12 +11,15 @@ import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.res.TypedArray;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
+import com.facebook.infer.annotation.Nullsafe;
 
 /** A fragment used to display the dialog. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class AlertFragment extends DialogFragment implements DialogInterface.OnClickListener {
 
   /* package */ static final String ARG_TITLE = "title";
@@ -39,6 +42,35 @@ public class AlertFragment extends DialogFragment implements DialogInterface.OnC
   }
 
   public static Dialog createDialog(
+      Context activityContext, Bundle arguments, DialogInterface.OnClickListener fragment) {
+    if (isAppCompatTheme(activityContext)) {
+      return createAppCompatDialog(activityContext, arguments, fragment);
+    } else {
+      return createAppDialog(activityContext, arguments, fragment);
+    }
+  }
+
+  /**
+   * Checks if the current activity is a descendant of an AppCompat theme. This check is required to
+   * safely display an AppCompat dialog. If the current activity is not a descendant of an AppCompat
+   * theme and we attempt to render an AppCompat dialog, this will cause a crash.
+   *
+   * @returns true if the current activity is a descendant of an AppCompat theme.
+   */
+  private static boolean isAppCompatTheme(Context activityContext) {
+    TypedArray attributes =
+        activityContext.obtainStyledAttributes(androidx.appcompat.R.styleable.AppCompatTheme);
+    boolean isAppCompat =
+        attributes.hasValue(androidx.appcompat.R.styleable.AppCompatTheme_windowActionBar);
+    attributes.recycle();
+    return isAppCompat;
+  }
+
+  /**
+   * Creates a dialog compatible only with AppCompat activities. This function should be kept in
+   * sync with {@link createAppDialog}.
+   */
+  private static Dialog createAppCompatDialog(
       Context activityContext, Bundle arguments, DialogInterface.OnClickListener fragment) {
     AlertDialog.Builder builder =
         new AlertDialog.Builder(activityContext).setTitle(arguments.getString(ARG_TITLE));
@@ -64,9 +96,42 @@ public class AlertFragment extends DialogFragment implements DialogInterface.OnC
     return builder.create();
   }
 
+  /**
+   * Creates a dialog compatible with non-AppCompat activities. This function should be kept in sync
+   * with {@link createAppCompatDialog}.
+   *
+   * @deprecated non-AppCompat dialogs are deprecated and will be removed in a future version.
+   */
+  private static Dialog createAppDialog(
+      Context activityContext, Bundle arguments, DialogInterface.OnClickListener fragment) {
+    android.app.AlertDialog.Builder builder =
+        new android.app.AlertDialog.Builder(activityContext)
+            .setTitle(arguments.getString(ARG_TITLE));
+
+    if (arguments.containsKey(ARG_BUTTON_POSITIVE)) {
+      builder.setPositiveButton(arguments.getString(ARG_BUTTON_POSITIVE), fragment);
+    }
+    if (arguments.containsKey(ARG_BUTTON_NEGATIVE)) {
+      builder.setNegativeButton(arguments.getString(ARG_BUTTON_NEGATIVE), fragment);
+    }
+    if (arguments.containsKey(ARG_BUTTON_NEUTRAL)) {
+      builder.setNeutralButton(arguments.getString(ARG_BUTTON_NEUTRAL), fragment);
+    }
+    // if both message and items are set, Android will only show the message
+    // and ignore the items argument entirely
+    if (arguments.containsKey(ARG_MESSAGE)) {
+      builder.setMessage(arguments.getString(ARG_MESSAGE));
+    }
+    if (arguments.containsKey(ARG_ITEMS)) {
+      builder.setItems(arguments.getCharSequenceArray(ARG_ITEMS), fragment);
+    }
+
+    return builder.create();
+  }
+
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
-    return createDialog(getActivity(), getArguments(), this);
+    return createDialog(requireActivity(), requireArguments(), this);
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
@@ -7,10 +7,11 @@
 
 package com.facebook.react.modules.dialog
 
-import android.app.AlertDialog
 import android.content.DialogInterface
 import android.os.Looper.getMainLooper
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
+import com.facebook.react.R
 import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
@@ -48,6 +49,9 @@ class DialogModuleTest {
   fun setUp() {
     activityController = Robolectric.buildActivity(FragmentActivity::class.java)
     activity = activityController.create().start().resume().get()
+    // We must set the theme to a descendant of AppCompat for the AlertDialog to show without
+    // raising an exception
+    activity.setTheme(APP_COMPAT_THEME)
 
     val context: ReactApplicationContext = mock(ReactApplicationContext::class.java)
     whenever(context.hasActiveReactInstance()).thenReturn(true)
@@ -60,6 +64,19 @@ class DialogModuleTest {
   @After
   fun tearDown() {
     activityController.pause().stop().destroy()
+  }
+
+  @Test
+  fun testIllegalActivityTheme() {
+    val options = JavaOnlyMap()
+    activity.setTheme(NON_APP_COMPAT_THEME)
+
+    assertThrows(NullPointerException::class.java) {
+      dialogModule.showAlert(options, null, null)
+      shadowOf(getMainLooper()).idle()
+    }
+
+    activity.setTheme(APP_COMPAT_THEME)
   }
 
   @Test
@@ -157,5 +174,10 @@ class DialogModuleTest {
   private fun getFragment(): AlertFragment? {
     return activity.supportFragmentManager.findFragmentByTag(DialogModule.FRAGMENT_TAG)
         as? AlertFragment
+  }
+
+  companion object {
+    private val APP_COMPAT_THEME: Int = R.style.Theme_ReactNative_AppCompat_Light
+    private val NON_APP_COMPAT_THEME: Int = android.R.style.Theme_DeviceDefault_Light
   }
 }


### PR DESCRIPTION
## Summary
Migrates the `AlertFragment` from `android.app.AlertDialog` to `androidx.appcompat.app.AlertDialog`. This backports tons of fixes that have gone into the AlertDialog component over the years, including proper line wrapping of button text, dark mode support, alignment of buttons, etc.

This change provides a fallback to the original `android.app.AlertDialog` if the current activity is not an AppCompat descendant.

## For consideration
- Alert dialog themes may no longer need the `android` namespace, meaning themes can now be specified as `alertDialogTheme` rather than `android:alertDialogTheme`.

## Changelog:

[Android] [Changed] - Migrated `AlertDialog` to androidx.appcompat

Differential Revision: D57019423 and D57113950


