### PR TITLE
Keep ReactImageView logging disabled in bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -45,6 +45,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.modules.fresco.ReactNetworkImageRequest;
 import com.facebook.react.uimanager.FloatUtil;
 import com.facebook.react.uimanager.PixelUtil;
@@ -601,7 +602,15 @@ public class ReactImageView extends GenericDraweeView {
   }
 
   private void warnImageSource(String uri) {
-    if (ReactBuildConfig.DEBUG) {
+    // TODO(T189014077): This code-path produces an infinite loop of js calls with logbox.
+    // This is an issue with Fabric view preallocation, react, and LogBox. Fix.
+    // The bug:
+    // 1. An app renders an <Image/>
+    // 2. Fabric preallocates <Image/>; sets a null src to ReactImageView (potential problem?).
+    // 3. ReactImageView detects the null src; displays a warning in LogBox (via this code).
+    // 3. LogBox renders an <Image/>, which fabric preallocates.
+    // 4. Rinse and repeat.
+    if (ReactBuildConfig.DEBUG && !ReactFeatureFlags.enableBridgelessArchitecture) {
       RNLog.w(
           (ReactContext) getContext(),
           "ReactImageView: Image source \"" + uri + "\" doesn't exist");


### PR DESCRIPTION
Summary:
In bridgeless mode, when we fix themed react context, this code-path slows rendering (in dev), starting a feedback loop.

Best understanding of feedback loop:
1. Some code tries to render an <Image/> component.
2. Fabric preallocates the <Image/> component, assigns a null src to the image.
3. The image component warns that there's no src: [RNLog.w](https://www.internalfb.com/code/fbsource/[8cf3936aee379b1f5fa31cc8f02745ceafa72ff3]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java?lines=603-609).
4. **Prior to the themed react context fix,** RNLog.w() would just noop: this [ThemedReactContext.hasActiveReactInstance()](https://www.internalfb.com/code/fbsource/[19ba3ff63f5342a4ba86e18f2e790c69c6cfc7e1]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RNLog.kt?lines=93-95) returned false.
5. **After the themed react context fix,** RNLog.w() dispatches a [native -> javascript call](https://github.com/facebook/react-native/blob/44f9371f246932215627a7ea01fbedf5c13e3019/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RNLog.kt#L94). This renders a LogBox.
6. LogBox renders a <Image/>, which re-starts this loop.

We're not sure what the right long-term solution here is. But, I will follow up! But, until then, it's important that we unblock the ThemedReactContext fix.

Changelog: [Internal]

Differential Revision: D56970919


