### PR TITLE
Remove `[RCTConvert UIBarStyle:]`

### DIFF
--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -87,9 +87,6 @@ typedef NSURL RCTFileURL;
 #endif
 
 + (UIViewContentMode)UIViewContentMode:(id)json;
-#if !TARGET_OS_TV
-+ (UIBarStyle)UIBarStyle:(id)json __deprecated;
-#endif
 
 + (RCTCursor)RCTCursor:(id)json;
 

--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -546,17 +546,6 @@ RCT_ENUM_CONVERTER(
     integerValue)
 
 RCT_ENUM_CONVERTER(
-    UIBarStyle,
-    (@{
-      @"default" : @(UIBarStyleDefault),
-      @"black" : @(UIBarStyleBlack),
-      @"blackOpaque" : @(UIBarStyleBlackOpaque),
-      @"blackTranslucent" : @(UIBarStyleBlackTranslucent),
-    }),
-    UIBarStyleDefault,
-    integerValue)
-
-RCT_ENUM_CONVERTER(
     RCTCursor,
     (@{
       @"auto" : @(RCTCursorAuto),


### PR DESCRIPTION
## Summary:
Resolves https://github.com/microsoft/react-native-macos/issues/2008

Followup to https://github.com/facebook/react-native/pull/42100 / https://github.com/facebook/react-native/commit/157cb0e02b6328e8b640f2b302a11c298a240493 , let's remove the deprecated RCTConvert method.

## Changelog:

[IOS] [REMOVED] - Remove `[RCTConvert UIBarStyle:]`

## Test Plan:

CI should pass