### PR TITLE
fix: run nightly CI only on the main repo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   set_release_type:
     runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
     outputs:
       RELEASE_TYPE: ${{ steps.set_release_type.outputs.RELEASE_TYPE }}
     env:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I've noticed that nightly CI build was also running on my fork. I don't think this is necessary for every React Native fork (there are 24k of forks). This can save lots of unnecessary CI time.  

## Changelog:

[INTERNAL] [FIXED] - Enable nightly run only on the main repo

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

CI Green
