### PR TITLE
Allow native module loads during react instance init

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -1073,6 +1073,9 @@ public class ReactHostImpl implements ReactHost {
                             getOrCreateReactHostInspectorTarget());
                     mReactInstance = instance;
 
+                    // eagerly initailize turbo modules
+                    instance.initializeEagerTurboModules();
+
                     MemoryPressureListener memoryPressureListener =
                         createMemoryPressureListener(instance);
                     mMemoryPressureListener = memoryPressureListener;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -198,11 +198,6 @@ final class ReactInstance {
             getJSCallInvokerHolder(),
             getNativeMethodCallInvokerHolder());
 
-    // Eagerly initialize TurboModules
-    for (String moduleName : mTurboModuleManager.getEagerInitModuleNames()) {
-      mTurboModuleManager.getModule(moduleName);
-    }
-
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
 
     // Set up Fabric
@@ -298,6 +293,13 @@ final class ReactInstance {
 
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+  }
+
+  void initializeEagerTurboModules() {
+    // Eagerly initialize TurboModules
+    for (String moduleName : mTurboModuleManager.getEagerInitModuleNames()) {
+      mTurboModuleManager.getModule(moduleName);
+    }
   }
 
   private static synchronized void loadLibraryIfNeeded() {


### PR DESCRIPTION
Summary:
## Context
Right now, the ReactInstance construtor eagerly initializes native modules.

## Problem
When these modules initialize, they may load other modules. But, all those loads will fail, because the react instance is in the process of being constructed.

## Changes
Eagerly initialize modules after the react instance is created. That way, these native module requires work.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D58537536
