### PR TITLE
Add <hex-color> to CSSParser

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValue.h
@@ -27,6 +27,7 @@ enum class CSSValueType : uint8_t {
   Percentage,
   Ratio,
   Angle,
+  Color,
 };
 
 /**
@@ -79,6 +80,13 @@ struct CSSRatio {
  */
 struct CSSAngle {
   float degrees{};
+};
+
+struct CSSColor {
+  uint8_t r{};
+  uint8_t g{};
+  uint8_t b{};
+  uint8_t a{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueVariant.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueVariant.h
@@ -109,6 +109,13 @@ class CSSValueVariant {
     return CSSValueVariant(CSSValueType::Angle, CSSAngle{degrees});
   }
 
+  static constexpr CSSValueVariant
+  color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+    requires(canRepresent<CSSColor>())
+  {
+    return CSSValueVariant(CSSValueType::Color, CSSColor{r, g, b, a});
+  }
+
   constexpr CSSValueType type() const {
     return type_;
   }
@@ -155,6 +162,12 @@ class CSSValueVariant {
     return getIf<CSSValueType::Angle, CSSAngle>();
   }
 
+  constexpr CSSColor getColor() const
+    requires(canRepresent<CSSColor>())
+  {
+    return getIf<CSSValueType::Color, CSSColor>();
+  }
+
   constexpr bool hasValue() const
     requires(canRepresent<CSSWideKeyword>())
   {
@@ -185,6 +198,8 @@ class CSSValueVariant {
         return getRatio() == other.getRatio();
       case CSSValueType::Angle:
         return getAngle() == other.getAngle();
+      case CSSValueType::Color:
+        return getColor() == other.getColor();
     }
 
     return false;

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSValueParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSValueParserTest.cpp
@@ -320,4 +320,61 @@ TEST(CSSValueParser, parse_length_prop_constexpr) {
   EXPECT_EQ(pxValue.getLength().unit, CSSLengthUnit::Px);
 }
 
+TEST(CSSValueParser, hex_color_values) {
+  auto emptyValue = parseCSSValue<CSSWideKeyword, CSSColor>("");
+  EXPECT_EQ(emptyValue.type(), CSSValueType::CSSWideKeyword);
+  EXPECT_EQ(emptyValue.getCSSWideKeyword(), CSSWideKeyword::Unset);
+
+  auto hex3DigitColorValue = parseCSSValue<CSSWideKeyword, CSSColor>("#fff");
+  EXPECT_EQ(hex3DigitColorValue.type(), CSSValueType::Color);
+  EXPECT_EQ(hex3DigitColorValue.getColor().r, 255);
+  EXPECT_EQ(hex3DigitColorValue.getColor().g, 255);
+  EXPECT_EQ(hex3DigitColorValue.getColor().b, 255);
+  EXPECT_EQ(hex3DigitColorValue.getColor().a, 255);
+
+  auto hex4DigitColorValue = parseCSSValue<CSSWideKeyword, CSSColor>("#ffff");
+  EXPECT_EQ(hex4DigitColorValue.type(), CSSValueType::Color);
+  EXPECT_EQ(hex4DigitColorValue.getColor().r, 255);
+  EXPECT_EQ(hex4DigitColorValue.getColor().g, 255);
+  EXPECT_EQ(hex4DigitColorValue.getColor().b, 255);
+  EXPECT_EQ(hex4DigitColorValue.getColor().a, 255);
+
+  auto hex6DigitColorValue = parseCSSValue<CSSWideKeyword, CSSColor>("#ffffff");
+  EXPECT_EQ(hex6DigitColorValue.type(), CSSValueType::Color);
+  EXPECT_EQ(hex6DigitColorValue.getColor().r, 255);
+  EXPECT_EQ(hex6DigitColorValue.getColor().g, 255);
+  EXPECT_EQ(hex6DigitColorValue.getColor().b, 255);
+  EXPECT_EQ(hex6DigitColorValue.getColor().a, 255);
+
+  auto hex8DigitColorValue =
+      parseCSSValue<CSSWideKeyword, CSSColor>("#ffffffff");
+  EXPECT_EQ(hex8DigitColorValue.type(), CSSValueType::Color);
+  EXPECT_EQ(hex8DigitColorValue.getColor().r, 255);
+  EXPECT_EQ(hex8DigitColorValue.getColor().g, 255);
+  EXPECT_EQ(hex8DigitColorValue.getColor().b, 255);
+  EXPECT_EQ(hex8DigitColorValue.getColor().a, 255);
+
+  auto hexMixedCaseColorValue =
+      parseCSSValue<CSSWideKeyword, CSSColor>("#FFCc99");
+  EXPECT_EQ(hexMixedCaseColorValue.type(), CSSValueType::Color);
+  EXPECT_EQ(hexMixedCaseColorValue.getColor().r, 255);
+  EXPECT_EQ(hexMixedCaseColorValue.getColor().g, 204);
+  EXPECT_EQ(hexMixedCaseColorValue.getColor().b, 153);
+  EXPECT_EQ(hexMixedCaseColorValue.getColor().a, 255);
+
+  auto hexDigitOnlyColorValue = parseCSSValue<CSSWideKeyword, CSSColor>("#369");
+  EXPECT_EQ(hexDigitOnlyColorValue.type(), CSSValueType::Color);
+  EXPECT_EQ(hexDigitOnlyColorValue.getColor().r, 51);
+  EXPECT_EQ(hexDigitOnlyColorValue.getColor().g, 102);
+  EXPECT_EQ(hexDigitOnlyColorValue.getColor().b, 153);
+  EXPECT_EQ(hexDigitOnlyColorValue.getColor().a, 255);
+
+  auto hexAlphaTestValue = parseCSSValue<CSSWideKeyword, CSSColor>("#FFFFFFCC");
+  EXPECT_EQ(hexAlphaTestValue.type(), CSSValueType::Color);
+  EXPECT_EQ(hexAlphaTestValue.getColor().r, 255);
+  EXPECT_EQ(hexAlphaTestValue.getColor().g, 255);
+  EXPECT_EQ(hexAlphaTestValue.getColor().b, 255);
+  EXPECT_EQ(hexAlphaTestValue.getColor().a, 204);
+}
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
The syntax for <color> is defined as (https://www.w3.org/TR/css-color-4/#color-syntax):

```
<color> = <color-base> | currentColor | <system-color> 

<color-base> = <hex-color> | <color-function> | <named-color> | transparent
<color-function> = <rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>
```

This diff implements in particular:
```
<color-base> = <hex-color>
```

We parse over a `<hash-token>` to extract a 3, 4, 6 or 8 digit long hexadecimal and parse it into a CSSColor struct representation:

```
struct Color {
    uint8_t r // 0-255
    uint8_t g // 0-255
    uint8_t b // 0-255
    uint8_t a // 0.0 - 1.0
}
```
Changelog: [Internal]

Differential Revision: D57287309


