### PR TITLE
Revise ComponentValue parsing model

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
+#include <concepts>
 #include <optional>
-#include <variant>
 #include <vector>
 
 #include <react/renderer/css/CSSTokenizer.h>
@@ -16,23 +16,84 @@
 namespace facebook::react {
 
 /**
- * CSSSyntaxParser allows parsing streams of CSS text into "component values",
- * being either a preserved token, or a function.
+ * Describes context for a CSS function component value.
+ */
+struct CSSFunctionBlock {
+  std::string_view name{};
+};
+
+/**
+ * Describes a preserved token component value.
+ */
+using CSSPreservedToken = CSSToken;
+
+/**
+ * Describes context for a CSS function component value.
+ */
+struct CSSSimpleBlock {
+  CSSTokenType openBracketType{};
+};
+
+/**
+ * A CSSFunctionVisitor is called to start parsing a function component value.
+ * At this point, the Parser is positioned at the start of the function
+ * component value list. It is expected that the visitor finishes before the end
+ * of the function block.
+ */
+template <typename T, typename ReturnT>
+concept CSSFunctionVisitor = requires(T visitor, CSSFunctionBlock func) {
+  { visitor(func) } -> std::convertible_to<ReturnT>;
+};
+
+/**
+ * A CSSPreservedTokenVisitor is called after parsing a preserved token
+ * component value.
+ */
+template <typename T, typename ReturnT>
+concept CSSPreservedTokenVisitor =
+    requires(T visitor, CSSPreservedToken token) {
+      { visitor(token) } -> std::convertible_to<ReturnT>;
+    };
+
+/**
+ * A CSSSimpleBlockVisitor is called after parsing a simple block component
+ * value. It is expected that the visitor finishes before the end
+ * of the block.
+ */
+template <typename T, typename ReturnT>
+concept CSSSimpleBlockVisitor = requires(T visitor, CSSSimpleBlock block) {
+  { visitor(block) } -> std::convertible_to<ReturnT>;
+};
+
+/**
+ * Any visitor for a component value.
+ */
+template <typename T, typename ReturnT>
+concept CSSComponentValueVisitor = CSSFunctionVisitor<T, ReturnT> ||
+    CSSPreservedTokenVisitor<T, ReturnT> || CSSSimpleBlockVisitor<T, ReturnT>;
+
+/**
+ * Represents a variadic set of CSSComponentValueVisitor with no more than one
+ * of a specific type of visitor.
+ */
+template <typename ReturnT, typename... VisitorsT>
+concept CSSUniqueComponentValueVisitors =
+    (CSSComponentValueVisitor<VisitorsT, ReturnT> && ...) &&
+    ((CSSFunctionVisitor<VisitorsT, ReturnT> ? 1 : 0) + ... + 0) <= 1 &&
+    ((CSSPreservedTokenVisitor<VisitorsT, ReturnT> ? 1 : 0) + ... + 0) <= 1 &&
+    ((CSSSimpleBlockVisitor<VisitorsT, ReturnT> ? 1 : 0) + ... + 0) <= 1;
+
+/**
+ * CSSSyntaxParser allows parsing streams of CSS text into "component
+ * values".
  *
  * https://www.w3.org/TR/css-syntax-3/#component-value
  */
 class CSSSyntaxParser {
+  template <typename ReturnT, CSSComponentValueVisitor<ReturnT>... VisitorsT>
+  friend struct CSSComponentValueVisitorDispatcher;
+
  public:
-  struct Function;
-
-  using PreservedToken = CSSToken;
-  using ComponentValue = std::variant<std::monostate, PreservedToken, Function>;
-
-  struct Function {
-    std::string_view name{};
-    std::vector<ComponentValue> args{};
-  };
-
   /**
    * Construct the parser over the given string_view, which must stay alive for
    * the duration of the CSSSyntaxParser.
@@ -40,19 +101,39 @@ class CSSSyntaxParser {
   explicit constexpr CSSSyntaxParser(std::string_view css)
       : tokenizer_{css}, currentToken_(tokenizer_.next()) {}
 
+  constexpr CSSSyntaxParser(const CSSSyntaxParser&) = default;
+  constexpr CSSSyntaxParser(CSSSyntaxParser&&) = default;
+
+  constexpr CSSSyntaxParser& operator=(const CSSSyntaxParser&) = default;
+  constexpr CSSSyntaxParser& operator=(CSSSyntaxParser&&) = default;
+
   /**
-   * Directly consume the next component value
+   * Directly consume the next component value. The component value is provided
+   * to a passed in "visitor", typically a lambda which accepts the component
+   * value in a new scope. The visitor may read this component parameter into a
+   * higher-level data structure, and continue parsing within its scope using
+   * the same underlying CSSSyntaxParser.
    *
    * https://www.w3.org/TR/css-syntax-3/#consume-component-value
+   *
+   * @param <ReturnT> caller-specified return type of visitors. This type will
+   * be set to its default constructed state if consuming a component value with
+   * no matching visitors.
+   * @param visitors A unique list of CSSComponentValueVisitor to be called on a
+   * match
    */
-  inline ComponentValue consumeComponentValue() {
-    if (peek().type() == CSSTokenType::Function) {
-      auto function = consumeFunction();
-      return function.has_value() ? ComponentValue{std::move(*function)}
-                                  : ComponentValue{};
-    } else {
-      return consumeToken();
+  template <typename ReturnT, CSSComponentValueVisitor<ReturnT>... VisitorsT>
+    requires(CSSUniqueComponentValueVisitors<ReturnT, VisitorsT...>)
+  constexpr ReturnT consumeComponentValue(VisitorsT&&... visitors);
+
+  constexpr void consumeWhitespace() {
+    while (currentToken_.type() == CSSTokenType::WhiteSpace) {
+      currentToken_ = tokenizer_.next();
     }
+  }
+
+  constexpr bool isFinished() const {
+    return currentToken_.type() == CSSTokenType::EndOfFile;
   }
 
  private:
@@ -66,40 +147,103 @@ class CSSSyntaxParser {
     return prevToken;
   }
 
-  inline std::optional<Function> consumeFunction() {
-    // https://www.w3.org/TR/css-syntax-3/#consume-a-function
-    Function function{.name = consumeToken().stringValue()};
-
-    while (true) {
-      auto nextValue = consumeComponentValue();
-      if (std::holds_alternative<std::monostate>(nextValue)) {
-        return {};
-      }
-
-      if (auto token = std::get_if<CSSToken>(&nextValue)) {
-        if (token->type() == CSSTokenType::CloseParen) {
-          return function;
-        }
-        if (token->type() == CSSTokenType::EndOfFile) {
-          return {};
-        }
-        function.args.emplace_back(std::move(*token));
-        continue;
-      }
-
-      if (auto func = std::get_if<Function>(&nextValue)) {
-        function.args.emplace_back(std::move(*func));
-        continue;
-      }
-
-      return {};
-    }
-
-    return function;
-  }
-
   CSSTokenizer tokenizer_;
   CSSToken currentToken_;
 };
+
+template <typename ReturnT, CSSComponentValueVisitor<ReturnT>... VisitorsT>
+struct CSSComponentValueVisitorDispatcher {
+  CSSSyntaxParser& parser;
+
+  constexpr ReturnT consumeComponentValue(VisitorsT&&... visitors) {
+    switch (parser.peek().type()) {
+      case CSSTokenType::Function:
+        if (auto ret = visitFunction(std::move(visitors)...)) {
+          return *ret;
+        }
+        break;
+      case CSSTokenType::OpenParen:
+        if (auto ret = visitSimpleBlock(
+                CSSTokenType::CloseParen, std::move(visitors)...)) {
+          return *ret;
+        }
+        break;
+      case CSSTokenType::OpenSquare:
+        if (auto ret = visitSimpleBlock(
+                CSSTokenType::CloseSquare, std::move(visitors)...)) {
+          return *ret;
+        }
+        break;
+      case CSSTokenType::OpenCurly:
+        if (auto ret = visitSimpleBlock(
+                CSSTokenType::CloseCurly, std::move(visitors)...)) {
+          return *ret;
+        }
+        break;
+      default:
+        if (auto ret = visitPreservedToken(std::move(visitors)...)) {
+          return *ret;
+        }
+        break;
+    }
+
+    return ReturnT{};
+  }
+
+  constexpr std::optional<ReturnT> visitFunction(VisitorsT&&... visitors) {
+    for (auto visitor : {visitors...}) {
+      if constexpr (CSSFunctionVisitor<decltype(visitor), ReturnT>) {
+        auto functionValue =
+            visitor({.name = parser.consumeToken().stringValue()});
+        parser.consumeWhitespace();
+        if (parser.peek().type() == CSSTokenType::CloseParen) {
+          parser.consumeToken();
+          return functionValue;
+        }
+
+        return {};
+      }
+    }
+
+    return {};
+  }
+
+  constexpr std::optional<ReturnT> visitSimpleBlock(
+      CSSTokenType endToken,
+      VisitorsT&&... visitors) {
+    for (auto visitor : {visitors...}) {
+      if constexpr (CSSSimpleBlockVisitor<decltype(visitor), ReturnT>) {
+        auto blockValue =
+            visitor({.openBracketType = parser.consumeToken().type()});
+        parser.consumeWhitespace();
+        if (parser.peek().type() == endToken) {
+          parser.consumeToken();
+          return blockValue;
+        }
+
+        return {};
+      }
+    }
+    return {};
+  }
+
+  constexpr std::optional<ReturnT> visitPreservedToken(
+      VisitorsT&&... visitors) {
+    for (auto visitor : {visitors...}) {
+      if constexpr (CSSPreservedTokenVisitor<decltype(visitor), ReturnT>) {
+        return visitor(parser.consumeToken());
+      }
+    }
+    return {};
+  }
+};
+
+template <typename ReturnT, CSSComponentValueVisitor<ReturnT>... VisitorsT>
+  requires(CSSUniqueComponentValueVisitors<ReturnT, VisitorsT...>)
+constexpr ReturnT CSSSyntaxParser::consumeComponentValue(
+    VisitorsT&&... visitors) {
+  return CSSComponentValueVisitorDispatcher<ReturnT, VisitorsT...>{*this}
+      .consumeComponentValue(std::forward<VisitorsT>(visitors)...);
+}
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSToken.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSToken.h
@@ -16,7 +16,9 @@ namespace facebook::react {
  * https://www.w3.org/TR/css-syntax-3/#tokenizer-definitions
  */
 enum class CSSTokenType {
+  CloseCurly,
   CloseParen,
+  CloseSquare,
   Comma,
   Delim,
   Dimension,
@@ -24,7 +26,9 @@ enum class CSSTokenType {
   Function,
   Ident,
   Number,
+  OpenCurly,
   OpenParen,
+  OpenSquare,
   Percentage,
   WhiteSpace,
 };

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
@@ -43,6 +43,14 @@ class CSSTokenizer {
         return consumeCharacter(CSSTokenType::OpenParen);
       case ')':
         return consumeCharacter(CSSTokenType::CloseParen);
+      case '[':
+        return consumeCharacter(CSSTokenType::OpenSquare);
+      case ']':
+        return consumeCharacter(CSSTokenType::CloseSquare);
+      case '{':
+        return consumeCharacter(CSSTokenType::OpenCurly);
+      case '}':
+        return consumeCharacter(CSSTokenType::CloseCurly);
       case ',':
         return consumeCharacter(CSSTokenType::Comma);
       case '+':

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <optional>
+#include <type_traits>
 
 #include <react/renderer/css/CSSAngleUnit.h>
 #include <react/renderer/css/CSSProperties.h>
@@ -18,190 +19,197 @@ namespace facebook::react {
 
 namespace detail {
 
+template <CSSDataType... AllowedTypesT>
 class CSSValueParser {
+  using CSSValue = CSSValueVariant<AllowedTypesT...>;
+
  public:
-  explicit inline CSSValueParser(std::string_view css)
-      : parser_{css}, currentComponentValue_{parser_.consumeComponentValue()} {}
+  explicit constexpr CSSValueParser(std::string_view css) : parser_{css} {}
 
   /*
    * Attempts to parse the characters starting at the current component value
    * into one of the given data types.
    */
-  template <CSSDataType... AllowedTypesT>
-  inline CSSValueVariant<AllowedTypesT...> consumeValue() {
-    using CSSValueT = CSSValueVariant<AllowedTypesT...>;
+  constexpr CSSValue consumeValue() {
+    return parser_.consumeComponentValue<CSSValue>(
+        [&](const CSSPreservedToken& token) {
+          // CSS-global keywords
+          if constexpr (hasType<CSSWideKeyword>()) {
+            if (auto cssWideKeyword = consumeCSSWideKeyword(token)) {
+              return *cssWideKeyword;
+            }
+          }
+          // Property-specific keywords
+          if constexpr (hasType<typename CSSValue::Keyword>()) {
+            if (auto keyword = consumeKeyword(token)) {
+              return *keyword;
+            }
+          }
+          // <ratio>
+          if constexpr (hasType<CSSRatio>()) {
+            if (auto ratio = consumeRatio(token)) {
+              return *ratio;
+            }
+          }
+          // <number>
+          if constexpr (hasType<CSSNumber>()) {
+            if (auto number = consumeNumber(token)) {
+              return *number;
+            }
+          }
+          // <length>
+          if constexpr (hasType<CSSLength>()) {
+            if (auto length = consumeLength(token)) {
+              return *length;
+            }
+          }
+          // <angle>
+          if constexpr (hasType<CSSAngle>()) {
+            if (auto angle = consumeAngle(token)) {
+              return *angle;
+            }
+          }
+          // <percentage>
+          if constexpr (hasType<CSSPercentage>()) {
+            if (auto percentage = consumePercentage(token)) {
+              return *percentage;
+            }
+          }
 
-    if (holdsToken()) {
-      switch (peekToken().type()) {
-        case CSSTokenType::Ident:
-          if (auto keywordValue =
-                  consumeIdentToken<CSSValueT, AllowedTypesT...>()) {
-            return *keywordValue;
-          }
-          break;
-        case CSSTokenType::Dimension:
-          if (auto dimensionValue =
-                  consumeDimensionToken<CSSValueT, AllowedTypesT...>()) {
-            return *dimensionValue;
-          }
-          break;
-        case CSSTokenType::Percentage:
-          if (auto percentageValue =
-                  consumePercentageToken<CSSValueT, AllowedTypesT...>()) {
-            return *percentageValue;
-          }
-          break;
-        case CSSTokenType::Number:
-          if (auto numberValue =
-                  consumeNumberToken<CSSValueT, AllowedTypesT...>()) {
-            return *numberValue;
-          }
-          break;
-        default:
-          break;
-      }
-    }
-
-    if (holdsFunction()) {
-      // Function component values not yet supported
-    }
-
-    consumeComponentValue();
-    return {};
+          return CSSValue{};
+        });
+    // TODO: support function component values and simple blocks
   }
 
-  inline void consumeWhitespace() {
-    while (holdsToken() && peekToken().type() == CSSTokenType::WhiteSpace) {
-      consumeComponentValue();
-    }
+  constexpr void consumeWhitespace() {
+    parser_.consumeWhitespace();
   }
 
   constexpr bool isFinished() const {
-    return holdsToken() && peekToken().type() == CSSTokenType::EndOfFile;
+    return parser_.isFinished();
   }
 
  private:
-  constexpr const CSSSyntaxParser::ComponentValue& peek() const {
-    return currentComponentValue_;
+  template <CSSDataType T>
+  constexpr static bool hasType() {
+    return traits::containsType<T, AllowedTypesT...>();
   }
 
-  constexpr bool holdsToken() const {
-    return std::holds_alternative<CSSSyntaxParser::PreservedToken>(peek());
+  template <typename T>
+  constexpr static bool hasType() {
+    return false;
   }
 
-  constexpr bool holdsFunction() const {
-    return std::holds_alternative<CSSSyntaxParser::Function>(peek());
-  }
-
-  constexpr const CSSSyntaxParser::PreservedToken& peekToken() const {
-    return std::get<CSSSyntaxParser::PreservedToken>(peek());
-  }
-
-  constexpr const CSSSyntaxParser::Function& peekFunction() const {
-    return std::get<CSSSyntaxParser::Function>(peek());
-  }
-
-  inline CSSSyntaxParser::ComponentValue consumeComponentValue() {
-    auto prevComponentValue = std::move(currentComponentValue_);
-    currentComponentValue_ = parser_.consumeComponentValue();
-    return prevComponentValue;
-  }
-
-  inline CSSSyntaxParser::PreservedToken consumeToken() {
-    return std::get<CSSSyntaxParser::PreservedToken>(consumeComponentValue());
-  }
-
-  inline CSSSyntaxParser::Function consumeFunction() {
-    return std::get<CSSSyntaxParser::Function>(consumeComponentValue());
-  }
-
-  template <typename CSSValueT, CSSDataType... AllowedTypesT>
-  inline std::optional<CSSValueT> consumeIdentToken() {
-    if constexpr (!std::is_same_v<typename CSSValueT::Keyword, void>) {
-      if (auto keyword = parseCSSKeyword<typename CSSValueT::Keyword>(
-              peekToken().stringValue())) {
-        consumeComponentValue();
-        return CSSValueT::keyword(*keyword);
-      }
-    }
-    if constexpr (traits::containsType<CSSWideKeyword, AllowedTypesT...>()) {
-      if (auto keyword =
-              parseCSSKeyword<CSSWideKeyword>(peekToken().stringValue())) {
-        consumeComponentValue();
-        return CSSValueT::cssWideKeyword(*keyword);
+  constexpr std::optional<CSSValue> consumeKeyword(
+      const CSSPreservedToken& token) {
+    if (token.type() == CSSTokenType::Ident) {
+      if (auto keyword = parseCSSKeyword<typename CSSValue::Keyword>(
+              token.stringValue())) {
+        return CSSValue::keyword(*keyword);
       }
     }
     return {};
   }
 
-  template <typename CSSValueT, CSSDataType... AllowedTypesT>
-  inline std::optional<CSSValueT> consumeDimensionToken() {
-    if constexpr (traits::containsType<CSSLength, AllowedTypesT...>()) {
-      if (auto unit = parseCSSLengthUnit(peekToken().unit())) {
-        return CSSValueT::length(consumeToken().numericValue(), *unit);
-      }
-    }
-    if constexpr (traits::containsType<CSSAngle, AllowedTypesT...>()) {
-      if (auto unit = parseCSSAngleUnit(peekToken().unit())) {
-        return CSSValueT::angle(
-            canonicalize(consumeToken().numericValue(), *unit));
+  constexpr std::optional<CSSValue> consumeCSSWideKeyword(
+      const CSSPreservedToken& token) {
+    if (token.type() == CSSTokenType::Ident) {
+      if (auto keyword = parseCSSKeyword<CSSWideKeyword>(token.stringValue())) {
+        return CSSValue::cssWideKeyword(*keyword);
       }
     }
     return {};
   }
 
-  template <typename CSSValueT, CSSDataType... AllowedTypesT>
-  constexpr std::optional<CSSValueT> consumePercentageToken() {
-    if constexpr (traits::containsType<CSSPercentage, AllowedTypesT...>()) {
-      return CSSValueT::percentage(consumeToken().numericValue());
+  constexpr std::optional<CSSValue> consumeAngle(
+      const CSSPreservedToken& token) {
+    if (token.type() == CSSTokenType::Dimension) {
+      if (auto unit = parseCSSAngleUnit(token.unit())) {
+        return CSSValue::angle(canonicalize(token.numericValue(), *unit));
+      }
     }
     return {};
   }
 
-  template <typename CSSValueT, CSSDataType... AllowedTypesT>
-  constexpr std::optional<CSSValueT> consumeNumberToken() {
+  constexpr std::optional<CSSValue> consumePercentage(
+      const CSSPreservedToken& token) {
+    if (token.type() == CSSTokenType::Percentage) {
+      return CSSValue::percentage(token.numericValue());
+    }
+
+    return {};
+  }
+
+  constexpr std::optional<CSSValue> consumeNumber(
+      const CSSPreservedToken& token) {
+    if (token.type() == CSSTokenType::Number) {
+      return CSSValue::number(token.numericValue());
+    }
+
+    return {};
+  }
+
+  constexpr std::optional<CSSValue> consumeLength(
+      const CSSPreservedToken& token) {
+    switch (token.type()) {
+      case CSSTokenType::Dimension:
+        if (auto unit = parseCSSLengthUnit(token.unit())) {
+          return CSSValue::length(token.numericValue(), *unit);
+        }
+        break;
+      case CSSTokenType::Number:
+        // For zero lengths the unit identifier is optional (i.e. can be
+        // syntactically represented as the <number> 0). However, if a 0
+        // could be parsed as either a <number> or a <length> in a
+        // property (such as line-height), it must parse as a <number>.
+        // https://www.w3.org/TR/css-values-4/#lengths
+        if (token.numericValue() == 0) {
+          return CSSValue::length(token.numericValue(), CSSLengthUnit::Px);
+        }
+        break;
+      default:
+        break;
+    }
+
+    return {};
+  }
+
+  constexpr std::optional<CSSValue> consumeRatio(
+      const CSSPreservedToken& token) {
     // <ratio> = <number [0,∞]> [ / <number [0,∞]> ]?
     // https://www.w3.org/TR/css-values-4/#ratio
-    if constexpr (traits::containsType<CSSRatio, AllowedTypesT...>()) {
-      if (isValidRatioPart(peekToken().numericValue())) {
-        float numerator = consumeToken().numericValue();
-        float denominator = 1.0;
+    if (isValidRatioPart(token.numericValue())) {
+      float numerator = token.numericValue();
 
-        consumeWhitespace();
+      CSSSyntaxParser lookaheadParser{parser_};
+      lookaheadParser.consumeWhitespace();
 
-        if (holdsToken() && peekToken().type() == CSSTokenType::Delim &&
-            peekToken().stringValue() == "/") {
-          consumeToken();
-          consumeWhitespace();
+      auto hasSolidus = lookaheadParser.consumeComponentValue<bool>(
+          [&](const CSSPreservedToken& token) {
+            return token.type() == CSSTokenType::Delim &&
+                token.stringValue() == "/";
+          });
 
-          // TODO: for now, we don't support denominator being a function
-          // component value. CSS math functions allow substituion though, where
-          // this usage is valid.
-          if (holdsToken() && peekToken().type() == CSSTokenType::Number &&
-              isValidRatioPart(peekToken().numericValue())) {
-            denominator = consumeToken().numericValue();
-          } else {
-            return {};
-          }
-        }
-
-        return CSSValueT::ratio(numerator, denominator);
+      if (!hasSolidus) {
+        return CSSValue::ratio(numerator, 1.0f);
       }
-    }
 
-    if constexpr (traits::containsType<CSSNumber, AllowedTypesT...>()) {
-      return CSSValueT::number(consumeToken().numericValue());
-    }
+      lookaheadParser.consumeWhitespace();
 
-    // For zero lengths the unit identifier is optional (i.e. can be
-    // syntactically represented as the <number> 0). However, if a 0
-    // could be parsed as either a <number> or a <length> in a
-    // property (such as line-height), it must parse as a <number>.
-    // https://www.w3.org/TR/css-values-4/#lengths
-    if constexpr (traits::containsType<CSSLength, AllowedTypesT...>()) {
-      if (peekToken().numericValue() == 0) {
-        return CSSValueT::length(
-            consumeToken().numericValue(), CSSLengthUnit::Px);
+      // TODO: support math expression substituion for <number>
+      auto denominator =
+          lookaheadParser.consumeComponentValue<std::optional<float>>(
+              [&](const CSSPreservedToken& token) {
+                if (token.type() == CSSTokenType::Number &&
+                    isValidRatioPart(token.numericValue())) {
+                  return std::optional(token.numericValue());
+                }
+                return std::optional<float>{};
+              });
+
+      if (denominator.has_value()) {
+        parser_ = lookaheadParser;
+        return CSSValue::ratio(numerator, *denominator);
       }
     }
 
@@ -217,17 +225,16 @@ class CSSValueParser {
   }
 
   CSSSyntaxParser parser_;
-  CSSSyntaxParser::ComponentValue currentComponentValue_;
 };
 
 template <CSSDataType... AllowedTypesT>
-inline void parseCSSValue(
+constexpr void parseCSSValue(
     std::string_view css,
     CSSValueVariant<AllowedTypesT...>& value) {
-  detail::CSSValueParser parser(css);
+  detail::CSSValueParser<AllowedTypesT...> parser(css);
 
   parser.consumeWhitespace();
-  auto componentValue = parser.consumeValue<AllowedTypesT...>();
+  auto componentValue = parser.consumeValue();
   parser.consumeWhitespace();
 
   if (parser.isFinished()) {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSValueParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSValueParserTest.cpp
@@ -307,4 +307,17 @@ TEST(CSSValueParser, parse_prop) {
   EXPECT_EQ(keywordlessValue.getLength().unit, CSSLengthUnit::Px);
 }
 
+TEST(CSSValueParser, parse_keyword_prop_constexpr) {
+  constexpr auto rowValue = parseCSSProp<CSSProp::FlexDirection>("row");
+  EXPECT_EQ(rowValue.type(), CSSValueType::Keyword);
+  EXPECT_EQ(rowValue.getKeyword(), CSSKeyword::Row);
+}
+
+TEST(CSSValueParser, parse_length_prop_constexpr) {
+  constexpr auto pxValue = parseCSSProp<CSSProp::BorderWidth>("2px");
+  EXPECT_EQ(pxValue.type(), CSSValueType::Length);
+  EXPECT_EQ(pxValue.getLength().value, 2.0f);
+  EXPECT_EQ(pxValue.getLength().unit, CSSLengthUnit::Px);
+}
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
D57089275 introduced a layer to parse component values out of the token stream. I modeled this similar to the tokenizer, as a flat iterator of component values. Because function components can nest a variable number of child component values, this now looks like storing a fully resolved tree of tokens on the heap during parsing.

This diff changes the model, so that `CSSSyntaxParser::consumeComponentValue()` no longer returns a resolved CSS function value. Instead, users of the parser are expected to provide "visitors" which continue parsing, matched based on component value type pattern matched. Visitors can perform parsing specific to their context, and propagate values up the stack, based on their evaluation of the component value.

Removing the heap allocated list of tokens here also lets this core CSS parsing stack keep constexpr, so I added that back, though we need to keep expression trees for math expressions in uncommon cases, so the layer up probaly won't keep constexpr.

Changelog: [Internal]

Differential Revision: D57206706


