### PR TITLE
Add EventEmitter code-gen support for C++ Turbo Modules

### DIFF
--- a/packages/react-native-codegen-typescript-test/src/__tests__/simple-scenario-frontend-test.ts
+++ b/packages/react-native-codegen-typescript-test/src/__tests__/simple-scenario-frontend-test.ts
@@ -29,6 +29,7 @@ export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
         excludedPlatforms: undefined,
         moduleName: 'SampleTurboModule',
         spec: {
+          eventEmitters: [],
           properties: [],
         },
         type: 'NativeModule',

--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -43,11 +43,14 @@ protected:
     : TurboModule(std::string{NativeArrayTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeArrayTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeArrayTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeArrayTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Array getArray(jsi::Runtime &rt, jsi::Array a) override {
       static_assert(
@@ -75,6 +78,7 @@ private:
     }
 
   private:
+    friend class NativeArrayTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -106,11 +110,14 @@ protected:
     : TurboModule(std::string{NativeBooleanTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeBooleanTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeBooleanTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeBooleanTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     bool getBoolean(jsi::Runtime &rt, bool arg) override {
       static_assert(
@@ -130,6 +137,7 @@ private:
     }
 
   private:
+    friend class NativeBooleanTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -161,11 +169,14 @@ protected:
     : TurboModule(std::string{NativeCallbackTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeCallbackTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeCallbackTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeCallbackTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     void getValueWithCallback(jsi::Runtime &rt, jsi::Function callback) override {
       static_assert(
@@ -185,6 +196,7 @@ private:
     }
 
   private:
+    friend class NativeCallbackTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -416,11 +428,14 @@ protected:
     : TurboModule(std::string{NativeEnumTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeEnumTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeEnumTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeEnumTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::String getStatusRegular(jsi::Runtime &rt, jsi::Object statusProp) override {
       static_assert(
@@ -464,6 +479,7 @@ private:
     }
 
   private:
+    friend class NativeEnumTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -499,11 +515,14 @@ protected:
     : TurboModule(std::string{NativeNullableTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeNullableTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeNullableTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeNullableTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     std::optional<bool> getBool(jsi::Runtime &rt, std::optional<bool> a) override {
       static_assert(
@@ -555,6 +574,7 @@ private:
     }
 
   private:
+    friend class NativeNullableTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -586,11 +606,14 @@ protected:
     : TurboModule(std::string{NativeNumberTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeNumberTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeNumberTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeNumberTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     double getNumber(jsi::Runtime &rt, double arg) override {
       static_assert(
@@ -610,6 +633,7 @@ private:
     }
 
   private:
+    friend class NativeNumberTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -644,11 +668,14 @@ protected:
     : TurboModule(std::string{NativeObjectTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeObjectTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeObjectTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeObjectTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getGenericObject(jsi::Runtime &rt, jsi::Object arg) override {
       static_assert(
@@ -692,6 +719,7 @@ private:
     }
 
   private:
+    friend class NativeObjectTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -722,11 +750,14 @@ protected:
     : TurboModule(std::string{NativeOptionalObjectTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeOptionalObjectTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeOptionalObjectTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeOptionalObjectTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -738,6 +769,7 @@ private:
     }
 
   private:
+    friend class NativeOptionalObjectTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -820,11 +852,14 @@ protected:
     : TurboModule(std::string{NativePartialAnnotationTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativePartialAnnotationTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativePartialAnnotationTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativePartialAnnotationTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getSomeObj(jsi::Runtime &rt) override {
       static_assert(
@@ -860,6 +895,7 @@ private:
     }
 
   private:
+    friend class NativePartialAnnotationTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -891,11 +927,14 @@ protected:
     : TurboModule(std::string{NativePromiseTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativePromiseTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativePromiseTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativePromiseTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Value getValueWithPromise(jsi::Runtime &rt, bool error) override {
       static_assert(
@@ -915,6 +954,7 @@ private:
     }
 
   private:
+    friend class NativePromiseTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -997,11 +1037,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -1109,6 +1152,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -1191,11 +1235,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleArraysCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleArraysCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleArraysCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleArraysCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -1303,6 +1350,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleArraysCxxSpec;
     T *instance_;
   };
 
@@ -1385,11 +1433,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleNullableCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleNullableCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleNullableCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleNullableCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -1497,6 +1548,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleNullableCxxSpec;
     T *instance_;
   };
 
@@ -1581,11 +1633,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleNullableAndOptionalCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -1693,6 +1748,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleNullableAndOptionalCxxSpec;
     T *instance_;
   };
 
@@ -1777,11 +1833,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleOptionalCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleOptionalCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleOptionalCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleOptionalCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -1889,6 +1948,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleOptionalCxxSpec;
     T *instance_;
   };
 
@@ -1920,11 +1980,14 @@ protected:
     : TurboModule(std::string{NativeStringTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeStringTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeStringTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeStringTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::String getString(jsi::Runtime &rt, jsi::String arg) override {
       static_assert(
@@ -1944,6 +2007,7 @@ private:
     }
 
   private:
+    friend class NativeStringTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -1997,11 +2061,14 @@ protected:
     : TurboModule(std::string{NativeArrayTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeArrayTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeArrayTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeArrayTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Array getArray(jsi::Runtime &rt, jsi::Array a) override {
       static_assert(
@@ -2029,6 +2096,7 @@ private:
     }
 
   private:
+    friend class NativeArrayTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2060,11 +2128,14 @@ protected:
     : TurboModule(std::string{NativeBooleanTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeBooleanTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeBooleanTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeBooleanTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     bool getBoolean(jsi::Runtime &rt, bool arg) override {
       static_assert(
@@ -2084,6 +2155,7 @@ private:
     }
 
   private:
+    friend class NativeBooleanTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2115,11 +2187,14 @@ protected:
     : TurboModule(std::string{NativeCallbackTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeCallbackTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeCallbackTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeCallbackTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     void getValueWithCallback(jsi::Runtime &rt, jsi::Function callback) override {
       static_assert(
@@ -2139,6 +2214,7 @@ private:
     }
 
   private:
+    friend class NativeCallbackTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2370,11 +2446,14 @@ protected:
     : TurboModule(std::string{NativeEnumTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeEnumTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeEnumTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeEnumTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::String getStatusRegular(jsi::Runtime &rt, jsi::Object statusProp) override {
       static_assert(
@@ -2418,6 +2497,7 @@ private:
     }
 
   private:
+    friend class NativeEnumTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2453,11 +2533,14 @@ protected:
     : TurboModule(std::string{NativeNullableTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeNullableTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeNullableTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeNullableTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     std::optional<bool> getBool(jsi::Runtime &rt, std::optional<bool> a) override {
       static_assert(
@@ -2509,6 +2592,7 @@ private:
     }
 
   private:
+    friend class NativeNullableTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2540,11 +2624,14 @@ protected:
     : TurboModule(std::string{NativeNumberTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeNumberTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeNumberTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeNumberTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     double getNumber(jsi::Runtime &rt, double arg) override {
       static_assert(
@@ -2564,6 +2651,7 @@ private:
     }
 
   private:
+    friend class NativeNumberTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2598,11 +2686,14 @@ protected:
     : TurboModule(std::string{NativeObjectTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeObjectTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeObjectTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeObjectTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getGenericObject(jsi::Runtime &rt, jsi::Object arg) override {
       static_assert(
@@ -2646,6 +2737,7 @@ private:
     }
 
   private:
+    friend class NativeObjectTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2676,11 +2768,14 @@ protected:
     : TurboModule(std::string{NativeOptionalObjectTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeOptionalObjectTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeOptionalObjectTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeOptionalObjectTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -2692,6 +2787,7 @@ private:
     }
 
   private:
+    friend class NativeOptionalObjectTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2774,11 +2870,14 @@ protected:
     : TurboModule(std::string{NativePartialAnnotationTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativePartialAnnotationTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativePartialAnnotationTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativePartialAnnotationTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getSomeObj(jsi::Runtime &rt) override {
       static_assert(
@@ -2814,6 +2913,7 @@ private:
     }
 
   private:
+    friend class NativePartialAnnotationTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2845,11 +2945,14 @@ protected:
     : TurboModule(std::string{NativePromiseTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativePromiseTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativePromiseTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativePromiseTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Value getValueWithPromise(jsi::Runtime &rt, bool error) override {
       static_assert(
@@ -2869,6 +2972,7 @@ private:
     }
 
   private:
+    friend class NativePromiseTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2951,11 +3055,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -3063,6 +3170,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -3145,11 +3253,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleArraysCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleArraysCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleArraysCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleArraysCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -3257,6 +3368,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleArraysCxxSpec;
     T *instance_;
   };
 
@@ -3339,11 +3451,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleNullableCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleNullableCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleNullableCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleNullableCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -3451,6 +3566,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleNullableCxxSpec;
     T *instance_;
   };
 
@@ -3535,11 +3651,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleNullableAndOptionalCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -3647,6 +3766,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleNullableAndOptionalCxxSpec;
     T *instance_;
   };
 
@@ -3731,11 +3851,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleOptionalCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleOptionalCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleOptionalCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleOptionalCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -3843,6 +3966,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleOptionalCxxSpec;
     T *instance_;
   };
 
@@ -3874,11 +3998,14 @@ protected:
     : TurboModule(std::string{NativeStringTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeStringTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeStringTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeStringTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::String getString(jsi::Runtime &rt, jsi::String arg) override {
       static_assert(
@@ -3898,6 +4025,7 @@ private:
     }
 
   private:
+    friend class NativeStringTurboModuleCxxSpec;
     T *instance_;
   };
 

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -58,6 +58,11 @@ export interface MixedTypeAnnotation {
   readonly type: 'MixedTypeAnnotation';
 }
 
+export interface EventEmitterTypeAnnotation {
+  readonly type: 'EventEmitterTypeAnnotation';
+  readonly typeAnnotation: NativeModuleBaseTypeAnnotation;
+}
+
 export interface FunctionTypeAnnotation<P, R> {
   readonly type: 'FunctionTypeAnnotation';
   readonly params: readonly NamedShape<P>[];
@@ -241,12 +246,15 @@ export interface NativeModuleSchema {
 }
 
 export interface NativeModuleSpec {
+  readonly eventEmitters: readonly NativeModuleEventEmitterShape[];
   readonly properties: readonly NativeModulePropertyShape[];
 }
 
 export type NativeModulePropertyShape = NamedShape<
   Nullable<NativeModuleFunctionTypeAnnotation>
 >;
+
+export type NativeModuleEventEmitterShape = NamedShape<EventEmitterTypeAnnotation>;
 
 export interface NativeModuleEnumMap {
   readonly [enumName: string]: NativeModuleEnumDeclarationWithMembers;

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -61,6 +61,11 @@ export type MixedTypeAnnotation = $ReadOnly<{
   type: 'MixedTypeAnnotation',
 }>;
 
+type EventEmitterTypeAnnotation = $ReadOnly<{
+  type: 'EventEmitterTypeAnnotation',
+  typeAnnotation: NativeModuleBaseTypeAnnotation,
+}>;
+
 type FunctionTypeAnnotation<+P, +R> = $ReadOnly<{
   type: 'FunctionTypeAnnotation',
   params: $ReadOnlyArray<NamedShape<P>>,
@@ -242,8 +247,12 @@ export type NativeModuleSchema = $ReadOnly<{
 }>;
 
 type NativeModuleSpec = $ReadOnly<{
+  eventEmitters: $ReadOnlyArray<NativeModuleEventEmitterShape>,
   properties: $ReadOnlyArray<NativeModulePropertyShape>,
 }>;
+
+export type NativeModuleEventEmitterShape =
+  NamedShape<EventEmitterTypeAnnotation>;
 
 export type NativeModulePropertyShape = NamedShape<
   Nullable<NativeModuleFunctionTypeAnnotation>,

--- a/packages/react-native-codegen/src/generators/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/__test_fixtures__/fixtures.js
@@ -44,6 +44,7 @@ const SCHEMA_WITH_TM_AND_FC: SchemaType = {
       aliasMap: {},
       enumMap: {},
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'add',

--- a/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
@@ -19,6 +19,7 @@ const EMPTY_NATIVE_MODULES: SchemaType = {
       aliasMap: {},
       enumMap: {},
       spec: {
+        eventEmitters: [],
         properties: [],
       },
       moduleName: 'SampleTurboModule',
@@ -83,6 +84,7 @@ const SIMPLE_NATIVE_MODULES: SchemaType = {
         },
       },
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'getConstants',
@@ -412,6 +414,7 @@ const TWO_MODULES_DIFFERENT_FILES: SchemaType = {
       aliasMap: {},
       enumMap: {},
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'voidFunc',
@@ -433,6 +436,7 @@ const TWO_MODULES_DIFFERENT_FILES: SchemaType = {
       aliasMap: {},
       enumMap: {},
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'getConstants',
@@ -471,6 +475,7 @@ const COMPLEX_OBJECTS: SchemaType = {
       aliasMap: {},
       enumMap: {},
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'difficult',
@@ -927,6 +932,7 @@ const NATIVE_MODULES_WITH_TYPE_ALIASES: SchemaType = {
       },
       enumMap: {},
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'getConstants',
@@ -1212,6 +1218,7 @@ const REAL_MODULE_EXAMPLE: SchemaType = {
       },
       enumMap: {},
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'getConstants',
@@ -1408,6 +1415,7 @@ const REAL_MODULE_EXAMPLE: SchemaType = {
       },
       enumMap: {},
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'reportFatalException',
@@ -1829,6 +1837,7 @@ const CXX_ONLY_NATIVE_MODULES: SchemaType = {
         },
       },
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'getArray',
@@ -2414,6 +2423,7 @@ const SAMPLE_WITH_UPPERCASE_NAME: SchemaType = {
       enumMap: {},
       aliasMap: {},
       spec: {
+        eventEmitters: [],
         properties: [],
       },
       moduleName: 'SampleTurboModule',

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -42,15 +42,19 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     
 
   private:
+    friend class NativeSampleTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -110,11 +114,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object difficult(jsi::Runtime &rt, jsi::Object A) override {
       static_assert(
@@ -174,6 +181,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -706,11 +714,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Array getArray(jsi::Runtime &rt, jsi::Array arg) override {
       static_assert(
@@ -930,6 +941,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -983,15 +995,19 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     
 
   private:
+    friend class NativeSampleTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -1120,11 +1136,14 @@ protected:
     : TurboModule(std::string{AliasTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public AliasTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      AliasTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      AliasTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -1144,6 +1163,7 @@ private:
     }
 
   private:
+    friend class AliasTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -1461,11 +1481,14 @@ protected:
     : TurboModule(std::string{NativeCameraRollManagerCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeCameraRollManagerCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeCameraRollManagerCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeCameraRollManagerCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -1501,6 +1524,7 @@ private:
     }
 
   private:
+    friend class NativeCameraRollManagerCxxSpec;
     T *instance_;
   };
 
@@ -1701,11 +1725,14 @@ protected:
     : TurboModule(std::string{NativeExceptionsManagerCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeExceptionsManagerCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeExceptionsManagerCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeExceptionsManagerCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     void reportFatalException(jsi::Runtime &rt, jsi::String message, jsi::Array stack, double exceptionId) override {
       static_assert(
@@ -1749,6 +1776,7 @@ private:
     }
 
   private:
+    friend class NativeExceptionsManagerCxxSpec;
     T *instance_;
   };
 
@@ -1902,11 +1930,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -2022,6 +2053,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2075,11 +2107,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     void voidFunc(jsi::Runtime &rt) override {
       static_assert(
@@ -2091,6 +2126,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModuleCxxSpec;
     T *instance_;
   };
 
@@ -2122,11 +2158,14 @@ protected:
     : TurboModule(std::string{NativeSampleTurboModule2CxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleTurboModule2CxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleTurboModule2CxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleTurboModule2CxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     jsi::Object getConstants(jsi::Runtime &rt) override {
       static_assert(
@@ -2146,6 +2185,7 @@ private:
     }
 
   private:
+    friend class NativeSampleTurboModule2CxxSpec;
     T *instance_;
   };
 

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -401,7 +401,7 @@ describe('buildSchemaFromConfigType', () => {
     type: 'NativeModule',
     aliasMap: {},
     enumMap: {},
-    spec: {properties: []},
+    spec: {eventEmitters: [], properties: []},
     moduleName: '',
   };
 
@@ -836,6 +836,7 @@ describe('buildSchema', () => {
             aliasMap: {},
             enumMap: {},
             spec: {
+              eventEmitters: [],
               properties: [
                 {
                   name: 'getArray',
@@ -1247,6 +1248,7 @@ describe('buildModuleSchema', () => {
       excludedPlatforms: undefined,
       moduleName: 'SampleTurboModule',
       spec: {
+        eventEmitters: [],
         properties: [
           {
             name: 'getArray',

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -26,6 +26,8 @@ const {
   UnsupportedArrayElementTypeAnnotationParserError,
   UnsupportedFunctionParamTypeAnnotationParserError,
   UnsupportedFunctionReturnTypeAnnotationParserError,
+  UnsupportedModuleEventEmitterPropertyParserError,
+  UnsupportedModuleEventEmitterTypePropertyParserError,
   UnsupportedModulePropertyParserError,
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   UntypedModuleRegistryCallParserError,
@@ -151,6 +153,46 @@ function throwIfUntypedModule(
       callExpression,
       methodName,
       moduleName,
+    );
+  }
+}
+
+function throwIfEventEmitterTypeIsUnsupported(
+  nativeModuleName: string,
+  propertyName: string,
+  propertyValueType: string,
+  parser: Parser,
+  nullable: boolean,
+  untyped: boolean,
+  cxxOnly: boolean,
+) {
+  if (nullable || untyped || !cxxOnly) {
+    throw new UnsupportedModuleEventEmitterPropertyParserError(
+      nativeModuleName,
+      propertyName,
+      propertyValueType,
+      parser.language(),
+      nullable,
+      untyped,
+      cxxOnly,
+    );
+  }
+}
+
+function throwIfEventEmitterEventTypeIsUnsupported(
+  nativeModuleName: string,
+  propertyName: string,
+  propertyValueType: string,
+  parser: Parser,
+  nullable: boolean,
+) {
+  if (nullable) {
+    throw new UnsupportedModuleEventEmitterTypePropertyParserError(
+      nativeModuleName,
+      propertyName,
+      propertyValueType,
+      parser.language(),
+      nullable,
     );
   }
 }
@@ -363,6 +405,8 @@ module.exports = {
   throwIfWrongNumberOfCallExpressionArgs,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
   throwIfUntypedModule,
+  throwIfEventEmitterTypeIsUnsupported,
+  throwIfEventEmitterEventTypeIsUnsupported,
   throwIfModuleTypeIsUnsupported,
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfUnsupportedFunctionParamTypeAnnotationParserError,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -76,6 +76,44 @@ class MoreThanOneModuleInterfaceParserError extends ParserError {
   }
 }
 
+class UnsupportedModuleEventEmitterTypePropertyParserError extends ParserError {
+  constructor(
+    nativeModuleName: string,
+    propertyValue: $FlowFixMe,
+    propertyName: string,
+    language: ParserType,
+    nullable: boolean,
+  ) {
+    super(
+      nativeModuleName,
+      propertyValue,
+      `Property '${propertyName}' is an EventEmitter and must have a non nullable eventType`,
+    );
+  }
+}
+
+class UnsupportedModuleEventEmitterPropertyParserError extends ParserError {
+  constructor(
+    nativeModuleName: string,
+    propertyValue: $FlowFixMe,
+    propertyName: string,
+    language: ParserType,
+    nullable: boolean,
+    untyped: boolean,
+    cxxOnly: boolean,
+  ) {
+    let message = `${language} interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's or non nullable 'EventEmitter's. Further the EventEmitter property `;
+    if (nullable) {
+      message += `'${propertyValue}' must non nullable.`;
+    } else if (untyped) {
+      message += `'${propertyValue}' must have a concrete or void eventType.`;
+    } else if (cxxOnly) {
+      message += `'${propertyValue}' is only supported in C++ Turbo Modules.`;
+    }
+    super(nativeModuleName, propertyValue, message);
+  }
+}
+
 class UnsupportedModulePropertyParserError extends ParserError {
   constructor(
     nativeModuleName: string,
@@ -87,7 +125,7 @@ class UnsupportedModulePropertyParserError extends ParserError {
     super(
       nativeModuleName,
       propertyValue,
-      `${language} interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's. Property '${propertyName}' refers to a '${invalidPropertyValueType}'.`,
+      `${language} interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's or non nullable 'EventEmitter's. Property '${propertyName}' refers to a '${invalidPropertyValueType}'.`,
     );
   }
 }
@@ -416,6 +454,8 @@ module.exports = {
   UnsupportedFunctionReturnTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
   UnsupportedUnionTypeAnnotationParserError,
+  UnsupportedModuleEventEmitterTypePropertyParserError,
+  UnsupportedModuleEventEmitterPropertyParserError,
   UnsupportedModulePropertyParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
   UnsupportedObjectPropertyValueTypeAnnotationParserError,

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -15,7 +15,7 @@ exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_ARR
 
 exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_ARRAY_WITH_NO_TYPE_FOR_CONTENT_AS_PARAM 1`] = `"Module NativeSampleTurboModule: Generic 'Array' must have type parameters."`;
 
-exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_NOT_ONLY_METHODS 1`] = `"Module NativeSampleTurboModule: Flow interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's. Property 'sampleBool' refers to a 'BooleanTypeAnnotation'."`;
+exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_NOT_ONLY_METHODS 1`] = `"Module NativeSampleTurboModule: Flow interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's or non nullable 'EventEmitter's. Property 'sampleBool' refers to a 'BooleanTypeAnnotation'."`;
 
 exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_PROMISE_WITHOUT_TYPE 1`] = `"Module NativeSampleTurboModule: Generic 'Promise' must have type parameters."`;
 
@@ -35,6 +35,7 @@ exports[`RN Codegen Flow Parser can generate fixture ANDROID_ONLY_NATIVE_MODULE 
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': []
       },
       'moduleName': 'SampleTurboModuleAndroid',
@@ -182,6 +183,7 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
         }
       },
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getCallback',
@@ -419,6 +421,7 @@ exports[`RN Codegen Flow Parser can generate fixture EMPTY_NATIVE_MODULE 1`] = `
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': []
       },
       'moduleName': 'SampleTurboModule'
@@ -485,6 +488,7 @@ exports[`RN Codegen Flow Parser can generate fixture IOS_ONLY_NATIVE_MODULE 1`] 
         }
       },
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getEnums',
@@ -578,6 +582,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ALIASES 
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getNumber',
@@ -742,6 +747,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WI
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -784,6 +790,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WI
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -820,6 +827,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_BASIC_AR
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -887,6 +895,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_BASIC_PA
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'passBool',
@@ -980,6 +989,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_CALLBACK
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getValueWithCallback',
@@ -1041,6 +1051,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -1101,6 +1112,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getObject',
@@ -1314,6 +1326,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getConstants',
@@ -1419,6 +1432,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_FLOAT_AN
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getInt',
@@ -1508,6 +1522,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_NESTED_A
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'foo1',
@@ -1566,6 +1581,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_NULLABLE
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'voidFunc',
@@ -1618,6 +1634,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_OBJECT_W
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getConstants',
@@ -1715,6 +1732,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getSomeObj',
@@ -1827,6 +1845,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getPartialPartial',
@@ -1916,6 +1935,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PROMISE 
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getValueWithPromise',
@@ -1976,6 +1996,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ROOT_TAG
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getRootTag',
@@ -2014,6 +2035,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_SIMPLE_O
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getObject',
@@ -2050,6 +2072,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION 1`
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getUnion',
@@ -2112,6 +2135,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNSAFE_O
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getUnsafeObject',
@@ -2186,6 +2210,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'returnStringArray',

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -17,6 +17,7 @@ import type {
   NativeModuleAliasMap,
   NativeModuleBaseTypeAnnotation,
   NativeModuleEnumMap,
+  NativeModuleEventEmitterShape,
   NativeModuleFunctionTypeAnnotation,
   NativeModuleParamTypeAnnotation,
   NativeModulePropertyShape,
@@ -40,6 +41,8 @@ import type {
 
 const {
   throwIfConfigNotfound,
+  throwIfEventEmitterEventTypeIsUnsupported,
+  throwIfEventEmitterTypeIsUnsupported,
   throwIfIncorrectModuleRegistryCallArgument,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
   throwIfModuleInterfaceIsMisnamed,
@@ -470,6 +473,63 @@ function buildPropertySchema(
   };
 }
 
+function buildEventEmitterSchema(
+  hasteModuleName: string,
+  // TODO(T108222691): [TS] Use flow-types for @babel/parser
+  // TODO(T71778680): [Flow] This is an ObjectTypeProperty containing either:
+  // - a FunctionTypeAnnotation or GenericTypeAnnotation
+  // - a NullableTypeAnnoation containing a FunctionTypeAnnotation or GenericTypeAnnotation
+  // Flow type this node
+  property: $FlowFixMe,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  enumMap: {...NativeModuleEnumMap},
+  tryParse: ParserErrorCapturer,
+  cxxOnly: boolean,
+  translateTypeAnnotation: $FlowFixMe,
+  parser: Parser,
+): NativeModuleEventEmitterShape {
+  let {key, value} = property;
+  const eventemitterName: string = key.name;
+
+  const resolveTypeAnnotationFN = parser.getResolveTypeAnnotationFN();
+  const [typeAnnotation, typeAnnotationNullable] = unwrapNullable(value);
+  const typeAnnotationUntyped =
+    value.typeParameters.params.length === 1 &&
+    value.typeParameters.params[0].type === 'ObjectTypeAnnotation' &&
+    value.typeParameters.params[0].properties.length === 0;
+
+  throwIfEventEmitterTypeIsUnsupported(
+    hasteModuleName,
+    key.name,
+    typeAnnotation.type,
+    parser,
+    typeAnnotationNullable,
+    typeAnnotationUntyped,
+    cxxOnly,
+  );
+  const eventTypeResolutionStatus = resolveTypeAnnotationFN(
+    typeAnnotation.typeParameters.params[0],
+    types,
+    parser,
+  );
+  throwIfEventEmitterEventTypeIsUnsupported(
+    hasteModuleName,
+    key.name,
+    eventTypeResolutionStatus.typeAnnotation,
+    parser,
+    eventTypeResolutionStatus.nullable,
+  );
+  return {
+    name: eventemitterName,
+    optional: false,
+    typeAnnotation: {
+      type: 'EventEmitterTypeAnnotation',
+      typeAnnotation: {type: eventTypeResolutionStatus.typeAnnotation.type},
+    },
+  };
+}
+
 function buildSchemaFromConfigType(
   configType: 'module' | 'component' | 'none',
   filename: ?string,
@@ -719,6 +779,10 @@ const buildModuleSchema = (
   const properties: $ReadOnlyArray<$FlowFixMe> =
     language === 'Flow' ? moduleSpec.body.properties : moduleSpec.body.body;
 
+  type PropertyShape =
+    | {type: 'eventEmitter', value: NativeModuleEventEmitterShape}
+    | {type: 'method', value: NativeModulePropertyShape};
+
   // $FlowFixMe[missing-type-arg]
   const nativeModuleSchema = properties
     .filter(
@@ -730,23 +794,44 @@ const buildModuleSchema = (
     .map<?{
       aliasMap: NativeModuleAliasMap,
       enumMap: NativeModuleEnumMap,
-      propertyShape: NativeModulePropertyShape,
+      propertyShape: PropertyShape,
     }>(property => {
       const enumMap: {...NativeModuleEnumMap} = {};
+      const isEventEmitter =
+        property?.value?.type === 'GenericTypeAnnotation' &&
+        property?.value?.id?.name === 'EventEmitter';
       return tryParse(() => ({
         aliasMap,
         enumMap,
-        propertyShape: buildPropertySchema(
-          hasteModuleName,
-          property,
-          types,
-          aliasMap,
-          enumMap,
-          tryParse,
-          cxxOnly,
-          translateTypeAnnotation,
-          parser,
-        ),
+        propertyShape: isEventEmitter
+          ? {
+              type: 'eventEmitter',
+              value: buildEventEmitterSchema(
+                hasteModuleName,
+                property,
+                types,
+                aliasMap,
+                enumMap,
+                tryParse,
+                cxxOnly,
+                translateTypeAnnotation,
+                parser,
+              ),
+            }
+          : {
+              type: 'method',
+              value: buildPropertySchema(
+                hasteModuleName,
+                property,
+                types,
+                aliasMap,
+                enumMap,
+                tryParse,
+                cxxOnly,
+                translateTypeAnnotation,
+                parser,
+              ),
+            },
       }));
     })
     .filter(Boolean)
@@ -756,7 +841,12 @@ const buildModuleSchema = (
         aliasMap: {...moduleSchema.aliasMap, ...aliasMap},
         enumMap: {...moduleSchema.enumMap, ...enumMap},
         spec: {
-          properties: [...moduleSchema.spec.properties, propertyShape],
+          eventEmitters: [...moduleSchema.spec.eventEmitters].concat(
+            propertyShape.type === 'eventEmitter' ? [propertyShape.value] : [],
+          ),
+          properties: [...moduleSchema.spec.properties].concat(
+            propertyShape.type === 'method' ? [propertyShape.value] : [],
+          ),
         },
         moduleName: moduleSchema.moduleName,
         excludedPlatforms: moduleSchema.excludedPlatforms,
@@ -765,7 +855,7 @@ const buildModuleSchema = (
         type: 'NativeModule',
         aliasMap: {},
         enumMap: {},
-        spec: {properties: []},
+        spec: {eventEmitters: [], properties: []},
         moduleName,
         excludedPlatforms:
           excludedPlatforms.length !== 0 ? [...excludedPlatforms] : undefined,
@@ -776,7 +866,10 @@ const buildModuleSchema = (
     type: 'NativeModule',
     aliasMap: getSortedObject(nativeModuleSchema.aliasMap),
     enumMap: getSortedObject(nativeModuleSchema.enumMap),
-    spec: {properties: nativeModuleSchema.spec.properties.sort()},
+    spec: {
+      eventEmitters: nativeModuleSchema.spec.eventEmitters.sort(),
+      properties: nativeModuleSchema.spec.properties.sort(),
+    },
     moduleName,
     excludedPlatforms: nativeModuleSchema.excludedPlatforms,
   };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -8,7 +8,7 @@ exports[`RN Codegen TypeScript Parser Fails with error message NATIVE_MODULES_WI
 
 exports[`RN Codegen TypeScript Parser Fails with error message NATIVE_MODULES_WITH_ARRAY_WITH_NO_TYPE_FOR_CONTENT_AS_PARAM 1`] = `"Module NativeSampleTurboModule: Generic 'Array' must have type parameters."`;
 
-exports[`RN Codegen TypeScript Parser Fails with error message NATIVE_MODULES_WITH_NOT_ONLY_METHODS 1`] = `"Module NativeSampleTurboModule: TypeScript interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's. Property 'sampleBool' refers to a 'TSBooleanKeyword'."`;
+exports[`RN Codegen TypeScript Parser Fails with error message NATIVE_MODULES_WITH_NOT_ONLY_METHODS 1`] = `"Module NativeSampleTurboModule: TypeScript interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's or non nullable 'EventEmitter's. Property 'sampleBool' refers to a 'TSBooleanKeyword'."`;
 
 exports[`RN Codegen TypeScript Parser Fails with error message NATIVE_MODULES_WITH_PROMISE_WITHOUT_TYPE 1`] = `"Module NativeSampleTurboModule: Generic 'Promise' must have type parameters."`;
 
@@ -26,6 +26,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture ANDROID_ONLY_NATIVE_M
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': []
       },
       'moduleName': 'SampleTurboModuleAndroid',
@@ -173,6 +174,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
         }
       },
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getCallback',
@@ -410,6 +412,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EMPTY_NATIVE_MODULE 1
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': []
       },
       'moduleName': 'SampleTurboModule'
@@ -476,6 +479,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture IOS_ONLY_NATIVE_MODUL
         }
       },
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getEnums',
@@ -569,6 +573,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AL
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getNumber',
@@ -733,6 +738,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -775,6 +781,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -811,6 +818,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -853,6 +861,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -889,6 +898,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -956,6 +966,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -1023,6 +1034,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'passBool',
@@ -1116,6 +1128,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CA
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getValueWithCallback',
@@ -1177,6 +1190,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -1237,6 +1251,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getArray',
@@ -1297,6 +1312,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getObject',
@@ -1510,6 +1526,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getConstants',
@@ -1615,6 +1632,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_FL
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getInt',
@@ -1720,6 +1738,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_IN
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'foo1',
@@ -1812,6 +1831,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'foo1',
@@ -1974,6 +1994,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'foo1',
@@ -2032,6 +2053,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NU
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'voidFunc',
@@ -2084,6 +2106,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_OB
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getConstants',
@@ -2181,6 +2204,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getSomeObj',
@@ -2293,6 +2317,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getPartialPartial',
@@ -2382,6 +2407,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PR
       },
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getValueWithPromise',
@@ -2442,6 +2468,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_RO
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getRootTag',
@@ -2480,6 +2507,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_SI
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getObject',
@@ -2516,6 +2544,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getUnion',
@@ -2578,6 +2607,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
       'aliasMap': {},
       'enumMap': {},
       'spec': {
+        'eventEmitters': [],
         'properties': [
           {
             'name': 'getUnsafeObject',

--- a/packages/react-native/Libraries/Types/CodegenTypes.js
+++ b/packages/react-native/Libraries/Types/CodegenTypes.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 import type {SyntheticEvent} from './CoreEventTypes';
 
 // Event types
@@ -40,3 +41,7 @@ type DefaultTypes = number | boolean | string | $ReadOnlyArray<string>;
 //
 // eslint-disable-next-line no-unused-vars
 export type WithDefault<Type: DefaultTypes, Value: ?Type | string> = ?Type;
+
+export type EventEmitter<T> = {
+  addListener(handler: (T) => mixed): EventSubscription,
+};

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8129,6 +8129,9 @@ export type UnsafeObject = $FlowFixMe;
 export type UnsafeMixed = mixed;
 type DefaultTypes = number | boolean | string | $ReadOnlyArray<string>;
 export type WithDefault<Type: DefaultTypes, Value: ?Type | string> = ?Type;
+export type EventEmitter<T> = {
+  addListener(handler: (T) => mixed): EventSubscription,
+};
 "
 `;
 

--- a/packages/react-native/ReactCommon/react/bridging/Bridging.h
+++ b/packages/react-native/ReactCommon/react/bridging/Bridging.h
@@ -13,6 +13,7 @@
 #include <react/bridging/Class.h>
 #include <react/bridging/Dynamic.h>
 #include <react/bridging/Error.h>
+#include <react/bridging/EventEmitter.h>
 #include <react/bridging/Function.h>
 #include <react/bridging/Number.h>
 #include <react/bridging/Object.h>

--- a/packages/react-native/ReactCommon/react/bridging/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/bridging/EventEmitter.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/bridging/Function.h>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#define FRIEND_TEST(test_case_name, test_name) \
+  friend class test_case_name##_##test_name##_Test
+
+namespace facebook::react {
+
+class EventSubscription {
+ public:
+  explicit EventSubscription(std::function<void()> remove)
+      : remove_(std::move(remove)) {}
+  ~EventSubscription() = default;
+  EventSubscription(EventSubscription&&) noexcept = default;
+  EventSubscription& operator=(EventSubscription&&) noexcept = default;
+  EventSubscription(const EventSubscription&) = delete;
+  EventSubscription& operator=(const EventSubscription&) = delete;
+
+ private:
+  friend Bridging<EventSubscription>;
+
+  std::function<void()> remove_;
+};
+
+template <>
+struct Bridging<EventSubscription> {
+  static jsi::Object toJs(
+      jsi::Runtime& rt,
+      const EventSubscription& eventSubscription,
+      const std::shared_ptr<CallInvoker>& jsInvoker) {
+    auto result = jsi::Object(rt);
+    result.setProperty(
+        rt, "remove", bridging::toJs(rt, eventSubscription.remove_, jsInvoker));
+    return result;
+  }
+};
+
+class IAsyncEventEmitter {
+ public:
+  IAsyncEventEmitter() noexcept = default;
+  virtual ~IAsyncEventEmitter() noexcept = default;
+  IAsyncEventEmitter(IAsyncEventEmitter&&) noexcept = default;
+  IAsyncEventEmitter& operator=(IAsyncEventEmitter&&) noexcept = default;
+  IAsyncEventEmitter(const IAsyncEventEmitter&) = delete;
+  IAsyncEventEmitter& operator=(const IAsyncEventEmitter&) = delete;
+
+  virtual jsi::Object get(
+      jsi::Runtime& rt,
+      const std::shared_ptr<CallInvoker>& jsInvoker) const = 0;
+};
+
+template <typename... Args>
+class AsyncEventEmitter : public IAsyncEventEmitter {
+  static_assert(
+      sizeof...(Args) <= 1,
+      "AsyncEventEmitter must have at most one argument");
+
+ public:
+  AsyncEventEmitter() : state_(std::make_shared<SharedState>()) {
+    listen_ = [state = state_](AsyncCallback<Args...> listener) {
+      std::lock_guard<std::mutex> lock(state->mutex);
+      auto listenerId = state->listenerId++;
+      state->listeners.emplace(listenerId, std::move(listener));
+      return EventSubscription([state, listenerId]() {
+        std::lock_guard<std::mutex> innerLock(state->mutex);
+        state->listeners.erase(listenerId);
+      });
+    };
+  }
+  ~AsyncEventEmitter() override = default;
+  AsyncEventEmitter(AsyncEventEmitter&&) noexcept = default;
+  AsyncEventEmitter& operator=(AsyncEventEmitter&&) noexcept = default;
+  AsyncEventEmitter(const AsyncEventEmitter&) = delete;
+  AsyncEventEmitter& operator=(const AsyncEventEmitter&) = delete;
+
+  void emit(Args... value) {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    for (const auto& [_, listener] : state_->listeners) {
+      listener.call(static_cast<Args>(value)...);
+    }
+  }
+
+  jsi::Object get(
+      jsi::Runtime& rt,
+      const std::shared_ptr<CallInvoker>& jsInvoker) const override {
+    auto result = jsi::Object(rt);
+    result.setProperty(
+        rt, "addListener", bridging::toJs(rt, listen_, jsInvoker));
+    return result;
+  }
+
+ private:
+  friend Bridging<AsyncEventEmitter>;
+  FRIEND_TEST(BridgingTest, eventEmitterTest);
+
+  struct SharedState {
+    std::mutex mutex;
+    std::unordered_map<size_t, AsyncCallback<Args...>> listeners;
+    size_t listenerId{};
+  };
+
+  std::function<EventSubscription(AsyncCallback<Args...>)> listen_;
+  std::shared_ptr<SharedState> state_;
+};
+
+template <typename... Args>
+struct Bridging<AsyncEventEmitter<Args...>> {
+  static jsi::Object toJs(
+      jsi::Runtime& rt,
+      const AsyncEventEmitter<Args...>& eventEmitter,
+      const std::shared_ptr<CallInvoker>& jsInvoker) {
+    return eventEmitter.get(rt, jsInvoker);
+  }
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -123,7 +123,7 @@ TEST_F(BridgingTest, hostObjectTest) {
   struct TestHostObject : public jsi::HostObject {
     jsi::Value get(jsi::Runtime& rt, const jsi::PropNameID& name) override {
       if (name.utf8(rt) == "test") {
-        return jsi::Value(1);
+        return {1};
       }
       return jsi::Value::undefined();
     }
@@ -424,6 +424,105 @@ TEST_F(BridgingTest, promiseTest) {
           .utf8(rt));
   EXPECT_NO_THROW(promise.resolve({"ignored"}));
   EXPECT_NO_THROW(promise.reject("ignored"));
+}
+
+template <typename EventType>
+static void addEventSubscription(
+    jsi::Runtime& rt,
+    const AsyncEventEmitter<EventType>& eventEmitter,
+    std::vector<std::pair<jsi::Object, std::shared_ptr<EventType>>>&
+        eventSubscriptionsWithListener,
+    const std::shared_ptr<TestCallInvoker>& invoker) {
+  auto eventEmitterJs = bridging::toJs(rt, eventEmitter, invoker);
+  auto lastEvent = std::make_shared<EventType>();
+  auto listenJs = bridging::toJs(
+      rt,
+      [lastEvent = lastEvent](const EventType& event) { *lastEvent = event; },
+      invoker);
+  eventSubscriptionsWithListener.emplace_back(std::make_pair(
+      jsi::Object(eventEmitterJs.getPropertyAsFunction(rt, "addListener")
+                      .callWithThis(rt, eventEmitterJs, listenJs)
+                      .asObject(rt)),
+      std::move(lastEvent)));
+}
+
+TEST_F(BridgingTest, eventEmitterTest) {
+  using EventType = std::vector<std::string>;
+  std::vector<std::pair<jsi::Object, std::shared_ptr<EventType>>>
+      eventSubscriptionsWithListener;
+
+  AsyncEventEmitter<EventType> eventEmitter;
+  EXPECT_NO_THROW(eventEmitter.emit({"one", "two", "three"}));
+  EXPECT_EQ(0, eventSubscriptionsWithListener.size());
+
+  // register 3 JavaScript listeners to the event emitter
+  for (int i = 0; i < 3; ++i) {
+    addEventSubscription<EventType>(
+        rt, eventEmitter, eventSubscriptionsWithListener, invoker);
+  }
+
+  EXPECT_TRUE(eventEmitter.state_->listeners.contains(0));
+  EXPECT_TRUE(eventEmitter.state_->listeners.contains(1));
+  EXPECT_TRUE(eventEmitter.state_->listeners.contains(2));
+
+  EXPECT_NO_THROW(eventEmitter.emit({"four", "five", "six"}));
+  flushQueue();
+
+  // verify all listeners received the event
+  for (const auto& [_, lastEvent] : eventSubscriptionsWithListener) {
+    EXPECT_EQ(3, lastEvent->size());
+    EXPECT_EQ("four", lastEvent->at(0));
+    EXPECT_EQ("five", lastEvent->at(1));
+    EXPECT_EQ("six", lastEvent->at(2));
+  }
+
+  // Remove 2nd eventSubscriptions
+  eventSubscriptionsWithListener[1]
+      .first.getPropertyAsFunction(rt, "remove")
+      .callWithThis(rt, eventSubscriptionsWithListener[1].first);
+  eventSubscriptionsWithListener.erase(
+      eventSubscriptionsWithListener.begin() + 1);
+
+  // Add 4th and 5th eventSubscriptions
+  addEventSubscription<EventType>(
+      rt, eventEmitter, eventSubscriptionsWithListener, invoker);
+  addEventSubscription<EventType>(
+      rt, eventEmitter, eventSubscriptionsWithListener, invoker);
+
+  EXPECT_TRUE(eventEmitter.state_->listeners.contains(0));
+  EXPECT_FALSE(eventEmitter.state_->listeners.contains(1));
+  EXPECT_TRUE(eventEmitter.state_->listeners.contains(2));
+  EXPECT_TRUE(eventEmitter.state_->listeners.contains(3));
+  EXPECT_TRUE(eventEmitter.state_->listeners.contains(4));
+
+  // Emit more events
+  EXPECT_NO_THROW(eventEmitter.emit({"seven", "eight", "nine"}));
+  flushQueue();
+
+  for (const auto& [_, lastEvent] : eventSubscriptionsWithListener) {
+    EXPECT_EQ(3, lastEvent->size());
+    EXPECT_EQ("seven", lastEvent->at(0));
+    EXPECT_EQ("eight", lastEvent->at(1));
+    EXPECT_EQ("nine", lastEvent->at(2));
+  }
+
+  // clean-up the event subscriptions
+  for (const auto& [eventSubscription, _] : eventSubscriptionsWithListener) {
+    eventSubscription.getPropertyAsFunction(rt, "remove")
+        .callWithThis(rt, eventSubscription);
+  }
+  flushQueue();
+
+  EXPECT_NO_THROW(eventEmitter.emit({"ten", "eleven", "twelve"}));
+  flushQueue();
+
+  // no new data as listeners had been removed
+  for (const auto& [_, lastEvent] : eventSubscriptionsWithListener) {
+    EXPECT_EQ(3, lastEvent->size());
+    EXPECT_EQ("seven", lastEvent->at(0));
+    EXPECT_EQ("eight", lastEvent->at(1));
+    EXPECT_EQ("nine", lastEvent->at(2));
+  }
 }
 
 TEST_F(BridgingTest, optionalTest) {

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -465,6 +465,7 @@ TEST_F(BridgingTest, eventEmitterTest) {
   EXPECT_TRUE(eventEmitter.state_->listeners.contains(1));
   EXPECT_TRUE(eventEmitter.state_->listeners.contains(2));
 
+  // emit with args
   EXPECT_NO_THROW(eventEmitter.emit({"four", "five", "six"}));
   flushQueue();
 
@@ -513,7 +514,12 @@ TEST_F(BridgingTest, eventEmitterTest) {
   }
   flushQueue();
 
-  EXPECT_NO_THROW(eventEmitter.emit({"ten", "eleven", "twelve"}));
+  // Emit with function
+  EXPECT_NO_THROW(eventEmitter.emit(
+      [jsInvoker = invoker,
+       value = {"ten", "eleven", "twelve"}](jsi::Runtime& rt) -> jsi::Value {
+        return bridging::toJs(rt, value, jsInvoker);
+      }));
   flushQueue();
 
   // no new data as listeners had been removed

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -7,12 +7,14 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 
 #include <jsi/jsi.h>
 
 #include <ReactCommon/CallInvoker.h>
+#include <react/bridging/EventEmitter.h>
 
 namespace facebook::react {
 
@@ -89,6 +91,8 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
         size_t count);
   };
   std::unordered_map<std::string, MethodMetadata> methodMap_;
+  std::unordered_map<std::string, std::shared_ptr<IAsyncEventEmitter>>
+      eventEmitterMap_;
 
   using ArgFactory =
       std::function<void(jsi::Runtime& runtime, std::vector<jsi::Value>& args)>;
@@ -122,12 +126,9 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
       jsi::Runtime& runtime,
       const jsi::PropNameID& propName) {
     std::string propNameUtf8 = propName.utf8(runtime);
-    auto p = methodMap_.find(propNameUtf8);
-    if (p == methodMap_.end()) {
-      // Method was not found, let JS decide what to do.
-      return facebook::jsi::Value::undefined();
-    } else {
-      const MethodMetadata& meta = p->second;
+    if (auto methodIter = methodMap_.find(propNameUtf8);
+        methodIter != methodMap_.end()) {
+      const MethodMetadata& meta = methodIter->second;
       return jsi::Function::createFromHostFunction(
           runtime,
           propName,
@@ -137,7 +138,12 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
               [[maybe_unused]] const jsi::Value& thisVal,
               const jsi::Value* args,
               size_t count) { return meta.invoker(rt, *this, args, count); });
+    } else if (auto eventEmitterIter = eventEmitterMap_.find(propNameUtf8);
+               eventEmitterIter != eventEmitterMap_.end()) {
+      return eventEmitterIter->second->get(runtime, jsInvoker_);
     }
+    // Neither Method nor EventEmitter were not found, let JS decide what to do.
+    return facebook::jsi::Value::undefined();
   }
 
  private:


### PR DESCRIPTION
Summary:
Adding react-native-codegen parser support for a new `EventEmitter` property type on C++ Turbo Modules.

It is possible to later expand this feature to other languages (Java, ObjC).

## Characteristics

An `EventEmitter` must:
- be non null:
 `EventEmitter<string>` works, `?EventEmitter<string>` does NOT
- have a non null eventType:
  `EventEmitter<number>` works, `EventEmitter<?number>` does NOT
- have at most 1 eventType, `void` is possible as well:
  `EventEmitter<>` or `EventEmitter<MyObject>` work - `EventEmitter<number, string>` do NOT
- have a concrete eventType, `{}` is not allowed
  `EventEmitter<{}>` does NOT work
- be used in `Cxx` Turbo Modules only at this time

## Example

For these 4 eventEmitters in on an RN JS TM spec
```
  +onPress: EventEmitter<void>;
  +onClick: EventEmitter<string>;
  +onChange: EventEmitter<ObjectStruct>;
  +onSubmit: EventEmitter<ObjectStruct[]>;
```
We now generate this code:
1.) in the spec based header `{MyModuleName}CxxSpec` in the constructor:
```
      ... // existing code
      eventEmitterMap_["onPress"] = std::make_shared<AsyncEventEmitter<>>();
      eventEmitterMap_["onClick"] = std::make_shared<AsyncEventEmitter<OnClickType>>();
      eventEmitterMap_["onChange"] = std::make_shared<AsyncEventEmitter<OnChangeType>>();
      eventEmitterMap_["onSubmit"] = std::make_shared<AsyncEventEmitter<OnSubmitType>>();
```
2.) as `protected` functions
```
  void emitOnPress() {
      std::static_pointer_cast<AsyncEventEmitter<>>(delegate_.eventEmitterMap_["onPress"])->emit();
  }

  void emitOnClick(const OnClickType& value) {
      std::static_pointer_cast<AsyncEventEmitter<OnClickType>>(delegate_.eventEmitterMap_["onClick"])->emit(value);
  }

  void emitOnChange(const OnChangeType& value) {
      std::static_pointer_cast<AsyncEventEmitter<OnChangeType>>(delegate_.eventEmitterMap_["onChange"])->emit(value);
  }

  void emitOnSubmit(const OnSubmitType& value) {
      std::static_pointer_cast<AsyncEventEmitter<OnSubmitType>>(delegate_.eventEmitterMap_["onSubmit"])->emit(value);
  }
```

## Changelog:

[General] [Added] - Add EventEmitter code-gen support for C++ Turbo Modules

Differential Revision: D57407871


