### PR TITLE
JS plumbing to get dropShadow into native

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -11,6 +11,25 @@ import {Animated} from '../Animated/Animated';
 import {ImageResizeMode} from '../Image/ImageResizeMode';
 import {ColorValue} from './StyleSheet';
 
+export type FilterPrimitive =
+  | {brightness: number | string}
+  | {blur: number | string}
+  | {contrast: number | string}
+  | {grayscale: number | string}
+  | {'hue-rotate': number | string}
+  | {invert: number | string}
+  | {opacity: number | string}
+  | {saturate: number | string}
+  | {sepia: number | string}
+  | {'drop-shadow': DropShadowPrimitive | string};
+
+export type DropShadowPrimitive = {
+  offsetX: number | string;
+  offsetY: number | string;
+  standardDeviation?: number | string | undefined;
+  color?: ColorValue | number | undefined;
+};
+
 type FlexAlignType =
   | 'flex-start'
   | 'flex-end'

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -11,7 +11,6 @@
 'use strict';
 
 import type AnimatedNode from '../Animated/nodes/AnimatedNode';
-import type {FilterPrimitive} from '../StyleSheet/processFilter';
 import type {
   ____DangerouslyImpreciseStyle_InternalOverrides,
   ____ImageStyle_InternalOverrides,
@@ -33,6 +32,25 @@ export type EdgeInsetsValue = {
   left: number,
   right: number,
   bottom: number,
+};
+
+export type FilterPrimitive =
+  | {brightness: number | string}
+  | {blur: number | string}
+  | {contrast: number | string}
+  | {grayscale: number | string}
+  | {'hue-rotate': number | string}
+  | {invert: number | string}
+  | {opacity: number | string}
+  | {saturate: number | string}
+  | {sepia: number | string}
+  | {'drop-shadow': DropShadowPrimitive | string};
+
+export type DropShadowPrimitive = {
+  offsetX: number | string,
+  offsetY: number | string,
+  standardDeviation?: number | string,
+  color?: ____ColorValue_Internal | number,
 };
 
 export type DimensionValue = number | string | 'auto' | AnimatedNode | null;

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processFilter-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processFilter-test.js
@@ -11,7 +11,9 @@
 
 'use strict';
 
-import type {FilterPrimitive} from '../processFilter';
+import type {FilterPrimitive} from '../StyleSheetTypes';
+
+import processColor from '../processColor';
 
 const processFilter = require('../processFilter').default;
 
@@ -38,15 +40,15 @@ describe('processFilter', () => {
     },
   ]);
 
-  testNumericFilter('hueRotate', 0, [{hueRotate: 0}]);
-  testUnitFilter('hueRotate', 90, 'deg', [{hueRotate: 90}]);
-  testUnitFilter('hueRotate', 1.5708, 'rad', [
-    {hueRotate: (180 * 1.5708) / Math.PI},
+  testNumericFilter('hue-rotate', 0, [{'hue-rotate': 0}]);
+  testUnitFilter('hue-rotate', 90, 'deg', [{'hue-rotate': 90}]);
+  testUnitFilter('hue-rotate', 1.5708, 'rad', [
+    {'hue-rotate': (180 * 1.5708) / Math.PI},
   ]);
-  testUnitFilter('hueRotate', -90, 'deg', [{hueRotate: -90}]);
-  testUnitFilter('hueRotate', 1.5, 'grad', []);
-  testNumericFilter('hueRotate', 90, []);
-  testUnitFilter('hueRotate', 50, '%', []);
+  testUnitFilter('hue-rotate', -90, 'deg', [{'hue-rotate': -90}]);
+  testUnitFilter('hue-rotate', 1.5, 'grad', []);
+  testNumericFilter('hue-rotate', 90, []);
+  testUnitFilter('hue-rotate', 50, '%', []);
 
   it('multiple filters', () => {
     expect(
@@ -54,9 +56,14 @@ describe('processFilter', () => {
         {brightness: 0.5},
         {opacity: 0.5},
         {blur: 5},
-        {hueRotate: '90deg'},
+        {'hue-rotate': '90deg'},
       ]),
-    ).toEqual([{brightness: 0.5}, {opacity: 0.5}, {blur: 5}, {hueRotate: 90}]);
+    ).toEqual([
+      {brightness: 0.5},
+      {opacity: 0.5},
+      {blur: 5},
+      {'hue-rotate': 90},
+    ]);
   });
   it('multiple filters one invalid', () => {
     expect(
@@ -64,7 +71,7 @@ describe('processFilter', () => {
         {brightness: 0.5},
         {opacity: 0.5},
         {blur: 5},
-        {hueRotate: '90foo'},
+        {'hue-rotate': '90foo'},
       ]),
     ).toEqual([]);
   });
@@ -83,6 +90,20 @@ describe('processFilter', () => {
       {brightness: 0.5},
     ]);
   });
+
+  it('should parse mixed case filters', () => {
+    expect(
+      processFilter(
+        'brIGhTneSs(0.5) hUE-rOTatE(0.5) briGhtNess(0.5) Brightness(0.5)',
+      ),
+    ).toEqual([
+      {brightness: 0.5},
+      {'hue-rotate': 0.5},
+      {brightness: 0.5},
+      {brightness: 0.5},
+    ]);
+  });
+
   it('empty', () => {
     expect(processFilter([])).toEqual([]);
   });
@@ -96,12 +117,17 @@ describe('processFilter', () => {
   });
   it('string multiple filters', () => {
     expect(
-      processFilter('brightness(0.5) opacity(0.5) blur(5) hueRotate(90deg)'),
-    ).toEqual([{brightness: 0.5}, {opacity: 0.5}, {blur: 5}, {hueRotate: 90}]);
+      processFilter('brightness(0.5) opacity(0.5) blur(5) hue-rotate(90deg)'),
+    ).toEqual([
+      {brightness: 0.5},
+      {opacity: 0.5},
+      {blur: 5},
+      {'hue-rotate': 90},
+    ]);
   });
   it('string multiple filters one invalid', () => {
     expect(
-      processFilter('brightness(0.5) opacity(0.5) blur(5) hueRotate(90foo)'),
+      processFilter('brightness(0.5) opacity(0.5) blur(5) hue-rotate(90foo)'),
     ).toEqual([]);
   });
   it('string multiple same filters', () => {
@@ -131,6 +157,8 @@ describe('processFilter', () => {
     // $FlowExpectedError[incompatible-call]
     expect(processFilter('brightness(.5)')).toEqual([{brightness: 0.5}]);
   });
+
+  testDropShadow();
 });
 
 function testStandardFilter(filter: string): void {
@@ -191,8 +219,8 @@ function createFilterPrimitive(
       return {contrast: value};
     case 'grayscale':
       return {grayscale: value};
-    case 'hueRotate':
-      return {hueRotate: value};
+    case 'hue-rotate':
+      return {'hue-rotate': value};
     case 'invert':
       return {invert: value};
     case 'opacity':
@@ -204,4 +232,173 @@ function createFilterPrimitive(
     default:
       throw new Error('Invalid filter: ' + filter);
   }
+}
+
+function testDropShadow() {
+  it('should parse string drop-shadow', () => {
+    expect(processFilter('drop-shadow(4px 4 10px red)')).toEqual([
+      {
+        'drop-shadow': {
+          offsetX: 4,
+          offsetY: 4,
+          color: processColor('red'),
+          standardDeviation: 10,
+        },
+      },
+    ]);
+  });
+
+  it('should parse string negative offsets drop-shadow', () => {
+    expect(processFilter('drop-shadow(-4 -4)')).toEqual([
+      {
+        'drop-shadow': {
+          offsetX: -4,
+          offsetY: -4,
+        },
+      },
+    ]);
+  });
+
+  it('should parse string multiple drop-shadows', () => {
+    expect(
+      processFilter('drop-shadow(4 4) drop-shadow(4 4) drop-shadow(4 4)'),
+    ).toEqual([
+      {
+        'drop-shadow': {
+          offsetX: 4,
+          offsetY: 4,
+        },
+      },
+      {
+        'drop-shadow': {
+          offsetX: 4,
+          offsetY: 4,
+        },
+      },
+      {
+        'drop-shadow': {
+          offsetX: 4,
+          offsetY: 4,
+        },
+      },
+    ]);
+  });
+
+  it('should parse string drop-shadow with random whitespaces', () => {
+    expect(
+      processFilter('    drop-shadow(4px  4   10px        red)    '),
+    ).toEqual([
+      {
+        'drop-shadow': {
+          offsetX: 4,
+          offsetY: 4,
+          color: processColor('red'),
+          standardDeviation: 10,
+        },
+      },
+    ]);
+  });
+
+  it('should parse string drop-shadow with multiple filters', () => {
+    expect(
+      processFilter(
+        'drop-shadow(4px 4 10px red) brightness(0.5) brightness(0.5)',
+      ),
+    ).toEqual([
+      {
+        'drop-shadow': {
+          offsetX: 4,
+          offsetY: 4,
+          color: processColor('red'),
+          standardDeviation: 10,
+        },
+      },
+      {brightness: 0.5},
+      {brightness: 0.5},
+    ]);
+  });
+
+  it('should parse string drop-shadow with color', () => {
+    expect(processFilter('drop-shadow(50 50 purple)')).toEqual([
+      {
+        'drop-shadow': {
+          offsetX: 50,
+          offsetY: 50,
+          color: processColor('purple'),
+        },
+      },
+    ]);
+  });
+
+  it('should parse string with mixed case drop-shadow', () => {
+    expect(processFilter('DroP-sHaDOw(50 50 purple)')).toEqual([
+      {
+        'drop-shadow': {
+          offsetX: 50,
+          offsetY: 50,
+          color: processColor('purple'),
+        },
+      },
+    ]);
+  });
+
+  it('should parse object drop-shadow', () => {
+    expect(
+      processFilter([
+        {
+          'drop-shadow': {
+            offsetX: 4,
+            offsetY: 4,
+            color: '#FFFFFF',
+            standardDeviation: '10',
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        'drop-shadow': {
+          offsetX: 4,
+          offsetY: 4,
+          standardDeviation: 10,
+          color: processColor('#FFFFFF'),
+        },
+      },
+    ]);
+  });
+
+  it('should fail to parse string comma separated drop-shadow', () => {
+    expect(processFilter('drop-shadow(4px, 4, 10px, red)')).toEqual([]);
+  });
+
+  it('should fail to parse other symbols after args comma separated drop-shadow', () => {
+    expect(processFilter('drop-shadow(4& 4* 10$ red)')).toEqual([]);
+  });
+
+  it('should fail on color between lengths string drop-shadow', () => {
+    expect(processFilter('drop-shadow(10 red 10 10')).toEqual([]);
+  });
+
+  it('should fail on color between offset & blur string drop-shadow', () => {
+    expect(processFilter('drop-shadow(10 10 red  10')).toEqual([]);
+  });
+
+  it('should fail on negative blue', () => {
+    expect(processFilter('drop-shadow(10 10 -10')).toEqual([]);
+  });
+
+  it('should fail on invalid object drop-shadow', () => {
+    expect(
+      // $FlowExpectedError[incompatible-call]
+      processFilter([
+        {'drop-shadow': {offsetX: 4, offsetY: 5, invalid: 'invalid arg'}},
+      ]),
+    ).toEqual([]);
+  });
+
+  it('should fail on invalid argument for drop-shadow object', () => {
+    expect(
+      // $FlowExpectedError[incompatible-call]
+      processFilter([{'drop-shadow': 8}]),
+    ).toEqual([]);
+  });
 }

--- a/packages/react-native/Libraries/StyleSheet/processFilter.js
+++ b/packages/react-native/Libraries/StyleSheet/processFilter.js
@@ -4,64 +4,97 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
+ * @format strict-local
  * @flow
+ * @oncall react-native
  */
 
 'use strict';
 
-export type FilterPrimitive =
-  | {brightness: number | string}
-  | {blur: number | string}
-  | {contrast: number | string}
-  | {grayscale: number | string}
-  | {hueRotate: number | string}
-  | {invert: number | string}
-  | {opacity: number | string}
-  | {saturate: number | string}
-  | {sepia: number | string};
+import type {ColorValue} from './StyleSheet';
+import type {DropShadowPrimitive, FilterPrimitive} from './StyleSheetTypes';
+
+import processColor from './processColor';
+
+type ParsedFilter =
+  | {brightness: number}
+  | {blur: number}
+  | {contrast: number}
+  | {grayscale: number}
+  | {'hue-rotate': number}
+  | {invert: number}
+  | {opacity: number}
+  | {saturate: number}
+  | {sepia: number}
+  | {'drop-shadow': ParsedDropShadow};
+
+type ParsedDropShadow = {
+  offsetX: number,
+  offsetY: number,
+  standardDeviation?: number,
+  color?: ColorValue,
+};
 
 export default function processFilter(
   filter: $ReadOnlyArray<FilterPrimitive> | string,
-): $ReadOnlyArray<FilterPrimitive> {
-  let result: Array<FilterPrimitive> = [];
+): $ReadOnlyArray<ParsedFilter> {
+  let result: Array<ParsedFilter> = [];
   if (typeof filter === 'string') {
-    // matches on functions with args like "brightness(1.5)"
-    const regex = new RegExp(/(\w+)\(([^)]+)\)/g);
+    // matches on functions with args like "drop-shadow(1.5)"
+    const regex = /([\w-]+)\(([^)]+)\)/g;
     let matches;
 
     while ((matches = regex.exec(filter))) {
-      const amount = _getFilterAmount(matches[1], matches[2]);
-
-      if (amount != null) {
-        const filterPrimitive = {};
-        // $FlowFixMe The key will be the correct one but flow can't see that.
-        filterPrimitive[matches[1]] = amount;
-        // $FlowFixMe The key will be the correct one but flow can't see that.
-        result.push(filterPrimitive);
+      let filterName = matches[1].toLowerCase();
+      if (filterName === 'drop-shadow') {
+        const dropShadow = parseDropShadow(matches[2]);
+        if (dropShadow != null) {
+          result.push({'drop-shadow': dropShadow});
+        } else {
+          return [];
+        }
       } else {
-        // If any primitive is invalid then apply none of the filters. This is how
-        // web works and makes it clear that something is wrong becuase no
-        // graphical effects are happening.
-        return [];
+        const amount = _getFilterAmount(filterName, matches[2]);
+
+        if (amount != null) {
+          const filterPrimitive = {};
+          // $FlowFixMe The key will be the correct one but flow can't see that.
+          filterPrimitive[filterName] = amount;
+          // $FlowFixMe The key will be the correct one but flow can't see that.
+          result.push(filterPrimitive);
+        } else {
+          // If any primitive is invalid then apply none of the filters. This is how
+          // web works and makes it clear that something is wrong becuase no
+          // graphical effects are happening.
+          return [];
+        }
       }
     }
   } else {
     for (const filterPrimitive of filter) {
       const [filterName, filterValue] = Object.entries(filterPrimitive)[0];
-      const amount = _getFilterAmount(filterName, filterValue);
-
-      if (amount != null) {
-        const resultObject = {};
+      if (filterName === 'drop-shadow') {
         // $FlowFixMe
-        resultObject[filterName] = amount;
-        // $FlowFixMe
-        result.push(resultObject);
+        const dropShadow = parseDropShadow(filterValue);
+        if (dropShadow == null) {
+          return [];
+        }
+        result.push({'drop-shadow': dropShadow});
       } else {
-        // If any primitive is invalid then apply none of the filters. This is how
-        // web works and makes it clear that something is wrong becuase no
-        // graphical effects are happening.
-        return [];
+        const amount = _getFilterAmount(filterName, filterValue);
+
+        if (amount != null) {
+          const resultObject = {};
+          // $FlowFixMe
+          resultObject[filterName] = amount;
+          // $FlowFixMe
+          result.push(resultObject);
+        } else {
+          // If any primitive is invalid then apply none of the filters. This is how
+          // web works and makes it clear that something is wrong becuase no
+          // graphical effects are happening.
+          return [];
+        }
       }
     }
   }
@@ -92,7 +125,7 @@ function _getFilterAmount(filterName: string, filterArgs: mixed): ?number {
   switch (filterName) {
     // Hue rotate takes some angle that can have a unit and can be
     // negative. Additionally, 0 with no unit is allowed.
-    case 'hueRotate':
+    case 'hue-rotate':
       if (filterArgAsNumber === 0) {
         return 0;
       }
@@ -129,4 +162,148 @@ function _getFilterAmount(filterName: string, filterArgs: mixed): ?number {
     default:
       return undefined;
   }
+}
+
+function parseDropShadow(
+  rawDropShadow: string | DropShadowPrimitive,
+): ?ParsedDropShadow {
+  const dropShadow =
+    typeof rawDropShadow === 'string'
+      ? parseDropShadowString(rawDropShadow)
+      : rawDropShadow;
+
+  const parsedDropShadow: ParsedDropShadow = {
+    offsetX: 0,
+    offsetY: 0,
+  };
+  let offsetX: number;
+  let offsetY: number;
+
+  for (const arg in dropShadow) {
+    let value;
+    switch (arg) {
+      case 'offsetX':
+        value =
+          typeof dropShadow.offsetX === 'string'
+            ? parseLength(dropShadow.offsetX)
+            : dropShadow.offsetX;
+        if (value == null) {
+          return null;
+        }
+        offsetX = value;
+        break;
+      case 'offsetY':
+        value =
+          typeof dropShadow.offsetY === 'string'
+            ? parseLength(dropShadow.offsetY)
+            : dropShadow.offsetY;
+        if (value == null) {
+          return null;
+        }
+        offsetY = value;
+        break;
+      case 'standardDeviation':
+        value =
+          typeof dropShadow.standardDeviation === 'string'
+            ? parseLength(dropShadow.standardDeviation)
+            : dropShadow.standardDeviation;
+        if (value == null || value < 0) {
+          return null;
+        }
+        parsedDropShadow.standardDeviation = value;
+        break;
+      case 'color':
+        const color = processColor(dropShadow.color);
+        if (color == null) {
+          return null;
+        }
+        parsedDropShadow.color = color;
+        break;
+      default:
+        return null;
+    }
+  }
+
+  if (offsetX == null || offsetY == null) {
+    return null;
+  }
+
+  parsedDropShadow.offsetX = offsetX;
+  parsedDropShadow.offsetY = offsetY;
+
+  return parsedDropShadow;
+}
+
+function parseDropShadowString(rawDropShadow: string): ?DropShadowPrimitive {
+  const dropShadow: DropShadowPrimitive = {
+    offsetX: 0,
+    offsetY: 0,
+  };
+  let offsetX: string;
+  let offsetY: string;
+  let lengthCount = 0;
+  let keywordDetectedAfterLength = false;
+
+  // split on all whitespaces
+  for (const arg of rawDropShadow.split(/\s+/)) {
+    console.log(rawDropShadow.split(/\s+/));
+    const processedColor = processColor(arg);
+    if (processedColor != null) {
+      if (dropShadow.color != null) {
+        return null;
+      }
+      if (offsetX != null) {
+        keywordDetectedAfterLength = true;
+      }
+      dropShadow.color = arg;
+      continue;
+    }
+
+    switch (lengthCount) {
+      case 0:
+        offsetX = arg;
+        lengthCount++;
+        break;
+      case 1:
+        if (keywordDetectedAfterLength) {
+          return null;
+        }
+        offsetY = arg;
+        lengthCount++;
+        break;
+      case 2:
+        if (keywordDetectedAfterLength) {
+          return null;
+        }
+        dropShadow.standardDeviation = arg;
+        lengthCount++;
+        break;
+      default:
+        return null;
+    }
+  }
+  if (offsetX == null || offsetY == null) {
+    return null;
+  }
+
+  dropShadow.offsetX = offsetX;
+  dropShadow.offsetY = offsetY;
+  return dropShadow;
+}
+
+function parseLength(length: string): ?number {
+  // matches on args with units like "1.5 5% -80deg"
+  const argsWithUnitsRegex = /([+-]?\d*(\.\d+)?)([\w\W]+)?/g;
+  const match = argsWithUnitsRegex.exec(length);
+  console.log(match);
+
+  if (!match || Number.isNaN(match[1])) {
+    return null;
+  }
+
+  if (match[3] != null && match[3] !== 'px') {
+    return null;
+  }
+
+  return Number(match[1]);
 }

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7571,6 +7571,23 @@ export type EdgeInsetsValue = {
   right: number,
   bottom: number,
 };
+export type FilterPrimitive =
+  | { brightness: number | string }
+  | { blur: number | string }
+  | { contrast: number | string }
+  | { grayscale: number | string }
+  | { \\"hue-rotate\\": number | string }
+  | { invert: number | string }
+  | { opacity: number | string }
+  | { saturate: number | string }
+  | { sepia: number | string }
+  | { \\"drop-shadow\\": DropShadowPrimitive | string };
+export type DropShadowPrimitive = {
+  offsetX: number | string,
+  offsetY: number | string,
+  standardDeviation?: number | string,
+  color?: ____ColorValue_Internal | number,
+};
 export type DimensionValue = number | string | \\"auto\\" | AnimatedNode | null;
 export type AnimatableNumericValue = number | AnimatedNode;
 export type CursorValue = \\"auto\\" | \\"pointer\\";
@@ -7988,19 +8005,26 @@ declare module.exports: processColorArray;
 `;
 
 exports[`public API should not change unintentionally Libraries/StyleSheet/processFilter.js 1`] = `
-"export type FilterPrimitive =
-  | { brightness: number | string }
-  | { blur: number | string }
-  | { contrast: number | string }
-  | { grayscale: number | string }
-  | { hueRotate: number | string }
-  | { invert: number | string }
-  | { opacity: number | string }
-  | { saturate: number | string }
-  | { sepia: number | string };
+"type ParsedFilter =
+  | { brightness: number }
+  | { blur: number }
+  | { contrast: number }
+  | { grayscale: number }
+  | { \\"hue-rotate\\": number }
+  | { invert: number }
+  | { opacity: number }
+  | { saturate: number }
+  | { sepia: number }
+  | { \\"drop-shadow\\": ParsedDropShadow };
+type ParsedDropShadow = {
+  offsetX: number,
+  offsetY: number,
+  standardDeviation?: number,
+  color?: ColorValue,
+};
 declare export default function processFilter(
   filter: $ReadOnlyArray<FilterPrimitive> | string
-): $ReadOnlyArray<FilterPrimitive>;
+): $ReadOnlyArray<ParsedFilter>;
 "
 `;
 


### PR DESCRIPTION
Summary:
DropShadow is a filter so we need to add the logic for sending it to native through the same process function for the other filters.

Drop shadow can have more arguments than the other filters. I'm following a similar pattern to boxShadow D57872933.

Changelog: [Internal]

Differential Revision: D58370127
