### PR TITLE
Call Turbo Module methods 'methods' in the Turbo Module JSON schema

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -248,7 +248,7 @@ export type NativeModuleSchema = $ReadOnly<{
 
 type NativeModuleSpec = $ReadOnly<{
   eventEmitters: $ReadOnlyArray<NativeModuleEventEmitterShape>,
-  properties: $ReadOnlyArray<NativeModulePropertyShape>,
+  methods: $ReadOnlyArray<NativeModulePropertyShape>,
 }>;
 
 export type NativeModuleEventEmitterShape =

--- a/packages/react-native-codegen/src/generators/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/__test_fixtures__/fixtures.js
@@ -45,7 +45,7 @@ const SCHEMA_WITH_TM_AND_FC: SchemaType = {
       enumMap: {},
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'add',
             optional: false,

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
@@ -249,11 +249,11 @@ module.exports = {
         const {
           aliasMap,
           enumMap,
-          spec: {properties},
+          spec: {methods},
           moduleName,
         } = nativeModule;
         const resolveAlias = createAliasResolver(aliasMap);
-        const hostFunctions = properties.map(property =>
+        const hostFunctions = methods.map(property =>
           serializePropertyIntoHostFunction(
             moduleName,
             hasteModuleName,
@@ -267,7 +267,7 @@ module.exports = {
           hasteModuleName,
           hostFunctions,
           moduleName,
-          methods: properties.map(
+          methods: methods.map(
             ({name: propertyName, typeAnnotation: nullableTypeAnnotation}) => {
               const [{params}] = unwrapNullable(nullableTypeAnnotation);
               return {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -606,7 +606,7 @@ module.exports = {
       return [
         ModuleClassDeclarationTemplate({
           hasteModuleName,
-          moduleProperties: spec.properties.map(prop =>
+          moduleProperties: spec.methods.map(prop =>
             translatePropertyToCpp(
               hasteModuleName,
               prop,
@@ -629,7 +629,7 @@ module.exports = {
               enumMap,
             ),
           ),
-          moduleProperties: spec.properties.map(prop =>
+          moduleProperties: spec.methods.map(prop =>
             translatePropertyToCpp(
               hasteModuleName,
               prop,

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -445,12 +445,8 @@ module.exports = {
     const outputDir = `java/${normalizedPackageName.replace(/\./g, '/')}`;
 
     Object.keys(nativeModules).forEach(hasteModuleName => {
-      const {
-        aliasMap,
-        excludedPlatforms,
-        moduleName,
-        spec: {properties},
-      } = nativeModules[hasteModuleName];
+      const {aliasMap, excludedPlatforms, moduleName, spec} =
+        nativeModules[hasteModuleName];
       if (excludedPlatforms != null && excludedPlatforms.includes('android')) {
         return;
       }
@@ -467,7 +463,7 @@ module.exports = {
         'javax.annotation.Nonnull',
       ]);
 
-      const methods = properties.map(method => {
+      const methods = spec.methods.map(method => {
         if (method.name === 'getConstants') {
           return buildGetConstantsMethod(method, imports, resolveAlias);
         }

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -438,11 +438,11 @@ module.exports = {
       .map(hasteModuleName => {
         const {
           aliasMap,
-          spec: {properties},
+          spec: {methods},
         } = nativeModules[hasteModuleName];
         const resolveAlias = createAliasResolver(aliasMap);
 
-        const translatedMethods = properties
+        const translatedMethods = methods
           .map(property =>
             translateMethodForImplementation(
               hasteModuleName,
@@ -457,7 +457,7 @@ module.exports = {
           '\n\n' +
           ModuleClassConstructorTemplate({
             hasteModuleName,
-            methods: properties
+            methods: methods
               .map(({name: propertyName, typeAnnotation}) => {
                 const [{returnTypeAnnotation, params}] =
                   unwrapNullable<NativeModuleFunctionTypeAnnotation>(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/index.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/index.js
@@ -142,11 +142,8 @@ module.exports = {
 
     const hasteModuleNames: Array<string> = Object.keys(nativeModules).sort();
     for (const hasteModuleName of hasteModuleNames) {
-      const {
-        aliasMap,
-        excludedPlatforms,
-        spec: {properties},
-      } = nativeModules[hasteModuleName];
+      const {aliasMap, excludedPlatforms, spec} =
+        nativeModules[hasteModuleName];
       if (excludedPlatforms != null && excludedPlatforms.includes('iOS')) {
         continue;
       }
@@ -169,10 +166,10 @@ module.exports = {
        * Note: As we serialize NativeModule methods, we insert structs into
        * StructCollector, as we encounter them.
        */
-      properties
+      spec.methods
         .filter(property => property.name !== 'getConstants')
         .forEach(serializeProperty);
-      properties
+      spec.methods
         .filter(property => property.name === 'getConstants')
         .forEach(serializeProperty);
 

--- a/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
@@ -20,7 +20,7 @@ const EMPTY_NATIVE_MODULES: SchemaType = {
       enumMap: {},
       spec: {
         eventEmitters: [],
-        properties: [],
+        methods: [],
       },
       moduleName: 'SampleTurboModule',
     },
@@ -85,7 +85,7 @@ const SIMPLE_NATIVE_MODULES: SchemaType = {
       },
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'getConstants',
             optional: false,
@@ -415,7 +415,7 @@ const TWO_MODULES_DIFFERENT_FILES: SchemaType = {
       enumMap: {},
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'voidFunc',
             optional: false,
@@ -437,7 +437,7 @@ const TWO_MODULES_DIFFERENT_FILES: SchemaType = {
       enumMap: {},
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'getConstants',
             optional: false,
@@ -476,7 +476,7 @@ const COMPLEX_OBJECTS: SchemaType = {
       enumMap: {},
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'difficult',
             optional: false,
@@ -933,7 +933,7 @@ const NATIVE_MODULES_WITH_TYPE_ALIASES: SchemaType = {
       enumMap: {},
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'getConstants',
             optional: false,
@@ -1219,7 +1219,7 @@ const REAL_MODULE_EXAMPLE: SchemaType = {
       enumMap: {},
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'getConstants',
             optional: false,
@@ -1416,7 +1416,7 @@ const REAL_MODULE_EXAMPLE: SchemaType = {
       enumMap: {},
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'reportFatalException',
             optional: false,
@@ -1838,7 +1838,7 @@ const CXX_ONLY_NATIVE_MODULES: SchemaType = {
       },
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'getArray',
             optional: false,
@@ -2424,7 +2424,7 @@ const SAMPLE_WITH_UPPERCASE_NAME: SchemaType = {
       aliasMap: {},
       spec: {
         eventEmitters: [],
-        properties: [],
+        methods: [],
       },
       moduleName: 'SampleTurboModule',
     },

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -401,7 +401,7 @@ describe('buildSchemaFromConfigType', () => {
     type: 'NativeModule',
     aliasMap: {},
     enumMap: {},
-    spec: {eventEmitters: [], properties: []},
+    spec: {eventEmitters: [], methods: []},
     moduleName: '',
   };
 
@@ -837,7 +837,7 @@ describe('buildSchema', () => {
             enumMap: {},
             spec: {
               eventEmitters: [],
-              properties: [
+              methods: [
                 {
                   name: 'getArray',
                   optional: false,
@@ -1249,7 +1249,7 @@ describe('buildModuleSchema', () => {
       moduleName: 'SampleTurboModule',
       spec: {
         eventEmitters: [],
-        properties: [
+        methods: [
           {
             name: 'getArray',
             optional: false,

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -36,7 +36,7 @@ exports[`RN Codegen Flow Parser can generate fixture ANDROID_ONLY_NATIVE_MODULE 
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': []
+        'methods': []
       },
       'moduleName': 'SampleTurboModuleAndroid',
       'excludedPlatforms': [
@@ -184,7 +184,7 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
       },
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getCallback',
             'optional': false,
@@ -422,7 +422,7 @@ exports[`RN Codegen Flow Parser can generate fixture EMPTY_NATIVE_MODULE 1`] = `
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': []
+        'methods': []
       },
       'moduleName': 'SampleTurboModule'
     }
@@ -489,7 +489,7 @@ exports[`RN Codegen Flow Parser can generate fixture IOS_ONLY_NATIVE_MODULE 1`] 
       },
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getEnums',
             'optional': false,
@@ -583,7 +583,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ALIASES 
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getNumber',
             'optional': false,
@@ -748,7 +748,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WI
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -791,7 +791,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WI
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -828,7 +828,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_BASIC_AR
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -896,7 +896,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_BASIC_PA
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'passBool',
             'optional': true,
@@ -990,7 +990,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_CALLBACK
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getValueWithCallback',
             'optional': false,
@@ -1052,7 +1052,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -1113,7 +1113,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getObject',
             'optional': false,
@@ -1327,7 +1327,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getConstants',
             'optional': false,
@@ -1433,7 +1433,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_FLOAT_AN
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getInt',
             'optional': false,
@@ -1523,7 +1523,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_NESTED_A
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'foo1',
             'optional': false,
@@ -1582,7 +1582,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_NULLABLE
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'voidFunc',
             'optional': false,
@@ -1635,7 +1635,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_OBJECT_W
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getConstants',
             'optional': false,
@@ -1733,7 +1733,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getSomeObj',
             'optional': false,
@@ -1846,7 +1846,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getPartialPartial',
             'optional': false,
@@ -1936,7 +1936,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PROMISE 
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getValueWithPromise',
             'optional': false,
@@ -1997,7 +1997,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ROOT_TAG
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getRootTag',
             'optional': false,
@@ -2036,7 +2036,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_SIMPLE_O
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getObject',
             'optional': false,
@@ -2073,7 +2073,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION 1`
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getUnion',
             'optional': false,
@@ -2136,7 +2136,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNSAFE_O
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getUnsafeObject',
             'optional': false,
@@ -2211,7 +2211,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'returnStringArray',
             'optional': false,

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
@@ -150,10 +150,9 @@ describe('Flow Module Parser', () => {
           export default TurboModuleRegistry.get<Spec>('Foo');
         `);
 
-        expect(module.spec.properties[0]).not.toBe(null);
-        const param = unwrapNullable(
-          module.spec.properties[0].typeAnnotation,
-        )[0].params[0];
+        expect(module.spec.methods[0]).not.toBe(null);
+        const param = unwrapNullable(module.spec.methods[0].typeAnnotation)[0]
+          .params[0];
         expect(param).not.toBe(null);
         expect(param.name).toBe(paramName);
         expect(param.optional).toBe(optional);
@@ -361,9 +360,9 @@ describe('Flow Module Parser', () => {
               export default TurboModuleRegistry.get<Spec>('Foo');
             `);
 
-            expect(module.spec.properties[0]).not.toBe(null);
+            expect(module.spec.methods[0]).not.toBe(null);
             const param = unwrapNullable(
-              module.spec.properties[0].typeAnnotation,
+              module.spec.methods[0].typeAnnotation,
             )[0].params[0];
             expect(param.name).toBe('arg');
             expect(param.optional).toBe(optional);
@@ -698,10 +697,10 @@ describe('Flow Module Parser', () => {
         export default TurboModuleRegistry.get<Spec>('Foo');
       `);
 
-      expect(module.spec.properties[0]).not.toBe(null);
+      expect(module.spec.methods[0]).not.toBe(null);
 
       const [functionTypeAnnotation, isFunctionTypeAnnotationNullable] =
-        unwrapNullable(module.spec.properties[0].typeAnnotation);
+        unwrapNullable(module.spec.methods[0].typeAnnotation);
       expect(isFunctionTypeAnnotationNullable).toBe(false);
 
       const [returnTypeAnnotation, isReturnTypeAnnotationNullable] =
@@ -732,9 +731,9 @@ describe('Flow Module Parser', () => {
           export default TurboModuleRegistry.get<Spec>('Foo');
         `);
 
-        expect(module.spec.properties[0]).not.toBe(null);
+        expect(module.spec.methods[0]).not.toBe(null);
         const [functionTypeAnnotation, isFunctionTypeAnnotationNullable] =
-          unwrapNullable(module.spec.properties[0].typeAnnotation);
+          unwrapNullable(module.spec.methods[0].typeAnnotation);
         expect(isFunctionTypeAnnotationNullable).toBe(false);
 
         const [returnTypeAnnotation, isReturnTypeAnnotationNullable] =

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -844,7 +844,7 @@ const buildModuleSchema = (
           eventEmitters: [...moduleSchema.spec.eventEmitters].concat(
             propertyShape.type === 'eventEmitter' ? [propertyShape.value] : [],
           ),
-          properties: [...moduleSchema.spec.properties].concat(
+          methods: [...moduleSchema.spec.methods].concat(
             propertyShape.type === 'method' ? [propertyShape.value] : [],
           ),
         },
@@ -855,7 +855,7 @@ const buildModuleSchema = (
         type: 'NativeModule',
         aliasMap: {},
         enumMap: {},
-        spec: {eventEmitters: [], properties: []},
+        spec: {eventEmitters: [], methods: []},
         moduleName,
         excludedPlatforms:
           excludedPlatforms.length !== 0 ? [...excludedPlatforms] : undefined,
@@ -868,7 +868,7 @@ const buildModuleSchema = (
     enumMap: getSortedObject(nativeModuleSchema.enumMap),
     spec: {
       eventEmitters: nativeModuleSchema.spec.eventEmitters.sort(),
-      properties: nativeModuleSchema.spec.properties.sort(),
+      methods: nativeModuleSchema.spec.methods.sort(),
     },
     moduleName,
     excludedPlatforms: nativeModuleSchema.excludedPlatforms,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -27,7 +27,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture ANDROID_ONLY_NATIVE_M
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': []
+        'methods': []
       },
       'moduleName': 'SampleTurboModuleAndroid',
       'excludedPlatforms': [
@@ -175,7 +175,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
       },
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getCallback',
             'optional': false,
@@ -413,7 +413,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EMPTY_NATIVE_MODULE 1
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': []
+        'methods': []
       },
       'moduleName': 'SampleTurboModule'
     }
@@ -480,7 +480,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture IOS_ONLY_NATIVE_MODUL
       },
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getEnums',
             'optional': false,
@@ -574,7 +574,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AL
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getNumber',
             'optional': false,
@@ -739,7 +739,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -782,7 +782,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -819,7 +819,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -862,7 +862,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -899,7 +899,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -967,7 +967,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -1035,7 +1035,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'passBool',
             'optional': true,
@@ -1129,7 +1129,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CA
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getValueWithCallback',
             'optional': false,
@@ -1191,7 +1191,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -1252,7 +1252,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getArray',
             'optional': false,
@@ -1313,7 +1313,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getObject',
             'optional': false,
@@ -1527,7 +1527,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getConstants',
             'optional': false,
@@ -1633,7 +1633,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_FL
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getInt',
             'optional': false,
@@ -1739,7 +1739,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_IN
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'foo1',
             'optional': false,
@@ -1832,7 +1832,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'foo1',
             'optional': false,
@@ -1995,7 +1995,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'foo1',
             'optional': false,
@@ -2054,7 +2054,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NU
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'voidFunc',
             'optional': false,
@@ -2107,7 +2107,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_OB
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getConstants',
             'optional': false,
@@ -2205,7 +2205,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getSomeObj',
             'optional': false,
@@ -2318,7 +2318,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getPartialPartial',
             'optional': false,
@@ -2408,7 +2408,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PR
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getValueWithPromise',
             'optional': false,
@@ -2469,7 +2469,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_RO
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getRootTag',
             'optional': false,
@@ -2508,7 +2508,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_SI
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getObject',
             'optional': false,
@@ -2545,7 +2545,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getUnion',
             'optional': false,
@@ -2608,7 +2608,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
       'enumMap': {},
       'spec': {
         'eventEmitters': [],
-        'properties': [
+        'methods': [
           {
             'name': 'getUnsafeObject',
             'optional': false,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
@@ -150,10 +150,9 @@ describe('TypeScript Module Parser', () => {
           export default TurboModuleRegistry.get<Spec>('Foo');
         `);
 
-        expect(module.spec.properties[0]).not.toBe(null);
-        const param = unwrapNullable(
-          module.spec.properties[0].typeAnnotation,
-        )[0].params[0];
+        expect(module.spec.methods[0]).not.toBe(null);
+        const param = unwrapNullable(module.spec.methods[0].typeAnnotation)[0]
+          .params[0];
         expect(param).not.toBe(null);
         expect(param.name).toBe(paramName);
         expect(param.optional).toBe(optional);
@@ -361,9 +360,9 @@ describe('TypeScript Module Parser', () => {
               export default TurboModuleRegistry.get<Spec>('Foo');
             `);
 
-            expect(module.spec.properties[0]).not.toBe(null);
+            expect(module.spec.methods[0]).not.toBe(null);
             const param = unwrapNullable(
-              module.spec.properties[0].typeAnnotation,
+              module.spec.methods[0].typeAnnotation,
             )[0].params[0];
             expect(param.name).toBe('arg');
             expect(param.optional).toBe(optional);
@@ -698,10 +697,10 @@ describe('TypeScript Module Parser', () => {
         export default TurboModuleRegistry.get<Spec>('Foo');
       `);
 
-      expect(module.spec.properties[0]).not.toBe(null);
+      expect(module.spec.methods[0]).not.toBe(null);
 
       const [functionTypeAnnotation, isFunctionTypeAnnotationNullable] =
-        unwrapNullable(module.spec.properties[0].typeAnnotation);
+        unwrapNullable(module.spec.methods[0].typeAnnotation);
       expect(isFunctionTypeAnnotationNullable).toBe(false);
 
       const [returnTypeAnnotation, isReturnTypeAnnotationNullable] =
@@ -732,9 +731,9 @@ describe('TypeScript Module Parser', () => {
           export default TurboModuleRegistry.get<Spec>('Foo');
         `);
 
-        expect(module.spec.properties[0]).not.toBe(null);
+        expect(module.spec.methods[0]).not.toBe(null);
         const [functionTypeAnnotation, isFunctionTypeAnnotationNullable] =
-          unwrapNullable(module.spec.properties[0].typeAnnotation);
+          unwrapNullable(module.spec.methods[0].typeAnnotation);
         expect(isFunctionTypeAnnotationNullable).toBe(false);
 
         const [returnTypeAnnotation, isReturnTypeAnnotationNullable] =


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Fixed] - Call Turbo Module methods 'methods' in the Turbo Module JSON schema

Differential Revision: D58510557
