### PR TITLE
[RN][CI]Update the testing-script to use github actions

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -747,6 +747,11 @@ jobs:
       - name: Publish NPM
         shell: bash
         run: |
+          # The checkout command puts react-native in a folder that is not "safe" for git
+          # Every git command run in an unsafe folder fails. We need to pick the current commit to use it as part of the version
+          # The following line marks the folder where react-native lives as "safe"
+          git config --global --add safe.directory /__w/react-native/react-native
+
           echo "GRADLE_OPTS = $GRADLE_OPTS"
           # We can't have a separate step because each command is executed in a separate shell
           # so variables exported in a command are not visible in another.

--- a/scripts/release-testing/utils/github-actions-utils.js
+++ b/scripts/release-testing/utils/github-actions-utils.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const {execSync: exec} = require('child_process');
+const fetch = require('node-fetch');
+
+/*::
+type CIHeaders = {
+  Authorization: string,
+  Accept: string,
+  'X-GitHub-Api-Version': string
+}
+
+type WorkflowRun = {
+  id: number,
+  name: string,
+  run_number: number,
+  status: string,
+  workflow_id: number,
+  url: string,
+  created_at: string,
+};
+
+
+type Artifact = {
+  id: number,
+  name: string,
+  url: string,
+  archive_download_url: string,
+}
+
+type WorkflowRuns = {
+  total_count: number,
+  workflow_runs: Array<WorkflowRun>,
+}
+
+type Artifacts = {
+  total_count: number,
+  artifacts: Array<Artifact>,
+}
+*/
+
+let token;
+let ciHeaders;
+let artifacts;
+let branch;
+let baseTemporaryPath;
+
+const reactNativeRepo = 'https://api.github.com/repos/facebook/react-native/';
+const reactNativeActionsURL = `${reactNativeRepo}actions/runs`;
+
+async function _getActionRunsOnBranch() /*: Promise<WorkflowRuns> */ {
+  const url = `${reactNativeActionsURL}?branch=${branch}`;
+  const options = {
+    method: 'GET',
+    headers: ciHeaders,
+  };
+
+  // $FlowIgnore[prop-missing] Conflicting .flowconfig in Meta's monorepo
+  // $FlowIgnore[incompatible-call]
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(JSON.stringify(await response.json()));
+  }
+
+  const body = await response
+    // eslint-disable-next-line func-call-spacing
+    .json /*::<WorkflowRuns>*/
+    ();
+  return body;
+}
+
+async function _getArtifacts(run_id /*: number */) /*: Promise<Artifacts> */ {
+  const url = `${reactNativeActionsURL}/${run_id}/artifacts`;
+  const options = {
+    method: 'GET',
+    headers: ciHeaders,
+  };
+
+  // $FlowIgnore[prop-missing] Conflicting .flowconfig in Meta's monorepo
+  // $FlowIgnore[incompatible-call]
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(JSON.stringify(await response.json()));
+  }
+
+  const body = await response
+    // eslint-disable-next-line func-call-spacing
+    .json /*::<Artifacts>*/
+    ();
+  return body;
+}
+
+// === Public Interface === //
+async function initialize(
+  ciToken /*: string */,
+  baseTempPath /*: string */,
+  branchName /*: string */,
+  useLastSuccessfulPipeline /*: boolean */ = false,
+) {
+  console.info('Getting GHA information');
+  baseTemporaryPath = baseTempPath;
+  exec(`mkdir -p ${baseTemporaryPath}`);
+
+  branch = branchName;
+
+  token = ciToken;
+  ciHeaders = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  const testAllWorkflow = (await _getActionRunsOnBranch()).workflow_runs
+    .filter(w => w.name === 'Test All')
+    .sort((a, b) => (a.created_at > b.created_at ? -1 : 1))[0];
+
+  artifacts = await _getArtifacts(testAllWorkflow.id);
+}
+
+function downloadArtifact(
+  artifactURL /*: string */,
+  destination /*: string */,
+) {
+  exec(`rm -rf ${destination}`);
+
+  const command = `curl ${artifactURL} \
+    -Lo ${destination} \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${token}" \
+    -H "X-GitHub-Api-Version: 2022-11-28"`;
+
+  exec(command, {stdio: 'inherit'});
+}
+
+async function artifactURLForJSCRNTesterAPK(
+  emulatorArch /*: string */,
+) /*: Promise<string> */ {
+  const url = artifacts.artifacts.filter(a => a.name === 'rntester-apk')[0]
+    .archive_download_url;
+  return Promise.resolve(url);
+}
+
+async function artifactURLForHermesRNTesterAPK(
+  emulatorArch /*: string */,
+) /*: Promise<string> */ {
+  const url = artifacts.artifacts.filter(a => a.name === 'rntester-apk')[0]
+    .archive_download_url;
+  return Promise.resolve(url);
+}
+
+async function artifactURLForMavenLocal() /*: Promise<string> */ {
+  const url = artifacts.artifacts.filter(a => a.name === 'maven-local')[0]
+    .archive_download_url;
+  return Promise.resolve(url);
+}
+
+async function artifactURLHermesDebug() /*: Promise<string> */ {
+  const url = artifacts.artifacts.filter(
+    a => a.name === 'hermes-darwin-bin-Debug',
+  )[0].archive_download_url;
+  return Promise.resolve(url);
+}
+
+async function artifactURLForReactNative() /*: Promise<string> */ {
+  const url = artifacts.artifacts.filter(
+    a => a.name === 'react-native-package',
+  )[0].archive_download_url;
+  return Promise.resolve(url);
+}
+
+function baseTmpPath() /*: string */ {
+  return baseTemporaryPath;
+}
+
+module.exports = {
+  initialize,
+  downloadArtifact,
+  artifactURLForJSCRNTesterAPK,
+  artifactURLForHermesRNTesterAPK,
+  artifactURLForMavenLocal,
+  artifactURLHermesDebug,
+  artifactURLForReactNative,
+  baseTmpPath,
+};

--- a/scripts/release-testing/utils/testing-utils.js
+++ b/scripts/release-testing/utils/testing-utils.js
@@ -20,6 +20,7 @@ const {
   generateiOSArtifacts,
 } = require('../../releases/utils/release-utils');
 const circleCIArtifactsUtils = require('./circle-ci-artifacts-utils.js');
+const ghaArtifactsUtils = require('./github-actions-utils.js');
 const fs = require('fs');
 // $FlowIgnore[cannot-resolve-module]
 const {spawn} = require('node:child_process');
@@ -177,30 +178,101 @@ async function setupCircleCIArtifacts(
   return circleCIArtifactsUtils;
 }
 
-async function downloadArtifactsFromCircleCI(
-  circleCIArtifacts /*: typeof circleCIArtifactsUtils */,
+/**
+ * Setups the CircleCIArtifacts if a token has been passed
+ *
+ * Parameters:
+ * - @circleciToken a valid CircleCI Token.
+ * - @branchName the branch of the name we want to use to fetch the artifacts.
+ */
+async function setupGHAArtifacts(
+  ciToken /*: ?string */,
+  branchName /*: string */,
+  useLastSuccessfulPipeline /*: boolean */,
+) /*: Promise<?typeof ghaArtifactsUtils> */ {
+  if (ciToken == null) {
+    return null;
+  }
+
+  const baseTmpPath = '/tmp/react-native-tmp';
+  await ghaArtifactsUtils.initialize(
+    ciToken,
+    baseTmpPath,
+    branchName,
+    useLastSuccessfulPipeline,
+  );
+  return ghaArtifactsUtils;
+}
+
+async function downloadArtifacts(
+  ciArtifacts /*: typeof circleCIArtifactsUtils */,
   mavenLocalPath /*: string */,
   localNodeTGZPath /*: string */,
 ) {
-  const mavenLocalURL = await circleCIArtifacts.artifactURLForMavenLocal();
-  const hermesURL = await circleCIArtifacts.artifactURLHermesDebug();
-  const reactNativeURL = await circleCIArtifacts.artifactURLForReactNative();
+  const mavenLocalURL = await ciArtifacts.artifactURLForMavenLocal();
+  const hermesURLZip = await ciArtifacts.artifactURLHermesDebug();
+  const reactNativeURLZip = await ciArtifacts.artifactURLForReactNative();
 
+  // Cleanup destination folder
+  exec(`rm -rf ${ciArtifacts.baseTmpPath()}`);
+  exec(`mkdir ${ciArtifacts.baseTmpPath()}`);
+
+  const hermesPathZip = path.join(
+    ciArtifacts.baseTmpPath(),
+    'hermes-ios-debug.zip',
+  );
+
+  const mavenLocalZipPath = `${mavenLocalPath}.zip`;
+  console.info(
+    `\n[Download] Maven Local Artifacts from ${mavenLocalURL} into ${mavenLocalZipPath}`,
+  );
+  ciArtifacts.downloadArtifact(mavenLocalURL, mavenLocalZipPath);
+  console.info(`Unzipping into ${mavenLocalPath}`);
+  exec(`unzip -oq ${mavenLocalZipPath} -d ${mavenLocalPath}`);
+
+  // Github Actions are zipping a zip. Needs to move it to the right place and unzip it again
+  exec(`rm -rf ${mavenLocalZipPath}`);
+  exec(`mv ${mavenLocalPath}/maven-local.zip ${mavenLocalZipPath}`);
+  exec(`unzip -oq ${mavenLocalZipPath} -d ${mavenLocalPath}`);
+
+  console.info('\n[Download] Hermes');
+  ciArtifacts.downloadArtifact(hermesURLZip, hermesPathZip);
+  exec(`unzip ${hermesPathZip} -d ${ciArtifacts.baseTmpPath()}/hermes`);
   const hermesPath = path.join(
-    circleCIArtifacts.baseTmpPath(),
+    ciArtifacts.baseTmpPath(),
+    'hermes',
     'hermes-ios-debug.tar.gz',
   );
 
-  console.info(`[Download] Maven Local Artifacts from ${mavenLocalURL}`);
-  const mavenLocalZipPath = `${mavenLocalPath}.zip`;
-  circleCIArtifacts.downloadArtifact(mavenLocalURL, mavenLocalZipPath);
-  exec(`unzip -oq ${mavenLocalZipPath} -d ${mavenLocalPath}`);
-  console.info('[Download] Hermes');
-  circleCIArtifacts.downloadArtifact(hermesURL, hermesPath);
-  console.info(`[Download] React Native from  ${reactNativeURL}`);
-  circleCIArtifacts.downloadArtifact(reactNativeURL, localNodeTGZPath);
+  console.info(`\n[Download] React Native from  ${reactNativeURLZip}`);
+  const reactNativeDestPath = path.join(
+    ciArtifacts.baseTmpPath(),
+    'react-native',
+  );
+  const reactNativeZipDestPath = `${reactNativeDestPath}.zip`;
+  ciArtifacts.downloadArtifact(reactNativeURLZip, reactNativeZipDestPath);
+  exec(`unzip ${reactNativeZipDestPath} -d ${reactNativeDestPath}`);
+  // For some reason, the commit on which the Github Action is running is not the same as the one
+  // that is running locally. This make so that the react-native package is created with a different
+  // commit sha in CI wrt what is used locally.
+  // As a result the react-native tgz is different. The next section of code use package that is created
+  // in CI as source of truth and sends back the new localNodeTGZ path so that the new apps can
+  // use it.
+  const tgzName = fs.readdirSync(reactNativeDestPath).filter(file => {
+    console.log(file);
+    return file.endsWith('.tgz');
+  })[0];
 
-  return hermesPath;
+  if (tgzName == null) {
+    throw new Error('Could not find the tgz file in the react-native folder');
+  }
+
+  const basePath = path.dirname(localNodeTGZPath);
+  const newLocalNodeTGZ = path.join(basePath, tgzName);
+  const reactNativeTGZ = path.join(reactNativeDestPath, tgzName);
+  exec(`mv ${reactNativeTGZ} ${newLocalNodeTGZ}`);
+
+  return {hermesPath, newLocalNodeTGZ};
 }
 
 function buildArtifactsLocally(
@@ -281,20 +353,23 @@ function buildArtifactsLocally(
  * - @hermesPath the path to hermes for iOS
  */
 async function prepareArtifacts(
-  circleCIArtifacts /*: ?typeof circleCIArtifactsUtils */,
+  ciArtifacts /*: ?typeof circleCIArtifactsUtils */,
   mavenLocalPath /*: string */,
   localNodeTGZPath /*: string */,
   releaseVersion /*: string */,
   buildType /*: BuildType */,
   reactNativePackagePath /*: string */,
-) /*: Promise<string> */ {
-  return circleCIArtifacts != null
-    ? await downloadArtifactsFromCircleCI(
-        circleCIArtifacts,
-        mavenLocalPath,
-        localNodeTGZPath,
-      )
-    : buildArtifactsLocally(releaseVersion, buildType, reactNativePackagePath);
+) /*: Promise<{hermesPath: string, newLocalNodeTGZ: string }> */ {
+  return ciArtifacts != null
+    ? await downloadArtifacts(ciArtifacts, mavenLocalPath, localNodeTGZPath)
+    : {
+        hermesPath: buildArtifactsLocally(
+          releaseVersion,
+          buildType,
+          reactNativePackagePath,
+        ),
+        newLocalNodeTGZ: localNodeTGZPath,
+      };
 }
 
 module.exports = {
@@ -303,5 +378,6 @@ module.exports = {
   isPackagerRunning,
   launchPackagerInSeparateWindow,
   setupCircleCIArtifacts,
+  setupGHAArtifacts,
   prepareArtifacts,
 };


### PR DESCRIPTION
## Summary:
With the migration to GHA, we are updating the testing scripts to work with the new CI.

There are a bit of shenanigans due to:
* How GHA archives artifacts => they are all `.zip` files, so I had to play around with unzipping them
* GHA seems to create a different commit, like if it is forking the repo instead of using it. I think that it is how the checkout action works. *Note:* this might be a problem for the `Create React Native Release` workflow because it has to commit on the stable branch! 
* Android is building only the simulator architecture when running from regular CI. The app is not configured to run only on that, so the RNTestProject was a failing because it was trying to build all the available architectures. It is an easy fix in the user project space when release testing.

## Changelog:
[Internal] - Update the testing script to work with the new CI

## Test Plan:
Tested locally.

* [iOS] RNTester - Hermes ✅ 
* [iOS] RNTester - JSC ✅ 
* [Android] RNTester - Hermes ✅ 
* [Android] RNTester - JSC ✅ 
* [iOS] RNTestProject - Hermes ✅  (The project is created correctly and it builds, crash at runtime for #44926) 
* [iOS] RNTestProject - JSC ✅ (The project is created correctly and it builds, crash at runtime for #44926)
* [Android] RNTester - Hermes ✅ (Needed to build only the simulator architecture)
* [Android] RNTester - JSC ✅ (Needed to build only the simulator architecture)
