### PR TITLE
provide default 'ReactJsExceptionHandler' when missing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -17,7 +17,6 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.fabric.ComponentFactory
-import com.facebook.react.interfaces.exceptionmanager.ReactJsExceptionHandler
 import com.facebook.react.runtime.JSCInstance
 import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
@@ -74,8 +73,6 @@ public object DefaultReactHost {
               reactPackages = packageList,
               jsRuntimeFactory = jsRuntimeFactory,
               turboModuleManagerDelegateBuilder = defaultTmmDelegateBuilder)
-      // TODO: T180971255 Improve default exception handler
-      val reactJsExceptionHandler = ReactJsExceptionHandler { _ -> }
       val componentFactory = ComponentFactory()
       DefaultComponentsRegistry.register(componentFactory)
       // TODO: T164788699 find alternative of accessing ReactHostImpl for initialising reactHost
@@ -85,7 +82,7 @@ public object DefaultReactHost {
                   defaultReactHostDelegate,
                   componentFactory,
                   true /* allowPackagerServerAccess */,
-                  reactJsExceptionHandler,
+                  null,
                   useDevSupport,
               )
               .apply {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -102,7 +102,7 @@ public class ReactHostImpl implements ReactHost {
   private final Context mContext;
   private final ReactHostDelegate mReactHostDelegate;
   private final ComponentFactory mComponentFactory;
-  private final ReactJsExceptionHandler mReactJsExceptionHandler;
+  private @Nullable final ReactJsExceptionHandler mReactJsExceptionHandler;
   private final DevSupportManager mDevSupportManager;
   private final Executor mBGExecutor;
   private final Executor mUIExecutor;
@@ -143,7 +143,7 @@ public class ReactHostImpl implements ReactHost {
       ReactHostDelegate delegate,
       ComponentFactory componentFactory,
       boolean allowPackagerServerAccess,
-      ReactJsExceptionHandler reactJsExceptionHandler,
+      @Nullable ReactJsExceptionHandler reactJsExceptionHandler,
       boolean useDevSupport) {
     this(
         context,
@@ -162,7 +162,7 @@ public class ReactHostImpl implements ReactHost {
       ComponentFactory componentFactory,
       Executor bgExecutor,
       Executor uiExecutor,
-      ReactJsExceptionHandler reactJsExceptionHandler,
+      @Nullable ReactJsExceptionHandler reactJsExceptionHandler,
       boolean allowPackagerServerAccess,
       boolean useDevSupport) {
     mContext = context;

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/StackTraceHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/StackTraceHelperTest.kt
@@ -7,11 +7,15 @@
 
 package com.facebook.react.devsupport
 
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.interfaces.exceptionmanager.ReactJsExceptionHandler.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(UnstableReactNativeAPI::class)
 @RunWith(RobolectricTestRunner::class)
 class StackTraceHelperTest {
   @Test
@@ -57,5 +61,64 @@ class StackTraceHelperTest {
     assertThat(frame.fileName).isEqualTo("")
     assertThat(frame.line).isEqualTo(-1)
     assertThat(frame.column).isEqualTo(-1)
+  }
+
+  @Test
+  fun testConvertParsedError() {
+    val error = getParsedErrorTestData()
+
+    val data = StackTraceHelper.convertParsedError(error)
+    assertThat(data.getString("message")).isEqualTo("error message")
+    assertThat(data.getInt("id")).isEqualTo(123)
+    assertThat(data.getBoolean("isFatal")).isEqualTo(true)
+
+    val stack = data.getArray("stack")
+    assertThat(stack).isNotNull()
+    stack?.let {
+      assertThat(stack.size()).isEqualTo(2)
+      assertStackFrameMap(stack.getMap(0), "file1", "method1", 1, 10)
+      assertStackFrameMap(stack.getMap(1), "file2", "method2", 2, 20)
+    }
+  }
+
+  private fun assertStackFrameMap(
+      map: ReadableMap,
+      filename: String,
+      methodName: String,
+      lineNumber: Int,
+      columnNumber: Int
+  ) {
+
+    assertThat(map.getString("file")).isEqualTo(filename)
+    assertThat(map.getString("methodName")).isEqualTo(methodName)
+    assertThat(map.getDouble("lineNumber").toInt()).isEqualTo(lineNumber)
+    assertThat(map.getDouble("column").toInt()).isEqualTo(columnNumber)
+  }
+
+  private fun getParsedErrorTestData(): ParsedError {
+    val frame1 =
+        object : ParsedError.StackFrame {
+          override val fileName = "file1"
+          override val methodName = "method1"
+          override val lineNumber = 1
+          override val columnNumber = 10
+        }
+
+    val frame2 =
+        object : ParsedError.StackFrame {
+          override val fileName = "file2"
+          override val methodName = "method2"
+          override val lineNumber = 2
+          override val columnNumber = 20
+        }
+
+    val frames = listOf(frame1, frame2)
+
+    return object : ParsedError {
+      override val frames = frames
+      override val message = "error message"
+      override val exceptionId = 123
+      override val isFatal = true
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactHostTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactHostTest.kt
@@ -88,7 +88,7 @@ class ReactHostTest {
             reactHostDelegate,
             componentFactory,
             false,
-            {},
+            null,
             false)
     val taskCompletionSource = TaskCompletionSource<Boolean>().apply { setResult(true) }
     mockedTaskCompletionSourceCtor =


### PR DESCRIPTION
Summary:
Making `ReactJsExceptionHandler` optional (using nullable) when passing into ReactHostImpl. Default implementation implemented in `ReactInstance.java` is provided when it is null. Default handler uses NativeExceptionHandler TurboModule to handle error.
Changing existing implementation using an empty stub with `null` so default implementation can be utilized.

Changelog: [Android][Added] Providing a default `ReactJsExceptionHandler` when `null` parameter is passed into `ReactHostImpl` constructor

Differential Revision: D58558762
