### PR TITLE
RN: Disable Babel Plugin for Arrow Functions for Hermes

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -84,9 +84,9 @@ const getPreset = (src, options) => {
     extraPlugins.push([require('@babel/plugin-transform-classes')]);
   }
 
-  // TODO(gaearon): put this back into '=>' indexOf bailout
-  // and patch react-refresh to not depend on this transform.
-  extraPlugins.push([require('@babel/plugin-transform-arrow-functions')]);
+  if (!isHermes && (isNull || src.includes('=>'))) {
+    extraPlugins.push([require('@babel/plugin-transform-arrow-functions')]);
+  }
 
   if (!isHermes) {
     extraPlugins.push([require('@babel/plugin-transform-computed-properties')]);


### PR DESCRIPTION
Summary:
Reapplies {D50818568} (reverted by D50885400).

Changelog:
[General][Change] - Disable Babel plugin for arrow functions for Hermes

Differential Revision: D57242622


