### PR TITLE
[RN][GHA] Properly export the hermes tarball path to reuse it in RNTester

### DIFF
--- a/.github/actions/test_ios_rntester/action.yml
+++ b/.github/actions/test_ios_rntester/action.yml
@@ -60,11 +60,6 @@ runs:
           exit 0
         fi
 
-        if [ ! -d ~/react-native ]; then
-          echo "No React Native checkout found. Run `checkout` first."
-          exit 0
-        fi
-
         TARBALL_FILENAME=$(node ./packages/react-native/scripts/hermes/get-tarball-name.js --buildType "${{ inputs.flavor }}")
         TARBALL_PATH=$HERMES_TARBALL_ARTIFACTS_DIR/$TARBALL_FILENAME
 
@@ -102,6 +97,8 @@ runs:
       run: |
         if [[ ${{ inputs.jsengine }} == "JSC" ]]; then
           export USE_HERMES=0
+        else
+          export HERMES_ENGINE_TARBALL_PATH=$HERMES_ENGINE_TARBALL_PATH
         fi
 
         if [[ ${{ inputs.use-frameworks }} == "DynamicFrameworks" ]]; then


### PR DESCRIPTION
## Summary:

While working on GHA, I realized that RNTester is not reusing the hermes package we create in the previous steps.

This change should fix that, saving ~5 minute per RNTester test as it does not have to rebuild hermes every time.

## Changelog:
[Internal] - Improve CI to reuse hermes tarballs

## Test Plan:
| Before | After |
| --- | --- |
| <img width="847" alt="Screenshot 2024-06-13 at 16 02 32" src="https://github.com/facebook/react-native/assets/11162307/099fd2d4-0954-4e64-baf0-6322e02d57bb"> | <img width="1203" alt="Screenshot 2024-06-13 at 16 34 20" src="https://github.com/facebook/react-native/assets/11162307/f8b9f9b6-0bd3-4ea4-8acd-3a4c1bffbc88"> |
