### PR TITLE
fix(react-native): filter out unrouteable addresses

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -15,7 +15,7 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 # Enables iOS devices to get the IP address of the machine running Metro
 if [[ ! "$SKIP_BUNDLING_METRO_IP" && "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
   for num in 0 1 2 3 4 5 6 7 8; do
-    IP=$(ipconfig getifaddr en${num} || echo "")
+    IP=$(ipconfig getifaddr en${num} | grep -v '127.' | grep -v '169.254.' || echo "")
     if [ ! -z "$IP" ]; then
       break
     fi


### PR DESCRIPTION
## Summary:

When iterating over each interface, filter out loopback (`127.`) and link-local (`169.254.`) addresses in a similar way as the fallback search. This fixes an issue where a low numbered interface with one of these addresses would cause an iOS device to be unable to connect to the metro bundler instance.

## Changelog:

[IOS] [FIXED] - filter out inaccessible loopback (`127.`) and link-local (`169.254.`) addresses in all cases

## Test Plan:

### Before

```
$ rm ip.txt
$ CONFIGURATION_BUILD_DIR=. CONFIGURATION=Debug SKIP_BUNDLING=1 packages/react-native/scripts/react-native-xcode.sh
+ DEST=./
+ [[ ! -n '' ]]
+ [[ Debug = *Debug* ]]
+ [[ ! '' == *simulator ]]
+ for num in 0 1 2 3 4 5 6 7 8
++ ipconfig getifaddr en0
+ IP=169.254.36.33
+ '[' '!' -z 169.254.36.33 ']'
+ break
+ '[' -z 169.254.36.33 ']'
+ echo 169.254.36.33
+ [[ -n 1 ]]
+ echo 'SKIP_BUNDLING enabled; skipping.'
SKIP_BUNDLING enabled; skipping.
+ exit 0
$ cat ip.txt
169.254.36.33
```

### After

```
$ rm ip.txt
$ CONFIGURATION_BUILD_DIR=. CONFIGURATION=Debug SKIP_BUNDLING=1 packages/react-native/scripts/react-native-xcode.sh
+ DEST=./
+ [[ ! -n '' ]]
+ [[ Debug = *Debug* ]]
+ [[ ! '' == *simulator ]]
+ for num in 0 1 2 3 4 5 6 7 8
++ ipconfig getifaddr en0
++ grep -v 127.
++ grep -v 169.254.
++ echo ''
+ IP=
+ '[' '!' -z '' ']'
+ for num in 0 1 2 3 4 5 6 7 8
++ ipconfig getifaddr en1
++ grep -v 127.
++ grep -v 169.254.
+ IP=192.168.9.13
+ '[' '!' -z 192.168.9.13 ']'
+ break
+ '[' -z 192.168.9.13 ']'
+ echo 192.168.9.13
+ [[ -n 1 ]]
+ echo 'SKIP_BUNDLING enabled; skipping.'
SKIP_BUNDLING enabled; skipping.
+ exit 0
$ cat ip.txt
192.168.9.13
```
