### PR TITLE
feat: build visionos hermes binary on the CI

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -780,7 +780,7 @@ jobs:
         default: "iphoneos"
         description: The Hermes Slice that this job has to build
         type: enum
-        enum: ["macosx", "iphoneos", "iphonesimulator", "catalyst"]
+        enum: ["macosx", "iphoneos", "iphonesimulator", "catalyst", "xros", "xrsimulator"]
     executor: reactnativeios
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
@@ -885,6 +885,10 @@ jobs:
           key: << parameters.slice_base_cache_key >>-iphonesimulator-<< parameters.flavor >>
       - restore_cache:
           key: << parameters.slice_base_cache_key >>-catalyst-<< parameters.flavor >>
+      - restore_cache:
+          key: << parameters.slice_base_cache_key >>-xros-<< parameters.flavor >>
+      - restore_cache:
+          key: << parameters.slice_base_cache_key >>-xrsimulator-<< parameters.flavor >>
       - run:
           name: "Move back build folders"
           command: |
@@ -893,6 +897,8 @@ jobs:
             mv build_iphoneos_<< parameters.flavor >> build_iphoneos
             mv build_iphonesimulator_<< parameters.flavor >> build_iphonesimulator
             mv build_catalyst_<< parameters.flavor >> build_catalyst
+            mv build_xros_<< parameters.flavor >> build_xros
+            mv build_xrsimulator_<< parameters.flavor >> build_xrsimulator
       - run:
           name: "Prepare destroot folder"
           command: |
@@ -943,6 +949,8 @@ jobs:
             mkdir -p "$WORKING_DIR/catalyst"
             mkdir -p "$WORKING_DIR/iphoneos"
             mkdir -p "$WORKING_DIR/iphonesimulator"
+            mkdir -p "$WORKING_DIR/xros"
+            mkdir -p "$WORKING_DIR/xrsimulator"
 
             cd ./packages/react-native/sdks/hermes || exit 1
 
@@ -951,6 +959,8 @@ jobs:
             cp -r build_catalyst/$DSYM_FILE_PATH "$WORKING_DIR/catalyst/"
             cp -r build_iphoneos/$DSYM_FILE_PATH "$WORKING_DIR/iphoneos/"
             cp -r build_iphonesimulator/$DSYM_FILE_PATH "$WORKING_DIR/iphonesimulator/"
+            cp -r build_xrsimulator/$DSYM_FILE_PATH "$WORKING_DIR/xrsimulator/"
+            cp -r build_xros/$DSYM_FILE_PATH "$WORKING_DIR/xros/"
 
             DEST_DIR="/tmp/hermes/dSYM/$FLAVOR"
             tar -C "$WORKING_DIR" -czvf "hermes.framework.dSYM" .

--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -25,7 +25,7 @@
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
-              slice: ["macosx", "iphoneos", "iphonesimulator", "catalyst"]
+              slice: ["macosx", "iphoneos", "iphonesimulator", "catalyst", "xros", "xrsimulator"]
       - build_hermes_macos:
           requires:
             - build_apple_slices_hermes

--- a/.circleci/configurations/test_workflows/testAndroid.yml
+++ b/.circleci/configurations/test_workflows/testAndroid.yml
@@ -25,7 +25,7 @@
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
-              slice: ["macosx", "iphoneos", "iphonesimulator", "catalyst"]
+              slice: ["macosx", "iphoneos", "iphonesimulator", "catalyst", "xros", "xrsimulator"]
       - build_hermes_macos:
           requires:
             - build_apple_slices_hermes

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -25,7 +25,7 @@
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
-              slice: ["macosx", "iphoneos", "iphonesimulator", "catalyst"]
+              slice: ["macosx", "iphoneos", "iphonesimulator", "catalyst", "xros", "xrsimulator"]
       - build_hermes_macos:
           requires:
             - build_apple_slices_hermes

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -114,7 +114,7 @@ jobs:
           . ./utils/build-apple-framework.sh
           build_host_hermesc_if_needed
   build_apple_slices_hermes:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [build_hermesc_apple, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -125,10 +125,12 @@ jobs:
       fail-fast: false
       matrix:
         flavor: [Debug, Release]
-        slice: [macosx, iphoneos, iphonesimulator, catalyst]
+        slice: [macosx, iphoneos, iphonesimulator, catalyst, xros, xrsimulator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
       - name: Cache setup
         id: cache_setup
         uses: ./.github/actions/cache_setup
@@ -269,6 +271,18 @@ jobs:
         with:
           path: ./packages/react-native/sdks/hermes/build_catalyst_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-catalyst-${{ matrix.flavor }}
+      - name: Slice cache xros 
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_xros_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xros-${{ matrix.flavor }}
+      - name: Slice cache xrsimulator
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_xrsimulator_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xrsimulator-${{ matrix.flavor }}
       - name: Move back build folders
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         run: |
@@ -278,6 +292,8 @@ jobs:
           mv build_iphoneos_${{ matrix.flavor }} build_iphoneos
           mv build_iphonesimulator_${{ matrix.flavor }} build_iphonesimulator
           mv build_catalyst_${{ matrix.flavor }} build_catalyst
+          mv build_xros_${{ matrix.flavor }} build_xros
+          mv build_xrsimulator_${{ matrix.flavor }} build_xrsimulator
       - name: Prepare destroot folder
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         run: |
@@ -335,6 +351,8 @@ jobs:
           mkdir -p "$WORKING_DIR/catalyst"
           mkdir -p "$WORKING_DIR/iphoneos"
           mkdir -p "$WORKING_DIR/iphonesimulator"
+          mkdir -p "$WORKING_DIR/xros"
+          mkdir -p "$WORKING_DIR/xrsimulator"
 
           cd ./packages/react-native/sdks/hermes || exit 1
 
@@ -343,6 +361,8 @@ jobs:
           cp -r build_catalyst/$DSYM_FILE_PATH "$WORKING_DIR/catalyst/"
           cp -r build_iphoneos/$DSYM_FILE_PATH "$WORKING_DIR/iphoneos/"
           cp -r build_iphonesimulator/$DSYM_FILE_PATH "$WORKING_DIR/iphonesimulator/"
+          cp -r build_xros/$DSYM_FILE_PATH "$WORKING_DIR/xros/"
+          cp -r build_xrsimulator/$DSYM_FILE_PATH "$WORKING_DIR/xrsimulator/"
 
           DEST_DIR="/tmp/hermes/dSYM/$FLAVOR"
           tar -C "$WORKING_DIR" -czvf "hermes.framework.dSYM" .

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
   spec.license     = package['license']
   spec.author      = "Facebook"
   spec.source      = source
-  spec.platforms   = { :osx => "10.13", :ios => "13.4" }
+  spec.platforms   = { :osx => "10.13", :ios => "13.4", :visionos => "1.0" }
 
   spec.preserve_paths      = '**/*.*'
   spec.source_files        = ''
@@ -44,6 +44,7 @@ Pod::Spec.new do |spec|
       ss.source_files = "destroot/include/hermes/**/*.h"
       ss.header_mappings_dir = "destroot/include"
       ss.ios.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
+      ss.visionos.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
       ss.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
     end
 

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -17,6 +17,8 @@ REACT_NATIVE_PATH=${REACT_NATIVE_PATH:-$CURR_SCRIPT_DIR/../../..}
 
 NUM_CORES=$(sysctl -n hw.ncpu)
 
+PLATFORMS=("macosx" "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator")
+
 if [[ -z "$JSI_PATH" ]]; then
   JSI_PATH="$REACT_NATIVE_PATH/ReactCommon/jsi"
 fi
@@ -35,6 +37,10 @@ function get_release_version {
 
 function get_ios_deployment_target {
   use_env_var_or_ruby_prop "${IOS_DEPLOYMENT_TARGET}" "deployment_target('ios')"
+}
+
+function get_visionos_deployment_target {
+  use_env_var_or_ruby_prop "${XROS_DEPLOYMENT_TARGET}" "deployment_target('visionos')"
 }
 
 function get_mac_deployment_target {
@@ -150,12 +156,12 @@ function build_apple_framework {
 }
 
 function prepare_dest_root_for_ci {
-  mkdir -p "destroot/Library/Frameworks/macosx" "destroot/bin" "destroot/Library/Frameworks/iphoneos" "destroot/Library/Frameworks/iphonesimulator" "destroot/Library/Frameworks/catalyst"
+  mkdir -p  "destroot/bin"
+  for platform in "${PLATFORMS[@]}"; do
+    mkdir -p "destroot/Library/Frameworks/$platform"
+    cp -R "./build_$platform/API/hermes/hermes.framework"* "destroot/Library/Frameworks/$platform"
+  done
 
-  cp -R "./build_macosx/API/hermes/hermes.framework"* "destroot/Library/Frameworks/macosx"
-  cp -R "./build_iphoneos/API/hermes/hermes.framework"* "destroot/Library/Frameworks/iphoneos"
-  cp -R "./build_iphonesimulator/API/hermes/hermes.framework"* "destroot/Library/Frameworks/iphonesimulator"
-  cp -R "./build_catalyst/API/hermes/hermes.framework"* "destroot/Library/Frameworks/catalyst"
   cp "./build_macosx/bin/"* "destroot/bin"
 
   # Copy over Hermes and JSI API headers.

--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -16,6 +16,9 @@ function get_platform_copy_destination {
     if [[ $1 == "macosx" ]]; then
       echo "macosx"
       return
+    elif [[ $1 == "xros" || $1 == "xrsimulator" ]]; then
+      echo "xros"
+      return
     fi
     
     echo "ios"
@@ -24,6 +27,9 @@ function get_platform_copy_destination {
 function get_deployment_target {
     if [[ $1 == "macosx" ]]; then
       echo ${MACOSX_DEPLOYMENT_TARGET}
+      return
+    elif [[ $1 == "xrsimulator" || $1 == "xros" ]]; then
+      echo ${XROS_DEPLOYMENT_TARGET}
       return
     fi
     

--- a/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -10,9 +10,9 @@ fi
 set -e
 
 # Given a specific target, retrieve the right architecture for it
-# $1 the target you want to build. Allowed values: iphoneos, iphonesimulator, catalyst
+# $1 the target you want to build. Allowed values: iphoneos, iphonesimulator, catalyst, xros, xrsimulator
 function get_architecture {
-    if [[ $1 == "iphoneos" ]]; then
+    if [[ $1 == "iphoneos" || $1 == "xros" || $1 == "xrsimulator" ]]; then
       echo "arm64"
     elif [[ $1 == "iphonesimulator" ]]; then
       echo "x86_64;arm64"
@@ -24,15 +24,23 @@ function get_architecture {
     fi
 }
 
+function get_deployment_target { 
+    if [[ $1 == "xros" || $1 == "xrsimulator" ]]; then
+      echo "$(get_visionos_deployment_target)"
+    else
+      echo "$(get_ios_deployment_target)"
+    fi
+}
+
 # build a single framework
 # $1 is the target to build
 function build_framework {
   if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
-    ios_deployment_target=$(get_ios_deployment_target)
+    deployment_target=$(get_deployment_target "$1")
 
     architecture=$(get_architecture "$1")
 
-    build_apple_framework "$1" "$architecture" "$ios_deployment_target"
+    build_apple_framework "$1" "$architecture" "$deployment_target"
   else
     echo "Skipping; Clean \"destroot\" to rebuild".
   fi
@@ -41,7 +49,7 @@ function build_framework {
 # group the frameworks together to create a universal framework
 function build_universal_framework {
     if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
-        create_universal_framework "iphoneos" "iphonesimulator" "catalyst"
+        create_universal_framework "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator"
     else
         echo "Skipping; Clean \"destroot\" to rebuild".
     fi
@@ -56,6 +64,8 @@ function create_framework {
         build_framework "iphoneos"
         build_framework "iphonesimulator"
         build_framework "catalyst"
+        build_framework "xros"
+        build_framework "xrsimulator"
 
         build_universal_framework
     else

--- a/packages/react-native/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh
@@ -19,7 +19,7 @@ pushd destroot/Library/Frameworks > /dev/null || exit 1
 
 echo '' > dummy.c
 
-platforms=( "macosx" "ios" ) # Add other platforms here if needed
+platforms=( "macosx" "ios" "xros" ) # Add other platforms here if needed
 
 for platform in "${platforms[@]}" 
 do 


### PR DESCRIPTION
## Summary:

As discussed with @cipolleschi offline, this PR adds visionOS to the prebuilt Hermes binary for the CI. 

## Changelog:

[IOS] [ADDED] - Prebuilt version of Hermes for visionOS 


## Test Plan:

Check if CI builds xcframework for visionOS.
