### PR TITLE
feat: remove redundant pressed state updates, if state is not used at…

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -240,6 +240,10 @@ function Pressable(props: Props, forwardedRef): React.Node {
 
   const android_rippleConfig = useAndroidRippleForView(android_ripple, viewRef);
 
+  const isStyleAFunction = typeof style === 'function';
+  const isChildrenAFunction = typeof children === 'function';
+  const shouldUpdateState = isStyleAFunction || isChildrenAFunction;
+
   const [pressed, setPressed] = usePressState(testOnly_pressed === true);
 
   let _accessibilityState = {
@@ -297,7 +301,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
         if (android_rippleConfig != null) {
           android_rippleConfig.onPressIn(event);
         }
-        setPressed(true);
+        shouldUpdateState && setPressed(true);
         if (onPressIn != null) {
           onPressIn(event);
         }
@@ -307,7 +311,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
         if (android_rippleConfig != null) {
           android_rippleConfig.onPressOut(event);
         }
-        setPressed(false);
+        shouldUpdateState && setPressed(false);
         if (onPressOut != null) {
           onPressOut(event);
         }
@@ -331,6 +335,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
       pressRetentionOffset,
       setPressed,
       unstable_pressDelay,
+      shouldUpdateState,
     ],
   );
   const eventHandlers = usePressability(config);
@@ -340,9 +345,9 @@ function Pressable(props: Props, forwardedRef): React.Node {
       {...restPropsWithDefaults}
       {...eventHandlers}
       ref={mergedRef}
-      style={typeof style === 'function' ? style({pressed}) : style}
+      style={isStyleAFunction ? style({pressed}) : style}
       collapsable={false}>
-      {typeof children === 'function' ? children({pressed}) : children}
+      {isChildrenAFunction ? children({pressed}) : children}
       {__DEV__ ? <PressabilityDebugView color="red" hitSlop={hitSlop} /> : null}
     </View>
   );


### PR DESCRIPTION
## Summary:

Goal of this PR is to optimise `Pressable` component, similarly to https://github.com/react-native-tvos/react-native-tvos/pull/724 . `Pressable` `style` and `children` properties can, but doesn't have to be functions. Usually we passing objects or arrays. `pressed` state is used only when `style` or `children` are `functions`, so let's update that state only in such case, otherwise let's skip state updates to improve the performance.

 That way we won't have to rerender the component when it is being pressed (assuming that `style` and `children` are not going to be functions)

## Changelog:

[GENERAL] [CHANGED] - Improve performance of `Pressable` component.

## Test Plan:

Verify that `Pressable` updates its `pressed` state  when `style` or `children` are functions or objects/arrays.