### PR TITLE
Align with code-gen output Sample Turbo Modules

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
@@ -24,67 +24,21 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule
     implements TurboModule {
+  public static final String NAME = "SampleTurboModule";
+
   public NativeSampleTurboModuleSpec(ReactApplicationContext reactContext) {
     super(reactContext);
   }
 
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract double getNumber(double arg);
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract WritableMap getValue(double x, String y, ReadableMap z);
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract WritableMap getObject(ReadableMap arg);
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract WritableMap getUnsafeObject(ReadableMap arg);
-
-  @ReactMethod
-  public abstract void voidFunc();
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract WritableArray getArray(ReadableArray arg);
-
-  @ReactMethod
-  public abstract void getValueWithPromise(boolean error, Promise promise);
-
-  @ReactMethod
-  public abstract void getValueWithCallback(Callback callback);
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract String getString(String arg);
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract double getRootTag(double arg);
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract boolean getBool(boolean arg);
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract double getEnum(double arg);
-
-  @ReactMethod()
-  public abstract void voidFuncThrows();
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract WritableMap getObjectThrows(ReadableMap arg);
-
-  @ReactMethod()
-  public abstract void promiseThrows(Promise promise);
-
-  @ReactMethod()
-  public abstract void voidFuncAssert();
-
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract WritableMap getObjectAssert(ReadableMap arg);
-
-  @ReactMethod()
-  public abstract void promiseAssert(Promise promise);
+  @Override
+  public @Nonnull String getName() {
+    return NAME;
+  }
 
   protected abstract Map<String, Object> getTypedExportedConstants();
 
@@ -93,7 +47,7 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
     Map<String, Object> constants = getTypedExportedConstants();
     if (ReactBuildConfig.DEBUG || ReactBuildConfig.IS_INTERNAL_BUILD) {
       Set<String> obligatoryFlowConstants =
-          new HashSet<>(Arrays.asList("const2", "const1", "const3"));
+          new HashSet<>(Arrays.asList("const1", "const2", "const3"));
       Set<String> optionalFlowConstants = new HashSet<>();
       Set<String> undeclaredConstants = new HashSet<>(constants.keySet());
       undeclaredConstants.removeAll(obligatoryFlowConstants);
@@ -111,4 +65,64 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
     }
     return constants;
   }
+
+  @ReactMethod
+  public abstract void voidFunc();
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract boolean getBool(boolean arg);
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public double getEnum(double arg) {
+    return 0;
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract double getNumber(double arg);
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract String getString(String arg);
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract WritableArray getArray(ReadableArray arg);
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract WritableMap getObject(ReadableMap arg);
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract WritableMap getUnsafeObject(ReadableMap arg);
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract double getRootTag(double arg);
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract WritableMap getValue(double x, String y, ReadableMap z);
+
+  @ReactMethod
+  public abstract void getValueWithCallback(Callback callback);
+
+  @ReactMethod
+  public abstract void getValueWithPromise(boolean error, Promise promise);
+
+  @ReactMethod
+  public void voidFuncThrows() {}
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableMap getObjectThrows(ReadableMap arg) {
+    return null;
+  }
+
+  @ReactMethod
+  public void promiseThrows(Promise promise) {}
+
+  @ReactMethod
+  public void voidFuncAssert() {}
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableMap getObjectAssert(ReadableMap arg) {
+    return null;
+  }
+
+  @ReactMethod
+  public void promiseAssert(Promise promise) {}
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
@@ -10,6 +10,23 @@
 #include <ReactCommon/SampleTurboModuleSpec.h>
 
 namespace facebook::react {
+static facebook::jsi::Value
+__hostFunction_NativeSampleTurboModuleSpecJSI_getConstants(
+    facebook::jsi::Runtime& rt,
+    TurboModule& turboModule,
+    const facebook::jsi::Value* args,
+    size_t count) {
+  static jmethodID cachedMethodId = nullptr;
+  return static_cast<JavaTurboModule&>(turboModule)
+      .invokeJavaMethod(
+          rt,
+          ObjectKind,
+          "getConstants",
+          "()Ljava/util/Map;",
+          args,
+          count,
+          cachedMethodId);
+}
 
 static facebook::jsi::Value
 __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc(
@@ -107,6 +124,24 @@ __hostFunction_NativeSampleTurboModuleSpecJSI_getObject(
           rt,
           ObjectKind,
           "getObject",
+          "(Lcom/facebook/react/bridge/ReadableMap;)Lcom/facebook/react/bridge/WritableMap;",
+          args,
+          count,
+          cachedMethodId);
+}
+
+static facebook::jsi::Value
+__hostFunction_NativeSampleTurboModuleSpecJSI_getUnsafeObject(
+    facebook::jsi::Runtime& rt,
+    TurboModule& turboModule,
+    const facebook::jsi::Value* args,
+    size_t count) {
+  static jmethodID cachedMethodId = nullptr;
+  return static_cast<JavaTurboModule&>(turboModule)
+      .invokeJavaMethod(
+          rt,
+          ObjectKind,
+          "getUnsafeObject",
           "(Lcom/facebook/react/bridge/ReadableMap;)Lcom/facebook/react/bridge/WritableMap;",
           args,
           count,
@@ -275,80 +310,47 @@ __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert(
           cachedMethodId);
 }
 
-static facebook::jsi::Value
-__hostFunction_NativeSampleTurboModuleSpecJSI_getConstants(
-    facebook::jsi::Runtime& rt,
-    TurboModule& turboModule,
-    const facebook::jsi::Value* args,
-    size_t count) {
-  static jmethodID cachedMethodId = nullptr;
-  return static_cast<JavaTurboModule&>(turboModule)
-      .invokeJavaMethod(
-          rt,
-          ObjectKind,
-          "getConstants",
-          "()Ljava/util/Map;",
-          args,
-          count,
-          cachedMethodId);
-}
-
 NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(
     const JavaTurboModule::InitParams& params)
     : JavaTurboModule(params) {
-  methodMap_["voidFunc"] =
-      MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc};
-
-  methodMap_["getBool"] =
-      MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getBool};
-
-  methodMap_["getEnum"] =
-      MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnum};
-
-  methodMap_["getNumber"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber};
-
-  methodMap_["getString"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getString};
-
-  methodMap_["getArray"] =
-      MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getArray};
-
-  methodMap_["getObject"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObject};
-
-  methodMap_["getRootTag"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getRootTag};
-
-  methodMap_["getValue"] =
-      MethodMetadata{3, __hostFunction_NativeSampleTurboModuleSpecJSI_getValue};
-
-  methodMap_["getValueWithCallback"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithCallback};
-
-  methodMap_["getValueWithPromise"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithPromise};
-
-  methodMap_["voidFuncThrows"] = MethodMetadata{
-      0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFuncThrows};
-
-  methodMap_["getObjectThrows"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectThrows};
-
-  methodMap_["promiseThrows"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseThrows};
-
-  methodMap_["voidFuncAssert"] = MethodMetadata{
-      0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFuncAssert};
-
-  methodMap_["getObjectAssert"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectAssert};
-
-  methodMap_["promiseAssert"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert};
-
   methodMap_["getConstants"] = MethodMetadata{
       0, __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants};
+  methodMap_["voidFunc"] =
+      MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc};
+  methodMap_["getBool"] =
+      MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getBool};
+  methodMap_["getEnum"] =
+      MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnum};
+  methodMap_["getNumber"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber};
+  methodMap_["getString"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getString};
+  methodMap_["getArray"] =
+      MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getArray};
+  methodMap_["getObject"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObject};
+  methodMap_["getUnsafeObject"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getUnsafeObject};
+  methodMap_["getRootTag"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getRootTag};
+  methodMap_["getValue"] =
+      MethodMetadata{3, __hostFunction_NativeSampleTurboModuleSpecJSI_getValue};
+  methodMap_["getValueWithCallback"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithCallback};
+  methodMap_["getValueWithPromise"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithPromise};
+  methodMap_["voidFuncThrows"] = MethodMetadata{
+      0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFuncThrows};
+  methodMap_["getObjectThrows"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectThrows};
+  methodMap_["promiseThrows"] = MethodMetadata{
+      0, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseThrows};
+  methodMap_["voidFuncAssert"] = MethodMetadata{
+      0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFuncAssert};
+  methodMap_["getObjectAssert"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectAssert};
+  methodMap_["promiseAssert"] = MethodMetadata{
+      0, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert};
 }
 
 std::shared_ptr<TurboModule> SampleTurboModuleSpec_ModuleProvider(

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.h
@@ -16,13 +16,14 @@
 namespace facebook::react {
 
 /**
- * C++ class for module 'SampleTurboModule'
+ * JNI C++ class for module 'NativeSampleTurboModule'
  */
 class JSI_EXPORT NativeSampleTurboModuleSpecJSI : public JavaTurboModule {
  public:
   NativeSampleTurboModuleSpecJSI(const JavaTurboModule::InitParams& params);
 };
 
+JSI_EXPORT
 std::shared_ptr<TurboModule> SampleTurboModuleSpec_ModuleProvider(
     const std::string& moduleName,
     const JavaTurboModule::InitParams& params);

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
@@ -34,10 +34,10 @@
 - (void)getValueWithPromise:(BOOL)error resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)voidFuncThrows;
 - (NSDictionary *)getObjectThrows:(NSDictionary *)arg;
-- (void)promiseThrows:(BOOL)error resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)promiseThrows:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)voidFuncAssert;
 - (NSDictionary *)getObjectAssert:(NSDictionary *)arg;
-- (void)promiseAssert:(BOOL)error resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void)promiseAssert:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (NSDictionary *)constantsToExport;
 - (NSDictionary *)getConstants;
 

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
@@ -130,16 +130,6 @@ static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getVal
           rt, PromiseKind, "getValueWithPromise", @selector(getValueWithPromise:resolve:reject:), args, count);
 }
 
-static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants(
-    facebook::jsi::Runtime &rt,
-    TurboModule &turboModule,
-    const facebook::jsi::Value *args,
-    size_t count)
-{
-  return static_cast<ObjCTurboModule &>(turboModule)
-      .invokeObjCMethod(rt, ObjectKind, "getConstants", @selector(getConstants), args, count);
-}
-
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidFuncThrows(
     facebook::jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -167,7 +157,7 @@ static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_promis
     size_t count)
 {
   return static_cast<ObjCTurboModule &>(turboModule)
-      .invokeObjCMethod(rt, PromiseKind, "promiseThrows", @selector(promiseThrows:resolve:reject:), args, count);
+      .invokeObjCMethod(rt, PromiseKind, "promiseThrows", @selector(promiseThrows:reject:), args, count);
 }
 
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidFuncAssert(
@@ -197,7 +187,17 @@ static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_promis
     size_t count)
 {
   return static_cast<ObjCTurboModule &>(turboModule)
-      .invokeObjCMethod(rt, PromiseKind, "promiseAssert", @selector(promiseAssert:resolve:reject:), args, count);
+      .invokeObjCMethod(rt, PromiseKind, "promiseAssert", @selector(promiseAssert:reject:), args, count);
+}
+
+static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants(
+    facebook::jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const facebook::jsi::Value *args,
+    size_t count)
+{
+  return static_cast<ObjCTurboModule &>(turboModule)
+      .invokeObjCMethod(rt, ObjectKind, "getConstants", @selector(getConstants), args, count);
 }
 
 NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const ObjCTurboModule::InitParams &params)
@@ -219,10 +219,10 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const ObjCTurboMo
       MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithPromise};
   methodMap_["voidFuncThrows"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFuncThrows};
   methodMap_["getObjectThrows"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectThrows};
-  methodMap_["promiseThrows"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseThrows};
+  methodMap_["promiseThrows"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseThrows};
   methodMap_["voidFuncAssert"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFuncAssert};
   methodMap_["getObjectAssert"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectAssert};
-  methodMap_["promiseAssert"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert};
+  methodMap_["promiseAssert"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert};
   methodMap_["getConstants"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants};
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -162,10 +162,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, getObjectThrows : (NSDiction
   @throw myException;
 }
 
-RCT_EXPORT_METHOD(promiseThrows
-                  : (BOOL)error resolve
-                  : (RCTPromiseResolveBlock)resolve reject
-                  : (RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(promiseThrows : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject)
 {
   NSException *myException = [NSException exceptionWithName:@"Excepption"
                                                      reason:@"Intentional exception from ObjC promiseThrows"
@@ -184,10 +181,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, getObjectAssert : (NSDiction
   return arg;
 }
 
-RCT_EXPORT_METHOD(promiseAssert
-                  : (BOOL)error resolve
-                  : (RCTPromiseResolveBlock)resolve reject
-                  : (RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(promiseAssert : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject)
 {
   RCTAssert(false, @"Intentional assert from ObjC promiseAssert");
 }


### PR DESCRIPTION
Summary:
These modules are manually typed and don't use `react-native-codgen` (as a show case to demonstrates what code-gen produces).

There are some typos in the manually written code and they don't exactly match the JS Spec used at runtime:

https://github.com/facebook/react-native/blob/main/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js#L45-L48

Changelog: [Internal][Fixed] Align with code-gen output Sample Turbo Modules

Differential Revision: D57624824


