### PR TITLE
configure to build from source

### DIFF
--- a/packages/helloworld/android/app/build.gradle
+++ b/packages/helloworld/android/app/build.gradle
@@ -23,7 +23,7 @@ react {
     //   The folder where the react-native NPM package is. Default is ../node_modules/react-native
     reactNativeDir = file("../../../react-native")
     //   The folder where the react-native Codegen package is. Default is ../node_modules/@react-native/codegen
-    codegenDir = file("../../../react-native-codegen")
+    codegenDir = file("$rootDir/node_modules/@react-native/codegen")
     //   The cli.js file which is the React Native CLI entrypoint. Default is ../node_modules/react-native/cli.js,
     //   but now points to our simplified bundle wrapper.
     cliFile = file("../../scripts/bundle.js")

--- a/packages/helloworld/android/app/build.gradle
+++ b/packages/helloworld/android/app/build.gradle
@@ -9,6 +9,9 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
+// Build a simple config (instead of depending on npx @react-native-communtiy/cli config).
+def generatedConfig = file("../../.react-native.config").getText().replaceAll("HELLOWORLD_PATH", project.file("../../").absolutePath)
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.
@@ -16,14 +19,14 @@ apply plugin: "com.facebook.react"
 react {
     /* Folders */
     //   The root of your project, i.e. where "package.json" lives. Default is '..'
-    // root = file("../")
+    root = file("../")
     //   The folder where the react-native NPM package is. Default is ../node_modules/react-native
-    // reactNativeDir = file("../node_modules/react-native")
+    reactNativeDir = file("../../../react-native")
     //   The folder where the react-native Codegen package is. Default is ../node_modules/@react-native/codegen
-    // codegenDir = file("../node_modules/@react-native/codegen")
-    //   The cli.js file which is the React Native CLI entrypoint. Default is ../node_modules/react-native/cli.js
-    // cliFile = file("../node_modules/react-native/cli.js")
-
+    codegenDir = file("../../../react-native-codegen")
+    //   The cli.js file which is the React Native CLI entrypoint. Default is ../node_modules/react-native/cli.js,
+    //   but now points to our simplified bundle wrapper.
+    cliFile = file("../../scripts/bundle.js")
     /* Variants */
     //   The list of variants to that are debuggable. For those we're going to
     //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
@@ -34,8 +37,9 @@ react {
     //   A list containing the node command and its flags. Default is just 'node'.
     // nodeExecutableAndArgs = ["node"]
     //
-    //   The command to run when bundling. By default is 'bundle'
-    // bundleCommand = "ram-bundle"
+    //   The command to run when bundling. By default is 'bundle', but since we're calling out simplified bundle
+    //   wrapper we need this to be empty.
+    bundleCommand = ""
     //
     //   The path to the CLI configuration file. Default is empty.
     // bundleConfig = file(../rn-cli.config.js)
@@ -49,6 +53,10 @@ react {
     //   A list of extra flags to pass to the 'bundle' commands.
     //   See https://github.com/react-native-community/cli/blob/main/docs/commands.md#bundle
     // extraPackagerArgs = []
+    extraPackagerArgs = [
+        "--load-config",
+        generatedConfig
+    ]
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'

--- a/packages/helloworld/android/settings.gradle
+++ b/packages/helloworld/android/settings.gradle
@@ -6,10 +6,18 @@
  */
 
 // Autolinking has now moved into the React Native Gradle Plugin
-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
+pluginManagement { includeBuild("../../react-native-gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 
 rootProject.name = 'HelloWorld'
 include ':app'
 includeBuild('../../react-native-gradle-plugin')
+includeBuild('../../react-native') {
+     dependencySubstitution {
+         substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
+         substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
+         substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
+         substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
+     }
+ }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -794,7 +794,15 @@ react {
 // module to apply the plugin to, so it's codegenDir and reactNativeDir won't be evaluated.
 if (rootProject.name == "react-native-build-from-source") {
   rootProject.extensions.getByType(PrivateReactExtension::class.java).apply {
-    codegenDir = file("$rootDir/../@react-native/codegen")
+    // We try to guess where codegen lives. Generally is inside
+    // node_modules/@react-native/codegen. If the file is not existing, we
+    // fallback to ../react-native-codegen (used for hello-world app).
+    codegenDir =
+        if (file("$rootDir/../@react-native/codegen").exists()) {
+          file("$rootDir/../@react-native/codegen")
+        } else {
+          file("$rootDir/../react-native-codegen")
+        }
     reactNativeDir = file("$rootDir")
   }
 }


### PR DESCRIPTION
Summary:
Configure helloworld to build from source, using a combination of our [How to Build from Source](https://reactnative.dev/contributing/how-to-build-from-source#update-your-project-to-build-from-source) guide, as well as using rn-tester's config as a guide.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D58287748
