### PR TITLE
Expose unstable_loadFusebox API on Android

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1994,6 +1994,7 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun load (ZZ)V
 	public static final fun load (ZZZ)V
 	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
+	public static final fun unstable_loadFusebox (Z)V
 }
 
 public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/facebook/react/ReactActivityDelegate {

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -136,6 +136,10 @@ class RNTesterApplication : Application(), ReactApplication {
     ReactFontManager.getInstance().addCustomFont(this, "Rubik", R.font.rubik)
     super.onCreate()
     SoLoader.init(this, /* native exopackage */ false)
+
+    // [Experiment] Enable the new debugger stack (codename Fusebox)
+    // unstable_loadFusebox(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
+
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       load()
     }


### PR DESCRIPTION
Summary:
- Enables an opt-in to the Fusebox stack on Android for both architectures in open source.
- Templates use of this opt-in in RNTester.

Changelog: [Internal]

Reviewed By: rubennorte

Differential Revision: D58359907
