### PR TITLE
Add publish_bumped_packages in GHA

### DIFF
--- a/.github/workflows/publish_bumped_packages.yml
+++ b/.github/workflows/publish_bumped_packages.yml
@@ -1,0 +1,21 @@
+name: Publish Bumped Packages
+
+on:
+  push:
+    branches:
+      - "main"
+      - "*-stable"
+
+jobs:
+  runs-on: ubuntu-latest
+  steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Build packages
+        command: yarn build
+      - name: Set NPM auth token
+        run: echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc
+      - name: Find and publish all bumped packages
+        run: node ./scripts/releases-ci/publish-updated-packages.js


### PR DESCRIPTION
Summary:
This change introduce the publish_bumped_packages job in GHA as this job was not ported before

## Changelog:
[Internal] - Add the `publish_bumped_packages` to GHA

Differential Revision: D58016209


