### PR TITLE
Add Gradle Wrapper validation workflow

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,13 @@
+name: "Validate Gradle Wrapper"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
Summary:
This is just a security measure against wrapper tampering attacks.
See more on this here: https://github.com/gradle/actions/blob/main/docs/wrapper-validation.md

Changelog:
[Internal] [Changed] - Add Gradle Wrapper validation workflow

Differential Revision: D58408099


