### PR TITLE
Mark IntBufferBatchMountItem as nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2782,7 +2782,7 @@ public class com/facebook/react/fabric/mounting/SurfaceMountingManager {
 	public fun setJSResponder (IIZ)V
 	public fun stopSurface ()V
 	public fun updateEventEmitter (ILcom/facebook/react/fabric/events/EventEmitterWrapper;)V
-	public fun updateLayout (IIIIIII)V
+	public fun updateLayout (IIIIIIII)V
 	public fun updateOverflowInset (IIIII)V
 	public fun updatePadding (IIIII)V
 	public fun updateProps (ILcom/facebook/react/bridge/ReadableMap;)V
@@ -5506,12 +5506,11 @@ public class com/facebook/react/uimanager/drawable/CSSBackgroundDrawable : andro
 	public fun getComputedBorderRadius ()Lcom/facebook/react/uimanager/style/ComputedBorderRadius;
 	public fun getDirectionAwareBorderInsets ()Landroid/graphics/RectF;
 	public fun getFullBorderWidth ()F
+	public fun getLayoutDirection ()I
 	public fun getOpacity ()I
 	public fun getOutline (Landroid/graphics/Outline;)V
-	public fun getResolvedLayoutDirection ()I
 	public fun hasRoundedBorders ()Z
 	protected fun onBoundsChange (Landroid/graphics/Rect;)V
-	public fun onResolvedLayoutDirectionChanged (I)Z
 	public fun paddingBoxPath ()Landroid/graphics/Path;
 	public fun setAlpha (I)V
 	public fun setBorderColor (IFF)V
@@ -5521,9 +5520,9 @@ public class com/facebook/react/uimanager/drawable/CSSBackgroundDrawable : andro
 	public fun setBorderWidth (IF)V
 	public fun setColor (I)V
 	public fun setColorFilter (Landroid/graphics/ColorFilter;)V
+	public fun setLayoutDirectionOverride (I)V
 	public fun setRadius (F)V
 	public fun setRadius (FI)V
-	public fun setResolvedLayoutDirection (I)Z
 }
 
 public abstract interface class com/facebook/react/uimanager/events/BatchEventDispatchedListener {
@@ -6608,6 +6607,7 @@ public class com/facebook/react/views/scroll/OnScrollDispatchHelper {
 
 public class com/facebook/react/views/scroll/ReactHorizontalScrollContainerView : com/facebook/react/views/view/ReactViewGroup {
 	public fun <init> (Landroid/content/Context;)V
+	public fun getLayoutDirection ()I
 	protected fun onLayout (ZIIII)V
 	public fun setRemoveClippedSubviews (Z)V
 }
@@ -7901,7 +7901,6 @@ public class com/facebook/react/views/view/ReactViewGroup : android/view/ViewGro
 	public fun onInterceptTouchEvent (Landroid/view/MotionEvent;)Z
 	protected fun onLayout (ZIIII)V
 	protected fun onMeasure (II)V
-	public fun onRtlPropertiesChanged (I)V
 	protected fun onSizeChanged (IIII)V
 	public fun onTouchEvent (Landroid/view/MotionEvent;)Z
 	public fun removeView (Landroid/view/View;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -35,6 +35,7 @@ import com.facebook.react.fabric.GuardedFrameCallback;
 import com.facebook.react.fabric.events.EventEmitterWrapper;
 import com.facebook.react.fabric.mounting.MountingManager.MountItemExecutor;
 import com.facebook.react.fabric.mounting.mountitems.MountItem;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.uimanager.IViewGroupManager;
@@ -934,7 +935,14 @@ public class SurfaceMountingManager {
 
   @UiThread
   public void updateLayout(
-      int reactTag, int parentTag, int x, int y, int width, int height, int displayType) {
+      int reactTag,
+      int parentTag,
+      int x,
+      int y,
+      int width,
+      int height,
+      int displayType,
+      int layoutDirection) {
     if (isStopped()) {
       return;
     }
@@ -948,6 +956,13 @@ public class SurfaceMountingManager {
     View viewToUpdate = viewState.mView;
     if (viewToUpdate == null) {
       throw new IllegalStateException("Unable to find View for tag: " + reactTag);
+    }
+
+    if (ReactNativeFeatureFlags.setAndroidLayoutDirection()) {
+      viewToUpdate.setLayoutDirection(
+          layoutDirection == 1
+              ? View.LAYOUT_DIRECTION_LTR
+              : layoutDirection == 2 ? View.LAYOUT_DIRECTION_RTL : View.LAYOUT_DIRECTION_INHERIT);
     }
 
     viewToUpdate.measure(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
@@ -11,8 +11,8 @@ import static com.facebook.react.fabric.FabricUIManager.ENABLE_FABRIC_LOGS;
 import static com.facebook.react.fabric.FabricUIManager.IS_DEVELOPMENT_ENVIRONMENT;
 import static com.facebook.react.fabric.mounting.mountitems.FabricNameComponentMapping.getFabricComponentName;
 
-import androidx.annotation.NonNull;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
@@ -36,6 +36,7 @@ import com.facebook.systrace.Systrace;
  * allocations in C++ and JNI round-trips.
  */
 @DoNotStrip
+@Nullsafe(Nullsafe.Mode.LOCAL)
 final class IntBufferBatchMountItem implements BatchMountItem {
   static final String TAG = IntBufferBatchMountItem.class.getSimpleName();
 
@@ -56,8 +57,8 @@ final class IntBufferBatchMountItem implements BatchMountItem {
   private final int mSurfaceId;
   private final int mCommitNumber;
 
-  private final @NonNull int[] mIntBuffer;
-  private final @NonNull Object[] mObjBuffer;
+  private final int[] mIntBuffer;
+  private final Object[] mObjBuffer;
 
   private final int mIntBufferLen;
   private final int mObjBufferLen;
@@ -92,7 +93,7 @@ final class IntBufferBatchMountItem implements BatchMountItem {
   }
 
   @Override
-  public void execute(@NonNull MountingManager mountingManager) {
+  public void execute(MountingManager mountingManager) {
     SurfaceMountingManager surfaceMountingManager = mountingManager.getSurfaceManager(mSurfaceId);
     if (surfaceMountingManager == null) {
       FLog.e(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
@@ -20,6 +20,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.fabric.events.EventEmitterWrapper;
 import com.facebook.react.fabric.mounting.MountingManager;
 import com.facebook.react.fabric.mounting.SurfaceMountingManager;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.systrace.Systrace;
 
@@ -149,9 +150,14 @@ final class IntBufferBatchMountItem implements BatchMountItem {
           int height = mIntBuffer[i++];
           int displayType = mIntBuffer[i++];
 
-          surfaceMountingManager.updateLayout(
-              reactTag, parentTag, x, y, width, height, displayType);
-
+          if (ReactNativeFeatureFlags.setAndroidLayoutDirection()) {
+            int layoutDirection = mIntBuffer[i++];
+            surfaceMountingManager.updateLayout(
+                reactTag, parentTag, x, y, width, height, displayType, layoutDirection);
+          } else {
+            surfaceMountingManager.updateLayout(
+                reactTag, parentTag, x, y, width, height, displayType, 0);
+          }
         } else if (type == INSTRUCTION_UPDATE_PADDING) {
           surfaceMountingManager.updatePadding(
               mIntBuffer[i++], mIntBuffer[i++], mIntBuffer[i++], mIntBuffer[i++], mIntBuffer[i++]);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
@@ -63,8 +63,8 @@ public object MountItemFactory {
   @JvmStatic
   public fun createIntBufferBatchMountItem(
       surfaceId: Int,
-      intBuf: IntArray?,
-      objBuf: Array<Any?>?,
+      intBuf: IntArray,
+      objBuf: Array<Any?>,
       commitNumber: Int
   ): MountItem = IntBufferBatchMountItem(surfaceId, intBuf, objBuf, commitNumber)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c35ee97cf5c4b5f77cdd045341f2848b>>
+ * @generated SignedSource<<0d5f4b26573154fb42c312b03c0dc6a7>>
  */
 
 /**
@@ -123,6 +123,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun preventDoubleTextMeasure(): Boolean = accessor.preventDoubleTextMeasure()
+
+  /**
+   * Propagate layout direction to Android views.
+   */
+  @JvmStatic
+  public fun setAndroidLayoutDirection(): Boolean = accessor.setAndroidLayoutDirection()
 
   /**
    * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1b84e5fa96120a511db6f831afb73eab>>
+ * @generated SignedSource<<60f7a791ff3eb270c26ebf598f65d8d5>>
  */
 
 /**
@@ -36,6 +36,7 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
   private var lazyAnimationCallbacksCache: Boolean? = null
   private var preventDoubleTextMeasureCache: Boolean? = null
+  private var setAndroidLayoutDirectionCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
   private var useStateAlignmentMechanismCache: Boolean? = null
@@ -180,6 +181,15 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.preventDoubleTextMeasure()
       preventDoubleTextMeasureCache = cached
+    }
+    return cached
+  }
+
+  override fun setAndroidLayoutDirection(): Boolean {
+    var cached = setAndroidLayoutDirectionCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.setAndroidLayoutDirection()
+      setAndroidLayoutDirectionCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2cd7ab4688ca2179ba3a19e9a062f695>>
+ * @generated SignedSource<<a217de50b6148069ad6ff915c1446f45>>
  */
 
 /**
@@ -59,6 +59,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun lazyAnimationCallbacks(): Boolean
 
   @DoNotStrip @JvmStatic public external fun preventDoubleTextMeasure(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun setAndroidLayoutDirection(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useModernRuntimeScheduler(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a2c4f2c950a7b92163fdc6219864d6ca>>
+ * @generated SignedSource<<c86391a2ae3dc6fbf5b8327b37bc30d2>>
  */
 
 /**
@@ -54,6 +54,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun lazyAnimationCallbacks(): Boolean = false
 
   override fun preventDoubleTextMeasure(): Boolean = false
+
+  override fun setAndroidLayoutDirection(): Boolean = false
 
   override fun useModernRuntimeScheduler(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<48f657b282ef658ab7e9024f470d37ad>>
+ * @generated SignedSource<<8f6a50230ef99335baa5929070b94ddc>>
  */
 
 /**
@@ -40,6 +40,7 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
   private var inspectorEnableModernCDPRegistryCache: Boolean? = null
   private var lazyAnimationCallbacksCache: Boolean? = null
   private var preventDoubleTextMeasureCache: Boolean? = null
+  private var setAndroidLayoutDirectionCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
   private var useStateAlignmentMechanismCache: Boolean? = null
@@ -200,6 +201,16 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
       cached = currentProvider.preventDoubleTextMeasure()
       accessedFeatureFlags.add("preventDoubleTextMeasure")
       preventDoubleTextMeasureCache = cached
+    }
+    return cached
+  }
+
+  override fun setAndroidLayoutDirection(): Boolean {
+    var cached = setAndroidLayoutDirectionCache
+    if (cached == null) {
+      cached = currentProvider.setAndroidLayoutDirection()
+      accessedFeatureFlags.add("setAndroidLayoutDirection")
+      setAndroidLayoutDirectionCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0f3d31f94f4bded41936fe4ecafbdd4a>>
+ * @generated SignedSource<<fcc8430187565628d83479182550ff21>>
  */
 
 /**
@@ -54,6 +54,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun lazyAnimationCallbacks(): Boolean
 
   @DoNotStrip public fun preventDoubleTextMeasure(): Boolean
+
+  @DoNotStrip public fun setAndroidLayoutDirection(): Boolean
 
   @DoNotStrip public fun useModernRuntimeScheduler(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.java
@@ -9,18 +9,29 @@ package com.facebook.react.modules.i18nmanager;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import androidx.annotation.Nullable;
 import androidx.core.text.TextUtilsCompat;
+import androidx.core.util.Preconditions;
 import androidx.core.view.ViewCompat;
+import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
+import java.lang.reflect.Method;
 import java.util.Locale;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class I18nUtil {
-  private static I18nUtil sharedI18nUtilInstance = null;
+  private static @Nullable I18nUtil sharedI18nUtilInstance = null;
 
+  private static final String TAG = "I18nUtil";
   private static final String SHARED_PREFS_NAME = "com.facebook.react.modules.i18nmanager.I18nUtil";
   private static final String KEY_FOR_PREFS_ALLOWRTL = "RCTI18nUtil_allowRTL";
   private static final String KEY_FOR_PREFS_FORCERTL = "RCTI18nUtil_forceRTL";
   private static final String KEY_FOR_PERFS_MAKE_RTL_FLIP_LEFT_AND_RIGHT_STYLES =
       "RCTI18nUtil_makeRTLFlipLeftAndRightStyles";
+
+  private boolean mHasCheckedRtlSupport = false;
+  private boolean mHasRtlSupport = true;
 
   private I18nUtil() {
     // Exists only to defeat instantiation.
@@ -42,10 +53,35 @@ public class I18nUtil {
    * </ul>
    */
   public boolean isRTL(Context context) {
+    if (!applicationHasRtlSupport(context)) {
+      return false;
+    }
+
     if (isRTLForced(context)) {
       return true;
     }
+
     return isRTLAllowed(context) && isDevicePreferredLanguageRTL();
+  }
+
+  /**
+   * Android relies on the presence of `android:supportsRtl="true"` being set in order to resolve
+   * RTL as a layout direction for native Android views. RTL in React Native relies on this being
+   * set.
+   */
+  private boolean applicationHasRtlSupport(Context context) {
+    if (!mHasCheckedRtlSupport) {
+      mHasCheckedRtlSupport = true;
+      ApplicationInfo applicationInfo = context.getApplicationInfo();
+      try {
+        Method hasRtlSupport = ApplicationInfo.class.getMethod("hasRtlSupport");
+        mHasRtlSupport =
+            Preconditions.checkNotNull((Boolean) hasRtlSupport.invoke(applicationInfo));
+      } catch (ReflectiveOperationException e) {
+        FLog.w(TAG, "Failed to check if application has RTL support");
+      }
+    }
+    return mHasRtlSupport;
   }
 
   /**
@@ -54,7 +90,9 @@ public class I18nUtil {
    * @return whether the app allows RTL layout, default is true
    */
   private boolean isRTLAllowed(Context context) {
-    return isPrefSet(context, KEY_FOR_PREFS_ALLOWRTL, true);
+    // We should only claim to allow RTL if `android:supportsRtl="true"` is set, otherwise the
+    // platform apart from Yoga ignores layout direction.
+    return applicationHasRtlSupport(context) && isPrefSet(context, KEY_FOR_PREFS_ALLOWRTL, true);
   }
 
   public void allowRTL(Context context, boolean allowRTL) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.uimanager.drawable;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -119,7 +120,9 @@ public class CSSBackgroundDrawable extends Drawable {
   private BorderRadiusStyle mBorderRadius = new BorderRadiusStyle();
   private ComputedBorderRadius mComputedBorderRadius = new ComputedBorderRadius();
   private final Context mContext;
-  private int mLayoutDirection;
+
+  // Should be removed after migrating to Android layout direction.
+  private int mLayoutDirectionOverride = -1;
 
   public CSSBackgroundDrawable(Context context) {
     mContext = context;
@@ -161,6 +164,19 @@ public class CSSBackgroundDrawable extends Drawable {
   @Override
   public void setColorFilter(ColorFilter cf) {
     // do nothing
+  }
+
+  @Deprecated
+  public void setLayoutDirectionOverride(int layoutDirection) {
+    if (mLayoutDirectionOverride != layoutDirection) {
+      mLayoutDirectionOverride = layoutDirection;
+    }
+  }
+
+  @Override
+  @SuppressLint("WrongConstant")
+  public int getLayoutDirection() {
+    return mLayoutDirectionOverride == -1 ? super.getLayoutDirection() : mLayoutDirectionOverride;
   }
 
   @Override
@@ -292,25 +308,6 @@ public class CSSBackgroundDrawable extends Drawable {
     invalidateSelf();
   }
 
-  /** Similar to Drawable.getLayoutDirection, but available in APIs < 23. */
-  public int getResolvedLayoutDirection() {
-    return mLayoutDirection;
-  }
-
-  /** Similar to Drawable.setLayoutDirection, but available in APIs < 23. */
-  public boolean setResolvedLayoutDirection(int layoutDirection) {
-    if (mLayoutDirection != layoutDirection) {
-      mLayoutDirection = layoutDirection;
-      return onResolvedLayoutDirectionChanged(layoutDirection);
-    }
-    return false;
-  }
-
-  /** Similar to Drawable.onLayoutDirectionChanged, but available in APIs < 23. */
-  public boolean onResolvedLayoutDirectionChanged(int layoutDirection) {
-    return false;
-  }
-
   @VisibleForTesting
   public int getColor() {
     return mColor;
@@ -392,7 +389,7 @@ public class CSSBackgroundDrawable extends Drawable {
         // Clip inner border
         canvas.clipPath(mInnerClipPathForBorderRadius, Region.Op.DIFFERENCE);
 
-        final boolean isRTL = getResolvedLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+        final boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
         int colorStart = getBorderColor(Spacing.START);
         int colorEnd = getBorderColor(Spacing.END);
 
@@ -591,7 +588,7 @@ public class CSSBackgroundDrawable extends Drawable {
 
     mComputedBorderRadius =
         mBorderRadius.resolve(
-            mLayoutDirection,
+            getLayoutDirection(),
             mContext,
             mOuterClipTempRectForBorderRadius.width(),
             mOuterClipTempRectForBorderRadius.height());
@@ -1080,7 +1077,7 @@ public class CSSBackgroundDrawable extends Drawable {
         colorTop = colorBlockStart;
       }
 
-      final boolean isRTL = getResolvedLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+      final boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
       int colorStart = getBorderColor(Spacing.START);
       int colorEnd = getBorderColor(Spacing.END);
 
@@ -1305,7 +1302,7 @@ public class CSSBackgroundDrawable extends Drawable {
     float borderRightWidth = getBorderWidthOrDefaultTo(borderWidth, Spacing.RIGHT);
 
     if (mBorderWidth != null) {
-      final boolean isRTL = getResolvedLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+      final boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
       float borderStartWidth = mBorderWidth.getRaw(Spacing.START);
       float borderEndWidth = mBorderWidth.getRaw(Spacing.END);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
@@ -10,6 +10,7 @@ package com.facebook.react.views.scroll;
 import android.content.Context;
 import androidx.core.view.ViewCompat;
 import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.views.view.ReactViewGroup;
 
@@ -28,13 +29,21 @@ public class ReactHorizontalScrollContainerView extends ReactViewGroup {
   }
 
   @Override
+  public int getLayoutDirection() {
+    if (ReactNativeFeatureFlags.setAndroidLayoutDirection()) {
+      return super.getLayoutDirection();
+    }
+    return mLayoutDirection;
+  }
+
+  @Override
   public void setRemoveClippedSubviews(boolean removeClippedSubviews) {
     // Clipping doesn't work well for horizontal scroll views in RTL mode - in both
     // Fabric and non-Fabric - especially with TextInputs. The behavior you could see
     // is TextInputs being blurred immediately after being focused. So, for now,
     // it's easier to just disable this for these specific RTL views.
     // TODO T86027499: support `setRemoveClippedSubviews` in RTL mode
-    if (mLayoutDirection == LAYOUT_DIRECTION_RTL) {
+    if (getLayoutDirection() == LAYOUT_DIRECTION_RTL) {
       super.setRemoveClippedSubviews(false);
       return;
     }
@@ -44,7 +53,7 @@ public class ReactHorizontalScrollContainerView extends ReactViewGroup {
 
   @Override
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-    if (mLayoutDirection == LAYOUT_DIRECTION_RTL) {
+    if (getLayoutDirection() == LAYOUT_DIRECTION_RTL) {
       // When the layout direction is RTL, we expect Yoga to give us a layout
       // that extends off the screen to the left so we re-center it with left=0
       int newLeft = 0;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -34,6 +34,7 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.build.ReactBuildConfig;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.MeasureSpecAssertions;
 import com.facebook.react.uimanager.PointerEvents;
@@ -1064,7 +1065,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     int firstOffset = 0;
     int lastOffset = maximumOffset;
     int width = getWidth() - ViewCompat.getPaddingStart(this) - ViewCompat.getPaddingEnd(this);
-    int layoutDirection = getReactScrollViewScrollState().getLayoutDirection();
+    int layoutDirection =
+        ReactNativeFeatureFlags.setAndroidLayoutDirection()
+            ? getLayoutDirection()
+            : mReactScrollViewScrollState.getLayoutDirection();
 
     // offsets are from the right edge in RTL layouts
     if (layoutDirection == LAYOUT_DIRECTION_RTL) {
@@ -1388,7 +1392,11 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     // does not shift layout. If `maintainVisibleContentPosition` is enabled, we try to adjust
     // position so that the viewport keeps the same insets to previously visible views. TODO: MVCP
     // does not work in RTL.
-    if (mReactScrollViewScrollState.getLayoutDirection() == LAYOUT_DIRECTION_RTL) {
+    int layoutDirection =
+        ReactNativeFeatureFlags.setAndroidLayoutDirection()
+            ? v.getLayoutDirection()
+            : mReactScrollViewScrollState.getLayoutDirection();
+    if (layoutDirection == LAYOUT_DIRECTION_RTL) {
       adjustPositionForContentChangeRTL(left, right, oldLeft, oldRight);
     } else if (mMaintainVisibleContentPositionHelper != null) {
       mMaintainVisibleContentPositionHelper.updateScrollPosition();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -63,7 +63,9 @@ static inline int getIntBufferSizeForType(CppMountItem::Type mountItemType) {
     case CppMountItem::Type::UpdatePadding:
       return 5; // tag, top, left, bottom, right
     case CppMountItem::Type::UpdateLayout:
-      return 7; // tag, parentTag, x, y, w, h, DisplayType
+      return ReactNativeFeatureFlags::setAndroidLayoutDirection()
+          ? 8 // tag, parentTag, x, y, w, h, DisplayType, LayoutDirection
+          : 7; // tag, parentTag, x, y, w, h, DisplayType
     case CppMountItem::Type::UpdateOverflowInset:
       return 5; // tag, left, top, right, bottom
     case CppMountItem::Undefined:
@@ -496,7 +498,7 @@ void FabricMountingManager::executeMount(
   int intBufferPosition = 0;
   int objBufferPosition = 0;
   int prevMountItemType = -1;
-  jint temp[7];
+  jint temp[8];
   for (int i = 0; i < cppCommonMountItems.size(); i++) {
     const auto& mountItem = cppCommonMountItems[i];
     const auto& mountItemType = mountItem.type;
@@ -656,7 +658,7 @@ void FabricMountingManager::executeMount(
         intBufferPosition);
 
     for (const auto& mountItem : cppUpdateLayoutMountItems) {
-      auto layoutMetrics = mountItem.newChildShadowView.layoutMetrics;
+      const auto& layoutMetrics = mountItem.newChildShadowView.layoutMetrics;
       auto pointScaleFactor = layoutMetrics.pointScaleFactor;
       auto frame = layoutMetrics.frame;
 
@@ -664,8 +666,8 @@ void FabricMountingManager::executeMount(
       int y = round(scale(frame.origin.y, pointScaleFactor));
       int w = round(scale(frame.size.width, pointScaleFactor));
       int h = round(scale(frame.size.height, pointScaleFactor));
-      int displayType =
-          toInt(mountItem.newChildShadowView.layoutMetrics.displayType);
+      int displayType = toInt(layoutMetrics.displayType);
+      int layoutDirection = toInt(layoutMetrics.layoutDirection);
 
       temp[0] = mountItem.newChildShadowView.tag;
       temp[1] = mountItem.parentShadowView.tag;
@@ -674,8 +676,15 @@ void FabricMountingManager::executeMount(
       temp[4] = w;
       temp[5] = h;
       temp[6] = displayType;
-      env->SetIntArrayRegion(intBufferArray, intBufferPosition, 7, temp);
-      intBufferPosition += 7;
+
+      if (ReactNativeFeatureFlags::setAndroidLayoutDirection()) {
+        temp[7] = layoutDirection;
+        env->SetIntArrayRegion(intBufferArray, intBufferPosition, 8, temp);
+        intBufferPosition += 8;
+      } else {
+        env->SetIntArrayRegion(intBufferArray, intBufferPosition, 7, temp);
+        intBufferPosition += 7;
+      }
     }
   }
   if (!cppUpdateOverflowInsetMountItems.empty()) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<630ef8f9e65223c8d4c2b07bcc0ebadd>>
+ * @generated SignedSource<<3974227d88e1ee8e676a38f5ac4faed1>>
  */
 
 /**
@@ -135,6 +135,12 @@ class ReactNativeFeatureFlagsProviderHolder
     return method(javaProvider_);
   }
 
+  bool setAndroidLayoutDirection() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("setAndroidLayoutDirection");
+    return method(javaProvider_);
+  }
+
   bool useModernRuntimeScheduler() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useModernRuntimeScheduler");
@@ -237,6 +243,11 @@ bool JReactNativeFeatureFlagsCxxInterop::preventDoubleTextMeasure(
   return ReactNativeFeatureFlags::preventDoubleTextMeasure();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::setAndroidLayoutDirection(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::setAndroidLayoutDirection();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::useModernRuntimeScheduler(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useModernRuntimeScheduler();
@@ -317,6 +328,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "preventDoubleTextMeasure",
         JReactNativeFeatureFlagsCxxInterop::preventDoubleTextMeasure),
+      makeNativeMethod(
+        "setAndroidLayoutDirection",
+        JReactNativeFeatureFlagsCxxInterop::setAndroidLayoutDirection),
       makeNativeMethod(
         "useModernRuntimeScheduler",
         JReactNativeFeatureFlagsCxxInterop::useModernRuntimeScheduler),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<39dde965f082a0dffbe00763e184d1db>>
+ * @generated SignedSource<<fd151d4269bfaf17dc5bac9a09015f3f>>
  */
 
 /**
@@ -76,6 +76,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool preventDoubleTextMeasure(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool setAndroidLayoutDirection(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useModernRuntimeScheduler(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d176ed0be7b015e7b9444a0b7ac7f7ba>>
+ * @generated SignedSource<<dc15f1bbaccc2e9522f12f13aaf4d36f>>
  */
 
 /**
@@ -83,6 +83,10 @@ bool ReactNativeFeatureFlags::lazyAnimationCallbacks() {
 
 bool ReactNativeFeatureFlags::preventDoubleTextMeasure() {
   return getAccessor().preventDoubleTextMeasure();
+}
+
+bool ReactNativeFeatureFlags::setAndroidLayoutDirection() {
+  return getAccessor().setAndroidLayoutDirection();
 }
 
 bool ReactNativeFeatureFlags::useModernRuntimeScheduler() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0f7b95b5d42c879dabea8f7d53f9cc17>>
+ * @generated SignedSource<<24c7fe3b2504e27f578262582719f581>>
  */
 
 /**
@@ -116,6 +116,11 @@ class ReactNativeFeatureFlags {
    * When enabled, ParagraphShadowNode will no longer call measure twice.
    */
   RN_EXPORT static bool preventDoubleTextMeasure();
+
+  /**
+   * Propagate layout direction to Android views.
+   */
+  RN_EXPORT static bool setAndroidLayoutDirection();
 
   /**
    * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<165de70ff21543c949e57971f1a8ff07>>
+ * @generated SignedSource<<1039989da579b07d4ff5926938f047c6>>
  */
 
 /**
@@ -317,6 +317,24 @@ bool ReactNativeFeatureFlagsAccessor::preventDoubleTextMeasure() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::setAndroidLayoutDirection() {
+  auto flagValue = setAndroidLayoutDirection_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(16, "setAndroidLayoutDirection");
+
+    flagValue = currentProvider_->setAndroidLayoutDirection();
+    setAndroidLayoutDirection_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::useModernRuntimeScheduler() {
   auto flagValue = useModernRuntimeScheduler_.load();
 
@@ -326,7 +344,7 @@ bool ReactNativeFeatureFlagsAccessor::useModernRuntimeScheduler() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(16, "useModernRuntimeScheduler");
+    markFlagAsAccessed(17, "useModernRuntimeScheduler");
 
     flagValue = currentProvider_->useModernRuntimeScheduler();
     useModernRuntimeScheduler_ = flagValue;
@@ -344,7 +362,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(17, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(18, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -362,7 +380,7 @@ bool ReactNativeFeatureFlagsAccessor::useStateAlignmentMechanism() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(18, "useStateAlignmentMechanism");
+    markFlagAsAccessed(19, "useStateAlignmentMechanism");
 
     flagValue = currentProvider_->useStateAlignmentMechanism();
     useStateAlignmentMechanism_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a9582288194b7e00f20bf6071458da61>>
+ * @generated SignedSource<<1818a852d68148dbabfe5bebd4142ae2>>
  */
 
 /**
@@ -47,6 +47,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool inspectorEnableModernCDPRegistry();
   bool lazyAnimationCallbacks();
   bool preventDoubleTextMeasure();
+  bool setAndroidLayoutDirection();
   bool useModernRuntimeScheduler();
   bool useNativeViewConfigsInBridgelessMode();
   bool useStateAlignmentMechanism();
@@ -60,7 +61,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 19> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 20> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> allowCollapsableChildren_;
@@ -78,6 +79,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> inspectorEnableModernCDPRegistry_;
   std::atomic<std::optional<bool>> lazyAnimationCallbacks_;
   std::atomic<std::optional<bool>> preventDoubleTextMeasure_;
+  std::atomic<std::optional<bool>> setAndroidLayoutDirection_;
   std::atomic<std::optional<bool>> useModernRuntimeScheduler_;
   std::atomic<std::optional<bool>> useNativeViewConfigsInBridgelessMode_;
   std::atomic<std::optional<bool>> useStateAlignmentMechanism_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<db008ef815b13a6d72acc099dd0ff704>>
+ * @generated SignedSource<<3563000e4692990818012aa6ee7480e5>>
  */
 
 /**
@@ -88,6 +88,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool preventDoubleTextMeasure() override {
+    return false;
+  }
+
+  bool setAndroidLayoutDirection() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<488476c6915add36fe67d53697a64801>>
+ * @generated SignedSource<<6206a6ce32afc6d7f83e1a11dfcb0f46>>
  */
 
 /**
@@ -41,6 +41,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool inspectorEnableModernCDPRegistry() = 0;
   virtual bool lazyAnimationCallbacks() = 0;
   virtual bool preventDoubleTextMeasure() = 0;
+  virtual bool setAndroidLayoutDirection() = 0;
   virtual bool useModernRuntimeScheduler() = 0;
   virtual bool useNativeViewConfigsInBridgelessMode() = 0;
   virtual bool useStateAlignmentMechanism() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ad6ff0fd6930b98b58c9383b7d0fb0ba>>
+ * @generated SignedSource<<4ccd72ad67edf83d62da6be13c1ec850>>
  */
 
 /**
@@ -115,6 +115,11 @@ bool NativeReactNativeFeatureFlags::lazyAnimationCallbacks(
 bool NativeReactNativeFeatureFlags::preventDoubleTextMeasure(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::preventDoubleTextMeasure();
+}
+
+bool NativeReactNativeFeatureFlags::setAndroidLayoutDirection(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::setAndroidLayoutDirection();
 }
 
 bool NativeReactNativeFeatureFlags::useModernRuntimeScheduler(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a3aae2684ef3f10db61782fc7823704b>>
+ * @generated SignedSource<<8e6f4fc87e96710fcd2011e5893f071b>>
  */
 
 /**
@@ -66,6 +66,8 @@ class NativeReactNativeFeatureFlags
   bool lazyAnimationCallbacks(jsi::Runtime& runtime);
 
   bool preventDoubleTextMeasure(jsi::Runtime& runtime);
+
+  bool setAndroidLayoutDirection(jsi::Runtime& runtime);
 
   bool useModernRuntimeScheduler(jsi::Runtime& runtime);
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -113,6 +113,10 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'When enabled, ParagraphShadowNode will no longer call measure twice.',
     },
+    setAndroidLayoutDirection: {
+      defaultValue: false,
+      description: 'Propagate layout direction to Android views.',
+    },
     useModernRuntimeScheduler: {
       defaultValue: false,
       description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<953d2d7e7adb016bf30c2be62ee0d89a>>
+ * @generated SignedSource<<723a8825d7a3281d90439e6600c839cb>>
  * @flow strict-local
  */
 
@@ -56,6 +56,7 @@ export type ReactNativeFeatureFlags = {
   inspectorEnableModernCDPRegistry: Getter<boolean>,
   lazyAnimationCallbacks: Getter<boolean>,
   preventDoubleTextMeasure: Getter<boolean>,
+  setAndroidLayoutDirection: Getter<boolean>,
   useModernRuntimeScheduler: Getter<boolean>,
   useNativeViewConfigsInBridgelessMode: Getter<boolean>,
   useStateAlignmentMechanism: Getter<boolean>,
@@ -165,6 +166,10 @@ export const lazyAnimationCallbacks: Getter<boolean> = createNativeFlagGetter('l
  * When enabled, ParagraphShadowNode will no longer call measure twice.
  */
 export const preventDoubleTextMeasure: Getter<boolean> = createNativeFlagGetter('preventDoubleTextMeasure', false);
+/**
+ * Propagate layout direction to Android views.
+ */
+export const setAndroidLayoutDirection: Getter<boolean> = createNativeFlagGetter('setAndroidLayoutDirection', false);
 /**
  * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<446991ce24c5765399940bfda55c0e5c>>
+ * @generated SignedSource<<0563625894ea466e12b8b6edd2f0022a>>
  * @flow strict-local
  */
 
@@ -39,6 +39,7 @@ export interface Spec extends TurboModule {
   +inspectorEnableModernCDPRegistry?: () => boolean;
   +lazyAnimationCallbacks?: () => boolean;
   +preventDoubleTextMeasure?: () => boolean;
+  +setAndroidLayoutDirection?: () => boolean;
   +useModernRuntimeScheduler?: () => boolean;
   +useNativeViewConfigsInBridgelessMode?: () => boolean;
   +useStateAlignmentMechanism?: () => boolean;

--- a/packages/react-native/template/android/app/src/main/AndroidManifest.xml
+++ b/packages/react-native/template/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:supportsRtl="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -37,7 +37,8 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:label="@string/app_name"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:supportsRtl="true">
     <activity
         android:name=".RNTesterActivity"
         android:label="@string/app_name"


### PR DESCRIPTION
Summary:
Noticed when running `arc nn`

> Advice xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java:39
> [Class has 0 issues and can be marked Nullsafe] Congrats! `IntBufferBatchMountItem` is free of nullability issues. Mark it `Nullsafe(Nullsafe.Mode.LOCAL)` to prevent regressions.

Changelog: [Internal]

Differential Revision: D57249958
