### PR TITLE
feat: Allow accessing `jsi::Value` on `RawProps`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -113,7 +113,7 @@ class RawProps final {
   /**
    * Get the `jsi::Runtime` if this `RawProps` instance stores a `jsi::Value`, or `nullptr` otherwise.
    * This API is used by pure JSI-based React Native Frameworks that skip the `RawPropsParser` route.
-   * DO NOT store this `jsi::Value` in memory.
+   * DO NOT store this `jsi::Runtime` in memory.
    */
   const jsi::Runtime* getJsiRuntime() const { return runtime_; }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -101,7 +101,19 @@ class RawProps final {
    */
   void iterateOverValues(
       const std::function<
-          void(RawPropsPropNameHash, const char*, const RawValue&)>& fn) const;
+          void(RawPropsPropNameHash, const char*, RawValue const&)>& fn) const;
+
+  /**
+   * Get the `jsi::Value` if this `RawProps` instance stores a `jsi::Value`, `jsi::Value::undefined()` otherwise.
+   * This API is used by pure JSI-based React Native Frameworks that skip the `RawPropsParser` route.
+   */
+  jsi::Value& getJsiValue() { return value_; }
+
+  /**
+   * Get the `jsi::Runtime` if this `RawProps` instance stores a `jsi::Value`, `nullptr` otherwise.
+   * This API is used by pure JSI-based React Native Frameworks that skip the `RawPropsParser` route.
+   */
+  jsi::Runtime* getJsiRuntime() { return runtime_; }
 
  private:
   friend class RawPropsParser;

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -104,16 +104,18 @@ class RawProps final {
           void(RawPropsPropNameHash, const char*, RawValue const&)>& fn) const;
 
   /**
-   * Get the `jsi::Value` if this `RawProps` instance stores a `jsi::Value`, `jsi::Value::undefined()` otherwise.
+   * Get the `jsi::Value` if this `RawProps` instance stores a `jsi::Value`, or `jsi::Value::undefined()` otherwise.
    * This API is used by pure JSI-based React Native Frameworks that skip the `RawPropsParser` route.
+   * DO NOT store this `jsi::Value` in memory.
    */
-  jsi::Value& getJsiValue() { return value_; }
+  jsi::Value& getJsiValue() const { return value_; }
 
   /**
-   * Get the `jsi::Runtime` if this `RawProps` instance stores a `jsi::Value`, `nullptr` otherwise.
+   * Get the `jsi::Runtime` if this `RawProps` instance stores a `jsi::Value`, or `nullptr` otherwise.
    * This API is used by pure JSI-based React Native Frameworks that skip the `RawPropsParser` route.
+   * DO NOT store this `jsi::Value` in memory.
    */
-  jsi::Runtime* getJsiRuntime() { return runtime_; }
+  jsi::Runtime* getJsiRuntime() const { return runtime_; }
 
  private:
   friend class RawPropsParser;

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -108,14 +108,14 @@ class RawProps final {
    * This API is used by pure JSI-based React Native Frameworks that skip the `RawPropsParser` route.
    * DO NOT store this `jsi::Value` in memory.
    */
-  jsi::Value& getJsiValue() const { return value_; }
+  const jsi::Value& getJsiValue() const { return value_; }
 
   /**
    * Get the `jsi::Runtime` if this `RawProps` instance stores a `jsi::Value`, or `nullptr` otherwise.
    * This API is used by pure JSI-based React Native Frameworks that skip the `RawPropsParser` route.
    * DO NOT store this `jsi::Value` in memory.
    */
-  jsi::Runtime* getJsiRuntime() const { return runtime_; }
+  const jsi::Runtime* getJsiRuntime() const { return runtime_; }
 
  private:
   friend class RawPropsParser;

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -21,7 +21,7 @@ namespace facebook::react {
  * Specialized (to a particular type of Props) parser that provides the most
  * efficient access to `RawProps` content.
  */
-class RawPropsParser final {
+class RawPropsParser {
  public:
   /*
    * Default constructor.

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -21,7 +21,7 @@ namespace facebook::react {
  * Specialized (to a particular type of Props) parser that provides the most
  * efficient access to `RawProps` content.
  */
-class RawPropsParser {
+class RawPropsParser final {
  public:
   /*
    * Default constructor.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I'm working on a new React Native Framework. It uses pure C++/JSI to create, mount and update a View under Fabric.

Unfortunately the `RawProps` type abstraction is not enough in my case, I need the actual `jsi::Value` (which might be a `jsi::HostObject`, NativeState, or other custom types I created).

Now my idea is to avoid going the `RawPropsParser` route and instead directly access the `RawProps`' `jsi::Value` (including it's `jsi::Runtime`) to go my route.

This will be _safe_ since I immediately convert the `jsi::Value` to other C++ types, and I don't keep that instance (nor the `jsi::Runtime`) in memory.

My previous approach was extending `RawPropsParser`, but that's a bit more complex since friendship is not inheritable in C++ and I also feel like we don't need the whole prop parsing loop. In my case, all of the parsing is statically generated with templates - **there will be no iterations**.


If there's a simpler or better alternative to this, I'm all ears - but from what I'm seeing in the codebase there is no better direct point to intercept all `jsi::Value`s for view components. Please correct me if I'm wrong (cc @philIip ?)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[INTERNAL] [CHANGED] - Allow accessing `RawProps`' `jsi::Value` directly for React Native Frameworks

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

I receive `RawProps` (e.g. in `ImageProps.cpp`), and directly access `jsi::Value` from there to convert the object to a C++ object (or individual C++ keys).


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
