### PR TITLE
Implement new HostTargetMetadata fields (iOS)

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -197,6 +197,13 @@ class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::
   {
   }
 
+  facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() override
+  {
+    return {
+        .integrationName = "iOS Bridge (RCTBridge)",
+    };
+  }
+
   void onReload(const PageReloadRequest &request) override
   {
     RCTAssertMainQueue();
@@ -458,11 +465,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
             // This can happen if we're about to be dealloc'd. Reject the connection.
             return nullptr;
           }
-          return strongSelf->_inspectorTarget->connect(
-              std::move(remote),
-              {
-                  .integrationName = "iOS Bridge (RCTBridge)",
-              });
+          return strongSelf->_inspectorTarget->connect(std::move(remote));
         },
         {.nativePageReloads = true, .prefersFuseboxFrontend = true});
   }

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -20,6 +20,7 @@
 #import <jsinspector-modern/ReactCdp.h>
 #import <optional>
 #import "RCTDevLoadingViewProtocol.h"
+#import "RCTInspectorUtils.h"
 #import "RCTJSThread.h"
 #import "RCTLog.h"
 #import "RCTModuleData.h"
@@ -199,8 +200,14 @@ class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::
 
   facebook::react::jsinspector_modern::HostTargetMetadata getMetadata() override
   {
+    auto metadata = [RCTInspectorUtils getHostMetadata];
+
     return {
+        .appIdentifier = metadata.appIdentifier,
+        .deviceName = metadata.deviceName,
         .integrationName = "iOS Bridge (RCTBridge)",
+        .platform = metadata.platform,
+        .reactNativeVersion = metadata.reactNativeVersion,
     };
   }
 

--- a/packages/react-native/React/DevSupport/RCTInspectorUtils.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorUtils.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <string>
+
+struct CommonHostMetadata {
+  std::string appIdentifier;
+  std::string deviceName;
+  std::string platform;
+  std::string reactNativeVersion;
+};
+
+@interface RCTInspectorUtils : NSObject
+
++ (CommonHostMetadata)getHostMetadata;
+
+@end

--- a/packages/react-native/React/DevSupport/RCTInspectorUtils.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorUtils.mm
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInspectorUtils.h"
+
+#import <React/RCTConstants.h>
+#import <React/RCTVersion.h>
+#import <UIKit/UIKit.h>
+
+@implementation RCTInspectorUtils
+
++ (CommonHostMetadata)getHostMetadata
+{
+  UIDevice *device = [UIDevice currentDevice];
+
+  NSString *appIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+  NSString *platform = RCTPlatformName;
+  NSString *deviceName = [device name];
+
+  auto version = RCTGetReactNativeVersion();
+  NSString *reactNativeVersion =
+      [NSString stringWithFormat:@"%i.%i.%i%@",
+                                 [version[@"minor"] intValue],
+                                 [version[@"major"] intValue],
+                                 [version[@"patch"] intValue],
+                                 [version[@"prerelease"] isKindOfClass:[NSNull class]]
+                                     ? @""
+                                     : [@"-" stringByAppendingString:[version[@"prerelease"] stringValue]]];
+
+  return {
+      .appIdentifier = [appIdentifier UTF8String],
+      .platform = [platform UTF8String],
+      .deviceName = [deviceName UTF8String],
+      .reactNativeVersion = [reactNativeVersion UTF8String],
+  };
+}
+
+@end

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -56,12 +56,7 @@ ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
         [inspectorTarget =
              inspectorTarget_](std::unique_ptr<IRemoteConnection> remote)
             -> std::unique_ptr<ILocalConnection> {
-          return inspectorTarget->connect(
-              std::move(remote),
-              {
-                  .integrationName =
-                      "Android Bridge (ReactInstanceManagerInspectorTarget)",
-              });
+          return inspectorTarget->connect(std::move(remote));
         },
         {.nativePageReloads = true, .prefersFuseboxFrontend = true});
   }
@@ -101,6 +96,13 @@ void ReactInstanceManagerInspectorTarget::registerNatives() {
           "sendDebuggerResumeCommand",
           ReactInstanceManagerInspectorTarget::sendDebuggerResumeCommand),
   });
+}
+
+jsinspector_modern::HostTargetMetadata
+ReactInstanceManagerInspectorTarget::getMetadata() {
+  return {
+      .integrationName = "Android Bridge (ReactInstanceManagerInspectorTarget)",
+  };
 }
 
 void ReactInstanceManagerInspectorTarget::onReload(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -51,6 +51,7 @@ class ReactInstanceManagerInspectorTarget
   jsinspector_modern::HostTarget* getInspectorTarget();
 
   // HostTargetDelegate methods
+  jsinspector_modern::HostTargetMetadata getMetadata() override;
   void onReload(const PageReloadRequest& request) override;
   void onSetPausedInDebuggerMessage(
       const OverlaySetPausedInDebuggerMessageRequest&) override;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -40,11 +40,7 @@ JReactHostInspectorTarget::JReactHostInspectorTarget(
             std::unique_ptr<IRemoteConnection> remote)
             -> std::unique_ptr<ILocalConnection> {
           if (auto inspectorTarget = inspectorTargetWeak.lock()) {
-            return inspectorTarget->connect(
-                std::move(remote),
-                {
-                    .integrationName = "Android Bridgeless (ReactHostImpl)",
-                });
+            return inspectorTarget->connect(std::move(remote));
           }
           // Reject the connection.
           return nullptr;
@@ -84,6 +80,13 @@ void JReactHostInspectorTarget::registerNatives() {
           "sendDebuggerResumeCommand",
           JReactHostInspectorTarget::sendDebuggerResumeCommand),
   });
+}
+
+jsinspector_modern::HostTargetMetadata
+JReactHostInspectorTarget::getMetadata() {
+  return {
+      .integrationName = "Android Bridgeless (ReactHostImpl)",
+  };
 }
 
 void JReactHostInspectorTarget::onReload(const PageReloadRequest& request) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -58,6 +58,7 @@ class JReactHostInspectorTarget
   jsinspector_modern::HostTarget* getInspectorTarget();
 
   // HostTargetDelegate methods
+  jsinspector_modern::HostTargetMetadata getMetadata() override;
   void onReload(const PageReloadRequest& request) override;
   void onSetPausedInDebuggerMessage(
       const OverlaySetPausedInDebuggerMessageRequest&) override;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -27,11 +27,11 @@ namespace facebook::react::jsinspector_modern {
 HostAgent::HostAgent(
     FrontendChannel frontendChannel,
     HostTargetController& targetController,
-    HostTarget::SessionMetadata sessionMetadata,
+    HostTargetMetadata hostMetadata,
     SessionState& sessionState)
     : frontendChannel_(frontendChannel),
       targetController_(targetController),
-      sessionMetadata_(std::move(sessionMetadata)),
+      hostMetadata_(std::move(hostMetadata)),
       sessionState_(sessionState) {}
 
 void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
@@ -49,10 +49,10 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
     }
 
     // Send a log entry with the integration name.
-    if (sessionMetadata_.integrationName) {
+    if (hostMetadata_.integrationName) {
       sendInfoLogEntry(
           ANSI_COLOR_BG_YELLOW "Debugger integration: " +
-          *sessionMetadata_.integrationName);
+          *hostMetadata_.integrationName);
     }
 
     shouldSendOKResponse = true;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -131,6 +131,20 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = true;
+  } else if (req.method == "ReactNativeApplication.enable") {
+    sessionState_.isReactNativeApplicationDomainEnabled = true;
+
+    frontendChannel_(cdp::jsonNotification(
+        "ReactNativeApplication.metadataUpdated",
+        hostMetadataToDynamic(hostMetadata_)));
+
+    shouldSendOKResponse = true;
+    isFinishedHandlingRequest = true;
+  } else if (req.method == "ReactNativeApplication.disable") {
+    sessionState_.isReactNativeApplicationDomainEnabled = false;
+
+    shouldSendOKResponse = true;
+    isFinishedHandlingRequest = true;
   } else if (req.method == "Tracing.start") {
     // @cdp Tracing.start is implemented as a stub only.
     frontendChannel_(cdp::jsonNotification(

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -37,13 +37,13 @@ class HostAgent final {
    * \param targetController An interface to the HostTarget that this agent is
    * attached to. The caller is responsible for ensuring that the
    * HostTargetDelegate and underlying HostTarget both outlive the agent.
-   * \param sessionMetadata Metadata about the session that created this agent.
+   * \param hostMetadata Metadata about the host that created this agent.
    * \param sessionState The state of the session that created this agent.
    */
   HostAgent(
       FrontendChannel frontendChannel,
       HostTargetController& targetController,
-      HostTarget::SessionMetadata sessionMetadata,
+      HostTargetMetadata hostMetadata,
       SessionState& sessionState);
 
   HostAgent(const HostAgent&) = delete;
@@ -94,7 +94,7 @@ class HostAgent final {
 
   FrontendChannel frontendChannel_;
   HostTargetController& targetController_;
-  const HostTarget::SessionMetadata sessionMetadata_;
+  const HostTargetMetadata hostMetadata_;
   std::shared_ptr<InstanceAgent> instanceAgent_;
   FuseboxClientType fuseboxClientType_{FuseboxClientType::Unknown};
   bool isPausedInDebuggerOverlayVisible_{false};

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -220,4 +220,12 @@ bool HostTargetController::decrementPauseOverlayCounter() {
   return true;
 }
 
+folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
+  folly::dynamic result = folly::dynamic::object;
+
+  result["integrationName"] = metadata.integrationName.value_or(nullptr);
+
+  return result;
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -223,7 +223,11 @@ bool HostTargetController::decrementPauseOverlayCounter() {
 folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
   folly::dynamic result = folly::dynamic::object;
 
+  result["appIdentifier"] = metadata.appIdentifier.value_or(nullptr);
+  result["deviceName"] = metadata.deviceName.value_or(nullptr);
   result["integrationName"] = metadata.integrationName.value_or(nullptr);
+  result["platform"] = metadata.platform.value_or(nullptr);
+  result["reactNativeVersion"] = metadata.reactNativeVersion.value_or(nullptr);
 
   return result;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -29,7 +29,7 @@ class HostTargetSession {
   explicit HostTargetSession(
       std::unique_ptr<IRemoteConnection> remote,
       HostTargetController& targetController,
-      HostTarget::SessionMetadata sessionMetadata)
+      HostTargetMetadata hostMetadata)
       : remote_(std::make_shared<RAIIRemoteConnection>(std::move(remote))),
         frontendChannel_(
             [remoteWeak = std::weak_ptr(remote_)](std::string_view message) {
@@ -40,7 +40,7 @@ class HostTargetSession {
         hostAgent_(
             frontendChannel_,
             targetController,
-            std::move(sessionMetadata),
+            std::move(hostMetadata),
             state_) {}
 
   /**
@@ -146,10 +146,9 @@ HostTarget::HostTarget(HostTargetDelegate& delegate)
       executionContextManager_{std::make_shared<ExecutionContextManager>()} {}
 
 std::unique_ptr<ILocalConnection> HostTarget::connect(
-    std::unique_ptr<IRemoteConnection> connectionToFrontend,
-    SessionMetadata sessionMetadata) {
+    std::unique_ptr<IRemoteConnection> connectionToFrontend) {
   auto session = std::make_shared<HostTargetSession>(
-      std::move(connectionToFrontend), controller_, std::move(sessionMetadata));
+      std::move(connectionToFrontend), controller_, delegate_.getMetadata());
   session->setCurrentInstance(currentInstance_.get());
   sessions_.insert(std::weak_ptr(session));
   return std::make_unique<CallbackLocalConnection>(

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -37,7 +37,11 @@ class HostCommandSender;
 class HostTarget;
 
 struct HostTargetMetadata {
+  std::optional<std::string> appIdentifier;
+  std::optional<std::string> deviceName;
   std::optional<std::string> integrationName;
+  std::optional<std::string> platform;
+  std::optional<std::string> reactNativeVersion;
 };
 
 /**
@@ -90,7 +94,8 @@ class HostTargetDelegate {
   virtual ~HostTargetDelegate();
 
   /**
-   * Returns a metadata object describing the host.
+   * Returns a metadata object describing the host. This is called on an
+   * initial response to @cdp ReactNativeApplication.enable.
    */
   virtual HostTargetMetadata getMetadata() = 0;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -251,4 +251,6 @@ class JSINSPECTOR_EXPORT HostTarget
   friend class HostTargetController;
 };
 
+folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata);
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -36,6 +36,10 @@ class HostAgent;
 class HostCommandSender;
 class HostTarget;
 
+struct HostTargetMetadata {
+  std::optional<std::string> integrationName;
+};
+
 /**
  * Receives events from a HostTarget. This is a shared interface that each
  * React Native platform needs to implement in order to integrate with the
@@ -84,6 +88,11 @@ class HostTargetDelegate {
   };
 
   virtual ~HostTargetDelegate();
+
+  /**
+   * Returns a metadata object describing the host.
+   */
+  virtual HostTargetMetadata getMetadata() = 0;
 
   /**
    * Called when the debugger requests a reload of the page. This is called on
@@ -150,10 +159,6 @@ class HostTargetController final {
 class JSINSPECTOR_EXPORT HostTarget
     : public EnableExecutorFromThis<HostTarget> {
  public:
-  struct SessionMetadata {
-    std::optional<std::string> integrationName;
-  };
-
   /**
    * Constructs a new HostTarget.
    * \param delegate The HostTargetDelegate that will
@@ -185,8 +190,7 @@ class JSINSPECTOR_EXPORT HostTarget
    * destructor execute.
    */
   std::unique_ptr<ILocalConnection> connect(
-      std::unique_ptr<IRemoteConnection> connectionToFrontend,
-      SessionMetadata sessionMetadata = {});
+      std::unique_ptr<IRemoteConnection> connectionToFrontend);
 
   /**
    * Registers an instance with this HostTarget.

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -22,6 +22,7 @@ struct SessionState {
   // TODO: Generalise this to arbitrary domains
   bool isDebuggerDomainEnabled{false};
   bool isLogDomainEnabled{false};
+  bool isReactNativeApplicationDomainEnabled{false};
   bool isRuntimeDomainEnabled{false};
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
@@ -49,9 +49,7 @@ class HostTargetTest : public Test {
   std::pair<std::unique_ptr<ILocalConnection>, MockRemoteConnection&>
   makeConnection() {
     size_t connectionIndex = remoteConnections_.objectsVended();
-    auto toPage = page_->connect(
-        remoteConnections_.make_unique(),
-        {.integrationName = "HostTargetTest"});
+    auto toPage = page_->connect(remoteConnections_.make_unique());
 
     // We'll always get an onDisconnect call when we tear
     // down the test. Expect it in order to satisfy the strict mock.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -118,6 +118,9 @@ class MockInspectorPackagerConnectionDelegate
 class MockHostTargetDelegate : public HostTargetDelegate {
  public:
   // HostTargetDelegate methods
+  HostTargetMetadata getMetadata() override {
+    return {.integrationName = "MockHostTargetDelegate"};
+  }
   MOCK_METHOD(void, onReload, (const PageReloadRequest& request), (override));
   MOCK_METHOD(
       void,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -332,6 +332,42 @@ TYPED_TEST(JsiIntegrationPortableTest, FuseboxSetClientMetadata) {
                                })");
 }
 
+TYPED_TEST(JsiIntegrationPortableTest, ReactNativeApplicationEnable) {
+  this->connect();
+
+  this->expectMessageFromPage(JsonEq(R"({
+                                          "id": 1,
+                                          "result": {}
+                                        })"));
+  this->expectMessageFromPage(JsonEq(R"({
+                                          "method": "ReactNativeApplication.metadataUpdated",
+                                          "params": {
+                                            "integrationName": "JsiIntegrationTest"
+                                          }
+                                        })"));
+
+  this->toPage_->sendMessage(R"({
+                                 "id": 1,
+                                 "method": "ReactNativeApplication.enable",
+                                 "params": {}
+                               })");
+}
+
+TYPED_TEST(JsiIntegrationPortableTest, ReactNativeApplicationDisable) {
+  this->connect();
+
+  this->expectMessageFromPage(JsonEq(R"({
+                                          "id": 1,
+                                          "result": {}
+                                        })"));
+
+  this->toPage_->sendMessage(R"({
+                                 "id": 1,
+                                 "method": "ReactNativeApplication.disable",
+                                 "params": {}
+                               })");
+}
+
 #pragma endregion // AllEngines
 #pragma region AllHermesVariants
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
@@ -91,9 +91,7 @@ class JsiIntegrationPortableTest : public ::testing::Test,
 
   void connect() {
     ASSERT_FALSE(toPage_) << "Can only connect once in a JSI integration test.";
-    toPage_ = page_->connect(
-        remoteConnections_.make_unique(),
-        {.integrationName = "JsiIntegrationTest"});
+    toPage_ = page_->connect(remoteConnections_.make_unique());
 
     using namespace ::testing;
     // Default to ignoring console messages originating inside the backend.
@@ -178,6 +176,10 @@ class JsiIntegrationPortableTest : public ::testing::Test,
 
  private:
   // HostTargetDelegate methods
+
+  HostTargetMetadata getMetadata() override {
+    return {.integrationName = "JsiIntegrationTest"};
+  }
 
   void onReload(const PageReloadRequest& request) override {
     (void)request;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
@@ -94,11 +94,8 @@ void ReactInstanceIntegrationTest::SetUp() {
         "mock-vm",
         [hostTargetIfModernCDP](std::unique_ptr<IRemoteConnection> remote)
             -> std::unique_ptr<ILocalConnection> {
-          auto localConnection = hostTargetIfModernCDP->connect(
-              std::move(remote),
-              {
-                  .integrationName = "ReactInstanceIntegrationTest",
-              });
+          auto localConnection =
+              hostTargetIfModernCDP->connect(std::move(remote));
           return localConnection;
         },
         // TODO: Allow customisation of InspectorTargetCapabilities

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -13,6 +13,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTFabricSurface.h>
 #import <React/RCTInspectorDevServerHelper.h>
+#import <React/RCTInspectorUtils.h>
 #import <React/RCTJSThread.h>
 #import <React/RCTLog.h>
 #import <React/RCTMockDef.h>
@@ -42,8 +43,14 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 
   jsinspector_modern::HostTargetMetadata getMetadata() override
   {
+    auto metadata = [RCTInspectorUtils getHostMetadata];
+
     return {
+        .appIdentifier = metadata.appIdentifier,
+        .deviceName = metadata.deviceName,
         .integrationName = "iOS Bridgeless (RCTHost)",
+        .platform = metadata.platform,
+        .reactNativeVersion = metadata.reactNativeVersion,
     };
   }
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -40,6 +40,13 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   {
   }
 
+  jsinspector_modern::HostTargetMetadata getMetadata() override
+  {
+    return {
+        .integrationName = "iOS Bridgeless (RCTHost)",
+    };
+  }
+
   void onReload(const PageReloadRequest &request) override
   {
     RCTAssertMainQueue();
@@ -233,11 +240,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
             // This can happen if we're about to be dealloc'd. Reject the connection.
             return nullptr;
           }
-          return strongSelf->_inspectorTarget->connect(
-              std::move(remote),
-              {
-                  .integrationName = "iOS Bridgeless (RCTHost)",
-              });
+          return strongSelf->_inspectorTarget->connect(std::move(remote));
         },
         {.nativePageReloads = true, .prefersFuseboxFrontend = true});
   }


### PR DESCRIPTION
Summary:
Adds the following debugger metadata fields (sent over the `ReactNativeApplication.metadataUpdated` CDP event), and implements these on iOS (Bridge and Bridgeless).

- `appIdentifier`
- `deviceName`
- `platform`
- `reactNativeVersion`

Changelog: [Internal]

Differential Revision: D58288489
