### PR TITLE
Remove faviconUrl field from CDP list response

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -188,7 +188,6 @@ describe('inspector proxy HTTP API', () => {
             description: 'bar-app',
             deviceName: 'foo',
             devtoolsFrontendUrl: expect.any(String),
-            faviconUrl: 'https://reactjs.org/favicon.ico',
             id: 'device1-page1',
             reactNative: {
               capabilities: {},
@@ -203,7 +202,6 @@ describe('inspector proxy HTTP API', () => {
             description: 'bar-app',
             deviceName: 'foo',
             devtoolsFrontendUrl: expect.any(String),
-            faviconUrl: 'https://reactjs.org/favicon.ico',
             id: 'device2-page1',
             reactNative: {
               capabilities: {},

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -155,11 +155,10 @@ export default class InspectorProxy implements InspectorProxyQueries {
 
     return {
       id: `${deviceId}-${page.id}`,
-      description: page.app,
       title: page.title,
-      faviconUrl: 'https://reactjs.org/favicon.ico',
-      devtoolsFrontendUrl,
+      description: page.app,
       type: 'node',
+      devtoolsFrontendUrl,
       webSocketDebuggerUrl,
       vm: page.vm,
       deviceName: device.getName(),

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -108,15 +108,17 @@ export type MessageToDevice =
 // Page description object that is sent in response to /json HTTP request from debugger.
 export type PageDescription = $ReadOnly<{
   id: string,
-  description: string,
   title: string,
-  faviconUrl: string,
-  devtoolsFrontendUrl: string,
+  description: string,
   type: string,
+  devtoolsFrontendUrl: string,
   webSocketDebuggerUrl: string,
+
+  // React Native specific fields
   deviceName: string,
   vm: string,
-  // Metadata specific to React Native
+
+  // React Native specific metadata
   reactNative: $ReadOnly<{
     logicalDeviceId: string,
     capabilities: Page['capabilities'],


### PR DESCRIPTION
Summary:
- Remove the nonstandard, unused `faviconUrl` field from CDP `/json` response targets (note: both legacy and modern targets).
- Reorder `PageDescription` members.

Changelog:
[General][Removed] - `react-native/dev-middleware`: Remove nonstandard `faviconUrl` field from CDP `/json` response

Differential Revision: D58092090
