### PR TITLE
[RN][CI] Fix Nightlies for Android

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,6 @@ on:
     schedule:
      - cron: '15 2 * * *'
 
-
 jobs:
   set_release_type:
     runs-on: ubuntu-latest
@@ -635,7 +634,7 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/react-native/react-native
           echo "GRADLE_OPTS = $GRADLE_OPTS"
-          export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a"
+          export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
           node ./scripts/releases-ci/publish-npm.js -t nightly
       - name: Zip Maven Artifacts from /tmp/maven-local
         working-directory: /tmp


### PR DESCRIPTION
## Summary:

While migrating from CCI to GHA, we mistakenly set the `ORG_GRADLE_PROJECT_reactNativeArchitectures` wrongly. The result was that the nightly was building only 1 architecture for android instead of all of them.

This change fixes that, but asking GHA to build all the architectures when running nightlies

## Changelog:
[Internal] - Build all the architectures for android when running nightlies

## Test Plan:
Run a nightly from the branch and see it working
