### PR TITLE
avoid calling setState when onScrollEmitter exists

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -963,9 +963,13 @@ class ScrollView extends React.Component<Props, State> {
     let subscription: ?EventSubscription;
 
     this.setState(
-      ({onScrollEmitter}) => ({
-        onScrollEmitter: onScrollEmitter ?? new EventEmitter(),
-      }),
+      ({onScrollEmitter}) => {
+        if (onScrollEmitter) {
+          return null;
+        } else {
+          return {onScrollEmitter: new EventEmitter()};
+        }
+      },
       () => {
         // If `subscription` is null, that means it was removed before we got
         // here so do nothing.


### PR DESCRIPTION
Summary:
changelog: [internal]

Do not call setState when onScrollEmitter exists to prevent unnecessary re-render.

Differential Revision: D57537436


