### PR TITLE
Re-enable event loop in OSS

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -297,7 +297,21 @@
 
 #pragma mark - Feature Flags
 
-class RCTAppDelegateBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults {};
+class RCTAppDelegateBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults {
+ public:
+  bool useModernRuntimeScheduler() override
+  {
+    return true;
+  }
+  bool enableMicrotasks() override
+  {
+    return true;
+  }
+  bool batchRenderingUpdatesInEventLoop() override
+  {
+    return true;
+  }
+};
 
 - (void)_setUpFeatureFlags
 {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -48,7 +48,13 @@ public object DefaultNewArchitectureEntryPoint {
     if (bridgelessEnabled) {
       ReactNativeFeatureFlags.override(
           object : ReactNativeFeatureFlagsDefaults() {
-            override fun useNativeViewConfigsInBridgelessMode(): Boolean = fabricEnabled
+            override fun useModernRuntimeScheduler(): Boolean = true
+
+            override fun enableMicrotasks(): Boolean = true
+
+            override fun batchRenderingUpdatesInEventLoop(): Boolean = true
+
+            override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
           })
     }
 


### PR DESCRIPTION
Summary:
We disabled the event loop in RN on the main branch after we found some issues in the implementation. Those have been resolved already so we can re-enable it again.

For context, it's already enabled in the latest branch so this is just for main.

Differential Revision: D58146393


