### PR TITLE
Add libmapbufferjni.so to pickFirst directives

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -98,6 +98,7 @@ internal object NdkConfiguratorUtils {
               "**/libfolly_runtime.so",
               "**/libglog.so",
               "**/libjsi.so",
+              "**/libmapbufferjni.so",
               "**/libreact_codegen_rncore.so",
               "**/libreact_debug.so",
               "**/libreact_nativemodule_core.so",


### PR DESCRIPTION
Summary:
After D57856389 (#44684), the build is now firing an issue as `libmapbufferjni.so` is exposed as a public `.so` and we're missing a pickFirst directive.

Changelog:
[Internal] [Changed] - Add libmapbufferjni.so to pickFirst directives

Differential Revision: D58284481
