### PR TITLE
Switch to use hermes-canary transform profile

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -106,12 +106,10 @@ const getPreset = (src, options) => {
       require('@babel/plugin-transform-named-capturing-groups-regex'),
     ]);
   }
-  if (!isHermesCanary) {
-    extraPlugins.push([
-      require('@babel/plugin-transform-destructuring'),
-      {useBuiltIns: true},
-    ]);
-  }
+  extraPlugins.push([
+    require('@babel/plugin-transform-destructuring'),
+    {useBuiltIns: true},
+  ]);
   if (!isHermes && (isNull || hasClass || src.indexOf('...') !== -1)) {
     extraPlugins.push(
       [require('@babel/plugin-transform-spread')],


### PR DESCRIPTION
Summary:
This diff makes the `hermes-canary` transform profile identical to `hermes-stable` by enabling destructuring.

Then make builds with SH use the `hermes-canary` profile.

Changelog: [Internal]

Differential Revision: D57738865


