### PR TITLE
Remove nonstandard "vm" field from modern CDP targets

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -172,7 +172,6 @@ describe('inspector proxy HTTP API', () => {
           app: 'bar-app',
           id: 'page1',
           title: 'bar-title',
-          vm: 'bar-vm',
         },
       ]);
 
@@ -209,7 +208,6 @@ describe('inspector proxy HTTP API', () => {
             },
             title: 'bar-title',
             type: 'node',
-            vm: 'bar-vm',
             webSocketDebuggerUrl: expect.any(String),
           },
         ]);

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -160,7 +160,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
       type: 'node',
       devtoolsFrontendUrl,
       webSocketDebuggerUrl,
-      vm: page.vm,
+      ...(page.vm != null ? {vm: page.vm} : null),
       deviceName: device.getName(),
       reactNative: {
         logicalDeviceId: deviceId,

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -53,12 +53,16 @@ export type TargetCapabilityFlags = $ReadOnly<{
 export type PageFromDevice = $ReadOnly<{
   id: string,
   title: string,
-  vm: string,
+  /** @deprecated This is sent from legacy targets only */
+  vm?: string,
   app: string,
   capabilities?: TargetCapabilityFlags,
 }>;
 
-export type Page = Required<PageFromDevice>;
+export type Page = $ReadOnly<{
+  ...PageFromDevice,
+  capabilities: $NonMaybeType<PageFromDevice['capabilities']>,
+}>;
 
 // Chrome Debugger Protocol message/event passed between device and debugger.
 export type WrappedEvent = $ReadOnly<{
@@ -116,7 +120,8 @@ export type PageDescription = $ReadOnly<{
 
   // React Native specific fields
   deviceName: string,
-  vm: string,
+  /** @deprecated This is sent from legacy targets only */
+  vm?: string,
 
   // React Native specific metadata
   reactNative: $ReadOnly<{

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp
@@ -161,7 +161,6 @@ folly::dynamic InspectorPackagerConnection::Impl::pages() {
     pageDescription["id"] = std::to_string(page.id);
     pageDescription["title"] = page.title + " [C++ connection]";
     pageDescription["app"] = app_;
-    pageDescription["vm"] = page.vm;
     pageDescription["capabilities"] =
         targetCapabilitiesToDynamic(page.capabilities);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
@@ -216,7 +216,6 @@ TEST_F(InspectorPackagerConnectionTest, TestGetPages) {
               ElementsAreArray({AllOf(
                   AtJsonPtr("/app", Eq("my-app")),
                   AtJsonPtr("/title", Eq("mock-title [C++ connection]")),
-                  AtJsonPtr("/vm", Eq("mock-vm")),
                   AtJsonPtr("/id", Eq(std::to_string(pageId))),
                   AtJsonPtr("/capabilities/nativePageReloads", Eq(true)),
                   AtJsonPtr(


### PR DESCRIPTION
Summary:
As titled. The `vm` field is not part of the CDP spec and will not be used by the modern debugger frontend or proxy.

This change affects modern CDP targets only (using `InspectorPackagerConnection`). We aim to enable sharing of more detailed metadata over 1/ a new, dedicated CDP domain, and 2/ namespaced under the existing `reactNative` field (for the latter, strictly limited to metadata necessary for dev server functionality).

Changelog: [Internal]

(Note: `/json` endpoint behaviour is unchanged for legacy CDP targets)

Differential Revision: D58285587
