### PR TITLE
RN: Cleanup Comment Reference to Navigator

### DIFF
--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -163,29 +163,9 @@ function createStackEntry(props: any): any {
 /**
  * Component to control the app status bar.
  *
- * ### Usage with Navigator
- *
  * It is possible to have multiple `StatusBar` components mounted at the same
  * time. The props will be merged in the order the `StatusBar` components were
- * mounted. One use case is to specify status bar styles per route using `Navigator`.
- *
- * ```
- *  <View>
- *    <StatusBar
- *      backgroundColor="blue"
- *      barStyle="light-content"
- *    />
- *    <Navigator
- *      initialRoute={{statusBarHidden: true}}
- *      renderScene={(route, navigator) =>
- *        <View>
- *          <StatusBar hidden={route.statusBarHidden} />
- *          ...
- *        </View>
- *      }
- *    />
- *  </View>
- * ```
+ * mounted.
  *
  * ### Imperative API
  *


### PR DESCRIPTION
Summary: React Native no longer has a `Navigator` component, so let's clean up this reference in a comment in the `StatusBar` component definition.

Differential Revision: D57251899


