### PR TITLE
fix: warn only in `init` command when CLI uses cached `npx` version

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -128,7 +128,12 @@ ${chalk.yellow('⚠')}️ The \`init\` command is deprecated.
  *
  */
 async function main() {
-  if (isNpxRuntime && !process.env.SKIP && currentVersion !== HEAD && isInitCommand) {
+  if (
+    isNpxRuntime &&
+    !process.env.SKIP &&
+    currentVersion !== HEAD &&
+    isInitCommand
+  ) {
     try {
       const latest = await getLatestVersion();
       // TODO: T184416093 When cli is deprecated, remove semver from package.json

--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -29,6 +29,7 @@ let cli = {
 };
 
 const isNpxRuntime = process.env.npm_lifecycle_event === 'npx';
+const isInitCommand = process.argv[2] === 'init';
 const DEFAULT_REGISTRY_HOST =
   process.env.npm_config_registry ?? 'https://registry.npmjs.org/';
 const HEAD = '1000.0.0';
@@ -65,7 +66,7 @@ async function getLatestVersion(registryHost = DEFAULT_REGISTRY_HOST) {
  * @see https://github.com/react-native-community/discussions-and-proposals/tree/main/proposals/0759-react-native-frameworks.md
  */
 function warnWhenRunningInit() {
-  if (process.argv[2] === 'init') {
+  if (isInitCommand) {
     console.warn(
       `\nRunning: ${chalk.grey.bold('npx @react-native-community/cli init')}\n`,
     );
@@ -80,7 +81,7 @@ function warnWhenRunningInit() {
  * @see https://github.com/react-native-community/discussions-and-proposals/tree/main/proposals/0759-react-native-frameworks.md
  */
 function warnWithDeprecationSchedule() {
-  if (process.argv[2] !== 'init') {
+  if (!isInitCommand) {
     return;
   }
 
@@ -127,7 +128,7 @@ ${chalk.yellow('⚠')}️ The \`init\` command is deprecated.
  *
  */
 async function main() {
-  if (isNpxRuntime && !process.env.SKIP && currentVersion !== HEAD) {
+  if (isNpxRuntime && !process.env.SKIP && currentVersion !== HEAD && isInitCommand) {
     try {
       const latest = await getLatestVersion();
       // TODO: T184416093 When cli is deprecated, remove semver from package.json


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In https://github.com/facebook/react-native/pull/37510, a check was introduced to check if user is using `@latest` version of `npx`, but right now it checks for every command executed, but it should only ensure that `@latest` is included when creating a new project. 

In this Pull Request I've added a condition to only warn if `init` was fired. 

## Changelog:


[GENERAL] [FIXED] - Warn only in `init` command when CLI uses cached `npx` version

## Test Plan:

Warning about using `@latest` version CLI should only be presented when running `init` command.