### PR TITLE
Support customizeRootView from RCTRootViewFactory

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -55,7 +55,6 @@
   if (self.newArchEnabled || self.fabricEnabled) {
     [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;
   }
-  [self customizeRootView:(RCTRootView *)rootView];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [self createRootViewController];
@@ -251,6 +250,10 @@
 
   configuration.createBridgeWithDelegate = ^RCTBridge *(id<RCTBridgeDelegate> delegate, NSDictionary *launchOptions) {
     return [weakSelf createBridgeWithDelegate:delegate launchOptions:launchOptions];
+  };
+
+  configuration.customizeRootView = ^(UIView * _Nonnull rootView) {
+    return [weakSelf customizeRootView:(RCTRootView *)rootView];
   };
 
   configuration.sourceURLForBridge = ^NSURL *_Nullable(RCTBridge *_Nonnull bridge)

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -24,6 +24,7 @@ typedef UIView *_Nonnull (
     ^RCTCreateRootViewWithBridgeBlock)(RCTBridge *bridge, NSString *moduleName, NSDictionary *initProps);
 typedef RCTBridge *_Nonnull (
     ^RCTCreateBridgeWithDelegateBlock)(id<RCTBridgeDelegate> delegate, NSDictionary *launchOptions);
+typedef void (^RCTCustomizeRootViewBlock)(UIView *rootView);
 typedef NSURL *_Nullable (^RCTSourceURLForBridgeBlock)(RCTBridge *bridge);
 typedef NSURL *_Nullable (^RCTBundleURLBlock)(void);
 typedef NSArray<id<RCTBridgeModule>> *_Nonnull (^RCTExtraModulesForBridgeBlock)(RCTBridge *bridge);
@@ -98,6 +99,13 @@ typedef void (^RCTHostDidReceiveJSErrorStackBlock)(
  * @returns: a newly created instance of RCTBridge.
  */
 @property (nonatomic, nullable) RCTCreateBridgeWithDelegateBlock createBridgeWithDelegate;
+
+/**
+ * Block that allows to customize the rootView that is passed to React Native.
+ *
+ * @parameter: rootView - The root view to customize.
+ */
+@property (nonatomic, nullable) RCTCustomizeRootViewBlock customizeRootView;
 
 #pragma mark - RCTBridgeDelegate blocks
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -150,17 +150,25 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
         sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact];
 
     surfaceHostingProxyRootView.backgroundColor = [UIColor systemBackgroundColor];
+    if (self->_configuration.customizeRootView != nil) {
+      self->_configuration.customizeRootView(surfaceHostingProxyRootView);
+    }
     return surfaceHostingProxyRootView;
   }
 
   [self createBridgeIfNeeded:launchOptions];
   [self createBridgeAdapterIfNeeded];
 
+  UIView *rootView;
   if (self->_configuration.createRootViewWithBridge != nil) {
-    return self->_configuration.createRootViewWithBridge(self.bridge, moduleName, initProps);
+    rootView = self->_configuration.createRootViewWithBridge(self.bridge, moduleName, initProps);
+  } else {
+    rootView = [self createRootViewWithBridge:self.bridge moduleName:moduleName initProps:initProps];
   }
-
-  return [self createRootViewWithBridge:self.bridge moduleName:moduleName initProps:initProps];
+  if (self->_configuration.customizeRootView != nil) {
+    self->_configuration.customizeRootView(rootView);
+  }
+  return rootView;
 }
 
 - (RCTBridge *)createBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions


### PR DESCRIPTION
## Summary:

The new `customizeRootView` does not have the feature parity as `createRootViewWithBridge` where reusing RCTRootViewFactory to create a root view, it does not call `customizeRootView`. This PR moves the `customizeRootView` support from RCTAppDelegate into RCTRootViewFactory and improves the customizeRootView support.

## Changelog:

[IOS] [CHANGED] - Support `customizeRootView` from `RCTRootViewFactory`

## Test Plan:

Add customizeRootView to **packages/rn-tester/RNTester/AppDelegate.mm** and test whether RNTester has blue background color in both new arch and old arch mode.

```objc
- (void)customizeRootView:(RCTRootView *)rootView
{
  rootView.backgroundColor = [UIColor blueColor];
}
```