### PR TITLE
-Add Nullability annotation to the bundle param of onCreate in ReactActivityDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -101,7 +101,7 @@ public class ReactActivityDelegate {
     return mMainComponentName;
   }
 
-  public void onCreate(Bundle savedInstanceState) {
+  public void onCreate(@Nullable Bundle savedInstanceState) {
     String mainComponentName = getMainComponentName();
     final Bundle launchOptions = composeLaunchOptions();
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isWideColorGamutEnabled()) {


### PR DESCRIPTION
## Changelog:

[General] [Added] - Add `Nullability` annotation to the bundle param of `onCreate` in `ReactActivityDelegate` 

## Summary:

The Bundle received by the Activity's `onCreate` method is nullable. Hence adding the `Nullability` annotation to ensure proper null-safety interpretation in the kotlin sub-classes

## Test Plan:

None


Differential Revision: D57335067


