### PR TITLE
Bump build_npm_package machine to more powerful ones

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -640,7 +640,7 @@ jobs:
           name: rntester-apk
           path: packages/rn-tester/android/app/build/outputs/apk/
   build_npm_package:
-    runs-on: 4-core-ubuntu-latest
+    runs-on: 8-core-ubuntu
     needs: [set_release_type, prepare_hermes_workspace, build_hermes_macos, build_hermesc_linux, build_hermesc_windows,build_android]
     container:
       image: reactnativecommunity/react-native-android:latest


### PR DESCRIPTION
Summary:
The build_npm_package jobs remains sometimes in queue because there are not enough executors for it to run.
This makes our signals less reliable.

Plus, it is rebuilding part of Android, so it can benefit from a bigger machine

## Changelog:
[Internal] - Bump build_npm_package machine to more powerful ones

Differential Revision: D58284884
