### PR TITLE
fix(iOS): Setting cursor on Text doesn't error

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.h
@@ -5,15 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <React/RCTComponent.h>
-
 #import <UIKit/UIKit.h>
+
+#import <React/RCTComponent.h>
+#import <React/RCTCursor.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RCTTextView : UIView
 
 @property (nonatomic, assign) BOOL selectable;
+
+@property (nonatomic, assign) RCTCursor cursor;
 
 - (void)setTextStorage:(NSTextStorage *)textStorage
           contentFrame:(CGRect)contentFrame

--- a/packages/rn-tester/js/examples/Cursor/CursorExample.js
+++ b/packages/rn-tester/js/examples/Cursor/CursorExample.js
@@ -46,6 +46,11 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     gap: 10,
   },
+  column: {
+    flexDirection: 'column',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
   centerContent: {
     justifyContent: 'center',
     alignItems: 'center',
@@ -54,39 +59,33 @@ const styles = StyleSheet.create({
 
 function CursorExampleAuto() {
   return (
-    <View style={styles.row}>
-      <View style={styles.box} />
-      <View style={styles.circle} />
-      <View style={styles.halfcircle} />
-      <View style={[styles.box, styles.solid]} />
-      <View style={[styles.circle, styles.solid]} />
-      <View style={[styles.halfcircle, styles.solid]} />
+    <View style={styles.column}>
+      <View style={styles.row}>
+        <View style={styles.box} />
+        <View style={styles.circle} />
+        <View style={styles.halfcircle} />
+        <View style={[styles.box, styles.solid]} />
+        <View style={[styles.circle, styles.solid]} />
+        <View style={[styles.halfcircle, styles.solid]} />
+      </View>
+      <Text>Some text</Text>
     </View>
+
   );
 }
 
 function CursorExamplePointer() {
   return (
-    <View style={styles.row}>
-      <View style={[styles.box, styles.pointer]} />
-      <View style={[styles.circle, styles.pointer]} />
-      <View style={[styles.halfcircle, styles.pointer]} />
-      <View style={[styles.box, styles.solid, styles.pointer]} />
-      <View style={[styles.circle, styles.solid, styles.pointer]} />
-      <View style={[styles.halfcircle, styles.solid, styles.pointer]} />
-    </View>
-  );
-}
-
-function CursorExamplePointer() {
-  return (
-    <View style={styles.row}>
-      <View style={[styles.box, styles.pointer]} />
-      <View style={[styles.circle, styles.pointer]} />
-      <View style={[styles.halfcircle, styles.pointer]} />
-      <View style={[styles.box, styles.solid, styles.pointer]} />
-      <View style={[styles.circle, styles.solid, styles.pointer]} />
-      <View style={[styles.halfcircle, styles.solid, styles.pointer]} />
+    <View style={styles.column}>
+      <View style={styles.row}>
+        <View style={[styles.box, styles.pointer]} />
+        <View style={[styles.circle, styles.pointer]} />
+        <View style={[styles.halfcircle, styles.pointer]} />
+        <View style={[styles.box, styles.solid, styles.pointer]} />
+        <View style={[styles.circle, styles.solid, styles.pointer]} />
+        <View style={[styles.halfcircle, styles.solid, styles.pointer]} />
+      </View>
+      <Text style={styles.pointer}>Some text</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary:

Related: https://github.com/facebook/react-native/issues/44559

On the old architecture, `RCTTextView`  didn't have the `cursor` property, so if you tried to set `cursor` on Text, you would get a redbox. Implementing cursor for Text wasn't super simple (there's some stuff that's in RCTView that's not in RCTTextView), so let's just add a property so it at least doesn't redbox. 

## Changelog:

[IOS] [FIXED] - Setting cursor on Text doesn't error


## Test Plan:

Updated the cursor example test page, and verified that:
- No red box pops up
- Setting cursor directly on Text doesn't actually do anything. 

https://github.com/facebook/react-native/assets/6722175/a56623d4-5851-4c38-84e3-8be62867e4df


