### PR TITLE
Reland: Simplify ReactViewGroup clip to border

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5555,21 +5555,21 @@ public abstract interface class com/facebook/react/uimanager/debug/NotThreadSafe
 
 public class com/facebook/react/uimanager/drawable/CSSBackgroundDrawable : android/graphics/drawable/Drawable {
 	public fun <init> (Landroid/content/Context;)V
-	public fun borderBoxPath ()Landroid/graphics/Path;
 	public fun draw (Landroid/graphics/Canvas;)V
 	public fun getAlpha ()I
+	public fun getBorderBoxPath ()Landroid/graphics/Path;
 	public fun getBorderColor (I)I
 	public fun getBorderRadius ()Lcom/facebook/react/uimanager/style/BorderRadiusStyle;
 	public fun getBorderWidthOrDefaultTo (FI)F
 	public fun getComputedBorderRadius ()Lcom/facebook/react/uimanager/style/ComputedBorderRadius;
-	public fun getDirectionAwareBorderInsets ()Landroid/graphics/RectF;
 	public fun getFullBorderWidth ()F
 	public fun getLayoutDirection ()I
 	public fun getOpacity ()I
 	public fun getOutline (Landroid/graphics/Outline;)V
+	public fun getPaddingBoxPath ()Landroid/graphics/Path;
+	public fun getPaddingBoxRect ()Landroid/graphics/RectF;
 	public fun hasRoundedBorders ()Z
 	protected fun onBoundsChange (Landroid/graphics/Rect;)V
-	public fun paddingBoxPath ()Landroid/graphics/Path;
 	public fun setAlpha (I)V
 	public fun setBorderColor (IFF)V
 	public fun setBorderRadius (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Lcom/facebook/react/uimanager/LengthPercentage;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowDrawable.kt
@@ -81,7 +81,13 @@ internal class BoxShadowDrawable(
     }
 
     with(canvas) {
-      clipOutPath(background.borderBoxPath())
+      val borderBoxPath = background.getBorderBoxPath()
+      if (borderBoxPath != null) {
+        clipOutPath(borderBoxPath)
+      } else {
+        clipOutRect(background.getBorderBoxRect())
+      }
+
       drawRenderNode(renderNode)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -316,14 +316,39 @@ public class CSSBackgroundDrawable extends Drawable {
     return mColor;
   }
 
-  public Path borderBoxPath() {
-    updatePath();
-    return Preconditions.checkNotNull(mOuterClipPathForBorderRadius);
+  public @Nullable Path getBorderBoxPath() {
+    if (hasRoundedBorders()) {
+      updatePath();
+      return Preconditions.checkNotNull(mOuterClipPathForBorderRadius);
+    }
+
+    return null;
   }
 
-  public Path paddingBoxPath() {
-    updatePath();
-    return Preconditions.checkNotNull(mInnerClipPathForBorderRadius);
+  public RectF getBorderBoxRect() {
+    return new RectF(getBounds());
+  }
+
+  public @Nullable Path getPaddingBoxPath() {
+    if (hasRoundedBorders()) {
+      updatePath();
+      return Preconditions.checkNotNull(mInnerClipPathForBorderRadius);
+    }
+
+    return null;
+  }
+
+  public RectF getPaddingBoxRect() {
+    @Nullable RectF insets = getDirectionAwareBorderInsets();
+    if (insets == null) {
+      return new RectF(0, 0, getBounds().width(), getBounds().height());
+    }
+
+    return new RectF(
+        insets.left,
+        insets.top,
+        getBounds().width() - insets.right,
+        getBounds().height() - insets.bottom);
   }
 
   private void drawRoundedBackgroundWithBorders(Canvas canvas) {
@@ -331,7 +356,7 @@ public class CSSBackgroundDrawable extends Drawable {
     canvas.save();
 
     // Clip outer border
-    canvas.clipPath(borderBoxPath(), Region.Op.INTERSECT);
+    canvas.clipPath(getBorderBoxPath(), Region.Op.INTERSECT);
 
     // Draws the View without its border first (with background color fill)
     int useColor = ColorUtils.setAlphaComponent(mColor, getOpacity());
@@ -390,7 +415,7 @@ public class CSSBackgroundDrawable extends Drawable {
         mPaint.setStyle(Paint.Style.FILL);
 
         // Clip inner border
-        canvas.clipPath(paddingBoxPath(), Region.Op.DIFFERENCE);
+        canvas.clipPath(getPaddingBoxPath(), Region.Op.DIFFERENCE);
 
         final boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
         int colorStart = getBorderColor(Spacing.START);
@@ -1304,7 +1329,7 @@ public class CSSBackgroundDrawable extends Drawable {
     return CSSBackgroundDrawable.colorFromAlphaAndRGBComponents(alpha, rgb);
   }
 
-  public RectF getDirectionAwareBorderInsets() {
+  private RectF getDirectionAwareBorderInsets() {
     final float borderWidth = getBorderWidthOrDefaultTo(0, Spacing.ALL);
     final float borderTopWidth = getBorderWidthOrDefaultTo(borderWidth, Spacing.TOP);
     final float borderBottomWidth = getBorderWidthOrDefaultTo(borderWidth, Spacing.BOTTOM);

--- a/packages/rn-tester/js/examples/Border/BorderExample.js
+++ b/packages/rn-tester/js/examples/Border/BorderExample.js
@@ -12,9 +12,11 @@
 
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
+import hotdog from '../../assets/hotdog.jpg';
 import * as React from 'react';
 import {
   DynamicColorIOS,
+  Image,
   Platform,
   PlatformColor,
   StyleSheet,
@@ -213,6 +215,23 @@ const styles = StyleSheet.create({
       Platform.OS === 'ios'
         ? DynamicColorIOS({light: 'magenta', dark: 'cyan'})
         : 'black',
+  },
+  borderWithoutClipping: {
+    borderWidth: 10,
+    overflow: 'visible',
+  },
+  borderWithClipping: {
+    borderWidth: 10,
+    overflow: 'hidden',
+  },
+  borderWithClippingAndRadius: {
+    borderWidth: 10,
+    borderRadius: 30,
+    overflow: 'hidden',
+  },
+  hotdog: {
+    width: 100,
+    height: 100,
   },
 });
 
@@ -474,6 +493,51 @@ export default ({
             testID="border-test-dynamic-color-ios"
             style={[styles.box, styles.border16]}
           />
+        );
+      },
+    },
+    {
+      title: 'Child without clipping',
+      name: 'child-no-clipping',
+      description:
+        '"overflow: visible" will cause child content to show above borders',
+      render: function (): React.Node {
+        return (
+          <View
+            testID="border-test-child-no-clipping"
+            style={[styles.box, styles.borderWithoutClipping]}>
+            <Image source={hotdog} style={styles.hotdog} />
+          </View>
+        );
+      },
+    },
+    {
+      title: 'Child clipping',
+      name: 'child-clipping',
+      description:
+        '"overflow: hidden" will cause child content to be clipped to borders',
+      render: function (): React.Node {
+        return (
+          <View
+            testID="border-test-child-clipping"
+            style={[styles.box, styles.borderWithClipping]}>
+            <Image source={hotdog} style={styles.hotdog} />
+          </View>
+        );
+      },
+    },
+    {
+      title: 'Child clipping with radius',
+      name: 'child-clipping-radius',
+      description:
+        '"overflow: hidden" will cause child content to be clipped to rounded corners',
+      render: function (): React.Node {
+        return (
+          <View
+            testID="border-test-child-clipping-radius"
+            style={[styles.box, styles.borderWithClippingAndRadius]}>
+            <Image source={hotdog} style={styles.hotdog} />
+          </View>
         );
       },
     },


### PR DESCRIPTION
Summary:
## Reland

The original change had getBorderBoxPath() and getBorderBoxPath() returning non-nullable path, which is incorrect. The fix here is to only calculate and return path when there are rounded corners set, and otherwise force caller to handle rect  when path is null. Code in ReactViewGroup was already handling this, but code in BoxShadowDrawable was not.

The crash seemed to happen on Android API 24 emulators, where `onBoundsChanged` is not called, so `mNeedUpdatePathForBorderRadius` is never set unless some other props are set. But, we really shouldn't force path creation unless needed.

## Original

We can remove most of the code for clipping children to border radius, and recalculating paths, in ReactViewGroup, and rely on the padding box path/rect already set.

I will move this to something more generic up the stack so other native components can reuse this logic.

Changelog: [Internal]

Differential Revision: D57934907


