### PR TITLE
Resolve CodeQL error in loadBundleFromServer.js

### DIFF
--- a/packages/react-native/Libraries/Core/Devtools/loadBundleFromServer.js
+++ b/packages/react-native/Libraries/Core/Devtools/loadBundleFromServer.js
@@ -134,7 +134,7 @@ module.exports = function (bundlePathAndQuery: string): Promise<void> {
         global.globalEvalWithSourceUrl(body, requestUrl);
       } else {
         // eslint-disable-next-line no-eval
-        eval(body);
+        eval(body); // CodeQL [js/eval-usage] Debug only. Developer inner loop.
       }
     })
     .catch<void>(e => {


### PR DESCRIPTION
## Summary:
https://github.com/microsoft/react-native-windows/issues/12704

Running [CodeQL](https://codeql.github.com/) on RNW produces the following errors:
![image](https://github.com/facebook/react-native/assets/1422161/c97d42e2-895c-4193-9601-c840287e716a)

## Changelog:
[INTERNAL] - Resolve CodeQL error in loadBundleFromServer.js

## Test Plan:
No code change. 
