### PR TITLE
Add Java assertions for order of Host/Instance inspector target teardown

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.bridge;
 
+import static com.facebook.infer.annotation.Assertions.assertCondition;
 import static com.facebook.infer.annotation.ThreadConfined.UI;
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
@@ -112,6 +113,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
 
   public native NativeMethodCallInvokerHolderImpl getNativeMethodCallInvokerHolder();
 
+  private @Nullable ReactInstanceManagerInspectorTarget mInspectorTarget;
+
   private CatalystInstanceImpl(
       final ReactQueueConfigurationSpec reactQueueConfigurationSpec,
       final JavaScriptExecutor jsExecutor,
@@ -134,6 +137,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
     mJSExceptionHandler = jSExceptionHandler;
     mNativeModulesQueueThread = mReactQueueConfiguration.getNativeModulesQueueThread();
     mTraceListener = new JSProfilerTraceListener(this);
+    mInspectorTarget = inspectorTarget;
     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
 
     FLog.d(ReactConstants.TAG, "Initializing React Xplat Bridge before initializeBridge");
@@ -146,7 +150,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
         mNativeModulesQueueThread,
         mNativeModuleRegistry.getJavaModules(this),
         mNativeModuleRegistry.getCxxModules(),
-        inspectorTarget);
+        mInspectorTarget);
     FLog.d(ReactConstants.TAG, "Initializing React Xplat Bridge after initializeBridge");
     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
 
@@ -346,6 +350,11 @@ public class CatalystInstanceImpl implements CatalystInstance {
       return;
     }
 
+    if (mInspectorTarget != null) {
+      assertCondition(
+          mInspectorTarget.isValid(),
+          "ReactInstanceManager inspector target destroyed before instance was unregistered");
+    }
     unregisterFromInspector();
 
     // TODO: tell all APIs to shut down

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -7,12 +7,14 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 @DoNotStripAny
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   public interface TargetDelegate {
     public void onReload();
@@ -44,6 +46,10 @@ public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
 
   public void close() {
     mHybridData.resetNative();
+  }
+
+  /*internal*/ boolean isValid() {
+    return mHybridData.isValid();
   }
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -1333,9 +1333,7 @@ public class ReactHostImpl implements ReactHost {
                     final ReactInstance reactInstance =
                         reactInstanceTaskUnwrapper.unwrap(task, "1: Starting reload");
 
-                    if (reactInstance != null) {
-                      reactInstance.unregisterFromInspector();
-                    }
+                    unregisterInstanceFromInspector(reactInstance);
 
                     final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
                     if (reactContext == null) {
@@ -1512,9 +1510,7 @@ public class ReactHostImpl implements ReactHost {
                     final ReactInstance reactInstance =
                         reactInstanceTaskUnwrapper.unwrap(task, "1: Starting destroy");
 
-                    if (reactInstance != null) {
-                      reactInstance.unregisterFromInspector();
-                    }
+                    unregisterInstanceFromInspector(reactInstance);
 
                     // Step 1: Destroy DevSupportManager
                     if (mUseDevSupport) {
@@ -1676,6 +1672,17 @@ public class ReactHostImpl implements ReactHost {
     if (mReactHostInspectorTarget != null) {
       mReactHostInspectorTarget.close();
       mReactHostInspectorTarget = null;
+    }
+  }
+
+  private void unregisterInstanceFromInspector(final @Nullable ReactInstance reactInstance) {
+    if (reactInstance != null) {
+      if (InspectorFlags.getFuseboxEnabled()) {
+        Assertions.assertCondition(
+            mReactHostInspectorTarget != null && mReactHostInspectorTarget.isValid(),
+            "Host inspector target destroyed before instance was unregistered");
+      }
+      reactInstance.unregisterFromInspector();
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -30,6 +30,10 @@ internal class ReactHostInspectorTarget(private val reactHostImpl: ReactHostImpl
     mHybridData.resetNative()
   }
 
+  fun isValid(): Boolean {
+    return mHybridData.isValid()
+  }
+
   private companion object {
     init {
       SoLoader.loadLibrary("rninstance")


### PR DESCRIPTION
Summary:
Changelog: [Internal]

There is currently a lifecycle bug in both the Bridge (`com.facebook.react.bridge`) and Bridgeless (`com.facebook.react.runtime`) integrations of Fusebox in React Native Android, whereby `HostTarget::unregisterInstance` gets called after the `HostTarget` has been destroyed. This manifests as a handful of related C++ crashes depending on the exact circumstances and build flags.

This diff makes the bug trigger a Java assertion instead of a C++ crash for ease of debugging. The next diff in the stack will actually fix the lifecycle issue.

Differential Revision: D58031217


