### PR TITLE
add fusebox flag to error case of launch debugger event

### DIFF
--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -160,6 +160,7 @@ export default function openDebuggerMiddleware({
           launchType,
           status: 'error',
           error: e,
+          prefersFuseboxFrontend: useFuseboxEntryPoint ?? false,
         });
         return;
       }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Add `prefers_fusebox_frontend` annotation to the error case for the launch debugger event

Differential Revision: D57866634


