### PR TITLE
Support clipping to children everywhere using ReactViewBackgroundManager

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5555,9 +5555,9 @@ public abstract interface class com/facebook/react/uimanager/debug/NotThreadSafe
 
 public class com/facebook/react/uimanager/drawable/CSSBackgroundDrawable : android/graphics/drawable/Drawable {
 	public fun <init> (Landroid/content/Context;)V
-	public fun borderBoxPath ()Landroid/graphics/Path;
 	public fun draw (Landroid/graphics/Canvas;)V
 	public fun getAlpha ()I
+	public fun getBorderBoxPath ()Landroid/graphics/Path;
 	public fun getBorderColor (I)I
 	public fun getBorderRadius ()Lcom/facebook/react/uimanager/style/BorderRadiusStyle;
 	public fun getBorderWidthOrDefaultTo (FI)F
@@ -5567,9 +5567,10 @@ public class com/facebook/react/uimanager/drawable/CSSBackgroundDrawable : andro
 	public fun getLayoutDirection ()I
 	public fun getOpacity ()I
 	public fun getOutline (Landroid/graphics/Outline;)V
+	public fun getPaddingBoxPath ()Landroid/graphics/Path;
+	public fun getPaddingBoxRect ()Landroid/graphics/RectF;
 	public fun hasRoundedBorders ()Z
 	protected fun onBoundsChange (Landroid/graphics/Rect;)V
-	public fun paddingBoxPath ()Landroid/graphics/Path;
 	public fun setAlpha (I)V
 	public fun setBorderColor (IFF)V
 	public fun setBorderRadius (Lcom/facebook/react/uimanager/style/BorderRadiusProp;Lcom/facebook/react/uimanager/LengthPercentage;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowDrawable.kt
@@ -81,7 +81,13 @@ internal class BoxShadowDrawable(
     }
 
     with(canvas) {
-      clipOutPath(background.borderBoxPath())
+      val borderBoxPath = background.getBorderBoxPath()
+      if (borderBoxPath != null) {
+        clipOutPath(borderBoxPath)
+      } else {
+        clipOutRect(background.getBorderBoxRect())
+      }
+
       drawRenderNode(renderNode)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -316,14 +316,39 @@ public class CSSBackgroundDrawable extends Drawable {
     return mColor;
   }
 
-  public Path borderBoxPath() {
-    updatePath();
-    return Preconditions.checkNotNull(mOuterClipPathForBorderRadius);
+  public @Nullable Path getBorderBoxPath() {
+    if (hasRoundedBorders()) {
+      updatePath();
+      return Preconditions.checkNotNull(mOuterClipPathForBorderRadius);
+    }
+
+    return null;
   }
 
-  public Path paddingBoxPath() {
-    updatePath();
-    return Preconditions.checkNotNull(mInnerClipPathForBorderRadius);
+  public RectF getBorderBoxRect() {
+    return new RectF(getBounds());
+  }
+
+  public @Nullable Path getPaddingBoxPath() {
+    if (hasRoundedBorders()) {
+      updatePath();
+      return Preconditions.checkNotNull(mInnerClipPathForBorderRadius);
+    }
+
+    return null;
+  }
+
+  public RectF getPaddingBoxRect() {
+    @Nullable RectF insets = getDirectionAwareBorderInsets();
+    if (insets == null) {
+      return new RectF(0, 0, getBounds().width(), getBounds().height());
+    }
+
+    return new RectF(
+        insets.left,
+        insets.top,
+        getBounds().width() - insets.right,
+        getBounds().height() - insets.bottom);
   }
 
   private void drawRoundedBackgroundWithBorders(Canvas canvas) {
@@ -331,7 +356,7 @@ public class CSSBackgroundDrawable extends Drawable {
     canvas.save();
 
     // Clip outer border
-    canvas.clipPath(borderBoxPath(), Region.Op.INTERSECT);
+    canvas.clipPath(Preconditions.checkNotNull(getBorderBoxPath()), Region.Op.INTERSECT);
 
     // Draws the View without its border first (with background color fill)
     int useColor = ColorUtils.setAlphaComponent(mColor, getOpacity());
@@ -390,7 +415,7 @@ public class CSSBackgroundDrawable extends Drawable {
         mPaint.setStyle(Paint.Style.FILL);
 
         // Clip inner border
-        canvas.clipPath(paddingBoxPath(), Region.Op.DIFFERENCE);
+        canvas.clipPath(Preconditions.checkNotNull(getPaddingBoxPath()), Region.Op.DIFFERENCE);
 
         final boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
         int colorStart = getBorderColor(Spacing.START);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -319,7 +319,7 @@ public class CSSBackgroundDrawable extends Drawable {
   public @Nullable Path getBorderBoxPath() {
     if (hasRoundedBorders()) {
       updatePath();
-      return Preconditions.checkNotNull(mOuterClipPathForBorderRadius);
+      return new Path(Preconditions.checkNotNull(mOuterClipPathForBorderRadius));
     }
 
     return null;
@@ -332,7 +332,7 @@ public class CSSBackgroundDrawable extends Drawable {
   public @Nullable Path getPaddingBoxPath() {
     if (hasRoundedBorders()) {
       updatePath();
-      return Preconditions.checkNotNull(mInnerClipPathForBorderRadius);
+      return new Path(Preconditions.checkNotNull(mInnerClipPathForBorderRadius));
     }
 
     return null;
@@ -356,7 +356,7 @@ public class CSSBackgroundDrawable extends Drawable {
     canvas.save();
 
     // Clip outer border
-    canvas.clipPath(Preconditions.checkNotNull(getBorderBoxPath()), Region.Op.INTERSECT);
+    canvas.clipPath(Preconditions.checkNotNull(mOuterClipPathForBorderRadius), Region.Op.INTERSECT);
 
     // Draws the View without its border first (with background color fill)
     int useColor = ColorUtils.setAlphaComponent(mColor, getOpacity());
@@ -415,7 +415,8 @@ public class CSSBackgroundDrawable extends Drawable {
         mPaint.setStyle(Paint.Style.FILL);
 
         // Clip inner border
-        canvas.clipPath(Preconditions.checkNotNull(getPaddingBoxPath()), Region.Op.DIFFERENCE);
+        canvas.clipPath(
+            Preconditions.checkNotNull(mInnerClipPathForBorderRadius), Region.Op.DIFFERENCE);
 
         final boolean isRTL = getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
         int colorStart = getBorderColor(Spacing.START);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -84,7 +84,6 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   private final OnScrollDispatchHelper mOnScrollDispatchHelper = new OnScrollDispatchHelper();
   private final @Nullable OverScroller mScroller;
   private final VelocityHelper mVelocityHelper = new VelocityHelper();
-  private final Rect mRect = new Rect();
   private final Rect mOverflowInset = new Rect();
 
   private boolean mActivelyScrolling;
@@ -145,6 +144,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
     setOnHierarchyChangeListener(this);
     setClipChildren(false);
+    mReactBackgroundManager.setOverflow(ViewProps.SCROLL);
   }
 
   public boolean getScrollEnabled() {
@@ -273,7 +273,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
   public void setOverflow(@Nullable String overflow) {
     mOverflow = overflow;
-    invalidate();
+    mReactBackgroundManager.setOverflow(overflow == null ? ViewProps.SCROLL : overflow);
   }
 
   public void setMaintainVisibleContentPosition(
@@ -306,14 +306,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   @Override
-  protected void onDraw(Canvas canvas) {
-    if (DEBUG_MODE) {
-      FLog.i(TAG, "onDraw[%d]", getId());
-    }
-    getDrawingRect(mRect);
-    if (!ViewProps.VISIBLE.equals(mOverflow)) {
-      canvas.clipRect(mRect);
-    }
+  public void onDraw(Canvas canvas) {
+    mReactBackgroundManager.maybeClipToPaddingBox(canvas);
     super.onDraw(canvas);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -83,7 +83,6 @@ public class ReactScrollView extends ScrollView
   private final OnScrollDispatchHelper mOnScrollDispatchHelper = new OnScrollDispatchHelper();
   private final @Nullable OverScroller mScroller;
   private final VelocityHelper mVelocityHelper = new VelocityHelper();
-  private final Rect mRect = new Rect(); // for reuse to avoid allocation
   private final Rect mTempRect = new Rect();
   private final Rect mOverflowInset = new Rect();
 
@@ -136,6 +135,7 @@ public class ReactScrollView extends ScrollView
     setOnHierarchyChangeListener(this);
     setScrollBarStyle(SCROLLBARS_OUTSIDE_OVERLAY);
     setClipChildren(false);
+    mReactBackgroundManager.setOverflow(ViewProps.SCROLL);
 
     ViewCompat.setAccessibilityDelegate(this, new ReactScrollViewAccessibilityDelegate());
   }
@@ -261,7 +261,7 @@ public class ReactScrollView extends ScrollView
 
   public void setOverflow(@Nullable String overflow) {
     mOverflow = overflow;
-    invalidate();
+    mReactBackgroundManager.setOverflow(overflow == null ? ViewProps.SCROLL : overflow);
   }
 
   public void setMaintainVisibleContentPosition(
@@ -640,13 +640,14 @@ public class ReactScrollView extends ScrollView
         mEndBackground.draw(canvas);
       }
     }
-    getDrawingRect(mRect);
-
-    if (!ViewProps.VISIBLE.equals(mOverflow)) {
-      canvas.clipRect(mRect);
-    }
 
     super.draw(canvas);
+  }
+
+  @Override
+  public void onDraw(Canvas canvas) {
+    mReactBackgroundManager.maybeClipToPaddingBox(canvas);
+    super.onDraw(canvas);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -382,6 +382,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
       setText(getSpanned());
     }
 
+    mReactBackgroundManager.maybeClipToPaddingBox(canvas);
+
     super.onDraw(canvas);
   }
 
@@ -740,5 +742,9 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     if (!Float.isNaN(mLetterSpacing)) {
       super.setLetterSpacing(mLetterSpacing);
     }
+  }
+
+  public void setOverflow(@Nullable String overflow) {
+    mReactBackgroundManager.setOverflow(overflow);
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.ReactAccessibilityDelegate;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.views.text.internal.span.ReactClickableSpan;
 import com.facebook.react.views.text.internal.span.TextInlineImageSpan;
 import com.facebook.yoga.YogaMeasureMode;
@@ -219,5 +220,10 @@ public class ReactTextViewManager
   @Override
   public void setPadding(ReactTextView view, int left, int top, int right, int bottom) {
     view.setPadding(left, top, right, bottom);
+  }
+
+  @ReactProp(name = "overflow")
+  public void setOverflow(ReactTextView view, @Nullable String overflow) {
+    view.setOverflow(overflow);
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -10,6 +10,7 @@ package com.facebook.react.views.textinput;
 import static com.facebook.react.uimanager.UIManagerHelper.getReactContext;
 
 import android.content.Context;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Rect;
@@ -1224,6 +1225,16 @@ public class ReactEditText extends AppCompatEditText {
 
   void setEventDispatcher(@Nullable EventDispatcher eventDispatcher) {
     mEventDispatcher = eventDispatcher;
+  }
+
+  public void setOverflow(@Nullable String overflow) {
+    mReactBackgroundManager.setOverflow(overflow);
+  }
+
+  @Override
+  public void onDraw(Canvas canvas) {
+    mReactBackgroundManager.maybeClipToPaddingBox(canvas);
+    super.onDraw(canvas);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1043,6 +1043,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setBorderColor(SPACING_TYPES[index], rgbComponent, alphaComponent);
   }
 
+  @ReactProp(name = "overflow")
+  public void setOverflow(ReactEditText view, @Nullable String overflow) {
+    view.setOverflow(overflow);
+  }
+
   @Override
   protected void onAfterUpdateTransaction(ReactEditText view) {
     super.onAfterUpdateTransaction(view);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
@@ -7,19 +7,30 @@
 
 package com.facebook.react.views.view;
 
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Path;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.view.View;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
+import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable;
 
 /** Class that manages the background for views and borders. */
 public class ReactViewBackgroundManager {
+  private static enum Overflow {
+    VISIBLE,
+    HIDDEN,
+    SCROLL,
+  }
 
-  private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
+  private @Nullable CSSBackgroundDrawable mCSSBackgroundDrawable;
   private View mView;
   private int mColor = Color.TRANSPARENT;
+  private Overflow mOverflow = Overflow.VISIBLE;
 
   public ReactViewBackgroundManager(View view) {
     mView = view;
@@ -28,29 +39,29 @@ public class ReactViewBackgroundManager {
   public void cleanup() {
     ViewCompat.setBackground(mView, null);
     mView = null;
-    mReactBackgroundDrawable = null;
+    mCSSBackgroundDrawable = null;
   }
 
-  private ReactViewBackgroundDrawable getOrCreateReactViewBackground() {
-    if (mReactBackgroundDrawable == null) {
-      mReactBackgroundDrawable = new ReactViewBackgroundDrawable(mView.getContext());
+  private CSSBackgroundDrawable getOrCreateReactViewBackground() {
+    if (mCSSBackgroundDrawable == null) {
+      mCSSBackgroundDrawable = new CSSBackgroundDrawable(mView.getContext());
       Drawable backgroundDrawable = mView.getBackground();
       ViewCompat.setBackground(
           mView, null); // required so that drawable callback is cleared before we add the
       // drawable back as a part of LayerDrawable
       if (backgroundDrawable == null) {
-        ViewCompat.setBackground(mView, mReactBackgroundDrawable);
+        ViewCompat.setBackground(mView, mCSSBackgroundDrawable);
       } else {
         LayerDrawable layerDrawable =
-            new LayerDrawable(new Drawable[] {mReactBackgroundDrawable, backgroundDrawable});
+            new LayerDrawable(new Drawable[] {mCSSBackgroundDrawable, backgroundDrawable});
         ViewCompat.setBackground(mView, layerDrawable);
       }
     }
-    return mReactBackgroundDrawable;
+    return mCSSBackgroundDrawable;
   }
 
   public void setBackgroundColor(int color) {
-    if (color == Color.TRANSPARENT && mReactBackgroundDrawable == null) {
+    if (color == Color.TRANSPARENT && mCSSBackgroundDrawable == null) {
       // don't do anything, no need to allocate ReactBackgroundDrawable for transparent background
     } else {
       getOrCreateReactViewBackground().setColor(color);
@@ -83,5 +94,51 @@ public class ReactViewBackgroundManager {
 
   public void setBorderStyle(@Nullable String style) {
     getOrCreateReactViewBackground().setBorderStyle(style);
+  }
+
+  public void setOverflow(@Nullable String overflow) {
+    Overflow lastOverflow = mOverflow;
+
+    if ("hidden".equals(overflow)) {
+      mOverflow = Overflow.HIDDEN;
+    } else if ("scroll".equals(overflow)) {
+      mOverflow = Overflow.SCROLL;
+    } else {
+      mOverflow = Overflow.VISIBLE;
+    }
+
+    if (lastOverflow != mOverflow) {
+      mView.invalidate();
+    }
+  }
+
+  /**
+   * Sets the canvas clipping region to exclude any area below or outide of borders if "overflow" is
+   * set to clip to padding box.
+   */
+  public void maybeClipToPaddingBox(Canvas canvas) {
+    if (mOverflow == Overflow.VISIBLE) {
+      return;
+    }
+
+    // The canvas may be scrolled, so we need to offset
+    Rect drawingRect = new Rect();
+    mView.getDrawingRect(drawingRect);
+
+    @Nullable CSSBackgroundDrawable cssBackground = mCSSBackgroundDrawable;
+    if (cssBackground == null) {
+      canvas.clipRect(drawingRect);
+      return;
+    }
+
+    @Nullable Path paddingBoxPath = cssBackground.getPaddingBoxPath();
+    if (paddingBoxPath != null) {
+      paddingBoxPath.offset(drawingRect.left, drawingRect.top);
+      canvas.clipPath(paddingBoxPath);
+    } else {
+      RectF paddingBoxRect = cssBackground.getPaddingBoxRect();
+      paddingBoxRect.offset(drawingRect.left, drawingRect.top);
+      canvas.clipRect(paddingBoxRect);
+    }
   }
 }

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -425,6 +425,24 @@ const examples: Array<RNTesterModuleExample> = [
       return <AppendingList />;
     },
   },
+  {
+    name: 'clipToPaddingBox',
+    title: '<ScrollView> clip to padding box\n',
+    description:
+      'Children should be clipped to the padding box of the ScrollView',
+    render() {
+      return <ClippingExampleVertical />;
+    },
+  },
+  {
+    name: 'clipToPaddingBoxHorizontal',
+    title: '<ScrollView> clip to padding box (horizontal = true)\n',
+    description:
+      'Children should be clipped to the padding box of the horizontal ScrollView',
+    render() {
+      return <ClippingExampleHorizontal />;
+    },
+  },
 ];
 
 if (Platform.OS === 'ios') {
@@ -1276,6 +1294,35 @@ const BouncesExampleVertical = () => {
     </View>
   );
 };
+
+function ClippingExampleVertical() {
+  return (
+    <ScrollView
+      testID="clipping_example_vertical"
+      style={[
+        styles.scrollView,
+        {height: 200, borderRadius: 100, borderColor: 'red', borderWidth: 5},
+      ]}
+      nestedScrollEnabled={true}>
+      {ITEMS.map(createItemRow)}
+    </ScrollView>
+  );
+}
+
+function ClippingExampleHorizontal() {
+  return (
+    <ScrollView
+      testID="clipping_example_horizontal"
+      horizontal={true}
+      style={[
+        styles.scrollView,
+        {height: 200, borderRadius: 100, borderColor: 'red', borderWidth: 5},
+      ]}
+      nestedScrollEnabled={true}>
+      {ITEMS.map(createItemRow)}
+    </ScrollView>
+  );
+}
 
 class Item extends React.PureComponent<{|
   msg?: string,

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -1340,6 +1340,29 @@ const examples = [
       );
     },
   },
+  {
+    title: 'Clipping',
+    name: 'clipping',
+    render: function (): React.Node {
+      return (
+        <View>
+          <Text
+            testID="text-clipping"
+            style={{
+              borderRadius: 50,
+              padding: 0,
+              borderColor: 'red',
+              borderWidth: 5,
+              overflow: 'hidden',
+              fontSize: 16,
+            }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </Text>
+        </View>
+      );
+    },
+  },
   TextInlineViewsExample,
 ];
 

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1329,6 +1329,29 @@ const examples = [
       );
     },
   },
+  {
+    title: 'Clipping',
+    name: 'clipping',
+    render: function (): React.Node {
+      return (
+        <View>
+          <Text
+            testID="text-clipping"
+            style={{
+              borderRadius: 50,
+              padding: 0,
+              borderColor: 'red',
+              borderWidth: 5,
+              overflow: 'hidden',
+              fontSize: 16,
+            }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </Text>
+        </View>
+      );
+    },
+  },
   TextInlineViewsExample,
 ];
 

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1097,4 +1097,28 @@ module.exports = ([
       );
     },
   },
+  {
+    title: 'Clipping',
+    name: 'clipping',
+    render: function (): React.Node {
+      return (
+        <View>
+          <ExampleTextInput
+            multiline={true}
+            testID="textinput-clipping"
+            style={{
+              borderRadius: 50,
+              padding: 0,
+              borderColor: 'red',
+              borderWidth: 5,
+              overflow: 'hidden',
+              fontSize: 16,
+            }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </ExampleTextInput>
+        </View>
+      );
+    },
+  },
 ]: Array<RNTesterModuleExample>);


### PR DESCRIPTION
Summary:
This integrates functionality for clipping content to padding box into `ReactViewBackgroundManager`, to be shared between several ViewManagers. In practice, this means:

1. `overflow` now works on `Text` and `TextInput`
2. ScrollView children are now clipped to the interior of borders, included curved ones via borderRadius 

This will be made more generic, then start being used in ReactViewGroup, and eventually ReactImage.

Different places in code currently do clipping in any of `draw()`, `onDraw()`, or `dispatchDraw()`. The distinction between these, is that `draw()` allows code to run before drawing background even, `onDraw()` is invoked before drawing foreground, and `dispatchDraw()` is before drawing children. We don't want to clip out borders/shadows, but do want to clip foreground content like text, so I used `onDraw()` here.

Changelog:
[Android][Fixed] - Better overflow support for ScrollView, Text, TextInput

Differential Revision: D57953429


