### PR TITLE
Implement re-entrance and unlocked scenarios for LazyShadowTreeRevisionConsistencyManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h
@@ -11,6 +11,7 @@
 #include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/mounting/ShadowTreeRegistry.h>
 #include <react/renderer/uimanager/consistency/ShadowTreeRevisionProvider.h>
+#include <cstdint>
 #include <memory>
 #include <shared_mutex>
 
@@ -47,7 +48,7 @@ class LazyShadowTreeRevisionConsistencyManager
   std::unordered_map<SurfaceId, RootShadowNode::Shared>
       capturedRootShadowNodesForConsistency_;
   ShadowTreeRegistry& shadowTreeRegistry_;
-  bool isLocked_{false};
+  uint_fast32_t lockCount{0};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h
@@ -12,6 +12,7 @@
 #include <react/renderer/mounting/ShadowTreeRegistry.h>
 #include <react/renderer/uimanager/consistency/ShadowTreeRevisionProvider.h>
 #include <memory>
+#include <shared_mutex>
 
 namespace facebook::react {
 
@@ -42,6 +43,7 @@ class LazyShadowTreeRevisionConsistencyManager
   void unlockRevisions() override;
 
  private:
+  std::mutex capturedRootShadowNodesForConsistencyMutex_;
   std::unordered_map<SurfaceId, RootShadowNode::Shared>
       capturedRootShadowNodesForConsistency_;
   ShadowTreeRegistry& shadowTreeRegistry_;


### PR DESCRIPTION
Summary:
We added a log message when trying to lock revisions in `LazyShadowTreeRevisionConsistencyManager` when they were already locked, and we've seen that being logged in existing experiments, which could indicate we're doing re-entrance from the JS runtime. 

This protects against that case migrating the boolean flag to an integer.

Differential Revision: D57509193


