### PR TITLE
Fix xplat/endtoend/jest-e2e/apps/facebook_xplat/ReactNativeCoreE2E/__tests__/Border-corner-radii-elevation-percentages-e2e.js to actually use the right example

### DIFF
--- a/packages/rn-tester/js/examples/Border/BorderExample.js
+++ b/packages/rn-tester/js/examples/Border/BorderExample.js
@@ -126,9 +126,9 @@ const styles = StyleSheet.create({
   },
   border9Percentages: {
     borderWidth: 10,
-    borderTopLeftRadius: '10%',
-    borderBottomRightRadius: '20%',
-    borderColor: 'black',
+    borderTopLeftRadius: '20%',
+    borderBottomRightRadius: '10%',
+    borderColor: 'red',
   },
   border10: {
     borderWidth: 10,
@@ -141,9 +141,9 @@ const styles = StyleSheet.create({
   border10Percentages: {
     borderWidth: 10,
     backgroundColor: 'white',
-    borderTopLeftRadius: '10%',
-    borderBottomRightRadius: '20%',
-    borderColor: 'black',
+    borderTopLeftRadius: '20%',
+    borderBottomRightRadius: '10%',
+    borderColor: 'red',
     elevation: 10,
   },
   border11: {
@@ -359,7 +359,7 @@ export default ({
     },
     {
       title: 'Corner Radii (Percentages)',
-      name: 'corner-radii',
+      name: 'corner-radii-percentages',
       description: 'borderTopLeftRadius & borderBottomRightRadius',
       render: function (): React.Node {
         return (
@@ -386,7 +386,7 @@ export default ({
     },
     {
       title: 'Corner Radii / Elevation (Percentages)',
-      name: 'corner-radii-elevation',
+      name: 'corner-radii-elevation-percentages',
       description: 'borderTopLeftRadius & borderBottomRightRadius & elevation',
       platform: 'android',
       render: function (): React.Node {

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -649,7 +649,7 @@ export default ({
     },
     {
       title: 'Rounded Borders (Percentages)',
-      name: 'rounded-borders-percentage',
+      name: 'rounded-borders-percentages',
       render(): React.Node {
         return (
           <View


### PR DESCRIPTION
Summary:
These examples were added, but their names were duplicated. This caused our internal e2e tests to accidentally target the wrong examples.

Changelog:
[General][Fixed] RNTester examples for border percentages are now properly covered by E2E screenshot tests.

Reviewed By: NickGerleman

Differential Revision: D57207306


