### PR TITLE
[RN][GHA] Fix publish-release regex

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,8 +3,7 @@ name: Publish release
 on:
   push:
     tags:
-      - "v0\.[0-9]+\.[0-9]+([-]\S+)?" # This should match v0.X.Y, v0.X.Y-rc.0
-
+      - "v0.[0-9]+.[0-9]+(-*)?"  # This should match v0.X.Y and v0.X.Y-RC.0
 jobs:
   set_release_type:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary:

The publish_release job is broken due to the initial regex. This change would like to fix it

## Changelog:
[Internal] - Fix publish_release job

## Test Plan:
Test on PR

<img width="1028" alt="Screenshot 2024-06-13 at 08 51 59" src="https://github.com/facebook/react-native/assets/11162307/0f68be41-a820-454e-9aca-99b2178984cd">

