### PR TITLE
Guard against null rootShadowNode in IntersectionObserverManager for initial notifications

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
@@ -49,6 +49,12 @@ void IntersectionObserverManager::observe(
     mountingCoordinator = shadowTree.getMountingCoordinator();
     rootShadowNode = shadowTree.getCurrentRevision().rootShadowNode;
   });
+
+  // If the surface doesn't exist for some reason, we skip initial notification.
+  if (!rootShadowNode) {
+    return;
+  }
+
   auto hasPendingTransactions = mountingCoordinator != nullptr &&
       mountingCoordinator->hasPendingTransactions();
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

In the `IntersectionObserver` API we dispatch the initial notification in the `observe` method, but it might be possible that the surface has been removed from the registry by the time we execute that code.

This guards against that case to possibly fix a crash we're seeing in on the `IntersectionObserver` experiments.

Differential Revision: D57213994


