### PR TITLE
add prefersFuseboxFrontend field to debugger_command

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -31,6 +31,11 @@ type RequestMetadata = $ReadOnly<{
   frontendUserAgent: string | null,
 }>;
 
+type ResponseMetadata = $ReadOnly<{
+  pageId: string | null,
+  frontendUserAgent: string | null,
+}>;
+
 class DeviceEventReporter {
   #eventReporter: EventReporter;
 
@@ -72,10 +77,7 @@ class DeviceEventReporter {
   logResponse(
     res: CDPResponse<>,
     origin: 'device' | 'proxy',
-    metadata: $ReadOnly<{
-      pageId: string | null,
-      frontendUserAgent: string | null,
-    }>,
+    metadata: ResponseMetadata,
   ): void {
     const pendingCommand = this.#pendingCommands.get(res.id);
     if (!pendingCommand) {

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -29,11 +29,13 @@ type DeviceMetadata = $ReadOnly<{
 type RequestMetadata = $ReadOnly<{
   pageId: string | null,
   frontendUserAgent: string | null,
+  prefersFuseboxFrontend: boolean | null,
 }>;
 
 type ResponseMetadata = $ReadOnly<{
   pageId: string | null,
   frontendUserAgent: string | null,
+  prefersFuseboxFrontend: boolean | null,
 }>;
 
 class DeviceEventReporter {
@@ -95,6 +97,7 @@ class DeviceEventReporter {
         deviceName: this.#metadata.deviceName,
         pageId: metadata.pageId,
         frontendUserAgent: metadata.frontendUserAgent,
+        prefersFuseboxFrontend: metadata.prefersFuseboxFrontend,
       });
       return;
     }
@@ -120,6 +123,7 @@ class DeviceEventReporter {
         deviceName: this.#metadata.deviceName,
         pageId: pendingCommand.metadata.pageId,
         frontendUserAgent: pendingCommand.metadata.frontendUserAgent,
+        prefersFuseboxFrontend: metadata.prefersFuseboxFrontend,
       });
       return;
     }
@@ -136,6 +140,7 @@ class DeviceEventReporter {
       deviceName: this.#metadata.deviceName,
       pageId: pendingCommand.metadata.pageId,
       frontendUserAgent: pendingCommand.metadata.frontendUserAgent,
+      prefersFuseboxFrontend: metadata.prefersFuseboxFrontend,
     });
   }
 
@@ -181,6 +186,7 @@ class DeviceEventReporter {
         deviceName: this.#metadata.deviceName,
         pageId: pendingCommand.metadata.pageId,
         frontendUserAgent: pendingCommand.metadata.frontendUserAgent,
+        prefersFuseboxFrontend: pendingCommand.metadata.prefersFuseboxFrontend,
       });
     }
     this.#pendingCommands.clear();
@@ -220,6 +226,7 @@ class DeviceEventReporter {
       deviceName: this.#metadata.deviceName,
       pageId: pendingCommand.metadata.pageId,
       frontendUserAgent: pendingCommand.metadata.frontendUserAgent,
+      prefersFuseboxFrontend: pendingCommand.metadata.prefersFuseboxFrontend,
     });
   }
 }

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -64,6 +64,7 @@ export type ReportableEvent =
       timeSinceStart: number | null,
       ...DebuggerSessionIDs,
       frontendUserAgent: string | null,
+      prefersFuseboxFrontend: boolean | null,
       ...
         | SuccessResult<void>
         | CodedErrorResult<


### PR DESCRIPTION
Summary:
Changelog: [internal]

As [discussed](https://fb.workplace.com/groups/react.devx.team/permalink/930483712103526/), we'll begin segmenting Telemetry signals by Fusebox/non-Fusebox.

* Add new flag in event reporter
* Add new column to the Scuba destination

Differential Revision: D57140479


