### PR TITLE
[RN][CI] Move to M1 machines

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -31,7 +31,7 @@ commands:
       - restore_cache:
           key: *rbenv_cache_key
       - run:
-          name: Bundle Install
+          name: Install the proper Ruby and run Bundle install
           command: |
             # Check if rbenv is installed. CircleCI is migrating to rbenv so we may not need to always install it.
 
@@ -60,8 +60,10 @@ commands:
             if [[ << parameters.ruby_version >> == "2.6.10" ]]; then
               # RubyGems 3.0.3.1 breaks Bundler
               gem update --system 3.2.3
+              rbenv rehash
               gem install bundler -v 2.4.22
             else
+              rbenv rehash
               gem install bundler
             fi
             bundle check || bundle install --path vendor/bundle --clean

--- a/.circleci/configurations/executors.yml
+++ b/.circleci/configurations/executors.yml
@@ -33,6 +33,6 @@ executors:
     <<: *defaults
     macos:
       xcode: *xcode_version
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     environment:
       - RCT_BUILD_HERMES_FROM_SOURCE: true

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -116,7 +116,7 @@ jobs:
     executor: reactnativeios
     parameters:
       ruby_version:
-        default: "2.7.7"
+        default: "2.7.8"
         description: The version of ruby that must be used
         type: string
     steps:
@@ -1094,15 +1094,13 @@ jobs:
       dry_run:
         type: boolean
         default: false
-    executor: reactnativeios
+    executor: nodelts
     steps:
       - checkout_code_with_cache
       - run_yarn
       - add_ssh_keys:
           fingerprints:
             - "1f:c7:61:c4:e2:ff:77:e3:cc:ca:a7:34:c2:79:e3:3c"
-      - brew_install:
-          package: cmake
       - run:
           name: Versioning workspace packages
           command: |
@@ -1114,6 +1112,11 @@ jobs:
       - run:
           name: Creating release commit
           command: |
+            # I'm seeing failures in automatically detect the email for the
+            # agent that should push the commit.
+            git config --global user.name "Distiller"
+            git config --global user.email "distiller@circleci.com"
+
             git commit -a -m "Release << parameters.version >>" -m "#publish-packages-to-npm&<< parameters.tag >>"
             git tag -a "v<< parameters.version >>" -m "v<< parameters.version >>"
             GIT_PAGER=cat git show HEAD

--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -57,8 +57,8 @@
       - test_ios_helloworld:
           requires:
             - build_hermes_macos
-          name: "Test Template with Ruby 3.2.0"
-          ruby_version: "3.2.0"
+          name: "Test Template with Ruby 3.2.2"
+          ruby_version: "3.2.2"
           architecture: "NewArch"
           flavor: "Debug"
           jsengine: "Hermes"
@@ -72,7 +72,7 @@
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
             exclude:
-              # This config is tested with Ruby 3.2.0. Let's not double test it.
+              # This config is tested with Ruby 3.2.2. Let's not double test it.
               - flavor: "Debug"
                 jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
@@ -81,7 +81,7 @@
             - build_hermes_macos
           use_frameworks: "DynamicFrameworks"
           architecture: "NewArch"
-          ruby_version: "3.2.0"
+          ruby_version: "3.2.2"
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]

--- a/.circleci/configurations/test_workflows/testE2E.yml
+++ b/.circleci/configurations/test_workflows/testE2E.yml
@@ -5,5 +5,5 @@
         - equal: [ false, << pipeline.parameters.run_nightly_workflow >> ]
     jobs:
       - test_e2e_ios:
-          ruby_version: "2.7.7"
+          ruby_version: "2.7.8"
       - test_e2e_android

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -46,8 +46,8 @@
       - test_ios_helloworld:
           requires:
             - build_hermes_macos
-          name: "Test Template with Ruby 3.2.0"
-          ruby_version: "3.2.0"
+          name: "Test Template with Ruby 3.2.2"
+          ruby_version: "3.2.2"
           architecture: "NewArch"
           flavor: "Debug"
           jsengine: "Hermes"
@@ -61,7 +61,7 @@
               jsengine: ["Hermes", "JSC"]
               use_frameworks: ["StaticLibraries", "DynamicFrameworks"]
             exclude:
-              # This config is tested with Ruby 3.2.0. Let's not double test it.
+              # This config is tested with Ruby 3.2.2. Let's not double test it.
               - flavor: "Debug"
                 jsengine: "Hermes"
                 use_frameworks: "StaticLibraries"
@@ -69,7 +69,7 @@
           requires:
             - build_hermes_macos
           use_frameworks: "DynamicFrameworks"
-          ruby_version: "3.2.0"
+          ruby_version: "3.2.2"
           architecture: "NewArch"
           matrix:
             parameters:

--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -71,31 +71,31 @@ references:
 
   cache_keys:
     checkout_cache_key: &checkout_cache_key v1-checkout
-    gems_cache_key: &gems_cache_key v2-gems-{{ checksum "Gemfile.lock" }}
+    gems_cache_key: &gems_cache_key v2-gems-{{ arch }}-{{ checksum "Gemfile.lock" }}
     gradle_cache_key: &gradle_cache_key v3-gradle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "packages/react-native/ReactAndroid/gradle.properties" }}
     yarn_cache_key: &yarn_cache_key v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}
-    rbenv_cache_key: &rbenv_cache_key v1-rbenv-{{ checksum "/tmp/required_ruby" }}
+    rbenv_cache_key: &rbenv_cache_key v1-rbenv-{{ arch }}-{{ checksum "/tmp/required_ruby" }}
     hermes_workspace_cache_key: &hermes_workspace_cache_key v5-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
     hermes_workspace_debug_cache_key: &hermes_workspace_debug_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_workspace_release_cache_key: &hermes_workspace_release_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
     hermes_linux_cache_key: &hermes_linux_cache_key v1-hermes-{{ .Environment.CIRCLE_JOB }}-linux-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_windows_cache_key: &hermes_windows_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-windows-{{ checksum "/Users/circleci/project/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     # Hermes iOS
-    hermesc_apple_cache_key: &hermesc_apple_cache_key v3-hermesc-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    hermes_apple_slices_cache_key: &hermes_apple_slices_cache_key v7-hermes-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
-    hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v5-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
-    hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v4-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
-    hermes_macosx_bin_release_cache_key: &hermes_macosx_bin_release_cache_key v4-hermes-release-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    hermes_macosx_bin_debug_cache_key: &hermes_macosx_bin_debug_cache_key v2-hermes-debug-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    hermes_dsym_debug_cache_key: &hermes_dsym_debug_cache_key v2-hermes-debug-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    hermes_dsym_release_cache_key: &hermes_dsym_release_cache_key v2-hermes-release-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
+    hermesc_apple_cache_key: &hermesc_apple_cache_key v4-hermesc-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
+    hermes_apple_slices_cache_key: &hermes_apple_slices_cache_key v8-hermes-apple-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
+    hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v6-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
+    hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v5-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}-{{ checksum "packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh" }}
+    hermes_macosx_bin_release_cache_key: &hermes_macosx_bin_release_cache_key v5-hermes-release-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
+    hermes_macosx_bin_debug_cache_key: &hermes_macosx_bin_debug_cache_key v3-hermes-debug-macosx-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
+    hermes_dsym_debug_cache_key: &hermes_dsym_debug_cache_key v3-hermes-debug-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
+    hermes_dsym_release_cache_key: &hermes_dsym_release_cache_key v3-hermes-release-dsym-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     # Cocoapods - RNTester
-    pods_cache_key: &pods_cache_key v11-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
-    cocoapods_cache_key: &cocoapods_cache_key v11-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
-    rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v10-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    pods_cache_key: &pods_cache_key v12-pods-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
+    cocoapods_cache_key: &cocoapods_cache_key v12-cocoapods-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock" }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    rntester_podfile_lock_cache_key: &rntester_podfile_lock_cache_key v11-podfilelock-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
     # Cocoapods - HelloWorld
-    helloworld_cocoapods_cache_key: &helloworld_cocoapods_cache_key v1-cocoapods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/helloworld/ios/Podfile.lock" }}-{{ checksum "packages/helloworld/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
-    helloworld_podfile_lock_cache_key: &helloworld_podfile_lock_cache_key v1-podfilelock-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/helloworld/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    helloworld_cocoapods_cache_key: &helloworld_cocoapods_cache_key v2-cocoapods-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/helloworld/ios/Podfile.lock" }}-{{ checksum "packages/helloworld/ios/Podfile" }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    helloworld_podfile_lock_cache_key: &helloworld_podfile_lock_cache_key v2-podfilelock-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/helloworld/ios/Podfile" }}-{{ checksum "/tmp/week_year" }}-{{ checksum "/tmp/hermes/hermesversion" }}
 
   cache_paths:
     hermes_workspace_macos_cache_paths: &hermes_workspace_macos_cache_paths


### PR DESCRIPTION
## Summary:

CircleCI is removing support for intel machines at the end of June, hence we have to migrate to M1.

## Changelog:
[Internal] - Migrate to M1

## Test Plan:
CircleCI is green
