### PR TITLE
Shortcut emitDeviceEvent in bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -134,6 +134,8 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
         && mInteropModuleRegistry.shouldReturnInteropModule(jsInterface)) {
       return mInteropModuleRegistry.getInteropModule(jsInterface);
     }
+
+    // TODO T189052462: ReactContext caches JavaScriptModule instances
     JavaScriptModule interfaceProxy =
         (JavaScriptModule)
             Proxy.newProxyInstance(
@@ -141,6 +143,13 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
                 new Class[] {jsInterface},
                 new BridgelessJSModuleInvocationHandler(mReactHost, jsInterface));
     return (T) interfaceProxy;
+  }
+
+  /** Shortcut RCTDeviceEventEmitter.emit since it's frequently used */
+  @Override
+  public void emitDeviceEvent(String eventName, @Nullable Object args) {
+    mReactHost.callFunctionOnModule(
+        "RCTDeviceEventEmitter", "emit", Arguments.fromJavaArgs(new Object[] {args}));
   }
 
   @Override


### PR DESCRIPTION
Summary:
`emitDeviceEvent` is frequently used for perf-critical operations such as sending network responses from native to JS. We don't need to go through JavaScriptModule Proxy (which is missing caching in bridgeless) and instead can immediately invoke the callable JS module.

Changelog: [Internal]

Differential Revision: D57329165


