### PR TITLE
swap test_ios_template for test_ios_helloworld in CircleCI (#44497)

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -58,6 +58,8 @@ commands:
             # Set ruby dependencies
             rbenv global << parameters.ruby_version >>
             if [[ << parameters.ruby_version >> == "2.6.10" ]]; then
+              # RubyGems 3.0.3.1 breaks Bundler
+              gem update --system 3.2.3
               gem install bundler -v 2.4.22
             else
               gem install bundler

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -384,9 +384,9 @@ jobs:
           destination: template-apk
 
   # -------------------------
-  #    JOBS: Test iOS Template
+  #    JOBS: Test iOS HelloWorld
   # -------------------------
-  test_ios_template:
+  test_ios_helloworld:
     parameters:
       flavor:
         default: "Debug"
@@ -412,25 +412,18 @@ jobs:
         default: "2.6.10"
         description: The version of ruby that must be used
         type: string
-      podfile_lock_path:
-        type: string
-        default: "/tmp/iOSTemplateProject/ios/Podfile.lock"
-      pods_build_folder:
-        type: string
-        default: "/tmp/iOSTemplateProject/ios/Pods"
       podfile_lock_cache_key:
         type: string
-        default: *template_podfile_lock_cache_key
+        default: *helloworld_podfile_lock_cache_key
       cocoapods_cache_key:
         type: string
-        default: *template_cocoapods_cache_key
+        default: *helloworld_cocoapods_cache_key
       executor:
         description: The executor to use
         default: reactnativeios
         type: string
     executor: << parameters.executor >>
     environment:
-      - PROJECT_NAME: "iOSTemplateProject"
       - HERMES_WS_DIR: *hermes_workspace_root
       - YARN_ENABLE_IMMUTABLE_INSTALLS: false
     steps:
@@ -451,48 +444,37 @@ jobs:
                   BUILD_TYPE="<< parameters.flavor >>"
                   TARBALL_FILENAME=$(node ./packages/react-native/scripts/hermes/get-tarball-name.js --buildType "$BUILD_TYPE")
                   echo "export HERMES_ENGINE_TARBALL_PATH=$HERMES_WS_DIR/hermes-runtime-darwin/$TARBALL_FILENAME" >> $BASH_ENV
-      - run:
-          name: Create iOS template project
-          command: |
-            REPO_ROOT=$(pwd)
-            PACKAGE=$(cat build/react-native-package-version)
-            PATH_TO_PACKAGE="$REPO_ROOT/build/$PACKAGE"
-            node ./scripts/releases/update-template-package.js "{\"react-native\":\"file:$PATH_TO_PACKAGE\"}"
-            node ./scripts/e2e/init-template-e2e.js --projectName $PROJECT_NAME --templatePath "$REPO_ROOT/packages/react-native" --directory "/tmp/$PROJECT_NAME" --verbose
       - with_xcodebuild_cache:
-          podfile_lock_path: << parameters.podfile_lock_path >>
-          pods_build_folder: << parameters.pods_build_folder >>
+          podfile_lock_path: packages/helloworld/ios/Podfile.lock
+          pods_build_folder: packages/helloworld/ios/Pods
           cocoapods_cache_key: << parameters.cocoapods_cache_key >>
           podfile_lock_cache_key: << parameters.podfile_lock_cache_key >>
           steps:
             - run:
                 name: Install iOS dependencies - Configuration << parameters.flavor >>; New Architecture << parameters.architecture >>; JS Engine << parameters.jsengine>>
                 command: |
-                  cd /tmp/$PROJECT_NAME/ios
-
-                  if [[ << parameters.architecture >> == "NewArch" ]]; then
-                    export RCT_NEW_ARCH_ENABLED=1
+                  cd packages/helloworld
+                  args=()
+                  if [[ << parameters.architecture >> == "OldArch" ]]; then
+                    args+=(--arch old)
                   fi
-
                   if [[ << parameters.jsengine >> == "JSC" ]]; then
-                    export USE_HERMES=0
+                    args+=(--jsvm jsc)
                   fi
-
                   if [[ << parameters.use_frameworks >> == "DynamicFrameworks" ]]; then
-                    export USE_FRAMEWORKS=dynamic
+                    args+=(--frameworks dynamic)
                   fi
-
-                  cd ..
-                  bundle install
-                  bundle exec pod install --project-directory=ios
+                  yarn bootstrap ios "${args[@]}" | cat
             - run:
-                name: Build template project
+                name: Build helloworld project
                 command: |
-                  xcodebuild build \
-                    -configuration << parameters.flavor >> \
-                    -workspace /tmp/$PROJECT_NAME/ios/$PROJECT_NAME.xcworkspace \
-                    -scheme $PROJECT_NAME \
-                    -sdk iphonesimulator
+                  cd packages/helloworld
+                  args=()
+                  if [[ << parameters.flavor >> == "Release" ]]; then
+                    args+=(--prod)
+                  fi
+                  yarn build ios "${args[@]}" | cat
+                  yarn bundle ios "${args[@]}" | cat
 
   # -------------------------
   #    JOBS: Test iOS RNTester

--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -54,19 +54,18 @@
               architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]
               flavor: ["Debug", "Release"]
-      - test_ios_template:
+      - test_ios_helloworld:
           requires:
-            - build_npm_package
+            - build_hermes_macos
           name: "Test Template with Ruby 3.2.0"
           ruby_version: "3.2.0"
           architecture: "NewArch"
           flavor: "Debug"
           jsengine: "Hermes"
           use_frameworks: "StaticLibraries"
-      - test_ios_template:
+      - test_ios_helloworld:
           requires:
-            - build_npm_package
-          architecture: "NewArch"
+            - build_hermes_macos
           matrix:
             parameters:
               flavor: ["Debug", "Release"]

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -43,19 +43,18 @@
             - build_hermesc_linux
             - build_hermes_macos
             - build_hermesc_windows
-      - test_ios_template:
+      - test_ios_helloworld:
           requires:
-            - build_npm_package
+            - build_hermes_macos
           name: "Test Template with Ruby 3.2.0"
           ruby_version: "3.2.0"
           architecture: "NewArch"
           flavor: "Debug"
           jsengine: "Hermes"
           use_frameworks: "StaticLibraries"
-      - test_ios_template:
+      - test_ios_helloworld:
           requires:
-            - build_npm_package
-          architecture: "NewArch"
+            - build_hermes_macos
           matrix:
             parameters:
               flavor: ["Debug", "Release"]

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -71,7 +71,7 @@ references:
 
   cache_keys:
     checkout_cache_key: &checkout_cache_key v1-checkout
-    gems_cache_key: &gems_cache_key v1-gems-{{ checksum "Gemfile.lock" }}
+    gems_cache_key: &gems_cache_key v2-gems-{{ checksum "Gemfile.lock" }}
     gradle_cache_key: &gradle_cache_key v3-gradle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "packages/react-native/ReactAndroid/gradle.properties" }}
     yarn_cache_key: &yarn_cache_key v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}
     rbenv_cache_key: &rbenv_cache_key v1-rbenv-{{ checksum "/tmp/required_ruby" }}
@@ -93,10 +93,9 @@ references:
     pods_cache_key: &pods_cache_key v11-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
     cocoapods_cache_key: &cocoapods_cache_key v11-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
     rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v10-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
-
-    # Cocoapods - Template
-    template_cocoapods_cache_key: &template_cocoapods_cache_key v6-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile.lock" }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
-    template_podfile_lock_cache_key: &template_podfile_lock_cache_key v6-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/iOSTemplateProject/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "packages/rn-tester/Podfile.lock" }}
+    # Cocoapods - HelloWorld
+    helloworld_cocoapods_cache_key: &helloworld_cocoapods_cache_key v1-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/helloworld/ios/Podfile.lock" }}-{{ checksum "packages/helloworld/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    helloworld_podfile_lock_cache_key: &helloworld_podfile_lock_cache_key v1-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/helloworld/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
 
   cache_paths:
     hermes_workspace_macos_cache_paths: &hermes_workspace_macos_cache_paths

--- a/packages/helloworld/cli.flow.js
+++ b/packages/helloworld/cli.flow.js
@@ -37,9 +37,9 @@ const cwd = {
 
 const possibleHermescPaths = [
   // OSS checkout
-  path.join(cwd.ios, 'Pods/hermes-engine/destroot/bin/hermesc'),
+  'destroot/bin/hermesc',
   // internal
-  path.join(cwd.ios, 'Pods/hermes-engine/build_host_hermesc/bin/hermesc'),
+  'build_host_hermesc/bin/hermesc',
 ];
 
 type BootstrapOptions = {
@@ -178,9 +178,10 @@ bundle
     );
 
     // Validate only after initial build, as hermesc may not be prebuilt
-    const hermesc = getExistingPath(possibleHermescPaths);
+    const hermesFolder = path.join(cwd.ios, 'Pods/hermes-engine');
+    const hermesc = getExistingPath(hermesFolder, possibleHermescPaths);
 
-    if (hermesc == null) {
+    if (hermesc == null && isHermesInstalled) {
       throw new Error(
         `Unable to find hermesc at:\n-${possibleHermescPaths
           .map(line => ' - ' + line)
@@ -202,8 +203,8 @@ bundle
           dev: !prod,
           jsvm: isHermesInstalled ? 'hermes' : 'jsc',
           hermes: {
-            path: path.join(cwd.ios, 'Pods', 'hermes-engine'),
-            hermesc: 'build_host_hermesc/bin/hermesc',
+            path: hermesFolder,
+            hermesc: hermesc ?? '',
           },
           callback: metroProcess => {
             const readline = require('readline');
@@ -229,8 +230,8 @@ bundle
           dev: !prod,
           jsvm: isHermesInstalled ? 'hermes' : 'jsc',
           hermes: {
-            path: path.join(cwd.ios, 'Pods/hermes-engine'),
-            hermesc: 'build_host_hermesc/bin/hermesc',
+            path: hermesFolder,
+            hermesc: hermesc ?? '',
           },
         });
 

--- a/packages/helloworld/lib/filesystem.js
+++ b/packages/helloworld/lib/filesystem.js
@@ -12,6 +12,7 @@
 import {execSync, spawn} from 'child_process';
 import debug from 'debug';
 import {existsSync} from 'fs';
+import path from 'path';
 
 const logWatchman = debug('helloworld:cli:watchman');
 
@@ -50,10 +51,13 @@ export async function pauseWatchman(command: () => Promise<mixed | void>) {
   }
 }
 
-export function getExistingPath(paths: $ReadOnlyArray<string>): string | null {
-  for (const path of paths) {
-    if (existsSync(path)) {
-      return path;
+export function getExistingPath(
+  folder: string,
+  paths: $ReadOnlyArray<string>,
+): string | null {
+  for (const p of paths) {
+    if (existsSync(path.join(folder, p))) {
+      return p;
     }
   }
   return null;


### PR DESCRIPTION
Summary:

Remove our `test_ios_template` job for `test_ios_helloworld`.

NOTE: There needs to be a followup to do the same in our Github Actions.


Changelog: [General][Changed] use helloworld instead of template for CI tests.

Reviewed By: cipolleschi

Differential Revision: D57122797


