### PR TITLE
'[skip ci] RN: Migrate from Shallow Renderer

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
@@ -9,40 +9,37 @@
  */
 
 import Keyboard from '../../Components/Keyboard/Keyboard';
-import ScrollView from '../../Components/ScrollView/ScrollView';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import * as LogBoxData from '../Data/LogBoxData';
 import LogBoxLog, {type LogLevel} from '../Data/LogBoxLog';
-import LogBoxInspectorCodeFrame from './LogBoxInspectorCodeFrame';
+import LogBoxInspectorBody from './LogBoxInspectorBody';
 import LogBoxInspectorFooter from './LogBoxInspectorFooter';
 import LogBoxInspectorHeader from './LogBoxInspectorHeader';
-import LogBoxInspectorMessageHeader from './LogBoxInspectorMessageHeader';
-import LogBoxInspectorReactFrames from './LogBoxInspectorReactFrames';
-import LogBoxInspectorStackFrames from './LogBoxInspectorStackFrames';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
+import {useEffect} from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   onDismiss: () => void,
   onChangeSelectedIndex: (index: number) => void,
   onMinimize: () => void,
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedIndex: number,
   fatalType?: ?LogLevel,
-|}>;
+}>;
 
-function LogBoxInspector(props: Props): React.Node {
+export default function LogBoxInspector(props: Props): React.Node {
   const {logs, selectedIndex} = props;
   let log = logs[selectedIndex];
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (log) {
       LogBoxData.symbolicateLogNow(log);
     }
   }, [log]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Optimistically symbolicate the last and next logs.
     if (logs.length > 1) {
       const selected = selectedIndex;
@@ -54,7 +51,7 @@ function LogBoxInspector(props: Props): React.Node {
     }
   }, [logs, selectedIndex]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     Keyboard.dismiss();
   }, []);
 
@@ -84,68 +81,9 @@ function LogBoxInspector(props: Props): React.Node {
   );
 }
 
-const headerTitleMap = {
-  warn: 'Console Warning',
-  error: 'Console Error',
-  fatal: 'Uncaught Error',
-  syntax: 'Syntax Error',
-  component: 'Render Error',
-};
-
-function LogBoxInspectorBody(props: {log: LogBoxLog, onRetry: () => void}) {
-  const [collapsed, setCollapsed] = React.useState(true);
-
-  React.useEffect(() => {
-    setCollapsed(true);
-  }, [props.log]);
-
-  const headerTitle =
-    props.log.type ??
-    headerTitleMap[props.log.isComponentError ? 'component' : props.log.level];
-
-  if (collapsed) {
-    return (
-      <>
-        <LogBoxInspectorMessageHeader
-          collapsed={collapsed}
-          onPress={() => setCollapsed(!collapsed)}
-          message={props.log.message}
-          level={props.log.level}
-          title={headerTitle}
-        />
-        <ScrollView style={styles.scrollBody}>
-          <LogBoxInspectorCodeFrame codeFrame={props.log.codeFrame} />
-          <LogBoxInspectorReactFrames log={props.log} />
-          <LogBoxInspectorStackFrames log={props.log} onRetry={props.onRetry} />
-        </ScrollView>
-      </>
-    );
-  }
-  return (
-    <ScrollView style={styles.scrollBody}>
-      <LogBoxInspectorMessageHeader
-        collapsed={collapsed}
-        onPress={() => setCollapsed(!collapsed)}
-        message={props.log.message}
-        level={props.log.level}
-        title={headerTitle}
-      />
-      <LogBoxInspectorCodeFrame codeFrame={props.log.codeFrame} />
-      <LogBoxInspectorReactFrames log={props.log} />
-      <LogBoxInspectorStackFrames log={props.log} onRetry={props.onRetry} />
-    </ScrollView>
-  );
-}
-
 const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: LogBoxStyle.getTextColor(),
   },
-  scrollBody: {
-    backgroundColor: LogBoxStyle.getBackgroundColor(0.9),
-    flex: 1,
-  },
 });
-
-export default LogBoxInspector;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorBody.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorBody.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import ScrollView from '../../Components/ScrollView/ScrollView';
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import LogBoxLog from '../Data/LogBoxLog';
+import LogBoxInspectorCodeFrame from './LogBoxInspectorCodeFrame';
+import LogBoxInspectorMessageHeader from './LogBoxInspectorMessageHeader';
+import LogBoxInspectorReactFrames from './LogBoxInspectorReactFrames';
+import LogBoxInspectorStackFrames from './LogBoxInspectorStackFrames';
+import * as LogBoxStyle from './LogBoxStyle';
+import * as React from 'react';
+import {useEffect, useState} from 'react';
+
+const headerTitleMap = {
+  warn: 'Console Warning',
+  error: 'Console Error',
+  fatal: 'Uncaught Error',
+  syntax: 'Syntax Error',
+  component: 'Render Error',
+};
+
+export default function LogBoxInspectorBody(props: {
+  log: LogBoxLog,
+  onRetry: () => void,
+}): React.Node {
+  const [collapsed, setCollapsed] = useState(true);
+
+  useEffect(() => {
+    setCollapsed(true);
+  }, [props.log]);
+
+  const headerTitle =
+    props.log.type ??
+    headerTitleMap[props.log.isComponentError ? 'component' : props.log.level];
+
+  if (collapsed) {
+    return (
+      <>
+        <LogBoxInspectorMessageHeader
+          collapsed={collapsed}
+          onPress={() => setCollapsed(!collapsed)}
+          message={props.log.message}
+          level={props.log.level}
+          title={headerTitle}
+        />
+        <ScrollView style={styles.scrollBody}>
+          <LogBoxInspectorCodeFrame codeFrame={props.log.codeFrame} />
+          <LogBoxInspectorReactFrames log={props.log} />
+          <LogBoxInspectorStackFrames log={props.log} onRetry={props.onRetry} />
+        </ScrollView>
+      </>
+    );
+  }
+  return (
+    <ScrollView style={styles.scrollBody}>
+      <LogBoxInspectorMessageHeader
+        collapsed={collapsed}
+        onPress={() => setCollapsed(!collapsed)}
+        message={props.log.message}
+        level={props.log.level}
+        title={headerTitle}
+      />
+      <LogBoxInspectorCodeFrame codeFrame={props.log.codeFrame} />
+      <LogBoxInspectorReactFrames log={props.log} />
+      <LogBoxInspectorStackFrames log={props.log} onRetry={props.onRetry} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: LogBoxStyle.getTextColor(),
+  },
+  scrollBody: {
+    backgroundColor: LogBoxStyle.getBackgroundColor(0.9),
+    flex: 1,
+  },
+});

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
@@ -15,9 +15,16 @@ const render = require('../../../../jest/renderer');
 const LogBoxButton = require('../LogBoxButton').default;
 const React = require('react');
 
+// Mock `TouchableWithoutFeedback` because we are interested in snapshotting the
+// behavior of `LogBoxButton`, not `TouchableWithoutFeedback`.
+jest.mock('../../../Components/Touchable/TouchableWithoutFeedback', () => ({
+  __esModule: true,
+  default: 'TouchableWithoutFeedback',
+}));
+
 describe('LogBoxButton', () => {
   it('should render only a view without an onPress', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxButton
         backgroundColor={{
           default: 'black',
@@ -31,7 +38,7 @@ describe('LogBoxButton', () => {
   });
 
   it('should render TouchableWithoutFeedback and pass through props', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxButton
         backgroundColor={{
           default: 'black',

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
@@ -16,6 +16,21 @@ const LogBoxLog = require('../../Data/LogBoxLog').default;
 const LogBoxInspector = require('../LogBoxInspector').default;
 const React = require('react');
 
+// Mock child components because we are interested in snapshotting the behavior
+// of `LogBoxInspector`, not its children.
+jest.mock('../LogBoxInspectorBody', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorBody',
+}));
+jest.mock('../LogBoxInspectorFooter', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorFooter',
+}));
+jest.mock('../LogBoxInspectorHeader', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorHeader',
+}));
+
 const logs = [
   new LogBoxLog({
     level: 'warn',
@@ -54,7 +69,7 @@ const logs = [
 
 describe('LogBoxContainer', () => {
   it('should render null with no logs', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}
@@ -68,7 +83,7 @@ describe('LogBoxContainer', () => {
   });
 
   it('should render warning with selectedIndex 0', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}
@@ -82,7 +97,7 @@ describe('LogBoxContainer', () => {
   });
 
   it('should render fatal with selectedIndex 2', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
@@ -15,17 +15,34 @@ const render = require('../../../../jest/renderer');
 const LogBoxInspectorCodeFrame = require('../LogBoxInspectorCodeFrame').default;
 const React = require('react');
 
+// Mock child components because we are interested in snapshotting the behavior
+// of `LogBoxInspectorCodeFrame`, not its children.
+jest.mock('../../../Components/ScrollView/ScrollView', () => ({
+  __esModule: true,
+  default: 'ScrollView',
+}));
+jest.mock('../AnsiHighlight', () => ({
+  __esModule: true,
+  default: 'Ansi',
+}));
+jest.mock('../LogBoxButton', () => ({
+  __esModule: true,
+  default: 'LogBoxButton',
+}));
+jest.mock('../LogBoxInspectorSection', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorSection',
+}));
+
 describe('LogBoxInspectorCodeFrame', () => {
   it('should render null for no code frame', () => {
-    const output = render.shallowRender(
-      <LogBoxInspectorCodeFrame codeFrame={null} />,
-    );
+    const output = render.create(<LogBoxInspectorCodeFrame codeFrame={null} />);
 
     expect(output).toMatchSnapshot();
   });
 
   it('should render a code frame', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorCodeFrame
         codeFrame={{
           fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',
@@ -43,7 +60,7 @@ describe('LogBoxInspectorCodeFrame', () => {
   });
 
   it('should render a code frame without a location', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorCodeFrame
         codeFrame={{
           fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
@@ -16,9 +16,16 @@ const LogBoxInspectorMessageHeader =
   require('../LogBoxInspectorMessageHeader').default;
 const React = require('react');
 
+// Mock `LogBoxMessage` because we are interested in snapshotting the
+// behavior of `LogBoxInspectorMessageHeader`, not `LogBoxMessage`.
+jest.mock('../LogBoxMessage', () => ({
+  __esModule: true,
+  default: 'LogBoxMessage',
+}));
+
 describe('LogBoxInspectorMessageHeader', () => {
   it('should render error', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Error"
         level="error"
@@ -35,7 +42,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render fatal', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Fatal Error"
         level="fatal"
@@ -52,7 +59,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render syntax error', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Syntax Error"
         level="syntax"
@@ -69,7 +76,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should not render See More button for short content', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -86,7 +93,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should not render "See More" if expanded', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -100,7 +107,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render "See More" if collapsed', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
@@ -35,7 +35,7 @@ exports[`LogBoxContainer should render fatal with selectedIndex 2 1`] = `
         "symbolicated": Object {
           "error": null,
           "stack": null,
-          "status": "NONE",
+          "status": "PENDING",
         },
         "symbolicatedComponentStack": Object {
           "componentStack": null,

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
@@ -18,9 +18,16 @@ const {
 } = require('../LogBoxNotificationContainer');
 const React = require('react');
 
+// Mock `LogBoxLogNotification` because we are interested in snapshotting the
+// behavior of `LogBoxNotificationContainer`, not `LogBoxLogNotification`.
+jest.mock('../UI/LogBoxNotification', () => ({
+  __esModule: true,
+  default: 'LogBoxLogNotification',
+}));
+
 describe('LogBoxNotificationContainer', () => {
   it('should render null with no logs', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer selectedLogIndex={-1} logs={[]} />,
     );
 
@@ -28,7 +35,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render null with no selected log and disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={-1}
@@ -52,7 +59,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render the latest warning notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -86,7 +93,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render the latest error notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -120,7 +127,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render both an error and warning notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -154,7 +161,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render selected fatal error even when disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}
@@ -178,7 +185,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render selected syntax error even when disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5523,16 +5523,23 @@ declare export default typeof LogBoxButton;
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspector.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   onDismiss: () => void,
   onChangeSelectedIndex: (index: number) => void,
   onMinimize: () => void,
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedIndex: number,
   fatalType?: ?LogLevel,
-|}>;
-declare function LogBoxInspector(props: Props): React.Node;
-declare export default typeof LogBoxInspector;
+}>;
+declare export default function LogBoxInspector(props: Props): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorBody.js 1`] = `
+"declare export default function LogBoxInspectorBody(props: {
+  log: LogBoxLog,
+  onRetry: () => void,
+}): React.Node;
 "
 `;
 


### PR DESCRIPTION
Summary:
Migrates this Jest unit test away from using  because it is no longer recommended.

Changelog:
[Internal]

Differential Revision: D58643061
