### PR TITLE
Fix TextInputShared Example

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1114,8 +1114,8 @@ module.exports = ([
               overflow: 'hidden',
               fontSize: 16,
             }}>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            <Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.</Text>
           </ExampleTextInput>
         </View>
       );


### PR DESCRIPTION
## Summary:

New example in TextInputSharedExample.js produces an error message in the React Native for Windows E2E tests stating that children of TextInput controls must be of component type Text. Edited example to resolve error. 

## Changelog:

Pick one each for the category and type tags:

[GENERAL][FIXED] - Fix broken example in TextInputSharedExample.js


## Test Plan:

Change passed CI successfully in React Native for Windows platform.
