### PR TITLE
remove default option experimental.global_find_ref=true

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -35,7 +35,6 @@ packages/react-native/interface.js
 packages/react-native/flow/
 
 [options]
-experimental.global_find_ref=true
 enums=true
 casting_syntax=both
 


### PR DESCRIPTION
Summary:
this has been the default for a while

Changelog: [Internal]

Differential Revision: D57195561


