### PR TITLE
Remove import of `com.facebook.react.ReactSettingsExtension`

### DIFF
--- a/packages/helloworld/android/settings.gradle
+++ b/packages/helloworld/android/settings.gradle
@@ -6,10 +6,9 @@
  */
 
 // Autolinking has now moved into the React Native Gradle Plugin
-import com.facebook.react.ReactSettingsExtension
 pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
-extensions.configure(ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 
 rootProject.name = 'HelloWorld'
 include ':app'

--- a/packages/react-native/template/android/settings.gradle
+++ b/packages/react-native/template/android/settings.gradle
@@ -1,7 +1,6 @@
-import com.facebook.react.ReactSettingsExtension
 pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
-extensions.configure(ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'HelloWorld'
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import com.facebook.react.ReactSettingsExtension
-
 pluginManagement {
   repositories {
     mavenCentral()
@@ -38,7 +36,7 @@ plugins {
   id("com.facebook.react.settings")
 }
 
-configure<ReactSettingsExtension> {
+configure<com.facebook.react.ReactSettingsExtension> {
   autolinkLibrariesFromCommand(
       workingDirectory = file("packages/rn-tester/"), lockFiles = files("yarn.lock"))
 }


### PR DESCRIPTION
Summary:
I'm removing this line from settings.gradle:
```
import com.facebook.react.ReactSettingsExtension
```
and just using a fully qualified class name in the `configure{}` block
as imports cannot be conditionally included and is making hard for RNTA
to integrated those changes.

Changelog:
[Internal] [Changed] - Remove import of `com.facebook.react.ReactSettingsExtension`

Differential Revision: D58354443
