### PR TITLE
clean up systrace for systrace View preallocation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -509,10 +509,6 @@ void Binding::schedulerShouldRenderTransactions(
 
 void Binding::schedulerDidRequestPreliminaryViewAllocation(
     const ShadowNode& shadowNode) {
-  if (!shadowNode.getTraits().check(ShadowNodeTraits::Trait::FormsView)) {
-    return;
-  }
-
   auto mountingManager = getMountingManager("preallocateView");
   if (!mountingManager) {
     return;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -786,6 +786,12 @@ void FabricMountingManager::executeMount(
 
 void FabricMountingManager::preallocateShadowView(
     const ShadowNode& shadowNode) {
+  if (!shadowNode.getTraits().check(ShadowNodeTraits::Trait::FormsView)) {
+    return;
+  }
+
+  SystraceSection section("FabricMountingManager::preallocateShadowView");
+
   {
     std::lock_guard lock(allocatedViewsMutex_);
     auto allocatedViewsIterator =

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -310,8 +310,6 @@ void Scheduler::uiManagerDidFinishTransaction(
 }
 
 void Scheduler::uiManagerDidCreateShadowNode(const ShadowNode& shadowNode) {
-  SystraceSection s("Scheduler::uiManagerDidCreateShadowNode");
-
   if (delegate_ != nullptr) {
     delegate_->schedulerDidRequestPreliminaryViewAllocation(shadowNode);
   }


### PR DESCRIPTION
Summary:
changelog: [internal]

do not show systrace logs for flattened views.

Reviewed By: rubennorte

Differential Revision: D58587946
