### PR TITLE
[RN][CI] Remove Old Arch build jobs

### DIFF
--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -66,27 +66,26 @@
       - test_ios_template:
           requires:
             - build_npm_package
+          architecture: "NewArch"
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
-              architecture: ["NewArch", "OldArch"]
             exclude:
               # This config is tested with Ruby 3.2.0. Let's not double test it.
               - flavor: "Debug"
                 jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
-                architecture: "NewArch"
       - test_ios_rntester:
           requires:
             - build_hermes_macos
           use_frameworks: "DynamicFrameworks"
+          architecture: "NewArch"
           ruby_version: "3.2.0"
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
-              architecture: ["NewArch", "OldArch"]
       - test_ios_rntester:
           run_unit_tests: true
           use_frameworks: "StaticLibraries"

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -55,27 +55,26 @@
       - test_ios_template:
           requires:
             - build_npm_package
+          architecture: "NewArch"
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
-              architecture: ["NewArch", "OldArch"]
             exclude:
               # This config is tested with Ruby 3.2.0. Let's not double test it.
               - flavor: "Debug"
                 jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
-                architecture: "NewArch"
       - test_ios_rntester:
           requires:
             - build_hermes_macos
           use_frameworks: "DynamicFrameworks"
           ruby_version: "3.2.0"
+          architecture: "NewArch"
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
-              architecture: ["NewArch", "OldArch"]
       - test_ios_rntester:
           run_unit_tests: true
           use_frameworks: "StaticLibraries"

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -8,7 +8,6 @@ on:
         - main
         - "*-stable"
 
-
 jobs:
   set_release_type:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary:

Based on #44723.
This PR removes some Old Arch build only jobs on iOS.
Some of the recent changes where unifying the build process across archs, so we don't have to build Old and New Arch

## Changelog:
[Internal] - Remove OldArch jobs when they are not required

## Test Plan:
CCI is green
