### PR TITLE
Use hasteModuleName for C++ Turbo Module structs

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -923,18 +923,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleAnimal
+#pragma mark - NativeSampleTurboModuleAnimal
 
 template <typename P0>
-struct SampleTurboModuleAnimal {
+struct NativeSampleTurboModuleAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleAnimalBridging {
+struct NativeSampleTurboModuleAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -1117,18 +1117,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleArraysAnimal
+#pragma mark - NativeSampleTurboModuleArraysAnimal
 
 template <typename P0>
-struct SampleTurboModuleArraysAnimal {
+struct NativeSampleTurboModuleArraysAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleArraysAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleArraysAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleArraysAnimalBridging {
+struct NativeSampleTurboModuleArraysAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -1311,18 +1311,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleNullableAnimal
+#pragma mark - NativeSampleTurboModuleNullableAnimal
 
 template <typename P0>
-struct SampleTurboModuleNullableAnimal {
+struct NativeSampleTurboModuleNullableAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleNullableAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleNullableAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleNullableAnimalBridging {
+struct NativeSampleTurboModuleNullableAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -1505,18 +1505,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleNullableAndOptionalAnimal
+#pragma mark - NativeSampleTurboModuleNullableAndOptionalAnimal
 
 template <typename P0>
-struct SampleTurboModuleNullableAndOptionalAnimal {
+struct NativeSampleTurboModuleNullableAndOptionalAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleNullableAndOptionalAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleNullableAndOptionalAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleNullableAndOptionalAnimalBridging {
+struct NativeSampleTurboModuleNullableAndOptionalAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -1701,18 +1701,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleOptionalAnimal
+#pragma mark - NativeSampleTurboModuleOptionalAnimal
 
 template <typename P0>
-struct SampleTurboModuleOptionalAnimal {
+struct NativeSampleTurboModuleOptionalAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleOptionalAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleOptionalAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleOptionalAnimalBridging {
+struct NativeSampleTurboModuleOptionalAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -2877,18 +2877,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleAnimal
+#pragma mark - NativeSampleTurboModuleAnimal
 
 template <typename P0>
-struct SampleTurboModuleAnimal {
+struct NativeSampleTurboModuleAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleAnimalBridging {
+struct NativeSampleTurboModuleAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -3071,18 +3071,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleArraysAnimal
+#pragma mark - NativeSampleTurboModuleArraysAnimal
 
 template <typename P0>
-struct SampleTurboModuleArraysAnimal {
+struct NativeSampleTurboModuleArraysAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleArraysAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleArraysAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleArraysAnimalBridging {
+struct NativeSampleTurboModuleArraysAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -3265,18 +3265,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleNullableAnimal
+#pragma mark - NativeSampleTurboModuleNullableAnimal
 
 template <typename P0>
-struct SampleTurboModuleNullableAnimal {
+struct NativeSampleTurboModuleNullableAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleNullableAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleNullableAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleNullableAnimalBridging {
+struct NativeSampleTurboModuleNullableAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -3459,18 +3459,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleNullableAndOptionalAnimal
+#pragma mark - NativeSampleTurboModuleNullableAndOptionalAnimal
 
 template <typename P0>
-struct SampleTurboModuleNullableAndOptionalAnimal {
+struct NativeSampleTurboModuleNullableAndOptionalAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleNullableAndOptionalAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleNullableAndOptionalAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleNullableAndOptionalAnimalBridging {
+struct NativeSampleTurboModuleNullableAndOptionalAnimalBridging {
   static T types;
 
   static T fromJs(
@@ -3655,18 +3655,18 @@ private:
 
 
   
-#pragma mark - SampleTurboModuleOptionalAnimal
+#pragma mark - NativeSampleTurboModuleOptionalAnimal
 
 template <typename P0>
-struct SampleTurboModuleOptionalAnimal {
+struct NativeSampleTurboModuleOptionalAnimal {
   P0 name;
-  bool operator==(const SampleTurboModuleOptionalAnimal &other) const {
+  bool operator==(const NativeSampleTurboModuleOptionalAnimal &other) const {
     return name == other.name;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleOptionalAnimalBridging {
+struct NativeSampleTurboModuleOptionalAnimalBridging {
   static T types;
 
   static T fromJs(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -211,7 +211,7 @@ function translatePrimitiveJSTypeToCpp(
 }
 
 function createStructsString(
-  moduleName: string,
+  hasteModuleName: string,
   aliasMap: NativeModuleAliasMap,
   resolveAlias: AliasResolver,
   enumMap: NativeModuleEnumMap,
@@ -221,7 +221,7 @@ function createStructsString(
     v: NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>,
   ) =>
     translatePrimitiveJSTypeToCpp(
-      moduleName,
+      hasteModuleName,
       parentObjectAlias,
       v.typeAnnotation,
       false,
@@ -236,7 +236,7 @@ function createStructsString(
       if (value.properties.length === 0) {
         return '';
       }
-      const structName = `${moduleName}${alias}`;
+      const structName = `${hasteModuleName}${alias}`;
       const templateParameter = value.properties.filter(
         v =>
           !isDirectRecursiveMember(alias, v.typeAnnotation) &&
@@ -530,7 +530,7 @@ module.exports = {
       } = nativeModules[hasteModuleName];
       const resolveAlias = createAliasResolver(aliasMap);
       const structs = createStructsString(
-        moduleName,
+        hasteModuleName,
         aliasMap,
         resolveAlias,
         enumMap,

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -316,20 +316,20 @@ struct Bridging<SampleTurboModuleCxxEnumStr> {
   }
 };
   
-#pragma mark - SampleTurboModuleCxxConstantsStruct
+#pragma mark - NativeSampleTurboModuleConstantsStruct
 
 template <typename P0, typename P1, typename P2>
-struct SampleTurboModuleCxxConstantsStruct {
+struct NativeSampleTurboModuleConstantsStruct {
   P0 const1;
   P1 const2;
   P2 const3;
-  bool operator==(const SampleTurboModuleCxxConstantsStruct &other) const {
+  bool operator==(const NativeSampleTurboModuleConstantsStruct &other) const {
     return const1 == other.const1 && const2 == other.const2 && const3 == other.const3;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleCxxConstantsStructBridging {
+struct NativeSampleTurboModuleConstantsStructBridging {
   static T types;
 
   static T fromJs(
@@ -372,20 +372,20 @@ struct SampleTurboModuleCxxConstantsStructBridging {
 
 
 
-#pragma mark - SampleTurboModuleCxxBinaryTreeNode
+#pragma mark - NativeSampleTurboModuleBinaryTreeNode
 
 template <typename P0>
-struct SampleTurboModuleCxxBinaryTreeNode {
-  std::unique_ptr<SampleTurboModuleCxxBinaryTreeNode<P0>> left;
+struct NativeSampleTurboModuleBinaryTreeNode {
+  std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> left;
   P0 value;
-  std::unique_ptr<SampleTurboModuleCxxBinaryTreeNode<P0>> right;
-  bool operator==(const SampleTurboModuleCxxBinaryTreeNode &other) const {
+  std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> right;
+  bool operator==(const NativeSampleTurboModuleBinaryTreeNode &other) const {
     return left == other.left && value == other.value && right == other.right;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleCxxBinaryTreeNodeBridging {
+struct NativeSampleTurboModuleBinaryTreeNodeBridging {
   static T types;
 
   static T fromJs(
@@ -431,19 +431,19 @@ struct SampleTurboModuleCxxBinaryTreeNodeBridging {
 
 
 
-#pragma mark - SampleTurboModuleCxxGraphNode
+#pragma mark - NativeSampleTurboModuleGraphNode
 
 template <typename P0>
-struct SampleTurboModuleCxxGraphNode {
+struct NativeSampleTurboModuleGraphNode {
   P0 label;
-  std::optional<std::vector<SampleTurboModuleCxxGraphNode<P0>>> neighbors;
-  bool operator==(const SampleTurboModuleCxxGraphNode &other) const {
+  std::optional<std::vector<NativeSampleTurboModuleGraphNode<P0>>> neighbors;
+  bool operator==(const NativeSampleTurboModuleGraphNode &other) const {
     return label == other.label && neighbors == other.neighbors;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleCxxGraphNodeBridging {
+struct NativeSampleTurboModuleGraphNodeBridging {
   static T types;
 
   static T fromJs(
@@ -481,20 +481,20 @@ struct SampleTurboModuleCxxGraphNodeBridging {
 
 
 
-#pragma mark - SampleTurboModuleCxxObjectStruct
+#pragma mark - NativeSampleTurboModuleObjectStruct
 
 template <typename P0, typename P1, typename P2>
-struct SampleTurboModuleCxxObjectStruct {
+struct NativeSampleTurboModuleObjectStruct {
   P0 a;
   P1 b;
   P2 c;
-  bool operator==(const SampleTurboModuleCxxObjectStruct &other) const {
+  bool operator==(const NativeSampleTurboModuleObjectStruct &other) const {
     return a == other.a && b == other.b && c == other.c;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleCxxObjectStructBridging {
+struct NativeSampleTurboModuleObjectStructBridging {
   static T types;
 
   static T fromJs(
@@ -538,20 +538,20 @@ struct SampleTurboModuleCxxObjectStructBridging {
 
 
 
-#pragma mark - SampleTurboModuleCxxValueStruct
+#pragma mark - NativeSampleTurboModuleValueStruct
 
 template <typename P0, typename P1, typename P2>
-struct SampleTurboModuleCxxValueStruct {
+struct NativeSampleTurboModuleValueStruct {
   P0 x;
   P1 y;
   P2 z;
-  bool operator==(const SampleTurboModuleCxxValueStruct &other) const {
+  bool operator==(const NativeSampleTurboModuleValueStruct &other) const {
     return x == other.x && y == other.y && z == other.z;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleCxxValueStructBridging {
+struct NativeSampleTurboModuleValueStructBridging {
   static T types;
 
   static T fromJs(
@@ -593,21 +593,21 @@ struct SampleTurboModuleCxxValueStructBridging {
 
 
 
-#pragma mark - SampleTurboModuleCxxMenuItem
+#pragma mark - NativeSampleTurboModuleMenuItem
 
 template <typename P0, typename P1, typename P2>
-struct SampleTurboModuleCxxMenuItem {
+struct NativeSampleTurboModuleMenuItem {
   P0 label;
   P1 onPress;
   P2 shortcut;
-  std::optional<std::vector<SampleTurboModuleCxxMenuItem<P0, P1, P2>>> items;
-  bool operator==(const SampleTurboModuleCxxMenuItem &other) const {
+  std::optional<std::vector<NativeSampleTurboModuleMenuItem<P0, P1, P2>>> items;
+  bool operator==(const NativeSampleTurboModuleMenuItem &other) const {
     return label == other.label && onPress == other.onPress && shortcut == other.shortcut && items == other.items;
   }
 };
 
 template <typename T>
-struct SampleTurboModuleCxxMenuItemBridging {
+struct NativeSampleTurboModuleMenuItemBridging {
   static T types;
 
   static T fromJs(
@@ -1175,23 +1175,23 @@ namespace facebook::react {
 
 
   
-#pragma mark - CameraRollManagerPhotoIdentifierImage
+#pragma mark - NativeCameraRollManagerPhotoIdentifierImage
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
-struct CameraRollManagerPhotoIdentifierImage {
+struct NativeCameraRollManagerPhotoIdentifierImage {
   P0 uri;
   P1 playableDuration;
   P2 width;
   P3 height;
   P4 isStored;
   P5 filename;
-  bool operator==(const CameraRollManagerPhotoIdentifierImage &other) const {
+  bool operator==(const NativeCameraRollManagerPhotoIdentifierImage &other) const {
     return uri == other.uri && playableDuration == other.playableDuration && width == other.width && height == other.height && isStored == other.isStored && filename == other.filename;
   }
 };
 
 template <typename T>
-struct CameraRollManagerPhotoIdentifierImageBridging {
+struct NativeCameraRollManagerPhotoIdentifierImageBridging {
   static T types;
 
   static T fromJs(
@@ -1253,18 +1253,18 @@ struct CameraRollManagerPhotoIdentifierImageBridging {
 
 
 
-#pragma mark - CameraRollManagerPhotoIdentifier
+#pragma mark - NativeCameraRollManagerPhotoIdentifier
 
 template <typename P0>
-struct CameraRollManagerPhotoIdentifier {
+struct NativeCameraRollManagerPhotoIdentifier {
   P0 node;
-  bool operator==(const CameraRollManagerPhotoIdentifier &other) const {
+  bool operator==(const NativeCameraRollManagerPhotoIdentifier &other) const {
     return node == other.node;
   }
 };
 
 template <typename T>
-struct CameraRollManagerPhotoIdentifierBridging {
+struct NativeCameraRollManagerPhotoIdentifierBridging {
   static T types;
 
   static T fromJs(
@@ -1294,19 +1294,19 @@ struct CameraRollManagerPhotoIdentifierBridging {
 
 
 
-#pragma mark - CameraRollManagerPhotoIdentifiersPage
+#pragma mark - NativeCameraRollManagerPhotoIdentifiersPage
 
 template <typename P0, typename P1>
-struct CameraRollManagerPhotoIdentifiersPage {
+struct NativeCameraRollManagerPhotoIdentifiersPage {
   P0 edges;
   P1 page_info;
-  bool operator==(const CameraRollManagerPhotoIdentifiersPage &other) const {
+  bool operator==(const NativeCameraRollManagerPhotoIdentifiersPage &other) const {
     return edges == other.edges && page_info == other.page_info;
   }
 };
 
 template <typename T>
-struct CameraRollManagerPhotoIdentifiersPageBridging {
+struct NativeCameraRollManagerPhotoIdentifiersPageBridging {
   static T types;
 
   static T fromJs(
@@ -1342,10 +1342,10 @@ struct CameraRollManagerPhotoIdentifiersPageBridging {
 
 
 
-#pragma mark - CameraRollManagerGetPhotosParams
+#pragma mark - NativeCameraRollManagerGetPhotosParams
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
-struct CameraRollManagerGetPhotosParams {
+struct NativeCameraRollManagerGetPhotosParams {
   P0 first;
   P1 after;
   P2 groupName;
@@ -1353,13 +1353,13 @@ struct CameraRollManagerGetPhotosParams {
   P4 assetType;
   P5 maxSize;
   P6 mimeTypes;
-  bool operator==(const CameraRollManagerGetPhotosParams &other) const {
+  bool operator==(const NativeCameraRollManagerGetPhotosParams &other) const {
     return first == other.first && after == other.after && groupName == other.groupName && groupTypes == other.groupTypes && assetType == other.assetType && maxSize == other.maxSize && mimeTypes == other.mimeTypes;
   }
 };
 
 template <typename T>
-struct CameraRollManagerGetPhotosParamsBridging {
+struct NativeCameraRollManagerGetPhotosParamsBridging {
   static T types;
 
   static T fromJs(
@@ -1509,22 +1509,22 @@ private:
 
 
   
-#pragma mark - ExceptionsManagerStackFrame
+#pragma mark - NativeExceptionsManagerStackFrame
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
-struct ExceptionsManagerStackFrame {
+struct NativeExceptionsManagerStackFrame {
   P0 column;
   P1 file;
   P2 lineNumber;
   P3 methodName;
   P4 collapse;
-  bool operator==(const ExceptionsManagerStackFrame &other) const {
+  bool operator==(const NativeExceptionsManagerStackFrame &other) const {
     return column == other.column && file == other.file && lineNumber == other.lineNumber && methodName == other.methodName && collapse == other.collapse;
   }
 };
 
 template <typename T>
-struct ExceptionsManagerStackFrameBridging {
+struct NativeExceptionsManagerStackFrameBridging {
   static T types;
 
   static T fromJs(
@@ -1584,10 +1584,10 @@ struct ExceptionsManagerStackFrameBridging {
 
 
 
-#pragma mark - ExceptionsManagerExceptionData
+#pragma mark - NativeExceptionsManagerExceptionData
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
-struct ExceptionsManagerExceptionData {
+struct NativeExceptionsManagerExceptionData {
   P0 message;
   P1 originalMessage;
   P2 name;
@@ -1596,13 +1596,13 @@ struct ExceptionsManagerExceptionData {
   P5 id;
   P6 isFatal;
   P7 extraData;
-  bool operator==(const ExceptionsManagerExceptionData &other) const {
+  bool operator==(const NativeExceptionsManagerExceptionData &other) const {
     return message == other.message && originalMessage == other.originalMessage && name == other.name && componentStack == other.componentStack && stack == other.stack && id == other.id && isFatal == other.isFatal && extraData == other.extraData;
   }
 };
 
 template <typename T>
-struct ExceptionsManagerExceptionDataBridging {
+struct NativeExceptionsManagerExceptionDataBridging {
   static T types;
 
   static T fromJs(

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
@@ -19,7 +19,7 @@ using NativeIntersectionObserverIntersectionObserverId = int32_t;
 using RectAsTuple = std::tuple<Float, Float, Float, Float>;
 
 using NativeIntersectionObserverObserveOptions =
-    NativeIntersectionObserverCxxNativeIntersectionObserverObserveOptions<
+    NativeIntersectionObserverNativeIntersectionObserverObserveOptions<
         // intersectionObserverId
         NativeIntersectionObserverIntersectionObserverId,
         // targetShadowNode
@@ -29,11 +29,11 @@ using NativeIntersectionObserverObserveOptions =
 
 template <>
 struct Bridging<NativeIntersectionObserverObserveOptions>
-    : NativeIntersectionObserverCxxNativeIntersectionObserverObserveOptionsBridging<
+    : NativeIntersectionObserverNativeIntersectionObserverObserveOptionsBridging<
           NativeIntersectionObserverObserveOptions> {};
 
 using NativeIntersectionObserverEntry =
-    NativeIntersectionObserverCxxNativeIntersectionObserverEntry<
+    NativeIntersectionObserverNativeIntersectionObserverEntry<
         // intersectionObserverId
         NativeIntersectionObserverIntersectionObserverId,
         // targetInstanceHandle
@@ -51,7 +51,7 @@ using NativeIntersectionObserverEntry =
 
 template <>
 struct Bridging<NativeIntersectionObserverEntry>
-    : NativeIntersectionObserverCxxNativeIntersectionObserverEntryBridging<
+    : NativeIntersectionObserverNativeIntersectionObserverEntryBridging<
           NativeIntersectionObserverEntry> {};
 
 class NativeIntersectionObserver

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
@@ -15,7 +15,7 @@
 namespace facebook::react {
 
 using NativeMutationObserverObserveOptions =
-    NativeMutationObserverCxxNativeMutationObserverObserveOptions<
+    NativeMutationObserverNativeMutationObserverObserveOptions<
         // mutationObserverId
         MutationObserverId,
         // targetShadowNode
@@ -25,10 +25,10 @@ using NativeMutationObserverObserveOptions =
 
 template <>
 struct Bridging<NativeMutationObserverObserveOptions>
-    : NativeMutationObserverCxxNativeMutationObserverObserveOptionsBridging<
+    : NativeMutationObserverNativeMutationObserverObserveOptionsBridging<
           NativeMutationObserverObserveOptions> {};
 
-using NativeMutationRecord = NativeMutationObserverCxxNativeMutationRecord<
+using NativeMutationRecord = NativeMutationObserverNativeMutationRecord<
     // mutationObserverId
     MutationObserverId,
     // target
@@ -40,8 +40,8 @@ using NativeMutationRecord = NativeMutationObserverCxxNativeMutationRecord<
 
 template <>
 struct Bridging<NativeMutationRecord>
-    : NativeMutationObserverCxxNativeMutationRecordBridging<
-          NativeMutationRecord> {};
+    : NativeMutationObserverNativeMutationRecordBridging<NativeMutationRecord> {
+};
 
 class NativeMutationObserver
     : public NativeMutationObserverCxxSpec<NativeMutationObserver> {

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformanceObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformanceObserver.h
@@ -9,7 +9,6 @@
 
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
-#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -35,12 +34,11 @@ struct Bridging<PerformanceEntryType> {
 
 template <>
 struct Bridging<PerformanceEntry>
-    : NativePerformanceObserverCxxRawPerformanceEntryBridging<
-          PerformanceEntry> {};
+    : NativePerformanceObserverRawPerformanceEntryBridging<PerformanceEntry> {};
 
 template <>
 struct Bridging<PerformanceEntryReporter::PopPendingEntriesResult>
-    : NativePerformanceObserverCxxGetPendingEntriesResultBridging<
+    : NativePerformanceObserverGetPendingEntriesResultBridging<
           PerformanceEntryReporter::PopPendingEntriesResult> {};
 
 #pragma mark - implementation

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -24,27 +24,27 @@ namespace facebook::react {
 
 #pragma mark - Structs
 using ConstantsStruct =
-    NativeCxxModuleExampleCxxConstantsStruct<bool, int32_t, std::string>;
+    NativeCxxModuleExampleConstantsStruct<bool, int32_t, std::string>;
 
 template <>
 struct Bridging<ConstantsStruct>
-    : NativeCxxModuleExampleCxxConstantsStructBridging<ConstantsStruct> {};
+    : NativeCxxModuleExampleConstantsStructBridging<ConstantsStruct> {};
 
-using ObjectStruct = NativeCxxModuleExampleCxxObjectStruct<
+using ObjectStruct = NativeCxxModuleExampleObjectStruct<
     int32_t,
     std::string,
     std::optional<std::string>>;
 
 template <>
 struct Bridging<ObjectStruct>
-    : NativeCxxModuleExampleCxxObjectStructBridging<ObjectStruct> {};
+    : NativeCxxModuleExampleObjectStructBridging<ObjectStruct> {};
 
 using ValueStruct =
-    NativeCxxModuleExampleCxxValueStruct<double, std::string, ObjectStruct>;
+    NativeCxxModuleExampleValueStruct<double, std::string, ObjectStruct>;
 
 template <>
 struct Bridging<ValueStruct>
-    : NativeCxxModuleExampleCxxValueStructBridging<ValueStruct> {};
+    : NativeCxxModuleExampleValueStructBridging<ValueStruct> {};
 
 #pragma mark - enums
 enum class CustomEnumInt : int32_t { A = 23, B = 42 };
@@ -93,39 +93,38 @@ using CustomHostObject = HostObjectWrapper<CustomHostObjectRef>;
 
 #pragma mark - recursive objects
 
-using BinaryTreeNode = NativeCxxModuleExampleCxxBinaryTreeNode<int32_t>;
+using BinaryTreeNode = NativeCxxModuleExampleBinaryTreeNode<int32_t>;
 
 template <>
 struct Bridging<BinaryTreeNode>
-    : NativeCxxModuleExampleCxxBinaryTreeNodeBridging<BinaryTreeNode> {};
+    : NativeCxxModuleExampleBinaryTreeNodeBridging<BinaryTreeNode> {};
 
-using GraphNode = NativeCxxModuleExampleCxxGraphNode<std::string>;
+using GraphNode = NativeCxxModuleExampleGraphNode<std::string>;
 
 template <>
 struct Bridging<GraphNode>
-    : NativeCxxModuleExampleCxxGraphNodeBridging<GraphNode> {};
+    : NativeCxxModuleExampleGraphNodeBridging<GraphNode> {};
 
 #pragma mark - functional object properties
 
-using MenuItem = NativeCxxModuleExampleCxxMenuItem<
+using MenuItem = NativeCxxModuleExampleMenuItem<
     std::string,
     AsyncCallback<std::string, bool>,
     std::optional<std::string>>;
 
 template <>
-struct Bridging<MenuItem>
-    : NativeCxxModuleExampleCxxMenuItemBridging<MenuItem> {};
+struct Bridging<MenuItem> : NativeCxxModuleExampleMenuItemBridging<MenuItem> {};
 
 #pragma mark - RCTDeviceEventEmitter events
 
-using CustomDeviceEvent = NativeCxxModuleExampleCxxCustomDeviceEvent<
+using CustomDeviceEvent = NativeCxxModuleExampleCustomDeviceEvent<
     std::string,
     int32_t,
     std::optional<float>>;
 
 template <>
 struct Bridging<CustomDeviceEvent>
-    : NativeCxxModuleExampleCxxCustomDeviceEventBridging<CustomDeviceEvent> {};
+    : NativeCxxModuleExampleCustomDeviceEventBridging<CustomDeviceEvent> {};
 
 #pragma mark - implementation
 class NativeCxxModuleExample


### PR DESCRIPTION
Summary:
Changelog:
[Internal][Breaking] Use hasteModuleName for C++ Turbo Module structs

This changes the names of C++ Turbo Modules structs to use the `hasteModuleName`.

Example: `NativeMyAbcModule.js` with this spec:
```
export type ValueStruct = {
  x: number,
  y: string,
  z: ObjectStruct,
};

export interface Spec extends TurboModule {
  +getValueStruct: () => ValueStruct
}

export default (TurboModuleRegistry.get<Spec>('MyAbcModuleCxx'): ?Spec);
```

Before now we generated a base C++ struct with the name:
```
MyAbcModuleCxxValueStruct 
           ^^^
```

Now the generate name is:
```
NativeMyAbcModuleValueStruct
^^^^^^
```

## Changes:
- No `Cxx` injected anymore
- Ensure base struct is `Native` prefixed (all RN JS TM specs start with it)

## Why?
- The `Cxx` extension is a temporary hint to react-native-codegen to enable extra capabilities and might disappear eventually
- The C++ base struct name should be 'stable'
- The name of the exported TM JS spec `TurboModuleRegistry.get<Spec>(...)` is abritrary, the hasteName is not
- The name of the RN JS TM spec must start with `Native` which better guarantees a consistent naming scheme for these generated base class
- The C++ Turbo Module base class has not the same prefix as the generated structs - `NativeMyAbcModule` for the example above

Differential Revision: D57599257


