### PR TITLE
[iOS]:- fixed image resize mode in release mode for iOS

### DIFF
--- a/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
@@ -11,6 +11,7 @@
 #import <memory>
 
 #import <React/RCTUtils.h>
+#import <React/RCTImageUtils.h>
 #import <ReactCommon/RCTTurboModule.h>
 
 #import "RCTImagePlugins.h"
@@ -49,7 +50,7 @@ RCT_EXPORT_MODULE()
                                          partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
                                           completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
 {
-  UIImage *image = RCTImageFromLocalAssetURL(imageURL);
+    UIImage *image = RCTDecodeImageWithLocalAssetURL(imageURL, size, scale, resizeMode);
   if (image) {
     if (progressHandler) {
       progressHandler(1, 1);

--- a/packages/react-native/Libraries/Image/RCTImageUtils.h
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.h
@@ -64,6 +64,16 @@ RCT_EXTERN UIImage *__nullable
 RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode);
 
 /**
+ * This function takes the source url for an image and decodes it at the
+ * specified size. If the original image is smaller than the destination size,
+ * the resultant image's scale will be decreased to compensate, so the
+ * width/height of the returned image is guaranteed to be >= destSize.
+ * Pass a destSize of CGSizeZero to decode the image at its original size.
+ */
+RCT_EXTERN UIImage *__nullable
+RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode);
+
+/**
  * This function takes the source data for an image and decodes just the
  * metadata, without decompressing the image itself.
  */

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -319,7 +319,7 @@ BOOL RCTUpscalingRequired(
 UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {
   CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
-    UIImage* image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
+    return decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
 
      return image;
    }
@@ -328,13 +328,13 @@ UIImage *__nullable RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize,
 {
   CGImageSourceRef sourceRef = CGImageSourceCreateWithURL((__bridge CFURLRef)url, NULL);
   UIImage* image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
-    
+
     if (!image) {
         image = RCTImageFromLocalAssetURL(url);
- 
+
   }
 
-  
+
   return image;
 }
 

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -323,24 +323,27 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
 
 
  }
-UIImage *__nullable RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
-{
-    // If the resizeMode is the default (assuming it's RCTResizeModeCover), directly return the image from the local asset URL
+
+UIImage *__nullable RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode) {
+    
+  
+    UIImage *image = nil;
     if (resizeMode == RCTResizeModeCover) {
-        return RCTImageFromLocalAssetURL(url);
+        image = RCTImageFromLocalAssetURL(url);
+    } else {
+        CGImageSourceRef sourceRef = CGImageSourceCreateWithURL((__bridge CFURLRef)url, NULL);
+        image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
+        CFRelease(sourceRef);
     }
 
-    // Otherwise, proceed with the original logic using decodeImageFromCGImageSourceRef
-    CGImageSourceRef sourceRef = CGImageSourceCreateWithURL((__bridge CFURLRef)url, NULL);
-    UIImage *image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
-
-    // If decoding the image failed, fallback to getting the image from the local asset URL
+  
     if (!image) {
         image = RCTImageFromLocalAssetURL(url);
     }
 
     return image;
 }
+
 
 NSDictionary<NSString *, id> *__nullable RCTGetImageMetadata(NSData *data)
 {

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -321,8 +321,8 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
   CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
     return decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
 
-     return image;
-   }
+
+ }
 
 UIImage *__nullable RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -55,6 +55,68 @@ static CGImagePropertyOrientation CGImagePropertyOrientationFromUIImageOrientati
   }
 }
 
+static UIImage* decodeImageFromCGImageSourceRef(
+    CGImageSourceRef sourceRef,
+    CGSize destSize,
+    CGFloat destScale,
+    RCTResizeMode resizeMode)
+{
+  if (!sourceRef) {
+    return nil;
+  }
+
+  // Get original image size
+  CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(sourceRef, 0, NULL);
+  if (!imageProperties) {
+    CFRelease(sourceRef);
+    return nil;
+  }
+  NSNumber *width = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelWidth);
+  NSNumber *height = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight);
+  CGSize sourceSize = {width.doubleValue, height.doubleValue};
+  CFRelease(imageProperties);
+
+  if (CGSizeEqualToSize(destSize, CGSizeZero)) {
+    destSize = sourceSize;
+    if (!destScale) {
+      destScale = 1;
+    }
+  } else if (!destScale) {
+    destScale = RCTScreenScale();
+  }
+
+  if (resizeMode == RCTResizeModeStretch) {
+    // Decoder cannot change aspect ratio, so RCTResizeModeStretch is equivalent
+    // to RCTResizeModeCover for our purposes
+    resizeMode = RCTResizeModeCover;
+  }
+
+  // Calculate target size
+  CGSize targetSize = RCTTargetSize(sourceSize, 1, destSize, destScale, resizeMode, NO);
+  CGSize targetPixelSize = RCTSizeInPixels(targetSize, destScale);
+  CGFloat maxPixelSize =
+    fmax(fmin(sourceSize.width, targetPixelSize.width), fmin(sourceSize.height, targetPixelSize.height));
+
+  NSDictionary<NSString *, NSNumber *> *options = @{
+    (id)kCGImageSourceShouldAllowFloat : @YES,
+    (id)kCGImageSourceCreateThumbnailWithTransform : @YES,
+    (id)kCGImageSourceCreateThumbnailFromImageAlways : @YES,
+    (id)kCGImageSourceThumbnailMaxPixelSize : @(maxPixelSize),
+  };
+
+  // Get thumbnail
+  CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(sourceRef, 0, (__bridge CFDictionaryRef)options);
+  CFRelease(sourceRef);
+  if (!imageRef) {
+    return nil;
+  }
+
+  // Return image
+  UIImage *image = [UIImage imageWithCGImage:imageRef scale:destScale orientation:UIImageOrientationUp];
+  CGImageRelease(imageRef);
+  return image;
+}
+
 CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {
   if (CGSizeEqualToSize(destSize, CGSizeZero)) {
@@ -257,59 +319,22 @@ BOOL RCTUpscalingRequired(
 UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {
   CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
-  if (!sourceRef) {
-    return nil;
+    UIImage* image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
+
+     return image;
+   }
+
+UIImage *__nullable RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
+{
+  CGImageSourceRef sourceRef = CGImageSourceCreateWithURL((__bridge CFURLRef)url, NULL);
+  UIImage* image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
+    
+    if (!image) {
+        image = RCTImageFromLocalAssetURL(url);
+ 
   }
 
-  // Get original image size
-  CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(sourceRef, 0, NULL);
-  if (!imageProperties) {
-    CFRelease(sourceRef);
-    return nil;
-  }
-  NSNumber *width = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelWidth);
-  NSNumber *height = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight);
-  CGSize sourceSize = {width.doubleValue, height.doubleValue};
-  CFRelease(imageProperties);
-
-  if (CGSizeEqualToSize(destSize, CGSizeZero)) {
-    destSize = sourceSize;
-    if (!destScale) {
-      destScale = 1;
-    }
-  } else if (!destScale) {
-    destScale = RCTScreenScale();
-  }
-
-  if (resizeMode == RCTResizeModeStretch) {
-    // Decoder cannot change aspect ratio, so RCTResizeModeStretch is equivalent
-    // to RCTResizeModeCover for our purposes
-    resizeMode = RCTResizeModeCover;
-  }
-
-  // Calculate target size
-  CGSize targetSize = RCTTargetSize(sourceSize, 1, destSize, destScale, resizeMode, NO);
-  CGSize targetPixelSize = RCTSizeInPixels(targetSize, destScale);
-  CGFloat maxPixelSize =
-      fmax(fmin(sourceSize.width, targetPixelSize.width), fmin(sourceSize.height, targetPixelSize.height));
-
-  NSDictionary<NSString *, NSNumber *> *options = @{
-    (id)kCGImageSourceShouldAllowFloat : @YES,
-    (id)kCGImageSourceCreateThumbnailWithTransform : @YES,
-    (id)kCGImageSourceCreateThumbnailFromImageAlways : @YES,
-    (id)kCGImageSourceThumbnailMaxPixelSize : @(maxPixelSize),
-  };
-
-  // Get thumbnail
-  CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(sourceRef, 0, (__bridge CFDictionaryRef)options);
-  CFRelease(sourceRef);
-  if (!imageRef) {
-    return nil;
-  }
-
-  // Return image
-  UIImage *image = [UIImage imageWithCGImage:imageRef scale:destScale orientation:UIImageOrientationUp];
-  CGImageRelease(imageRef);
+  
   return image;
 }
 

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -323,19 +323,23 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
 
 
  }
-
 UIImage *__nullable RCTDecodeImageWithLocalAssetURL(NSURL *url, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {
-  CGImageSourceRef sourceRef = CGImageSourceCreateWithURL((__bridge CFURLRef)url, NULL);
-  UIImage* image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
+    // If the resizeMode is the default (assuming it's RCTResizeModeCover), directly return the image from the local asset URL
+    if (resizeMode == RCTResizeModeCover) {
+        return RCTImageFromLocalAssetURL(url);
+    }
 
+    // Otherwise, proceed with the original logic using decodeImageFromCGImageSourceRef
+    CGImageSourceRef sourceRef = CGImageSourceCreateWithURL((__bridge CFURLRef)url, NULL);
+    UIImage *image = decodeImageFromCGImageSourceRef(sourceRef, destSize, destScale, resizeMode);
+
+    // If decoding the image failed, fallback to getting the image from the local asset URL
     if (!image) {
         image = RCTImageFromLocalAssetURL(url);
+    }
 
-  }
-
-
-  return image;
+    return image;
 }
 
 NSDictionary<NSString *, id> *__nullable RCTGetImageMetadata(NSData *data)

--- a/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
@@ -11,6 +11,7 @@
 #import <memory>
 
 #import <React/RCTUtils.h>
+#import <React/RCTImageUtils.h>
 #import <ReactCommon/RCTTurboModule.h>
 
 #import "RCTImagePlugins.h"
@@ -49,7 +50,7 @@ RCT_EXPORT_MODULE()
                                          partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
                                           completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
 {
-  UIImage *image = RCTImageFromLocalAssetURL(imageURL);
+    UIImage *image = RCTDecodeImageWithLocalAssetURL(imageURL, size, scale, resizeMode);
   if (image) {
     if (progressHandler) {
       progressHandler(1, 1);


### PR DESCRIPTION

## Summary:

**On iOS, when attempting to use a local image with a different resizeMode than the default one in a release build, it doesn't work as expected if the image is a local asset. The problem lies in how the image is loaded and processed.**
In a debug build, the image loads correctly with the desired resizeMode. This is because the method RCTDecodeImageWithData is employed, which handles the resizeMode properly.



https://github.com/facebook/react-native/assets/72331432/763d07db-4345-42f0-add3-ce7c1a606104





In contrast, in a release build, the image does not load with the desired resizeMode. This is due to the use of RCTImageFromLocalAssetURL, which is designed specifically to load an image by URL and does not handle resizeMode.

To address this issue, a new method called RCTDecodeImageWithLocalAssetURL has been introduced. This method replicates the resizeMode handling strategy of RCTDecodeImageWithData but loads the image by URL instead of by data.
To ensure backwards compatibility and handle edge cases where the image cannot be loaded using the new method, a fallback to RCTImageFromLocalAssetURL is retained.

Following has been done to fix the same:-

1. Created RCTDecodeImageWithLocalAssetURL to handle loading images by URL with proper resizeMode.
2. Retained fallback mechanism to use RCTImageFromLocalAssetURL when necessary.


## Changelog:

[IOS] [FIXED] - fixed resize mode in release mode for iOS



## Test Plan:

tried to implement the changes in a react native scaffold by changing the node_module files and it worked perfectly

https://github.com/facebook/react-native/assets/72331432/7660ef0e-0a82-457c-8a19-cbaff64748fa



cc @NickGerleman  @cipolleschi @javache @blakef 



