### PR TITLE
Fix for broken test_helloworld_android on Release

### DIFF
--- a/packages/helloworld/android/app/build.gradle
+++ b/packages/helloworld/android/app/build.gradle
@@ -137,3 +137,11 @@ dependencies {
         implementation jscFlavor
     }
 }
+
+afterEvaluate {
+    // As HelloWorld is building from source, we need to make sure hermesc is built before the JS bundle is created.
+    // Otherwise the release version of the app will fail to build due to missing hermesc.
+    tasks
+        .getByName("createBundleReleaseJsAndAssets")
+        .dependsOn(gradle.includedBuild("react-native").task(":packages:react-native:ReactAndroid:hermes-engine:buildHermesC"))
+}


### PR DESCRIPTION
Summary:
The test_helloworld_android Release variant are broken on GHA.
This fixes it as it forces hermesc to be built *before* the app attempts to create a bundle.

Changelog:
[Internal] [Changed] - Fix for broken test_helloworld_android on Release

Reviewed By: cipolleschi, blakef

Differential Revision: D58591480
