### PR TITLE
Don't strip TargetDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 @DoNotStripAny
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
+  @DoNotStripAny
   public interface TargetDelegate {
     public void onReload();
 


### PR DESCRIPTION
Summary:
Was seeing crash due to:
> Abort message: 'terminating due to uncaught exception of type facebook::jni::JniException: java.lang.NoSuchMethodError: no non-static method "Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$
TargetDelegate;.onSetPausedInDebuggerMessage(Ljava/lang/String;)V"

Changelog: [Internal]

Differential Revision: D58165901


