### PR TITLE
[iOS][FIXED] Add missing call to super.viewDidLoad in RCTRedBox.mm

### DIFF
--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -95,6 +95,7 @@
 
 - (void)viewDidLoad
 {
+  [super viewDidLoad];
   self.view.backgroundColor = [UIColor blackColor];
 
   const CGFloat buttonHeight = 60;


### PR DESCRIPTION
## Summary:

When running the Analyzer in Xcode, I got a warning denoting that `viewDidLoad` was not called on `super` in the overridden `RCTRedBox.viewDidLoad`. While I have not observed any anomalies, it is best practice to call on super in the overridden view controller life cycle methods.

## Changelog:

[iOS] [FIXED] - Add missing call to `[super viewDidLoad]` in `RCTRedBox.mm`.

## Test Plan:

Running the RNTester yielded the following screenshot:

<img width="549" alt="Screenshot 2024-05-27 at 11 26 40" src="https://github.com/facebook/react-native/assets/2263015/b91e126c-9dc1-4e52-8a6b-50ea8bea2c3f">
