### PR TITLE
Add ObjC Turbo Module Event Emitter example

### DIFF
--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -164,9 +164,8 @@ function throwIfEventEmitterTypeIsUnsupported(
   parser: Parser,
   nullable: boolean,
   untyped: boolean,
-  cxxOnly: boolean,
 ) {
-  if (nullable || untyped || !cxxOnly) {
+  if (nullable || untyped) {
     throw new UnsupportedModuleEventEmitterPropertyParserError(
       nativeModuleName,
       propertyName,
@@ -174,7 +173,6 @@ function throwIfEventEmitterTypeIsUnsupported(
       parser.language(),
       nullable,
       untyped,
-      cxxOnly,
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -100,15 +100,12 @@ class UnsupportedModuleEventEmitterPropertyParserError extends ParserError {
     language: ParserType,
     nullable: boolean,
     untyped: boolean,
-    cxxOnly: boolean,
   ) {
     let message = `${language} interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's or non nullable 'EventEmitter's. Further the EventEmitter property `;
     if (nullable) {
       message += `'${propertyValue}' must non nullable.`;
     } else if (untyped) {
       message += `'${propertyValue}' must have a concrete or void eventType.`;
-    } else if (cxxOnly) {
-      message += `'${propertyValue}' is only supported in C++ Turbo Modules.`;
     }
     super(nativeModuleName, propertyValue, message);
   }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -506,7 +506,6 @@ function buildEventEmitterSchema(
     parser,
     typeAnnotationNullable,
     typeAnnotationUntyped,
-    cxxOnly,
   );
   const eventTypeResolutionStatus = resolveTypeAnnotationFN(
     typeAnnotation.typeParameters.params[0],

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
+import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.annotations.StableReactNativeAPI;
@@ -53,6 +54,8 @@ public abstract class BaseJavaModule implements NativeModule {
   public static final String METHOD_TYPE_ASYNC = "async";
   public static final String METHOD_TYPE_PROMISE = "promise";
   public static final String METHOD_TYPE_SYNC = "sync";
+
+  @Nullable protected CxxCallbackImpl mEventEmitterCallback;
 
   private final @Nullable ReactApplicationContext mReactApplicationContext;
 
@@ -128,5 +131,10 @@ public abstract class BaseJavaModule implements NativeModule {
       ReactSoftExceptionLogger.logSoftException(ReactConstants.TAG, new RuntimeException(msg));
     }
     return null;
+  }
+
+  @DoNotStrip
+  private final void setEventEmitterCallback(CxxCallbackImpl eventEmitterCallback) {
+    mEventEmitterCallback = eventEmitterCallback;
   }
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
@@ -51,6 +51,8 @@ class JSI_EXPORT JavaTurboModule : public TurboModule {
       size_t argCount,
       jmethodID& cachedMethodID);
 
+  void setEventEmitterCallback(jni::alias_ref<jobject> instance);
+
  private:
   // instance_ can be of type JTurboModule, or JNativeModule
   jni::global_ref<jobject> instance_;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#import <memory>
-
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridge.h>
@@ -16,6 +14,9 @@
 #import <React/RCTModuleMethod.h>
 #import <ReactCommon/CallInvoker.h>
 #import <ReactCommon/TurboModule.h>
+#import <react/bridging/bridging.h>
+#import <functional>
+#import <memory>
 #import <string>
 #import <unordered_map>
 
@@ -27,11 +28,22 @@ namespace facebook::react {
 
 class CallbackWrapper;
 class Instance;
+using EventEmitterCallback = std::function<void(const std::string &, id)>;
 
 namespace TurboModuleConvertUtils {
+
 jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
 id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker);
+
 } // namespace TurboModuleConvertUtils
+
+template <>
+struct Bridging<id> {
+  static jsi::Value toJs(jsi::Runtime &rt, const id &value)
+  {
+    return TurboModuleConvertUtils::convertObjCObjectToJSIValue(rt, value);
+  }
+};
 
 /**
  * ObjC++ specific TurboModule base class.
@@ -63,6 +75,8 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 
  protected:
   void setMethodArgConversionSelector(NSString *methodName, size_t argIndex, NSString *fnName);
+
+  void setEventEmitterCallback(EventEmitterCallback eventEmitterCallback);
 
   /**
    * Why is this virtual?
@@ -157,6 +171,12 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 @protocol RCTTurboModule <NSObject>
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params;
+@end
+
+@interface EventEmitterCallbackWrapper : NSObject {
+ @public
+  facebook::react::EventEmitterCallback _eventEmitterCallback;
+}
 @end
 
 /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -813,5 +813,20 @@ void ObjCTurboModule::setMethodArgConversionSelector(NSString *methodName, size_
   methodArgConversionSelectors_[methodName][argIndex] = selectorValue;
 }
 
+void ObjCTurboModule::setEventEmitterCallback(EventEmitterCallback eventEmitterCallback)
+{
+  SEL selector = NSSelectorFromString(@"setEventEmitterCallback:");
+  EventEmitterCallbackWrapper *wrapper = [EventEmitterCallbackWrapper new];
+  wrapper->_eventEmitterCallback = std::move(eventEmitterCallback);
+  NSInvocation *inv =
+      [NSInvocation invocationWithMethodSignature:[[instance_ class] instanceMethodSignatureForSelector:selector]];
+  [inv setSelector:selector];
+  [inv setArgument:(void *)&wrapper atIndex:2];
+  [inv invokeWithTarget:instance_];
+}
+
 } // namespace react
 } // namespace facebook
+
+@implementation EventEmitterCallbackWrapper
+@end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
@@ -35,6 +35,22 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
     super(reactContext);
   }
 
+  protected final void emitOnPress() {
+    mEventEmitterCallback.invoke("onPress");
+  }
+
+  protected final void emitOnClick(String value) {
+    mEventEmitterCallback.invoke("onClick", value);
+  }
+
+  protected final void emitOnChange(ReadableMap value) {
+    mEventEmitterCallback.invoke("onChange", value);
+  }
+
+  protected void emitOnSubmit(ReadableArray value) {
+    mEventEmitterCallback.invoke("onSubmit", value);
+  }
+
   @Override
   public @Nonnull String getName() {
     return NAME;

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
@@ -351,6 +351,15 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(
       1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectAssert};
   methodMap_["promiseAssert"] = MethodMetadata{
       0, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert};
+  eventEmitterMap_["onPress"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onClick"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onChange"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onSubmit"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  setEventEmitterCallback(params.instance);
 }
 
 std::shared_ptr<TurboModule> SampleTurboModuleSpec_ModuleProvider(

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -104,7 +104,26 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec
   @Override
   public void voidFunc() {
     log("voidFunc", "<void>", "<void>");
-    return;
+    emitOnPress();
+    emitOnClick("click");
+    {
+      WritableNativeMap map = new WritableNativeMap();
+      map.putInt("a", 1);
+      map.putString("b", "two");
+      emitOnChange(map);
+    }
+    {
+      WritableNativeArray array = new WritableNativeArray();
+      WritableNativeMap map = new WritableNativeMap();
+      map.putInt("a", 1);
+      map.putString("b", "two");
+      array.pushMap(map);
+      WritableNativeMap map1 = new WritableNativeMap();
+      map1.putInt("a", 3);
+      map1.putString("b", "four");
+      array.pushMap(map1);
+      emitOnSubmit(array);
+    }
   }
 
   // This function returns {@link WritableMap} instead of {@link Map} for backward compat with

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
@@ -43,6 +43,20 @@
 
 @end
 
+@interface BaseRCTSampleTurboModule : NSObject
+
+- (void)emitOnPress;
+
+- (void)emitOnClick:(NSString *)value;
+
+- (void)emitOnChange:(NSDictionary *)value;
+
+- (void)emitOnSubmit:(NSArray *)value;
+
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
+
+@end
+
 namespace facebook::react {
 
 /**

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
@@ -224,6 +224,44 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const ObjCTurboMo
   methodMap_["getObjectAssert"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectAssert};
   methodMap_["promiseAssert"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert};
   methodMap_["getConstants"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants};
+  eventEmitterMap_["onPress"] = std::make_shared<AsyncEventEmitter<id>>();
+  eventEmitterMap_["onClick"] = std::make_shared<AsyncEventEmitter<id>>();
+  eventEmitterMap_["onChange"] = std::make_shared<AsyncEventEmitter<id>>();
+  eventEmitterMap_["onSubmit"] = std::make_shared<AsyncEventEmitter<id>>();
+  setEventEmitterCallback([&](const std::string &name, id value) {
+    static_cast<AsyncEventEmitter<id> &>(*eventEmitterMap_[name]).emit(value);
+  });
 }
 
 } // namespace facebook::react
+
+@implementation BaseRCTSampleTurboModule {
+  facebook::react::EventEmitterCallback _eventEmitterCallback;
+}
+
+- (void)emitOnPress
+{
+  _eventEmitterCallback("onPress", nil);
+}
+
+- (void)emitOnClick:(NSString *)value
+{
+  _eventEmitterCallback("onClick", value);
+}
+
+- (void)emitOnChange:(NSDictionary *)value
+{
+  _eventEmitterCallback("onChange", value);
+}
+
+- (void)emitOnSubmit:(NSArray *)value
+{
+  _eventEmitterCallback("onSubmit", value);
+}
+
+- (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper
+{
+  _eventEmitterCallback = std::move(eventEmitterCallbackWrapper->_eventEmitterCallback);
+}
+
+@end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.h
@@ -13,6 +13,6 @@
  * Sample iOS-specific impl of a TurboModule, conforming to the spec protocol.
  * This class is also 100% compatible with the NativeModule system.
  */
-@interface RCTSampleTurboModule : NSObject <NativeSampleTurboModuleSpec>
+@interface RCTSampleTurboModule : BaseRCTSampleTurboModule <NativeSampleTurboModuleSpec>
 
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -82,6 +82,10 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(voidFunc)
 {
   // Nothing to do
+  [self emitOnPress];
+  [self emitOnClick:@"click"];
+  [self emitOnChange:@{@"a" : @1, @"b" : @"two"}];
+  [self emitOnSubmit:@[ @{@"a" : @1, @"b" : @"two"}, @{@"a" : @3, @"b" : @"four"} ]];
 }
 
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getBool : (BOOL)arg)

--- a/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js
@@ -12,7 +12,10 @@ import type {
   RootTag,
   TurboModule,
 } from '../../../../Libraries/TurboModule/RCTExport';
-import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
+import type {
+  EventEmitter,
+  UnsafeObject,
+} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -21,7 +24,17 @@ export enum EnumInt {
   B = 42,
 }
 
+export type ObjectStruct = {
+  a: number,
+  b: string,
+  c?: ?string,
+};
+
 export interface Spec extends TurboModule {
+  +onPress: EventEmitter<void>;
+  +onClick: EventEmitter<string>;
+  +onChange: EventEmitter<ObjectStruct>;
+  +onSubmit: EventEmitter<ObjectStruct[]>;
   // Exported methods.
   +getConstants: () => {|
     const1: boolean,

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -9,6 +9,7 @@
  */
 
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
+import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 import styles from './TurboModuleExampleCommon';
 import * as React from 'react';
@@ -68,6 +69,7 @@ type ErrorExamples =
 
 class SampleTurboModuleExample extends React.Component<{||}, State> {
   static contextType: React$Context<RootTag> = RootTagContext;
+  eventSubscriptions: EventSubscription[] = [];
 
   state: State = {
     testResults: {},
@@ -217,6 +219,30 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
       throw new Error(
         'The JSI bindings for SampleTurboModule are not installed.',
       );
+    }
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onPress(value => console.log('onPress: ()')),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onClick(value =>
+        console.log(`onClick: (${value})`),
+      ),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onChange(value =>
+        console.log(`onChange: (${JSON.stringify(value)})`),
+      ),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onSubmit(value =>
+        console.log(`onSubmit: (${JSON.stringify(value)})`),
+      ),
+    );
+  }
+
+  componentWillUnmount() {
+    for (const subscription of this.eventSubscriptions) {
+      subscription.remove();
     }
   }
 


### PR DESCRIPTION
Summary:
Shows a proof of concept how '*strongly typed Turbo Module scoped*' `EventEmitters` can be used in a ObjC Turbo Module.

## Changelog:

[Android] [Added] - Add Java Turbo Module Event Emitter example

Differential Revision: D57650830
