### PR TITLE
Enable Fusebox by default in RNTester

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -149,7 +149,7 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 // [Experiment] Enable the new debugger stack (codename Fusebox)
 - (BOOL)unstable_fuseboxEnabled
 {
-  return false;
+  return true;
 }
 
 #pragma mark - RCTComponentViewFactoryComponentProvider

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -21,6 +21,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.assets.ReactFontManager
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.unstable_loadFusebox
 import com.facebook.react.defaults.DefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.module.model.ReactModuleInfo
@@ -138,7 +139,7 @@ class RNTesterApplication : Application(), ReactApplication {
     SoLoader.init(this, /* native exopackage */ false)
 
     // [Experiment] Enable the new debugger stack (codename Fusebox)
-    // unstable_loadFusebox(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
+    unstable_loadFusebox(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
 
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       load()


### PR DESCRIPTION
Summary:
Enables the new debugger stack (codename Fusebox) in RNTester.

This feature is experimental and is enabled for testing purposes only. This change **should not** be adopted as the default by React Native frameworks.

Changelog: [Internal]

Reviewed By: cortinico, rubennorte, NickGerleman

Differential Revision: D58366246
