### PR TITLE
Defer HostTarget destruction until after the instance has been unregistered

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.bridge;
 
+import static com.facebook.infer.annotation.Assertions.assertCondition;
 import static com.facebook.infer.annotation.ThreadConfined.UI;
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
@@ -112,6 +113,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
 
   public native NativeMethodCallInvokerHolderImpl getNativeMethodCallInvokerHolder();
 
+  private @Nullable ReactInstanceManagerInspectorTarget mInspectorTarget;
+
   private CatalystInstanceImpl(
       final ReactQueueConfigurationSpec reactQueueConfigurationSpec,
       final JavaScriptExecutor jsExecutor,
@@ -134,6 +137,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
     mJSExceptionHandler = jSExceptionHandler;
     mNativeModulesQueueThread = mReactQueueConfiguration.getNativeModulesQueueThread();
     mTraceListener = new JSProfilerTraceListener(this);
+    mInspectorTarget = inspectorTarget;
     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
 
     FLog.d(ReactConstants.TAG, "Initializing React Xplat Bridge before initializeBridge");
@@ -146,7 +150,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
         mNativeModulesQueueThread,
         mNativeModuleRegistry.getJavaModules(this),
         mNativeModuleRegistry.getCxxModules(),
-        inspectorTarget);
+        mInspectorTarget);
     FLog.d(ReactConstants.TAG, "Initializing React Xplat Bridge after initializeBridge");
     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
 
@@ -346,6 +350,11 @@ public class CatalystInstanceImpl implements CatalystInstance {
       return;
     }
 
+    if (mInspectorTarget != null) {
+      assertCondition(
+          mInspectorTarget.isValid(),
+          "ReactInstanceManager inspector target destroyed before instance was unregistered");
+    }
     unregisterFromInspector();
 
     // TODO: tell all APIs to shut down

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -7,12 +7,14 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 @DoNotStripAny
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   public interface TargetDelegate {
     public void onReload();
@@ -44,6 +46,10 @@ public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
 
   public void close() {
     mHybridData.resetNative();
+  }
+
+  /*internal*/ boolean isValid() {
+    return mHybridData.isValid();
   }
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -1333,9 +1333,7 @@ public class ReactHostImpl implements ReactHost {
                     final ReactInstance reactInstance =
                         reactInstanceTaskUnwrapper.unwrap(task, "1: Starting reload");
 
-                    if (reactInstance != null) {
-                      reactInstance.unregisterFromInspector();
-                    }
+                    unregisterInstanceFromInspector(reactInstance);
 
                     final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
                     if (reactContext == null) {
@@ -1512,9 +1510,7 @@ public class ReactHostImpl implements ReactHost {
                     final ReactInstance reactInstance =
                         reactInstanceTaskUnwrapper.unwrap(task, "1: Starting destroy");
 
-                    if (reactInstance != null) {
-                      reactInstance.unregisterFromInspector();
-                    }
+                    unregisterInstanceFromInspector(reactInstance);
 
                     // Step 1: Destroy DevSupportManager
                     if (mUseDevSupport) {
@@ -1676,6 +1672,17 @@ public class ReactHostImpl implements ReactHost {
     if (mReactHostInspectorTarget != null) {
       mReactHostInspectorTarget.close();
       mReactHostInspectorTarget = null;
+    }
+  }
+
+  private void unregisterInstanceFromInspector(final @Nullable ReactInstance reactInstance) {
+    if (reactInstance != null) {
+      if (InspectorFlags.getFuseboxEnabled()) {
+        Assertions.assertCondition(
+            mReactHostInspectorTarget != null && mReactHostInspectorTarget.isValid(),
+            "Host inspector target destroyed before instance was unregistered");
+      }
+      reactInstance.unregisterFromInspector();
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -892,7 +892,11 @@ public class ReactHostImpl implements ReactHost {
   @ThreadConfined(UI)
   private void moveToHostDestroy(@Nullable ReactContext currentContext) {
     mReactLifecycleStateManager.moveToOnHostDestroy(currentContext);
-    destroyReactHostInspectorTarget();
+    if (currentContext == null) {
+      // There's no current context/instance that requires the host inspector
+      // target to be kept alive, so we can destroy it immediately.
+      destroyInspectorHostTarget();
+    }
     setCurrentActivity(null);
   }
 
@@ -1668,13 +1672,15 @@ public class ReactHostImpl implements ReactHost {
     return mReactHostInspectorTarget;
   }
 
-  private void destroyReactHostInspectorTarget() {
+  @ThreadConfined(UI)
+  private void destroyInspectorHostTarget() {
     if (mReactHostInspectorTarget != null) {
       mReactHostInspectorTarget.close();
       mReactHostInspectorTarget = null;
     }
   }
 
+  @ThreadConfined(UI)
   private void unregisterInstanceFromInspector(final @Nullable ReactInstance reactInstance) {
     if (reactInstance != null) {
       if (InspectorFlags.getFuseboxEnabled()) {
@@ -1683,6 +1689,12 @@ public class ReactHostImpl implements ReactHost {
             "Host inspector target destroyed before instance was unregistered");
       }
       reactInstance.unregisterFromInspector();
+    }
+    if (mReactLifecycleStateManager.getLifecycleState() == LifecycleState.BEFORE_CREATE) {
+      // If the host is being destroyed, now that the current context/instance
+      // has been unregistered, we can safely destroy the host's inspector
+      // target.
+      destroyInspectorHostTarget();
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -30,6 +30,10 @@ internal class ReactHostInspectorTarget(private val reactHostImpl: ReactHostImpl
     mHybridData.resetNative()
   }
 
+  fun isValid(): Boolean {
+    return mHybridData.isValid()
+  }
+
   private companion object {
     init {
       SoLoader.loadLibrary("rninstance")


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Fixes a lifecycle bug in both the Bridge (`com.facebook.react.bridge`) and Bridgeless (`com.facebook.react.runtime`) integrations of Fusebox in React Native Android, whereby `HostTarget::unregisterInstance` gets called after the `HostTarget` has been destroyed.

The solution consists of two parts:

1. If a ReactHost / InstanceManager is asked to destroy itself while it contains no active ReactInstance / ReactContext, we destroy the `HostTarget` immediately.
2. Otherwise, if there *is* a live ReactInstance / ReactContext that has yet to be destroyed, we wait for that to happen before destroying the `HostTarget`. In practice, we do this by checking for the BEFORE_CREATE ( = Host destroyed) lifecycle state every time we destroy a ReactInstance / ReactContext.

Differential Revision: D58031215


