### PR TITLE
Fix test_android_template

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -834,8 +834,6 @@ jobs:
             -H "Authorization: Bearer $REACT_NATIVE_BOT_GITHUB_TOKEN" \
             -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${{ github.ref_name }}\" }}"
   test_android_template:
-    # TODO: Re-enable once passing
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs: [prepare_hermes_workspace, build_npm_package]
     container:
@@ -883,13 +881,7 @@ jobs:
           node ./scripts/releases/update-template-package.js "{\"react-native\":\"file:$GITHUB_WORKSPACE/build/$(cat build/react-native-package-version)\"}"
           node ./scripts/e2e/init-template-e2e.js --projectName $PROJECT_NAME --templatePath "$GITHUB_WORKSPACE/packages/react-native" --directory "/tmp/$PROJECT_NAME" --verbose
       - name: Setup gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: 8.6
-      - name: Yarn install in template project
-        run: |
-          cd /tmp/$PROJECT_NAME
-          yarn install --non-interactive
+        uses: ./.github/actions/setup-gradle
       - name: Build the template application for ${{ matrix.flavor }} with Architecture set to ${{ matrix.architecture }}, and using the ${{ matrix.jsengine }} JS engine.
         shell: bash
         run: |
@@ -911,6 +903,7 @@ jobs:
         with:
           name: template-apk-${{ matrix.flavor }}-${{ matrix.architecture }}-${{ matrix.jsengine }}
           path: /tmp/AndroidTemplateProject/android/app/build/outputs/apk/
+          compression-level: 0
   test_ios_template_with_ruby_3_2_0:
     runs-on: macos-13
     needs: [prepare_hermes_workspace, build_npm_package]


### PR DESCRIPTION
Summary:
This re-enables and fix `test_android_template`.
The problem was that we were invoking `yarn install` inside the template after we already installed with `npm install --registry`.
So this was invalidating the Verdaccio setup and effectively fetching packages from NPM

Changelog:
[Internal] [Changed] - Fix test_android_template

Differential Revision: D58407941
