### PR TITLE
Add VisionOS support to GHA nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,7 +105,7 @@ jobs:
           . ./utils/build-apple-framework.sh
           build_host_hermesc_if_needed
   build_apple_slices_hermes:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [build_hermesc_apple, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -116,10 +116,12 @@ jobs:
       fail-fast: false
       matrix:
         flavor: [Debug, Release]
-        slice: [macosx, iphoneos, iphonesimulator, catalyst]
+        slice: [macosx, iphoneos, iphonesimulator, catalyst, xros, xrsimulator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
       - name: Cache setup
         id: cache_setup
         uses: ./.github/actions/cache_setup
@@ -260,6 +262,18 @@ jobs:
         with:
           path: ./packages/react-native/sdks/hermes/build_catalyst_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-catalyst-${{ matrix.flavor }}
+      - name: Slice cache xros
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_xros_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xros-${{ matrix.flavor }}
+      - name: Slice cache xrsimulator
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        uses: actions/cache@v4.0.0
+        with:
+          path: ./packages/react-native/sdks/hermes/build_xrsimulator_${{ matrix.flavor }}
+          key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xrsimulator-${{ matrix.flavor }}
       - name: Move back build folders
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         run: |
@@ -269,6 +283,8 @@ jobs:
           mv build_iphoneos_${{ matrix.flavor }} build_iphoneos
           mv build_iphonesimulator_${{ matrix.flavor }} build_iphonesimulator
           mv build_catalyst_${{ matrix.flavor }} build_catalyst
+          mv build_xros_${{ matrix.flavor }} build_xros
+          mv build_xrsimulator_${{ matrix.flavor }} build_xrsimulator
       - name: Prepare destroot folder
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         run: |
@@ -326,6 +342,8 @@ jobs:
           mkdir -p "$WORKING_DIR/catalyst"
           mkdir -p "$WORKING_DIR/iphoneos"
           mkdir -p "$WORKING_DIR/iphonesimulator"
+          mkdir -p "$WORKING_DIR/xros"
+          mkdir -p "$WORKING_DIR/xrsimulator"
 
           cd ./packages/react-native/sdks/hermes || exit 1
 
@@ -334,6 +352,8 @@ jobs:
           cp -r build_catalyst/$DSYM_FILE_PATH "$WORKING_DIR/catalyst/"
           cp -r build_iphoneos/$DSYM_FILE_PATH "$WORKING_DIR/iphoneos/"
           cp -r build_iphonesimulator/$DSYM_FILE_PATH "$WORKING_DIR/iphonesimulator/"
+          cp -r build_xros/$DSYM_FILE_PATH "$WORKING_DIR/xros/"
+          cp -r build_xrsimulator/$DSYM_FILE_PATH "$WORKING_DIR/xrsimulator/"
 
           DEST_DIR="/tmp/hermes/dSYM/$FLAVOR"
           tar -C "$WORKING_DIR" -czvf "hermes.framework.dSYM" .


### PR DESCRIPTION
Summary:
We recently landed a change that added support for VisionOS in the general test case for GHA but we forgot to include nightlies.

This change takes the same changes applied to [this file](https://github.com/facebook/react-native/pull/44691/files#diff-12d2c3c126fcc84106dce4b6d2be2220f018661b111a5382ad6effc1047f66aeR114-R368) and applies them to the nightlies.

## Changelog:
[Internal] - Add GHA nightlies support for VisionOS

Reviewed By: huntie

Differential Revision: D58358115
