### PR TITLE
Remove the workaround to import the Paper renderer

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -54,10 +54,6 @@ import memoize from 'memoize-one';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 
-if (Platform.OS === 'ios') {
-  require('../../Renderer/shims/ReactNative'); // Force side effects to prevent T55744311
-}
-
 /*
  * iOS scroll event timing nuances:
  * ===============================


### PR DESCRIPTION
Summary:
We needed this workaround to import the paper renderer in the New Architecture to make sure that the event emitter is properly registered before we use it.

With the previous change, we don't need this lines of code anymore as we are using a different mechanism for the events.

## Changelog:
[Internal] - Avoid to import the old Renderer in the New Architecture

## Facebook:
This diff was initially part of D57097880, but I split them for the OTA

Reviewed By: cortinico

Differential Revision: D58234325
