### PR TITLE
Back out "chore(dev-middleware): add `localhost` as default host in `start` command config"

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/index.js
+++ b/packages/community-cli-plugin/src/commands/start/index.js
@@ -27,7 +27,7 @@ const startCommand: Command = {
     },
     {
       name: '--host <string>',
-      default: 'localhost',
+      default: '',
     },
     {
       name: '--projectRoot <path>',

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -34,7 +34,7 @@ export type StartCommandArgs = {
   cert?: string,
   customLogReporterPath?: string,
   experimentalDebugger: boolean,
-  host: string,
+  host?: string,
   https?: boolean,
   maxWorkers?: number,
   key?: string,
@@ -63,13 +63,14 @@ async function runServer(
     projectRoot: args.projectRoot,
     sourceExts: args.sourceExts,
   });
+  const hostname = args.host?.length ? args.host : 'localhost';
   const {
     projectRoot,
     server: {port},
     watchFolders,
   } = metroConfig;
   const protocol = args.https === true ? 'https' : 'http';
-  const devServerUrl = url.format({protocol, hostname: args.host, port});
+  const devServerUrl = url.format({protocol, hostname, port});
 
   logger.info(`Welcome to React Native v${ctx.reactNativeVersion}`);
 
@@ -103,7 +104,7 @@ async function runServer(
     messageSocketEndpoint,
     eventsSocketEndpoint,
   } = createDevServerMiddleware({
-    host: args.host,
+    host: hostname,
     port,
     watchFolders,
   });


### PR DESCRIPTION
Summary:
This is a revert of https://github.com/facebook/react-native/pull/44244, as we've observed [breaking behaviour](https://github.com/facebook/react-native/pull/44244#issuecomment-2078957734) where Android emulators could not connect to the dev server with default settings.

The team doesn't have bandwidth/prio to figure this out with the default `host` value just now, so we are reverting.

Changelog: [Internal] (Nullifies c402dcf)

Differential Revision: D58192651


