### PR TITLE
Switch 'number of lines' validation to DEV only

### DIFF
--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -212,9 +212,11 @@ const Text: React.AbstractComponent<
 
   let _numberOfLines = numberOfLines;
   if (_numberOfLines != null && !(_numberOfLines >= 0)) {
-    console.error(
-      `'numberOfLines' in <Text> must be a non-negative number, received: ${_numberOfLines}. The value will be set to 0.`,
-    );
+    if (__DEV__) {
+      console.error(
+        `'numberOfLines' in <Text> must be a non-negative number, received: ${_numberOfLines}. The value will be set to 0.`,
+      );
+    }
     _numberOfLines = 0;
   }
 


### PR DESCRIPTION
Summary:
Switch the "number of lines" warning, which ensures this value is not negative, to only fire in DEV.

Changelog: [Internal]

Differential Revision: D58472148
