### PR TITLE
Disable `test-android-template` on PR

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -823,6 +823,8 @@ jobs:
             -H "Authorization: Bearer $REACT_NATIVE_BOT_GITHUB_TOKEN" \
             -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${{ github.ref_name }}\" }}"
   test_android_template:
+    # TODO: Re-enable once passing
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs: [prepare_hermes_workspace, build_npm_package]
     container:


### PR DESCRIPTION
Summary:
This has not yet passed on main since we started testing on main two weeks ago: https://github.com/facebook/react-native/actions/runs/9316380994/job/25688028045

This change disables the GitHub Actions version `test_android_template` as a signal for PRs or diffs, since it isn't stable yet (but we still run it on main, and can manually dispatch it on any branch). This coverage is still enabled in CircleCI.

Changelog: [Internal]

Differential Revision: D58394745
