### PR TITLE
EventPerformanceLogger + BoundedConsumableBuffer - switch members to size_t

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/timeline/BoundedConsumableBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/BoundedConsumableBuffer.h
@@ -13,7 +13,7 @@
 
 namespace facebook::react {
 
-constexpr int DEFAULT_MAX_SIZE = 1024;
+constexpr size_t DEFAULT_MAX_SIZE = 1024;
 
 /**
  * A container for storing entries of type T, with the following properties:
@@ -47,7 +47,7 @@ class BoundedConsumableBuffer {
     DROP = 2,
   };
 
-  BoundedConsumableBuffer(int maxSize = DEFAULT_MAX_SIZE) : maxSize_(maxSize) {
+  BoundedConsumableBuffer(size_t maxSize = DEFAULT_MAX_SIZE) : maxSize_(maxSize) {
     entries_.reserve(maxSize_);
   }
 
@@ -229,18 +229,18 @@ class BoundedConsumableBuffer {
  private:
   std::vector<T> entries_;
 
-  const int maxSize_;
+  const size_t maxSize_;
 
   // Current starting position in the circular buffer:
-  int position_{0};
+  size_t position_{0};
 
-  // Current "cursor" - positions of the firsst and after last unconsumed
+  // Current "cursor" - positions of the first and after last unconsumed
   // element, relative to the starting position:
-  int cursorStart_{0};
-  int cursorEnd_{0};
+  size_t cursorStart_{0};
+  size_t cursorEnd_{0};
 
   // Number of currently unconsumed elements:
-  int numToConsume_{0};
+  size_t numToConsume_{0};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.cpp
@@ -15,7 +15,7 @@ namespace facebook::react {
 namespace {
 
 struct StrKey {
-  uint32_t key;
+  size_t key;
   StrKey(std::string_view s) : key(std::hash<std::string_view>{}(s)) {}
 
   bool operator==(const StrKey& rhs) const {
@@ -25,7 +25,7 @@ struct StrKey {
 
 struct StrKeyHash {
   constexpr size_t operator()(const StrKey& strKey) const {
-    return static_cast<size_t>(strKey.key);
+    return strKey.key;
   }
 };
 


### PR DESCRIPTION
## Summary:

The RNW integration to RN 04/13 (https://github.com/microsoft/react-native-windows/pull/13226) adds EventPerformanceLogger.cpp and PerformanceEntryReporter.cpp. 

We're getting the following errors:
![image](https://github.com/facebook/react-native/assets/1422161/33a4dc42-1d14-4ac4-befd-87ec5cd02640)

![image](https://github.com/facebook/react-native/assets/1422161/6269968d-c0e8-489b-992e-0bb41b6ef7c6)

Switching to size_t fixes it. 

## Changelog:
[Internal] [FIXED] - EventPerformanceLogger + BoundedConsumableBuffer - switch members to size_t


## Test Plan:

Builds on Windows
