### PR TITLE
Format code-workspace file, clarify use of .vscode/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,8 +146,11 @@ vendor/
 /packages/react-native/sdks/hermesc
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz
 
-# Visual studio
-.vscode
+# Visual Studio Code (config dir - if present, this merges user defined
+# workspace settings on top of react-native.code-workspace)
+/.vscode
+
+# Visual Studio
 .vs
 
 # Android memory profiler files

--- a/.prettierrc
+++ b/.prettierrc
@@ -8,6 +8,12 @@
   "endOfLine": "lf",
   "overrides": [
     {
+      "files": ["*.code-workspace"],
+      "options": {
+        "parser": "json"
+      }
+    },
+    {
       "files": [
         "*.js",
         "*.js.flow"

--- a/react-native.code-workspace
+++ b/react-native.code-workspace
@@ -1,20 +1,20 @@
 {
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"extensions": {
-		"recommendations": [
-			"dbaeumer.vscode-eslint",
-			"editorconfig.editorconfig",
-			"esbenp.prettier-vscode",
-			"flowtype.flow-for-vscode"
-		],
-	},
-	"settings": {
-		"editor.formatOnSave": true,
-		"flow.pathToFlow": "${workspaceFolder}/node_modules/.bin/flow",
-		"javascript.validate.enable": false
-	}
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "extensions": {
+    "recommendations": [
+      "dbaeumer.vscode-eslint",
+      "editorconfig.editorconfig",
+      "esbenp.prettier-vscode",
+      "flowtype.flow-for-vscode"
+    ]
+  },
+  "settings": {
+    "editor.formatOnSave": true,
+    "flow.pathToFlow": "${workspaceFolder}/node_modules/.bin/flow",
+    "javascript.validate.enable": false
+  }
 }


### PR DESCRIPTION
Summary:
While reviewing https://github.com/facebook/react/pull/29830, I noticed this file was committed with tab indentation in React Native. I have also used the `.gitignore` entry to clarify how `react-native.code-workspace` interacts with an optional user `.vscode/` config directory.

Note: The `json-stringify` parser can be used with Prettier 3+ only, so we use `json` instead.

Changelog: [Internal]

Differential Revision: D58413581
