### PR TITLE
Suppress LogBox for low-severity errors and warnings if Fusebox console is available

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import NativeDevSettings from '../../NativeModules/specs/NativeDevSettings';
+
 ('use strict');
 
 import type {ExtendedError} from '../../Core/ExtendedError';
@@ -25,13 +27,13 @@ import LogBoxLog from './LogBoxLog';
 import {parseLogBoxException} from './parseLogBoxLog';
 import * as React from 'react';
 export type LogBoxLogs = Set<LogBoxLog>;
-export type LogData = $ReadOnly<{|
+export type LogData = $ReadOnly<{
   level: LogLevel,
   message: Message,
   category: Category,
   componentStack: ComponentStack,
   stack?: string,
-|}>;
+}>;
 
 export type Observer = (
   $ReadOnly<{|
@@ -72,6 +74,7 @@ let logs: LogBoxLogs = new Set();
 let updateTimeout: $FlowFixMe | null = null;
 let _isDisabled = false;
 let _selectedIndex = -1;
+let hasShownFuseboxUpsellMessage = false;
 
 let warningFilter: WarningFilter = function (format) {
   return {
@@ -193,6 +196,11 @@ function appendNewLog(newLog: LogBoxLog) {
 }
 
 export function addLog(log: LogData): void {
+  if (log.level !== 'fatal' && global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
+    // Under Fusebox, only report fatal errors to LogBox.
+    showFuseboxUpsellMessageOnce();
+    return;
+  }
   const errorForStackTrace = new Error();
 
   // Parsing logs are expensive so we schedule this
@@ -218,6 +226,11 @@ export function addLog(log: LogData): void {
 }
 
 export function addException(error: ExtendedExceptionData): void {
+  if (!error.isFatal && global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
+    // Under Fusebox, only report fatal errors to LogBox.
+    showFuseboxUpsellMessageOnce();
+    return;
+  }
   // Parsing logs are expensive so we schedule this
   // otherwise spammy logs would pause rendering.
   setImmediate(() => {
@@ -452,4 +465,30 @@ export function withSubscription(
   }
 
   return LogBoxStateSubscription;
+}
+
+function showFuseboxUpsellMessageOnce() {
+  if (hasShownFuseboxUpsellMessage) {
+    return;
+  }
+  hasShownFuseboxUpsellMessage = true;
+  appendNewLog(
+    new LogBoxLog({
+      level: 'fusebox-upsell',
+      message: {
+        content: 'Open debugger to view logs.',
+        substitutions: [],
+      },
+      isComponentError: false,
+      stack: [],
+      category: 'fusebox-upsell',
+      componentStack: [],
+      onNotificationPress: () => {
+        if (NativeDevSettings.openDebugger) {
+          NativeDevSettings.openDebugger();
+        }
+        clear();
+      },
+    }),
+  );
 }

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxLog.js
@@ -21,7 +21,7 @@ import * as LogBoxSymbolication from './LogBoxSymbolication';
 
 type SymbolicationStatus = 'NONE' | 'PENDING' | 'COMPLETE' | 'FAILED';
 
-export type LogLevel = 'warn' | 'error' | 'fatal' | 'syntax';
+export type LogLevel = 'fusebox-upsell' | 'warn' | 'error' | 'fatal' | 'syntax';
 
 // TODO: once component stacks are fully supported, we can refactor
 // ComponentStack to just be Stack and remove these conversions fns.
@@ -66,6 +66,7 @@ export type LogBoxLogData = $ReadOnly<{|
   codeFrame?: ?CodeFrame,
   isComponentError: boolean,
   extraData?: mixed,
+  onNotificationPress?: ?() => void,
 |}>;
 
 class LogBoxLog {
@@ -102,6 +103,7 @@ class LogBoxLog {
     componentStack: null,
     status: 'NONE',
   };
+  onNotificationPress: ?() => void;
 
   constructor(data: LogBoxLogData) {
     this.level = data.level;
@@ -115,6 +117,7 @@ class LogBoxLog {
     this.isComponentError = data.isComponentError;
     this.extraData = data.extraData;
     this.count = 1;
+    this.onNotificationPress = data.onNotificationPress;
   }
 
   incrementCount(): void {

--- a/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
+++ b/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
@@ -35,7 +35,15 @@ export function _LogBoxNotificationContainer(props: Props): React.Node {
     LogBoxData.setSelectedLog(index);
   };
 
+  const onDismissAll = () => {
+    LogBoxData.clear();
+  };
+
   function openLog(log: LogBoxLog) {
+    if (log.onNotificationPress) {
+      log.onNotificationPress();
+      return;
+    }
     let index = logs.length - 1;
 
     // Stop at zero because if we don't find any log, we'll open the first log.
@@ -53,6 +61,7 @@ export function _LogBoxNotificationContainer(props: Props): React.Node {
   const errors = logs.filter(
     log => log.level === 'error' || log.level === 'fatal',
   );
+  const fuseboxUpsells = logs.filter(log => log.level === 'fusebox-upsell');
   return (
     <View style={styles.list}>
       {warnings.length > 0 && (
@@ -74,6 +83,17 @@ export function _LogBoxNotificationContainer(props: Props): React.Node {
             totalLogCount={errors.length}
             onPressOpen={() => openLog(errors[errors.length - 1])}
             onPressDismiss={onDismissErrors}
+          />
+        </View>
+      )}
+      {fuseboxUpsells.length > 0 && (
+        <View style={styles.toast}>
+          <LogBoxLogNotification
+            log={fuseboxUpsells[0]}
+            level="fusebox-upsell"
+            totalLogCount={fuseboxUpsells.length}
+            onPressOpen={() => openLog(fuseboxUpsells[0])}
+            onPressDismiss={onDismissAll}
           />
         </View>
       )}

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
@@ -90,6 +90,9 @@ const headerTitleMap = {
   fatal: 'Uncaught Error',
   syntax: 'Syntax Error',
   component: 'Render Error',
+
+  // Never actually rendered
+  'fusebox-upsell': 'React Native DevTools',
 };
 
 function LogBoxInspectorBody(props: {log: LogBoxLog, onRetry: () => void}) {

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
@@ -88,6 +88,10 @@ const backgroundForLevel = (level: LogLevel) =>
       default: 'transparent',
       pressed: LogBoxStyle.getFatalDarkColor(),
     },
+    'fusebox-upsell': {
+      default: 'transparent',
+      pressed: LogBoxStyle.getLogDarkColor(),
+    },
   })[level];
 
 function LogBoxInspectorHeaderButton(
@@ -140,6 +144,9 @@ const styles = StyleSheet.create({
   },
   error: {
     backgroundColor: LogBoxStyle.getErrorColor(),
+  },
+  'fusebox-upsell': {
+    backgroundColor: LogBoxStyle.getLogColor(),
   },
   header: {
     flexDirection: 'row',

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js
@@ -94,6 +94,9 @@ const messageStyles = StyleSheet.create({
     includeFontPadding: false,
     lineHeight: 28,
   },
+  'fusebox-upsell': {
+    color: LogBoxStyle.getLogColor(1),
+  },
   warn: {
     color: LogBoxStyle.getWarningColor(1),
   },

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxNotification.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxNotification.js
@@ -24,7 +24,7 @@ import * as React from 'react';
 type Props = $ReadOnly<{
   log: LogBoxLog,
   totalLogCount: number,
-  level: 'warn' | 'error',
+  level: 'fusebox-upsell' | 'warn' | 'error',
   onPressOpen: () => void,
   onPressDismiss: () => void,
 }>;
@@ -56,7 +56,10 @@ function LogBoxLogNotification(props: Props): React.Node {
   );
 }
 
-function CountBadge(props: {count: number, level: 'error' | 'warn'}) {
+function CountBadge(props: {
+  count: number,
+  level: 'fusebox-upsell' | 'error' | 'warn',
+}) {
   return (
     <View style={countStyles.outside}>
       {/* $FlowFixMe[incompatible-type] (>=0.114.0) This suppression was added
@@ -119,7 +122,7 @@ const countStyles = StyleSheet.create({
   error: {
     backgroundColor: LogBoxStyle.getErrorColor(1),
   },
-  log: {
+  'fusebox-upsell': {
     backgroundColor: LogBoxStyle.getLogColor(1),
   },
   outside: {

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxStyle.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxStyle.js
@@ -48,6 +48,10 @@ export function getLogColor(opacity?: number): string {
   return `rgba(119, 119, 119, ${opacity == null ? 1 : opacity})`;
 }
 
+export function getLogDarkColor(opacity?: number): string {
+  return `rgba(87, 87, 87, ${opacity == null ? 1 : opacity})`;
+}
+
 export function getWarningHighlightColor(opacity?: number): string {
   return `rgba(252, 176, 29, ${opacity == null ? 1 : opacity})`;
 }

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -501,6 +501,15 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
   }
 }
 
+RCT_EXPORT_METHOD(openDebugger)
+{
+#ifdef RCT_ENABLE_INSPECTOR
+  [RCTInspectorDevServerHelper
+          openDebugger:self.bundleManager.bundleURL
+      withErrorMessage:@"Failed to open debugger. Please check that the dev server is running and reload the app."];
+#endif
+}
+
 #pragma mark - Internal
 
 /**
@@ -606,6 +615,9 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
 {
 }
 - (void)setupHMRClientWithAdditionalBundleURL:(NSURL *)bundleURL
+{
+}
+- (void)openDebugger
 {
 }
 - (void)addMenuItem:(NSString *)title

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.kt
@@ -61,6 +61,10 @@ public class DevSettingsModule(
     }
   }
 
+  override fun openDebugger() {
+    devSupportManager.openDebugger()
+  }
+
   override fun setIsShakeToShowDevMenuEnabled(enabled: Boolean) {
     // iOS only
   }

--- a/packages/react-native/src/private/specs/modules/NativeDevSettings.js
+++ b/packages/react-native/src/private/specs/modules/NativeDevSettings.js
@@ -21,6 +21,7 @@ export interface Spec extends TurboModule {
   +setProfilingEnabled: (isProfilingEnabled: boolean) => void;
   +toggleElementInspector: () => void;
   +addMenuItem: (title: string) => void;
+  +openDebugger?: () => void;
 
   // Events
   +addListener: (eventName: string) => void;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Showing warnings and low-severity errors in LogBox is noisy, confusing for web developers, and not the best use of screen real estate on mobile platforms. Since the Fusebox console offers a superior experience, as of this diff we'll suppress warnings and low-severity errors in LogBox if we detect that Fusebox is available.

*The first time* a warning or error is suppressed (i.e. at most once per app launch), we'll show a "log" level notification pointing the user towards Fusebox. When the notification is clicked, we call the `DevSettings.openDebugger` method and dismiss it.

The wording of the notification ("Open debugger to view logs") is intentional:

1. It's short enough to fit on small screens in its entirety.
2. It doesn't actually say "*click here* to open the debugger". This is for the best because `DevSettings.openDebugger` is a best-effort method that might fail, and in the current implementation there's no reliable feedback to the user about the success/failure of the launch.

Differential Revision: D57681446


