### PR TITLE
fix: make it possible to add multiple mountingOverrideDelegates

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -172,7 +172,7 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
 
 - (void)setupAnimationDriver:(const facebook::react::SurfaceHandler &)surfaceHandler
 {
-  surfaceHandler.getMountingCoordinator()->setMountingOverrideDelegate(_animationDriver);
+  surfaceHandler.getMountingCoordinator()->addMountingOverrideDelegate(_animationDriver);
 }
 
 - (void)onAnimationStarted

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -129,7 +129,7 @@ void Binding::startSurface(
 
   surfaceHandler.start();
 
-  surfaceHandler.getMountingCoordinator()->setMountingOverrideDelegate(
+  surfaceHandler.getMountingCoordinator()->addMountingOverrideDelegate(
       animationDriver_);
 
   {
@@ -197,7 +197,7 @@ void Binding::startSurfaceWithConstraints(
 
   surfaceHandler.start();
 
-  surfaceHandler.getMountingCoordinator()->setMountingOverrideDelegate(
+  surfaceHandler.getMountingCoordinator()->addMountingOverrideDelegate(
       animationDriver_);
 
   {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
@@ -104,9 +104,8 @@ std::optional<MountingTransaction> MountingCoordinator::pullTransaction()
   }
 
   // Override case
-  for(auto it = mountingOverrideDelegates_.begin(); it < mountingOverrideDelegates_.end(); it++)
+  for(const auto &delegate : mountingOverrideDelegates_)
   {
-    auto &delegate = *it;
     auto mountingOverrideDelegate = delegate.lock();
     auto shouldOverridePullTransaction = mountingOverrideDelegate &&
     mountingOverrideDelegate->shouldOverridePullTransaction();

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
@@ -203,7 +203,7 @@ ShadowTreeRevision MountingCoordinator::getBaseRevision() const {
   return baseRevision_;
 }
 
-void MountingCoordinator::setMountingOverrideDelegate(
+void MountingCoordinator::addMountingOverrideDelegate(
     std::weak_ptr<const MountingOverrideDelegate> delegate) const {
   std::scoped_lock lock(mutex_);
   mountingOverrideDelegates_.insert(mountingOverrideDelegates_.end(), std::move(delegate));

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
@@ -104,31 +104,35 @@ std::optional<MountingTransaction> MountingCoordinator::pullTransaction()
   }
 
   // Override case
-  auto mountingOverrideDelegate = mountingOverrideDelegate_.lock();
-  auto shouldOverridePullTransaction = mountingOverrideDelegate &&
-      mountingOverrideDelegate->shouldOverridePullTransaction();
+  for(auto it = mountingOverrideDelegates_.begin(); it < mountingOverrideDelegates_.end(); it++)
+  {
+    auto &delegate = *it;
+    auto mountingOverrideDelegate = delegate.lock();
+    auto shouldOverridePullTransaction = mountingOverrideDelegate &&
+    mountingOverrideDelegate->shouldOverridePullTransaction();
+    
+    if (shouldOverridePullTransaction) {
+        SystraceSection section2("MountingCoordinator::overridePullTransaction");
 
-  if (shouldOverridePullTransaction) {
-    SystraceSection section2("MountingCoordinator::overridePullTransaction");
+        auto mutations = ShadowViewMutation::List{};
+        auto telemetry = TransactionTelemetry{};
 
-    auto mutations = ShadowViewMutation::List{};
-    auto telemetry = TransactionTelemetry{};
-
-    if (transaction.has_value()) {
-      mutations = transaction->getMutations();
-      telemetry = transaction->getTelemetry();
-    } else {
-      number_++;
-      telemetry.willLayout();
-      telemetry.didLayout();
-      telemetry.willCommit();
-      telemetry.didCommit();
-      telemetry.willDiff();
-      telemetry.didDiff();
+        if (transaction.has_value()) {
+            mutations = transaction->getMutations();
+            telemetry = transaction->getTelemetry();
+        } else {
+            number_++;
+            telemetry.willLayout();
+            telemetry.didLayout();
+            telemetry.willCommit();
+            telemetry.didCommit();
+            telemetry.willDiff();
+            telemetry.didDiff();
+        }
+        
+        transaction = mountingOverrideDelegate->pullTransaction(
+            surfaceId_, number_, telemetry, std::move(mutations));
     }
-
-    transaction = mountingOverrideDelegate->pullTransaction(
-        surfaceId_, number_, telemetry, std::move(mutations));
   }
 
 #ifdef RN_SHADOW_TREE_INTROSPECTION
@@ -203,7 +207,7 @@ ShadowTreeRevision MountingCoordinator::getBaseRevision() const {
 void MountingCoordinator::setMountingOverrideDelegate(
     std::weak_ptr<const MountingOverrideDelegate> delegate) const {
   std::scoped_lock lock(mutex_);
-  mountingOverrideDelegate_ = std::move(delegate);
+  mountingOverrideDelegates_.insert(mountingOverrideDelegates_.end(), std::move(delegate));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -119,8 +119,8 @@ class MountingCoordinator final {
   mutable std::optional<ShadowTreeRevision> lastRevision_{};
   mutable MountingTransaction::Number number_{0};
   mutable std::condition_variable signal_;
-  mutable std::weak_ptr<const MountingOverrideDelegate>
-      mountingOverrideDelegate_;
+  mutable std::vector<std::weak_ptr<const MountingOverrideDelegate>>
+      mountingOverrideDelegates_;
 
   TelemetryController telemetryController_;
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -89,7 +89,7 @@ class MountingCoordinator final {
   void updateBaseRevision(const ShadowTreeRevision& baseRevision) const;
   void resetLatestRevision() const;
 
-  void setMountingOverrideDelegate(
+  void addMountingOverrideDelegate(
       std::weak_ptr<const MountingOverrideDelegate> delegate) const;
 
   /*


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

PR changing the single mountingOverrideDelegate to a vector of those, so other listeners can operate on the transaction. Used by `react-native-screens` in https://github.com/software-mansion/react-native-screens/pull/2134 and `react-native-reanimated` in https://github.com/software-mansion/react-native-reanimated/pull/6055.

Till now, only one listener could be added there, meaning that e.g. `Layout Animations` from `react-native`,  `Layout Animations` from `react-native-reanimated` and listening for `Screen` removal in `react-native-screens` could not operate at the same time.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Add option for multiple `mountingOverrideDelegates`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

The code of `LayoutAnimations` inside `react-native` should work the same since it will add just one listener then. For other cases, different libraries can read/mutate transactions. 
