### PR TITLE
Avoid returning mutable Path in CSSBackgroundDrawable

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5555,9 +5555,10 @@ public abstract interface class com/facebook/react/uimanager/debug/NotThreadSafe
 
 public class com/facebook/react/uimanager/drawable/CSSBackgroundDrawable : android/graphics/drawable/Drawable {
 	public fun <init> (Landroid/content/Context;)V
-	public fun borderBoxPath ()Landroid/graphics/Path;
 	public fun draw (Landroid/graphics/Canvas;)V
 	public fun getAlpha ()I
+	public fun getBorderBoxPath ()Landroid/graphics/Path;
+	public fun getBorderBoxRect ()Landroid/graphics/RectF;
 	public fun getBorderColor (I)I
 	public fun getBorderRadius ()Lcom/facebook/react/uimanager/style/BorderRadiusStyle;
 	public fun getBorderWidthOrDefaultTo (FI)F
@@ -5567,9 +5568,10 @@ public class com/facebook/react/uimanager/drawable/CSSBackgroundDrawable : andro
 	public fun getLayoutDirection ()I
 	public fun getOpacity ()I
 	public fun getOutline (Landroid/graphics/Outline;)V
+	public fun getPaddingBoxPath ()Landroid/graphics/Path;
+	public fun getPaddingBoxRect ()Landroid/graphics/RectF;
 	public fun hasRoundedBorders ()Z
 	protected fun onBoundsChange (Landroid/graphics/Rect;)V
-	public fun paddingBoxPath ()Landroid/graphics/Path;
 	public fun setAlpha (I)V
 	public fun setBorderColor (IFF)V
 	public fun setBorderRadius (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Lcom/facebook/react/uimanager/LengthPercentage;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowDrawable.kt
@@ -81,7 +81,13 @@ internal class BoxShadowDrawable(
     }
 
     with(canvas) {
-      clipOutPath(background.borderBoxPath())
+      val borderBoxPath = background.getBorderBoxPath()
+      if (borderBoxPath != null) {
+        clipOutPath(borderBoxPath)
+      } else {
+        clipOutRect(background.getBorderBoxRect())
+      }
+
       drawRenderNode(renderNode)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -316,14 +316,39 @@ public class CSSBackgroundDrawable extends Drawable {
     return mColor;
   }
 
-  public Path borderBoxPath() {
-    updatePath();
-    return Preconditions.checkNotNull(mOuterClipPathForBorderRadius);
+  public @Nullable Path getBorderBoxPath() {
+    if (hasRoundedBorders()) {
+      updatePath();
+      return Preconditions.checkNotNull(mOuterClipPathForBorderRadius);
+    }
+
+    return null;
   }
 
-  public Path paddingBoxPath() {
-    updatePath();
-    return Preconditions.checkNotNull(mInnerClipPathForBorderRadius);
+  public RectF getBorderBoxRect() {
+    return new RectF(getBounds());
+  }
+
+  public @Nullable Path getPaddingBoxPath() {
+    if (hasRoundedBorders()) {
+      updatePath();
+      return Preconditions.checkNotNull(mInnerClipPathForBorderRadius);
+    }
+
+    return null;
+  }
+
+  public RectF getPaddingBoxRect() {
+    @Nullable RectF insets = getDirectionAwareBorderInsets();
+    if (insets == null) {
+      return new RectF(0, 0, getBounds().width(), getBounds().height());
+    }
+
+    return new RectF(
+        insets.left,
+        insets.top,
+        getBounds().width() - insets.right,
+        getBounds().height() - insets.bottom);
   }
 
   private void drawRoundedBackgroundWithBorders(Canvas canvas) {
@@ -331,7 +356,7 @@ public class CSSBackgroundDrawable extends Drawable {
     canvas.save();
 
     // Clip outer border
-    canvas.clipPath(borderBoxPath(), Region.Op.INTERSECT);
+    canvas.clipPath(Preconditions.checkNotNull(getBorderBoxPath()), Region.Op.INTERSECT);
 
     // Draws the View without its border first (with background color fill)
     int useColor = ColorUtils.setAlphaComponent(mColor, getOpacity());
@@ -390,7 +415,7 @@ public class CSSBackgroundDrawable extends Drawable {
         mPaint.setStyle(Paint.Style.FILL);
 
         // Clip inner border
-        canvas.clipPath(paddingBoxPath(), Region.Op.DIFFERENCE);
+        canvas.clipPath(Preconditions.checkNotNull(getPaddingBoxPath()), Region.Op.DIFFERENCE);
 
         final boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
         int colorStart = getBorderColor(Spacing.START);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -319,7 +319,7 @@ public class CSSBackgroundDrawable extends Drawable {
   public @Nullable Path getBorderBoxPath() {
     if (hasRoundedBorders()) {
       updatePath();
-      return Preconditions.checkNotNull(mOuterClipPathForBorderRadius);
+      return new Path(Preconditions.checkNotNull(mOuterClipPathForBorderRadius));
     }
 
     return null;
@@ -332,7 +332,7 @@ public class CSSBackgroundDrawable extends Drawable {
   public @Nullable Path getPaddingBoxPath() {
     if (hasRoundedBorders()) {
       updatePath();
-      return Preconditions.checkNotNull(mInnerClipPathForBorderRadius);
+      return new Path(Preconditions.checkNotNull(mInnerClipPathForBorderRadius));
     }
 
     return null;
@@ -356,7 +356,7 @@ public class CSSBackgroundDrawable extends Drawable {
     canvas.save();
 
     // Clip outer border
-    canvas.clipPath(Preconditions.checkNotNull(getBorderBoxPath()), Region.Op.INTERSECT);
+    canvas.clipPath(Preconditions.checkNotNull(mOuterClipPathForBorderRadius), Region.Op.INTERSECT);
 
     // Draws the View without its border first (with background color fill)
     int useColor = ColorUtils.setAlphaComponent(mColor, getOpacity());
@@ -415,7 +415,8 @@ public class CSSBackgroundDrawable extends Drawable {
         mPaint.setStyle(Paint.Style.FILL);
 
         // Clip inner border
-        canvas.clipPath(Preconditions.checkNotNull(getPaddingBoxPath()), Region.Op.DIFFERENCE);
+        canvas.clipPath(
+            Preconditions.checkNotNull(mInnerClipPathForBorderRadius), Region.Op.DIFFERENCE);
 
         final boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
         int colorStart = getBorderColor(Spacing.START);


### PR DESCRIPTION
Summary:
We are returning a Path to callers, which shouldn't be mutated. This isn't really safe. Return a copy to external callers instead, if they need a path to work with.

Changelog: [Internal]

Differential Revision: D57996157


