### PR TITLE
JS plumbing to get boxShadow into native

### DIFF
--- a/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -11,6 +11,7 @@
 import type {AnyAttributeType} from '../../Renderer/shims/ReactNativeTypes';
 
 import processAspectRatio from '../../StyleSheet/processAspectRatio';
+import processBoxShadow from '../../StyleSheet/processBoxShadow';
 import processColor from '../../StyleSheet/processColor';
 import processFilter from '../../StyleSheet/processFilter';
 import processFontVariant from '../../StyleSheet/processFontVariant';
@@ -124,6 +125,11 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
    * MixBlendMode
    */
   experimental_mixBlendMode: true,
+
+  /*
+   * BoxShadow
+   */
+  experimental_boxShadow: {process: processBoxShadow},
 
   /**
    * View

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -170,6 +170,9 @@ const validAttributesForNonEventProps = {
     process: require('../StyleSheet/processFilter').default,
   },
   experimental_mixBlendMode: true,
+  experimental_boxShadow: {
+    process: require('../StyleSheet/processBoxShadow').default,
+  },
   opacity: true,
   elevation: true,
   shadowColor: {process: require('../StyleSheet/processColor').default},

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -223,6 +223,9 @@ const validAttributesForNonEventProps = {
   experimental_filter: {
     process: require('../StyleSheet/processFilter').default,
   },
+  experimental_boxShadow: {
+    process: require('../StyleSheet/processBoxShadow').default,
+  },
 
   borderTopWidth: true,
   borderTopColor: {process: require('../StyleSheet/processColor').default},

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -30,6 +30,15 @@ export type DropShadowPrimitive = {
   color?: ColorValue | number | undefined;
 };
 
+export type BoxShadowPrimitive = {
+  offsetX: number | string;
+  offsetY: number | string;
+  color?: string | undefined;
+  blurRadius?: ColorValue | number | undefined;
+  spreadDistance?: number | string | undefined;
+  inset?: boolean | undefined;
+};
+
 type FlexAlignType =
   | 'flex-start'
   | 'flex-end'
@@ -250,6 +259,7 @@ export interface TransformsStyle {
  * @see https://reactnative.dev/docs/view#style
  */
 export interface ViewStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
+  experimental_boxShadow?: BoxShadowPrimitive | undefined;
   backfaceVisibility?: 'visible' | 'hidden' | undefined;
   backgroundColor?: ColorValue | undefined;
   borderBlockColor?: ColorValue | undefined;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -19,6 +19,7 @@ import type {
   ____ViewStyle_InternalOverrides,
 } from './private/_StyleSheetTypesOverrides';
 import type {____TransformStyle_Internal} from './private/_TransformStyle';
+import type {ColorValue} from './StyleSheet';
 
 declare export opaque type NativeColorValue;
 export type ____ColorValue_Internal = null | string | number | NativeColorValue;
@@ -51,6 +52,15 @@ export type DropShadowPrimitive = {
   offsetY: number | string,
   standardDeviation?: number | string,
   color?: ____ColorValue_Internal | number,
+};
+
+export type BoxShadowPrimitive = {
+  offsetX: number | string,
+  offsetY: number | string,
+  color?: number | ColorValue,
+  blurRadius?: number | string,
+  spreadDistance?: number | string,
+  inset?: boolean,
 };
 
 export type DimensionValue = number | string | 'auto' | AnimatedNode | null;
@@ -731,12 +741,17 @@ export type ____MixBlendMode_Internal =
   | 'color'
   | 'luminosity';
 
+type ____BoxShadowStyle_Internal = $ReadOnly<{
+  experimental_boxShadow?: $ReadOnlyArray<BoxShadowPrimitive>,
+}>;
+
 export type ____ViewStyle_InternalCore = $ReadOnly<{
   ...$Exact<____LayoutStyle_Internal>,
   ...$Exact<____ShadowStyle_Internal>,
   ...$Exact<____TransformStyle_Internal>,
   ...____FilterStyle_Internal,
   experimental_mixBlendMode?: ____MixBlendMode_Internal,
+  ...____BoxShadowStyle_Internal,
   backfaceVisibility?: 'visible' | 'hidden',
   backgroundColor?: ____ColorValue_Internal,
   borderColor?: ____ColorValue_Internal,

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBoxShadow-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBoxShadow-test.js
@@ -1,0 +1,269 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import processBoxShadow from '../processBoxShadow';
+import processColor from '../processColor';
+
+// js1 test processBoxShadow
+describe('processBoxShadow', () => {
+  it('should parse basic string', () => {
+    expect(processBoxShadow('10px 5')).toEqual([
+      {
+        offsetX: 10,
+        offsetY: 5,
+      },
+    ]);
+  });
+
+  it('should parse basic string with multiple whitespaces', () => {
+    expect(processBoxShadow('10px    5')).toEqual([
+      {
+        offsetX: 10,
+        offsetY: 5,
+      },
+    ]);
+  });
+
+  it('should parse string with color', () => {
+    expect(processBoxShadow('red 10 5')).toEqual([
+      {
+        color: processColor('red'),
+        offsetX: 10,
+        offsetY: 5,
+      },
+    ]);
+  });
+
+  it('should parse string with color function rgba', () => {
+    expect(processBoxShadow('rgba(255, 255, 255, 0.5) 10 5')).toEqual([
+      {
+        color: processColor('rgba(255, 255, 255, 0.5)'),
+        offsetX: 10,
+        offsetY: 5,
+      },
+    ]);
+  });
+
+  it('should parse string with color function hsl', () => {
+    expect(processBoxShadow('hsl(318, 69%, 55%) 10 5')).toEqual([
+      {
+        color: processColor('hsl(318, 69%, 55%)'),
+        offsetX: 10,
+        offsetY: 5,
+      },
+    ]);
+  });
+
+  it('should parse string with hex color', () => {
+    expect(processBoxShadow('#FFFFFF 10 5')).toEqual([
+      {
+        color: processColor('#FFFFFF'),
+        offsetX: 10,
+        offsetY: 5,
+      },
+    ]);
+  });
+
+  it('should parse string with blurRadius', () => {
+    expect(processBoxShadow('red 10 5 2')).toEqual([
+      {
+        color: processColor('red'),
+        blurRadius: 2,
+        offsetX: 10,
+        offsetY: 5,
+      },
+    ]);
+  });
+
+  it('should parse string with spreadDistance', () => {
+    expect(processBoxShadow('red 10 5 2 3')).toEqual([
+      {
+        color: processColor('red'),
+        blurRadius: 2,
+        offsetX: 10,
+        offsetY: 5,
+        spreadDistance: 3,
+      },
+    ]);
+  });
+
+  it('should parse string arguments with units', () => {
+    expect(processBoxShadow('5px 2px')).toEqual([
+      {
+        offsetX: 5,
+        offsetY: 2,
+      },
+    ]);
+  });
+
+  it('should parse string with inset', () => {
+    expect(processBoxShadow('5px 2px inset')).toEqual([
+      {
+        offsetX: 5,
+        offsetY: 2,
+        inset: true,
+      },
+    ]);
+  });
+
+  it('should parse string with inset and color before and after lengths', () => {
+    expect(processBoxShadow('red 10 10 inset')).toEqual([
+      {
+        color: processColor('red'),
+        offsetX: 10,
+        offsetY: 10,
+        inset: true,
+      },
+    ]);
+  });
+
+  it('should parse multiple box shadow strings', () => {
+    expect(
+      processBoxShadow('10 5 red, 5 12 inset, inset 10 45 13 red'),
+    ).toEqual([
+      {
+        offsetX: 10,
+        offsetY: 5,
+        color: processColor('red'),
+      },
+      {
+        offsetX: 5,
+        offsetY: 12,
+        inset: true,
+      },
+      {
+        offsetX: 10,
+        offsetY: 45,
+        blurRadius: 13,
+        inset: true,
+        color: processColor('red'),
+      },
+    ]);
+  });
+
+  it('should fail to parse string with invalid units', () => {
+    expect(processBoxShadow('red 10em 5$ 2| 3rp')).toEqual([]);
+  });
+
+  it('should fail to parse too many lengths', () => {
+    expect(processBoxShadow('10 5 2 3 10 10')).toEqual([]);
+  });
+
+  it('should fail to parse inset between lengths', () => {
+    expect(processBoxShadow('10 inset 5 2 3,')).toEqual([]);
+  });
+
+  it('should fail to parse double color', () => {
+    expect(processBoxShadow('red red 10 5')).toEqual([]);
+  });
+
+  it('should fail to parse double inset', () => {
+    expect(processBoxShadow('10 5 inset inset')).toEqual([]);
+  });
+
+  it('should fail to parse color between lengths', () => {
+    expect(processBoxShadow('10 red 5 2 3,')).toEqual([]);
+  });
+
+  it('should fail to parse invalid unit', () => {
+    expect(processBoxShadow('red 10foo 5 2 3,')).toEqual([]);
+  });
+
+  it('should fail to parse invalid argument', () => {
+    expect(processBoxShadow('red asf 5 2 3')).toEqual([]);
+  });
+
+  it('should fail to parse negative blur', () => {
+    expect(processBoxShadow('red 5 2 -3')).toEqual([]);
+  });
+
+  it('should parse simple object', () => {
+    expect(
+      processBoxShadow([
+        {
+          offsetX: 10,
+          offsetY: 5,
+        },
+      ]),
+    ).toEqual([
+      {
+        offsetX: 10,
+        offsetY: 5,
+      },
+    ]);
+  });
+
+  it('should parse object with color', () => {
+    expect(
+      processBoxShadow([
+        {
+          offsetX: 10,
+          offsetY: 5,
+          color: 'red',
+        },
+      ]),
+    ).toEqual([
+      {
+        offsetX: 10,
+        offsetY: 5,
+        color: processColor('red'),
+      },
+    ]);
+  });
+
+  it('should parse complex box shadow', () => {
+    expect(
+      processBoxShadow([
+        {
+          offsetX: '10px',
+          offsetY: 5,
+          blurRadius: 2,
+          spreadDistance: 3,
+          inset: true,
+          color: '#FFFFFF',
+        },
+      ]),
+    ).toEqual([
+      {
+        offsetX: 10,
+        offsetY: 5,
+        blurRadius: 2,
+        spreadDistance: 3,
+        inset: true,
+        color: processColor('#FFFFFF'),
+      },
+    ]);
+  });
+
+  it('should fail to parse object with negative blur', () => {
+    expect(
+      processBoxShadow([
+        {
+          offsetX: 10,
+          offsetY: 5,
+          color: 'red',
+          blurRadius: -3,
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('should fail to parse object with invalid argument', () => {
+    expect(
+      processBoxShadow([
+        {
+          offsetX: 10,
+          offsetY: 'asdf',
+        },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/packages/react-native/Libraries/StyleSheet/processBoxShadow.js
+++ b/packages/react-native/Libraries/StyleSheet/processBoxShadow.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react-native
+ */
+
+import type {ProcessedColorValue} from './processColor';
+import type {BoxShadowPrimitive} from './StyleSheetTypes';
+
+import processColor from './processColor';
+
+export type ParsedBoxShadow = {
+  offsetX: number,
+  offsetY: number,
+  color?: ProcessedColorValue,
+  blurRadius?: number,
+  spreadDistance?: number,
+  inset?: boolean,
+};
+
+export default function processBoxShadow(
+  rawBoxShadows: $ReadOnlyArray<BoxShadowPrimitive> | string,
+): Array<ParsedBoxShadow> {
+  const result: Array<ParsedBoxShadow> = [];
+
+  const boxShadowList =
+    typeof rawBoxShadows === 'string'
+      ? parseBoxShadowString(rawBoxShadows)
+      : rawBoxShadows;
+
+  for (const rawBoxShadow of boxShadowList) {
+    const parsedBoxShadow: ParsedBoxShadow = {
+      offsetX: 0,
+      offsetY: 0,
+    };
+
+    let value;
+    for (const arg in rawBoxShadow) {
+      switch (arg) {
+        case 'offsetX':
+          value =
+            typeof rawBoxShadow.offsetX === 'string'
+              ? parseLength(rawBoxShadow.offsetX)
+              : rawBoxShadow.offsetX;
+          if (value == null) {
+            return [];
+          }
+
+          parsedBoxShadow.offsetX = value;
+          break;
+        case 'offsetY':
+          value =
+            typeof rawBoxShadow.offsetY === 'string'
+              ? parseLength(rawBoxShadow.offsetY)
+              : rawBoxShadow.offsetY;
+          if (value == null) {
+            return [];
+          }
+
+          parsedBoxShadow.offsetY = value;
+          break;
+        case 'spreadDistance':
+          value =
+            typeof rawBoxShadow.spreadDistance === 'string'
+              ? parseLength(rawBoxShadow.spreadDistance)
+              : rawBoxShadow.spreadDistance;
+          if (value == null) {
+            return [];
+          }
+
+          parsedBoxShadow.spreadDistance = value;
+          break;
+        case 'blurRadius':
+          value =
+            typeof rawBoxShadow.blurRadius === 'string'
+              ? parseLength(rawBoxShadow.blurRadius)
+              : rawBoxShadow.blurRadius;
+          if (value == null || value < 0) {
+            return [];
+          }
+
+          parsedBoxShadow.blurRadius = value;
+          break;
+        case 'color':
+          const color = processColor(rawBoxShadow.color);
+          if (color == null) {
+            return [];
+          }
+
+          parsedBoxShadow.color = color;
+          break;
+        case 'inset':
+          parsedBoxShadow.inset = rawBoxShadow.inset;
+      }
+    }
+    result.push(parsedBoxShadow);
+  }
+  return result;
+}
+
+function parseBoxShadowString(
+  rawBoxShadows: string,
+): Array<BoxShadowPrimitive> {
+  let result: Array<BoxShadowPrimitive> = [];
+
+  for (const rawBoxShadow of rawBoxShadows
+    .split(/,(?![^()]*\))/) // split by comma that is not in parenthesis
+    .map(bS => bS.trim())
+    .filter(bS => bS !== '')) {
+    const boxShadow: BoxShadowPrimitive = {
+      offsetX: 0,
+      offsetY: 0,
+    };
+    let offsetX: number | string;
+    let offsetY: number | string;
+    let keywordDetectedAfterLength = false;
+
+    let lengthCount = 0;
+
+    // split rawBoxShadow string by all whitespaces that are not in parenthesis
+    const args = rawBoxShadow.split(/\s+(?![^(]*\))/);
+    for (const arg of args) {
+      const processedColor = processColor(arg);
+      if (processedColor != null) {
+        if (boxShadow.color != null) {
+          return [];
+        }
+        if (offsetX != null) {
+          keywordDetectedAfterLength = true;
+        }
+        boxShadow.color = arg;
+        continue;
+      }
+
+      if (arg === 'inset') {
+        if (boxShadow.inset != null) {
+          return [];
+        }
+        if (offsetX != null) {
+          keywordDetectedAfterLength = true;
+        }
+        boxShadow.inset = true;
+        continue;
+      }
+
+      switch (lengthCount) {
+        case 0:
+          offsetX = arg;
+          lengthCount++;
+          break;
+        case 1:
+          if (keywordDetectedAfterLength) {
+            return [];
+          }
+          offsetY = arg;
+          lengthCount++;
+          break;
+        case 2:
+          if (keywordDetectedAfterLength) {
+            return [];
+          }
+          boxShadow.blurRadius = arg;
+          lengthCount++;
+          break;
+        case 3:
+          if (keywordDetectedAfterLength) {
+            return [];
+          }
+          boxShadow.spreadDistance = arg;
+          lengthCount++;
+          break;
+        default:
+          return [];
+      }
+    }
+
+    if (offsetX == null || offsetY == null) {
+      return [];
+    }
+
+    boxShadow.offsetX = offsetX;
+    boxShadow.offsetY = offsetY;
+
+    result.push(boxShadow);
+  }
+  return result;
+}
+
+function parseLength(length: string): ?number {
+  // matches on args with units like "1.5 5% -80deg"
+  const argsWithUnitsRegex = /([+-]?\d*(\.\d+)?)([\w\W]+)?/g;
+  const match = argsWithUnitsRegex.exec(length);
+
+  if (!match || Number.isNaN(match[1])) {
+    return null;
+  }
+
+  if (match[3] != null && match[3] !== 'px') {
+    return null;
+  }
+
+  return Number(match[1]);
+}

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7587,6 +7587,13 @@ export type DropShadowPrimitive = {
   offsetY: number | string,
   standardDeviation?: number | string,
   color?: ____ColorValue_Internal | number,
+export type BoxShadowPrimitive = {
+  offsetX: number | string,
+  offsetY: number | string,
+  color?: number | ColorValue,
+  blurRadius?: number | string,
+  spreadDistance?: number | string,
+  inset?: boolean,
 };
 export type DimensionValue = number | string | \\"auto\\" | AnimatedNode | null;
 export type AnimatableNumericValue = number | AnimatedNode;
@@ -7720,12 +7727,16 @@ export type ____MixBlendMode_Internal =
   | \\"saturation\\"
   | \\"color\\"
   | \\"luminosity\\";
+type ____BoxShadowStyle_Internal = $ReadOnly<{
+  experimental_boxShadow?: $ReadOnlyArray<BoxShadowPrimitive>,
+}>;
 export type ____ViewStyle_InternalCore = $ReadOnly<{
   ...$Exact<____LayoutStyle_Internal>,
   ...$Exact<____ShadowStyle_Internal>,
   ...$Exact<____TransformStyle_Internal>,
   ...____FilterStyle_Internal,
   experimental_mixBlendMode?: ____MixBlendMode_Internal,
+  ...____BoxShadowStyle_Internal,
   backfaceVisibility?: \\"visible\\" | \\"hidden\\",
   backgroundColor?: ____ColorValue_Internal,
   borderColor?: ____ColorValue_Internal,
@@ -8002,6 +8013,21 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/priva
 exports[`public API should not change unintentionally Libraries/StyleSheet/processAspectRatio.js 1`] = `
 "declare function processAspectRatio(aspectRatio?: number | string): ?number;
 declare module.exports: processAspectRatio;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/StyleSheet/processBoxShadow.js 1`] = `
+"export type ParsedBoxShadow = {
+  offsetX: number,
+  offsetY: number,
+  color?: ProcessedColorValue,
+  blurRadius?: number,
+  spreadDistance?: number,
+  inset?: boolean,
+};
+declare export default function processBoxShadow(
+  rawBoxShadows: $ReadOnlyArray<BoxShadowPrimitive> | string
+): Array<ParsedBoxShadow>;
 "
 `;
 


### PR DESCRIPTION
Summary:
With this we enable <View> to use BoxShadow. 

BoxShadow property can be a string as defined on MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow

Or it can also be a list of BoxShadow primitives:
```
[
{
  offsetX: 10,
  offsetY: 5, 
  color: 'red',
  inset: true, 
},
{
  ...
},
]
```

The diff includes:

* Style sheet changes so typing is valid
* Process function to turn boxShadow format into parsed boxShadow primitive
* Test for process function
* View config changes on Android, iOS and ReactNativeStyleAttributes

Changelog: [Internal]

Differential Revision: D57872933


