### PR TITLE
Implement thread-safety for LazyShadowTreeRevisionConsistencyManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.cpp
@@ -18,6 +18,7 @@ LazyShadowTreeRevisionConsistencyManager::
 void LazyShadowTreeRevisionConsistencyManager::updateCurrentRevision(
     SurfaceId surfaceId,
     RootShadowNode::Shared rootShadowNode) {
+  std::unique_lock lock(capturedRootShadowNodesForConsistencyMutex_);
   capturedRootShadowNodesForConsistency_[surfaceId] = std::move(rootShadowNode);
 }
 
@@ -26,6 +27,8 @@ void LazyShadowTreeRevisionConsistencyManager::updateCurrentRevision(
 RootShadowNode::Shared
 LazyShadowTreeRevisionConsistencyManager::getCurrentRevision(
     SurfaceId surfaceId) {
+  std::unique_lock lock(capturedRootShadowNodesForConsistencyMutex_);
+
   auto it = capturedRootShadowNodesForConsistency_.find(surfaceId);
   if (it != capturedRootShadowNodesForConsistency_.end()) {
     return it->second;
@@ -65,6 +68,8 @@ void LazyShadowTreeRevisionConsistencyManager::unlockRevisions() {
   }
 
   isLocked_ = false;
+
+  std::unique_lock lock(capturedRootShadowNodesForConsistencyMutex_);
   capturedRootShadowNodesForConsistency_.clear();
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h
@@ -12,6 +12,7 @@
 #include <react/renderer/mounting/ShadowTreeRegistry.h>
 #include <react/renderer/uimanager/consistency/ShadowTreeRevisionProvider.h>
 #include <memory>
+#include <shared_mutex>
 
 namespace facebook::react {
 
@@ -42,6 +43,7 @@ class LazyShadowTreeRevisionConsistencyManager
   void unlockRevisions() override;
 
  private:
+  std::shared_mutex capturedRootShadowNodesForConsistencyMutex_;
   std::unordered_map<SurfaceId, RootShadowNode::Shared>
       capturedRootShadowNodesForConsistency_;
   ShadowTreeRegistry& shadowTreeRegistry_;


### PR DESCRIPTION
Summary:
Some methods in `LazyShadowTreeRevisionConsistencyManager` can be called in parallel when using synchronous state updates (which is also behind a flag). This implements thread-safety to cover that case so we don't have issues when testing that variant in production.

Changelog: [internal]

Differential Revision: D57506540


