### PR TITLE
Adjust iOS line height calculation

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
@@ -123,48 +123,40 @@
 
 - (void)postprocessAttributedText:(NSMutableAttributedString *)attributedText
 {
-  __block CGFloat maximumLineHeight = 0;
+    // Retrieve paragraph line height value
+    __block CGFloat paragraphLineHeight = 0;
+    [attributedText enumerateAttribute:NSParagraphStyleAttributeName
+                               inRange:NSMakeRange(0, attributedText.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
+                              if (!paragraphStyle) {
+                                return;
+                              }
 
-  [attributedText enumerateAttribute:NSParagraphStyleAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                          usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
-                            if (!paragraphStyle) {
-                              return;
-                            }
+                              paragraphLineHeight = paragraphStyle.maximumLineHeight;
+                            }];
 
-                            maximumLineHeight = MAX(paragraphStyle.maximumLineHeight, maximumLineHeight);
-                          }];
+    // Retrieve font size and font line height values
+    __block CGFloat fontSize = 0;
+    __block CGFloat fontLineHeight = 0;
+    [attributedText enumerateAttribute:NSFontAttributeName
+                               inRange:NSMakeRange(0, attributedText.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
+                              if (!font) {
+                                return;
+                              }
+                    
+                              fontSize = font.pointSize;
+                              fontLineHeight = font.lineHeight;
+                            }];
 
-  if (maximumLineHeight == 0) {
-    // `lineHeight` was not specified, nothing to do.
-    return;
-  }
-
-  __block CGFloat maximumFontLineHeight = 0;
-
-  [attributedText enumerateAttribute:NSFontAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                          usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
-                            if (!font) {
-                              return;
-                            }
-
-                            if (maximumFontLineHeight <= font.lineHeight) {
-                              maximumFontLineHeight = font.lineHeight;
-                            }
-                          }];
-
-  if (maximumLineHeight < maximumFontLineHeight) {
-    return;
-  }
-
-  CGFloat baseLineOffset = maximumLineHeight / 2.0 - maximumFontLineHeight / 2.0;
-
-  [attributedText addAttribute:NSBaselineOffsetAttributeName
-                         value:@(baseLineOffset)
-                         range:NSMakeRange(0, attributedText.length)];
+    // Calculate baseline offset based on font size and maximum available line height value
+    CGFloat maximumLineHeight = MAX(paragraphLineHeight, fontLineHeight);
+    CGFloat baselineOffset = (fontSize - maximumLineHeight) / 1.5;
+    [attributedText addAttribute:NSBaselineOffsetAttributeName
+                           value:@(baselineOffset)
+                           range:NSMakeRange(0, attributedText.length)];
 }
 
 - (NSAttributedString *)attributedTextWithMeasuredAttachmentsThatFitSize:(CGSize)size

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.mm
@@ -195,48 +195,40 @@
 
 - (void)postprocessAttributedText:(NSMutableAttributedString *)attributedText
 {
-  __block CGFloat maximumLineHeight = 0;
+    // Retrieve paragraph line height value
+    __block CGFloat paragraphLineHeight = 0;
+    [attributedText enumerateAttribute:NSParagraphStyleAttributeName
+                               inRange:NSMakeRange(0, attributedText.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
+                              if (!paragraphStyle) {
+                                return;
+                              }
 
-  [attributedText enumerateAttribute:NSParagraphStyleAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                          usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
-                            if (!paragraphStyle) {
-                              return;
-                            }
+                              paragraphLineHeight = paragraphStyle.maximumLineHeight;
+                            }];
 
-                            maximumLineHeight = MAX(paragraphStyle.maximumLineHeight, maximumLineHeight);
-                          }];
+    // Retrieve font size and font line height values
+    __block CGFloat fontSize = 0;
+    __block CGFloat fontLineHeight = 0;
+    [attributedText enumerateAttribute:NSFontAttributeName
+                               inRange:NSMakeRange(0, attributedText.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
+                              if (!font) {
+                                return;
+                              }
+                    
+                              fontSize = font.pointSize;
+                              fontLineHeight = font.lineHeight;
+                            }];
 
-  if (maximumLineHeight == 0) {
-    // `lineHeight` was not specified, nothing to do.
-    return;
-  }
-
-  __block CGFloat maximumFontLineHeight = 0;
-
-  [attributedText enumerateAttribute:NSFontAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                          usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
-                            if (!font) {
-                              return;
-                            }
-
-                            if (maximumFontLineHeight <= font.lineHeight) {
-                              maximumFontLineHeight = font.lineHeight;
-                            }
-                          }];
-
-  if (maximumLineHeight < maximumFontLineHeight) {
-    return;
-  }
-
-  CGFloat baseLineOffset = maximumLineHeight / 2.0 - maximumFontLineHeight / 2.0;
-
-  [attributedText addAttribute:NSBaselineOffsetAttributeName
-                         value:@(baseLineOffset)
-                         range:NSMakeRange(0, attributedText.length)];
+    // Calculate baseline offset based on font size and maximum available line height value
+    CGFloat maximumLineHeight = MAX(paragraphLineHeight, fontLineHeight);
+    CGFloat baselineOffset = (fontSize - maximumLineHeight) / 1.5;
+    [attributedText addAttribute:NSBaselineOffsetAttributeName
+                           value:@(baselineOffset)
+                           range:NSMakeRange(0, attributedText.length)];
 }
 
 #pragma mark -

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -302,46 +302,40 @@ NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(c
 
 static void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
 {
-  __block CGFloat maximumLineHeight = 0;
+    // Retrieve paragraph line height value
+    __block CGFloat paragraphLineHeight = 0;
+    [attributedText enumerateAttribute:NSParagraphStyleAttributeName
+                               inRange:NSMakeRange(0, attributedText.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
+                              if (!paragraphStyle) {
+                                return;
+                              }
 
-  [attributedText enumerateAttribute:NSParagraphStyleAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                          usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
-                            if (!paragraphStyle) {
-                              return;
-                            }
+                              paragraphLineHeight = paragraphStyle.maximumLineHeight;
+                            }];
 
-                            maximumLineHeight = MAX(paragraphStyle.maximumLineHeight, maximumLineHeight);
-                          }];
+    // Retrieve font size and font line height values
+    __block CGFloat fontSize = 0;
+    __block CGFloat fontLineHeight = 0;
+    [attributedText enumerateAttribute:NSFontAttributeName
+                               inRange:NSMakeRange(0, attributedText.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
+                              if (!font) {
+                                return;
+                              }
+                    
+                              fontSize = font.pointSize;
+                              fontLineHeight = font.lineHeight;
+                            }];
 
-  if (maximumLineHeight == 0) {
-    // `lineHeight` was not specified, nothing to do.
-    return;
-  }
-
-  __block CGFloat maximumFontLineHeight = 0;
-
-  [attributedText enumerateAttribute:NSFontAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
-                             options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
-                          usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
-                            if (!font) {
-                              return;
-                            }
-
-                            maximumFontLineHeight = MAX(font.lineHeight, maximumFontLineHeight);
-                          }];
-
-  if (maximumLineHeight < maximumFontLineHeight) {
-    return;
-  }
-
-  CGFloat baseLineOffset = (maximumLineHeight - maximumFontLineHeight) / 2.0;
-
-  [attributedText addAttribute:NSBaselineOffsetAttributeName
-                         value:@(baseLineOffset)
-                         range:NSMakeRange(0, attributedText.length)];
+    // Calculate baseline offset based on font size and maximum available line height value
+    CGFloat maximumLineHeight = MAX(paragraphLineHeight, fontLineHeight);
+    CGFloat baselineOffset = (fontSize - maximumLineHeight) / 1.5;
+    [attributedText addAttribute:NSBaselineOffsetAttributeName
+                           value:@(baselineOffset)
+                           range:NSMakeRange(0, attributedText.length)];
 }
 
 static NSMutableAttributedString *RCTNSAttributedStringFragmentFromFragment(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This diff will adjust line height calculation for `Text` and `TextInput` on iOS which is needed to fix cropped text in some fonts that have higher accent, e.g. Vietnam.

Line height calculation will use `fontSize` as the anchor to define the text offset.

On Android, it seems fine, text not cropped, attached on the `Test Plan` section.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [CHANGED] - Adjust line height calculation

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

It was tested using [Be Vietnam Pro](https://fonts.google.com/specimen/Be+Vietnam+Pro) font to render `CHỖ` text. Before the adjustment, the text will be cropped as it needs higher line height.

### Before

<img alt="before" src="https://github.com/facebook/react-native/assets/5382429/bd3664a6-2e00-45c5-8403-a27ca231de37" width="500px" />

### After

<img alt="after" src="https://github.com/facebook/react-native/assets/5382429/00a15e5f-a891-45f8-b03b-aff7a072ac06" width="500px" />

### Android

<img alt="android" src="https://github.com/facebook/react-native/assets/5382429/9c2e21e5-80c9-490a-ba7a-32ff3aa480a0" width="500px" />
