### PR TITLE
Add test showcasing memory leak in RemoteObjectsTable in Hermes

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ConsoleApiTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ConsoleApiTest.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <folly/executors/QueuedImmediateExecutor.h>
 #include "JsiIntegrationTest.h"
 
 #include "engines/JsiIntegrationTestHermesEngineAdapter.h"
@@ -44,12 +45,13 @@ struct Params {
 /**
  * A test fixture for the Console API.
  */
-class ConsoleApiTest
-    : public JsiIntegrationPortableTest<JsiIntegrationTestHermesEngineAdapter>,
-      public WithParamInterface<Params> {
+class ConsoleApiTest : public JsiIntegrationPortableTestBase<
+                           JsiIntegrationTestHermesEngineAdapter,
+                           folly::QueuedImmediateExecutor>,
+                       public WithParamInterface<Params> {
  protected:
   void SetUp() override {
-    JsiIntegrationPortableTest::SetUp();
+    JsiIntegrationPortableTestBase::SetUp();
     connect();
     EXPECT_CALL(
         fromPage(),
@@ -81,7 +83,7 @@ class ConsoleApiTest
     if (!GetParam().runtimeEnabledAtStart) {
       enableRuntimeDomain();
     }
-    JsiIntegrationPortableTest::TearDown();
+    JsiIntegrationPortableTestBase::TearDown();
   }
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <folly/dynamic.h>
-#include <folly/executors/QueuedImmediateExecutor.h>
 #include <folly/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -42,15 +41,15 @@ namespace facebook::react::jsinspector_modern {
  * for a particular engine, plus exposes access to a RuntimeExecutor (based on
  * the provided folly::Executor) and the corresponding jsi::Runtime.
  */
-template <typename EngineAdapter>
-class JsiIntegrationPortableTest : public ::testing::Test,
-                                   private HostTargetDelegate {
-  folly::QueuedImmediateExecutor immediateExecutor_;
-
+template <typename EngineAdapter, typename Executor>
+class JsiIntegrationPortableTestBase : public ::testing::Test,
+                                       private HostTargetDelegate {
  protected:
-  JsiIntegrationPortableTest()
+  Executor executor_;
+
+  JsiIntegrationPortableTestBase()
       : inspectorFlagsGuard_{EngineAdapter::getInspectorFlagOverrides()},
-        engineAdapter_{immediateExecutor_} {}
+        engineAdapter_{executor_} {}
 
   void SetUp() override {
     // NOTE: Using SetUp() so we can call virtual methods like
@@ -63,7 +62,7 @@ class JsiIntegrationPortableTest : public ::testing::Test,
     loadMainBundle();
   }
 
-  ~JsiIntegrationPortableTest() override {
+  ~JsiIntegrationPortableTestBase() override {
     toPage_.reset();
     if (runtimeTarget_) {
       EXPECT_TRUE(instance_);
@@ -118,7 +117,7 @@ class JsiIntegrationPortableTest : public ::testing::Test,
       instance_ = nullptr;
     }
     // Recreate the engine (e.g. to wipe any state in the inner jsi::Runtime)
-    engineAdapter_.emplace(immediateExecutor_);
+    engineAdapter_.emplace(executor_);
     instance_ = &page_->registerInstance(instanceTargetDelegate_);
     setupRuntimeBeforeRegistration(engineAdapter_->getRuntime());
     runtimeTarget_ = &instance_->registerRuntime(
@@ -133,7 +132,7 @@ class JsiIntegrationPortableTest : public ::testing::Test,
   }
 
   VoidExecutor inspectorExecutor_ = [this](auto callback) {
-    immediateExecutor_.add(callback);
+    executor_.add(callback);
   };
 
   jsi::Value eval(std::string_view code) {


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Added a small test that uses `folly:ManualExecutor`, which reproduces the memory leak issue in Hermes' RemoteObjectsTable:
1. Send `Runtime.enable`
2. Evaluate `console.log(<object>);` to populate `RemoteObjectsTable`
3. Send `Page.reload` to reload VM

This test is expected to fail, because by the time it is published, the D58398254 hasn't landed.

Differential Revision: D58531763
