### PR TITLE
Add package.json to default `lockFiles` for ReactSettingsExtension

### DIFF
--- a/packages/react-native-gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
+++ b/packages/react-native-gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
@@ -40,7 +40,9 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
       command: List<String> = listOf("npx", "@react-native-community/cli", "config"),
       workingDirectory: File? = settings.layout.rootDirectory.dir("../").asFile,
       lockFiles: FileCollection =
-          settings.layout.rootDirectory.dir("../").files("yarn.lock", "package-lock.json")
+          settings.layout.rootDirectory
+              .dir("../")
+              .files("yarn.lock", "package-lock.json", "package.json")
   ) {
     outputFile.parentFile.mkdirs()
     val lockFilesChanged = checkAndUpdateLockfiles(lockFiles, outputFolder)


### PR DESCRIPTION
Summary:
This is a small improvement suggested by tido64 to also account for package.json when computing caching
for autolinking of libraries.

Changelog:
[Internal] [Changed] - Add package.json to default `lockFiles` for ReactSettingsExtension

Differential Revision: D58587739
