### PR TITLE
Fix incorrect AppState value on UIApplicationWillEnterForegroundNotification

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAppState.mm
+++ b/packages/react-native/React/CoreModules/RCTAppState.mm
@@ -117,7 +117,7 @@ RCT_EXPORT_MODULE()
   if ([notification.name isEqualToString:UIApplicationWillResignActiveNotification]) {
     newState = @"inactive";
   } else if ([notification.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
-    newState = @"background";
+    newState = @"active";
   } else {
     newState = RCTCurrentAppState();
   }


### PR DESCRIPTION
## Summary:

As I was trying to use AppState in my app, "active" state wasn't emitted.
It turns out that the native module reports that app went to background on UIApplicationWillEnterForegroundNotification
which according to Apple Docs reports as app is becoming active 

## Changelog:

[IOS] [FIXED] - Fix active state in AppState
