### PR TITLE
DrawerLayoutAndroid fix for Layout inspector to select correct node

### DIFF
--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -119,7 +119,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 type State = {|
-  statusBarBackgroundColor: ColorValue,
+  drawerOpened: boolean,
 |};
 
 /**
@@ -168,7 +168,9 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
       React.ElementRef<typeof AndroidDrawerLayoutNativeComponent>,
     >();
 
-  state: State = {statusBarBackgroundColor: null};
+  state: State = {
+    drawerOpened: false,
+  };
 
   render(): React.Node {
     const {
@@ -189,6 +191,7 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
             backgroundColor: drawerBackgroundColor,
           },
         ]}
+        pointerEvents={this.state.drawerOpened ? 'auto' : 'none'}
         collapsable={false}>
         {renderNavigationView()}
         {drawStatusBar && <View style={styles.drawerStatusBar} />}
@@ -245,12 +248,18 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
   };
 
   _onDrawerOpen = () => {
+    this.setState({
+      drawerOpened: true,
+    });
     if (this.props.onDrawerOpen) {
       this.props.onDrawerOpen();
     }
   };
 
   _onDrawerClose = () => {
+    this.setState({
+      drawerOpened: false,
+    });
     if (this.props.onDrawerClose) {
       this.props.onDrawerClose();
     }

--- a/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/__snapshots__/DrawerAndroid-test.js.snap
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/__snapshots__/DrawerAndroid-test.js.snap
@@ -33,6 +33,7 @@ exports[`<DrawerLayoutAndroid /> should render as expected: should deep render w
   />
   <View
     collapsable={false}
+    pointerEvents="none"
     style={
       Array [
         Object {
@@ -85,6 +86,7 @@ exports[`<DrawerLayoutAndroid /> should render as expected: should deep render w
   />
   <View
     collapsable={false}
+    pointerEvents="none"
     style={
       Array [
         Object {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

For DrawerLayoutAndroid in New Architecture, when we use ReactDev Tools layout inspection, incorrect node is being shown in the inspector tools.

This is because pointerEvents is not set to either `box-none` or `none` based on the drawer open/close state for the drawer child wrapper `View`.

Differential Revision: D57873834


