### PR TITLE
[RN][GHA] Migrate the Prepare Release workflow

### DIFF
--- a/.github/actions/prepare_release/action.yml
+++ b/.github/actions/prepare_release/action.yml
@@ -1,0 +1,35 @@
+name: prepare_release
+description: Prepare React Native release
+runs:
+  using: composite
+  steps:
+    - name: Yarn install
+      shell: bash
+      run: yarn install --non-interactive
+    - name: Versioning workspace packages
+      shell: bash
+      run: |
+        node scripts/releases/set-version "${{ inputs.version }}" --skip-react-native-version
+    - name: Versioning react-native package
+      shell: bash
+      run: |
+        node scripts/releases/set-rn-version.js -v "<< parameters.version >>" --build-type "release"
+    - name: Creating release commit
+      shell: bash
+      run: |
+        git commit -a -m "Release ${{ inputs.version }}" -m "#publish-packages-to-npm&${{ inputs.tag }}"
+        git tag -a "v${{ inputs.version }}" -m "v${{ inputs.version }}"
+        GIT_PAGER=cat git show HEAD
+    - name: Update "latest" tag if needed
+      shell: bash
+      if: ${{ inputs.tag == 'latest' }}
+      run: |
+        git tag -d "latest"
+        git push origin :latest
+        git tag -a "latest" -m "latest"
+    - name: Pushing release commit
+      shell: bash
+      if: ${{ inputs.dry_run == false }}
+      run: |
+        CURR_BRANCH="$(git branch --show-current)"
+        git push origin "$CURR_BRANCH" --follow-tags

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,38 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version of React Native we want to release'
+        required: true
+        type: string
+      tag:
+        description: 'The tag name that will be associated with the published npm packages. A tag of "latest" will also be written as a Git tag.'
+        required: true
+        type: string
+      dry_run:
+        description: 'Whether the job should be executed in dry-run mode or not'
+        type: boolean
+        default: false
+
+jobs:
+  prepare_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Check if on stable branch
+        id: check_stable_branch
+        run: |
+          BRANCH="$(git branch --show-current)"
+          PATTERN='^0\.[0-9]+-stable$'
+          if [[ $BRANCH =~ $PATTERN ]]; then
+            echo "On a stable branch"
+            echo "ON_STABLE_BRANCH=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Print output
+        run: echo "ON_STABLE_BRANCH ${{steps.check_stable_branch.outputs.ON_STABLE_BRANCH}}"
+      - name: Execute Prepare Release
+        if: ${{ steps.check_stable_branch.outputs.ON_STABLE_BRANCH }}
+        uses: ./.github/actions/prepare_release

--- a/scripts/releases-local/trigger-react-native-release.js
+++ b/scripts/releases-local/trigger-react-native-release.js
@@ -38,7 +38,7 @@ let argv = yargs
   .option('t', {
     alias: 'token',
     describe:
-      'Your CircleCI personal API token. See https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token to set one',
+      'Your GitHub personal API token. See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens.',
     required: true,
   })
   .option('v', {
@@ -183,34 +183,32 @@ async function main() {
   }
 
   const parameters = {
-    run_release_workflow: true,
-    release_version: version,
-    release_tag: npmTag,
-    // NOTE: Necessary for 0.74, should be dropped for 0.75+
-    release_monorepo_packages_version: nextMonorepoPackagesVersion,
+    version: version,
+    tag: npmTag,
     // $FlowFixMe[prop-missing]
-    release_dry_run: argv.dryRun,
+    dry_run: argv.dryRun,
   };
 
   const options = {
     method: 'POST',
-    url: 'https://circleci.com/api/v2/project/github/facebook/react-native/pipeline',
+    url: 'https://api.github.com/repos/facebook/react-native/actions/workflows/prepare-release/dispatches',
     headers: {
-      'Circle-Token': token,
-      'content-type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
     },
     body: {
-      branch,
-      parameters,
+      ref: branch,
+      inputs: parameters,
     },
     json: true,
   };
 
-  // See response: https://circleci.com/docs/api/v2/#operation/triggerPipeline
-  const body = await triggerReleaseWorkflow(options);
+  // See response: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
+  await triggerReleaseWorkflow(options);
   console.log(
     // $FlowFixMe[incompatible-use]
-    `Monitor your release workflow: https://app.circleci.com/pipelines/github/facebook/react-native/${body.number}`,
+    'Monitor your release workflow: https://github.com/facebook/react-native/actions/workflows/prepare-release.yml',
   );
 
   // TODO


### PR DESCRIPTION
## Summary:

This change migrates the prepare_release workflow from CCI to GHA

## Changelog:
[Internal] - Migrate from CCI to GHA

## Test Plan:
Test on GHA
