### PR TITLE
Move `showSoftInputOnFocus` example to `TextInputSharedExamples`

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -810,18 +810,6 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     },
   },
   {
-    title: 'showSoftInputOnFocus',
-    render: function (): React.Node {
-      return (
-        <View>
-          <WithLabel label="showSoftInputOnFocus: false">
-            <ExampleTextInput showSoftInputOnFocus={false} />
-          </WithLabel>
-        </View>
-      );
-    },
-  },
-  {
     title: 'Line Break Strategy',
     render: function (): React.Node {
       const lineBreakStrategy = ['none', 'standard', 'hangul-word', 'push-out'];

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1085,4 +1085,16 @@ module.exports = ([
     name: 'textStyles',
     render: () => <TextStylesExample />,
   },
+  {
+    title: 'showSoftInputOnFocus',
+    render: function (): React.Node {
+      return (
+        <View>
+          <WithLabel label="showSoftInputOnFocus: false">
+            <ExampleTextInput showSoftInputOnFocus={false} />
+          </WithLabel>
+        </View>
+      );
+    },
+  },
 ]: Array<RNTesterModuleExample>);


### PR DESCRIPTION
Summary:
Right now this is only exposed to RNTester on iOS, but the prop exists on both platforms.

Changelog: [Internal]

Differential Revision: D57281892


