### PR TITLE
Fix Privacy Manifest generator when it does not contain a `NSPrivacyAccessedAPITypes` key

### DIFF
--- a/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
+++ b/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
@@ -105,7 +105,7 @@ module PrivacyManifestUtils
                 if File.basename(file_path) == 'PrivacyInfo.xcprivacy'
                     content = Xcodeproj::Plist.read_from_path(file_path)
                     accessed_api_types = content["NSPrivacyAccessedAPITypes"]
-                    accessed_api_types.each do |accessed_api|
+                    accessed_api_types&.each do |accessed_api|
                       api_type = accessed_api["NSPrivacyAccessedAPIType"]
                       reasons = accessed_api["NSPrivacyAccessedAPITypeReasons"]
                       next unless api_type


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

 XCode privacy files might not contain a `NSPrivacyAccessedAPITypes` key, which causes the following error:

```
[!] An error occurred while processing the post-install hook of the Podfile.

undefined method `each' for nil

node_modules/react-native/scripts/cocoapods/privacy_manifest_utils.rb:111:in `block (4 levels) in get_used_required_reason_apis'
node_modules/react-native/scripts/cocoapods/privacy_manifest_utils.rb:106:in `each'
node_modules/react-native/scripts/cocoapods/privacy_manifest_utils.rb:106:in `block (3 levels) in get_used_required_reason_apis'
```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Privacy Manifest aggregation failing due to no `NSPrivacyAccessedAPITypes` key

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested this patch on our own app and it solved the issue.