### PR TITLE
Fix experimental_filter validation error in bridgeless

### DIFF
--- a/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -14,6 +14,7 @@ const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleA
 const resolveAssetSource = require('../Image/resolveAssetSource');
 const processColor = require('../StyleSheet/processColor').default;
 const processColorArray = require('../StyleSheet/processColorArray');
+const processFilter = require('../StyleSheet/processFilter').default;
 const insetsDiffer = require('../Utilities/differ/insetsDiffer');
 const matricesDiffer = require('../Utilities/differ/matricesDiffer');
 const pointsDiffer = require('../Utilities/differ/pointsDiffer');
@@ -188,6 +189,8 @@ function getProcessorForType(typeName: string): ?(nextProp: any) => any {
       return processColor;
     case 'ColorArray':
       return processColorArray;
+    case 'Filter':
+      return processFilter;
     case 'ImageSource':
       return resolveAssetSource;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -187,7 +187,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   }
 
   @Override
-  @ReactProp(name = ViewProps.FILTER)
+  @ReactProp(name = ViewProps.FILTER, customType = "Filter")
   public void setFilter(@NonNull T view, @Nullable ReadableArray filter) {
     view.setTag(R.id.filter, filter);
   }


### PR DESCRIPTION
Summary:
After D56845572, I've started seeing the following redbox when running apps in bridgless mode:

 {F1633641432}

Note sure this is the correct/complete fix but, after this, the error seems to go away.

Reviewed By: RSNara

Differential Revision: D57207925


