### PR TITLE
DevSupport classes included in release build with proguard enabled. Resolves unnecessary usage of BridgeDevSupportManager in DevLoadingModule.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -65,8 +65,6 @@ import java.util.concurrent.TimeoutException;
  */
 public final class BridgeDevSupportManager extends DevSupportManagerBase {
   private boolean mIsSamplingProfilerEnabled = false;
-  private ReactInstanceDevHelper mReactInstanceManagerHelper;
-  private @Nullable DevLoadingViewManager mDevLoadingViewManager;
 
   public BridgeDevSupportManager(
       Context applicationContext,
@@ -90,9 +88,6 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
         customPackagerCommandHandlers,
         surfaceDelegateFactory,
         devLoadingViewManager);
-
-    mReactInstanceManagerHelper = reactInstanceManagerHelper;
-    mDevLoadingViewManager = devLoadingViewManager;
 
     if (getDevSettings().isStartSamplingProfilerOnInit()) {
       // Only start the profiler. If its already running, there is an error
@@ -131,14 +126,6 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
             }
           });
     }
-  }
-
-  public DevLoadingViewManager getDevLoadingViewManager() {
-    return mDevLoadingViewManager;
-  }
-
-  public ReactInstanceDevHelper getReactInstanceManagerHelper() {
-    return mReactInstanceManagerHelper;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -770,7 +770,11 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     return mDevServerHelper;
   }
 
-  protected ReactInstanceDevHelper getReactInstanceDevHelper() {
+  public DevLoadingViewManager getDevLoadingViewManager() {
+    return mDevLoadingViewManager;
+  }
+
+  public ReactInstanceDevHelper getReactInstanceDevHelper() {
     return mReactInstanceDevHelper;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.SurfaceDelegate;
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback;
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevOptionHandler;
 import com.facebook.react.devsupport.interfaces.DevSplitBundleCallback;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -124,6 +125,11 @@ public class DisabledDevSupportManager implements DevSupportManager {
 
   @Override
   public String getDownloadedJSBundleFile() {
+    return null;
+  }
+
+  @Override
+  public DevLoadingViewManager getDevLoadingViewManager() {
     return null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -66,6 +66,8 @@ public interface DevSupportManager extends JSExceptionHandler {
 
   String getDownloadedJSBundleFile();
 
+  DevLoadingViewManager getDevLoadingViewManager();
+
   boolean hasUpToDateJSBundleInCache();
 
   void reloadSettings();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.java
@@ -13,8 +13,7 @@ import com.facebook.react.bridge.JSExceptionHandler;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
-import com.facebook.react.devsupport.BridgeDevSupportManager;
-import com.facebook.react.devsupport.DefaultDevLoadingViewImplementation;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.module.annotations.ReactModule;
 
@@ -28,14 +27,9 @@ public class DevLoadingModule extends NativeDevLoadingViewSpec {
   public DevLoadingModule(ReactApplicationContext reactContext) {
     super(reactContext);
     mJSExceptionHandler = reactContext.getJSExceptionHandler();
-    if (mJSExceptionHandler != null && mJSExceptionHandler instanceof BridgeDevSupportManager) {
+    if (mJSExceptionHandler != null && mJSExceptionHandler instanceof DevSupportManager) {
       mDevLoadingViewManager =
-          ((BridgeDevSupportManager) mJSExceptionHandler).getDevLoadingViewManager();
-      mDevLoadingViewManager =
-          mDevLoadingViewManager != null
-              ? mDevLoadingViewManager
-              : new DefaultDevLoadingViewImplementation(
-                  ((BridgeDevSupportManager) mJSExceptionHandler).getReactInstanceManagerHelper());
+          ((DevSupportManager) mJSExceptionHandler).getDevLoadingViewManager();
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.java
@@ -40,7 +40,9 @@ public class DevLoadingModule extends NativeDevLoadingViewSpec {
         new Runnable() {
           @Override
           public void run() {
-            mDevLoadingViewManager.showMessage(message);
+            if (mDevLoadingViewManager != null) {
+              mDevLoadingViewManager.showMessage(message);
+            }
           }
         });
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Resolves https://github.com/facebook/react-native/issues/44682
Intended for React Native 0.72

BridgeDevSupportManager class and its dependencies should be stripped by Proguard in release builds. However, due to the usage of BridgeDevSupportManager in DevLoadingModule this wasn't happening.

Refactored the code to use only the DevSupportManager interface to mitigate the above problem. This is in line with the design pattern here https://github.com/facebook/react-native/blob/d724007364c4315e2cabace0fc6eae6e6212431d/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.java#L21-L26
DevSupportManagerBase always creates an instance of DevLoadingViewManager, which is why it need not be initialized again in DevLoadingModule.

This change brings down devsupport package size from ~52KB to ~12KB in release builds with proguard enabled


Also added a missing null check in mDevLoadingViewManager.showMessage() which could cause app crashes in certain cases.
Most of this PR is inspired by https://github.com/facebook/react-native/pull/40999 which is already in 0.73-stable 


## Changelog:
[INTERNAL] [FIXED] - Remove unnecessary usage of BridgeDevSupportManager in DevLoadingModule.

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Most of these changes are already live in 0.73. Checked template app release variant dex files in APK analyzer for before and after size comparison. Tested fast refresh capability in debug variant
