### PR TITLE
Expose unstable_fuseboxEnabled API on iOS

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -160,6 +160,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return: `true` if the new initialization layer is enabled. Otherwise returns `false`.
 - (BOOL)bridgelessEnabled;
 
+/// Controls whether the new debugger stack (codename Fusebox) is enabled.
+- (BOOL)unstable_fuseboxEnabled;
+
 /// Return the bundle URL for the main bundle.
 - (NSURL *__nullable)bundleURL;
 

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -151,6 +151,11 @@
   return [self newArchEnabled];
 }
 
+- (BOOL)unstable_fuseboxEnabled
+{
+  return [self unstable_fuseboxEnabled];
+}
+
 - (NSURL *)bundleURL
 {
   [NSException raise:@"RCTAppDelegate::bundleURL not implemented"
@@ -300,8 +305,26 @@
 
 #pragma mark - Feature Flags
 
-class RCTAppDelegateBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults {
+class RCTAppDelegateFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults {
  public:
+  RCTAppDelegateFeatureFlags(bool fuseboxEnabled)
+  {
+    fuseboxEnabled_ = fuseboxEnabled;
+  }
+
+  bool fuseboxEnabledDebug() override
+  {
+    return fuseboxEnabled_;
+  }
+
+ private:
+  bool fuseboxEnabled_;
+};
+
+class RCTAppDelegateBridgelessFeatureFlags : public RCTAppDelegateFeatureFlags {
+ public:
+  RCTAppDelegateBridgelessFeatureFlags(bool fuseboxEnabled) : RCTAppDelegateFeatureFlags(fuseboxEnabled) {}
+
   bool useModernRuntimeScheduler() override
   {
     return true;
@@ -319,7 +342,11 @@ class RCTAppDelegateBridgelessFeatureFlags : public facebook::react::ReactNative
 - (void)_setUpFeatureFlags
 {
   if ([self bridgelessEnabled]) {
-    facebook::react::ReactNativeFeatureFlags::override(std::make_unique<RCTAppDelegateBridgelessFeatureFlags>());
+    facebook::react::ReactNativeFeatureFlags::override(
+        std::make_unique<RCTAppDelegateBridgelessFeatureFlags>([self unstable_fuseboxEnabled]));
+  } else {
+    facebook::react::ReactNativeFeatureFlags::override(
+        std::make_unique<RCTAppDelegateFeatureFlags>([self unstable_fuseboxEnabled]));
   }
 }
 

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -144,6 +144,14 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   return [super bridgelessEnabled];
 }
 
+#pragma mark - Experimental settings
+
+// [Experiment] Enable the new debugger stack (codename Fusebox)
+- (BOOL)unstable_fuseboxEnabled
+{
+  return false;
+}
+
 #pragma mark - RCTComponentViewFactoryComponentProvider
 
 #ifndef RN_DISABLE_OSS_PLUGIN_HEADER


### PR DESCRIPTION
Summary:
- Enables an opt-in to the Fusebox stack on iOS for both architectures in open source.
- Templates use of this opt-in in RNTester.

Changelog: [Internal]

Differential Revision: D58364053
