### PR TITLE
Add Clipboard module to base packages

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.kt
@@ -42,4 +42,8 @@ public class ClipboardModule(context: ReactApplicationContext) : NativeClipboard
     val clipdata: ClipData = ClipData.newPlainText(null, text)
     clipboardService.setPrimaryClip(clipdata)
   }
+
+  public companion object {
+    public const val NAME: String = NativeClipboardSpec.NAME
+  }
 }


### PR DESCRIPTION
Summary:
Updates the companion object for `ClipboardModule` to re-export the generated parent's `NAME`.

Changelog: [Internal]

Differential Revision: D58426185
