### PR TITLE
Avoid static_pointer_cast in GenerateModuleH.js

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -568,9 +568,9 @@ function translateEventEmitterToCpp(
       isArray ? `std::vector<${templateName}>` : templateName
     }, ${jsiType}>, "value cannnot be converted to ${jsiType}");`
     }
-    std::static_pointer_cast<AsyncEventEmitter<${
+    static_cast<AsyncEventEmitter<${
       isVoidTypeAnnotation ? '' : 'jsi::Value'
-    }>>(delegate_.eventEmitterMap_["${eventEmitter.name}"])->emit(${
+    }>&>(*delegate_.eventEmitterMap_["${eventEmitter.name}"]).emit(${
       isVoidTypeAnnotation
         ? ''
         : `[jsInvoker = jsInvoker_, eventValue = value](jsi::Runtime& rt) -> jsi::Value {


### PR DESCRIPTION
Summary:
Avoid static_pointer_cast. It provides no type-safety, and requires increasing the shared_ptr

## Changelog:

[Internal] [Fixed] - Avoid static_pointer_cast in GenerateModuleH.js

Differential Revision: D58449748
