### PR TITLE
disable on PRs

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2,7 +2,6 @@ name: Test All
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
Summary:
While moving from CircleCI → GHA, we're removing this blocking folks landing PRs and just running on main.  We will re-enable once GHA is stable.

Changelog: [General][Changed] Disable GHA on PRs until it's stable

Differential Revision: D58478000
