### PR TITLE
fix: use local scheduler for thread-safe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -91,7 +91,7 @@ void Binding::setPixelDensity(float pointScaleFactor) {
 }
 
 void Binding::driveCxxAnimations() {
-  scheduler_->animationTick();
+  getScheduler()->animationTick();
 }
 
 void Binding::reportMount(SurfaceId surfaceId) {
@@ -189,7 +189,7 @@ void Binding::startSurfaceWithConstraints(
       isRTL ? LayoutDirection::RightToLeft : LayoutDirection::LeftToRight;
 
   auto surfaceHandler = SurfaceHandler{moduleName->toStdString(), surfaceId};
-  surfaceHandler.setContextContainer(scheduler_->getContextContainer());
+  surfaceHandler.setContextContainer(scheduler->getContextContainer());
   surfaceHandler.setProps(initialProps->consume());
   surfaceHandler.constraintLayout(constraints, context);
 


### PR DESCRIPTION
## Summary:

`getScheduler()` is intended for thread-safe

## Changelog:

[ANDROID|INTERNAL] [FIXED] - local scheduler for thread-safe

## Test Plan:

none