### PR TITLE
Fix(windows): Adds float cast to endDraggingSensitivityMultiplie

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -108,7 +108,7 @@ ScrollViewProps::ScrollViewProps(
                     rawProps,
                     "endDraggingSensitivityMultiplier",
                     sourceProps.endDraggingSensitivityMultiplier,
-                    1)),
+                    (Float)1)),
       enableSyncOnScroll(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.enableSyncOnScroll


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Windows has a more strict sets of rules for correctly casting ints/floats. This conversion from an int to float caused us to fork ScrollViewProps in our repository. Adding this cast will allow us to remove the fork :)

## Changelog:

[GENERAL] [FIXED] - Adds float cast to endDraggingSensitivityMultiplier


## Test Plan:
tested in RNW repository
