### PR TITLE
Add Java Turbo Module Event Emitter example

### DIFF
--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -164,9 +164,8 @@ function throwIfEventEmitterTypeIsUnsupported(
   parser: Parser,
   nullable: boolean,
   untyped: boolean,
-  cxxOnly: boolean,
 ) {
-  if (nullable || untyped || !cxxOnly) {
+  if (nullable || untyped) {
     throw new UnsupportedModuleEventEmitterPropertyParserError(
       nativeModuleName,
       propertyName,
@@ -174,7 +173,6 @@ function throwIfEventEmitterTypeIsUnsupported(
       parser.language(),
       nullable,
       untyped,
-      cxxOnly,
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -100,15 +100,12 @@ class UnsupportedModuleEventEmitterPropertyParserError extends ParserError {
     language: ParserType,
     nullable: boolean,
     untyped: boolean,
-    cxxOnly: boolean,
   ) {
     let message = `${language} interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's or non nullable 'EventEmitter's. Further the EventEmitter property `;
     if (nullable) {
       message += `'${propertyValue}' must non nullable.`;
     } else if (untyped) {
       message += `'${propertyValue}' must have a concrete or void eventType.`;
-    } else if (cxxOnly) {
-      message += `'${propertyValue}' is only supported in C++ Turbo Modules.`;
     }
     super(nativeModuleName, propertyValue, message);
   }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -506,7 +506,6 @@ function buildEventEmitterSchema(
     parser,
     typeAnnotationNullable,
     typeAnnotationUntyped,
-    cxxOnly,
   );
   const eventTypeResolutionStatus = resolveTypeAnnotationFN(
     typeAnnotation.typeParameters.params[0],

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
+import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.annotations.StableReactNativeAPI;
@@ -53,6 +54,8 @@ public abstract class BaseJavaModule implements NativeModule {
   public static final String METHOD_TYPE_ASYNC = "async";
   public static final String METHOD_TYPE_PROMISE = "promise";
   public static final String METHOD_TYPE_SYNC = "sync";
+
+  @Nullable protected CxxCallbackImpl mEventEmitterCallback;
 
   private final @Nullable ReactApplicationContext mReactApplicationContext;
 
@@ -128,5 +131,10 @@ public abstract class BaseJavaModule implements NativeModule {
       ReactSoftExceptionLogger.logSoftException(ReactConstants.TAG, new RuntimeException(msg));
     }
     return null;
+  }
+
+  @DoNotStrip
+  private final void setEventEmitterCallback(CxxCallbackImpl eventEmitterCallback) {
+    mEventEmitterCallback = eventEmitterCallback;
   }
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
@@ -51,6 +51,8 @@ class JSI_EXPORT JavaTurboModule : public TurboModule {
       size_t argCount,
       jmethodID& cachedMethodID);
 
+  void setEventEmitterCallback(jni::alias_ref<jobject> instance);
+
  private:
   // instance_ can be of type JTurboModule, or JNativeModule
   jni::global_ref<jobject> instance_;

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
@@ -35,6 +35,22 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
     super(reactContext);
   }
 
+  protected final void emitOnPress() {
+    mEventEmitterCallback.invoke("onPress");
+  }
+
+  protected final void emitOnClick(String value) {
+    mEventEmitterCallback.invoke("onClick", value);
+  }
+
+  protected final void emitOnChange(ReadableMap value) {
+    mEventEmitterCallback.invoke("onChange", value);
+  }
+
+  protected void emitOnSubmit(ReadableArray value) {
+    mEventEmitterCallback.invoke("onSubmit", value);
+  }
+
   @Override
   public @Nonnull String getName() {
     return NAME;

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
@@ -351,6 +351,15 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(
       1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectAssert};
   methodMap_["promiseAssert"] = MethodMetadata{
       0, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert};
+  eventEmitterMap_["onPress"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onClick"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onChange"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onSubmit"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  setEventEmitterCallback(params.instance);
 }
 
 std::shared_ptr<TurboModule> SampleTurboModuleSpec_ModuleProvider(

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -104,7 +104,26 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec
   @Override
   public void voidFunc() {
     log("voidFunc", "<void>", "<void>");
-    return;
+    emitOnPress();
+    emitOnClick("click");
+    {
+      WritableNativeMap map = new WritableNativeMap();
+      map.putInt("a", 1);
+      map.putString("b", "two");
+      emitOnChange(map);
+    }
+    {
+      WritableNativeArray array = new WritableNativeArray();
+      WritableNativeMap map = new WritableNativeMap();
+      map.putInt("a", 1);
+      map.putString("b", "two");
+      array.pushMap(map);
+      WritableNativeMap map1 = new WritableNativeMap();
+      map1.putInt("a", 3);
+      map1.putString("b", "four");
+      array.pushMap(map1);
+      emitOnSubmit(array);
+    }
   }
 
   // This function returns {@link WritableMap} instead of {@link Map} for backward compat with

--- a/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js
@@ -12,7 +12,10 @@ import type {
   RootTag,
   TurboModule,
 } from '../../../../Libraries/TurboModule/RCTExport';
-import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
+import type {
+  EventEmitter,
+  UnsafeObject,
+} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -21,7 +24,17 @@ export enum EnumInt {
   B = 42,
 }
 
+export type ObjectStruct = {
+  a: number,
+  b: string,
+  c?: ?string,
+};
+
 export interface Spec extends TurboModule {
+  +onPress: EventEmitter<void>;
+  +onClick: EventEmitter<string>;
+  +onChange: EventEmitter<ObjectStruct>;
+  +onSubmit: EventEmitter<ObjectStruct[]>;
   // Exported methods.
   +getConstants: () => {|
     const1: boolean,

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -9,6 +9,7 @@
  */
 
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
+import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 import styles from './TurboModuleExampleCommon';
 import * as React from 'react';
@@ -68,6 +69,7 @@ type ErrorExamples =
 
 class SampleTurboModuleExample extends React.Component<{||}, State> {
   static contextType: React$Context<RootTag> = RootTagContext;
+  eventSubscriptions: EventSubscription[] = [];
 
   state: State = {
     testResults: {},
@@ -217,6 +219,30 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
       throw new Error(
         'The JSI bindings for SampleTurboModule are not installed.',
       );
+    }
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onPress(value => console.log('onPress: ()')),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onClick(value =>
+        console.log(`onClick: (${value})`),
+      ),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onChange(value =>
+        console.log(`onChange: (${JSON.stringify(value)})`),
+      ),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onSubmit(value =>
+        console.log(`onSubmit: (${JSON.stringify(value)})`),
+      ),
+    );
+  }
+
+  componentWillUnmount() {
+    for (const subscription of this.eventSubscriptions) {
+      subscription.remove();
     }
   }
 


### PR DESCRIPTION
Summary:
Shows a proof of concept how '*strongly typed Turbo Module scoped*' `EventEmitters` can be used in a Java Turbo Module.

## Changelog:

[Android] [Added] - Add Java Turbo Module Event Emitter example

Differential Revision: D57530807
