### PR TITLE
Make hermesc executable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -638,6 +638,10 @@ jobs:
 
           cp -r $HERMES_WS_DIR/win64-bin/* ./packages/react-native/sdks/hermesc/win64-bin/.
           cp -r $HERMES_WS_DIR/linux64-bin/* ./packages/react-native/sdks/hermesc/linux64-bin/.
+
+          # Make sure the hermesc files are actually executable.
+          chmod -R +x packages/react-native/sdks/hermesc/*
+
           mkdir -p ./packages/react-native/ReactAndroid/external-artifacts/artifacts/
           cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-Debug.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-debug.tar.gz
           cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-Release.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-release.tar.gz

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -767,6 +767,10 @@ jobs:
 
           cp -r $HERMES_WS_DIR/win64-bin/* ./packages/react-native/sdks/hermesc/win64-bin/.
           cp -r $HERMES_WS_DIR/linux64-bin/* ./packages/react-native/sdks/hermesc/linux64-bin/.
+
+          # Make sure the hermesc files are actually executable.
+          chmod -R +x packages/react-native/sdks/hermesc/*
+
           mkdir -p ./packages/react-native/ReactAndroid/external-artifacts/artifacts/
           cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-Debug.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-debug.tar.gz
           cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-Release.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-release.tar.gz


### PR DESCRIPTION
Summary:
Seems like hermesc produced by GitHub Actions is not executable. This fixes it.

Changelog:
[Internal] [Changed] - Make hermesc executable

Reviewed By: cipolleschi

Differential Revision: D58407086
