### PR TITLE
Allow out of tree platforms to customize cursor values

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -765,12 +765,148 @@ inline void fromRawValue(
     return;
   }
   auto stringValue = (std::string)value;
+  if (stringValue == "alias") {
+    result = Cursor::Alias;
+    return;
+  }
+  if (stringValue == "all-scroll") {
+    result = Cursor::AllScroll;
+    return;
+  }
   if (stringValue == "auto") {
     result = Cursor::Auto;
     return;
   }
+  if (stringValue == "cell") {
+    result = Cursor::Cell;
+    return;
+  }
+  if (stringValue == "col-resize") {
+    result = Cursor::ColResize;
+    return;
+  }
+  if (stringValue == "context-menu") {
+    result = Cursor::ContextMenu;
+    return;
+  }
+  if (stringValue == "copy") {
+    result = Cursor::Copy;
+    return;
+  }
+  if (stringValue == "crosshair") {
+    result = Cursor::Crosshair;
+    return;
+  }
+  if (stringValue == "default") {
+    result = Cursor::Default;
+    return;
+  }
+  if (stringValue == "e-resize") {
+    result = Cursor::EResize;
+    return;
+  }
+  if (stringValue == "ew-resize") {
+    result = Cursor::EWResize;
+    return;
+  }
+  if (stringValue == "grab") {
+    result = Cursor::Grab;
+    return;
+  }
+  if (stringValue == "grabbing") {
+    result = Cursor::Grabbing;
+    return;
+  }
+  if (stringValue == "help") {
+    result = Cursor::Help;
+    return;
+  }
+  if (stringValue == "move") {
+    result = Cursor::Move;
+    return;
+  }
+  if (stringValue == "n-resize") {
+    result = Cursor::NResize;
+    return;
+  }
+  if (stringValue == "ne-resize") {
+    result = Cursor::NEResize;
+    return;
+  }
+  if (stringValue == "nesw-resize") {
+    result = Cursor::NESWResize;
+    return;
+  }
+  if (stringValue == "ns-resize") {
+    result = Cursor::NSResize;
+    return;
+  }
+  if (stringValue == "nw-resize") {
+    result = Cursor::NWResize;
+    return;
+  }
+  if (stringValue == "nwse-resize") {
+    result = Cursor::NWSEResize;
+    return;
+  }
+  if (stringValue == "no-drop") {
+    result = Cursor::NoDrop;
+    return;
+  }
+  if (stringValue == "none") {
+    result = Cursor::None;
+    return;
+  }
+  if (stringValue == "not-allowed") {
+    result = Cursor::NotAllowed;
+    return;
+  }
   if (stringValue == "pointer") {
     result = Cursor::Pointer;
+    return;
+  }
+  if (stringValue == "progress") {
+    result = Cursor::Progress;
+    return;
+  }
+  if (stringValue == "row-resize") {
+    result = Cursor::RowResize;
+    return;
+  }
+  if (stringValue == "s-resize") {
+    result = Cursor::SResize;
+    return;
+  }
+  if (stringValue == "se-resize") {
+    result = Cursor::SEResize;
+    return;
+  }
+  if (stringValue == "sw-resize") {
+    result = Cursor::SWResize;
+    return;
+  }
+  if (stringValue == "text") {
+    result = Cursor::Text;
+    return;
+  }
+  if (stringValue == "url") {
+    result = Cursor::Url;
+    return;
+  }
+  if (stringValue == "w-resize") {
+    result = Cursor::WResize;
+    return;
+  }
+  if (stringValue == "wait") {
+    result = Cursor::Wait;
+    return;
+  }
+  if (stringValue == "zoom-in") {
+    result = Cursor::ZoomIn;
+    return;
+  }
+  if (stringValue == "zoom-out") {
+    result = Cursor::ZoomOut;
     return;
   }
   LOG(ERROR) << "Could not parse Cursor:" << stringValue;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -92,7 +92,44 @@ enum class BorderCurve : uint8_t { Circular, Continuous };
 
 enum class BorderStyle : uint8_t { Solid, Dotted, Dashed };
 
-enum class Cursor : uint8_t { Auto, Pointer };
+enum class Cursor : uint8_t {
+  Auto,
+  Alias,
+  AllScroll,
+  Cell,
+  ColResize,
+  ContextMenu,
+  Copy,
+  Crosshair,
+  Default,
+  EResize,
+  EWResize,
+  Grab,
+  Grabbing,
+  Help,
+  Move,
+  NEResize,
+  NESWResize,
+  NResize,
+  NSResize,
+  NWResize,
+  NWSEResize,
+  NoDrop,
+  None,
+  NotAllowed,
+  Pointer,
+  Progress,
+  RowResize,
+  SResize,
+  SEResize,
+  SWResize,
+  Text,
+  Url,
+  WResize,
+  Wait,
+  ZoomIn,
+  ZoomOut,
+};
 
 enum class LayoutConformance : uint8_t { Undefined, Classic, Strict };
 


### PR DESCRIPTION
Summary:
This change adds native support in Fabric for the remaining CSS cursor style values as defined here: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor. Please note, this functionality is simply for prop parsing capabilities in Fabric, which are shared across all platforms. This does not add any additional cursor behavior support to iOS or Android, and the Flow and TypeScript types for cursor style values are still limited to `auto` and `pointer`.

## Changelog

[General][Added] Fabric prop parsing capabilities for all CSS cursor style values

Differential Revision: D58301970
