### PR TITLE
Add missing FormData methods

### DIFF
--- a/packages/react-native/Libraries/Network/FormData.js
+++ b/packages/react-native/Libraries/Network/FormData.js
@@ -64,6 +64,19 @@ class FormData {
     this._parts.push([key, value]);
   }
 
+  set(key: string, value: FormDataValue) {
+    this.delete(key);
+    this.append(key, value);
+  }
+
+  delete(key: string) {
+    this._parts = this._parts.filter(([name]) => name !== key);
+  }
+
+  entries(): Iterable<FormDataNameValuePair> {
+    return this._parts.entries();
+  }
+
   getAll(key: string): Array<FormDataValue> {
     return this._parts
       .filter(([name]) => name === key)

--- a/packages/react-native/Libraries/Network/__tests__/FormData-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/FormData-test.js
@@ -130,4 +130,46 @@ describe('FormData', function () {
 
     expect(formData.getAll('file').length).toBe(0);
   });
+
+  it('should overwrite values based on the given key', function () {
+    formData.set('username', 'Chris');
+    formData.set('username', 'Bob');
+
+    expect(formData.getAll('username').length).toBe(1);
+
+    expect(formData.getAll('username')).toMatchObject(['Bob']);
+  });
+
+  it('should delete values based on the given key', function () {
+    formData.append('username', 'Chris');
+    formData.append('username', 'Bob');
+
+    expect(formData.getAll('username').length).toBe(2);
+
+    formData.delete('username');
+
+    expect(formData.getAll('username').length).toBe(0);
+  });
+
+  it('should return the correct entries', function () {
+    formData.append('username', 'Chris');
+    formData.append('username', 'Bob');
+
+    formData.append('photo', {
+      uri: 'arbitrary/path',
+      type: 'image/jpeg',
+      name: 'photo.jpg',
+    });
+
+    const expectedPart = {
+      url: 'arbitrary/path',
+      type: 'image/jpeg',
+      name: 'photo.jpg',
+    };
+
+    const entries = formData.entries();
+    expect(entries.next().value).toMatchObject(['username', 'Chris']);
+    expect(entries.next().value).toMatchObject(['username', 'Bob']);
+    expect(entries.next().value).toMatchObject(['photo', expectedPart]);
+  });
 });


### PR DESCRIPTION
## Summary:

The FormData implementation here only provides two of the standard APIs– `append()` and `getAll()`. For greater (but not complete) compatibility with [the XHR standard](https://developer.mozilla.org/en-US/docs/Web/API/FormData), I've implemented `set()`, `delete()` and `entries()`.

## Changelog:

[GENERAL] [ADDED] - Add `set()`, `delete()` and `entries()` to FormData

## Test Plan:

Unit tests are included, but I was unable to run them.