### PR TITLE
Make soft exceptions easier to spot in logcat

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -903,11 +903,13 @@ public class ReactHostImpl implements ReactHost {
     setCurrentActivity(null);
   }
 
-  private void raiseSoftException(String method, String message) {
-    raiseSoftException(method, message, null);
+  private void raiseSoftException(String callingMethod, String message) {
+    raiseSoftException(callingMethod, message, null);
   }
 
-  private void raiseSoftException(String method, String message, @Nullable Throwable throwable) {
+  private void raiseSoftException(
+      String callingMethod, String message, @Nullable Throwable throwable) {
+    final String method = "raiseSoftException(" + callingMethod + ")";
     log(method, message);
     if (throwable != null) {
       ReactSoftExceptionLogger.logSoftException(


### PR DESCRIPTION
Summary:
Now, all soft exception methods will have raiseSoftException(...)

## Before

```
BridgelessReact: ReactHost{0}.getOrCreateDestroyTask(): handleHostException(message = "Unable to load script. Make sure you're either running Metro (run 'npx react-native start') or that your bundle 'RNTesterBundle.js' is packaged correctly for release.")
```

## After
```
BridgelessReact: ReactHost{0}.raiseSoftException(getOrCreateDestroyTask()): handleHostException(message = "Unable to load script. Make sure you're either running Metro (run 'npx react-native start') or that your bundle 'RNTesterBundle.js' is packaged correctly for release.")
```

Changelog: [Internal]

Differential Revision: D58593609
