### PR TITLE
Clean up dead code in LogBoxStateSubscription

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -449,31 +449,6 @@ export function withSubscription(
         this._subscription.unsubscribe();
       }
     }
-
-    _handleDismiss = (): void => {
-      // Here we handle the cases when the log is dismissed and it
-      // was either the last log, or when the current index
-      // is now outside the bounds of the log array.
-      const {selectedLogIndex, logs: stateLogs} = this.state;
-      const logsArray = Array.from(stateLogs);
-      if (selectedLogIndex != null) {
-        if (logsArray.length - 1 <= 0) {
-          setSelectedLog(-1);
-        } else if (selectedLogIndex >= logsArray.length - 1) {
-          setSelectedLog(selectedLogIndex - 1);
-        }
-
-        dismiss(logsArray[selectedLogIndex]);
-      }
-    };
-
-    _handleMinimize = (): void => {
-      setSelectedLog(-1);
-    };
-
-    _handleSetSelectedLog = (index: number): void => {
-      setSelectedLog(index);
-    };
   }
 
   return LogBoxStateSubscription;


### PR DESCRIPTION
Summary:
The removed code was moved to LogBoxInspectorContainer, and is not referenced inside the LogBoxStateSubscription component.

## Changelog

[Internal]

Differential Revision: D57168569


