### PR TITLE
fix hint when using createRootViewWithBridge to show correct method name

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -105,7 +105,7 @@
   if (currentClassImp != baseClassImp) {
     NSString *warnMessage =
         @"If you are using the `createRootViewWithBridge` to customize the root view appearence,"
-         "for example to set the backgroundColor, please migrate to `customiseView` method.\n"
+         "for example to set the backgroundColor, please migrate to `customizeRootView` method.\n"
          "The `createRootViewWithBridge` method is not invoked in bridgeless.";
     RCTLogWarn(@"%@", warnMessage);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I used the `createRootViewWithBridge` in a Project and got the hint to migrate to the `customiseView` Method. I searched for the Method, but found it under a different name: `customizeRootView`.
So i thought it would be helpful to use the correct Method name inside the hint message.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - fixed Method name in hint from customiseView to customizeRootView

## Test Plan:
* Use `createRootViewWithBridge`
* Should get a hint to migrate to `customizeRootView` method
