### PR TITLE
Fix issue where % width would be wrong if physical and relative padding defined on parent

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -342,6 +342,7 @@ void layoutAbsoluteChild(
       childWidth = boundAxis(
           child,
           FlexDirection::Row,
+          direction,
           childWidth,
           containingBlockWidth,
           containingBlockWidth);
@@ -373,6 +374,7 @@ void layoutAbsoluteChild(
       childHeight = boundAxis(
           child,
           FlexDirection::Column,
+          direction,
           childHeight,
           containingBlockHeight,
           containingBlockWidth);

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
@@ -19,13 +19,12 @@ namespace facebook::yoga {
 inline float paddingAndBorderForAxis(
     const yoga::Node* const node,
     const FlexDirection axis,
+    const Direction direction,
     const float widthSize) {
-  // The total padding/border for a given axis does not depend on the direction
-  // so hardcoding LTR here to avoid piping direction to this function
   return node->style().computeInlineStartPaddingAndBorder(
-             axis, Direction::LTR, widthSize) +
+             axis, direction, widthSize) +
       node->style().computeInlineEndPaddingAndBorder(
-          axis, Direction::LTR, widthSize);
+          axis, direction, widthSize);
 }
 
 inline FloatOptional boundAxisWithinMinAndMax(
@@ -60,13 +59,14 @@ inline FloatOptional boundAxisWithinMinAndMax(
 inline float boundAxis(
     const yoga::Node* const node,
     const FlexDirection axis,
+    const Direction direction,
     const float value,
     const float axisSize,
     const float widthSize) {
   return yoga::maxOrDefined(
       boundAxisWithinMinAndMax(node, axis, FloatOptional{value}, axisSize)
           .unwrap(),
-      paddingAndBorderForAxis(node, axis, widthSize));
+      paddingAndBorderForAxis(node, axis, direction, widthSize));
 }
 
 } // namespace facebook::yoga


### PR DESCRIPTION
Summary:
This should fix https://github.com/facebook/yoga/issues/1657. Rather insidious bug but we had code like

```
  // The total padding/border for a given axis does not depend on the direction
  // so hardcoding LTR here to avoid piping direction to this function
  return node->style().computeInlineStartPaddingAndBorder(
             axis, Direction::LTR, widthSize) +
      node->style().computeInlineEndPaddingAndBorder(
          axis, Direction::LTR, widthSize);
```

That comment is NOT true if someone sets both the physical edge and relative edge. So like paddingLeft and paddingEnd for RTL. This diff simply pipes the direction to that spot to use instead of hardcoding LTR. Every file changed is just to pipe `direction`.

Differential Revision: D58169843


