### PR TITLE
'[skip ci] RN: Migrate from Shallow Renderer

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
@@ -16,9 +16,16 @@ const LogBoxInspectorMessageHeader =
   require('../LogBoxInspectorMessageHeader').default;
 const React = require('react');
 
+// Mock `LogBoxMessage` because we are interested in snapshotting the
+// behavior of `LogBoxInspectorMessageHeader`, not `LogBoxMessage`.
+jest.mock('../LogBoxMessage', () => ({
+  __esModule: true,
+  default: 'LogBoxMessage',
+}));
+
 describe('LogBoxInspectorMessageHeader', () => {
   it('should render error', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Error"
         level="error"
@@ -35,7 +42,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render fatal', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Fatal Error"
         level="fatal"
@@ -52,7 +59,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render syntax error', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Syntax Error"
         level="syntax"
@@ -69,7 +76,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should not render See More button for short content', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -86,7 +93,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should not render "See More" if expanded', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -100,7 +107,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render "See More" if collapsed', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
@@ -18,9 +18,16 @@ const {
 } = require('../LogBoxNotificationContainer');
 const React = require('react');
 
+// Mock `LogBoxLogNotification` because we are interested in snapshotting the
+// behavior of `LogBoxNotificationContainer`, not `LogBoxLogNotification`.
+jest.mock('../UI/LogBoxNotification', () => ({
+  __esModule: true,
+  default: 'LogBoxLogNotification',
+}));
+
 describe('LogBoxNotificationContainer', () => {
   it('should render null with no logs', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer selectedLogIndex={-1} logs={[]} />,
     );
 
@@ -28,7 +35,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render null with no selected log and disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={-1}
@@ -52,7 +59,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render the latest warning notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -86,7 +93,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render the latest error notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -120,7 +127,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render both an error and warning notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -154,7 +161,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render selected fatal error even when disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}
@@ -178,7 +185,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render selected syntax error even when disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}


### PR DESCRIPTION
Summary:
Migrates this Jest unit test away from using  because it is no longer recommended.

Changelog:
[Internal]

Differential Revision: D58641096
