### PR TITLE
Configure ViewHierarchy dump for RNTester

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/FBEndToEndDumpsysHelper.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/FBEndToEndDumpsysHelper.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react
+
+import java.io.PrintWriter
+
+object FBEndToEndDumpsysHelper {
+  fun maybeDump(prefix: String, writer: PrintWriter, args: Array<String>?) {
+    // no-op This is an empty implementation to stub out Meta's internal dumpsys helper.
+  }
+}

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -8,9 +8,12 @@
 package com.facebook.react.uiapp
 
 import android.os.Bundle
+import com.facebook.react.FBEndToEndDumpsysHelper
 import com.facebook.react.ReactActivity
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import java.io.FileDescriptor
+import java.io.PrintWriter
 
 class RNTesterActivity : ReactActivity() {
   class RNTesterActivityDelegate(val activity: ReactActivity, mainComponentName: String) :
@@ -37,4 +40,13 @@ class RNTesterActivity : ReactActivity() {
   override fun createReactActivityDelegate() = RNTesterActivityDelegate(this, mainComponentName)
 
   override fun getMainComponentName() = "RNTesterApp"
+
+  override fun dump(
+      prefix: String,
+      fd: FileDescriptor?,
+      writer: PrintWriter,
+      args: Array<String>?
+  ) {
+    FBEndToEndDumpsysHelper.maybeDump(prefix, writer, args)
+  }
 }


### PR DESCRIPTION
Summary: Changelog: [General][Android] add FBEndToEndDumpsysHelper stub to RNTester Android to be able to dump ViewHierarcies internally.

Differential Revision: D54662739


