### PR TITLE
Implement NetworkRequestDelegate on iOS

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -14,6 +14,7 @@
 #import "RCTConvert.h"
 #if RCT_ENABLE_INSPECTOR
 #import "RCTInspectorDevServerHelper.h"
+#import "RCTInspectorNetworkHelper.h"
 #endif
 #import <jsinspector-modern/InspectorFlags.h>
 #import <jsinspector-modern/InspectorInterfaces.h>
@@ -193,7 +194,9 @@ void RCTUIManagerSetDispatchAccessibilityManagerInitOntoMain(BOOL enabled)
 class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::HostTargetDelegate {
  public:
   RCTBridgeHostTargetDelegate(RCTBridge *bridge)
-      : bridge_(bridge), pauseOverlayController_([[RCTPausedInDebuggerOverlayController alloc] init])
+      : bridge_(bridge),
+        pauseOverlayController_([[RCTPausedInDebuggerOverlayController alloc] init]),
+        networkHelper_([[RCTInspectorNetworkHelper alloc] init])
   {
   }
 
@@ -226,9 +229,15 @@ class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::
     }
   }
 
+  void networkRequest(const std::string &url, RCTInspectorNetworkListener listener) override
+  {
+    [networkHelper_ networkRequestWithUrl:url listener:listener];
+  }
+
  private:
   __weak RCTBridge *bridge_;
   RCTPausedInDebuggerOverlayController *pauseOverlayController_;
+  RCTInspectorNetworkHelper *networkHelper_;
 };
 
 @interface RCTBridge () <RCTReloadListener>

--- a/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <jsinspector-modern/ReactCdp.h>
+
+#import <Foundation/Foundation.h>
+
+typedef std::shared_ptr<facebook::react::jsinspector_modern::NetworkRequestListener> RCTInspectorNetworkListener;
+
+/**
+ * A helper class that wraps around NSURLSession to make network requests.
+ */
+@interface RCTInspectorNetworkHelper : NSObject
+- (instancetype)init;
+- (void)networkRequestWithUrl:(const std::string &)url listener:(RCTInspectorNetworkListener)listener;
+@end

--- a/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.mm
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInspectorNetworkHelper.h"
+
+// Wraps RCTInspectorNetworkListener (a C++ shared_ptr) in an NSObject,
+// maintaining a ref while making it id-compatible for an NSDictionary.
+@interface RCTInspectorNetworkListenerWrapper : NSObject
+@property (nonatomic, readonly) RCTInspectorNetworkListener listener;
+- (instancetype)initWithListener:(RCTInspectorNetworkListener)listener;
+@end
+
+@interface RCTInspectorNetworkHelper () <NSURLSessionDataDelegate>
+@property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, strong)
+    NSMutableDictionary<NSNumber *, RCTInspectorNetworkListenerWrapper *> *listenerWrappersByTaskId;
+@end
+
+@implementation RCTInspectorNetworkHelper
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    self.session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:nil];
+    self.listenerWrappersByTaskId = [NSMutableDictionary new];
+  }
+  return self;
+}
+
+- (void)networkRequestWithUrl:(const std::string &)rawUrl listener:(RCTInspectorNetworkListener)listener
+{
+  NSString *urlString = [NSString stringWithUTF8String:rawUrl.c_str()];
+  NSURL *url = [NSURL URLWithString:urlString];
+  if (url == nil) {
+    listener->onError([NSString stringWithFormat:@"Not a valid URL: %@", urlString].UTF8String);
+    return;
+  }
+
+  NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
+  [urlRequest setHTTPMethod:@"GET"];
+  NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:urlRequest];
+  __weak NSURLSessionDataTask *weakDataTask = dataTask;
+  listener->setCancelFunction([weakDataTask]() { [weakDataTask cancel]; });
+  // Store the listener using the task identifier as the key
+  RCTInspectorNetworkListenerWrapper *listenerWrapper =
+      [[RCTInspectorNetworkListenerWrapper alloc] initWithListener:listener];
+  self.listenerWrappersByTaskId[@(dataTask.taskIdentifier)] = listenerWrapper;
+  [dataTask resume];
+}
+
+- (RCTInspectorNetworkListener)listenerForTask:(NSNumber *)taskIdentifier
+{
+  auto *listenerWrapper = self.listenerWrappersByTaskId[taskIdentifier];
+  return listenerWrapper ? listenerWrapper.listener : nil;
+}
+
+#pragma mark - NSURLSessionDataDelegate
+
+- (void)URLSession:(NSURLSession *)session
+              dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveResponse:(NSURLResponse *)response
+     completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
+{
+  RCTInspectorNetworkListener listener = [self listenerForTask:@(dataTask.taskIdentifier)];
+  if (!listener) {
+    [dataTask cancel];
+    return;
+  }
+  if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+    std::map<std::string, std::string> headersMap;
+    for (NSString *key in httpResponse.allHeaderFields) {
+      headersMap[[key UTF8String]] = [[httpResponse.allHeaderFields objectForKey:key] UTF8String];
+    }
+    completionHandler(NSURLSessionResponseAllow);
+    listener->onHeaders(httpResponse.statusCode, headersMap);
+  } else {
+    listener->onError("Unsupported response type");
+    completionHandler(NSURLSessionResponseCancel);
+  }
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+{
+  RCTInspectorNetworkListener listener = [self listenerForTask:@(dataTask.taskIdentifier)];
+  if (!listener) {
+    [dataTask cancel];
+    return;
+  }
+  if (data) {
+    listener->onData(std::string_view(static_cast<const char *>(data.bytes), data.length));
+  }
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+  RCTInspectorNetworkListener listener = [self listenerForTask:@(task.taskIdentifier)];
+  if (!listener) {
+    return;
+  }
+  if (error != nil) {
+    listener->onError(error.localizedDescription.UTF8String);
+  } else {
+    listener->onEnd();
+  }
+  [self.listenerWrappersByTaskId removeObjectForKey:@(task.taskIdentifier)];
+}
+
+@end
+
+@implementation RCTInspectorNetworkListenerWrapper {
+  RCTInspectorNetworkListener _listener;
+}
+
+- (instancetype)initWithListener:(RCTInspectorNetworkListener)listener
+{
+  if (self = [super init]) {
+    _listener = listener;
+  }
+  return self;
+}
+
+- (RCTInspectorNetworkListener)listener
+{
+  return _listener;
+}
+
+@end

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include "CdpJson.h"
 #include "HostTarget.h"
+#include "NetworkIO.h"
 #include "SessionState.h"
 
 #include <jsinspector-modern/InspectorInterfaces.h>
@@ -98,12 +100,20 @@ class HostAgent final {
   std::shared_ptr<InstanceAgent> instanceAgent_;
   FuseboxClientType fuseboxClientType_{FuseboxClientType::Unknown};
   bool isPausedInDebuggerOverlayVisible_{false};
+  std::shared_ptr<NetworkIO> networkIO_;
 
   /**
    * A shared reference to the session's state. This is only safe to access
    * during handleRequest and other method calls on the same thread.
    */
   SessionState& sessionState_;
+
+  /** Handle a Network.loadNetworkResource CDP request. */
+  void handleLoadNetworkResource(const cdp::PreparsedRequest& req);
+  /** Handle an IO.read CDP request. */
+  void handleIoRead(const cdp::PreparsedRequest& req);
+  /** Handle an IO.close CDP request. */
+  void handleIoClose(const cdp::PreparsedRequest& req);
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -35,7 +35,7 @@ class IDestructible {
 
 struct InspectorTargetCapabilities {
   bool nativePageReloads = false;
-  bool nativeSourceCodeFetching = false;
+  bool nativeSourceCodeFetching = true;
   bool prefersFuseboxFrontend = false;
 };
 
@@ -128,6 +128,19 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
    */
   virtual void registerPageStatusListener(
       std::weak_ptr<IPageStatusListener> listener) = 0;
+};
+
+class NotImplementedException : public std::exception {
+ public:
+  explicit NotImplementedException(std::string message)
+      : msg_(std::move(message)) {}
+
+  const char* what() const noexcept override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
 };
 
 /// getInspectorInstance retrieves the singleton inspector that tracks all

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIO.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIO.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NetworkIO.h"
+#include <folly/base64.h>
+
+namespace facebook::react::jsinspector_modern {
+
+static constexpr unsigned long DEFAULT_BYTES_PER_READ =
+    1048576; // 1MB (Chrome v112 default)
+
+void NetworkIO::loadNetworkResource(
+    const LoadNetworkResourceParams& params,
+    NetworkRequestDelegate& delegate,
+    std::function<void(NetworkResource)> callback) {
+  // This is an opaque identifier, but an incrementing integer in a string is
+  // consistent with Chrome.
+  StreamID streamId = std::to_string(nextStreamId_++);
+  auto stream = std::make_shared<Stream>(
+      [streamId, callback, weakSelf = weak_from_this()](
+          std::variant<InitStreamError, InitStreamResult> resultOrError) {
+        NetworkResource toReturn;
+        if (std::holds_alternative<InitStreamResult>(resultOrError)) {
+          auto& result = std::get<InitStreamResult>(resultOrError);
+          if (result.httpStatusCode >= 200 && result.httpStatusCode < 400) {
+            toReturn = NetworkResource{
+                .success = true,
+                .stream = streamId,
+                .httpStatusCode = result.httpStatusCode,
+                .headers = result.headers};
+          } else {
+            toReturn = NetworkResource{
+                .success = false,
+                .httpStatusCode = result.httpStatusCode,
+                .headers = result.headers};
+          }
+        } else {
+          auto& error = std::get<InitStreamError>(resultOrError);
+          toReturn = NetworkResource{.success = false, .netErrorName = error};
+        }
+        if (!toReturn.success) {
+          if (auto strongSelf = weakSelf.lock()) {
+            strongSelf->cancelAndRemoveStreamIfExists(streamId);
+          }
+        }
+        callback(toReturn);
+      });
+  stream->setExecutor(executorFromThis());
+  streams_[streamId] = stream;
+  // Begin the network request on the platform, passing a shared_ptr to stream
+  // (a NetworkRequestListener) for platform code to call back into.
+  delegate.networkRequest(params.url, stream);
+}
+
+void NetworkIO::readStream(
+    const ReadStreamParams& params,
+    std::function<void(std::variant<IOReadError, IOReadResult>)> callback) {
+  auto it = streams_.find(params.handle);
+  if (it == streams_.end()) {
+    callback(IOReadError{"Stream not found with handle " + params.handle});
+  } else {
+    it->second->read(
+        params.size ? *params.size : DEFAULT_BYTES_PER_READ, callback);
+    return;
+  }
+}
+
+void NetworkIO::closeStream(
+    const StreamID& streamId,
+    std::function<void(std::optional<std::string> error)> callback) {
+  if (cancelAndRemoveStreamIfExists(streamId)) {
+    callback(std::nullopt);
+  } else {
+    callback("Stream not found: " + streamId);
+  }
+}
+
+bool NetworkIO::cancelAndRemoveStreamIfExists(const StreamID& streamId) {
+  auto it = streams_.find(streamId);
+  if (it == streams_.end()) {
+    return false;
+  } else {
+    it->second->cancel();
+    streams_.erase(it->first);
+    return true;
+  }
+}
+
+NetworkIO::~NetworkIO() {
+  // Each stream is also retained by the delegate for as long as the request
+  // is in progress. Cancel the network operation (if implemented by the
+  // platform) to avoid unnecessary traffic and allow cleanup as soon as
+  // possible.
+  for (auto& [_, stream] : streams_) {
+    stream->cancel();
+  }
+}
+
+Stream::Stream(
+    std::function<void(std::variant<InitStreamError, InitStreamResult>)> initCb)
+    : initCb_(std::move(initCb)) {}
+
+void Stream::onData(std::string_view data) {
+  executorFromThis()([copy = std::string(data)](Stream& self) {
+    self.data_ << copy;
+    self.bytesReceived_ += copy.length();
+    self.processPending();
+  });
+}
+
+void Stream::onHeaders(int httpStatusCode, const Headers& headers) {
+  executorFromThis()([=](Stream& self) {
+    // If we've already seen an error, the initial callback as already been
+    // called with it.
+    if (self.initCb_) {
+      self.initCb_(InitStreamResult{httpStatusCode, headers});
+      self.initCb_ = nullptr;
+    }
+  });
+}
+
+void Stream::onError(const std::string& message) {
+  executorFromThis()([=](Stream& self) {
+    // Only call the error callback once.
+    if (!self.error_) {
+      self.error_ = message;
+      if (self.initCb_) {
+        self.initCb_(InitStreamError{message});
+        self.initCb_ = nullptr;
+      }
+    }
+    self.processPending();
+  });
+}
+
+void Stream::onEnd() {
+  executorFromThis()([](Stream& self) {
+    self.completed_ = true;
+    self.processPending();
+  });
+}
+
+void Stream::setCancelFunction(std::function<void()> cancelFunction) {
+  cancelFunction_ = std::move(cancelFunction);
+}
+
+// Must be called from the executor thread
+void Stream::read(
+    unsigned long maxBytesToRead,
+    std::function<void(std::variant<IOReadError, IOReadResult>)> callback) {
+  pendingReadRequests_.emplace_back(std::make_tuple(maxBytesToRead, callback));
+  processPending();
+}
+
+void Stream::cancel() {
+  executorFromThis()([](Stream& self) {
+    if (self.cancelFunction_) {
+      (*self.cancelFunction_)();
+    }
+    self.error_ = "Cancelled";
+    if (self.initCb_) {
+      self.initCb_(InitStreamError{"Cancelled"});
+      self.initCb_ = nullptr;
+    }
+    // Respond to any in-flight read requests with an error.
+    self.processPending();
+  });
+}
+
+IOReadResult Stream::respond(unsigned long maxBytesToRead) {
+  std::vector<char> buffer(maxBytesToRead);
+  data_.read(buffer.data(), maxBytesToRead);
+  auto bytesRead = data_.gcount();
+  buffer.resize(bytesRead);
+  return IOReadResult{
+      .data = folly::base64Encode(std::string_view(&buffer[0], buffer.size())),
+      .eof = bytesRead == 0 && completed_,
+      // TODO: Support UTF-8 string responses
+      .base64Encoded = true};
+}
+
+void Stream::processPending() {
+  // Go through each pending request in insertion order - execute the callback
+  // and remove it from pending if it can be satisfied.
+  for (auto it = pendingReadRequests_.begin();
+       it != pendingReadRequests_.end();) {
+    auto maxBytesToRead = std::get<0>(*it);
+    auto callback = std::get<1>(*it);
+
+    if (error_) {
+      callback(IOReadError{*error_});
+    } else if (
+        completed_ || (bytesReceived_ - data_.tellg() >= maxBytesToRead)) {
+      try {
+        callback(respond(maxBytesToRead));
+      } catch (const std::runtime_error& error) {
+        callback(IOReadError{error.what()});
+      }
+    } else {
+      // Not yet received enough data
+      ++it;
+      continue;
+    }
+    it = pendingReadRequests_.erase(it);
+  }
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIO.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIO.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "InspectorInterfaces.h"
+#include "ScopedExecutor.h"
+
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::react::jsinspector_modern {
+
+using StreamID = const std::string;
+using Headers = std::map<std::string, std::string>;
+using IOReadError = const std::string;
+
+struct InitStreamResult {
+  int httpStatusCode;
+  const Headers& headers;
+};
+using InitStreamError = const std::string;
+
+struct LoadNetworkResourceParams {
+  std::string url;
+};
+
+struct ReadStreamParams {
+  StreamID handle;
+  std::optional<unsigned long> size;
+  std::optional<unsigned long> offset;
+};
+
+struct NetworkResource {
+  bool success{};
+  std::optional<std::string> stream;
+  std::optional<int> httpStatusCode;
+  std::optional<std::string> netErrorName;
+  std::optional<Headers> headers;
+};
+
+struct IOReadResult {
+  std::string data;
+  bool eof;
+  bool base64Encoded;
+};
+
+class NetworkRequestListener {
+ public:
+  NetworkRequestListener() = default;
+  NetworkRequestListener(const NetworkRequestListener&) = delete;
+  NetworkRequestListener& operator=(const NetworkRequestListener&) = delete;
+  NetworkRequestListener(NetworkRequestListener&&) noexcept = default;
+  NetworkRequestListener& operator=(NetworkRequestListener&&) noexcept =
+      default;
+  virtual ~NetworkRequestListener() = default;
+  virtual void onData(std::string_view data) = 0;
+  virtual void onHeaders(int httpStatusCode, const Headers& headers) = 0;
+  virtual void onError(const std::string& message) = 0;
+  virtual void onEnd() = 0;
+  virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
+};
+
+class NetworkRequestDelegate {
+ public:
+  NetworkRequestDelegate() = default;
+  NetworkRequestDelegate(const NetworkRequestDelegate&) = delete;
+  NetworkRequestDelegate& operator=(const NetworkRequestDelegate&) = delete;
+  NetworkRequestDelegate(NetworkRequestDelegate&&) noexcept = delete;
+  NetworkRequestDelegate& operator=(NetworkRequestDelegate&&) noexcept = delete;
+  virtual ~NetworkRequestDelegate() = default;
+  virtual void networkRequest(
+      const std::string& /*url*/,
+      std::shared_ptr<NetworkRequestListener> /*listener*/) {
+    throw NotImplementedException(
+        "NetworkRequestDelegate.networkRequest is not implemented by this delegate.");
+  }
+};
+
+namespace {
+
+/**
+ * Private class owning state and implementing the listener for a particular
+ * request
+ *
+ * NetworkRequestListener overrides are thread safe, all other methods must be
+ * called from the same thread.
+ */
+class Stream : public NetworkRequestListener,
+               public EnableExecutorFromThis<Stream> {
+ public:
+  explicit Stream(
+      std::function<void(std::variant<InitStreamError, InitStreamResult>)>
+          initCb);
+
+  /**
+   * NetworkIO-facing API. Enqueue a read request for up to maxBytesToRead
+   * bytes, starting from the end of the previous read.
+   */
+  void read(
+      unsigned long maxBytesToRead,
+      std::function<void(std::variant<IOReadError, IOReadResult>)> callback);
+
+  /**
+   * NetworkIO-facing API. Call the platform-provided cancelFunction, if any,
+   * call the error callbacks of any in-flight read requests, and the initial
+   * error callback if it has not already fulfilled with success or error.
+   */
+  void cancel();
+
+  /**
+   * Implementation of NetworkRequestListener, to be called by platform
+   * HostTargetDelegate. Any of these methods may be called from any thread.
+   */
+  void onData(std::string_view data) override;
+  void onHeaders(int httpStatusCode, const Headers& headers) override;
+  void onError(const std::string& message) override;
+  void onEnd() override;
+  void setCancelFunction(std::function<void()> cancelFunction) override;
+  /* End NetworkRequestListener */
+
+ private:
+  void processPending();
+  IOReadResult respond(unsigned long maxBytesToRead);
+
+  bool completed_{false};
+  std::optional<std::string> error_;
+  std::stringstream data_;
+  unsigned long bytesReceived_{0};
+  std::optional<std::function<void()>> cancelFunction_{std::nullopt};
+  std::function<void(std::variant<InitStreamError, InitStreamResult>)> initCb_;
+  std::vector<std::tuple<
+      unsigned long /* bytesToRead */,
+      std::function<void(
+          std::variant<IOReadError, IOReadResult>)> /* read callback */>>
+      pendingReadRequests_;
+};
+
+} // namespace
+
+/**
+ * Provides the core implementation for handling CDP's
+ * Network.loadNetworkResource, IO.read and IO.close.
+ *
+ * Owns state of all in-progress and completed HTTP requests - ensure
+ * closeStream is used to free resources once consumed.
+ *
+ * Public methods must be called on the same thread. Callbacks will be called
+ * through the given executor.
+ */
+class NetworkIO : public EnableExecutorFromThis<NetworkIO> {
+ public:
+  ~NetworkIO();
+
+  /**
+   * Begin loading an HTTP resource, delegating platform-specific
+   * implementation. The callback will be called when either headers are
+   * received or an error occurs. If successful, the Stream ID provided to the
+   * callback can be used to read the contents of the resource via readStream().
+   */
+  void loadNetworkResource(
+      const LoadNetworkResourceParams& params,
+      NetworkRequestDelegate& delegate,
+      std::function<void(NetworkResource)> callback);
+
+  /**
+   * Close a given stream by its handle, call the callback with std::nullopt if
+   * a stream is found and destroyed, or with an error message if the stream is
+   * not found. Safely aborts any in-flight request.
+   */
+  void closeStream(
+      const StreamID& streamId,
+      std::function<void(std::optional<std::string> error)> callback);
+
+  /**
+   * Read a chunk of data from the stream, once enough has been downloaded, or
+   * call back with an error.
+   */
+  void readStream(
+      const ReadStreamParams& params,
+      std::function<void(std::variant<IOReadError, IOReadResult> result)>
+          callback);
+
+ private:
+  /**
+   * Map of stream objects, which contain data received, accept read requests
+   * and listen for delegate events. Delegates have a shared_ptr to the Stream
+   * instance, but Streams should not live beyond the destruction of this
+   * NetworkIO instance.
+   */
+  std::unordered_map<std::string, std::shared_ptr<Stream>> streams_;
+  unsigned long nextStreamId_{0};
+
+  bool cancelAndRemoveStreamIfExists(const StreamID& streamId);
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
@@ -700,4 +700,283 @@ TEST_F(HostTargetTest, HostCommands) {
   page_->unregisterInstance(instanceTarget);
 }
 
+TEST_F(HostTargetTest, NetworkLoadNetworkResourceSuccess) {
+  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
+
+  connect();
+
+  InSequence s;
+
+  std::shared_ptr<NetworkRequestListener> listener;
+  EXPECT_CALL(hostTargetDelegate_, networkRequest(Eq("http://example.com"), _))
+      .Times(1)
+      .WillOnce([&listener](
+                    const std::string& /*url*/,
+                    std::shared_ptr<NetworkRequestListener> listenerArg) {
+        // Capture the NetworkRequestLister to use later.
+        listener = listenerArg;
+      })
+      .RetiresOnSaturation();
+
+  // Load the resource, expect a CDP response as soon as headers are received.
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": "Network.loadNetworkResource",
+                           "params": {
+                             "url": "http://example.com"
+                            }
+                         })");
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                            "id": 1,
+                                            "result": {
+                                              "resource": {
+                                                "success": true,
+                                                "stream": "0",
+                                                "httpStatusCode": 200,
+                                                "headers": {
+                                                  "x-test": "foo"
+                                                }
+                                              }
+                                            }
+                                          })")));
+
+  listener->onHeaders(200, Headers{{"x-test", "foo"}});
+
+  // Retrieve the first chunk of data.
+  toPage_->sendMessage(R"({
+                          "id": 2,
+                          "method": "IO.read",
+                          "params": {
+                            "handle": "0",
+                            "size": 8
+                          }
+                        })");
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+    "id": 2,
+    "result": {
+      "data": "SGVsbG8sIFc=",
+      "eof": false,
+      "base64Encoded": true
+    }
+  })")));
+  listener->onData("Hello, World!");
+
+  // Retrieve the remaining data.
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                            "id": 3,
+                                            "result": {
+                                              "data": "b3JsZCE=",
+                                              "eof": false,
+                                              "base64Encoded": true
+                                            }
+                                          })")));
+  toPage_->sendMessage(R"({
+                          "id": 3,
+                          "method": "IO.read",
+                          "params": {
+                            "handle": "0",
+                            "size": 8
+                          }
+                        })");
+
+  // No more data - expect empty payload with eof: true.
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                            "id": 4,
+                                            "result": {
+                                              "data": "",
+                                              "eof": true,
+                                              "base64Encoded": true
+                                            }
+                                          })")));
+  toPage_->sendMessage(R"({
+                          "id": 4,
+                          "method": "IO.read",
+                          "params": {
+                            "handle": "0",
+                            "size": 8
+                          }
+                        })");
+  listener->onEnd();
+
+  // Close the stream.
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+    "id": 5,
+    "result": {}
+  })")));
+  toPage_->sendMessage(R"({
+                          "id": 5,
+                          "method": "IO.close",
+                          "params": {
+                            "handle": "0"
+                          }
+                        })");
+
+  page_->unregisterInstance(instanceTarget);
+}
+
+TEST_F(HostTargetTest, NetworkLoadNetworkResourceStreamInterrupted) {
+  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
+
+  connect();
+
+  InSequence s;
+
+  std::shared_ptr<NetworkRequestListener> listener;
+  EXPECT_CALL(hostTargetDelegate_, networkRequest(Eq("http://example.com"), _))
+      .Times(1)
+      .WillOnce([&listener](
+                    const std::string& /*url*/,
+                    std::shared_ptr<NetworkRequestListener> listenerArg) {
+        listener = listenerArg;
+      })
+      .RetiresOnSaturation();
+
+  // Load the resource, receiving headers succesfully.
+  toPage_->sendMessage(R"({
+                           "id": 1,
+                           "method": "Network.loadNetworkResource",
+                           "params": {
+                             "url": "http://example.com"
+                            }
+                         })");
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+    "id": 1,
+    "result": {
+      "resource": {
+        "success": true,
+        "stream": "0",
+        "httpStatusCode": 200,
+        "headers": {
+          "x-test": "foo"
+        }
+      }
+    }
+  })")));
+
+  listener->onHeaders(200, Headers{{"x-test", "foo"}});
+
+  // Retrieve the first chunk of data.
+  toPage_->sendMessage(R"({
+                          "id": 2,
+                          "method": "IO.read",
+                          "params": {
+                            "handle": "0",
+                            "size": 20
+                          }
+                        })");
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+    "id": 2,
+    "result": {
+      "data": "VGhlIG1lYW5pbmcgb2YgbGlmZSA=",
+      "eof": false,
+      "base64Encoded": true
+    }
+  })")));
+  listener->onData("The meaning of life is...");
+
+  // Simulate an error mid-stream, expect in-flight IO.reads to return a CDP
+  // error.
+  toPage_->sendMessage(R"({
+                          "id": 3,
+                          "method": "IO.read",
+                          "params": {
+                            "handle": "0",
+                            "size": 20
+                          }
+                        })");
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+    "id": 3,
+    "error": {
+      "code": -32603,
+      "message": "Connection lost"
+    }
+  })")));
+  listener->onError("Connection lost");
+
+  // IO.close should be a successful no-op after an error.
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+    "id": 4,
+    "result": {}
+  })")));
+  toPage_->sendMessage(R"({
+                          "id": 4,
+                          "method": "IO.close",
+                          "params": {
+                            "handle": "0"
+                          }
+                        })");
+
+  page_->unregisterInstance(instanceTarget);
+}
+
+TEST_F(HostTargetTest, NetworkLoadNetworkResource404) {
+  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
+
+  connect();
+
+  InSequence s;
+
+  std::shared_ptr<NetworkRequestListener> listener;
+  EXPECT_CALL(
+      hostTargetDelegate_, networkRequest(Eq("http://notexists.com"), _))
+      .Times(1)
+      .WillOnce([&listener](
+                    const std::string& /*url*/,
+                    std::shared_ptr<NetworkRequestListener> listenerArg) {
+        listener = std::move(listenerArg);
+      })
+      .RetiresOnSaturation();
+
+  // A 404 response should trigger a CDP result with success: false, including
+  // the status code, headers, but *no* stream handle.
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+    "id": 1,
+    "result": {
+      "resource": {
+        "success": false,
+        "httpStatusCode": 404,
+        "headers": {
+          "x-test": "foo"
+        }
+      }
+    }
+  })")));
+
+  toPage_->sendMessage(R"({
+                        "id": 1,
+                        "method": "Network.loadNetworkResource",
+                        "params": {
+                          "url": "http://notexists.com"
+                        }
+                      })");
+
+  listener->onHeaders(404, Headers{{"x-test", "foo"}});
+
+  // Assuming a successful request would have assigned handle "0", verify that
+  // handle has *not* been assigned.
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+    "id": 2,
+    "error": {
+      "code": -32603,
+      "message": "Stream not found with handle 0"
+    }
+  })")));
+
+  toPage_->sendMessage(R"({
+                          "id": 2,
+                          "method": "IO.read",
+                          "params": {
+                            "handle": "0",
+                            "size": 20
+                          }
+                        })");
+
+  page_->unregisterInstance(instanceTarget);
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -124,6 +124,12 @@ class MockHostTargetDelegate : public HostTargetDelegate {
       onSetPausedInDebuggerMessage,
       (const OverlaySetPausedInDebuggerMessageRequest& request),
       (override));
+  MOCK_METHOD(
+      void,
+      networkRequest,
+      (const std::string& url,
+       std::shared_ptr<NetworkRequestListener> listener),
+      (override));
 };
 
 class MockInstanceTargetDelegate : public InstanceTargetDelegate {};

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -13,6 +13,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTFabricSurface.h>
 #import <React/RCTInspectorDevServerHelper.h>
+#import <React/RCTInspectorNetworkHelper.h>
 #import <React/RCTJSThread.h>
 #import <React/RCTLog.h>
 #import <React/RCTMockDef.h>
@@ -36,7 +37,9 @@ using namespace facebook::react;
 class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::HostTargetDelegate {
  public:
   RCTHostHostTargetDelegate(RCTHost *host)
-      : host_(host), pauseOverlayController_([[RCTPausedInDebuggerOverlayController alloc] init])
+      : host_(host),
+        pauseOverlayController_([[RCTPausedInDebuggerOverlayController alloc] init]),
+        networkHelper_([[RCTInspectorNetworkHelper alloc] init])
   {
   }
 
@@ -69,9 +72,15 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     }
   }
 
+  void networkRequest(const std::string &rawUrl, RCTInspectorNetworkListener listener) override
+  {
+    [networkHelper_ networkRequestWithUrl:rawUrl listener:listener];
+  }
+
  private:
   __weak RCTHost *host_;
   RCTPausedInDebuggerOverlayController *pauseOverlayController_;
+  RCTInspectorNetworkHelper *networkHelper_;
 };
 
 @implementation RCTHost {


### PR DESCRIPTION
Summary:
Implement `jsinspector_modern:: NetworkRequestDelegate` for iOS (bridge and bridgeless) to satisfy CDP `Network.loadNetworkResource` (etc) requests.

Changelog:
[iOS][Added] Debugger: Implement CDP methods for loading network resources through the debug target.

Differential Revision: D54496969
