### PR TITLE
mark hasRtlSupport as public API

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3351,6 +3351,7 @@ public final class com/facebook/react/modules/i18nmanager/I18nUtil {
 	public final fun doLeftAndRightSwapInRTL (Landroid/content/Context;)Z
 	public final fun forceRTL (Landroid/content/Context;Z)V
 	public static final fun getInstance ()Lcom/facebook/react/modules/i18nmanager/I18nUtil;
+	public final fun hasRtlSupport (Landroid/content/Context;)Z
 	public final fun isRTL (Landroid/content/Context;)Z
 	public final fun swapLeftAndRightInRTL (Landroid/content/Context;Z)V
 }


### PR DESCRIPTION
Summary:
Contributed in D57248205 / facebook/react-native#44538

From:
```
buck2 run //xplat/js/scripts/rn-api:generate-rn-api-metadata
```

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D57487065


