### PR TITLE
Cleanup imports and types

### DIFF
--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -8,13 +8,14 @@
  * @format
  */
 
+import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
+import type {ProcessedColorValue} from '../StyleSheet/processColor';
+import type {PressEvent} from '../Types/CoreEventTypes';
+import type {TextProps} from './TextProps';
+
 import {createViewConfig} from '../NativeComponent/ViewConfig';
 import UIManager from '../ReactNative/UIManager';
 import createReactNativeComponentClass from '../Renderer/shims/createReactNativeComponentClass';
-import {type HostComponent} from '../Renderer/shims/ReactNativeTypes';
-import {type ProcessedColorValue} from '../StyleSheet/processColor';
-import {type PressEvent} from '../Types/CoreEventTypes';
-import {type TextProps} from './TextProps';
 
 type NativeTextProps = $ReadOnly<{
   ...TextProps,

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -26,23 +26,23 @@ import type {
 } from '../Types/CoreEventTypes';
 import type {Node} from 'react';
 
-export type PressRetentionOffset = $ReadOnly<{|
+export type PressRetentionOffset = $ReadOnly<{
   top: number,
   left: number,
   bottom: number,
   right: number,
-|}>;
+}>;
 
-type PointerEventProps = $ReadOnly<{|
+type PointerEventProps = $ReadOnly<{
   onPointerEnter?: (event: PointerEvent) => void,
   onPointerLeave?: (event: PointerEvent) => void,
   onPointerMove?: (event: PointerEvent) => void,
-|}>;
+}>;
 
 /**
  * @see https://reactnative.dev/docs/text#reference
  */
-export type TextProps = $ReadOnly<{|
+export type TextProps = $ReadOnly<{
   ...PointerEventProps,
 
   /**
@@ -265,4 +265,4 @@ export type TextProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/text.html#linebreakstrategyios
    */
   lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
-|}>;
+}>;


### PR DESCRIPTION
Summary:
Clean up:
* type imports to be consistent
* Remove long since deprecated `{| ... |}` exact object style.

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D58381905
