### PR TITLE
Make consistent focusable behavior

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -342,7 +342,9 @@ class TouchableHighlight extends React.Component<Props, State> {
         nextFocusRight={this.props.nextFocusRight}
         nextFocusUp={this.props.nextFocusUp}
         focusable={
-          this.props.focusable !== false && this.props.onPress !== undefined
+          this.props.focusable !== false &&
+          this.props.onPress !== undefined &&
+          !this.props.disabled
         }
         nativeID={this.props.id ?? this.props.nativeID}
         testID={this.props.testID}

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -287,7 +287,9 @@ class TouchableOpacity extends React.Component<Props, State> {
         hasTVPreferredFocus={this.props.hasTVPreferredFocus}
         hitSlop={this.props.hitSlop}
         focusable={
-          this.props.focusable !== false && this.props.onPress !== undefined
+          this.props.focusable !== false &&
+          this.props.onPress !== undefined &&
+          !this.props.disabled
         }
         ref={this.props.hostRef}
         {...eventHandlersWithoutBlurAndFocus}>

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -208,7 +208,10 @@ module.exports = function TouchableWithoutFeedback(props: Props): React.Node {
             disabled: props.disabled,
           }
         : _accessibilityState,
-    focusable: props.focusable !== false && props.onPress !== undefined,
+    focusable:
+      props.focusable !== false &&
+      props.onPress !== undefined &&
+      !props.disabled,
 
     accessibilityElementsHidden:
       props['aria-hidden'] ?? props.accessibilityElementsHidden,


### PR DESCRIPTION
Summary:
`focusable` props behaviors are inconsistent across different flavors of Touchable components. Some use the disabled prop to check if the component should be focusable, others do not.

This ensures all Touchable* component flavors use the disabled prop.

## Changelog

[General][Fixed] Fixed inconsistency in TouchableX component disabled / focusable behavior

Differential Revision: D57910488


