### PR TITLE
Expose DevSettings.openDebugger method to JS

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -501,6 +501,15 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
   }
 }
 
+RCT_EXPORT_METHOD(openDebugger)
+{
+#ifdef RCT_ENABLE_INSPECTOR
+  [RCTInspectorDevServerHelper
+          openDebugger:self.bundleManager.bundleURL
+      withErrorMessage:@"Failed to open debugger. Please check that the dev server is running and reload the app."];
+#endif
+}
+
 #pragma mark - Internal
 
 /**
@@ -606,6 +615,9 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
 {
 }
 - (void)setupHMRClientWithAdditionalBundleURL:(NSURL *)bundleURL
+{
+}
+- (void)openDebugger
 {
 }
 - (void)addMenuItem:(NSString *)title

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.kt
@@ -61,6 +61,10 @@ public class DevSettingsModule(
     }
   }
 
+  override fun openDebugger() {
+    devSupportManager.openDebugger()
+  }
+
   override fun setIsShakeToShowDevMenuEnabled(enabled: Boolean) {
     // iOS only
   }

--- a/packages/react-native/src/private/specs/modules/NativeDevSettings.js
+++ b/packages/react-native/src/private/specs/modules/NativeDevSettings.js
@@ -21,6 +21,7 @@ export interface Spec extends TurboModule {
   +setProfilingEnabled: (isProfilingEnabled: boolean) => void;
   +toggleElementInspector: () => void;
   +addMenuItem: (title: string) => void;
+  +openDebugger?: () => void;
 
   // Events
   +addListener: (eventName: string) => void;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a private API that gives JS the ability to trigger the same "open debugger" action as in the Dev Menu. This is in preparation for changes to LogBox.

For simplicity, this method operates on a best-effort basis - i.e. it doesn't report the success or failure (or failure reason) of the launch.

Differential Revision: D57681447


