### PR TITLE
Make getContentOriginOffset to know info about if call-site want transform or not

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.cpp
@@ -63,9 +63,11 @@ void ScrollViewShadowNode::layout(LayoutContext layoutContext) {
   updateStateIfNeeded();
 }
 
-Point ScrollViewShadowNode::getContentOriginOffset() const {
+Point ScrollViewShadowNode::getContentOriginOffset(
+    bool /*includeTransform*/) const {
   auto stateData = getStateData();
   auto contentOffset = stateData.contentOffset;
+
   return {-contentOffset.x, -contentOffset.y + stateData.scrollAwayPaddingTop};
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
@@ -37,7 +37,7 @@ class ScrollViewShadowNode final : public ConcreteViewShadowNode<
 #pragma mark - LayoutableShadowNode
 
   void layout(LayoutContext layoutContext) override;
-  Point getContentOriginOffset() const override;
+  Point getContentOriginOffset(bool includeTransform) const override;
 
  private:
   void updateStateIfNeeded();

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -151,7 +151,11 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
     }
 
     if (i != 0 && policy.includeTransform) {
-      resultFrame.origin += currentShadowNode->getContentOriginOffset();
+      // Transformation is not applied here and instead we delegated out in
+      // getContentOriginOffset. The reason is that for `ScrollViewShadowNode`,
+      // we need to consider `scrollAwayPaddingTop` which should NOT be included
+      // in the transform.
+      resultFrame.origin += currentShadowNode->getContentOriginOffset(true);
     }
 
     if (policy.enableOverflowClipping) {
@@ -188,7 +192,8 @@ Transform LayoutableShadowNode::getTransform() const {
   return Transform::Identity();
 }
 
-Point LayoutableShadowNode::getContentOriginOffset() const {
+Point LayoutableShadowNode::getContentOriginOffset(
+    bool /*includeTransform*/) const {
   return {0, 0};
 }
 
@@ -269,7 +274,7 @@ ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
   }
 
   auto newPoint = point - transformedFrame.origin -
-      layoutableShadowNode->getContentOriginOffset();
+      layoutableShadowNode->getContentOriginOffset(false);
 
   auto sortedChildren = node->getChildren();
   std::stable_sort(

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -122,8 +122,11 @@ class LayoutableShadowNode : public ShadowNode {
    * Returns offset which is applied to children's origin in
    * `LayoutableShadowNode::getRelativeLayoutMetrics` and
    * `LayoutableShadowNode::findNodeAtPoint`.
+   * i`ncludeTransform` is a flag to include the transform in the offset. This
+   * is a rare case but needed for case where transform is involved for e.g. in
+   * ScrollView.
    */
-  virtual Point getContentOriginOffset() const;
+  virtual Point getContentOriginOffset(bool includeTransform) const;
 
   /*
    * Sets layout metrics for the shadow node.

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/TestComponent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/TestComponent.h
@@ -76,7 +76,8 @@ class TestShadowNode final : public ConcreteViewShadowNode<
 
   facebook::react::Point _contentOriginOffset{};
 
-  facebook::react::Point getContentOriginOffset() const override {
+  facebook::react::Point getContentOriginOffset(
+      bool /*includeTransform*/) const override {
     return _contentOriginOffset;
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
@@ -357,7 +357,7 @@ DOMPoint getScrollPosition(
     return DOMPoint{};
   }
 
-  auto scrollPosition = layoutableShadowNode->getContentOriginOffset();
+  auto scrollPosition = layoutableShadowNode->getContentOriginOffset(false);
 
   return DOMPoint{
       .x = scrollPosition.x == 0 ? 0 : -scrollPosition.x,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This is to make `getContentOriginOffset` to have `includeTransform` information passed during Layout computation.

Differential Revision: D58223380
