### PR TITLE
Fix signed/unsigned mismatch in BoundedConsumableBuffer.h

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/timeline/BoundedConsumableBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/BoundedConsumableBuffer.h
@@ -179,7 +179,7 @@ class BoundedConsumableBuffer {
 
   void getEntries(std::vector<T>& res, std::function<bool(const T&)> predicate)
       const {
-    for (int i = 0; i < entries_.size(); i++) {
+    for (size_t i = 0; i < entries_.size(); i++) {
       const T& el = entries_[(i + position_) % entries_.size()];
       if (predicate(el)) {
         res.push_back(el);


### PR DESCRIPTION
## Summary:

Previous PR (#44564) missed one int -> size_t switch to fix C4018 in react-native-windows.
![image](https://github.com/facebook/react-native/assets/1422161/373480ed-7f49-4c01-a7ac-ea65a347ab1c)


## Changelog:

[INTERNAL] - Fix signed/unsigned mismatch in BoundedConsumableBuffer.h

## Test Plan:
Builds on Windows + identical to forked file used in react-native-windows. 
