### PR TITLE
Add getNativeModule(String) to ReactContext interface

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
@@ -130,6 +130,14 @@ public class BridgeReactContext extends ReactApplicationContext {
   }
 
   @Override
+  public @Nullable NativeModule getNativeModule(String moduleName) {
+    if (mCatalystInstance == null) {
+      raiseCatalystInstanceMissingException();
+    }
+    return mCatalystInstance.getNativeModule(moduleName);
+  }
+
+  @Override
   public CatalystInstance getCatalystInstance() {
     return Assertions.assertNotNull(mCatalystInstance);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -151,6 +151,11 @@ public abstract class ReactContext extends ContextWrapper {
   public abstract <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface);
 
   /**
+   * @return the instance of the specified module interface associated with this ReactContext.
+   */
+  public abstract @Nullable NativeModule getNativeModule(String moduleName);
+
+  /**
    * Calls RCTDeviceEventEmitter.emit to JavaScript, with given event name and an optional list of
    * arguments.
    */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -182,6 +182,11 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   }
 
   @Override
+  public @Nullable NativeModule getNativeModule(String name) {
+    return mReactHost.getNativeModule(name);
+  }
+
+  @Override
   @FrameworkAPI
   @UnstableReactNativeAPI
   public @Nullable JavaScriptContextHolder getJavaScriptContextHolder() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -100,6 +100,12 @@ public class ThemedReactContext extends ReactContext {
     return mReactApplicationContext.getNativeModule(nativeModuleInterface);
   }
 
+  @Nullable
+  @Override
+  public NativeModule getNativeModule(String moduleName) {
+    return mReactApplicationContext.getNativeModule(moduleName);
+  }
+
   @Override
   public CatalystInstance getCatalystInstance() {
     return mReactApplicationContext.getCatalystInstance();


### PR DESCRIPTION
Summary:
This method is available on the (deprecated) CatalystInstance interface, but not on ReactContext, even though it is trivially supported.

Changelog: [Android][Added] - Added getNativeModule(name) to ReactContext

Differential Revision: D58355135
