### PR TITLE
Fix border-radius percentage formula typo

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -63,7 +63,7 @@ public class LengthPercentage(
 
   public fun resolve(width: Float, height: Float): Float {
     if (unit == LengthPercentageType.PERCENT) {
-      return (value / 100) * Math.max(width, height)
+      return (value / 100) * Math.min(width, height)
     }
 
     return value


### PR DESCRIPTION
Summary:
The percentage formula was incorrect. We actually want to consider the shorter side as 100%. If we set a radius > minimum side there are no changes reflected. This is correct on iOS. 

D56943825's summary also highlights the reasoning.

Changelog:
[Android][Fixed] Border-Radius percentages are now correctly resolved.

Differential Revision: D57214561


