### PR TITLE
Clean up old code for microtasks in Hermes

### DIFF
--- a/packages/react-native/Libraries/Core/setUpTimers.js
+++ b/packages/react-native/Libraries/Core/setUpTimers.js
@@ -63,17 +63,12 @@ if (
   // mechanism to pass feature flags from RN to React in OSS.
   global.RN$enableMicrotasksInReact = true;
 
-  polyfillGlobal('queueMicrotask', () => {
-    const nativeQueueMicrotask =
+  polyfillGlobal(
+    'queueMicrotask',
+    () =>
       require('../../src/private/webapis/microtasks/specs/NativeMicrotasks')
-        .default?.queueMicrotask;
-    if (nativeQueueMicrotask) {
-      return nativeQueueMicrotask;
-    } else {
-      // For backwards-compatibility
-      return global.HermesInternal?.enqueueJob;
-    }
-  });
+        .default.queueMicrotask,
+  );
 
   // We shim the immediate APIs via `queueMicrotask` to maintain the backward
   // compatibility.

--- a/packages/react-native/src/private/webapis/microtasks/specs/NativeMicrotasks.js
+++ b/packages/react-native/src/private/webapis/microtasks/specs/NativeMicrotasks.js
@@ -16,4 +16,6 @@ export interface Spec extends TurboModule {
   +queueMicrotask: (callback: () => mixed) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('NativeMicrotasksCxx'): ?Spec);
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeMicrotasksCxx',
+): Spec);


### PR DESCRIPTION
Summary:
Changelog: [internal]

We had a fallback to use a Hermes internal API if the native module exposing `queueMicrotask` wasn't available. This is no longer necessary as the module is available everywhere we enable the event loop, so we can remove it.

Differential Revision: D57922076


