### PR TITLE
Fix default accessor for unstable_fuseboxEnabled (RNTester crash)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -153,7 +153,7 @@
 
 - (BOOL)unstable_fuseboxEnabled
 {
-  return [self unstable_fuseboxEnabled];
+  return NO;
 }
 
 - (NSURL *)bundleURL


### PR DESCRIPTION
Summary: Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D58527490
