### PR TITLE
Remove `android.enableJetifier`

### DIFF
--- a/packages/helloworld/android/gradle.properties
+++ b/packages/helloworld/android/gradle.properties
@@ -7,7 +7,6 @@
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 android.useAndroidX=true
-android.enableJetifier=true
 reactNativeArchitectures=arm64-v8a
 newArchEnabled=true
 hermesEnabled=true

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -2,7 +2,6 @@ VERSION_NAME=1000.0.0
 react.internal.publishingGroup=com.facebook.react
 
 android.useAndroidX=true
-android.enableJetifier=true
 
 # We want to have more fine grained control on the Java version for
 # ReactAndroid, therefore we disable RGNP Java version alignment mechanism

--- a/packages/react-native/template/android/gradle.properties
+++ b/packages/react-native/template/android/gradle.properties
@@ -21,8 +21,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using

--- a/packages/rn-tester/android/app/gradle.properties
+++ b/packages/rn-tester/android/app/gradle.properties
@@ -2,7 +2,6 @@ org.gradle.parallel=true
 # This is causing issue with dependencies task: https://github.com/gradle/gradle/issues/9645#issuecomment-530746758
 # org.gradle.configureondemand=true
 android.useAndroidX=true
-android.enableJetifier=true
 
 # RN-Tester is building with NewArch always enabled
 newArchEnabled=true


### PR DESCRIPTION
Summary:
We probably don't need Jetifier anymore at this point.
Also see: https://github.com/react-native-community/template/pull/9

Changelog:
[Internal] [Changed] - Remove `android.enableJetifier`

Differential Revision: D58416487
