### PR TITLE
Do not publish Gradle Scans

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -7,6 +7,3 @@ runs:
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-version: wrapper
-        build-scan-publish: true
-        build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
-        build-scan-terms-of-use-agree: "yes"


### PR DESCRIPTION
Summary:
I have the suspect this is causing our builds to be slower and especially causing the template tests to take 6 hours.
Let's try to disable it.

Changelog:
[Internal] [Changed] - Do not publish Gradle Scans

Differential Revision: D58520463
