### PR TITLE
Fix crash in ParagraphState when running with USE_FABRIC_DEBUG

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/ReadableMapBuffer.kt
@@ -226,19 +226,23 @@ public class ReadableMapBuffer : MapBuffer {
 
   override fun toString(): String {
     val builder = StringBuilder("{")
-    for (entry in this) {
-      val key = entry.key
-      builder.append(key)
-      builder.append('=')
-      when (entry.type) {
-        MapBuffer.DataType.BOOL -> builder.append(entry.booleanValue)
-        MapBuffer.DataType.INT -> builder.append(entry.intValue)
-        MapBuffer.DataType.LONG -> builder.append(entry.longValue)
-        MapBuffer.DataType.DOUBLE -> builder.append(entry.doubleValue)
-        MapBuffer.DataType.STRING -> builder.append(entry.stringValue)
-        MapBuffer.DataType.MAP -> builder.append(entry.mapBufferValue.toString())
+    joinTo(builder) { entry ->
+      StringBuilder().apply {
+        append(entry.key)
+        append('=')
+        when (entry.type) {
+          MapBuffer.DataType.BOOL -> append(entry.booleanValue)
+          MapBuffer.DataType.INT -> append(entry.intValue)
+          MapBuffer.DataType.LONG -> append(entry.longValue)
+          MapBuffer.DataType.DOUBLE -> append(entry.doubleValue)
+          MapBuffer.DataType.STRING -> {
+            append('"')
+            append(entry.stringValue)
+            append('"')
+          }
+          MapBuffer.DataType.MAP -> append(entry.mapBufferValue.toString())
+        }
       }
-      builder.append(',')
     }
     builder.append('}')
     return builder.toString()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.java
@@ -92,6 +92,11 @@ public class StateWrapperImpl implements StateWrapper {
       return "<destroyed>";
     }
 
+    ReadableMapBuffer mapBuffer = getStateMapBufferDataImpl();
+    if (mapBuffer != null) {
+      return mapBuffer.toString();
+    }
+
     ReadableNativeMap map = getStateDataImpl();
     if (map == null) {
       return "<unexpected null>";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/PreAllocateViewMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/PreAllocateViewMountItem.java
@@ -84,12 +84,9 @@ final class PreAllocateViewMountItem implements MountItem {
     if (IS_DEVELOPMENT_ENVIRONMENT) {
       result
           .append(" props: ")
-          .append(mProps != null ? mProps : "<null>")
+          .append(mProps != null ? mProps.toString() : "<null>")
           .append(" state: ")
-          .append(
-              mStateWrapper != null && mStateWrapper.getStateData() != null
-                  ? mStateWrapper.getStateData().toString()
-                  : "<null>");
+          .append(mStateWrapper != null ? mStateWrapper.toString() : "<null>");
     }
 
     return result.toString();


### PR DESCRIPTION
Summary:
`toDynamic` no longer exists for ParagraphState, so try the MapBuffer value first, before triggering the error introduced in D56963463.

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D57439386


