### PR TITLE
fix startTransition inside renderers when _callbacks is undefined

### DIFF
--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -17912,6 +17912,10 @@ to return true:wantsResponderID|                            |
       var transition = ReactCurrentBatchConfig$1.transition;
 
       if (transition !== null) {
+        if (!transition._callbacks) {
+          transition._callbacks = new Set();
+        }
+
         // Whenever a transition update is scheduled, register a callback on the
         // transition object so we can get the return value of the scope function.
         transition._callbacks.add(handleAsyncAction);

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
@@ -7629,8 +7629,12 @@ function requestUpdateLane(fiber) {
   if (0 !== (executionContext & 2) && 0 !== workInProgressRootRenderLanes)
     return workInProgressRootRenderLanes & -workInProgressRootRenderLanes;
   fiber = ReactCurrentBatchConfig$1.transition;
-  null !== fiber && fiber._callbacks.add(handleAsyncAction);
   if (null !== fiber)
+    if (!fiber._callbacks) {
+      fiber._callbacks = new Set();
+    }
+    fiber._callbacks.add(handleAsyncAction);
+    
     return (
       0 === currentEventTransitionLane &&
         (currentEventTransitionLane = claimNextTransitionLane()),

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
@@ -8015,8 +8015,12 @@ function requestUpdateLane(fiber) {
   if (0 !== (executionContext & 2) && 0 !== workInProgressRootRenderLanes)
     return workInProgressRootRenderLanes & -workInProgressRootRenderLanes;
   fiber = ReactCurrentBatchConfig$1.transition;
-  null !== fiber && fiber._callbacks.add(handleAsyncAction);
   if (null !== fiber)
+    if (!fiber._callbacks) {
+      fiber._callbacks = new Set();
+    }
+    fiber._callbacks.add(handleAsyncAction);
+
     return (
       0 === currentEventTransitionLane &&
         (currentEventTransitionLane = claimNextTransitionLane()),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When using `startTransition` using latest react-native (0.74.1, new arch enabled)  we get this error: 

```
TypeError: Cannot read property 'add' of undefined
```

You can easily reproduce this issue creating a new react-native app (latest) and add a transition and execute it.

Sample app here: https://github.com/sync/Shift

<img width="927" alt="Screenshot 2024-05-16 at 7 57 05 AM" src="https://github.com/facebook/react-native/assets/21725/aff54c45-959b-4976-9bf6-c3ac6b2ef625">


## Changelog:

[GENERAL] [FIXED] - fixed startTransition inside renderers when _callbacks is undefined

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

### Before

<img width="927" alt="Screenshot 2024-05-16 at 7 57 05 AM" src="https://github.com/facebook/react-native/assets/21725/011a186b-729e-4ebd-8dfe-83e09c226792">

### After

all good with the patch: https://github.com/sync/Shift/pull/1
