### PR TITLE
Tentative fix for NPE `JavaTimerManager$IdleCallbackRunnable.cancel`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
@@ -101,8 +101,11 @@ public class JavaTimerManager implements LifecycleEventListener, HeadlessJsTaskE
       }
 
       // If the JS thread is busy for multiple frames we cancel any other pending runnable.
-      if (mCurrentIdleCallbackRunnable != null) {
-        mCurrentIdleCallbackRunnable.cancel();
+      // We also capture the idleCallbackRunnable to tentatively fix:
+      // https://github.com/facebook/react-native/issues/44842
+      IdleCallbackRunnable idleCallbackRunnable = mCurrentIdleCallbackRunnable;
+      if (idleCallbackRunnable != null) {
+        idleCallbackRunnable.cancel();
       }
 
       mCurrentIdleCallbackRunnable = new IdleCallbackRunnable(frameTimeNanos);


### PR DESCRIPTION
Summary:
This attempts to fix #44842 by capturing the accessed field in a new variable.
We don't have a way to reproduce this & this is a best guess fix.

Changelog:
[Android] [Fixed] - Tentative fix for NPE `JavaTimerManager$IdleCallbackRunnable.cancel`

Differential Revision: D58356826
