### PR TITLE
Implement Network.loadNetworkResource etc in C++

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include "CdpJson.h"
 #include "HostTarget.h"
+#include "NetworkIO.h"
 #include "SessionState.h"
 
 #include <jsinspector-modern/InspectorInterfaces.h>
@@ -98,12 +100,20 @@ class HostAgent final {
   std::shared_ptr<InstanceAgent> instanceAgent_;
   FuseboxClientType fuseboxClientType_{FuseboxClientType::Unknown};
   bool isPausedInDebuggerOverlayVisible_{false};
+  std::shared_ptr<NetworkIO> networkIO_;
 
   /**
    * A shared reference to the session's state. This is only safe to access
    * during handleRequest and other method calls on the same thread.
    */
   SessionState& sessionState_;
+
+  /** Handle a Network.loadNetworkResource CDP request. */
+  void handleLoadNetworkResource(const cdp::PreparsedRequest& req);
+  /** Handle an IO.read CDP request. */
+  void handleIoRead(const cdp::PreparsedRequest& req);
+  /** Handle an IO.close CDP request. */
+  void handleIoClose(const cdp::PreparsedRequest& req);
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -130,6 +130,19 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
       std::weak_ptr<IPageStatusListener> listener) = 0;
 };
 
+class NotImplementedException : public std::exception {
+ public:
+  explicit NotImplementedException(std::string message)
+      : msg_(std::move(message)) {}
+
+  const char* what() const noexcept override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
 /// getInspectorInstance retrieves the singleton inspector that tracks all
 /// debuggable pages in this process.
 extern IInspector& getInspectorInstance();

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIO.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIO.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NetworkIO.h"
+#include <folly/base64.h>
+
+namespace facebook::react::jsinspector_modern {
+
+static constexpr long DEFAULT_BYTES_PER_READ =
+    1048576; // 1MB (Chrome v112 default)
+
+namespace {
+
+struct InitStreamResult {
+  int httpStatusCode;
+  const Headers& headers;
+};
+using InitStreamError = const std::string;
+
+/**
+ * Private class owning state and implementing the listener for a particular
+ * request
+ *
+ * NetworkRequestListener overrides are thread safe, all other methods must be
+ * called from the same thread.
+ */
+class Stream : public NetworkRequestListener,
+               public EnableExecutorFromThis<Stream> {
+ public:
+  explicit Stream(
+      std::function<void(std::variant<InitStreamError, InitStreamResult>)>
+          initCb)
+      : initCb_(std::move(initCb)) {}
+
+  /**
+   * NetworkIO-facing API. Enqueue a read request for up to maxBytesToRead
+   * bytes, starting from the end of the previous read.
+   */
+  void read(
+      long maxBytesToRead,
+      std::function<void(std::variant<IOReadError, IOReadResult>)> callback) {
+    pendingReadRequests_.emplace_back(
+        std::make_tuple(maxBytesToRead, callback));
+    processPending();
+  }
+
+  /**
+   * NetworkIO-facing API. Call the platform-provided cancelFunction, if any,
+   * call the error callbacks of any in-flight read requests, and the initial
+   * error callback if it has not already fulfilled with success or error.
+   */
+  void cancel() {
+    executorFromThis()([](Stream& self) {
+      if (self.cancelFunction_) {
+        (*self.cancelFunction_)();
+      }
+      self.error_ = "Cancelled";
+      if (self.initCb_) {
+        self.initCb_(InitStreamError{"Cancelled"});
+        self.initCb_ = nullptr;
+      }
+      // Respond to any in-flight read requests with an error.
+      self.processPending();
+    });
+  }
+
+  /**
+   * Implementation of NetworkRequestListener, to be called by platform
+   * HostTargetDelegate. Any of these methods may be called from any thread.
+   */
+  void onData(std::string_view data) override {
+    executorFromThis()([copy = std::string(data)](Stream& self) {
+      self.data_ << copy;
+      self.bytesReceived_ += copy.length();
+      self.processPending();
+    });
+  }
+
+  void onHeaders(int httpStatusCode, const Headers& headers) override {
+    executorFromThis()([=](Stream& self) {
+      // If we've already seen an error, the initial callback as already been
+      // called with it.
+      if (self.initCb_) {
+        self.initCb_(InitStreamResult{httpStatusCode, headers});
+        self.initCb_ = nullptr;
+      }
+    });
+  }
+
+  void onError(const std::string& message) override {
+    executorFromThis()([=](Stream& self) {
+      // Only call the error callback once.
+      if (!self.error_) {
+        self.error_ = message;
+        if (self.initCb_) {
+          self.initCb_(InitStreamError{message});
+          self.initCb_ = nullptr;
+        }
+      }
+      self.processPending();
+    });
+  }
+
+  void onEnd() override {
+    executorFromThis()([](Stream& self) {
+      self.completed_ = true;
+      self.processPending();
+    });
+  }
+
+  void setCancelFunction(std::function<void()> cancelFunction) override {
+    cancelFunction_ = std::move(cancelFunction);
+  }
+  /* End NetworkRequestListener */
+
+ private:
+  void processPending() {
+    // Go through each pending request in insertion order - execute the
+    // callback and remove it from pending if it can be satisfied.
+    for (auto it = pendingReadRequests_.begin();
+         it != pendingReadRequests_.end();) {
+      auto maxBytesToRead = std::get<0>(*it);
+      auto callback = std::get<1>(*it);
+
+      if (error_) {
+        callback(IOReadError{*error_});
+      } else if (
+          completed_ || (bytesReceived_ - data_.tellg() >= maxBytesToRead)) {
+        try {
+          callback(respond(maxBytesToRead));
+        } catch (const std::runtime_error& error) {
+          callback(IOReadError{error.what()});
+        }
+      } else {
+        // Not yet received enough data
+        ++it;
+        continue;
+      }
+      it = pendingReadRequests_.erase(it);
+    }
+  }
+
+  IOReadResult respond(long maxBytesToRead) {
+    std::vector<char> buffer(maxBytesToRead);
+    data_.read(buffer.data(), maxBytesToRead);
+    auto bytesRead = data_.gcount();
+    buffer.resize(bytesRead);
+    return IOReadResult{
+        .data =
+            folly::base64Encode(std::string_view(buffer.data(), buffer.size())),
+        .eof = bytesRead == 0 && completed_,
+        // TODO: Support UTF-8 string responses
+        .base64Encoded = true};
+  }
+
+  bool completed_{false};
+  std::optional<std::string> error_;
+  std::stringstream data_;
+  long bytesReceived_{0};
+  std::optional<std::function<void()>> cancelFunction_{std::nullopt};
+  std::function<void(std::variant<InitStreamError, InitStreamResult>)> initCb_;
+  std::vector<std::tuple<
+      long /* bytesToRead */,
+      std::function<void(
+          std::variant<IOReadError, IOReadResult>)> /* read callback */>>
+      pendingReadRequests_;
+};
+} // namespace
+
+void NetworkIO::loadNetworkResource(
+    const LoadNetworkResourceParams& params,
+    NetworkRequestDelegate& delegate,
+    std::function<void(NetworkResource)> callback) {
+  // This is an opaque identifier, but an incrementing integer in a string is
+  // consistent with Chrome.
+  StreamID streamId = std::to_string(nextStreamId_++);
+  auto stream = std::make_shared<Stream>(
+      [streamId, callback, weakSelf = weak_from_this()](
+          std::variant<InitStreamError, InitStreamResult> resultOrError) {
+        NetworkResource toReturn;
+        if (std::holds_alternative<InitStreamResult>(resultOrError)) {
+          auto& result = std::get<InitStreamResult>(resultOrError);
+          if (result.httpStatusCode >= 200 && result.httpStatusCode < 400) {
+            toReturn = NetworkResource{
+                .success = true,
+                .stream = streamId,
+                .httpStatusCode = result.httpStatusCode,
+                .headers = result.headers};
+          } else {
+            toReturn = NetworkResource{
+                .success = false,
+                .httpStatusCode = result.httpStatusCode,
+                .headers = result.headers};
+          }
+        } else {
+          auto& error = std::get<InitStreamError>(resultOrError);
+          toReturn = NetworkResource{.success = false, .netErrorName = error};
+        }
+        if (!toReturn.success) {
+          if (auto strongSelf = weakSelf.lock()) {
+            strongSelf->cancelAndRemoveStreamIfExists(streamId);
+          }
+        }
+        callback(toReturn);
+      });
+  stream->setExecutor(executorFromThis());
+  streams_[streamId] = stream;
+  // Begin the network request on the platform, passing a shared_ptr to stream
+  // (a NetworkRequestListener) for platform code to call back into.
+  delegate.networkRequest(params.url, stream);
+}
+
+void NetworkIO::readStream(
+    const ReadStreamParams& params,
+    std::function<void(std::variant<IOReadError, IOReadResult>)> callback) {
+  auto it = streams_.find(params.handle);
+  if (it == streams_.end()) {
+    callback(IOReadError{"Stream not found with handle " + params.handle});
+  } else {
+    it->second->read(
+        params.size ? *params.size : DEFAULT_BYTES_PER_READ, callback);
+    return;
+  }
+}
+
+void NetworkIO::closeStream(
+    const StreamID& streamId,
+    std::function<void(std::optional<std::string> error)> callback) {
+  if (cancelAndRemoveStreamIfExists(streamId)) {
+    callback(std::nullopt);
+  } else {
+    callback("Stream not found: " + streamId);
+  }
+}
+
+bool NetworkIO::cancelAndRemoveStreamIfExists(const StreamID& streamId) {
+  auto it = streams_.find(streamId);
+  if (it == streams_.end()) {
+    return false;
+  } else {
+    it->second->cancel();
+    streams_.erase(it->first);
+    return true;
+  }
+}
+
+NetworkIO::~NetworkIO() {
+  // Each stream is also retained by the delegate for as long as the request
+  // is in progress. Cancel the network operation (if implemented by the
+  // platform) to avoid unnecessary traffic and allow cleanup as soon as
+  // possible.
+  for (auto& [_, stream] : streams_) {
+    stream->cancel();
+  }
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIO.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIO.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "InspectorInterfaces.h"
+#include "ScopedExecutor.h"
+
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::react::jsinspector_modern {
+
+using StreamID = const std::string;
+using Headers = std::map<std::string, std::string>;
+using IOReadError = const std::string;
+
+namespace {
+class Stream;
+}
+
+struct LoadNetworkResourceParams {
+  std::string url;
+};
+
+struct ReadStreamParams {
+  StreamID handle;
+  std::optional<unsigned long> size;
+  std::optional<unsigned long> offset;
+};
+
+struct NetworkResource {
+  bool success{};
+  std::optional<std::string> stream;
+  std::optional<int> httpStatusCode;
+  std::optional<std::string> netErrorName;
+  std::optional<Headers> headers;
+};
+
+struct IOReadResult {
+  std::string data;
+  bool eof;
+  bool base64Encoded;
+};
+
+class NetworkRequestListener {
+ public:
+  NetworkRequestListener() = default;
+  NetworkRequestListener(const NetworkRequestListener&) = delete;
+  NetworkRequestListener& operator=(const NetworkRequestListener&) = delete;
+  NetworkRequestListener(NetworkRequestListener&&) noexcept = default;
+  NetworkRequestListener& operator=(NetworkRequestListener&&) noexcept =
+      default;
+  virtual ~NetworkRequestListener() = default;
+  virtual void onData(std::string_view data) = 0;
+  virtual void onHeaders(int httpStatusCode, const Headers& headers) = 0;
+  virtual void onError(const std::string& message) = 0;
+  virtual void onEnd() = 0;
+  virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
+};
+
+class NetworkRequestDelegate {
+ public:
+  NetworkRequestDelegate() = default;
+  NetworkRequestDelegate(const NetworkRequestDelegate&) = delete;
+  NetworkRequestDelegate& operator=(const NetworkRequestDelegate&) = delete;
+  NetworkRequestDelegate(NetworkRequestDelegate&&) noexcept = delete;
+  NetworkRequestDelegate& operator=(NetworkRequestDelegate&&) noexcept = delete;
+  virtual ~NetworkRequestDelegate() = default;
+  virtual void networkRequest(
+      const std::string& /*url*/,
+      std::shared_ptr<NetworkRequestListener> /*listener*/) {
+    throw NotImplementedException(
+        "NetworkRequestDelegate.networkRequest is not implemented by this delegate.");
+  }
+};
+
+/**
+ * Provides the core implementation for handling CDP's
+ * Network.loadNetworkResource, IO.read and IO.close.
+ *
+ * Owns state of all in-progress and completed HTTP requests - ensure
+ * closeStream is used to free resources once consumed.
+ *
+ * Public methods must be called on the same thread. Callbacks will be called
+ * through the given executor.
+ */
+class NetworkIO : public EnableExecutorFromThis<NetworkIO> {
+ public:
+  ~NetworkIO();
+
+  /**
+   * Begin loading an HTTP resource, delegating platform-specific
+   * implementation. The callback will be called when either headers are
+   * received or an error occurs. If successful, the Stream ID provided to the
+   * callback can be used to read the contents of the resource via readStream().
+   */
+  void loadNetworkResource(
+      const LoadNetworkResourceParams& params,
+      NetworkRequestDelegate& delegate,
+      std::function<void(NetworkResource)> callback);
+
+  /**
+   * Close a given stream by its handle, call the callback with std::nullopt if
+   * a stream is found and destroyed, or with an error message if the stream is
+   * not found. Safely aborts any in-flight request.
+   */
+  void closeStream(
+      const StreamID& streamId,
+      std::function<void(std::optional<std::string> error)> callback);
+
+  /**
+   * Read a chunk of data from the stream, once enough has been downloaded, or
+   * call back with an error.
+   */
+  void readStream(
+      const ReadStreamParams& params,
+      std::function<void(std::variant<IOReadError, IOReadResult> result)>
+          callback);
+
+ private:
+  /**
+   * Map of stream objects, which contain data received, accept read requests
+   * and listen for delegate events. Delegates have a shared_ptr to the Stream
+   * instance, but Streams should not live beyond the destruction of this
+   * NetworkIO instance.
+   */
+  std::unordered_map<std::string, std::shared_ptr<Stream>> streams_;
+  unsigned long nextStreamId_{0};
+
+  bool cancelAndRemoveStreamIfExists(const StreamID& streamId);
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -124,6 +124,12 @@ class MockHostTargetDelegate : public HostTargetDelegate {
       onSetPausedInDebuggerMessage,
       (const OverlaySetPausedInDebuggerMessageRequest& request),
       (override));
+  MOCK_METHOD(
+      void,
+      networkRequest,
+      (const std::string& url,
+       std::shared_ptr<NetworkRequestListener> listener),
+      (override));
 };
 
 class MockInstanceTargetDelegate : public InstanceTargetDelegate {};


### PR DESCRIPTION
Summary:
## Design
 - `NetworkIO` is an object owned by the `HostAgent`, created by `HostTarget` where it is given a scoped executor.
 - `HostAgent` passes most handling of CDP `Network.loadNetworkResource` through `NetworkIO`.
 - `NetworkIO.loadNetworkResource` creates and holds a shared_ptr to a `Stream` representing a single resource load, and owning received headers and data. A reference is held in a map `streams_` until an error or it is closed with `IO.close`. `delegate.networkRequest` is called with the `stream`, which it retains for the lifetime of the request, and uses its methods to call back with headers, data and errors.

 - Callbacks for `IO.read` requests are held by the `Stream` until the incoming data is complete or enough data is available to fill the request (an implementation choice to optimise for fewest round trips). Any incoming data or error causes any pending requests to be rechecked.

## Unimplemented platforms
 - Platforms may optionally implement `HostTargetDelegate.networkRequest` (as of this diff, none do). If they don't we report a CDP "not implemented" error, similar to the status quo where it was unimplemented by the C++ agent.

Differential Revision: D54309633
