### PR TITLE
Deduplicate test case for TextExample in preparation of rntester android onboarding

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/FBEndToEndDumpsysHelper.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/FBEndToEndDumpsysHelper.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react
+
+import java.io.PrintWriter
+
+object FBEndToEndDumpsysHelper {
+  fun maybeDump(prefix: String, writer: PrintWriter, args: Array<String>?) {
+    // no-op This is an empty implementation to stub out Meta's internal dumpsys helper.
+  }
+}

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -8,9 +8,12 @@
 package com.facebook.react.uiapp
 
 import android.os.Bundle
+import com.facebook.react.FBEndToEndDumpsysHelper
 import com.facebook.react.ReactActivity
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import java.io.FileDescriptor
+import java.io.PrintWriter
 
 class RNTesterActivity : ReactActivity() {
   class RNTesterActivityDelegate(val activity: ReactActivity, mainComponentName: String) :
@@ -37,4 +40,13 @@ class RNTesterActivity : ReactActivity() {
   override fun createReactActivityDelegate() = RNTesterActivityDelegate(this, mainComponentName)
 
   override fun getMainComponentName() = "RNTesterApp"
+
+  override fun dump(
+      prefix: String,
+      fd: FileDescriptor?,
+      writer: PrintWriter,
+      args: Array<String>?
+  ) {
+    FBEndToEndDumpsysHelper.maybeDump(prefix, writer, args)
+  }
 }

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -199,6 +199,10 @@ const RNTesterApp = ({
     [dispatch],
   );
   React.useEffect(() => {
+    // Initial deeplink
+    Linking.getInitialURL()
+      .then(url => url != null && handleOpenUrlRequest({url: url}))
+      .catch(_ => {});
     const subscription = Linking.addEventListener('url', handleOpenUrlRequest);
     return () => subscription.remove();
   }, [handleOpenUrlRequest]);

--- a/packages/rn-tester/js/components/RNTTestDetails.js
+++ b/packages/rn-tester/js/components/RNTTestDetails.js
@@ -23,7 +23,7 @@ function RNTTestDetails({
   title: string,
   theme: RNTesterTheme,
 }): React.Node {
-  const [collapsed, setCollapsed] = React.useState(false);
+  const [collapsed, setCollapsed] = React.useState(true);
 
   const content = (
     <>

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -1211,7 +1211,7 @@ const examples = [
   },
   {
     title: 'Inline views',
-    name: 'inlineViews',
+    name: 'inlineViewsBasic',
     render: function (): React.Node {
       return <TextInlineView.Basic />;
     },


### PR DESCRIPTION
Summary:
D57197676 reordered the TextExample test cases, but accidentally reused the same string as the case in packages/rn-tester/js/examples/Text/TextInlineViewsExample.js

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D57279961


