### PR TITLE
stop sending State in view preallocation on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -750,7 +750,6 @@ public class FabricUIManager
       final String componentName,
       @Nullable Object props,
       @Nullable Object stateWrapper,
-      @Nullable Object eventEmitterWrapper,
       boolean isLayoutable) {
 
     mMountItemDispatcher.addPreAllocateMountItem(
@@ -760,7 +759,6 @@ public class FabricUIManager
             componentName,
             (ReadableMap) props,
             (StateWrapper) stateWrapper,
-            (EventEmitterWrapper) eventEmitterWrapper,
             isLayoutable));
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -74,7 +74,6 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactRoot;
 import com.facebook.react.uimanager.ReactRootViewTagGenerator;
 import com.facebook.react.uimanager.RootViewUtil;
-import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewManagerPropertyUpdater;
@@ -749,17 +748,11 @@ public class FabricUIManager
       int reactTag,
       final String componentName,
       @Nullable Object props,
-      @Nullable Object stateWrapper,
       boolean isLayoutable) {
 
     mMountItemDispatcher.addPreAllocateMountItem(
         MountItemFactory.createPreAllocateViewMountItem(
-            rootTag,
-            reactTag,
-            componentName,
-            (ReadableMap) props,
-            (StateWrapper) stateWrapper,
-            isLayoutable));
+            rootTag, reactTag, componentName, (ReadableMap) props, isLayoutable));
   }
 
   @SuppressLint("NotInvokedPrivateMethod")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -1238,7 +1238,6 @@ public class SurfaceMountingManager {
       int reactTag,
       @Nullable ReadableMap props,
       @Nullable StateWrapper stateWrapper,
-      @Nullable EventEmitterWrapper eventEmitterWrapper,
       boolean isLayoutable) {
     UiThreadUtil.assertOnUiThread();
 
@@ -1251,8 +1250,7 @@ public class SurfaceMountingManager {
       return;
     }
 
-    createViewUnsafe(
-        componentName, reactTag, props, stateWrapper, eventEmitterWrapper, isLayoutable);
+    createViewUnsafe(componentName, reactTag, props, stateWrapper, null, isLayoutable);
   }
 
   @AnyThread

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -1237,7 +1237,6 @@ public class SurfaceMountingManager {
       @NonNull String componentName,
       int reactTag,
       @Nullable ReadableMap props,
-      @Nullable StateWrapper stateWrapper,
       boolean isLayoutable) {
     UiThreadUtil.assertOnUiThread();
 
@@ -1250,7 +1249,7 @@ public class SurfaceMountingManager {
       return;
     }
 
-    createViewUnsafe(componentName, reactTag, props, stateWrapper, null, isLayoutable);
+    createViewUnsafe(componentName, reactTag, props, null, null, isLayoutable);
   }
 
   @AnyThread

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
@@ -9,7 +9,6 @@ package com.facebook.react.fabric.mounting.mountitems
 
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.fabric.events.EventEmitterWrapper
 import com.facebook.react.uimanager.StateWrapper
 
 /** Factory class that expose creation of [MountItem] */
@@ -50,11 +49,9 @@ public object MountItemFactory {
       component: String,
       props: ReadableMap?,
       stateWrapper: StateWrapper?,
-      eventEmitterWrapper: EventEmitterWrapper?,
       isLayoutable: Boolean
   ): MountItem =
-      PreAllocateViewMountItem(
-          surfaceId, reactTag, component, props, stateWrapper, eventEmitterWrapper, isLayoutable)
+      PreAllocateViewMountItem(surfaceId, reactTag, component, props, stateWrapper, isLayoutable)
 
   /**
    * @return a [MountItem] that will be read and execute a collection of MountItems serialized in

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
@@ -9,7 +9,6 @@ package com.facebook.react.fabric.mounting.mountitems
 
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.uimanager.StateWrapper
 
 /** Factory class that expose creation of [MountItem] */
 public object MountItemFactory {
@@ -48,10 +47,8 @@ public object MountItemFactory {
       reactTag: Int,
       component: String,
       props: ReadableMap?,
-      stateWrapper: StateWrapper?,
       isLayoutable: Boolean
-  ): MountItem =
-      PreAllocateViewMountItem(surfaceId, reactTag, component, props, stateWrapper, isLayoutable)
+  ): MountItem = PreAllocateViewMountItem(surfaceId, reactTag, component, props, isLayoutable)
 
   /**
    * @return a [MountItem] that will be read and execute a collection of MountItems serialized in

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/PreAllocateViewMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/PreAllocateViewMountItem.java
@@ -16,7 +16,6 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.fabric.events.EventEmitterWrapper;
 import com.facebook.react.fabric.mounting.MountingManager;
 import com.facebook.react.fabric.mounting.SurfaceMountingManager;
 import com.facebook.react.uimanager.StateWrapper;
@@ -30,7 +29,6 @@ final class PreAllocateViewMountItem implements MountItem {
   private final int mReactTag;
   private final @Nullable ReadableMap mProps;
   private final @Nullable StateWrapper mStateWrapper;
-  private final @Nullable EventEmitterWrapper mEventEmitterWrapper;
   private final boolean mIsLayoutable;
 
   PreAllocateViewMountItem(
@@ -39,13 +37,11 @@ final class PreAllocateViewMountItem implements MountItem {
       @NonNull String component,
       @Nullable ReadableMap props,
       @Nullable StateWrapper stateWrapper,
-      @Nullable EventEmitterWrapper eventEmitterWrapper,
       boolean isLayoutable) {
     mComponent = getFabricComponentName(component);
     mSurfaceId = surfaceId;
     mProps = props;
     mStateWrapper = stateWrapper;
-    mEventEmitterWrapper = eventEmitterWrapper;
     mReactTag = reactTag;
     mIsLayoutable = isLayoutable;
   }
@@ -65,7 +61,7 @@ final class PreAllocateViewMountItem implements MountItem {
       return;
     }
     surfaceMountingManager.preallocateView(
-        mComponent, mReactTag, mProps, mStateWrapper, mEventEmitterWrapper, mIsLayoutable);
+        mComponent, mReactTag, mProps, mStateWrapper, mIsLayoutable);
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/PreAllocateViewMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/PreAllocateViewMountItem.java
@@ -18,7 +18,6 @@ import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.fabric.mounting.MountingManager;
 import com.facebook.react.fabric.mounting.SurfaceMountingManager;
-import com.facebook.react.uimanager.StateWrapper;
 
 /** {@link MountItem} that is used to pre-allocate views for JS components. */
 @Nullsafe(Nullsafe.Mode.LOCAL)
@@ -28,7 +27,6 @@ final class PreAllocateViewMountItem implements MountItem {
   private final int mSurfaceId;
   private final int mReactTag;
   private final @Nullable ReadableMap mProps;
-  private final @Nullable StateWrapper mStateWrapper;
   private final boolean mIsLayoutable;
 
   PreAllocateViewMountItem(
@@ -36,12 +34,10 @@ final class PreAllocateViewMountItem implements MountItem {
       int reactTag,
       @NonNull String component,
       @Nullable ReadableMap props,
-      @Nullable StateWrapper stateWrapper,
       boolean isLayoutable) {
     mComponent = getFabricComponentName(component);
     mSurfaceId = surfaceId;
     mProps = props;
-    mStateWrapper = stateWrapper;
     mReactTag = reactTag;
     mIsLayoutable = isLayoutable;
   }
@@ -60,8 +56,7 @@ final class PreAllocateViewMountItem implements MountItem {
           "Skipping View PreAllocation; no SurfaceMountingManager found for [" + mSurfaceId + "]");
       return;
     }
-    surfaceMountingManager.preallocateView(
-        mComponent, mReactTag, mProps, mStateWrapper, mIsLayoutable);
+    surfaceMountingManager.preallocateView(mComponent, mReactTag, mProps, mIsLayoutable);
   }
 
   @Override
@@ -78,11 +73,7 @@ final class PreAllocateViewMountItem implements MountItem {
             .append(mIsLayoutable);
 
     if (IS_DEVELOPMENT_ENVIRONMENT) {
-      result
-          .append(" props: ")
-          .append(mProps != null ? mProps.toString() : "<null>")
-          .append(" state: ")
-          .append(mStateWrapper != null ? mStateWrapper.toString() : "<null>");
+      result.append(" props: ").append(mProps != null ? mProps.toString() : "<null>");
     }
 
     return result.toString();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -817,7 +817,7 @@ void FabricMountingManager::maybePreallocateShadowView(
 
   static auto preallocateView =
       JFabricUIManager::javaClassStatic()
-          ->getMethod<void(jint, jint, jstring, jobject, jobject, jboolean)>(
+          ->getMethod<void(jint, jint, jstring, jobject, jboolean)>(
               "preallocateView");
 
   // Do not hold onto Java object from C
@@ -840,7 +840,6 @@ void FabricMountingManager::maybePreallocateShadowView(
       shadowView.tag,
       component.get(),
       props.get(),
-      (javaStateWrapper != nullptr ? javaStateWrapper.get() : nullptr),
       isLayoutableShadowNode);
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -817,8 +817,7 @@ void FabricMountingManager::maybePreallocateShadowView(
 
   static auto preallocateView =
       JFabricUIManager::javaClassStatic()
-          ->getMethod<void(
-              jint, jint, jstring, jobject, jobject, jobject, jboolean)>(
+          ->getMethod<void(jint, jint, jstring, jobject, jobject, jboolean)>(
               "preallocateView");
 
   // Do not hold onto Java object from C
@@ -831,9 +830,6 @@ void FabricMountingManager::maybePreallocateShadowView(
     cStateWrapper->setState(shadowView.state);
   }
 
-  // Do not hold a reference to javaEventEmitter from the C++ side.
-  jni::local_ref<EventEmitterWrapper::JavaPart> javaEventEmitter = nullptr;
-
   jni::local_ref<jobject> props = getProps({}, shadowView);
 
   auto component = getPlatformComponentName(shadowView);
@@ -845,7 +841,6 @@ void FabricMountingManager::maybePreallocateShadowView(
       component.get(),
       props.get(),
       (javaStateWrapper != nullptr ? javaStateWrapper.get() : nullptr),
-      (javaEventEmitter != nullptr ? javaEventEmitter.get() : nullptr),
       isLayoutableShadowNode);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -9,7 +9,6 @@
 #include <react/config/ReactNativeConfig.h>
 #include <react/renderer/components/view/HostPlatformViewTraitsInitializer.h>
 #include <react/renderer/components/view/primitives.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 


### PR DESCRIPTION
Summary:
changelog: [internal]

state object is usually invalid when first constructed and with view preallocation, it remains unused. This is unnecessary work that we can avoid by simply not sending state through jni during view preallocation.

Differential Revision: D58529357
