### PR TITLE
Integrate perfetto with UserPerformance API

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -11,7 +11,7 @@
 
 namespace facebook::react {
 
-std::shared_ptr<PerformanceEntryReporter>
+std::shared_ptr<PerformanceEntryReporter>&
 PerformanceEntryReporter::getInstance() {
   static auto instance = std::make_shared<PerformanceEntryReporter>();
   return instance;

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -89,7 +89,7 @@ class PerformanceEntryReporter {
   // the same thread.
   // TODO: Consider passing it as a parameter to the corresponding modules at
   // creation time instead of having the singleton.
-  static std::shared_ptr<PerformanceEntryReporter> getInstance();
+  static std::shared_ptr<PerformanceEntryReporter>& getInstance();
 
   struct PopPendingEntriesResult {
     std::vector<PerformanceEntry> entries;

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoCategories.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoCategories.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ReactPerfettoCategories.h"
+
+#ifdef WITH_PERFETTO
+
+PERFETTO_TRACK_EVENT_STATIC_STORAGE();
+
+#endif

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoCategories.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoCategories.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef WITH_PERFETTO
+
+#include <perfetto.h>
+
+PERFETTO_DEFINE_CATEGORIES(
+    perfetto::Category("react-native")
+        .SetDescription("User timing events from React Native"));
+
+#endif


### PR DESCRIPTION
Summary:
Based on bgirard initial changes in D53478653, this creates an initial integration of the Perfetto SDK with the User Timing API, allowing performance information to be logged from JS to Perfetto traces.

The logic in `initializePerfetto` may need to be to other targets (eg reactperflogger) once we want to make this usable in other components, but keeping it scoped to User Timing for now.

Changelog: [Internal]

Differential Revision: D57881823


