### PR TITLE
Sanitize measure function results

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 
 #include <yoga/debug/AssertFatal.h>
+#include <yoga/debug/Log.h>
 #include <yoga/node/Node.h>
 #include <yoga/numeric/Comparison.h>
 
@@ -49,12 +50,29 @@ Node::Node(Node&& node) noexcept
 }
 
 YGSize Node::measure(
-    float width,
+    float availableWidth,
     MeasureMode widthMode,
-    float height,
+    float availableHeight,
     MeasureMode heightMode) {
-  return measureFunc_(
-      this, width, unscopedEnum(widthMode), height, unscopedEnum(heightMode));
+  const auto size = measureFunc_(
+      this,
+      availableWidth,
+      unscopedEnum(widthMode),
+      availableHeight,
+      unscopedEnum(heightMode));
+
+  if (yoga::isUndefined(size.height) || size.height < 0 ||
+      yoga::isUndefined(size.width) || size.width < 0) {
+    yoga::log(
+        this,
+        LogLevel::Error,
+        "Measure function returned an invalid dimension to Yoga: [width=%f, height=%f]",
+        size.width,
+        size.height);
+    return {.width = 0.0f, .height = 0.0f};
+  }
+
+  return size;
 }
 
 float Node::baseline(float width, float height) const {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -66,9 +66,9 @@ class YG_EXPORT Node : public ::YGNode {
   }
 
   YGSize measure(
-      float width,
+      float availableWidth,
       MeasureMode widthMode,
-      float height,
+      float availableHeight,
       MeasureMode heightMode);
 
   bool hasBaselineFunc() const noexcept {


### PR DESCRIPTION
Summary:
We've started seeing assertion failures in Yoga where a `NaN` value makes its way to an `availableHeight` constrtaint when measuring Litho nodes.

Because it's only happening on Litho, I have some suspicion this might be originating from a Litho-specific measure function. This adds santization in Yoga to measure function results, where we will log an error, and set size to zero, if either dimension ends up being negative of `NaN`.

Changelog: [Internal]

Differential Revision: D57285584


