### PR TITLE
Revert debugger launch behaviour to default profile

### DIFF
--- a/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
@@ -51,6 +51,7 @@ const DefaultBrowserLauncher: BrowserLauncher = {
       `react-native-debugger-frontend-${browserType}`,
     );
     const launchedChrome = await ChromeLauncher.launch({
+      ignoreDefaultFlags: true,
       chromeFlags: [
         ...ChromeLauncher.Launcher.defaultFlags().filter(
           /**
@@ -64,10 +65,8 @@ const DefaultBrowserLauncher: BrowserLauncher = {
         `--app=${url}`,
         `--user-data-dir=${userDataDir}`,
         '--window-size=1200,600',
-        '--guest',
       ],
       chromePath,
-      ignoreDefaultFlags: true,
     });
 
     return {


### PR DESCRIPTION
Summary:
Reverts the debugger launch flow to use the default `ChromeLauncher` profile. This is the approach used in the current `--experimental-debugger` experiment and by Expo.

This is motivated after a review of the tradeoffs of a guest profile — which allow us to programatically quit the browser process, however takes over system URL handling.

Changelog: [Internal]

Differential Revision: D57619542


