### PR TITLE
Add suppression for deprecated setters and getters

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.kt
@@ -31,6 +31,7 @@ import com.facebook.react.uimanager.PixelUtil
 public class StatusBarModule(reactContext: ReactApplicationContext?) :
     NativeStatusBarManagerAndroidSpec(reactContext) {
 
+  @Suppress("DEPRECATION")
   override fun getTypedExportedConstants(): Map<String, Any> {
     val context = getReactApplicationContext()
     val heightResId = context.resources.getIdentifier("status_bar_height", "dimen", "android")
@@ -53,6 +54,7 @@ public class StatusBarModule(reactContext: ReactApplicationContext?) :
     )
   }
 
+  @Suppress("DEPRECATION")
   override fun setColor(colorDouble: Double, animated: Boolean) {
     val color = colorDouble.toInt()
     val activity = getCurrentActivity()


### PR DESCRIPTION
Summary:
Some of the setters and getters in these functions, like [`getStatusBarColor`](https://developer.android.com/reference/android/view/Window#getStatusBarColor), have been marked as deprecated in [`VANILLA_ICE_CREAM`](https://developer.android.com/reference/android/os/Build.VERSION_CODES#VANILLA_ICE_CREAM). This change suppresses deprecation warnings until we can move to newer alternatives.

## Changelog

[Android] [Changed] - Added suppression for deprecated getter/setter usage in StatusBarModule

Differential Revision: D57780503


